### PR TITLE
Fixes #31768: keep live log auto-follow on after a hand-made resume

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AgentLogStreamHandover.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AgentLogStreamHandover.spec.ts
@@ -327,6 +327,11 @@ test.describe('Agent log stream handover to the paginated endpoint', () => {
   test('Scrolling a live log pauses auto-follow and the toolbar toggle resumes it', async ({
     page,
   }) => {
+    // Every step below waits for the stream to append again, and a reconnect can
+    // take seconds on a loaded runner. The default budget is one such wait, not
+    // the four this test needs, so it timed out on retry rather than failing.
+    test.slow();
+
     await openAgentLogs(page, {
       terminal: false,
       lineCount: SCROLLABLE_LOG_LINE_COUNT,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/IngestionLogStreamLive.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/IngestionLogStreamLive.spec.ts
@@ -290,13 +290,22 @@ test.describe(
         ).toBeGreaterThan(0);
 
         // The server reads the run's log every 2s (LogStreamSettings.pollSeconds),
-        // so a still-running agent must push more lines within a few ticks. A
-        // stream that connects but delivers nothing fails here.
+        // but the connector does not write at a steady rate: it logs a burst, then
+        // goes quiet for however long its next phase takes. The longest gap is
+        // between the connection test and the first topic being ingested, where the
+        // Kafka consumer joins its group and blocks on an empty poll — nothing is
+        // logged for the whole of it. A measured CI run sat silent for 29.8s there
+        // and this assertion, then budgeted 30s, gave up 0.2s before the next burst
+        // landed. The window has to clear that gap with margin rather than race it;
+        // `test.slow()` above leaves ample room (the whole test ran in 33s).
+        //
+        // A stream that connects but delivers nothing still fails here — 90s of
+        // silence is not something a healthy run produces.
         await expect
           .poll(() => getLogViewerLineCount(page), {
             message:
               'the log viewer should keep receiving lines while the run is live',
-            timeout: 30_000,
+            timeout: 90_000,
             intervals: [2_000],
           })
           .toBeGreaterThan(initialLineCount);

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/LogViewerModal/LogViewerModal.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/LogViewerModal/LogViewerModal.interface.ts
@@ -74,6 +74,7 @@ export interface ScrollFacts {
   fillsViewport: boolean;
   userMovedTheView: boolean;
   movedAwayFromTail: boolean;
+  movedTowardsTail: boolean;
 }
 
 export interface UseLogAutoFollowParams {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/LogViewerModal/LogViewerModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/LogViewerModal/LogViewerModal.test.tsx
@@ -821,6 +821,90 @@ describe('LogViewerModal — auto-follow', () => {
     );
   });
 
+  it('keeps following after a hand-made resume when an append lands short of the tail', () => {
+    render(<LogViewerModal {...defaultProps} mode="stream" />);
+
+    act(() => mockLazyLog.onScroll?.(atTail));
+    fireEvent.wheel(screen.getByTestId('log-viewer-body'), { deltaY: -120 });
+    fireEvent.wheel(screen.getByTestId('log-viewer-body'), { deltaY: 120 });
+    act(() => mockLazyLog.onScroll?.(scrolledBackToTail));
+
+    expect(screen.getByTestId('log-viewer-follow')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+
+    // The library scrolls itself on every append and lands approximately: the
+    // offset moved a long way *towards* the tail and still stopped short of it.
+    // Nobody scrolls down in order to leave the tail, so this cannot be the user.
+    act(() =>
+      mockLazyLog.onScroll?.({
+        scrollTop: 800,
+        scrollHeight: 1500,
+        clientHeight: 400,
+      })
+    );
+
+    expect(screen.getByTestId('log-viewer-follow')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+  });
+
+  it('grants a hand-made resume the same catch-up grace as the toggle', () => {
+    render(<LogViewerModal {...defaultProps} mode="stream" />);
+
+    act(() => mockLazyLog.onScroll?.(atTail));
+    fireEvent.wheel(screen.getByTestId('log-viewer-body'), { deltaY: -120 });
+    fireEvent.wheel(screen.getByTestId('log-viewer-body'), { deltaY: 120 });
+    act(() => mockLazyLog.onScroll?.(scrolledBackToTail));
+    mockLazyLog.scrollToIndex.mockClear();
+
+    // One gestureless report pulling away from the tail is what a relayout does
+    // on its way to re-pinning it, so it is caught up rather than obeyed — the
+    // same answer the toolbar toggle's resume gets.
+    act(() =>
+      mockLazyLog.onScroll?.({
+        scrollTop: 500,
+        scrollHeight: 1100,
+        clientHeight: 400,
+      })
+    );
+
+    expect(screen.getByTestId('log-viewer-follow')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    expect(mockLazyLog.scrollToIndex).toHaveBeenCalledWith(2);
+  });
+
+  it('still lets a gestureless drag take back a hand-made resume', () => {
+    render(<LogViewerModal {...defaultProps} mode="stream" />);
+
+    act(() => mockLazyLog.onScroll?.(atTail));
+    fireEvent.wheel(screen.getByTestId('log-viewer-body'), { deltaY: -120 });
+    fireEvent.wheel(screen.getByTestId('log-viewer-body'), { deltaY: 120 });
+    act(() => mockLazyLog.onScroll?.(scrolledBackToTail));
+
+    // A native scrollbar drag reports no wheel and no key. Pulling away from the
+    // tail twice in a row is something the catch-up never does, so the grace the
+    // resume granted has to be outrun rather than being indefinite.
+    for (const scrollTop of [500, 300]) {
+      act(() =>
+        mockLazyLog.onScroll?.({
+          scrollTop,
+          scrollHeight: 1100,
+          clientHeight: 400,
+        })
+      );
+    }
+
+    expect(screen.getByTestId('log-viewer-follow')).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+  });
+
   it('keeps following when its own catch-up reports an offset short of the tail', () => {
     render(<LogViewerModal {...defaultProps} mode="stream" />);
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/LogViewerModal/LogViewerModal.utils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/LogViewerModal/LogViewerModal.utils.tsx
@@ -99,6 +99,12 @@ export const SCROLL_MOVED_THRESHOLD_PX = 4;
  * view also leaving the tail — a relayout emits long runs of offset corrections
  * (12 in a row on one measured wrap toggle) that track the tail as the content
  * shrinks, and those are the viewer keeping up, not the user leaving.
+ *
+ * `movedTowardsTail` is its mirror: the offset travelled in the direction of the
+ * tail and still stopped short of it, which is what the library's own scroll on
+ * an append looks like when the content grew again on the way. Positive evidence
+ * of the direction, so a first report — which has no previous offset to compare
+ * against — is neither.
  */
 export const readScrollFacts = (
   { scrollTop, scrollHeight, clientHeight }: LogViewerScrollValues,
@@ -117,5 +123,7 @@ export const readScrollFacts = (
       isFirstReport || Math.abs(movedBy) > SCROLL_MOVED_THRESHOLD_PX,
     movedAwayFromTail:
       !isBottom && !isFirstReport && movedBy > SCROLL_MOVED_THRESHOLD_PX,
+    movedTowardsTail:
+      !isBottom && !isFirstReport && movedBy < -SCROLL_MOVED_THRESHOLD_PX,
   };
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/LogViewerModal/useLogAutoFollow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/LogViewerModal/useLogAutoFollow.ts
@@ -103,14 +103,24 @@ export const useLogAutoFollow = ({
     setFollow(isLive || follow);
   }, [open, isLive, follow, setFollow]);
 
-  const resumeFollowingTail = useCallback(() => {
-    forwardGestureAtRef.current = Date.now();
+  /**
+   * Starts following from a view that is already at the tail. Shared by every
+   * resume path: whoever gets back to the tail — the toolbar toggle or the user
+   * scrolling there — has to grant the catch-up the same grace, or the first
+   * append that reports an offset short of the tail reads as the user leaving.
+   */
+  const beginFollowingFromTail = useCallback(() => {
     upwardMovesRef.current = 0;
     caughtUpRef.current = false;
     viewerScrollAtRef.current = Date.now();
     setFollow(true);
+  }, [setFollow]);
+
+  const resumeFollowingTail = useCallback(() => {
+    forwardGestureAtRef.current = Date.now();
+    beginFollowingFromTail();
     scrollToEnd();
-  }, [scrollToEnd, setFollow]);
+  }, [beginFollowingFromTail, scrollToEnd]);
 
   const toggleFollow = useCallback(() => {
     if (followTailRef.current) {
@@ -163,8 +173,17 @@ export const useLogAutoFollow = ({
    * it resumes following.
    */
   const applyUserScrollIntent = useCallback(
-    (isBottom: boolean) => {
-      if (!isBottom) {
+    (facts: ScrollFacts) => {
+      if (!facts.isBottom) {
+        // A followed log whose offset moved *towards* the tail and stopped short
+        // of it is the viewer landing approximately — the library scrolls itself
+        // on every append and a virtualised list re-estimates its height as rows
+        // are measured. Nobody scrolls down in order to leave the tail, so only a
+        // move pulling away from it hands control over.
+        if (followTailRef.current && facts.movedTowardsTail) {
+          return;
+        }
+
         // Leaving the tail withdraws any earlier request to be at it.
         forwardGestureAtRef.current = 0;
         setFollow(false);
@@ -179,10 +198,10 @@ export const useLogAutoFollow = ({
         Date.now() - forwardGestureAtRef.current < FORWARD_GESTURE_GRACE_MS;
 
       if (askedToFollow) {
-        setFollow(true);
+        beginFollowingFromTail();
       }
     },
-    [setFollow]
+    [beginFollowingFromTail, setFollow]
   );
 
   const trackScroll = useCallback(
@@ -210,7 +229,7 @@ export const useLogAutoFollow = ({
         facts.userMovedTheView &&
         !viewerOwnsThisScroll
       ) {
-        applyUserScrollIntent(facts.isBottom);
+        applyUserScrollIntent(facts);
       }
 
       return facts;


### PR DESCRIPTION
### Describe your changes:

Fixes #31768

Auto-follow in the live log viewer could resume two ways — the toolbar toggle, or the user scrolling back down to the tail — and the two left **different internal state**. After a hand-made resume, following switched itself back off a moment later while the stream was still appending.

`pauseFollow()` zeroes `viewerScrollAtRef` (the "the viewer moved the view, not the user" grace), and only `resumeFollowingTail()` re-armed it. So a pause → scroll-back-to-tail sequence resumed with no grace. The pause decision then keyed on `userMovedTheView`, which is direction-agnostic (`Math.abs(movedBy) > SCROLL_MOVED_THRESHOLD_PX`), so the next report in which `LazyLog`'s own follow-scroll landed more than 40px short of the tail — which a virtualised list emits when a second append arrives mid-scroll or rows are re-measured — was read as *the user leaving the tail*, and following paused.

The toolbar-toggle path never showed it because it asserts inside the freshly armed 1s grace.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change. Three source files, one behavioural invariant.

Two complementary changes in `useLogAutoFollow.ts`:

1. **Extract `beginFollowingFromTail()`** and call it from *both* resume paths (`resumeFollowingTail` and the resume arm of `applyUserScrollIntent`), so the two cannot drift apart again — that drift is the bug.
2. **Gate the pause on direction.** New `movedTowardsTail` fact in `readScrollFacts`: a view that travelled *towards* the tail and stopped short of it is the viewer landing approximately, not the user leaving. Nobody scrolls down in order to abandon the tail.

`movedTowardsTail` is deliberately **positive evidence of direction** rather than `!movedAwayFromTail`. A first report has no previous offset to compare against, so it is neither — which preserves the existing "log opens already scrolled up ⇒ don't follow" behaviour. My first attempt used the negation and regressed three existing tests; those tests are what caught it.

Rejected alternative: arming the grace on the scroll-resume path *only* (change 1 without change 2). That fixes the reported failure but leaves a residual race — once the 1s grace lapses, a quiet stream is exposed to the same misread. Change 2 is the load-bearing one; change 1 makes the two paths consistent.

#
### Tests:

#### Use cases covered

- A user reading back through a live log scrolls down to the tail by hand; the log keeps following as new lines arrive, instead of pausing itself.
- The toolbar toggle's resume behaves identically to a hand-made resume (same grace, same catch-up).
- A native scrollbar drag — no wheel, no key, no pointer event — still takes the log back from a hand-made resume, so the fix is not over-applied.
- A log that opens already scrolled away from the tail still does not follow (first-report behaviour unchanged).

#### Unit tests

- [x] I added unit tests for the changed logic.
- Files updated: `openmetadata-ui/src/main/resources/ui/src/components/common/LogViewerModal/LogViewerModal.test.tsx` (3 new cases in the `— auto-follow` describe)
- **2 of the 3 new tests fail on `main`** — verified by stashing the source changes and re-running; they reproduce both defect paths deterministically. The third is a regression guard for the over-application described above.
- Coverage (`yarn test src/components/common/LogViewerModal --coverage`): **`useLogAutoFollow.ts` 98.27% lines / 93.75% branch, `LogViewerModal.utils.tsx` 100% lines**, 97.87% lines across the directory. 78/78 tests pass.

#### Backend integration tests

- [x] Not applicable (no backend changes).

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Covered by the existing spec — it is what caught this.
- Files updated: `openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AgentLogStreamHandover.spec.ts`

The `:327` test (`Scrolling a live log pauses auto-follow and the toolbar toggle resumes it`) already asserts the exact failing step. The only change there is `test.slow()`: the test contains four `expect.poll` calls with `timeout: 60_000` against the global 60s budget, and it ran **56.6s / 54.9s / 4.3s** across three identical local runs. That 13× swing against a 60s ceiling is why CI attempt 2 died with `Test timeout of 60000ms exceeded` instead of reporting the real assertion failure.

#### Manual testing performed

Ran against a local dev server on a free port (`yarn start --port 3055 --strictPort`, `PLAYWRIGHT_TEST_BASE_URL=http://localhost:3055`) with a real backend on :8585 — not the prebuilt bundle.

1. `AgentLogStreamHandover.spec.ts:327` with `--repeat-each=5 --workers=1` → **5/5 passed** (a single green run proves nothing for a race).
2. Full `AgentLogStreamHandover.spec.ts` with `--repeat-each=3` → **12 passed**.
3. `playwright/e2e/Pages/IngestionLogStreamLive.spec.ts` → **passed (33.1s)**. This is the important one: it drives the same hook against a **real SSE stream from a real Airflow run**, not the mocked one. Required starting the `openmetadata_ingestion` container, without which it fails at `Deploying pipeline <id> failed with 400` before touching any UI.
4. `npx tsc --noEmit` → no errors in the touched files.
5. `make ui-checkstyle-changed` → 0 errors.

#### Unrelated flake fixed in passing

`playwright/e2e/Pages/IngestionLogStreamLive.spec.ts` failed then passed on retry in this PR's own CI run ([32255074087](https://github.com/open-metadata/OpenMetadata/actions/runs/32255074087)). It predates this PR (added in #31324) and is untouched by the product change here — it asserts line **count**, which auto-follow does not affect — but it was worth fixing while in the area.

Its `Log content keeps growing without a reload` step budgeted 30s for the next batch of lines, assuming a live run writes at a steady rate. It does not. From the failing run's page snapshot:

- burst of 21 log lines across `13:32:19.15` → `13:32:21.83` (2.7s)
- **29.8s of complete silence**
- next burst at `13:32:51.62`

The 30s budget expired **0.2s** before the next burst landed. The gap is the connector's own startup — between the connection test and the first topic being ingested, the Kafka consumer joins its group and blocks on an empty poll, logging nothing. The budget was calibrated directly on top of the gap it had to clear, so which side it fell on was a coin flip.

Widened to 90s. The test already carries `test.slow()` (180s) and ran in 33s, so there is ample headroom, and a stream that connects but delivers nothing still fails — a healthy run does not go silent for 90s.

#
### UI screen recording / screenshots:

Not applicable — no visual change. The rendered output is identical; only *when* the `Live auto-scroll` toggle flips changes. The behaviour is asserted through `aria-pressed` in both the Jest and Playwright tests above, which is a tighter check than a recording would be.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: N/A — no schema changes.
- [x] For UI changes: no visual change, see above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR aligns both live-log auto-follow resume paths and uses scroll direction to avoid mistaking the viewer’s catch-up movement for user intent.
- Extracts shared resume-state initialization for toolbar and manual resumes.
- Adds directional scroll facts and preserves auto-follow for movement toward the tail.
- Adds regression coverage and increases timing allowances for long-running Playwright scenarios.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/common/LogViewerModal/useLogAutoFollow.ts | Unifies resume initialization and prevents toward-tail catch-up movement from disabling auto-follow. |
| openmetadata-ui/src/main/resources/ui/src/components/common/LogViewerModal/LogViewerModal.utils.tsx | Adds directional classification for scroll movement while preserving first-report behavior. |
| openmetadata-ui/src/main/resources/ui/src/components/common/LogViewerModal/LogViewerModal.test.tsx | Covers manual resume persistence, equivalent catch-up grace, and gestureless scrollbar takeover. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AgentLogStreamHandover.spec.ts | Extends the existing multi-stage live-stream test budget with test.slow(). |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/IngestionLogStreamLive.spec.ts | Expands the live-line polling timeout to accommodate legitimate quiet ingestion phases. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Stop IngestionLogStreamLive racing the c..."](https://github.com/open-metadata/openmetadata/commit/cf80e02ef417463b1de8ec0f5b53484943784170) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54748663)</sub>

<!-- /greptile_comment -->