### PR TITLE
fix(ui): applied tag color styling on Data Product and Domain pages

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/TagChip/TagChip.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/TagChip/TagChip.test.tsx
@@ -17,20 +17,6 @@ jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-jest.mock('../../../../utils/IconUtils', () => ({
-  renderIcon: jest.fn(() => <span data-testid="tag-icon" />),
-}));
-
-jest.mock('@openmetadata/ui-core-components', () => ({
-  Box: ({ children, ...props }: Record<string, unknown>) => (
-    <div {...props}>{children as React.ReactNode}</div>
-  ),
-  Typography: ({ children, ...props }: Record<string, unknown>) => (
-    <span {...props}>{children as React.ReactNode}</span>
-  ),
-  ButtonUtility: (props: Record<string, unknown>) => <button {...props} />,
-}));
-
 describe('TagChip color styling', () => {
   it('tints the background and colors the label when tagColor is provided', () => {
     render(

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/TagChip/TagChip.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/TagChip/TagChip.test.tsx
@@ -1,0 +1,69 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+import TagChip from './TagChip';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('../../../../utils/IconUtils', () => ({
+  renderIcon: jest.fn(() => <span data-testid="tag-icon" />),
+}));
+
+jest.mock('@openmetadata/ui-core-components', () => ({
+  Box: ({ children, ...props }: Record<string, unknown>) => (
+    <div {...props}>{children as React.ReactNode}</div>
+  ),
+  Typography: ({ children, ...props }: Record<string, unknown>) => (
+    <span {...props}>{children as React.ReactNode}</span>
+  ),
+  ButtonUtility: (props: Record<string, unknown>) => <button {...props} />,
+}));
+
+describe('TagChip color styling', () => {
+  it('tints the background and colors the label when tagColor is provided', () => {
+    render(
+      <TagChip
+        data-testid="tags"
+        label="Confidential"
+        labelDataTestId="tag-color-test"
+        tagColor="#ff0000"
+      />
+    );
+
+    expect(screen.getByTestId('tags')).toHaveStyle(
+      'background-color: rgba(255, 0, 0, 0.05)'
+    );
+    expect(screen.getByTestId('tag-color-test')).toHaveStyle({
+      color: '#ff0000',
+    });
+  });
+
+  it('does not apply a tag color when tagColor is absent', () => {
+    render(
+      <TagChip
+        data-testid="tags"
+        label="Plain"
+        labelDataTestId="tag-plain-test"
+      />
+    );
+
+    expect(screen.getByTestId('tags')).not.toHaveStyle(
+      'background-color: rgba(255, 0, 0, 0.05)'
+    );
+    expect(screen.getByTestId('tag-plain-test')).not.toHaveStyle(
+      'color: rgb(255, 0, 0)'
+    );
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/TagChip/TagChip.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/TagChip/TagChip.tsx
@@ -20,6 +20,7 @@ import { Tag01, XClose } from '@untitledui/icons';
 import classNames from 'classnames';
 import { FC, KeyboardEvent, MouseEvent, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { reduceColorOpacity } from '../../../../utils/ColorUtils';
 import { renderIcon } from '../../../../utils/IconUtils';
 
 export interface TagChipProps {
@@ -121,7 +122,7 @@ const TagChip: FC<TagChipProps> = ({
         sizeStyles[size].root,
         variantStyles[variant],
         {
-          'tw:relative tw:pl-3': tagColor,
+          'tw:relative tw:overflow-hidden tw:pl-3': tagColor,
           'tw:cursor-not-allowed tw:opacity-50': disabled,
         },
         className
@@ -129,17 +130,30 @@ const TagChip: FC<TagChipProps> = ({
       data-tag-index={otherProps['data-tag-index']}
       data-testid={otherProps['data-testid']}
       role={onDelete ? 'button' : undefined}
-      style={{ maxWidth }}
+      style={{
+        maxWidth,
+        ...(tagColor
+          ? {
+              backgroundColor: reduceColorOpacity(tagColor, 0.05),
+              borderColor: reduceColorOpacity(tagColor, 0.2),
+            }
+          : {}),
+      }}
       tabIndex={tabIndex}
       onKeyDown={onDelete ? handleKeyDown : undefined}>
       {tagColor && (
         <span
-          className="tw:absolute tw:left-0 tw:top-1/2 tw:h-[70%] tw:w-0.75 tw:-translate-y-1/2 tw:rounded-[2px_0_0_2px]"
+          aria-hidden
+          className="tw:absolute tw:inset-y-0 tw:left-0 tw:w-1.5"
           style={{ backgroundColor: tagColor }}
         />
       )}
       {showIcon && chipIcon && (
-        <Box inline align="center" className="tw:mr-1 tw:shrink-0">
+        <Box
+          inline
+          align="center"
+          className="tw:mr-1 tw:shrink-0"
+          style={tagColor ? { color: tagColor } : undefined}>
           {chipIcon}
         </Box>
       )}
@@ -148,6 +162,7 @@ const TagChip: FC<TagChipProps> = ({
         data-testid={labelDataTestId}
         ellipsis={showEllipsis}
         size={sizeStyles[size].typography}
+        style={tagColor ? { color: tagColor } : undefined}
         weight={variant === 'blueGray' ? 'regular' : 'medium'}>
         {label}
       </Typography>


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #31733 
Styled classification tags (those with a color, e.g. Confidential/Restricted) now render with their color highlight  tinted background, colored bar, colored icon and text  on the Data Product and Domain pages, matching how they already appear on asset pages.

<img width="1336" height="709" alt="Screenshot 2026-08-19 at 6 39 58 PM" src="https://github.com/user-attachments/assets/4621a008-009c-4c9e-a766-57e7b43fdb63" />
<img width="1512" height="713" alt="Screenshot 2026-08-19 at 6 44 21 PM" src="https://github.com/user-attachments/assets/9a323fb8-54d5-4235-808e-3b2b1ff5e669" />


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests

- [x] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>


#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR applies classification tag colors to the TagChip background, border, accent bar, icon, and label, with tests covering colored and uncolored states.
- Adds tinted background and border styling derived from `tagColor`.
- Applies the tag color to the accent, icon, and label.
- Tests the behavior through the production UI primitives.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/common/atoms/TagChip/TagChip.tsx | Applies the supplied tag color consistently across the chip’s visual elements without introducing a blocking issue. |
| openmetadata-ui/src/main/resources/ui/src/components/common/atoms/TagChip/TagChip.test.tsx | Verifies colored and default rendering using the real Box and Typography components, resolving the prior mock-fidelity concern. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;issue-31733&#39; of https://gi..."](https://github.com/open-metadata/openmetadata/commit/e142cc6e8a0916cfef733767b30fd396ea7726c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54755692)</sub>

<!-- /greptile_comment -->