### PR TITLE
test(ui): fix Activity Feed widget filter clicks landing on the wrong dropdown option

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/PLAYWRIGHT_DEVELOPER_HANDBOOK.md
+++ b/openmetadata-ui/src/main/resources/ui/playwright/PLAYWRIGHT_DEVELOPER_HANDBOOK.md
@@ -374,6 +374,42 @@ await expect(page.locator(".ant-select-dropdown:visible")).not.toBeVisible();
 
 **Why**: Stored `:visible` locators become stale when re-queried. Always chain them inline!
 
+### ⚠️ CRITICAL: Clicking an Ant Design Dropdown Menu Item
+
+**A click on the item you located can select the item above it.**
+
+Ant Design animates a dropdown open with `transform: scaleY(0.8) -> scaleY(1)` around
+`transform-origin: 0 0`, and rc-motion applies the start class one frame before the `-active`
+class that begins the transition. Playwright's actionability check ("bounding box unchanged
+across two consecutive animation frames") can be satisfied on those pre-transition frames, so
+the click point is computed against the 0.8-scaled menu. Once the menu finishes growing, that
+point has slid onto the previous item. Under CI worker contention this happens often.
+
+```typescript
+// ❌ WRONG - clicks while the menu is still scaling open
+await trigger.click();
+const response = page.waitForResponse("/api/v1/activity/following");
+await page.getByRole("menuitem", { name: "Following" }).click();
+await response; // may hang forever - "My Data" was selected and my-feed was fetched
+
+// ✅ CORRECT - wait for the popup to settle, then assert the selection took
+await trigger.click();
+const menuItem = page.getByRole("menuitem", { name: "Following" });
+await expect(menuItem).toBeVisible();
+await waitForAntdPopupToSettle(page); // from playwright/utils/common.ts
+const response = page.waitForResponse("/api/v1/activity/following");
+await menuItem.click();
+await expect(trigger).toContainText("Following"); // fails fast if the click drifted
+await response;
+```
+
+**Always assert the post-click state** (trigger label, `ant-*-item-selected`, rendered content)
+before awaiting a response. A `waitForResponse` whose predicate can never match does not fail —
+it hangs until the test timeout and then reports `Target page, context or browser has been
+closed`, which points nowhere near the real cause.
+
+`playwright/utils/widgetFilters.ts` (`selectWidgetSortOption`) is the reference implementation.
+
 ### Modal and Scrollable Container Patterns
 
 ```typescript

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -395,6 +395,29 @@ export const clickOutside = async (page: Page) => {
   });
 };
 
+/**
+ * Blocks until every open Ant Design overlay has finished its enter animation.
+ *
+ * Ant Design animates a dropdown open with `transform: scaleY(0.8) -> scaleY(1)`
+ * around `transform-origin: 0 0`, and rc-motion applies the start class one frame
+ * before the `-active` class that begins the transition. Playwright's actionability
+ * check ("bounding box unchanged across two consecutive animation frames") can be
+ * satisfied on those pre-transition frames, so the click point gets computed against
+ * the 0.8-scaled menu. Once the menu finishes growing, that point has slid onto the
+ * item above the intended one — the click silently selects the wrong option.
+ *
+ * rc-motion strips the `-appear`/`-enter` classes on `animationend`, so their absence
+ * is the signal that the popup geometry is final.
+ */
+export const waitForAntdPopupToSettle = async (page: Page) => {
+  await expect(
+    page.locator(
+      '.ant-dropdown:not(.ant-dropdown-hidden)[class*="-appear"], ' +
+        '.ant-dropdown:not(.ant-dropdown-hidden)[class*="-enter"]'
+    )
+  ).toHaveCount(0);
+};
+
 export const searchFromSearchInput = async (
   page: Page,
   searchInput: Locator,

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/widgetFilters.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/widgetFilters.ts
@@ -10,9 +10,17 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, type Locator, type Page } from '@playwright/test';
+import {
+  expect,
+  type Locator,
+  type Page,
+  type Response,
+} from '@playwright/test';
+import { waitForAntdPopupToSettle } from './common';
 import { waitForLandingPageWidget } from './customizeLandingPage';
 import { waitForAllLoadersToDisappear } from './entity';
+
+type ResponseMatcher = (response: Response) => boolean;
 
 const getWidgetForFilters = async (
   page: Page,
@@ -27,6 +35,62 @@ const getWidgetForFilters = async (
   await expect(widget.getByTestId('widget-sort-by-dropdown')).toBeVisible();
 
   return widget;
+};
+
+const searchQueryMatcher =
+  (index: string, sortField: string, sortOrder: string): ResponseMatcher =>
+  (response) =>
+    response.url().includes('/api/v1/search/query') &&
+    response.url().includes(`index=${index}`) &&
+    response.url().includes(`sort_field=${sortField}`) &&
+    response.url().includes(`sort_order=${sortOrder}`);
+
+/**
+ * Opens a widget's sort/filter dropdown, picks an option, and returns the response
+ * the option was expected to trigger.
+ *
+ * Two guards make this reliable, and both are load bearing:
+ *
+ * 1. `waitForAntdPopupToSettle` — without it the click can land on the option *above*
+ *    the intended one while the menu is still scaling open, silently selecting the
+ *    wrong filter.
+ * 2. The trigger-label assertion — if a click still drifts, this fails immediately
+ *    with "expected Following, received My Data" instead of leaving the caller blocked
+ *    on a response that can never arrive.
+ *
+ * The response listener is registered after the menu has settled but before the click,
+ * so a request fired synchronously by the selection cannot be missed.
+ */
+const selectWidgetSortOption = async (
+  page: Page,
+  widget: Locator,
+  optionName: string,
+  responseMatcher: ResponseMatcher
+): Promise<Response> => {
+  const trigger = widget.getByTestId('widget-sort-by-dropdown');
+  const menuItem = page.getByRole('menuitem', { name: optionName });
+
+  await trigger.click();
+  await expect(menuItem).toBeVisible();
+  await waitForAntdPopupToSettle(page);
+
+  const filterResponse = page.waitForResponse(responseMatcher);
+  // Nothing resolves this promise if the selection assertion below fails. Marking it
+  // handled keeps its teardown rejection out of the report so the reported failure
+  // stays the real one; the `await` further down still surfaces a genuine timeout.
+  filterResponse.catch(() => undefined);
+
+  await menuItem.click();
+
+  await expect(trigger).toContainText(optionName);
+
+  const response = await filterResponse;
+
+  await widget.getByTestId('entity-list-skeleton').waitFor({
+    state: 'detached',
+  });
+
+  return response;
 };
 
 /**
@@ -44,23 +108,16 @@ export const selectActivityFeedFilterAndVerifyEndpoint = async (
   filterName: string,
   expectedPath: string
 ) => {
-  await widget.getByTestId('widget-sort-by-dropdown').click();
-
-  const activityResponse = page.waitForResponse(
-    (response) =>
-      response.request().method() === 'GET' &&
-      new URL(response.url()).pathname === expectedPath
+  const response = await selectWidgetSortOption(
+    page,
+    widget,
+    filterName,
+    (candidate) =>
+      candidate.request().method() === 'GET' &&
+      new URL(candidate.url()).pathname === expectedPath
   );
 
-  await page.getByRole('menuitem', { name: filterName }).click();
-
-  const response = await activityResponse;
-
   expect(response.status()).toBe(200);
-
-  await widget.getByTestId('entity-list-skeleton').waitFor({
-    state: 'detached',
-  });
 };
 
 export const verifyActivityFeedFilters = async (
@@ -101,47 +158,26 @@ export const verifyDataFilters = async (
 ) => {
   const widget = await getWidgetForFilters(page, widgetKey);
 
-  await widget.getByTestId('widget-sort-by-dropdown').click();
-  const aToZFilter = page.waitForResponse(
-    (response) =>
-      response.url().includes('/api/v1/search/query') &&
-      response.url().includes(`index=${searchIndex}`) &&
-      response.url().includes('sort_field=name.keyword') &&
-      response.url().includes('sort_order=asc')
+  await selectWidgetSortOption(
+    page,
+    widget,
+    'A to Z',
+    searchQueryMatcher(searchIndex, 'name.keyword', 'asc')
   );
-  await page.getByRole('menuitem', { name: 'A to Z' }).click();
-  await aToZFilter;
-  await widget.getByTestId('entity-list-skeleton').waitFor({
-    state: 'detached',
-  });
 
-  await widget.getByTestId('widget-sort-by-dropdown').click();
-  const zToAFilter = page.waitForResponse(
-    (response) =>
-      response.url().includes('/api/v1/search/query') &&
-      response.url().includes(`index=${searchIndex}`) &&
-      response.url().includes('sort_field=name.keyword') &&
-      response.url().includes('sort_order=desc')
+  await selectWidgetSortOption(
+    page,
+    widget,
+    'Z to A',
+    searchQueryMatcher(searchIndex, 'name.keyword', 'desc')
   );
-  await page.getByRole('menuitem', { name: 'Z to A' }).click();
-  await zToAFilter;
-  await widget.getByTestId('entity-list-skeleton').waitFor({
-    state: 'detached',
-  });
 
-  await widget.getByTestId('widget-sort-by-dropdown').click();
-  const latestFilter = page.waitForResponse(
-    (response) =>
-      response.url().includes('/api/v1/search/query') &&
-      response.url().includes(`index=${searchIndex}`) &&
-      response.url().includes('sort_field=updatedAt') &&
-      response.url().includes('sort_order=desc')
+  await selectWidgetSortOption(
+    page,
+    widget,
+    'Latest',
+    searchQueryMatcher(searchIndex, 'updatedAt', 'desc')
   );
-  await page.getByRole('menuitem', { name: 'Latest' }).click();
-  await latestFilter;
-  await widget.getByTestId('entity-list-skeleton').waitFor({
-    state: 'detached',
-  });
 };
 
 export const verifyTotalDataAssetsFilters = async (
@@ -150,39 +186,28 @@ export const verifyTotalDataAssetsFilters = async (
 ) => {
   const widget = await getWidgetForFilters(page, widgetKey);
 
-  await widget.getByTestId('widget-sort-by-dropdown').click();
-  const last14DaysFilter = page.waitForResponse(
-    (response) =>
-      response
-        .url()
-        .includes(
-          '/api/v1/analytics/dataInsights/system/charts/name/total_data_assets/data'
-        ) &&
-      response.url().includes('start=') &&
-      response.url().includes('end=')
-  );
-  await page.getByRole('menuitem', { name: 'Last 14 days' }).click();
-  await last14DaysFilter;
-  await widget.getByTestId('entity-list-skeleton').waitFor({
-    state: 'detached',
-  });
+  const totalDataAssetsMatcher: ResponseMatcher = (response) =>
+    response
+      .url()
+      .includes(
+        '/api/v1/analytics/dataInsights/system/charts/name/total_data_assets/data'
+      ) &&
+    response.url().includes('start=') &&
+    response.url().includes('end=');
 
-  await widget.getByTestId('widget-sort-by-dropdown').click();
-  const last7DaysFilter = page.waitForResponse(
-    (response) =>
-      response
-        .url()
-        .includes(
-          '/api/v1/analytics/dataInsights/system/charts/name/total_data_assets/data'
-        ) &&
-      response.url().includes('start=') &&
-      response.url().includes('end=')
+  await selectWidgetSortOption(
+    page,
+    widget,
+    'Last 14 days',
+    totalDataAssetsMatcher
   );
-  await page.getByRole('menuitem', { name: 'Last 7 days' }).click();
-  await last7DaysFilter;
-  await widget.getByTestId('entity-list-skeleton').waitFor({
-    state: 'detached',
-  });
+
+  await selectWidgetSortOption(
+    page,
+    widget,
+    'Last 7 days',
+    totalDataAssetsMatcher
+  );
 };
 
 export const verifyDataProductsFilters = async (
@@ -191,100 +216,57 @@ export const verifyDataProductsFilters = async (
 ) => {
   const widget = await getWidgetForFilters(page, widgetKey);
 
-  const sortDropdown = widget.getByTestId('widget-sort-by-dropdown');
-
-  await sortDropdown.click();
-  const aToZFilter = page.waitForResponse(
-    (response) =>
-      response.url().includes('/api/v1/search/query') &&
-      response.url().includes('index=dataProduct') &&
-      response.url().includes('sort_field=name.keyword') &&
-      response.url().includes('sort_order=asc')
+  await selectWidgetSortOption(
+    page,
+    widget,
+    'A to Z',
+    searchQueryMatcher('dataProduct', 'name.keyword', 'asc')
   );
-  await page.getByRole('menuitem', { name: 'A to Z' }).click();
-  await aToZFilter;
-  await widget.getByTestId('entity-list-skeleton').waitFor({
-    state: 'detached',
-  });
 
-  await sortDropdown.click();
-  const zToAFilter = page.waitForResponse(
-    (response) =>
-      response.url().includes('/api/v1/search/query') &&
-      response.url().includes('index=dataProduct') &&
-      response.url().includes('sort_field=name.keyword') &&
-      response.url().includes('sort_order=desc')
+  await selectWidgetSortOption(
+    page,
+    widget,
+    'Z to A',
+    searchQueryMatcher('dataProduct', 'name.keyword', 'desc')
   );
-  await page.getByRole('menuitem', { name: 'Z to A' }).click();
-  await zToAFilter;
-  await widget.getByTestId('entity-list-skeleton').waitFor({
-    state: 'detached',
-  });
 
-  await sortDropdown.click();
-  const latestFilter = page.waitForResponse(
-    (response) =>
-      response.url().includes('/api/v1/search/query') &&
-      response.url().includes('index=dataProduct') &&
-      response.url().includes('sort_field=updatedAt') &&
-      response.url().includes('sort_order=desc')
+  await selectWidgetSortOption(
+    page,
+    widget,
+    'Latest',
+    searchQueryMatcher('dataProduct', 'updatedAt', 'desc')
   );
-  await page.getByRole('menuitem', { name: 'Latest' }).click();
-  await latestFilter;
-  await widget.getByTestId('entity-list-skeleton').waitFor({
-    state: 'detached',
-  });
 };
 
 export const verifyDomainsFilters = async (page: Page, widgetKey: string) => {
   const widget = await getWidgetForFilters(page, widgetKey);
 
-  await widget.getByTestId('widget-sort-by-dropdown').click();
-  const aToZFilter = page.waitForResponse(
-    (response) =>
-      response.url().includes('/api/v1/search/query') &&
-      response.url().includes('index=domain') &&
-      response.url().includes('sort_field=name.keyword') &&
-      response.url().includes('sort_order=asc')
+  await selectWidgetSortOption(
+    page,
+    widget,
+    'A to Z',
+    searchQueryMatcher('domain', 'name.keyword', 'asc')
   );
-  await page.getByRole('menuitem', { name: 'A to Z' }).click();
-  await aToZFilter;
-  await widget.getByTestId('entity-list-skeleton').waitFor({
-    state: 'detached',
-  });
 
-  await widget.getByTestId('widget-sort-by-dropdown').click();
-  const zToAFilter = page.waitForResponse(
-    (response) =>
-      response.url().includes('/api/v1/search/query') &&
-      response.url().includes('index=domain') &&
-      response.url().includes('sort_field=name.keyword') &&
-      response.url().includes('sort_order=desc')
+  await selectWidgetSortOption(
+    page,
+    widget,
+    'Z to A',
+    searchQueryMatcher('domain', 'name.keyword', 'desc')
   );
-  await page.getByRole('menuitem', { name: 'Z to A' }).click();
-  await zToAFilter;
-  await widget.getByTestId('entity-list-skeleton').waitFor({
-    state: 'detached',
-  });
 
-  await widget.getByTestId('widget-sort-by-dropdown').click();
-  const latestFilter = page.waitForResponse(
-    (response) =>
-      response.url().includes('/api/v1/search/query') &&
-      response.url().includes('index=domain') &&
-      response.url().includes('sort_field=updatedAt') &&
-      response.url().includes('sort_order=desc')
+  await selectWidgetSortOption(
+    page,
+    widget,
+    'Latest',
+    searchQueryMatcher('domain', 'updatedAt', 'desc')
   );
-  await page.getByRole('menuitem', { name: 'Latest' }).click();
-  await latestFilter;
-  await widget.getByTestId('entity-list-skeleton').waitFor({
-    state: 'detached',
-  });
 };
 
 export const verifyTaskFilters = async (page: Page, widgetKey: string) => {
-  const waitForTaskFilterResponse = (filterType: string) =>
-    page.waitForResponse((response) => {
+  const taskFilterMatcher =
+    (filterType: string): ResponseMatcher =>
+    (response) => {
       const url = response.url();
 
       return (
@@ -293,35 +275,32 @@ export const verifyTaskFilters = async (page: Page, widgetKey: string) => {
           url.includes('type=Task') &&
           url.includes(`filterType=${filterType}`))
       );
-    });
+    };
 
   const widget = await getWidgetForFilters(page, widgetKey);
 
   await expect(widget.getByTestId('task-feed-card').first()).toBeVisible();
 
-  await widget.getByTestId('widget-sort-by-dropdown').click();
-  const mentionsTaskFilter = waitForTaskFilterResponse('MENTIONS');
-  await page.getByRole('menuitem', { name: 'Mentions' }).click();
-  await mentionsTaskFilter;
-  await widget.getByTestId('entity-list-skeleton').waitFor({
-    state: 'detached',
-  });
+  await selectWidgetSortOption(
+    page,
+    widget,
+    'Mentions',
+    taskFilterMatcher('MENTIONS')
+  );
 
-  await widget.getByTestId('widget-sort-by-dropdown').click();
-  const assignedTasksFilter = waitForTaskFilterResponse('ASSIGNED_TO');
-  await page.getByRole('menuitem', { name: 'Assigned' }).click();
-  await assignedTasksFilter;
-  await widget.getByTestId('entity-list-skeleton').waitFor({
-    state: 'detached',
-  });
+  await selectWidgetSortOption(
+    page,
+    widget,
+    'Assigned',
+    taskFilterMatcher('ASSIGNED_TO')
+  );
 
-  await widget.getByTestId('widget-sort-by-dropdown').click();
-  const allTasksFilter = waitForTaskFilterResponse('OWNER_OR_FOLLOWS');
-  await page.getByRole('menuitem', { name: 'All' }).click();
-  await allTasksFilter;
-  await widget.getByTestId('entity-list-skeleton').waitFor({
-    state: 'detached',
-  });
+  await selectWidgetSortOption(
+    page,
+    widget,
+    'All',
+    taskFilterMatcher('OWNER_OR_FOLLOWS')
+  );
 };
 
 export const verifyDataAssetsFilters = async (
@@ -330,58 +309,12 @@ export const verifyDataAssetsFilters = async (
 ) => {
   const widget = await getWidgetForFilters(page, widgetKey);
 
-  const sortDropdown = widget.getByTestId('widget-sort-by-dropdown');
+  const tableSearchMatcher: ResponseMatcher = (response) =>
+    response.url().includes('/api/v1/search/query') &&
+    response.url().includes('index=table');
 
-  // Test A to Z sorting
-  await sortDropdown.click();
-  const aToZFilter = page.waitForResponse(
-    (response) =>
-      response.url().includes('/api/v1/search/query') &&
-      response.url().includes('index=table')
-  );
-  await page.getByRole('menuitem', { name: 'A to Z' }).click();
-  await aToZFilter;
-  await widget.getByTestId('entity-list-skeleton').waitFor({
-    state: 'detached',
-  });
-
-  // Test Z to A sorting
-  await sortDropdown.click();
-  const zToAFilter = page.waitForResponse(
-    (response) =>
-      response.url().includes('/api/v1/search/query') &&
-      response.url().includes('index=table')
-  );
-  await page.getByRole('menuitem', { name: 'Z to A' }).click();
-  await zToAFilter;
-  await widget.getByTestId('entity-list-skeleton').waitFor({
-    state: 'detached',
-  });
-
-  // Test High to Low sorting
-  await sortDropdown.click();
-  const highToLowFilter = page.waitForResponse(
-    (response) =>
-      response.url().includes('/api/v1/search/query') &&
-      response.url().includes('index=table')
-  );
-  await page.getByRole('menuitem', { name: 'High to Low' }).click();
-  await highToLowFilter;
-  await widget.getByTestId('entity-list-skeleton').waitFor({
-    state: 'detached',
-  });
-
-  // Test Low to High sorting
-  await sortDropdown.click();
-  const lowToHighFilter = page.waitForResponse(
-    (response) =>
-      response.url().includes('/api/v1/search/query') &&
-      response.url().includes('index=table')
-  );
-  await page.getByRole('menuitem', { name: 'Low to High' }).click();
-  await lowToHighFilter;
-
-  await widget.getByTestId('entity-list-skeleton').waitFor({
-    state: 'detached',
-  });
+  await selectWidgetSortOption(page, widget, 'A to Z', tableSearchMatcher);
+  await selectWidgetSortOption(page, widget, 'Z to A', tableSearchMatcher);
+  await selectWidgetSortOption(page, widget, 'High to Low', tableSearchMatcher);
+  await selectWidgetSortOption(page, widget, 'Low to High', tableSearchMatcher);
 };


### PR DESCRIPTION
### Describe your changes:

<!-- No linked issue yet — this came out of an RCA on a nightly Playwright failure. -->

`ActivityAPI.spec.ts` › **"shows the followed entity activity under the Following filter"** failed
**both** attempts of the nightly run on `c6f7297a` ([run 32244089433](https://github.com/open-metadata/OpenMetadata/actions/runs/32244089433)) with:

```
Test timeout of 180000ms exceeded.
Error: page.waitForResponse: Target page, context or browser has been closed
    at playwright/utils/widgetFilters.ts:49:33  (selectActivityFeedFilterAndVerifyEndpoint)
    at playwright/e2e/Features/ActivityAPI.spec.ts:391:7
