### PR TITLE
ci(playwright): survive registry 5xx — yarn restore-keys fallback + retry

### DIFF
--- a/.github/workflows/playwright-e2e-reusable.yml
+++ b/.github/workflows/playwright-e2e-reusable.yml
@@ -592,22 +592,53 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version-file: openmetadata-ui/src/main/resources/ui/.nvmrc
-          cache: yarn
-          cache-dependency-path: openmetadata-ui/src/main/resources/ui/yarn.lock
+
+      # setup-node's built-in `cache: yarn` is exact-key only — a yarn.lock
+      # change leaves the cache completely cold and yarn re-fetches all
+      # ~2000 tarballs from the registry, maximizing exposure to transient
+      # registry 5xx (run 32222855561: a single 502 on one tarball killed
+      # planning for the whole queue entry). An explicit cache with
+      # restore-keys falls back to the most recent lockfile's cache, so a
+      # lockfile change only fetches the delta.
+      - name: Restore yarn package cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/yarn
+          key: yarn-pkg-cache-${{ runner.os }}-${{ hashFiles('openmetadata-ui/src/main/resources/ui/yarn.lock') }}
+          restore-keys: |
+            yarn-pkg-cache-${{ runner.os }}-
 
       - name: Install dependencies
         working-directory: openmetadata-ui/src/main/resources/ui
         run: |
           corepack enable
-          yarn --ignore-scripts --frozen-lockfile
+          # Retry transient registry failures (5xx on tarball fetches) —
+          # yarn v1 does not retry HTTP errors on its own.
+          for attempt in 1 2 3; do
+            yarn --ignore-scripts --frozen-lockfile --network-timeout 100000 && break
+            if [[ "$attempt" -eq 3 ]]; then
+              echo "yarn install failed after 3 attempts" >&2
+              exit 1
+            fi
+            echo "::warning::yarn install attempt $attempt failed (registry blip?); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
 
+      # These two steps SEED the run-scoped browser cache for the 30+ shard
+      # jobs downstream: the plan job finishes before any shard starts, so
+      # on a yarn.lock change the new browser-cache key is populated exactly
+      # once here instead of every shard downloading ~250 MB of Chromium in
+      # parallel. `--list` itself never launches a browser, so a seeding
+      # failure must not fail planning — shards self-install as a fallback.
       - name: Seed Playwright browser cache
+        continue-on-error: true
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('openmetadata-ui/src/main/resources/ui/yarn.lock') }}
 
       - name: Install cached Chromium
+        continue-on-error: true
         working-directory: openmetadata-ui/src/main/resources/ui
         run: npx playwright install chromium
 
@@ -865,15 +896,32 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version-file: openmetadata-ui/src/main/resources/ui/.nvmrc
-          cache: yarn
-          cache-dependency-path: openmetadata-ui/src/main/resources/ui/yarn.lock
+
+      # restore-keys fallback + retry — see the rationale on the
+      # plan-playwright job's yarn cache step.
+      - name: Restore yarn package cache
+        if: ${{ needs.restore-playwright-fixture.outputs.fixture_cache_hit != 'true' || (needs.plan-playwright.outputs.requires_airflow == 'true' && needs.restore-playwright-fixture.outputs.ingestion_cache_hit != 'true') }}
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/yarn
+          key: yarn-pkg-cache-${{ runner.os }}-${{ hashFiles('openmetadata-ui/src/main/resources/ui/yarn.lock') }}
+          restore-keys: |
+            yarn-pkg-cache-${{ runner.os }}-
 
       - name: Install fixture-state dependencies
         if: ${{ needs.restore-playwright-fixture.outputs.fixture_cache_hit != 'true' || (needs.plan-playwright.outputs.requires_airflow == 'true' && needs.restore-playwright-fixture.outputs.ingestion_cache_hit != 'true') }}
         working-directory: openmetadata-ui/src/main/resources/ui
         run: |
           corepack enable
-          yarn --ignore-scripts --frozen-lockfile
+          for attempt in 1 2 3; do
+            yarn --ignore-scripts --frozen-lockfile --network-timeout 100000 && break
+            if [[ "$attempt" -eq 3 ]]; then
+              echo "yarn install failed after 3 attempts" >&2
+              exit 1
+            fi
+            echo "::warning::yarn install attempt $attempt failed (registry blip?); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
 
       - name: Restore Playwright browser cache
         if: ${{ needs.restore-playwright-fixture.outputs.fixture_cache_hit != 'true' || (needs.plan-playwright.outputs.requires_airflow == 'true' && needs.restore-playwright-fixture.outputs.ingestion_cache_hit != 'true') }}
@@ -1209,15 +1257,31 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version-file: "openmetadata-ui/src/main/resources/ui/.nvmrc"
-          cache: yarn
-          cache-dependency-path: openmetadata-ui/src/main/resources/ui/yarn.lock
+
+      # restore-keys fallback + retry — see the rationale on the
+      # plan-playwright job's yarn cache step.
+      - name: Restore yarn package cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/yarn
+          key: yarn-pkg-cache-${{ runner.os }}-${{ hashFiles('openmetadata-ui/src/main/resources/ui/yarn.lock') }}
+          restore-keys: |
+            yarn-pkg-cache-${{ runner.os }}-
 
       - name: Install dependencies
         id: install-dependencies
         working-directory: openmetadata-ui/src/main/resources/ui/
         run: |
           corepack enable
