### PR TITLE
ci(playwright): break the cache-eviction death spiral + make apt retries survivable

### DIFF
--- a/.github/workflows/playwright-e2e-reusable.yml
+++ b/.github/workflows/playwright-e2e-reusable.yml
@@ -600,8 +600,17 @@ jobs:
       # planning for the whole queue entry). An explicit cache with
       # restore-keys falls back to the most recent lockfile's cache, so a
       # lockfile change only fetches the delta.
+      # RESTORE-ONLY on purpose: this workflow runs on ephemeral refs
+      # (merge-queue branches, PR merge refs) whose exact cache key can
+      # never be re-used by another run — saving here produced a ~700 MB
+      # duplicate per job, blew straight through the repo's 10 GB cache
+      # budget (17.5 GB observed, 49/50 caches on ephemeral refs), and
+      # LRU-evicted every main-scoped cache within ~30 minutes. That
+      # eviction is what kept turning cache "hits" into cold registry
+      # fetches. The main-scoped copy is saved exclusively by
+      # populate-playwright-apt-cache.yml on main.
       - name: Restore yarn package cache
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: ~/.cache/yarn
           key: yarn-pkg-cache-${{ runner.os }}-${{ hashFiles('openmetadata-ui/src/main/resources/ui/yarn.lock') }}
@@ -901,7 +910,7 @@ jobs:
       # plan-playwright job's yarn cache step.
       - name: Restore yarn package cache
         if: ${{ needs.restore-playwright-fixture.outputs.fixture_cache_hit != 'true' || (needs.plan-playwright.outputs.requires_airflow == 'true' && needs.restore-playwright-fixture.outputs.ingestion_cache_hit != 'true') }}
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: ~/.cache/yarn
           key: yarn-pkg-cache-${{ runner.os }}-${{ hashFiles('openmetadata-ui/src/main/resources/ui/yarn.lock') }}
@@ -923,9 +932,12 @@ jobs:
             sleep $((attempt * 15))
           done
 
+      # Restore-only — same churn rationale as the yarn cache above. The
+      # main-scoped copy is saved by populate-playwright-apt-cache.yml; the
+      # plan job additionally seeds a run-scoped copy on lockfile changes.
       - name: Restore Playwright browser cache
         if: ${{ needs.restore-playwright-fixture.outputs.fixture_cache_hit != 'true' || (needs.plan-playwright.outputs.requires_airflow == 'true' && needs.restore-playwright-fixture.outputs.ingestion_cache_hit != 'true') }}
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('openmetadata-ui/src/main/resources/ui/yarn.lock') }}
@@ -1005,12 +1017,28 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$APT_DEPS_CACHE_HIT" != "true" ]]; then
+            # `timeout` only signals the direct child (npx/node) — the
+            # underlying apt-get survives the SIGTERM and keeps holding
+            # /var/lib/apt/lists/lock, so a retry without reaping dies
+            # instantly on "Could not get lock ... held by process N"
+            # (run 32233411840). The same stale lock can be left behind by
+            # a timed-out cache-apt-pkgs action earlier in this job, so
+            # reap BEFORE the first attempt too.
+            reap_apt() {
+              sudo killall -9 apt apt-get dpkg 2>/dev/null || true
+              sudo rm -f /var/lib/apt/lists/lock \
+                /var/cache/apt/archives/lock \
+                /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend
+              sudo dpkg --configure -a 2>/dev/null || true
+            }
             install_deps() {
               timeout --signal=TERM --kill-after=30s 8m \
                 npx playwright install-deps chromium
             }
+            reap_apt
             if ! install_deps; then
-              echo "::warning::install-deps chromium failed on first attempt; sleeping 15s and retrying once before failing the workflow" >&2
+              echo "::warning::install-deps chromium failed on first attempt; reaping orphaned apt processes and retrying once before failing the workflow" >&2
+              reap_apt
               sleep 15
               install_deps
             fi
@@ -1260,8 +1288,17 @@ jobs:
 
       # restore-keys fallback + retry — see the rationale on the
       # plan-playwright job's yarn cache step.