```

**The click intended for "Following" selected "My Data".** Ant Design animates a dropdown open with
`transform: scaleY(0.8) -> scaleY(1)` around `transform-origin: 0 0`, and rc-motion applies the start
class one frame *before* the `-active` class that begins the transition. Playwright's actionability
check — "bounding box unchanged across two consecutive animation frames" — can be satisfied on those
pre-transition frames, so the click point is computed against the **0.8-scaled** menu. By the time the
click dispatches the menu has grown, and that point has slid onto the item *above* the intended one.

Evidence from the trace:

| Signal | Value |
|---|---|
| Locator resolved | `<li role="menuitem" value="FOLLOWS" data-menu-id="rc-menu-uuid-13028-3-FOLLOWS">` |
| Popup class at the click (`input@call@92`) | `ant-slide-up-appear ant-slide-up-appear-active` — still animating |
| Preceding ~130 ms | stuck in `ant-slide-up-appear-prepare`, no `-placement-` class (not yet positioned) |
| After the click | `ant-dropdown-menu-item-selected` on `value="OWNER"`; trigger label reads `My Data` |
| Network | only `GET /api/v1/activity/my-feed` (200). `/api/v1/activity/following` never requested |

So `page.waitForResponse` was waiting on `pathname === '/api/v1/activity/following'`, a predicate that
could never match. It hung to the 180 s test timeout and then reported the misleading
`Target page, context or browser has been closed` — pointing nowhere near the real cause.

Measured against a live stack with the popup held in its pre-transition state, the drift is exact:

| | y span (settled) |
|---|---|
| All Activity | 356.56 – 398.56 |
| **My Data** | **398.56 – 440.56** |
| Following | 440.56 – 482.56 |

Following's pre-settle centre is **y = 438.16** → **inside "My Data", 2.4 px above the boundary.**
That razor-thin margin is why this passes most of the time and why the 94-worker nightly (`actualWorkers: 94`)
is where it surfaces: CPU starvation widens the gap between rc-motion's start-class frame and its
`-active` frame, so Playwright's two-frame stability window slips through.

**The widget is correct.** The sibling test `routes each Activity Feed widget filter to its own endpoint`
passed on the same commit — it just happens to click "My Data" first, where the same drift would land on
"All Activity" and simply didn't fire. No product code is touched by this PR.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

**1. `waitForAntdPopupToSettle(page)` — new export in `playwright/utils/common.ts`**

Blocks until no visible `.ant-dropdown` carries an `-appear`/`-enter` class. rc-motion strips those on
`animationend`, so their absence is the signal that the popup geometry is final. The selector deliberately
matches both phases (`-appear-prepare` and `-appear-active`), because the CI failure spent most of its
time in *prepare* — mounted and hit-testable, but not yet positioned.

**2. One `selectWidgetSortOption` helper in `playwright/utils/widgetFilters.ts`**

All eight widget-filter helpers previously repeated the same four-step block: click trigger →
`page.waitForResponse(...)` → click menu item → wait for skeleton detach. They now route through one helper:

```ts
await trigger.click();
await expect(menuItem).toBeVisible();
await waitForAntdPopupToSettle(page);          // (1) removes the root cause

