### PR TITLE
ci(playwright): derive the chromium budget from the execution tail, not the average

### DIFF
--- a/.github/scripts/build_playwright_shards.py
+++ b/.github/scripts/build_playwright_shards.py
@@ -60,15 +60,29 @@ LANE_WORKERS = {
     "search-rbac": 1,
 }
 TARGET_MS = 20 * 60 * 1000
-# The chromium lane has outgrown a 19-minute shard: at the COMMON_MAX_SHARDS
-# ceiling the heaviest shard is predicted at 19.2m, so full-mode planning aborts
-# and every merge-queue run fails before a single test runs. The binding limit
-# is the 25m `timeout` wrapper around `npx playwright test`, against which 21m
-# leaves ~4m; the 35m playwright-ci job clock is looser still, since
-# it also has to cover ~5-8m of setup and teardown around that wrapper.
-COMMON_SHARD_BUDGET_MS = 21 * 60 * 1000
+# Chromium shard budget, derived from the predicted→actual execution tail
+# rather than from the average. Measured on merge_group run 32219260486
+# (23 chromium shards, fresh auto-refreshed baseline): actual/predicted
+# execution ratio has median 0.96 — predictions are well calibrated — but
+# the tail reaches 1.08 on a healthy run and 1.23 on a noisy one
+# (chromium-01 in run 32209040146 was SIGTERM'd by the 25-minute wrapper
+# with 162/164 tests already passed). The binding constraint is that
+# budget × worst-tail-ratio must stay under the 1500-second wrapper:
+#   21 min × 1.23 = 1550 s  → dead shard, all tests green (the outage)
+#   19 min × 1.23 = 1402 s  → 98 s of margin
+#   19 min × 1.32 = 1500 s  → break-even; tolerated tail is 1.32
+# 21 min was a stop-gap (#30784) to fit the lane under the old 24-shard
+# ceiling; the ceiling is now 28 (below), which is what actually makes a
+# 19-minute budget feasible again.
+COMMON_SHARD_BUDGET_MS = 19 * 60 * 1000
 EFFICIENCY = 0.85
-COMMON_MAX_SHARDS = 24
+# Raised 24 → 28 together with the budget revert above. Current chromium
+# content (~71,700 predicted worker-seconds) needs 25 shards at a
+# 19-minute budget — over the old cap, which is exactly why #30784 had to
+# raise the budget instead. 28 leaves ~12% content-growth headroom before
+# planning aborts; if the lane grows past that, split heavy suites (see
+# AUDITED_PARALLEL_SUITES) before considering another cap raise.
+COMMON_MAX_SHARDS = 28
 # Weight assigned to a test that has no timing evidence in `timing-baseline.json`
 # (or in any additional history payloads). Bumped from 20 s → 30 s alongside the
 # all-zero-history fix in `load_history`: a suite re-enabled after being

--- a/.github/scripts/tests/test_playwright_ci_planning.py
+++ b/.github/scripts/tests/test_playwright_ci_planning.py
@@ -40,11 +40,18 @@ def test_basic_and_chromium_share_the_bounded_common_lane():
     planner = load_script("build_playwright_shards")
 
     assert planner.PROJECT_LANES["Basic"] == "chromium"
-    assert planner.lane_bounds("chromium", "full") == (5, 24)
+    assert planner.lane_bounds("chromium", "full") == (
+        5,
+        planner.COMMON_MAX_SHARDS,
+    )
 
 
-def test_full_common_shard_count_is_capped_at_24():
+def test_full_common_shard_count_is_capped_at_the_common_max():
     planner = load_script("build_playwright_shards")
+    cap = planner.COMMON_MAX_SHARDS
+    # Enough content to push the calculated shard count comfortably above
+    # the cap — the exact figure is unimportant; we just need
+    # `calculated > cap` so the min(cap, …) clamp is what returns.
     units = [
         planner.Unit(
             "chromium",
@@ -52,22 +59,21 @@ def test_full_common_shard_count_is_capped_at_24():
             str(index),
             weight_ms=1_000_000,
         )
-        for index in range(81)
+        for index in range(cap * 4)
     ]
-    units.append(
-        planner.Unit("chromium", "remainder.spec.ts", "remainder", weight_ms=363_055)
-    )
 
-    assert planner.shard_count(units, "chromium", "full") == 24
+    assert planner.shard_count(units, "chromium", "full") == cap
 
 
 def test_common_lane_carries_its_own_shard_budget():
-    # The chromium lane no longer sits a minute under TARGET_MS: the suite grew
-    # past what COMMON_MAX_SHARDS could hold at 19m, so it now runs a minute
-    # above the other lanes. Both still fit the 25m playwright timeout wrapper.
+    # Chromium's budget is a minute UNDER the other lanes' TARGET_MS, derived
+    # from the predicted→actual execution tail: actuals run up to 1.23× the
+    # prediction on noisy runs (run 32209040146), and 19 min × 1.32 is the
+    # break-even against the 25-minute playwright wrapper. See the derivation
+    # comment on COMMON_SHARD_BUDGET_MS.
     planner = load_script("build_playwright_shards")
 
