### PR TITLE
test: exercise Python checkstyle setup

### DIFF
--- a/.github/workflows/py-checkstyle.yml
+++ b/.github/workflows/py-checkstyle.yml
@@ -15,6 +15,10 @@ name: Python Checkstyle
 # access to secrets
 on:
   merge_group:
+  pull_request:
+    paths-ignore:
+      - "openmetadata-ui/src/main/resources/ui/playwright/doc-generator/**"
+      - "openmetadata-ui/src/main/resources/ui/playwright/docs/**"
   pull_request_target:
     types: [labeled, opened, synchronize, reopened, ready_for_review]
     paths-ignore:

--- a/ingestion/tests/ci_checkstyle_canary.py
+++ b/ingestion/tests/ci_checkstyle_canary.py
@@ -1,0 +1,1 @@
+"""Temporary canary used to exercise the Python Checkstyle workflow."""


### PR DESCRIPTION
Temporary canary PR to run the updated Python Checkstyle workflow. The Python file is intentionally harmless and will be removed with this test branch.

----
## Summary by Gitar

- **CI Workflows:**
    - Updated `py-checkstyle.yml` to trigger on `pull_request` events with path filters

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds a standard pull-request trigger to the Python Checkstyle workflow and introduces a temporary Python file intended to exercise that workflow.
- Runs Python Checkstyle from `pull_request` events while preserving the existing `pull_request_target` and merge-queue triggers.
- Adds a docstring-only canary under the ingestion tests.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no eligible blocking failure remains in this follow-up review.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/py-checkstyle.yml | Adds the temporary `pull_request` entry point used to exercise Python Checkstyle from the PR branch. |
| ingestion/tests/ci_checkstyle_canary.py | Adds the harmless docstring-only canary described in the PR. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test: run checkstyle canary from branch ..."](https://github.com/open-metadata/openmetadata/commit/d1c3fd975f21e02097dff3c9c0b00da49eb683ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54728551)</sub>

<!-- /greptile_comment -->