const filterResponse = page.waitForResponse(responseMatcher);
await menuItem.click();

await expect(trigger).toContainText(optionName); // (2) diagnostic backstop
const response = await filterResponse;
```

Guard (2) is what turns this failure mode from a 180 s hang into a fast, readable failure —
"expected Following, received My Data" — instead of blocking on a response that can never arrive. It is
the same pattern `common.ts` already uses after the page-size menu (`toHaveText('25 / Page')`).

The repeated URL predicates also collapse into matcher factories (`searchQueryMatcher(index, sortField, sortOrder)`),
which is where most of the −232 lines come from. Net: **397 → 224 lines.**

**Alternatives rejected**

- *Add an explicit `timeout` to `waitForResponse`* — makes the symptom fail faster but leaves the wrong
  option genuinely selected, and per review direction this PR uses default timeouts only.
- *Set `actionTimeout` in `playwright.config.ts`* — the config sets `navigationTimeout` and
  `expect.timeout` but not `actionTimeout`, so every action in the suite is unbounded (`"timeout": "0"`
  in the trace). Worth fixing, but it is a suite-wide behaviour change that needs its own PR and a
  nightly run to measure. Deliberately **not** included here.
- *`expect(...).toPass()` retry around the click* — an unbounded `toPass` reintroduces the same silent
  hang, and a bounded one needs the explicit timeout we are not adding.

**Rollout / compat:** test-only. No product code, no schema, no migration. All 12 existing call sites
(`ActivityAPI.spec.ts` ×4, `ActivityFeed.spec.ts` ×7, `CustomizeWidgets.spec.ts` via
`verifyActivityFeedFilters`) keep their signatures and gain an assertion they did not have.

#
### Tests:

#### Use cases covered
- Selecting **All Activity / My Data / Following** in the home Activity Feed widget each calls its own
  endpoint (`/api/v1/activity`, `/api/v1/activity/my-feed`, `/api/v1/activity/following`) — and the
  widget's trigger label now proves the intended option was actually selected.
- The same guarantee for every other widget sort dropdown: My Data, Following Assets, Domains,
  Data Products, Total Data Assets, My Tasks.
- A click issued while the dropdown is still animating no longer silently selects a neighbouring option.

#### Unit tests
- [x] Not applicable — test-infrastructure change; no product classes or components are modified, so
  there is no changed-class coverage to report (`jacoco` / `yarn test:coverage` have nothing to measure).

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Files updated:
  - `playwright/utils/common.ts` — added `waitForAntdPopupToSettle`
  - `playwright/utils/widgetFilters.ts` — added `selectWidgetSortOption` + matcher factories; all 8
    helpers routed through it
  - `playwright/PLAYWRIGHT_DEVELOPER_HANDBOOK.md` — new "Clicking an Ant Design Dropdown Menu Item"
    entry under Anti-Flakiness Patterns

No new spec file — the 12 existing call sites are the coverage, and they now assert the selection took
effect. Results, run against a Vite dev server (`PLAYWRIGHT_TEST_BASE_URL`) with a real backend:

| Run | Result |
|---|---|
| `ActivityAPI.spec.ts` | **8/8 passed** — the failing test now **2.2 s** (was 180 s × 2) |
| `ActivityAPI.spec.ts --repeat-each=5` (widget tests) | **20/20 passed** |
| `ActivityFeed.spec.ts` (5 tests, 7 helper call sites) | **5/5 passed** |
| `CustomizeWidgets.spec.ts` — 7 widgets, `--workers=1` | **7/7 passed** |
| `CustomizeWidgets.spec.ts` — `My Tasks Widget` w/ full `entity-data-setup` | **passed** (covers `verifyTaskFilters`) |
| `make ui-checkstyle-changed` | exit 0, no net changes to the changed files |
| `tsc -p playwright/tsconfig.json` | 164 errors, all pre-existing (identical on a reverted-code baseline); none in the changed files |

#### Manual testing performed
1. Started a Vite dev server from this branch and pointed Playwright at it
   (`PLAYWRIGHT_TEST_BASE_URL=http://localhost:3010`) against a local `:8585` backend, so the tests run
   this branch's code rather than a prebuilt bundle.
