### PR TITLE
fix(playwright): give the log-handover scroll scenario a budget that contains its own polls

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AgentLogStreamHandover.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AgentLogStreamHandover.spec.ts
@@ -327,6 +327,20 @@ test.describe('Agent log stream handover to the paginated endpoint', () => {
   test('Scrolling a live log pauses auto-follow and the toolbar toggle resumes it', async ({
     page,
   }) => {
+    // This scenario's declared waits cannot fit the 60s project default: the
+    // steps below carry expect.poll budgets of 60s (wrap relayout) + 30s
+    // (gestureless drag) + 60s (append while paused) + 60s (append while
+    // followed), plus ~15s attribute expects between them. Those budgets are
+    // deliberate — the mock closes every connection, so appends arrive on the
+    // client's reconnect-backoff cadence, which stretches under shard load.
+    // With the default ceiling the test killed itself mid-poll while the
+    // stream was legitimately still backing off (merge-queue runs
+    // 32238830063, 32244090565, 32248621065, 32249698790: "Test timeout of
+    // 60000ms exceeded" with the line count about to grow). Budget = sum of
+    // declared polls + interaction slack; a genuine assertion failure still
+    // fails fast via the per-expect 15s timeouts.
+    test.setTimeout(240_000);
+
     await openAgentLogs(page, {
       terminal: false,
       lineCount: SCROLLABLE_LOG_LINE_COUNT,


### PR DESCRIPTION
## Summary

`AgentLogStreamHandover.spec.ts:327` (*Scrolling a live log pauses auto-follow and the toolbar toggle resumes it*) is the **top merge-queue blocker since the infra fixes landed** — four ejected queue entries today ([32238830063](https://github.com/open-metadata/OpenMetadata/actions/runs/32238830063), [32244090565](https://github.com/open-metadata/OpenMetadata/actions/runs/32244090565), [32248621065](https://github.com/open-metadata/OpenMetadata/actions/runs/32248621065), [32249698790](https://github.com/open-metadata/OpenMetadata/actions/runs/32249698790)), same signature each time:

```
Error: the stream should append more lines after a reconnect
Expected: > 557   Received: 557
Test timeout of 60000ms exceeded
```

## Root cause — structural, not a product race

The scenario declares **~210 s of `expect.poll` budgets** (60 s wrap relayout + 30 s gestureless drag + 60 s append-while-paused + 60 s append-while-followed, plus 15 s attribute expects between steps) inside the **60 s project-default test ceiling**. The poll budgets are deliberate: the mock closes every SSE connection, so appends arrive on the client's reconnect-backoff cadence, which stretches under shard load. The test kills itself mid-poll while the stream is legitimately still backing off; the retry dies the same way at whichever step the budget runs out on. It passes whenever the shard is lightly loaded — which is why it survived until #31732's 27-shard co-location reshuffle changed its neighbors.

## Fix

Explicit `test.setTimeout(240_000)` — the sum of the declared poll budgets plus interaction slack — with the arithmetic documented on the test.

- Genuine assertion failures still fail fast via the per-expect 15 s timeouts; only the deliberate stream-cadence waits use the long budget.
- Healthy runtime (~28 s per the timing baseline) is unchanged → shard-planning weights unaffected.
- Deliberately **not** `test.slow()` — an explicit, justified number instead of a silent multiplier (lesson from #30822).

## Not in this PR

`IngestionLogStreamLive.spec.ts:217` (the other confirmed repeat, ✕2 today) runs against a **real** agent with a correct 180 s budget — different failure mode, needs its own investigation. Also on the flake watchlist: `Glossary.spec.ts:1171` (✕2) and `ActivityAPI.spec.ts:381` (✕1).

## Test plan

- [x] Prettier + ESLint clean.
- [ ] Merge-queue entries stop ejecting on this test (it was 4 of the last ~7 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR raises the timeout for one reconnect-sensitive Playwright scenario from the 60-second project default to 240 seconds.
- Documents the scenario’s cumulative polling budgets and reconnect-backoff behavior.
- Leaves assertion-level timeouts unchanged so assertion failures still terminate promptly.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the change is isolated to the timeout ceiling of one Playwright scenario.

The larger test-local budget contains the scenario’s deliberate reconnect polling without changing product behavior or weakening the existing assertion-level failure checks.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AgentLogStreamHandover.spec.ts | Adds a test-local 240-second timeout with rationale; no actionable defect was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(playwright): give the log-handover s..."](https://github.com/open-metadata/openmetadata/commit/45dd850e1edbac0cd1ae298744bce3c9f3aa711b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54758633)</sub>

<!-- /greptile_comment -->

Fixes #31768
