### PR TITLE
Fixes 31748: give the group-by aggregation key its own index so named metrics do not collide

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchLineChartAggregator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchLineChartAggregator.java
@@ -193,8 +193,6 @@ public class ElasticSearchLineChartAggregator
                   return termsBuilder.aggregations(finalMetricAggregations);
                 });
 
-        // One group-by aggregation per metric. `i` only advances for UNNAMED metrics, so keying on
-        // it collapsed every named metric onto "term_0" and only the last one survived.
         aggregationsMap.put("term_" + groupByAggIndex++, groupByAgg);
       } else {
         aggregationsMap.putAll(metricAggregations);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchLineChartAggregator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchLineChartAggregator.java
@@ -49,6 +49,7 @@ public class ElasticSearchLineChartAggregator
     LineChart lineChart = JsonUtils.convertValue(diChart.getChartDetails(), LineChart.class);
     Map<String, Aggregation> aggregationsMap = new HashMap<>();
     int i = 0;
+    int groupByAggIndex = 0;
     long startTime = start;
 
     for (LineChartMetric metric : lineChart.getMetrics()) {
@@ -192,7 +193,9 @@ public class ElasticSearchLineChartAggregator
                   return termsBuilder.aggregations(finalMetricAggregations);
                 });
 
-        aggregationsMap.put("term_" + i, groupByAgg);
+        // One group-by aggregation per metric. `i` only advances for UNNAMED metrics, so keying on
+        // it collapsed every named metric onto "term_0" and only the last one survived.
+        aggregationsMap.put("term_" + groupByAggIndex++, groupByAgg);
       } else {
         aggregationsMap.putAll(metricAggregations);
       }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchLineChartAggregator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchLineChartAggregator.java
@@ -190,8 +190,6 @@ public class OpenSearchLineChartAggregator implements OpenSearchDynamicChartAggr
                   return termsBuilder.aggregations(finalMetricAggregations);
                 });
 
-        // One group-by aggregation per metric. `i` only advances for UNNAMED metrics, so keying on
-        // it collapsed every named metric onto "term_0" and only the last one survived.
         aggregationsMap.put("term_" + groupByAggIndex++, groupByAgg);
       } else {
         aggregationsMap.putAll(metricAggregations);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchLineChartAggregator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchLineChartAggregator.java
@@ -48,6 +48,7 @@ public class OpenSearchLineChartAggregator implements OpenSearchDynamicChartAggr
     LineChart lineChart = JsonUtils.convertValue(diChart.getChartDetails(), LineChart.class);
     Map<String, Aggregation> aggregationsMap = new HashMap<>();
     int i = 0;
+    int groupByAggIndex = 0;
     long startTime = start;
 
     for (LineChartMetric metric : lineChart.getMetrics()) {
@@ -189,7 +190,9 @@ public class OpenSearchLineChartAggregator implements OpenSearchDynamicChartAggr
                   return termsBuilder.aggregations(finalMetricAggregations);
                 });
 
-        aggregationsMap.put("term_" + i, groupByAgg);
+        // One group-by aggregation per metric. `i` only advances for UNNAMED metrics, so keying on
+        // it collapsed every named metric onto "term_0" and only the last one survived.
+        aggregationsMap.put("term_" + groupByAggIndex++, groupByAgg);
       } else {
         aggregationsMap.putAll(metricAggregations);
       }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchLineChartAggregatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchLineChartAggregatorTest.java