2. **Reproduced the failure deterministically.** With a throwaway spec that holds the popup in its
   pre-transition state (`.ant-slide-up-appear-active { animation-delay: 800ms; animation-fill-mode: both }`),
   clicked the *stale* pre-settle coordinates via `page.mouse.click(x, y)` after the menu settled:
   the trigger read **"My Data"** and `GET /api/v1/activity/my-feed` returned 200 — exactly the CI failure.
3. **Confirmed the fix under the same stall.** `selectActivityFeedFilterAndVerifyEndpoint(page, widget,
   'Following', '/api/v1/activity/following')` passed with the enter animation stalled.
4. Captured the geometry numbers in the RCA above by logging `boundingBox()` before and after
   `waitForAntdPopupToSettle`.
5. Ran the suites in the table above; the scratch spec was deleted and is not part of this PR.
6. **Ruled out collateral damage.** Two `CustomizeWidgets.spec.ts` failures I hit mid-verification were
   reproduced on a **reverted-code control run**, so they are pre-existing and unrelated: those tests each
   mutate the *same* persona's landing-page layout, so a parallel `-g` subset corrupts itself (the failing
   widget moves between runs). `My Tasks Widget` additionally needs `entity-data-setup`, which
   `PW_PRESEEDED_STATE=true` skips. Both pass serially / with the setup project, as shown above.