-    assert planner.shard_budget_ms_for_lane("chromium") == 21 * 60 * 1000
+    assert planner.shard_budget_ms_for_lane("chromium") == 19 * 60 * 1000
     assert planner.shard_budget_ms_for_lane("search") == 20 * 60 * 1000
 
 
@@ -98,18 +104,26 @@ def test_common_assignment_stays_within_the_execution_ceiling():
     )
 
 
-def test_full_mode_chromium_converges_at_the_shard_ceiling():
-    # Regression guard for the merge-queue outage: a lane of this shape exhausted
-    # COMMON_MAX_SHARDS under the old 19m budget and aborted planning outright.
-    # The allocator must converge at or before the ceiling, and the resulting
-    # plan genuinely needs the window above 19m -- so quietly reverting the
-    # budget to 19m fails on the final assertion rather than only in CI.
+def test_full_mode_chromium_converges_above_the_old_24_shard_ceiling():
+    # Regression guard for BOTH historical outages on this lane:
+    # 1. Under budget=19m × cap=24, content past ~1163 worker-minutes
+    #    exhausted the cap and aborted planning outright (the #30784
+    #    outage — its stop-gap was raising the budget to 21m).
+    # 2. Under budget=21m, packed shards ran into the 25-minute wrapper on
+    #    tail-ratio runs (run 32209040146 — SIGTERM with 162/164 passed).
+    # The durable configuration is budget=19m × cap=28: the allocator must
+    # converge within the ceiling AND genuinely need more than 24 shards —
+    # so quietly reverting COMMON_MAX_SHARDS to 24 fails here rather than
+    # only in the merge queue. The content shape mirrors reality post
+    # audit-splitting: many fine-grained units (1300 × 1 min ≈ today's
+    # ~1200 worker-minutes of chromium content), not a few near-atomic
+    # blocks whose granularity would distort LPT balance.
     planner = load_script("build_playwright_shards")
     units = [
         planner.Unit(
-            "chromium", f"heavy-{index}.spec.ts", str(index), weight_ms=13 * 60 * 1000
+            "chromium", f"fine-{index}.spec.ts", str(index), weight_ms=60_000
         )
-        for index in range(96)
+        for index in range(1300)
     ]
 
     shards = planner.assign_lane_within_budget(units, "chromium", "full")
@@ -120,7 +134,7 @@ def test_full_mode_chromium_converges_at_the_shard_ceiling():
     )
     assert len(shards) <= planner.COMMON_MAX_SHARDS
     assert heaviest_ms <= planner.COMMON_SHARD_BUDGET_MS
-    assert heaviest_ms > 19 * 60 * 1000
+    assert len(shards) > 24
 
 
 def test_full_mode_chromium_reports_a_lane_the_ceiling_cannot_hold():
@@ -132,7 +146,7 @@ def test_full_mode_chromium_reports_a_lane_the_ceiling_cannot_hold():
         for index in range(120)
     ]
 
-    with pytest.raises(SystemExit, match=r"needs more than 24 shards"):
+    with pytest.raises(SystemExit, match=r"needs more than 28 shards"):
         planner.assign_lane_within_budget(units, "chromium", "full")
 
 
@@ -992,7 +1006,7 @@ def test_hook_heavy_subsuites_in_audited_suite_stay_atomic():
     ]
 
 
-def test_common_shards_enforce_the_twenty_one_minute_budget(tmp_path):
+def test_common_shards_enforce_the_nineteen_minute_budget(tmp_path):
     planner = load_script("build_playwright_shards")
     within_budget = planner.Unit(
         "chromium",
@@ -1000,7 +1014,7 @@ def test_common_shards_enforce_the_twenty_one_minute_budget(tmp_path):
         "within",
         grep_titles={("chromium", "within.spec.ts", "within")},
         test_ids={"within"},
-        weight_ms=21 * 60 * 1000,
+        weight_ms=19 * 60 * 1000,
     )
     above_budget = planner.Unit(
         "chromium",
@@ -1008,11 +1022,11 @@ def test_common_shards_enforce_the_twenty_one_minute_budget(tmp_path):
         "above",
         grep_titles={("chromium", "above.spec.ts", "above")},
         test_ids={"above"},
-        weight_ms=21 * 60 * 1000 + 1,
+        weight_ms=19 * 60 * 1000 + 1,
     )
 
     planner.write_plan(tmp_path, "chromium", 0, [within_budget])
-    with pytest.raises(SystemExit, match="above the 21-minute plan budget"):
+    with pytest.raises(SystemExit, match="above the 19-minute plan budget"):
         planner.write_plan(tmp_path, "chromium", 1, [above_budget])
 
 