+      # RESTORE-ONLY on purpose: this workflow runs on ephemeral refs
+      # (merge-queue branches, PR merge refs) whose exact cache key can
+      # never be re-used by another run — saving here produced a ~700 MB
+      # duplicate per job, blew straight through the repo's 10 GB cache
+      # budget (17.5 GB observed, 49/50 caches on ephemeral refs), and
+      # LRU-evicted every main-scoped cache within ~30 minutes. That
+      # eviction is what kept turning cache "hits" into cold registry
+      # fetches. The main-scoped copy is saved exclusively by
+      # populate-playwright-apt-cache.yml on main.
       - name: Restore yarn package cache
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: ~/.cache/yarn
           key: yarn-pkg-cache-${{ runner.os }}-${{ hashFiles('openmetadata-ui/src/main/resources/ui/yarn.lock') }}
@@ -1283,9 +1320,10 @@ jobs:
             sleep $((attempt * 15))
           done
 
+      # Restore-only — same churn rationale as the yarn cache above.
       - name: Restore Playwright browser cache
         id: restore-browser
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('openmetadata-ui/src/main/resources/ui/yarn.lock') }}
@@ -1348,8 +1386,27 @@ jobs:
           APT_DEPS_CACHE_HIT: ${{ steps.apt-deps-cache.outputs.cache-hit }}
         run: |
           if [[ "$APT_DEPS_CACHE_HIT" != "true" ]]; then
-            timeout --signal=TERM --kill-after=30s 8m \
-              npx playwright install-deps chromium
+            # See the reap_apt rationale on the fixture-builder install step:
+            # `timeout` orphans the underlying apt-get, whose stale lock
+            # otherwise kills any retry (run 32233411840).
+            reap_apt() {
+              sudo killall -9 apt apt-get dpkg 2>/dev/null || true
+              sudo rm -f /var/lib/apt/lists/lock \
+                /var/cache/apt/archives/lock \
+                /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend
+              sudo dpkg --configure -a 2>/dev/null || true
+            }
+            install_deps() {
+              timeout --signal=TERM --kill-after=30s 8m \
+                npx playwright install-deps chromium
+            }
+            reap_apt
+            if ! install_deps; then
+              echo "::warning::install-deps chromium failed on first attempt; reaping orphaned apt processes and retrying once before failing the shard" >&2
+              reap_apt
+              sleep 15
+              install_deps
+            fi
           else
             echo "apt deps cache hit — skipping install-deps (files already restored; apt would re-download from the mirror)"
           fi
@@ -1705,8 +1762,17 @@ jobs:
 
       # restore-keys fallback + retry — see the rationale on the
       # plan-playwright job's yarn cache step.
+      # RESTORE-ONLY on purpose: this workflow runs on ephemeral refs
+      # (merge-queue branches, PR merge refs) whose exact cache key can
+      # never be re-used by another run — saving here produced a ~700 MB
+      # duplicate per job, blew straight through the repo's 10 GB cache
+      # budget (17.5 GB observed, 49/50 caches on ephemeral refs), and
+      # LRU-evicted every main-scoped cache within ~30 minutes. That
+      # eviction is what kept turning cache "hits" into cold registry
+      # fetches. The main-scoped copy is saved exclusively by
+      # populate-playwright-apt-cache.yml on main.
       - name: Restore yarn package cache
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: ~/.cache/yarn
           key: yarn-pkg-cache-${{ runner.os }}-${{ hashFiles('openmetadata-ui/src/main/resources/ui/yarn.lock') }}

--- a/.github/workflows/populate-playwright-apt-cache.yml
+++ b/.github/workflows/populate-playwright-apt-cache.yml
@@ -19,8 +19,18 @@
 #
 # The fix has two halves: playwright-e2e-reusable.yml uses RESTORE-ONLY
 # cache steps (no saves from ephemeral refs), and THIS workflow is the one
-# writer — it saves the yarn, browser, and apt caches from main's scope so
+# writer — it saves the apt, yarn, and browser caches from main's scope so
 # every downstream run gets a hit.
+#
+# STRUCTURE: each cache is warmed INDEPENDENTLY. The apt populate runs
+# first (most critical, no node/yarn dependency); the yarn and browser
+# warmers are continue-on-error so a registry or CDN outage on one cannot
+# block refreshing the others; each save is explicitly gated on its warmer
+# succeeding so a failed warm can never bake a partial cache under an
+# exact key (actions/cache never overwrites an existing key, so a partial
+# save would be permanent for that lockfile). A final step fails the job
+# if any warmer failed — full signal, but only after every cache had its
+# chance.
 #
 # Triggers:
 #   * schedule (6h)      — keeps last_accessed fresh and re-saves after any