#
### UI screen recording / screenshots:

Not applicable — no product code or UI is changed; this PR only touches Playwright test utilities and
the testing handbook.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` — no issue is linked yet (see note below).
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above — **not yet linked**; the
      PR Metadata Validation check will flag this until an issue number is added.
- [x] I have commented on my code, particularly in hard-to-understand areas — the animation race and the
      reason each guard exists are documented on `waitForAntdPopupToSettle` and `selectWidgetSortOption`.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable (no UI change).
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

Bug fix
- [x] I have added a test that covers the exact scenario we are fixing — rather than a new spec, the
      existing 12 call sites now assert the post-click selection, which is the assertion whose absence
      let this fail silently for 180 s. The deterministic repro is described in Manual testing step 2.

#### Notes for the reviewer
- `verifyDataAssetsFilters` in `widgetFilters.ts` has **no callers** — it is a dead export. I refactored
  it along with the rest rather than delete it, since removing a public helper is outside the scope of
  this fix. Happy to drop it in a follow-up (or here) if preferred.
- The unbounded `actionTimeout` described under "Alternatives rejected" is a real, separate gap worth its
  own issue: any never-matching `waitForResponse` predicate anywhere in the suite costs a full test
  timeout and reports a post-mortem error instead of the real one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This test-only PR hardens Activity Feed and other widget-filter interactions against Ant Design dropdown animation races.
- Adds a shared wait for visible dropdown enter animations to finish.
- Consolidates widget option selection, response matching, selected-label verification, and loading completion.
- Documents the required anti-flakiness pattern in the Playwright handbook.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code failure identified.

The refactor preserves the existing response predicates and helper interfaces while registering listeners before selection, waiting for the observed Ant Design motion lifecycle to finish, and verifying that the intended option became selected.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts | Adds a retrying Playwright assertion that waits for visible Ant Design dropdown enter or appear motion classes to disappear. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/widgetFilters.ts | Consolidates widget filter interactions into a shared animation-safe helper while preserving existing response predicates and public helper signatures. |
| openmetadata-ui/src/main/resources/ui/playwright/PLAYWRIGHT_DEVELOPER_HANDBOOK.md | Documents the dropdown click race, the shared settling helper, and post-click state verification. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Test as Playwright helper
  participant Menu as Ant Design dropdown
  participant Widget as Widget
  participant API as Backend API
  Test->>Menu: Open dropdown
  Test->>Menu: Wait until menu item is visible
  Test->>Menu: Wait for enter animation classes to clear
  Test->>Test: Register response listener
  Test->>Menu: Click intended option
  Menu->>Widget: Apply selected filter
  Widget->>API: Request filtered data
  Test->>Widget: Verify selected label
  API-->>Test: Matching response
  Test->>Widget: Wait for loading skeleton to detach
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): fix widget filter clicks landi..."](https://github.com/open-metadata/openmetadata/commit/529e31a43405a38f6df19b4bb9db036b492814f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54753232)</sub>

<!-- /greptile_comment -->