### PR DESCRIPTION
## Summary

Fixes the last known non-genuine failure class in the merge queue: shards killed by the 25-minute wrapper **with nearly all tests passing**. Chromium-01 in [run 32209040146](https://github.com/open-metadata/OpenMetadata/actions/runs/32209040146) died at 162/164 tests — plan predicted 1223 s, real execution exceeded 1500 s.

## Root cause — the budget had no room for the tail

Predictions are **well calibrated at the median**. Measured across all 23 chromium shards of the latest green run ([32219260486](https://github.com/open-metadata/OpenMetadata/actions/runs/32219260486)):

| metric | value |
|---|---|
| actual/predicted median | **0.96** |
| max on a healthy run | 1.08 |
| max on a noisy run (the outage) | **~1.23** |

The failure isn't prediction quality (the auto-refreshed baseline works) — it's that a 21-min-packed shard times a 1.23 tail event straight into the wrapper:

```
21 min × 1.23 = 1550 s  > 1500 s wrapper  → dead shard, all tests green
19 min × 1.23 = 1402 s  → 98 s margin
19 min break-even tail  = 1.32
```

## Changes

- **`COMMON_SHARD_BUDGET_MS`: 21 → 19 min** — derivation documented on the constant. 21 min was #30784's stop-gap forced by the old 24-shard ceiling, not a design point.
- **`COMMON_MAX_SHARDS`: 24 → 28** — current content needs 25 shards at 19 min (over the old cap, which is exactly why #30784 raised the budget instead). 28 leaves ~12% growth headroom; past that, split heavy suites before raising again.

## Validation against the real world (not just unit tests)

Ran `npx playwright test --list` locally (all 14 projects) and fed the real test list + the current auto-refreshed baseline through the real planner under the new constants:

- **0 chromium units above 19 min** (heaviest: 13.1 min) — no unit is stranded
- **Chromium converges at 25 shards**, heaviest predicted **18.6 min ≤ 19**
- **18.6 × 1.23 worst-observed tail = 22.9 min ≤ 25 min wrapper** — 2 min of margin at the worst tail ever seen
- All other lanes unchanged (they plan against `TARGET_MS`)
- Cost: **+2 concurrent runners** per full run (25 vs 23)

## Test updates

- Budget/cap assertions → 19 min, derive from `COMMON_MAX_SHARDS`.
- `test_full_mode_chromium_converges_at_the_shard_ceiling` reworked: the old 96×13-min shape was hand-built to justify 21 min via a granularity artifact (4×13 m per shard = 20.4 m predicted — infeasible at 19 m at *any* shard count; real post-audit units are ≤13 min and mostly ≪5 min). New shape mirrors reality (1300×1-min ≈ today's ~1200 worker-min) and guards **both** historical outages: must converge within the 28 cap AND need >24 shards — quietly reverting either constant fails the suite instead of the merge queue.

**117 tests pass.**

Related: #30784 (the stop-gap this reverts, with the cap fix it lacked), #30812/#30871/#30872 (baseline freshness that makes predictions trustworthy), #31691/#31718/#31730 (infra resilience — with this PR, all known non-genuine failure classes have mitigations except the Airflow fixture flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR lowers Chromium's predicted shard budget from 21 to 19 minutes and raises its full-mode shard ceiling from 24 to 28, providing more runtime-tail margin under the 25-minute wrapper.
- Documents the tail-based budget derivation beside the planner constants.
- Updates planner tests for the new budget and ceiling.
- Reworks the convergence fixture to model many fine-grained Chromium units and require more than 24 shards.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only a non-blocking documentation update needed for the newly changed shard limits.

The planner and workflow support up to 28 dynamically generated shards, and the revised tests preserve exact guards for the 19-minute budget and 28-shard ceiling; only the published Playwright README remains inconsistent.

**Files Needing Attention:** .github/scripts/build_playwright_shards.py and .github/playwright/README.md
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/scripts/build_playwright_shards.py | Lowers the Chromium allocation budget to 19 minutes and raises the shard ceiling to 28; workflow consumers support the dynamic count, but related README limits are stale. |
| .github/scripts/tests/test_playwright_ci_planning.py | Updates budget and cap assertions and adds a fine-grained workload regression that converges above the former 24-shard ceiling. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  U[Chromium test units] --> P[Shard planner]
  P --> B{Predicted shard time <= 19 min?}
  B -- No --> N[Increase shard count]
  N --> C{Count <= 28?}
  C -- Yes --> P
  C -- No --> F[Abort planning]
  B -- Yes --> M[Emit dynamic workflow matrix]
  M --> W[25-minute Playwright wrapper]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci(playwright): derive the chromium budg..."](https://github.com/open-metadata/openmetadata/commit/13b7fc073a9f960407ce6aca3cf28a7cfe11c441) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54671537)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->