-          yarn --ignore-scripts --frozen-lockfile
+          for attempt in 1 2 3; do
+            yarn --ignore-scripts --frozen-lockfile --network-timeout 100000 && break
+            if [[ "$attempt" -eq 3 ]]; then
+              echo "yarn install failed after 3 attempts" >&2
+              exit 1
+            fi
+            echo "::warning::yarn install attempt $attempt failed (registry blip?); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
 
       - name: Restore Playwright browser cache
         id: restore-browser
@@ -1638,14 +1702,30 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version-file: openmetadata-ui/src/main/resources/ui/.nvmrc
-          cache: yarn
-          cache-dependency-path: openmetadata-ui/src/main/resources/ui/yarn.lock
+
+      # restore-keys fallback + retry — see the rationale on the
+      # plan-playwright job's yarn cache step.
+      - name: Restore yarn package cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/yarn
+          key: yarn-pkg-cache-${{ runner.os }}-${{ hashFiles('openmetadata-ui/src/main/resources/ui/yarn.lock') }}
+          restore-keys: |
+            yarn-pkg-cache-${{ runner.os }}-
 
       - name: Install dependencies
         working-directory: openmetadata-ui/src/main/resources/ui/
         run: |
           corepack enable
-          yarn --ignore-scripts --frozen-lockfile
+          for attempt in 1 2 3; do
+            yarn --ignore-scripts --frozen-lockfile --network-timeout 100000 && break
+            if [[ "$attempt" -eq 3 ]]; then
+              echo "yarn install failed after 3 attempts" >&2
+              exit 1
+            fi
+            echo "::warning::yarn install attempt $attempt failed (registry blip?); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
 
       - name: Download blob reports
         uses: actions/download-artifact@v7


### PR DESCRIPTION
## Summary

[Run 32222855561](https://github.com/open-metadata/OpenMetadata/actions/runs/32222855561/job/95978507789)'s `plan-playwright` died on one upstream blip:

```
error https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz:
Request failed "502 Bad Gateway"
```

## Two compounding defects

**1. Exact-key-only yarn caching.** `actions/setup-node`'s built-in `cache: yarn` has no `restore-keys`. The queue batch changed `yarn.lock` → new hash → completely cold cache (`yarn cache is not found` in the log) → yarn cold-fetched **all ~2000 tarballs**, maximizing exposure to any single 5xx.

**2. No retry.** yarn v1 does not retry HTTP errors on tarball downloads — one 502 killed the plan job and ejected the queue entry. This was the last infra dependency in the pipeline without a retry (docker pulls: #30826; apt: cached + gated via #31691/#31718).

## Changes (all four install call sites: plan-playwright, prepare-playwright-fixture, playwright-ci, slack-notify)

- **Explicit `actions/cache` on `~/.cache/yarn`** keyed on the lockfile hash **with `restore-keys` fallback** — a lockfile change now restores the previous cache and fetches only the delta (a handful of tarballs instead of ~2000). Replaces setup-node's built-in caching.
- **3-attempt retry** around `yarn --ignore-scripts --frozen-lockfile` (15 s / 30 s backoff, `--network-timeout 100000`). Idiom verified safe under the runner's `bash -e`.

## Bonus: plan-playwright browser seeding made non-fatal

During investigation I initially flagged the plan job's Chromium install as dead weight (`--list` never launches a browser) — that read was wrong. The step **seeds the run-scoped browser cache** once so 30+ downstream shards don't each download ~250 MB on a lockfile change. Kept it, but marked both seeding steps `continue-on-error` so a CDN failure degrades to shards self-installing instead of failing planning. Comment now documents the seeding role explicitly.

`id: setup-node` / `id: install-dependencies` outcome wiring in the shard job is preserved.

## Test plan

- [x] YAML validated.
- [x] Retry idiom verified under `bash -e` semantics (the `cmd && break` list does not trip errexit).
- [x] Grep-verified: 4 cache steps with restore-keys, 4 retry loops, 0 remaining `cache: yarn` usages (the one string match left is inside a comment).
- [ ] Next run with a yarn.lock change: `Restore yarn package cache` logs a restore-keys fallback hit; install fetches only the delta.
- [ ] Any registry 502 mid-install: warning annotation + retry instead of job failure.

## Follow-up (separate PR)

Cache the discovery output itself — `playwright-test-list.json` is a pure function of the `playwright/` tree + config + mode flags; on a key hit, `plan-playwright` can skip install **and** discovery entirely (~30 s job, zero registry traffic).

Related: #30826 (docker retry), #31691 (apt gate), #31718 (main-scoped apt cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes Playwright dependency installation more resilient to transient registry failures.
- Replaces setup-node’s exact-key Yarn caching with explicit caches that support restore-key fallback.
- Retries Yarn installation up to three times with increasing delays and a network timeout.
- Makes plan-stage browser-cache seeding non-fatal so downstream shards can install Chromium themselves.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified in the changed workflow behavior.

The new cache steps target the Yarn Classic default cache, retries retain frozen-lockfile failure semantics, and downstream jobs retain unconditional Chromium installation when plan-stage seeding fails.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/playwright-e2e-reusable.yml | Adds consistent Yarn cache fallback and bounded install retries across four jobs while preserving downstream browser-install fallback behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(playwright): survive registry 5xx — y..."](https://github.com/open-metadata/openmetadata/commit/b0992b3e0310a2d81bf603a3693a1ecb4d7651dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54667618)</sub>

<!-- /greptile_comment -->