### PR TITLE
Fixes 31747: stop advertising nested subfields as Data Insights chart fields

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchDataInsightAggregatorManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchDataInsightAggregatorManager.java
@@ -190,7 +190,7 @@ public class ElasticSearchDataInsightAggregatorManager implements DataInsightAgg
     return QueryCostRecordsAggregator.parseQueryCostResponse(searchResponse);
   }
 
-  private void getFieldNames(
+  static void getFieldNames(
       Map<String, Property> properties,
       String prefix,
       List<Map<String, String>> fieldList,
@@ -236,11 +236,12 @@ public class ElasticSearchDataInsightAggregatorManager implements DataInsightAgg
         }
       }
 
-      // Recursively process nested or object fields
+      // Recurse into object fields only. A `nested` mapping stores its children as separate hidden
+      // Lucene documents, so neither a terms aggregation nor the root-level query_string a chart
+      // formula's q= compiles to can reach them: every descendant of a nested field is unusable in
+      // a custom chart and must not be advertised.
       if (property.isObject() && property.object().properties() != null) {
         getFieldNames(property.object().properties(), baseFieldName, fieldList, entityType);
-      } else if (property.isNested() && property.nested().properties() != null) {
-        getFieldNames(property.nested().properties(), baseFieldName, fieldList, entityType);
       }
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchDataInsightAggregatorManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchDataInsightAggregatorManager.java
@@ -197,7 +197,7 @@ public class OpenSearchDataInsightAggregatorManager implements DataInsightAggreg
     return processor.process(dataInsightChartType);
   }
 
-  private void getFieldNames(
+  static void getFieldNames(
       Map<String, Property> properties,
       String parent,
       List<Map<String, String>> fields,
@@ -240,11 +240,12 @@ public class OpenSearchDataInsightAggregatorManager implements DataInsightAggreg
         }
       }
 
-      // Recurse into nested/object fields
+      // Recurse into object fields only. A `nested` mapping stores its children as separate hidden
+      // Lucene documents, so neither a terms aggregation nor the root-level query_string a chart
+      // formula's q= compiles to can reach them: every descendant of a nested field is unusable in
+      // a custom chart and must not be advertised.
       if (property.isObject() && property.object().properties() != null) {
         getFieldNames(property.object().properties(), baseFieldName, fields, entityType);
-      } else if (property.isNested() && property.nested().properties() != null) {
-        getFieldNames(property.nested().properties(), baseFieldName, fields, entityType);
       }
     }
   }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/ElasticSearchDataInsightAggregatorManagerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/ElasticSearchDataInsightAggregatorManagerTest.java