@@ -65,17 +75,33 @@ jobs:
         with:
           persist-credentials: false
 
+      # FIRST and independent: the apt cache is the one whose absence takes
+      # down whole matrices on Ubuntu-mirror incidents, so nothing may run
+      # before it. continue-on-error so a mirror outage during populate
+      # still lets the yarn/browser warmers below run.
+      - name: Populate Playwright system deps cache
+        id: warm-apt
+        continue-on-error: true
+        uses: awalsh128/cache-apt-pkgs-action@v1.5.1
+        with:
+          packages: >-
+            fonts-ipafont-gothic fonts-freefont-ttf fonts-tlwg-loma-otf
+            fonts-unifont fonts-wqy-zenhei xfonts-encodings xfonts-utils
+            xfonts-cyrillic xfonts-scalable
+            libasound2t64 libatk-bridge2.0-0t64 libatk1.0-0t64
+            libatspi2.0-0t64 libcairo2 libcups2t64 libgbm1 libglib2.0-0t64
+            libnspr4 libnss3 libpango-1.0-0 libx11-6 libxcb1 libxcomposite1
+            libxdamage1 libxext6 libxfixes3 libxkbcommon0 libxrandr2
+          version: playwright-chromium-deps-v2
+
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
           node-version-file: openmetadata-ui/src/main/resources/ui/.nvmrc
 
-      # actions/cache (save-capable) is deliberate here and ONLY here: this
-      # workflow runs on main, so its post-job save creates the main-scoped
-      # copy every other run restores. Key must match the restore-only steps
-      # in playwright-e2e-reusable.yml.
-      - name: Yarn package cache (main-scoped writer)
-        uses: actions/cache@v5
+      - name: Restore yarn package cache
+        id: yarn-restore
+        uses: actions/cache/restore@v5
         with:
           path: ~/.cache/yarn
           key: yarn-pkg-cache-${{ runner.os }}-${{ hashFiles('openmetadata-ui/src/main/resources/ui/yarn.lock') }}
@@ -83,6 +109,8 @@ jobs:
             yarn-pkg-cache-${{ runner.os }}-
 
       - name: Warm yarn cache
+        id: warm-yarn
+        continue-on-error: true
         working-directory: openmetadata-ui/src/main/resources/ui
         run: |
           corepack enable
@@ -96,25 +124,55 @@ jobs:
             sleep $((attempt * 15))
           done
 
-      - name: Playwright browser cache (main-scoped writer)
-        uses: actions/cache@v5
+      # Save is gated on the warmer SUCCEEDING — a failed install must never
+      # bake a partial ~/.cache/yarn under the exact lockfile key, because
+      # actions/cache cannot overwrite an existing key and the partial copy
+      # would be permanent for this lockfile.
+      - name: Save yarn package cache (main-scoped writer)
+        if: steps.warm-yarn.outcome == 'success' && steps.yarn-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.cache/yarn
+          key: yarn-pkg-cache-${{ runner.os }}-${{ hashFiles('openmetadata-ui/src/main/resources/ui/yarn.lock') }}
+
+      - name: Restore Playwright browser cache
+        id: browser-restore
+        uses: actions/cache/restore@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('openmetadata-ui/src/main/resources/ui/yarn.lock') }}
 
+      # Needs node_modules from the yarn warmer (npx resolves the pinned
+      # @playwright/test from the local install) — skipped if that failed.
       - name: Warm Chromium browser cache
+        id: warm-browser
+        if: steps.warm-yarn.outcome == 'success'
+        continue-on-error: true
         working-directory: openmetadata-ui/src/main/resources/ui
         run: npx playwright install chromium
 
-      - name: Populate Playwright system deps cache
-        uses: awalsh128/cache-apt-pkgs-action@v1.5.1
+      - name: Save Playwright browser cache (main-scoped writer)
+        if: steps.warm-browser.outcome == 'success' && steps.browser-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
         with:
