### PR TITLE
fix(search): apply RBAC, queryFilter and deleted to the NLQ happy path

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java
@@ -370,6 +370,129 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
     }
   }
 
+  /**
+   * Applies the caller's {@code queryFilter} on top of whatever query the builder already carries.
+   * Extracted so the NLQ path applies the same filter as the keyword path — it previously ran the
+   * LLM-transformed query with the caller's filter silently dropped.
+   */
+  private void applyQueryFilter(
+      ElasticSearchRequestBuilder requestBuilder,
+      org.openmetadata.schema.search.SearchRequest request) {
+    if (!nullOrEmpty(request.getQueryFilter()) && !request.getQueryFilter().equals("{}")) {
+      try {
+        String queryToProcess = EsUtils.parseJsonQuery(request.getQueryFilter());
+        Query filterQuery = Query.of(q -> q.withJson(new StringReader(queryToProcess)));
+        Query existingQuery = requestBuilder.query();
+        if (existingQuery != null) {
+          Query combinedQuery =
+              Query.of(
+                  q ->
+                      q.bool(
+                          b -> {
+                            b.must(existingQuery);
+                            b.filter(filterQuery);
+                            return b;
+                          }));
+          requestBuilder.query(combinedQuery);
+        } else {
+          requestBuilder.query(filterQuery);
+        }
+      } catch (Exception ex) {
+        LOG.error("Error parsing query_filter from query parameters, ignoring filter", ex);
+      }
+    }
+  }
+
+  /**
+   * Applies the {@code deleted} constraint, tolerating documents that carry no {@code deleted} field
+   * at all on the multi-entity aliases. Extracted for reuse by the NLQ path, which previously ignored
+   * the flag entirely and so could return soft-deleted assets.
+   */
+  private void applyDeletedFilter(
+      ElasticSearchRequestBuilder requestBuilder,
+      org.openmetadata.schema.search.SearchRequest request,
+      String indexName) {
+    if (!nullOrEmpty(request.getDeleted())) {
+      Query existingQuery = requestBuilder.query();
+      Query deletedQuery;
+
+      if (indexName.equals(GLOBAL_SEARCH_ALIAS) || indexName.equals(DATA_ASSET_SEARCH_ALIAS)) {
+        deletedQuery =
+            Query.of(
+                q ->
+                    q.bool(
+                        b ->
+                            b.should(
+                                    s ->
+                                        s.bool(
+                                            bb ->
+                                                bb.must(existingQuery)
+                                                    .must(m -> m.exists(e -> e.field("deleted")))
+                                                    .must(
+                                                        m ->
+                                                            m.term(
+                                                                t ->
+                                                                    t.field("deleted")
+                                                                        .value(
+                                                                            FieldValue.of(
+                                                                                request
+                                                                                    .getDeleted()))))))
+                                .should(
+                                    s ->
+                                        s.bool(
+                                            bb ->
+                                                bb.must(existingQuery)
+                                                    .mustNot(
+                                                        mn ->
+                                                            mn.exists(e -> e.field("deleted")))))));
+      } else {
+        deletedQuery =
+            Query.of(
+                q ->
+                    q.bool(
+                        b ->
+                            b.must(existingQuery)
+                                .must(
+                                    m ->
+                                        m.term(
+                                            t ->
+                                                t.field("deleted")
+                                                    .value(FieldValue.of(request.getDeleted()))))));
+      }
+      requestBuilder.query(deletedQuery);
+    }
+  }
+
+  /**
+   * Builds the request for an NLQ search whose query the provider already transformed.
+   *
+   * <p>The happy path used to apply only context-memory visibility, while {@code
+   * fallbackToBasicSearch} applied RBAC as well — so the same user got different results depending on
+   * whether the NLQ provider answered or failed. RBAC, the caller's {@code queryFilter} (which is
+   * where the Collate AI-dashboard visibility injection rides) and the {@code deleted} flag are all
+   * applied here, so both paths are constrained identically.
+   */
+  ElasticSearchRequestBuilder buildNlqRequestBuilder(
+      org.openmetadata.schema.search.SearchRequest request,
+      SubjectContext subjectContext,
+      String transformedQuery)
+      throws com.fasterxml.jackson.core.JsonProcessingException {
+    ElasticSearchRequestBuilder requestBuilder = new ElasticSearchRequestBuilder();
+    String queryToProcess = EsUtils.parseJsonQuery(transformedQuery);
+    requestBuilder.query(Query.of(q -> q.withJson(new StringReader(queryToProcess))));
+    requestBuilder.from(request.getFrom());
+    requestBuilder.size(request.getSize());
+
+    // applyRbacCondition already applies the ContextMemory visibility filter.
+    applyRbacCondition(subjectContext, requestBuilder);
+    applyQueryFilter(requestBuilder, request);
+    // Strip any clusterAlias prefix first, the same way doSearch does — the deleted filter compares
+    // this against the dataAsset/all aliases.
+    String indexName = Entity.getSearchRepository().getIndexNameWithoutAlias(request.getIndex());
+    applyDeletedFilter(requestBuilder, request, indexName);
+    return requestBuilder;
+  }
+
   private void applyRbacCondition(
       SubjectContext subjectContext, ElasticSearchRequestBuilder requestBuilder) {
     if (shouldApplyRbacConditions(subjectContext, rbacConditionEvaluator)) {
@@ -594,15 +717,8 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
         io.micrometer.core.instrument.Timer.Sample searchTimerSample =
             org.openmetadata.service.monitoring.RequestLatencyContext.startSearchOperation();
 
-        // Parse the transformed query and create Query object
-        ElasticSearchRequestBuilder requestBuilder = new ElasticSearchRequestBuilder();
-        String queryToProcess = EsUtils.parseJsonQuery(transformedQuery);
-        Query nlqQuery = Query.of(q -> q.withJson(new StringReader(queryToProcess)));
-        requestBuilder.query(nlqQuery);
-
-        requestBuilder.from(request.getFrom());
-        requestBuilder.size(request.getSize());
-        applyContextMemoryVisibility(subjectContext, requestBuilder);
+        ElasticSearchRequestBuilder requestBuilder =
+            buildNlqRequestBuilder(request, subjectContext, transformedQuery);
 
         // Add aggregations for NLQ query
         addAggregationsToNLQQuery(requestBuilder, request.getIndex());
@@ -1241,30 +1357,7 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
     // Apply RBAC query
     applyRbacCondition(subjectContext, requestBuilder);
 
-    // Apply query filter
-    if (!nullOrEmpty(request.getQueryFilter()) && !request.getQueryFilter().equals("{}")) {
-      try {
-        String queryToProcess = EsUtils.parseJsonQuery(request.getQueryFilter());
-        Query filterQuery = Query.of(q -> q.withJson(new StringReader(queryToProcess)));
-        Query existingQuery = requestBuilder.query();
-        if (existingQuery != null) {
-          Query combinedQuery =
-              Query.of(
-                  q ->
-                      q.bool(
-                          b -> {
-                            b.must(existingQuery);
-                            b.filter(filterQuery);
-                            return b;
-                          }));
-          requestBuilder.query(combinedQuery);
-        } else {
-          requestBuilder.query(filterQuery);
-        }
-      } catch (Exception ex) {
-        LOG.error("Error parsing query_filter from query parameters, ignoring filter", ex);
-      }
-    }
+    applyQueryFilter(requestBuilder, request);
 
     // Apply post filter
     if (!nullOrEmpty(request.getPostFilter())) {
@@ -1284,56 +1377,7 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
       requestBuilder.searchAfter(searchAfterValues);
     }
 
-    // Handle deleted field for backward compatibility
-    if (!nullOrEmpty(request.getDeleted())) {
-      Query existingQuery = requestBuilder.query();
-      Query deletedQuery;
-
-      if (indexName.equals(GLOBAL_SEARCH_ALIAS) || indexName.equals(DATA_ASSET_SEARCH_ALIAS)) {
-        deletedQuery =
-            Query.of(
-                q ->
-                    q.bool(
-                        b ->
-                            b.should(
-                                    s ->
-                                        s.bool(
-                                            bb ->
-                                                bb.must(existingQuery)
-                                                    .must(m -> m.exists(e -> e.field("deleted")))
-                                                    .must(
-                                                        m ->
-                                                            m.term(
-                                                                t ->
-                                                                    t.field("deleted")
-                                                                        .value(
-                                                                            FieldValue.of(
-                                                                                request
-                                                                                    .getDeleted()))))))
-                                .should(
-                                    s ->
-                                        s.bool(
-                                            bb ->
-                                                bb.must(existingQuery)
-                                                    .mustNot(
-                                                        mn ->
-                                                            mn.exists(e -> e.field("deleted")))))));
-      } else {
-        deletedQuery =
-            Query.of(
-                q ->
-                    q.bool(
-                        b ->
-                            b.must(existingQuery)
-                                .must(
-                                    m ->
-                                        m.term(
-                                            t ->
-                                                t.field("deleted")
-                                                    .value(FieldValue.of(request.getDeleted()))))));
-      }
-      requestBuilder.query(deletedQuery);
-    }
+    applyDeletedFilter(requestBuilder, request, indexName);
 
     // Handle sorting — always append a deterministic tiebreaker so equal-ranked docs order
     // identically across shards/replicas; without it the same query bounces between copies.

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
@@ -574,15 +574,8 @@ public class OpenSearchSearchManager implements SearchManagementClient {
         // Start search operation timing
         Timer.Sample searchTimerSample = RequestLatencyContext.startSearchOperation();
 
-        // Parse the transformed query and create Query object
-        OpenSearchRequestBuilder requestBuilder = new OpenSearchRequestBuilder();
-        String queryToProcess = OsUtils.parseJsonQuery(transformedQuery);
-        Query nlqQuery = Query.of(q -> q.wrapper(w -> w.query(queryToProcess)));
-        requestBuilder.query(nlqQuery);
-
-        requestBuilder.from(request.getFrom());
-        requestBuilder.size(request.getSize());
-        applyContextMemoryVisibility(subjectContext, requestBuilder);
+        OpenSearchRequestBuilder requestBuilder =
+            buildNlqRequestBuilder(request, subjectContext, transformedQuery);
 
         // Add aggregations for NLQ query
         addAggregationsToNLQQuery(requestBuilder, request.getIndex());
@@ -895,6 +888,129 @@ public class OpenSearchSearchManager implements SearchManagementClient {
     return query == null
         ? memoryFilter
         : Query.of(q -> q.bool(b -> b.must(query).filter(memoryFilter)));
+  }
+
+  /**
+   * Applies the caller's {@code queryFilter} on top of whatever query the builder already carries.
+   * Extracted so the NLQ path applies the same filter as the keyword path — it previously ran the
+   * LLM-transformed query with the caller's filter silently dropped.
+   */
+  private void applyQueryFilter(
+      OpenSearchRequestBuilder requestBuilder,
+      org.openmetadata.schema.search.SearchRequest request) {
+    if (!nullOrEmpty(request.getQueryFilter()) && !request.getQueryFilter().equals("{}")) {
+      try {
+        String queryToProcess = OsUtils.parseJsonQuery(request.getQueryFilter());
+        Query filterQuery = Query.of(q -> q.wrapper(w -> w.query(queryToProcess)));
+        Query existingQuery = requestBuilder.query();
+        if (existingQuery != null) {
+          Query combinedQuery =
+              Query.of(
+                  q ->
+                      q.bool(
+                          b -> {
+                            b.must(existingQuery);
+                            b.filter(filterQuery);
+                            return b;
+                          }));
+          requestBuilder.query(combinedQuery);
+        } else {
+          requestBuilder.query(filterQuery);
+        }
+      } catch (Exception ex) {
+        LOG.error("Error parsing query_filter from query parameters, ignoring filter", ex);
+      }
+    }
+  }
+
+  /**
+   * Applies the {@code deleted} constraint, tolerating documents that carry no {@code deleted} field
+   * at all on the multi-entity aliases. Extracted for reuse by the NLQ path, which previously ignored
+   * the flag entirely and so could return soft-deleted assets.
+   */
+  private void applyDeletedFilter(
+      OpenSearchRequestBuilder requestBuilder,
+      org.openmetadata.schema.search.SearchRequest request,
+      String indexName) {
+    if (!nullOrEmpty(request.getDeleted())) {
+      Query existingQuery = requestBuilder.query();
+      Query deletedQuery;
+
+      if (indexName.equals(GLOBAL_SEARCH_ALIAS) || indexName.equals(DATA_ASSET_SEARCH_ALIAS)) {
+        deletedQuery =
+            Query.of(
+                q ->
+                    q.bool(
+                        b ->
+                            b.should(
+                                    s ->
+                                        s.bool(
+                                            bb ->
+                                                bb.must(existingQuery)
+                                                    .must(m -> m.exists(e -> e.field("deleted")))
+                                                    .must(
+                                                        m ->
+                                                            m.term(
+                                                                t ->
+                                                                    t.field("deleted")
+                                                                        .value(
+                                                                            FieldValue.of(
+                                                                                request
+                                                                                    .getDeleted()))))))
+                                .should(
+                                    s ->
+                                        s.bool(
+                                            bb ->
+                                                bb.must(existingQuery)
+                                                    .mustNot(
+                                                        mn ->
+                                                            mn.exists(e -> e.field("deleted")))))));
+      } else {
+        deletedQuery =
+            Query.of(
+                q ->
+                    q.bool(
+                        b ->
+                            b.must(existingQuery)
+                                .must(
+                                    m ->
+                                        m.term(
+                                            t ->
+                                                t.field("deleted")
+                                                    .value(FieldValue.of(request.getDeleted()))))));
+      }
+      requestBuilder.query(deletedQuery);
+    }
+  }
+
+  /**
+   * Builds the request for an NLQ search whose query the provider already transformed.
+   *
+   * <p>The happy path used to apply only context-memory visibility, while {@code
+   * fallbackToBasicSearch} applied RBAC as well — so the same user got different results depending on
+   * whether the NLQ provider answered or failed. RBAC, the caller's {@code queryFilter} (which is
+   * where the Collate AI-dashboard visibility injection rides) and the {@code deleted} flag are all
+   * applied here, so both paths are constrained identically.
+   */
+  OpenSearchRequestBuilder buildNlqRequestBuilder(
+      org.openmetadata.schema.search.SearchRequest request,
+      SubjectContext subjectContext,
+      String transformedQuery)
+      throws com.fasterxml.jackson.core.JsonProcessingException {
+    OpenSearchRequestBuilder requestBuilder = new OpenSearchRequestBuilder();
+    String queryToProcess = OsUtils.parseJsonQuery(transformedQuery);
+    requestBuilder.query(Query.of(q -> q.wrapper(w -> w.query(queryToProcess))));
+    requestBuilder.from(request.getFrom());
+    requestBuilder.size(request.getSize());
+
+    applyRbacQueryWithCaching(subjectContext, requestBuilder);
+    applyContextMemoryVisibility(subjectContext, requestBuilder);
+    applyQueryFilter(requestBuilder, request);
+    // Strip any clusterAlias prefix first, the same way doSearch does — the deleted filter compares
+    // this against the dataAsset/all aliases.
+    String indexName = Entity.getSearchRepository().getIndexNameWithoutAlias(request.getIndex());
+    applyDeletedFilter(requestBuilder, request, indexName);
+    return requestBuilder;
   }
 
   private void applyContextMemoryVisibility(
@@ -1288,30 +1404,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
     applyRbacQueryWithCaching(subjectContext, requestBuilder);
     applyContextMemoryVisibility(subjectContext, requestBuilder);
 
-    // Apply query filter
-    if (!nullOrEmpty(request.getQueryFilter()) && !request.getQueryFilter().equals("{}")) {
-      try {
-        String queryToProcess = OsUtils.parseJsonQuery(request.getQueryFilter());
-        Query filterQuery = Query.of(q -> q.wrapper(w -> w.query(queryToProcess)));
-        Query existingQuery = requestBuilder.query();
-        if (existingQuery != null) {
-          Query combinedQuery =
-              Query.of(
-                  q ->
-                      q.bool(
-                          b -> {
-                            b.must(existingQuery);
-                            b.filter(filterQuery);
-                            return b;
-                          }));
-          requestBuilder.query(combinedQuery);
-        } else {
-          requestBuilder.query(filterQuery);
-        }
-      } catch (Exception ex) {
-        LOG.error("Error parsing query_filter from query parameters, ignoring filter", ex);
-      }
-    }
+    applyQueryFilter(requestBuilder, request);
 
     // Apply post filter
     if (!nullOrEmpty(request.getPostFilter())) {
@@ -1333,56 +1426,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
       requestBuilder.searchAfter(searchAfterValues);
     }
 
-    // Handle deleted field for backward compatibility
-    if (!nullOrEmpty(request.getDeleted())) {
-      Query existingQuery = requestBuilder.query();
-      Query deletedQuery;
-
-      if (indexName.equals(GLOBAL_SEARCH_ALIAS) || indexName.equals(DATA_ASSET_SEARCH_ALIAS)) {
-        deletedQuery =
-            Query.of(
-                q ->
-                    q.bool(
-                        b ->
-                            b.should(
-                                    s ->
-                                        s.bool(
-                                            bb ->
-                                                bb.must(existingQuery)
-                                                    .must(m -> m.exists(e -> e.field("deleted")))
-                                                    .must(
-                                                        m ->
-                                                            m.term(
-                                                                t ->
-                                                                    t.field("deleted")
-                                                                        .value(
-                                                                            FieldValue.of(
-                                                                                request
-                                                                                    .getDeleted()))))))
-                                .should(
-                                    s ->
-                                        s.bool(
-                                            bb ->
-                                                bb.must(existingQuery)
-                                                    .mustNot(
-                                                        mn ->
-                                                            mn.exists(e -> e.field("deleted")))))));
-      } else {
-        deletedQuery =
-            Query.of(
-                q ->
-                    q.bool(
-                        b ->
-                            b.must(existingQuery)
-                                .must(
-                                    m ->
-                                        m.term(
-                                            t ->
-                                                t.field("deleted")
-                                                    .value(FieldValue.of(request.getDeleted()))))));
-      }
-      requestBuilder.query(deletedQuery);
-    }
+    applyDeletedFilter(requestBuilder, request, indexName);
 
     // Handle sorting — always append a deterministic tiebreaker so equal-ranked docs order
     // identically across shards/replicas; without it the same query bounces between copies.

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/ElasticSearchNlqRequestBuilderTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/ElasticSearchNlqRequestBuilderTest.java
@@ -13,6 +13,7 @@ import es.co.elastic.clients.elasticsearch._types.FieldValue;
 import es.co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import java.util.List;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,13 +45,22 @@ class ElasticSearchNlqRequestBuilderTest {
   private static final String RBAC_MARKER = "rbac_marker";
 
   private SearchRepository searchRepository;
+  private SearchRepository previousSearchRepository;
 
   @BeforeEach
   void setUp() {
+    // Entity.searchRepository is process-global and the JVM is reused across test classes, so the
+    // previous value is restored in tearDown to keep other tests order-independent.
+    previousSearchRepository = Entity.getSearchRepository();
     searchRepository = mock(SearchRepository.class);
     when(searchRepository.getIndexNameWithoutAlias(anyString()))
         .thenAnswer(invocation -> invocation.getArgument(0));
     Entity.setSearchRepository(searchRepository);
+  }
+
+  @AfterEach
+  void tearDown() {
+    Entity.setSearchRepository(previousSearchRepository);
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/ElasticSearchNlqRequestBuilderTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/ElasticSearchNlqRequestBuilderTest.java
@@ -1,0 +1,189 @@
+package org.openmetadata.service.search.elasticsearch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import es.co.elastic.clients.elasticsearch._types.FieldValue;
+import es.co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openmetadata.schema.api.search.GlobalSettings;
+import org.openmetadata.schema.api.search.SearchSettings;
+import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.settings.SettingsType;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.resources.settings.SettingsCache;
+import org.openmetadata.service.search.SearchRepository;
+import org.openmetadata.service.search.elasticsearch.queries.ElasticQueryBuilder;
+import org.openmetadata.service.search.security.RBACConditionEvaluator;
+import org.openmetadata.service.security.policyevaluator.SubjectContext;
+
+/**
+ * The NLQ happy path used to run the LLM-transformed query with only context-memory visibility
+ * applied — no RBAC clause, no queryFilter, no deleted filter — while the fallback path applied all
+ * three. Results therefore differed depending on whether the NLQ provider happened to answer.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ElasticSearchNlqRequestBuilderTest {
+
+  private static final String TRANSFORMED_QUERY = "{\"match_all\":{}}";
+  private static final String RBAC_MARKER = "rbac_marker";
+
+  private SearchRepository searchRepository;
+
+  @BeforeEach
+  void setUp() {
+    searchRepository = mock(SearchRepository.class);
+    when(searchRepository.getIndexNameWithoutAlias(anyString()))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    Entity.setSearchRepository(searchRepository);
+  }
+
+  @Test
+  void nlqRequestCarriesTheRbacClause() throws Exception {
+    Query rbacQuery = termQuery(RBAC_MARKER);
+    ElasticQueryBuilder rbacBuilder = mock(ElasticQueryBuilder.class);
+    when(rbacBuilder.buildV2()).thenReturn(rbacQuery);
+    RBACConditionEvaluator evaluator = mock(RBACConditionEvaluator.class);
+    when(evaluator.evaluateConditions(any())).thenReturn(rbacBuilder);
+
+    try (MockedStatic<SettingsCache> settings = accessControl(true)) {
+      ElasticSearchRequestBuilder builder =
+          manager(evaluator)
+              .buildNlqRequestBuilder(request(null, null), subject(), TRANSFORMED_QUERY);
+
+      assertTrue(containsFilter(builder.query(), rbacQuery), "RBAC clause missing from NLQ query");
+    }
+  }
+
+  @Test
+  void nlqRequestMergesTheCallerQueryFilter() throws Exception {
+    try (MockedStatic<SettingsCache> settings = accessControl(false)) {
+      ElasticSearchRequestBuilder builder =
+          manager(null)
+              .buildNlqRequestBuilder(
+                  request("{\"term\":{\"service.name.keyword\":\"snowflake\"}}", null),
+                  subject(),
+                  TRANSFORMED_QUERY);
+
+      assertNotNull(builder.query());
+      assertTrue(
+          containsTermOnField(builder.query(), "service.name.keyword"),
+          "queryFilter was dropped from the NLQ query");
+    }
+  }
+
+  @Test
+  void nlqRequestHonoursTheDeletedFlag() throws Exception {
+    try (MockedStatic<SettingsCache> settings = accessControl(false)) {
+      ElasticSearchRequestBuilder builder =
+          manager(null).buildNlqRequestBuilder(request(null, true), subject(), TRANSFORMED_QUERY);
+
+      assertTrue(
+          containsTermOnField(builder.query(), "deleted"), "deleted filter missing from NLQ query");
+    }
+  }
+
+  @Test
+  void deletedFilterTreatsAClusterAliasPrefixedIndexAsTheDataAssetAlias() throws Exception {
+    // doSearch strips the clusterAlias prefix before comparing against the dataAsset/all aliases,
+    // which selects the lenient branch that also keeps documents carrying no "deleted" field. The
+    // NLQ path has to strip it the same way, or a cluster-alias deployment silently drops those
+    // documents.
+    when(searchRepository.getIndexNameWithoutAlias("collate_prod_dataAsset"))
+        .thenReturn("dataAsset");
+
+    try (MockedStatic<SettingsCache> settings = accessControl(false)) {
+      org.openmetadata.schema.search.SearchRequest request =
+          request(null, true).withIndex("collate_prod_dataAsset");
+
+      ElasticSearchRequestBuilder builder =
+          manager(null).buildNlqRequestBuilder(request, subject(), TRANSFORMED_QUERY);
+
+      assertEquals(
+          2,
+          builder.query().bool().should().size(),
+          "prefixed dataAsset alias took the strict deleted branch");
+    }
+  }
+
+  /** Walks the bool tree looking for a term clause on {@code field}. */
+  private static boolean containsTermOnField(Query query, String field) {
+    boolean found = false;
+    if (query != null) {
+      if (query.isTerm()) {
+        found = field.equals(query.term().field());
+      } else if (query.isBool()) {
+        found =
+            java.util.stream.Stream.of(
+                    query.bool().must(),
+                    query.bool().should(),
+                    query.bool().filter(),
+                    query.bool().mustNot())
+                .flatMap(List::stream)
+                .anyMatch(child -> containsTermOnField(child, field));
+      }
+    }
+    return found;
+  }
+
+  private static boolean containsFilter(Query query, Query expected) {
+    return query != null
+        && query.isBool()
+        && (query.bool().filter().contains(expected)
+            || query.bool().must().stream().anyMatch(m -> containsFilter(m, expected)));
+  }
+
+  private static Query termQuery(String field) {
+    return Query.of(q -> q.term(t -> t.field(field).value(FieldValue.of(true))));
+  }
+
+  private ElasticSearchSearchManager manager(RBACConditionEvaluator evaluator) {
+    return new ElasticSearchSearchManager(null, evaluator, "", null);
+  }
+
+  private static org.openmetadata.schema.search.SearchRequest request(
+      String queryFilter, Boolean deleted) {
+    return new org.openmetadata.schema.search.SearchRequest()
+        .withQuery("which tables hold customer data")
+        .withIndex("dataAsset")
+        .withFrom(0)
+        .withSize(10)
+        .withQueryFilter(queryFilter)
+        .withDeleted(deleted);
+  }
+
+  private static SubjectContext subject() {
+    User user = new User().withId(UUID.randomUUID()).withName("analyst").withRoles(List.of());
+    SubjectContext subjectContext = mock(SubjectContext.class);
+    when(subjectContext.isAdmin()).thenReturn(false);
+    when(subjectContext.isBot()).thenReturn(false);
+    when(subjectContext.user()).thenReturn(user);
+    return subjectContext;
+  }
+
+  private static MockedStatic<SettingsCache> accessControl(boolean enabled) {
+    MockedStatic<SettingsCache> settings = mockStatic(SettingsCache.class);
+    SearchSettings searchSettings =
+        new SearchSettings()
+            .withGlobalSettings(new GlobalSettings().withEnableAccessControl(enabled));
+    settings
+        .when(() -> SettingsCache.getSetting(SettingsType.SEARCH_SETTINGS, SearchSettings.class))
+        .thenReturn(searchSettings);
+    return settings;
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchNlqRequestBuilderTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchNlqRequestBuilderTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,13 +45,22 @@ class OpenSearchNlqRequestBuilderTest {
   private static final String RBAC_MARKER = "rbac_marker";
 
   private SearchRepository searchRepository;
+  private SearchRepository previousSearchRepository;
 
   @BeforeEach
   void setUp() {
+    // Entity.searchRepository is process-global and the JVM is reused across test classes, so the
+    // previous value is restored in tearDown to keep other tests order-independent.
+    previousSearchRepository = Entity.getSearchRepository();
     searchRepository = mock(SearchRepository.class);
     when(searchRepository.getIndexNameWithoutAlias(anyString()))
         .thenAnswer(invocation -> invocation.getArgument(0));
     Entity.setSearchRepository(searchRepository);
+  }
+
+  @AfterEach
+  void tearDown() {
+    Entity.setSearchRepository(previousSearchRepository);
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchNlqRequestBuilderTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchNlqRequestBuilderTest.java
@@ -1,0 +1,210 @@
+package org.openmetadata.service.search.opensearch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openmetadata.schema.api.search.GlobalSettings;
+import org.openmetadata.schema.api.search.SearchSettings;
+import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.settings.SettingsType;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.resources.settings.SettingsCache;
+import org.openmetadata.service.search.SearchRepository;
+import org.openmetadata.service.search.opensearch.queries.OpenSearchQueryBuilder;
+import org.openmetadata.service.search.security.RBACConditionEvaluator;
+import org.openmetadata.service.security.policyevaluator.SubjectContext;
+import os.org.opensearch.client.opensearch._types.FieldValue;
+import os.org.opensearch.client.opensearch._types.query_dsl.Query;
+
+/**
+ * The NLQ happy path used to run the LLM-transformed query with only context-memory visibility
+ * applied — no RBAC clause, no queryFilter, no deleted filter — while the fallback path applied all
+ * three. Results therefore differed depending on whether the NLQ provider happened to answer.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class OpenSearchNlqRequestBuilderTest {
+
+  private static final String TRANSFORMED_QUERY = "{\"match_all\":{}}";
+  private static final String RBAC_MARKER = "rbac_marker";
+
+  private SearchRepository searchRepository;
+
+  @BeforeEach
+  void setUp() {
+    searchRepository = mock(SearchRepository.class);
+    when(searchRepository.getIndexNameWithoutAlias(anyString()))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    Entity.setSearchRepository(searchRepository);
+  }
+
+  @Test
+  void nlqRequestCarriesTheRbacClause() throws Exception {
+    Query rbacQuery = termQuery(RBAC_MARKER);
+    OpenSearchQueryBuilder rbacBuilder = mock(OpenSearchQueryBuilder.class);
+    when(rbacBuilder.buildV2()).thenReturn(rbacQuery);
+    RBACConditionEvaluator evaluator = mock(RBACConditionEvaluator.class);
+    when(evaluator.evaluateConditions(any())).thenReturn(rbacBuilder);
+
+    try (MockedStatic<SettingsCache> settings = accessControl(true)) {
+      OpenSearchRequestBuilder builder =
+          manager(evaluator)
+              .buildNlqRequestBuilder(request(null, null), subject(), TRANSFORMED_QUERY);
+
+      assertTrue(containsFilter(builder.query(), rbacQuery), "RBAC clause missing from NLQ query");
+    }
+  }
+
+  @Test
+  void nlqRequestMergesTheCallerQueryFilter() throws Exception {
+    try (MockedStatic<SettingsCache> settings = accessControl(false)) {
+      OpenSearchRequestBuilder builder =
+          manager(null)
+              .buildNlqRequestBuilder(
+                  request("{\"term\":{\"service.name.keyword\":\"snowflake\"}}", null),
+                  subject(),
+                  TRANSFORMED_QUERY);
+
+      assertNotNull(builder.query());
+      // The transformed NLQ query is one wrapper; the caller's queryFilter is a second one. Only
+      // one is present when the filter is dropped.
+      assertEquals(2, countWrappers(builder.query()), "queryFilter was dropped from the NLQ query");
+    }
+  }
+
+  @Test
+  void nlqRequestHonoursTheDeletedFlag() throws Exception {
+    try (MockedStatic<SettingsCache> settings = accessControl(false)) {
+      OpenSearchRequestBuilder builder =
+          manager(null).buildNlqRequestBuilder(request(null, true), subject(), TRANSFORMED_QUERY);
+
+      assertTrue(
+          containsTermOnField(builder.query(), "deleted"), "deleted filter missing from NLQ query");
+    }
+  }
+
+  @Test
+  void deletedFilterTreatsAClusterAliasPrefixedIndexAsTheDataAssetAlias() throws Exception {
+    // doSearch strips the clusterAlias prefix before comparing against the dataAsset/all aliases,
+    // which selects the lenient branch that also keeps documents carrying no "deleted" field. The
+    // NLQ path has to strip it the same way, or a cluster-alias deployment silently drops those
+    // documents.
+    when(searchRepository.getIndexNameWithoutAlias("collate_prod_dataAsset"))
+        .thenReturn("dataAsset");
+
+    try (MockedStatic<SettingsCache> settings = accessControl(false)) {
+      org.openmetadata.schema.search.SearchRequest request =
+          request(null, true).withIndex("collate_prod_dataAsset");
+
+      OpenSearchRequestBuilder builder =
+          manager(null).buildNlqRequestBuilder(request, subject(), TRANSFORMED_QUERY);
+
+      assertEquals(
+          2,
+          builder.query().bool().should().size(),
+          "prefixed dataAsset alias took the strict deleted branch");
+    }
+  }
+
+  /** Counts wrapper (raw-JSON) queries in the bool tree. */
+  private static int countWrappers(Query query) {
+    int count = 0;
+    if (query != null) {
+      if (query.isWrapper()) {
+        count = 1;
+      } else if (query.isBool()) {
+        count =
+            java.util.stream.Stream.of(
+                    query.bool().must(),
+                    query.bool().should(),
+                    query.bool().filter(),
+                    query.bool().mustNot())
+                .flatMap(List::stream)
+                .mapToInt(OpenSearchNlqRequestBuilderTest::countWrappers)
+                .sum();
+      }
+    }
+    return count;
+  }
+
+  /** Walks the bool tree looking for a term clause on {@code field}. */
+  private static boolean containsTermOnField(Query query, String field) {
+    boolean found = false;
+    if (query != null) {
+      if (query.isTerm()) {
+        found = field.equals(query.term().field());
+      } else if (query.isBool()) {
+        found =
+            java.util.stream.Stream.of(
+                    query.bool().must(),
+                    query.bool().should(),
+                    query.bool().filter(),
+                    query.bool().mustNot())
+                .flatMap(List::stream)
+                .anyMatch(child -> containsTermOnField(child, field));
+      }
+    }
+    return found;
+  }
+
+  private static boolean containsFilter(Query query, Query expected) {
+    return query != null
+        && query.isBool()
+        && (query.bool().filter().contains(expected)
+            || query.bool().must().stream().anyMatch(m -> containsFilter(m, expected)));
+  }
+
+  private static Query termQuery(String field) {
+    return Query.of(q -> q.term(t -> t.field(field).value(FieldValue.of(true))));
+  }
+
+  private OpenSearchSearchManager manager(RBACConditionEvaluator evaluator) {
+    return new OpenSearchSearchManager(null, evaluator, "", null);
+  }
+
+  private static org.openmetadata.schema.search.SearchRequest request(
+      String queryFilter, Boolean deleted) {
+    return new org.openmetadata.schema.search.SearchRequest()
+        .withQuery("which tables hold customer data")
+        .withIndex("dataAsset")
+        .withFrom(0)
+        .withSize(10)
+        .withQueryFilter(queryFilter)
+        .withDeleted(deleted);
+  }
+
+  private static SubjectContext subject() {
+    User user = new User().withId(UUID.randomUUID()).withName("analyst").withRoles(List.of());
+    SubjectContext subjectContext = mock(SubjectContext.class);
+    when(subjectContext.isAdmin()).thenReturn(false);
+    when(subjectContext.isBot()).thenReturn(false);
+    when(subjectContext.user()).thenReturn(user);
+    return subjectContext;
+  }
+
+  private static MockedStatic<SettingsCache> accessControl(boolean enabled) {
+    MockedStatic<SettingsCache> settings = mockStatic(SettingsCache.class);
+    SearchSettings searchSettings =
+        new SearchSettings()
+            .withGlobalSettings(new GlobalSettings().withEnableAccessControl(enabled));
+    settings
+        .when(() -> SettingsCache.getSetting(SettingsType.SEARCH_SETTINGS, SearchSettings.class))
+        .thenReturn(searchSettings);
+    return settings;
+  }
+}


### PR DESCRIPTION
fixes: https://github.com/open-metadata/OpenMetadata/issues/31753

`searchWithNLQ` has two paths. When the NLQ provider successfully transforms a query, the request was built with only `applyContextMemoryVisibility` — no RBAC clause, no caller `queryFilter`, no `deleted` filter. When the provider fails, `fallbackToBasicSearch` applies RBAC. So the same user asking the same question got different filtering depending on whether the translation happened to succeed.

Applied on both search managers. Affects the REST NLQ endpoint (`SearchResource:562`) and the `nlq_search` MCP tool.

Most of the diff is a pure move: the inline `queryFilter` and `deleted` blocks are extracted from `doSearch` into `applyQueryFilter` / `applyDeletedFilter` so the NLQ path reuses them instead of duplicating ~50 lines per engine. The keyword path is unchanged — same helpers, same call order, same `indexName` (cluster-alias stripped).

Only exploitable with a real NLQ provider configured; the shipped `NoOpNLQService` returns null and always forces the RBAC-enforced fallback.

## Verified live

With a stub provider forcing the happy path and `enableAccessControl` on, the query sent to OpenSearch now carries all three:

- RBAC: `owners.id` term for the calling user's own id
- `queryFilter`: survives into the final query
- `deleted`: `{exists: {field: deleted}}` + `{term: {deleted: false}}`

## Tests

New `OpenSearchNlqRequestBuilderTest` and `ElasticSearchNlqRequestBuilderTest` assert each of the three clauses is present, and each was confirmed to fail with the fix reverted.

Split out of #31723 to keep that PR scoped to `openmetadata-mcp/`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR aligns successful NLQ requests with standard search authorization and filtering behavior in both Elasticsearch and OpenSearch.
- Applies RBAC, context-memory visibility, caller query filters, and deleted-state filtering to transformed NLQ queries.
- Extracts shared query and deleted-filter helpers for reuse by keyword and NLQ paths.
- Adds focused tests for both search engines, including cluster-prefixed aliases and restoration of the process-global search repository.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java | Extracts reusable filter helpers and applies RBAC, queryFilter, and deleted filtering to successful Elasticsearch NLQ requests. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java | Mirrors standard OpenSearch constraint ordering when constructing successful NLQ requests. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/ElasticSearchNlqRequestBuilderTest.java | Covers Elasticsearch NLQ constraints and now restores the shared SearchRepository after each test. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchNlqRequestBuilderTest.java | Covers OpenSearch NLQ constraints and now restores the shared SearchRepository after each test. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[NLQ request] --> B{Provider transforms query?}
  B -->|Yes| C[Build transformed query]
  C --> D[Apply RBAC and context visibility]
  D --> E[Apply queryFilter]
  E --> F[Apply deleted filter]
  F --> G[Execute NLQ search]
  B -->|No| H[Fallback to basic search]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(search): restore the shared search ..."](https://github.com/open-metadata/openmetadata/commit/a4f40075d4d0671b07712beead770058ee98d021) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54661019)</sub>

<!-- /greptile_comment -->