@@ -1,0 +1,64 @@
+package org.openmetadata.service.search.elasticsearch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import es.co.elastic.clients.elasticsearch._types.mapping.Property;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ElasticSearchDataInsightAggregatorManagerTest {
+
+  private static final String ENTITY_TYPE = "table";
+
+  @Test
+  void nestedSubtreeIsNotAdvertisedAsChartField() {
+    List<String> names = catalogFieldNames();
+
+    assertTrue(
+        names.stream().noneMatch(name -> name.startsWith("owners")),
+        "owners is nested: its children can be neither grouped on nor filtered -> " + names);
+  }
+
+  @Test
+  void flatTwinAndObjectChildrenStayInTheCatalog() {
+    List<String> names = catalogFieldNames();
+
+    assertTrue(names.contains("ownerName"), "Flat ownerName twin must survive: " + names);
+    assertTrue(names.contains("service.name.keyword"), "object children must survive: " + names);
+    assertEquals(2, names.size(), names.toString());
+  }
+
+  private static List<String> catalogFieldNames() {
+    List<Map<String, String>> fields = new ArrayList<>();
+    ElasticSearchDataInsightAggregatorManager.getFieldNames(
+        dataAssetMapping(), "", fields, ENTITY_TYPE);
+    return fields.stream().map(field -> field.get("name")).toList();
+  }
+
+  /** Mirrors the DI data-asset mapping: nested `owners`, flat `ownerName`, object `service`. */
+  private static Map<String, Property> dataAssetMapping() {
+    Property keyword = Property.of(property -> property.keyword(builder -> builder));
+    Property owners =
+        Property.of(
+            property ->
+                property.nested(
+                    nested ->
+                        nested
+                            .properties("id", keyword)
+                            .properties("name", keyword)
+                            .properties("displayName", keyword)));
+    Property service =
+        Property.of(
+            property ->
+                property.object(
+                    object ->
+                        object.properties(
+                            "name",
+                            Property.of(
+                                inner -> inner.text(text -> text.fields("keyword", keyword))))));
+    return Map.of("owners", owners, "ownerName", keyword, "service", service);
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchDataInsightAggregatorManagerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchDataInsightAggregatorManagerTest.java
@@ -1,0 +1,64 @@
+package org.openmetadata.service.search.opensearch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import os.org.opensearch.client.opensearch._types.mapping.Property;
+
+class OpenSearchDataInsightAggregatorManagerTest {
+
+  private static final String ENTITY_TYPE = "table";
+
+  @Test
+  void nestedSubtreeIsNotAdvertisedAsChartField() {
+    List<String> names = catalogFieldNames();
+
+    assertTrue(
+        names.stream().noneMatch(name -> name.startsWith("owners")),
+        "owners is nested: its children can be neither grouped on nor filtered -> " + names);
+  }
+
+  @Test
+  void flatTwinAndObjectChildrenStayInTheCatalog() {
+    List<String> names = catalogFieldNames();
+
+    assertTrue(names.contains("ownerName"), "Flat ownerName twin must survive: " + names);
+    assertTrue(names.contains("service.name.keyword"), "object children must survive: " + names);
+    assertEquals(2, names.size(), names.toString());
+  }
+
+  private static List<String> catalogFieldNames() {
+    List<Map<String, String>> fields = new ArrayList<>();
+    OpenSearchDataInsightAggregatorManager.getFieldNames(
+        dataAssetMapping(), "", fields, ENTITY_TYPE);
+    return fields.stream().map(field -> field.get("name")).toList();
+  }
+
+  /** Mirrors the DI data-asset mapping: nested `owners`, flat `ownerName`, object `service`. */
+  private static Map<String, Property> dataAssetMapping() {
+    Property keyword = Property.of(property -> property.keyword(builder -> builder));
+    Property owners =
+        Property.of(
+            property ->
+                property.nested(
+                    nested ->
+                        nested
+                            .properties("id", keyword)
+                            .properties("name", keyword)
+                            .properties("displayName", keyword)));
+    Property service =
+        Property.of(
+            property ->
+                property.object(
+                    object ->
+                        object.properties(
+                            "name",
+                            Property.of(
+                                inner -> inner.text(text -> text.fields("keyword", keyword))))));
+    return Map.of("owners", owners, "ownerName", keyword, "service", service);
+  }
+}


### PR DESCRIPTION
### Describe your changes:

Fixes #31747

`getFieldNames` skipped the `nested` container itself but then recursed into its children, so `GET /v1/analytics/dataInsights/custom/charts/fields` advertised every descendant of a `nested` mapping as an available chart field. Those fields can never be used — a `nested` mapping stores its children as separate hidden Lucene documents, so neither a `terms` aggregation nor the root-level `query_string` a formula's `q=` compiles to can reach them. Because a root-level query on a nested path is not an error in Elasticsearch, the resulting chart renders a confident `0` instead of failing.

I stopped the recursion from descending into `nested` subtrees, mirrored in both engines. Children of ordinary `object` mappings and root-level fields such as `ownerName` are unaffected.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

One note for review: I deliberately did **not** extract the shared implementation, despite the two `getFieldNames` bodies being identical. They operate on `os.org.opensearch...Property` and `es.co.elastic.clients...Property`, which are unrelated shaded classes with no common supertype, so unifying them needs a mapping-tree adapter. That is a refactor rather than a bug fix; happy to file it separately.

#
### Tests:

#### Use cases covered
- The chart wizard's Group By picker no longer offers fields that produce an empty chart.
- The AI chart assistant is no longer shown `owners.*` paths that silently match zero documents.
- `ownerName`, the flat twin that actually works, is still offered.
- `owners.*` is still offered for `testCaseResult`, where `owners` is a plain `object` and those fields are genuinely queryable.

#### Unit tests
- [x] Added, one per engine:
  - `openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchDataInsightAggregatorManagerTest.java`
  - `openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/ElasticSearchDataInsightAggregatorManagerTest.java`

Each builds a mapping with a `nested` `owners`, a flat `ownerName` and an `object` `service`, then asserts no `owners*` field is emitted while `ownerName` and `service.name.keyword` survive. Both fail before this change (5 fields emitted) and pass after (2).

#### Backend integration tests
- [x] Not applicable (no API contract change; the endpoint returns fewer, already-unusable entries).

#### Ingestion integration tests
- [x] Not applicable.

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Against a local 2.0.0-SNAPSHOT stack seeded with ~37k entities and 2,709 owned tables:

1. Before: `GET /v1/analytics/dataInsights/custom/charts/fields` returned **415** fields, including `owners.id`, `owners.name`, `owners.id.keyword` and `customPropertiesTyped.*`, all with `aggregatable: true`.
2. After: **343** fields. The 72 removed are all nested descendants. `ownerName` is still present, and `owners.*` is still present for `testCaseResult` (where a flat query returns 5/5 docs, so they are usable).
3. Confirmed the removed fields were genuinely dead: `groupBy` on any `owners.*` path returned no buckets, and `count(k='id.keyword', q='owners.id: *')` returned 0 against 2,709 owned tables, while `q='ownerName: *'` returned 2,709.
4. Checked regression risk on persisted charts: of 33 Data Insights charts on that instance, 0 referenced any `owners.*` path and 9 already used `ownerName`.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR stops Elasticsearch and OpenSearch Data Insights field discovery from advertising descendants of nested mappings, while preserving ordinary object traversal and flat fields.
- Removes recursive traversal of nested mapping properties in both search backends.
- Adds equivalent regression coverage for Elasticsearch and OpenSearch.
- Verifies flat fields and children of ordinary object mappings remain available.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The field catalog now excludes nested descendants that the Data Insights execution path cannot query or aggregate, while tests confirm supported flat and ordinary object fields remain available in both engines.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchDataInsightAggregatorManager.java | Correctly limits field discovery to root-level and ordinary object fields supported by the Elasticsearch chart builders. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchDataInsightAggregatorManager.java | Mirrors the Elasticsearch fix and remains consistent with OpenSearch chart-query behavior. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/ElasticSearchDataInsightAggregatorManagerTest.java | Covers nested-subtree exclusion and preservation of flat and ordinary object fields. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchDataInsightAggregatorManagerTest.java | Provides matching OpenSearch regression coverage for field-catalog behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(data-insights): stop advertising nes..."](https://github.com/open-metadata/openmetadata/commit/4676c951f3e3809dc2187e898f9b1f9616ca03cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54709982)</sub>

<!-- /greptile_comment -->