-          packages: >-
-            fonts-ipafont-gothic fonts-freefont-ttf fonts-tlwg-loma-otf
-            fonts-unifont fonts-wqy-zenhei xfonts-encodings xfonts-utils
-            xfonts-cyrillic xfonts-scalable
-            libasound2t64 libatk-bridge2.0-0t64 libatk1.0-0t64
-            libatspi2.0-0t64 libcairo2 libcups2t64 libgbm1 libglib2.0-0t64
-            libnspr4 libnss3 libpango-1.0-0 libx11-6 libxcb1 libxcomposite1
-            libxdamage1 libxext6 libxfixes3 libxkbcommon0 libxrandr2
-          version: playwright-chromium-deps-v2
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('openmetadata-ui/src/main/resources/ui/yarn.lock') }}
+
+      # Every warmer ran (or was skipped by a failed dependency); NOW fail
+      # the job if anything went wrong so the schedule/dispatch surface a
+      # clear signal without ever blocking a sibling cache's refresh.
+      - name: Report warm failures
+        env:
+          APT_OUTCOME: ${{ steps.warm-apt.outcome }}
+          YARN_OUTCOME: ${{ steps.warm-yarn.outcome }}
+          BROWSER_OUTCOME: ${{ steps.warm-browser.outcome }}
+        run: |
+          echo "apt=$APT_OUTCOME yarn=$YARN_OUTCOME browser=$BROWSER_OUTCOME"
+          failed=""
+          [[ "$APT_OUTCOME" == "failure" ]] && failed="$failed apt"
+          [[ "$YARN_OUTCOME" == "failure" ]] && failed="$failed yarn"
+          [[ "$BROWSER_OUTCOME" == "failure" || "$BROWSER_OUTCOME" == "skipped" ]] && failed="$failed browser"
+          if [[ -n "$failed" ]]; then
+            echo "::error::cache warmers failed:$failed — downstream runs stay on the previous main-scoped copies (or the resilient miss path) until the next populate"
+            exit 1
+          fi

--- a/.github/workflows/populate-playwright-apt-cache.yml
+++ b/.github/workflows/populate-playwright-apt-cache.yml
@@ -1,36 +1,39 @@
-# Keep a MAIN-scoped copy of the Playwright chromium apt-deps cache alive.
+# Keep MAIN-scoped copies of every cache the Playwright pipeline restores.
 #
-# Why this workflow exists: GitHub Actions cache scoping means a workflow run
-# can only restore caches created on its own ref or on the default branch.
-# Merge-queue refs (gh-readonly-queue/main/pr-N-sha) are unique per queue
-# entry and deleted after the run — so an apt cache populated during a
-# merge_group run is unreachable by every other queue entry. Unless a run ON
-# MAIN has saved this cache, every merge-queue shard misses it, falls back to
-# `apt-get install` against the Azure Ubuntu mirror, and the whole matrix
-# goes red whenever that mirror has a bad day (runs 32157314266, 32166970973,
-# 32209207109 — zero tests executed, all shards dead in setup).
+# Why this workflow exists — two GitHub Actions cache mechanics compound:
 #
-# This job saves the same cache key the Playwright reusable workflow restores
-# (`playwright-chromium-deps-v2` + identical package list), from main's
-# scope, so every merge_group / PR / nightly run downstream gets a hit and
-# never talks to the mirror on the hot path.
+# 1. SCOPING: a workflow run can only restore caches created on its own ref
+#    or on the default branch. Merge-queue refs (gh-readonly-queue/main/...)
+#    and PR merge refs are unique per entry and die after the run — caches
+#    saved there are unreachable by every other run. Only main-scoped copies
+#    are universally restorable.
+# 2. EVICTION: the repo cache budget is 10 GB, LRU-evicted. When ephemeral
+#    refs are allowed to SAVE caches, per-queue-entry duplicates (~700 MB
+#    yarn + ~250 MB browser each) blow the budget within the hour and evict
+#    the main-scoped copies — observed at 17.5 GB with 49/50 caches on
+#    ephemeral refs, the main apt cache evicted ~30 minutes after creation.
+#    That eviction turns every downstream "cache hit" into a cold fetch
+#    against apt mirrors / registry.yarnpkg.com / the Playwright CDN, and a
+#    bad day on any of those takes the whole matrix down (runs 32157314266,
+#    32166970973, 32209207109, 32222855561, 32233411840).
+#
+# The fix has two halves: playwright-e2e-reusable.yml uses RESTORE-ONLY
+# cache steps (no saves from ephemeral refs), and THIS workflow is the one
+# writer — it saves the yarn, browser, and apt caches from main's scope so
+# every downstream run gets a hit.
 #
 # Triggers:
-#   * schedule (6h)      — keeps the cache warm; GitHub evicts caches unused
-#                          for 7 days and LRU-evicts beyond the 10 GB repo
-#                          budget, so a periodic touch guarantees presence.
-#   * workflow_dispatch  — populate immediately (first run, or after an
-#                          eviction during an incident).
-#   * push to main touching the reusable workflow — the package list and the
-#                          `version:` key live there; any change repopulates
-#                          the new key right away instead of waiting ≤6 h,
-#                          during which every queue run would take the
-#                          mirror-dependent miss path.
+#   * schedule (6h)      — keeps last_accessed fresh and re-saves after any
+#                          eviction or runner-image roll.
+#   * workflow_dispatch  — populate immediately (first run / mid-incident).
+#   * push to main touching the reusable workflow, this file, or yarn.lock —
+#                          key inputs changed; repopulate the new keys right
+#                          away instead of waiting ≤6 h.
 #
-# IMPORTANT: the package list and `version:` below MUST stay identical to the
-# two "Cache Playwright system deps" steps in playwright-e2e-reusable.yml —
-# a drifted list populates a key nobody restores. Update both files together.
-name: Populate Playwright apt cache
+# IMPORTANT: the cache keys and the apt package list below MUST stay
+# identical to their counterparts in playwright-e2e-reusable.yml — a drifted
+# key populates a cache nobody restores. Update both files together.
+name: Populate Playwright CI caches
 
 on:
   schedule:
@@ -42,6 +45,8 @@ on:
     paths:
       - .github/workflows/playwright-e2e-reusable.yml
       - .github/workflows/populate-playwright-apt-cache.yml
+      - openmetadata-ui/src/main/resources/ui/yarn.lock
+      - openmetadata-ui/src/main/resources/ui/.nvmrc
 
 permissions:
   contents: read
@@ -53,8 +58,54 @@ concurrency:
 jobs:
   populate:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: openmetadata-ui/src/main/resources/ui/.nvmrc
+
+      # actions/cache (save-capable) is deliberate here and ONLY here: this
+      # workflow runs on main, so its post-job save creates the main-scoped
+      # copy every other run restores. Key must match the restore-only steps
+      # in playwright-e2e-reusable.yml.
+      - name: Yarn package cache (main-scoped writer)
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/yarn
+          key: yarn-pkg-cache-${{ runner.os }}-${{ hashFiles('openmetadata-ui/src/main/resources/ui/yarn.lock') }}
+          restore-keys: |
+            yarn-pkg-cache-${{ runner.os }}-
+
+      - name: Warm yarn cache
+        working-directory: openmetadata-ui/src/main/resources/ui
+        run: |
+          corepack enable
+          for attempt in 1 2 3; do
+            yarn --ignore-scripts --frozen-lockfile --network-timeout 100000 && break
+            if [[ "$attempt" -eq 3 ]]; then
+              echo "yarn install failed after 3 attempts" >&2
+              exit 1
+            fi
+            echo "::warning::yarn install attempt $attempt failed (registry blip?); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
+
+      - name: Playwright browser cache (main-scoped writer)
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('openmetadata-ui/src/main/resources/ui/yarn.lock') }}
+
+      - name: Warm Chromium browser cache
+        working-directory: openmetadata-ui/src/main/resources/ui
+        run: npx playwright install chromium
+
       - name: Populate Playwright system deps cache
         uses: awalsh128/cache-apt-pkgs-action@v1.5.1
         with:


### PR DESCRIPTION
## Summary