@@ -16,8 +16,10 @@ import jakarta.json.stream.JsonGenerator;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChart;
@@ -34,6 +36,8 @@ class ElasticSearchLineChartAggregatorTest {
 
   private static final String SERVICE_NAME = "myservice";
   private static final String X_AXIS_FIELD = "service.name.keyword";
+  private static final String OWNER_METRIC = "withOwner";
+  private static final String DESCRIPTION_METRIC = "withDescription";
   private static final long END_TIME = 24L * 60 * 60 * 1000;
 
   private final ElasticSearchLineChartAggregator aggregator =
@@ -91,6 +95,21 @@ class ElasticSearchLineChartAggregatorTest {
     assertThrows(IllegalArgumentException.class, () -> prepare(chart));
   }
 
+  @Test
+  void groupedChartKeepsAnAggregationForEveryNamedMetric() throws Exception {
+    JsonNode aggregations =
+        OBJECT_MAPPER
+            .readTree(serializeToJson(prepare(groupedMultiMetricChart())))
+            .path("aggregations");
+
+    assertEquals(2, aggregations.size(), "Each metric needs its own group-by aggregation");
+
+    Set<String> metricNames = new HashSet<>();
+    aggregations.forEach(
+        groupBy -> groupBy.path("aggregations").fieldNames().forEachRemaining(metricNames::add));
+    assertEquals(Set.of(OWNER_METRIC, DESCRIPTION_METRIC), metricNames);
+  }
+
   private SearchRequest prepare(DataInsightCustomChart chart) {
     return aggregator.prepareSearchRequest(
         chart, 0L, END_TIME, new ArrayList<>(), new HashMap<>(), true);
@@ -145,6 +164,24 @@ class ElasticSearchLineChartAggregatorTest {
             .withIncludeXAxisFiled(includeService);
     return new DataInsightCustomChart()
         .withName("total_data_assets_live")
+        .withChartDetails(lineChart);
+  }
+
+  private static DataInsightCustomChart groupedMultiMetricChart() {
+    LineChart lineChart =
+        new LineChart()
+            .withMetrics(
+                List.of(
+                    new LineChartMetric()
+                        .withName(OWNER_METRIC)
+                        .withFormula("count(k='id.keyword',q='ownerName: *')"),
+                    new LineChartMetric()
+                        .withName(DESCRIPTION_METRIC)
+                        .withFormula("count(k='id.keyword',q='hasDescription: 1')")))
+            .withGroupBy("entityType")
+            .withxAxisField(X_AXIS_FIELD);
+    return new DataInsightCustomChart()
+        .withName("ownership_and_description_by_entity_type_live")
         .withChartDetails(lineChart);
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchLineChartAggregatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchLineChartAggregatorTest.java
@@ -14,8 +14,10 @@ import jakarta.json.stream.JsonGenerator;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChart;
@@ -34,6 +36,8 @@ class OpenSearchLineChartAggregatorTest {
 
   private static final String SERVICE_NAME = "myservice";
   private static final String X_AXIS_FIELD = "service.name.keyword";
+  private static final String OWNER_METRIC = "withOwner";
+  private static final String DESCRIPTION_METRIC = "withDescription";
   private static final long END_TIME = 24L * 60 * 60 * 1000;
 
   private final OpenSearchLineChartAggregator aggregator = new OpenSearchLineChartAggregator();
@@ -90,6 +94,21 @@ class OpenSearchLineChartAggregatorTest {
     assertThrows(IllegalArgumentException.class, () -> prepare(chart));
   }
 
+  @Test
+  void groupedChartKeepsAnAggregationForEveryNamedMetric() throws Exception {
+    JsonNode aggregations =
+        OBJECT_MAPPER
+            .readTree(serializeToJson(prepare(groupedMultiMetricChart())))
+            .path("aggregations");
+
+    assertEquals(2, aggregations.size(), "Each metric needs its own group-by aggregation");
+
+    Set<String> metricNames = new HashSet<>();
+    aggregations.forEach(
+        groupBy -> groupBy.path("aggregations").fieldNames().forEachRemaining(metricNames::add));
+    assertEquals(Set.of(OWNER_METRIC, DESCRIPTION_METRIC), metricNames);
+  }
+
   private SearchRequest prepare(DataInsightCustomChart chart) {
     return aggregator.prepareSearchRequest(
         chart, 0L, END_TIME, new ArrayList<>(), new HashMap<>(), true);
@@ -144,6 +163,24 @@ class OpenSearchLineChartAggregatorTest {
             .withIncludeXAxisFiled(includeService);
     return new DataInsightCustomChart()
         .withName("total_data_assets_live")
+        .withChartDetails(lineChart);
+  }
+
+  private static DataInsightCustomChart groupedMultiMetricChart() {
+    LineChart lineChart =
+        new LineChart()
+            .withMetrics(
+                List.of(
+                    new LineChartMetric()
+                        .withName(OWNER_METRIC)
+                        .withFormula("count(k='id.keyword',q='ownerName: *')"),
+                    new LineChartMetric()
+                        .withName(DESCRIPTION_METRIC)
+                        .withFormula("count(k='id.keyword',q='hasDescription: 1')")))
+            .withGroupBy("entityType")
+            .withxAxisField(X_AXIS_FIELD);
+    return new DataInsightCustomChart()
+        .withName("ownership_and_description_by_entity_type_live")
         .withChartDetails(lineChart);
   }
 


### PR DESCRIPTION
### Describe your changes:

Fixes #31748

A Data Insights custom LineChart that sets `groupBy` and defines more than one **named** metric silently returned only the last metric.

`prepareSearchRequest` used one counter for two unrelated purposes:

```java
 51:  int i = 0;
 55:  String metricName = metric.getName() == null ? "metric_" + ++i : metric.getName();
195:  aggregationsMap.put("term_" + i, groupByAgg);
```

`i` advances only on the unnamed-metric branch. When every metric has a name — the normal case, and the only case the AI chart assistant can produce — `i` stays `0`, so every metric's group-by aggregation is written to the same `"term_0"` key and each iteration overwrites the previous one. `metricAggregations` is rebuilt per iteration and holds only the current metric, so earlier metrics never reached Elasticsearch at all.

I gave the group-by key its own per-iteration counter, leaving metric naming untouched. Mirrored in both engines.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

Two notes for review:

1. The top-level `"term_N"` key is write-only. The response parser dispatches on `agg.isSterms()` and discards `entry.getKey()` (`ElasticSearchLineChartAggregator.java:249-284`), so no parser change is needed. The **sub**-aggregation key is the metric name and *is* load-bearing — it keys `metricFormulaHolder` via unguarded `.get(subAggName).formula` — so I deliberately left metric naming alone.
2. I used a dedicated counter rather than keying on the metric name: unique by construction even if a caller supplies duplicate names, and it preserves `term_0` for the existing single-metric case, keeping the behavioural delta as small as possible.

#
### Tests:

#### Use cases covered
- A chart with two named metrics and a `groupBy` returns both series per group, instead of silently dropping all but the last.
- Existing single-metric grouped charts and multi-metric ungrouped charts are unchanged.

#### Unit tests
- [x] Added, one per engine, in the existing test classes:
  - `ElasticSearchLineChartAggregatorTest#groupedChartKeepsAnAggregationForEveryNamedMetric`
  - `OpenSearchLineChartAggregatorTest#groupedChartKeepsAnAggregationForEveryNamedMetric`

Each builds a grouped chart with two named metrics and asserts two distinct top-level aggregations carrying both metric names. Both fail before this change (`expected: <2> but was: <1>`) and pass after. The 5 existing tests per class are unaffected.

#### Backend integration tests
- [x] Not applicable (no API contract change).

#### Ingestion integration tests
- [x] Not applicable.

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Against a local 2.0.0-SNAPSHOT stack with a populated Data Insights index:

1. Posted a two-metric grouped chart (`owner_pct` + `desc_pct`, `groupBy: service.name.keyword`) to `/v1/analytics/dataInsights/custom/charts/preview`.
2. Before: **7 rows, all `desc_pct`** — `owner_pct` absent, no error raised.
3. After: **14 rows**, 7 per metric, with correct values (54.16% ownership on the seeded service, 100% description coverage).
4. Confirmed the diagnosis by inverting the trigger: the same chart with **unnamed** metrics returned both metrics even before the fix, because `++i` advances on that branch.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR fixes grouped line charts with multiple named metrics by assigning each metric an independent top-level group-by aggregation key in both search engines.
- Adds a dedicated per-iteration group-by aggregation index for Elasticsearch and OpenSearch.
- Adds matching regression tests confirming both named metrics remain in grouped requests.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchLineChartAggregator.java | Uses an independent group-by aggregation counter so named metrics no longer overwrite one another. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchLineChartAggregator.java | Mirrors the Elasticsearch aggregation-key fix for OpenSearch. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchLineChartAggregatorTest.java | Adds regression coverage asserting distinct grouped aggregations retain both named metrics. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchLineChartAggregatorTest.java | Adds equivalent grouped multi-metric request coverage for OpenSearch. |

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(data-insights): drop the redund..."](https://github.com/open-metadata/openmetadata/commit/b9dd638848df7914343792b6fa29e22a0dd72211) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54710003)</sub>

<!-- /greptile_comment -->