Root-cause fix for the recurring setup failures (runs [32223093113](https://github.com/open-metadata/OpenMetadata/actions/runs/32223093113), [32233411840](https://github.com/open-metadata/OpenMetadata/actions/runs/32233411840)). Supersedes #31737 — its apt-lock diagnosis was half right, and its logic is adopted here at the location where it can actually work.

## Defect 1 — cache-eviction death spiral (the systemic wall)

Measured state: **17.5 GB of caches against the 10 GB LRU budget, 49 of 50 on ephemeral refs.**

- On ephemeral refs (merge-queue branches, PR merge refs) the exact cache key can never pre-exist → `actions/cache` saved a fresh duplicate per job. The #31730 yarn cache alone: **9 × ~700 MB = 6.4 GB of churn**.
- Those saves LRU-evicted every main-scoped cache within ~30 min (the #31718 apt cache created 06:15 was **gone before 06:49**).
- Evicted main copies → downstream "hits" became cold fetches against apt mirrors / registry.yarnpkg.com / Playwright CDN → any upstream bad day killed the whole matrix → more misses → more ephemeral saves → more eviction.

**Fix:** all yarn + browser cache steps in the reusable workflow become **restore-only** (`actions/cache/restore@v5`). The single writer is `populate-playwright-apt-cache.yml` (now "Populate Playwright CI caches"), which warms **yarn + browser + apt** from main's scope — on the 6 h schedule, on dispatch, and on pushes touching `yarn.lock` / `.nvmrc` / the workflows. The plan job's run-scoped browser seeder stays save-capable for lockfile-change entries (no-ops on hit once eviction stops). Projected steady state: **~6–8 GB, under budget, zero evictions.**

## Defect 2 — the install retry could never succeed

Run 32233411840's exact sequence:
1. apt failed over from the dead Azure mirror to `archive.ubuntu.com` (`Ign:` → `Hit:`) and was **slowly succeeding**
2. the 8-min `timeout` killed the `npx` wrapper mid-download —
3. **but `timeout` only signals the direct child**; the underlying `apt-get` (pid 15226) survived, still holding `/var/lib/apt/lists/lock`
4. the retry died instantly: `E: Could not get lock … held by process 15226` → exit 100 → job dead

**Fix:** a `reap_apt()` helper (kill orphaned apt/dpkg, remove stale locks, `dpkg --configure -a`) runs **before the first attempt and between attempts** at both `install-deps` call sites. The shard job also gains the one-retry loop it never had. This is #31737's cleanup at the right place — the stale lock is created by *our own timed-out first attempt* (or a timed-out cache action in the same job), so clearing locks before the cache step runs too early to help.

## Defect 3 — populate workflow too narrow

It only warmed apt; yarn and browser caches had **no main-scoped writer at all**, so their first ephemeral-ref miss started the duplicate churn. Now it warms all three.

## Verified

- [x] YAML valid on both files.
- [x] All 6 yarn/browser cache steps in the reusable workflow audited restore-only; plan-job seeder confirmed retained.
- [x] reap+retry idiom tested under `bash -e`.
- [ ] After merge: dispatch `populate-playwright-apt-cache.yml` once, then `gh api /repos/{owner}/{repo}/actions/cache/usage` should trend below 10 GB within a few hours and `?key=cache-apt-pkgs` / `?key=yarn-pkg-cache` should show stable `ref=refs/heads/main` entries.
- [ ] Merge-queue shards log cache hits and 1–5 s installs even during mirror incidents.

## Recommendation for #31737

Close in favor of this PR — the lock-clearing idea is incorporated where it's effective (inside the retry loop, after our own timeout creates the lock).

Related: #31718, #31730, #31691, #30847.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes Playwright cache consumption restore-only on ephemeral refs, centralizes main-scoped apt, yarn, and browser cache writes, and adds apt-process cleanup around retried browser dependency installation.
- Runs the apt cache population before the yarn and browser warmers so their failures cannot block apt refresh.
- Gates cache saves on successful warmers and reports failures only after each independent cache has had an opportunity to update.
- Reaps orphaned apt and dpkg processes before retrying timed-out Playwright dependency installation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/playwright-e2e-reusable.yml | Converts ephemeral-ref yarn and browser caches to restore-only usage and adds apt cleanup plus retry handling at both dependency-install call sites. |
| .github/workflows/populate-playwright-apt-cache.yml | Expands the main-scoped population workflow to warm apt first and then independently warm and save yarn and browser caches. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Populate workflow on main] --> B[Warm apt cache first]
  B --> C[Warm yarn cache]
  C --> D[Warm browser cache]
  B --> E[Main-scoped apt cache]
  C --> F[Main-scoped yarn cache]
  D --> G[Main-scoped browser cache]
  E --> H[Reusable Playwright jobs restore only]
  F --> H
  G --> H
  H --> I[Reap stale apt processes on cache miss]
  I --> J[Retry install-deps]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["address greptile P1 — make the cache war..."](https://github.com/open-metadata/openmetadata/commit/e48a0cbdff53449d16783146f53ac439f10d7d68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54702674)</sub>

<!-- /greptile_comment -->