### PR TITLE
feat(contextCenter): support sortBy/sortOrder on page hierarchy search (2.0 cherry-pick of #31625)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/KnowledgePageHierarchyIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/KnowledgePageHierarchyIT.java
@@ -12,6 +12,7 @@
  */
 package org.openmetadata.it.tests;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -19,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.ws.rs.core.Response;
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 import org.apache.http.client.HttpResponseException;
@@ -55,6 +57,7 @@ public class KnowledgePageHierarchyIT {
 
   private static final String KC_PATH = "v1/contextCenter/pages";
   private static final String KC_HIERARCHY_PATH = KC_PATH + "/hierarchy";
+  private static final String KC_SEARCH_HIERARCHY_PATH = KC_PATH + "/search/hierarchy";
   private static final String PARENT_FIELD = "parent";
   private static final String RELATED_ENTITIES_FIELD = "relatedEntities";
   private static final String ORGANIZATION_NAME = "Organization";
@@ -118,6 +121,72 @@ public class KnowledgePageHierarchyIT {
 
   private boolean containsTopLevelId(ResultList<PageHierarchy> hierarchy, UUID id) {
     return hierarchy.getData().stream().anyMatch(node -> id.equals(node.getId()));
+  }
+
+  private ResultList<PageHierarchy> listSearchHierarchy(RestClient rest, String query) {
+    String path = KC_SEARCH_HIERARCHY_PATH + query;
+    try (Response response = rest.rawGet(path)) {
+      assertEquals(
+          200, response.getStatus(), "Search hierarchy call failed: " + response.getStatus());
+      String body = response.readEntity(String.class);
+      return JsonUtils.readValue(body, new TypeReference<ResultList<PageHierarchy>>() {});
+    }
+  }
+
+  private int indexOfId(List<PageHierarchy> nodes, UUID id) {
+    for (int i = 0; i < nodes.size(); i++) {
+      if (id.equals(nodes.get(i).getId())) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  @Test
+  void testSearchHierarchyRejectsInvalidSortBy(TestNamespace ns) {
+    RestClient rest = RestClient.admin();
+    try (Response response = rest.rawGet(KC_SEARCH_HIERARCHY_PATH + "?sortBy=notAField")) {
+      assertEquals(400, response.getStatus(), response.readEntity(String.class));
+    }
+  }
+
+  @Test
+  void testSearchHierarchyRejectsInvalidSortOrder(TestNamespace ns) {
+    RestClient rest = RestClient.admin();
+    try (Response response =
+        rest.rawGet(KC_SEARCH_HIERARCHY_PATH + "?sortBy=name&sortOrder=sideways")) {
+      assertEquals(400, response.getStatus(), response.readEntity(String.class));
+    }
+  }
+
+  @Test
+  void testSearchHierarchySortsByName(TestNamespace ns) throws HttpResponseException {
+    RestClient rest = RestClient.admin();
+    Page pageA = createPage(rest, buildCreateRequest(ns.prefix("aaa-sort"), null));
+    Page pageM = createPage(rest, buildCreateRequest(ns.prefix("mmm-sort"), null));
+    Page pageZ = createPage(rest, buildCreateRequest(ns.prefix("zzz-sort"), null));
+
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(
+            () -> {
+              List<PageHierarchy> asc =
+                  listSearchHierarchy(rest, "?limit=1000&sortBy=name&sortOrder=asc").getData();
+              int a = indexOfId(asc, pageA.getId());
+              int m = indexOfId(asc, pageM.getId());
+              int z = indexOfId(asc, pageZ.getId());
+              assertTrue(
+                  a >= 0 && m >= 0 && z >= 0, "All created pages must be indexed and returned");
+              assertTrue(a < m && m < z, "Ascending name sort must order aaa < mmm < zzz");
+            });
+
+    List<PageHierarchy> desc =
+        listSearchHierarchy(rest, "?limit=1000&sortBy=name&sortOrder=desc").getData();
+    int a = indexOfId(desc, pageA.getId());
+    int m = indexOfId(desc, pageM.getId());
+    int z = indexOfId(desc, pageZ.getId());
+    assertTrue(z < m && m < a, "Descending name sort must order zzz < mmm < aaa");
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KnowledgePageRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KnowledgePageRepository.java
@@ -63,6 +63,7 @@ import org.openmetadata.service.governance.workflows.WorkflowHandler;
 import org.openmetadata.service.resources.feeds.MessageParser;
 import org.openmetadata.service.resources.knowledge.KnowledgePageResource;
 import org.openmetadata.service.search.PropagationDescriptor;
+import org.openmetadata.service.search.SearchSortFilter;
 import org.openmetadata.service.search.vector.PageBodyTextContributor;
 import org.openmetadata.service.security.AuthorizationException;
 import org.openmetadata.service.util.EntityUtil;
@@ -418,19 +419,19 @@ public class KnowledgePageRepository extends EntityRepository<Page> {
   }
 
   public ResultList<PageHierarchy> getHierarchyWithSearch(
-      String parent, PageType pageType, int offset, int limit) {
+      String parent, PageType pageType, SearchSortFilter sortFilter, int offset, int limit) {
     String pageTypeValue = pageType != null ? pageType.value() : null;
     return searchRepository
         .getSearchClient()
-        .listPageHierarchy(parent, pageTypeValue, offset, limit);
+        .listPageHierarchy(parent, pageTypeValue, sortFilter, offset, limit);
   }
 
   public ResultList<PageHierarchy> getHierarchyWithSearchForActivePage(
-      String activeFqn, PageType pageType, int offset, int limit) {
+      String activeFqn, PageType pageType, SearchSortFilter sortFilter, int offset, int limit) {
     String pageTypeValue = pageType != null ? pageType.value() : null;
     return searchRepository
         .getSearchClient()
-        .listPageHierarchyForActivePage(activeFqn, pageTypeValue, offset, limit);
+        .listPageHierarchyForActivePage(activeFqn, pageTypeValue, sortFilter, offset, limit);
   }
 
   public List<PageHierarchy> listHierarchy(ListFilter filter, int limit) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/knowledge/KnowledgePageResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/knowledge/KnowledgePageResource.java
@@ -398,13 +398,37 @@ public class KnowledgePageResource extends EntityResource<Page, KnowledgePageRep
               description =
                   "FQN of the active page to show the active page correctly in  the hierarchy , while showing other root nodes at level 1.")
           @QueryParam("activeFqn")
-          String activeFqn) {
+          String activeFqn,
+      @Parameter(
+              description = "Field to sort by. Supported: name, updatedAt.",
+              schema =
+                  @Schema(
+                      type = "string",
+                      allowableValues = {"name", "updatedAt"}))
+          @QueryParam("sortBy")
+          String sortBy,
+      @Parameter(
+              description = "Sort order. Supported: asc, desc. Defaults to desc.",
+              schema =
+                  @Schema(
+                      type = "string",
+                      allowableValues = {"asc", "desc"}))
+          @QueryParam("sortOrder")
+          String sortOrder) {
+    SearchSortFilter sortFilter = buildHierarchySortFilter(sortBy, sortOrder);
     if (!CommonUtil.nullOrEmpty(activeFqn)) {
       return repository.getHierarchyWithSearchForActivePage(
-          activeFqn, knowledgePageType, offset, limit);
+          activeFqn, knowledgePageType, sortFilter, offset, limit);
     } else {
-      return repository.getHierarchyWithSearch(parent, knowledgePageType, offset, limit);
+      return repository.getHierarchyWithSearch(
+          parent, knowledgePageType, sortFilter, offset, limit);
     }
+  }
+
+  private static SearchSortFilter buildHierarchySortFilter(String sortBy, String sortOrder) {
+    String effectiveSortBy = CommonUtil.nullOrEmpty(sortBy) ? "updatedAt" : sortBy;
+    return new SearchSortFilter(
+        resolveSortField(effectiveSortBy), resolveSortOrder(sortOrder), null, null);
   }
 
   @GET

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java
@@ -797,7 +797,8 @@ public interface SearchClient
    Used for listing knowledge page hierarchy for a given parent and page type, used in Elastic/Open SearchClientExtension
   */
   @SuppressWarnings("unused")
-  default ResultList listPageHierarchy(String parent, String pageType, int offset, int limit) {
+  default ResultList listPageHierarchy(
+      String parent, String pageType, SearchSortFilter sortFilter, int offset, int limit) {
     throw new CustomExceptionMessage(
         Response.Status.NOT_IMPLEMENTED, NOT_IMPLEMENTED_ERROR_TYPE, NOT_IMPLEMENTED_METHOD);
   }
@@ -807,7 +808,7 @@ public interface SearchClient
   */
   @SuppressWarnings("unused")
   default ResultList listPageHierarchyForActivePage(
-      String activeFqn, String pageType, int offset, int limit) {
+      String activeFqn, String pageType, SearchSortFilter sortFilter, int offset, int limit) {
     throw new CustomExceptionMessage(
         Response.Status.NOT_IMPLEMENTED, NOT_IMPLEMENTED_ERROR_TYPE, NOT_IMPLEMENTED_METHOD);
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import es.co.elastic.clients.elasticsearch.ElasticsearchClient;
 import es.co.elastic.clients.elasticsearch._types.FieldValue;
 import es.co.elastic.clients.elasticsearch._types.Refresh;
+import es.co.elastic.clients.elasticsearch._types.SortOptions;
 import es.co.elastic.clients.elasticsearch._types.SortOrder;
 import es.co.elastic.clients.elasticsearch._types.aggregations.FiltersBucket;
 import es.co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
@@ -102,6 +103,7 @@ public class ElasticSearchClient implements SearchClient {
 
   private volatile boolean isClientAvailable;
   private static final long HEALTH_CHECK_CACHE_MS = 5000;
+  private static final String SORT_ORDER_DESC = "desc";
   private final AtomicLong lastHealthCheckAt = new AtomicLong();
 
   private volatile boolean isNewClientAvailable;
@@ -1169,20 +1171,44 @@ public class ElasticSearchClient implements SearchClient {
   @Override
   @lombok.SneakyThrows
   public ResultList<PageHierarchy> listPageHierarchy(
-      String parentFqn, String pageType, int offset, int limit) {
-    return getPageHierarchyFromSearch(parentFqn, pageType, offset, limit);
+      String parentFqn, String pageType, SearchSortFilter sortFilter, int offset, int limit) {
+    return getPageHierarchyFromSearch(parentFqn, pageType, sortFilter, offset, limit);
   }
 
   @Override
   @lombok.SneakyThrows
   public ResultList<PageHierarchy> listPageHierarchyForActivePage(
-      String activeFqn, String pageType, int offset, int limit) {
-    return getPageHierarchyFromSearchForActivePage(activeFqn, pageType, offset, limit);
+      String activeFqn, String pageType, SearchSortFilter sortFilter, int offset, int limit) {
+    return getPageHierarchyFromSearchForActivePage(activeFqn, pageType, sortFilter, offset, limit);
+  }
+
+  private List<SortOptions> buildPageHierarchySortOptions(SearchSortFilter sortFilter) {
+    List<SortOptions> sortOptions = new ArrayList<>();
+    if (sortFilter != null
+        && sortFilter.getSortField() != null
+        && !Entity.FIELD_FULLY_QUALIFIED_NAME.equals(sortFilter.getSortField())) {
+      String field = sortFilter.getSortField();
+      SortOrder order =
+          SORT_ORDER_DESC.equalsIgnoreCase(sortFilter.getSortType())
+              ? SortOrder.Desc
+              : SortOrder.Asc;
+      sortOptions.add(SortOptions.of(so -> so.field(f -> f.field(field).order(order))));
+    }
+    // Always append a stable tiebreaker on fullyQualifiedName (keyword, unique per page) so
+    // from/size pagination cannot miss/duplicate hits when the primary sort field is not unique.
+    // _id cannot be used as a sort field on ES 9.x / OpenSearch 3.x without setting
+    // indices.id_field_data.enabled=true at the cluster level.
+    sortOptions.add(
+        SortOptions.of(
+            so -> so.field(f -> f.field(Entity.FIELD_FULLY_QUALIFIED_NAME).order(SortOrder.Asc))));
+    return sortOptions;
   }
 
   private ResultList<PageHierarchy> getPageHierarchyFromSearch(
-      String parentFqn, String pageType, int offset, int limit) throws IOException {
+      String parentFqn, String pageType, SearchSortFilter sortFilter, int offset, int limit)
+      throws IOException {
     Query boolQuery = buildPageHierarchyBoolQuery(parentFqn, pageType);
+    List<SortOptions> sortOptions = buildPageHierarchySortOptions(sortFilter);
 
     es.co.elastic.clients.elasticsearch.core.SearchRequest searchRequest =
         es.co.elastic.clients.elasticsearch.core.SearchRequest.of(
@@ -1192,13 +1218,7 @@ public class ElasticSearchClient implements SearchClient {
                             .getIndexOrAliasName(
                                 KnowledgePageRepository.KNOWLEDGE_PAGE_TERM_SEARCH_INDEX))
                     .query(boolQuery)
-                    // Stable sort so from/size pagination cannot miss/duplicate hits.
-                    // fullyQualifiedName is a keyword field with doc_values and is unique per
-                    // page (name is unique within a parent's children), so no tiebreaker is
-                    // needed. _id cannot be used as a sort field on ES 9.x / OpenSearch 3.x
-                    // without setting indices.id_field_data.enabled=true at the cluster level.
-                    .sort(
-                        sort -> sort.field(f -> f.field("fullyQualifiedName").order(SortOrder.Asc)))
+                    .sort(sortOptions)
                     .from(offset)
                     .size(limit));
 
@@ -1214,8 +1234,10 @@ public class ElasticSearchClient implements SearchClient {
   }
 
   private ResultList<PageHierarchy> getPageHierarchyFromSearchForActivePage(
-      String activeFqn, String pageType, int offset, int limit) throws IOException {
+      String activeFqn, String pageType, SearchSortFilter sortFilter, int offset, int limit)
+      throws IOException {
     Query boolQuery = buildPageHierarchyBoolQueryForActivePage(activeFqn, pageType);
+    List<SortOptions> sortOptions = buildPageHierarchySortOptions(sortFilter);
 
     es.co.elastic.clients.elasticsearch.core.SearchRequest searchRequest =
         es.co.elastic.clients.elasticsearch.core.SearchRequest.of(
@@ -1225,9 +1247,7 @@ public class ElasticSearchClient implements SearchClient {
                             .getIndexOrAliasName(
                                 KnowledgePageRepository.KNOWLEDGE_PAGE_TERM_SEARCH_INDEX))
                     .query(boolQuery)
-                    // Stable sort by fqn (keyword, unique per page). See note above on _id.
-                    .sort(
-                        sort -> sort.field(f -> f.field("fullyQualifiedName").order(SortOrder.Asc)))
+                    .sort(sortOptions)
                     .from(offset)
                     .size(limit));
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java
@@ -75,6 +75,7 @@ import org.openmetadata.service.workflows.searchIndex.ReindexingUtil;
 import os.org.opensearch.client.json.JsonData;
 import os.org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import os.org.opensearch.client.opensearch._types.FieldValue;
+import os.org.opensearch.client.opensearch._types.SortOptions;
 import os.org.opensearch.client.opensearch._types.SortOrder;
 import os.org.opensearch.client.opensearch._types.aggregations.FiltersBucket;
 import os.org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
@@ -104,6 +105,7 @@ public class OpenSearchClient implements SearchClient {
 
   private volatile boolean isClientAvailable;
   private static final long HEALTH_CHECK_CACHE_MS = 5000;
+  private static final String SORT_ORDER_DESC = "desc";
   private final AtomicLong lastHealthCheckAt = new AtomicLong();
   private final RBACConditionEvaluator rbacConditionEvaluator;
 
@@ -1190,20 +1192,44 @@ public class OpenSearchClient implements SearchClient {
   @Override
   @lombok.SneakyThrows
   public ResultList<PageHierarchy> listPageHierarchy(
-      String parentFqn, String pageType, int offset, int limit) {
-    return getPageHierarchyFromSearch(parentFqn, pageType, offset, limit);
+      String parentFqn, String pageType, SearchSortFilter sortFilter, int offset, int limit) {
+    return getPageHierarchyFromSearch(parentFqn, pageType, sortFilter, offset, limit);
   }
 
   @Override
   @lombok.SneakyThrows
   public ResultList<PageHierarchy> listPageHierarchyForActivePage(
-      String activeFqn, String pageType, int offset, int limit) {
-    return getPageHierarchyFromSearchForActivePage(activeFqn, pageType, offset, limit);
+      String activeFqn, String pageType, SearchSortFilter sortFilter, int offset, int limit) {
+    return getPageHierarchyFromSearchForActivePage(activeFqn, pageType, sortFilter, offset, limit);
+  }
+
+  private List<SortOptions> buildPageHierarchySortOptions(SearchSortFilter sortFilter) {
+    List<SortOptions> sortOptions = new ArrayList<>();
+    if (sortFilter != null
+        && sortFilter.getSortField() != null
+        && !Entity.FIELD_FULLY_QUALIFIED_NAME.equals(sortFilter.getSortField())) {
+      String field = sortFilter.getSortField();
+      SortOrder order =
+          SORT_ORDER_DESC.equalsIgnoreCase(sortFilter.getSortType())
+              ? SortOrder.Desc
+              : SortOrder.Asc;
+      sortOptions.add(SortOptions.of(so -> so.field(f -> f.field(field).order(order))));
+    }
+    // Always append a stable tiebreaker on fullyQualifiedName (keyword, unique per page) so
+    // from/size pagination cannot miss/duplicate hits when the primary sort field is not unique.
+    // _id cannot be used as a sort field on ES 9.x / OpenSearch 3.x without setting
+    // indices.id_field_data.enabled=true at the cluster level.
+    sortOptions.add(
+        SortOptions.of(
+            so -> so.field(f -> f.field(Entity.FIELD_FULLY_QUALIFIED_NAME).order(SortOrder.Asc))));
+    return sortOptions;
   }
 
   private ResultList<PageHierarchy> getPageHierarchyFromSearch(
-      String parentFqn, String pageType, int offset, int limit) throws IOException {
+      String parentFqn, String pageType, SearchSortFilter sortFilter, int offset, int limit)
+      throws IOException {
     Query boolQuery = buildPageHierarchyBoolQuery(parentFqn, pageType);
+    List<SortOptions> sortOptions = buildPageHierarchySortOptions(sortFilter);
 
     os.org.opensearch.client.opensearch.core.SearchRequest searchRequest =
         os.org.opensearch.client.opensearch.core.SearchRequest.of(
@@ -1213,13 +1239,7 @@ public class OpenSearchClient implements SearchClient {
                             .getIndexOrAliasName(
                                 KnowledgePageRepository.KNOWLEDGE_PAGE_TERM_SEARCH_INDEX))
                     .query(boolQuery)
-                    // Stable sort so from/size pagination cannot miss/duplicate hits.
-                    // fullyQualifiedName is a keyword field with doc_values and is unique per
-                    // page (name is unique within a parent's children), so no tiebreaker is
-                    // needed. _id cannot be used as a sort field on ES 9.x / OpenSearch 3.x
-                    // without setting indices.id_field_data.enabled=true at the cluster level.
-                    .sort(
-                        sort -> sort.field(f -> f.field("fullyQualifiedName").order(SortOrder.Asc)))
+                    .sort(sortOptions)
                     .from(offset)
                     .size(limit));
 
@@ -1235,8 +1255,10 @@ public class OpenSearchClient implements SearchClient {
   }
 
   private ResultList<PageHierarchy> getPageHierarchyFromSearchForActivePage(
-      String activeFqn, String pageType, int offset, int limit) throws IOException {
+      String activeFqn, String pageType, SearchSortFilter sortFilter, int offset, int limit)
+      throws IOException {
     Query boolQuery = buildPageHierarchyBoolQueryForActivePage(activeFqn, pageType);
+    List<SortOptions> sortOptions = buildPageHierarchySortOptions(sortFilter);
 
     os.org.opensearch.client.opensearch.core.SearchRequest searchRequest =
         os.org.opensearch.client.opensearch.core.SearchRequest.of(
@@ -1246,9 +1268,7 @@ public class OpenSearchClient implements SearchClient {
                             .getIndexOrAliasName(
                                 KnowledgePageRepository.KNOWLEDGE_PAGE_TERM_SEARCH_INDEX))
                     .query(boolQuery)
-                    // Stable sort by fqn (keyword, unique per page). See note above on _id.
-                    .sort(
-                        sort -> sort.field(f -> f.field("fullyQualifiedName").order(SortOrder.Asc)))
+                    .sort(sortOptions)
                     .from(offset)
                     .size(limit));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePageDetailComponent/KnowledgePageDetailComponent.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePageDetailComponent/KnowledgePageDetailComponent.tsx
@@ -106,12 +106,16 @@ interface KnowledgePageDetailComponentProps {
   onPageChange: (page: Partial<KnowledgeCenterPageProps>) => void;
   isRightPanelOpen?: boolean;
   onToggleRightPanel?: () => void;
+  // Called after a successful save so the left-tree can re-fetch and reflect the
+  // updatedAt-desc order (the edited page moves to the top of its branch).
+  onArticleSaved?: () => void;
 }
 
 const KnowledgePageDetailComponent: FC<KnowledgePageDetailComponentProps> = ({
   onPageChange,
   isRightPanelOpen = true,
   onToggleRightPanel,
+  onArticleSaved,
 }) => {
   const { t } = i18n;
   const { hash } = useCustomLocation();
@@ -448,6 +452,7 @@ const KnowledgePageDetailComponent: FC<KnowledgePageDetailComponentProps> = ({
           };
         });
         didSucceed = true;
+        onArticleSaved?.();
       } catch (error) {
         showErrorToast(error as AxiosError);
       } finally {
@@ -460,6 +465,7 @@ const KnowledgePageDetailComponent: FC<KnowledgePageDetailComponentProps> = ({
       permissions,
       beginTrackedSave,
       endTrackedSave,
+      onArticleSaved,
     ]
   );
 
@@ -529,6 +535,7 @@ const KnowledgePageDetailComponent: FC<KnowledgePageDetailComponentProps> = ({
       if (existingDraft) {
         setDraft(currentKnowledgePage.id, { version: response.version });
       }
+      onArticleSaved?.();
     } catch (error) {
       showErrorToast(error as AxiosError);
     }
@@ -560,6 +567,7 @@ const KnowledgePageDetailComponent: FC<KnowledgePageDetailComponentProps> = ({
       if (existingDraft) {
         setDraft(currentKnowledgePage.id, { version: response.version });
       }
+      onArticleSaved?.();
     } catch (error) {
       showErrorToast(error as AxiosError);
     }
@@ -611,6 +619,7 @@ const KnowledgePageDetailComponent: FC<KnowledgePageDetailComponentProps> = ({
           };
         });
         didSucceed = true;
+        onArticleSaved?.();
       } catch (error) {
         showErrorToast(error as AxiosError);
       } finally {
@@ -623,6 +632,7 @@ const KnowledgePageDetailComponent: FC<KnowledgePageDetailComponentProps> = ({
       permissions,
       beginTrackedSave,
       endTrackedSave,
+      onArticleSaved,
     ]
   );
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterArticlesPage/ContextCenterArticlesPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterArticlesPage/ContextCenterArticlesPage.tsx
@@ -79,6 +79,8 @@ import { showErrorToast, showSuccessToast } from '../../../utils/ToastUtils';
 import { useRequiredParams } from '../../../utils/useRequiredParams';
 import KnowledgePageVersionPage from '../../KnowledgePageVersionPage/KnowledgePageVersionPage';
 
+const ARTICLE_PLURAL_LABEL = 'label.article-plural';
+
 const ContextCenterArticlesPage = () => {
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
@@ -301,14 +303,14 @@ const ContextCenterArticlesPage = () => {
             </Dropdown.Root>
           </LimitWrapper>
         }
-        breadcrumbs={[{ label: t('label.article-plural') }]}
+        breadcrumbs={[{ label: t(ARTICLE_PLURAL_LABEL) }]}
         hasPermission={permissions?.Create}
         searchPlaceholder={t('label.search-entity', {
-          entity: t('label.article-plural'),
+          entity: t(ARTICLE_PLURAL_LABEL),
         })}
         searchQuery={articleSearchQuery}
         subtitle={t('message.internal-knowledge-base-agent-training')}
-        title={t('label.article-plural')}
+        title={t(ARTICLE_PLURAL_LABEL)}
         onSearch={setArticleSearchQuery}
       />
     );
@@ -350,6 +352,7 @@ const ContextCenterArticlesPage = () => {
       return (
         <KnowledgePageDetailComponent
           isRightPanelOpen={isRightPanelOpen}
+          onArticleSaved={() => handleFetchKnowledgePageHierarchy(true)}
           onPageChange={handlePageChange}
           onToggleRightPanel={handleToggleRightPanel}
         />
@@ -402,7 +405,7 @@ const ContextCenterArticlesPage = () => {
         dir={i18n.dir()}
         direction="col"
         id="knowledge-center-layout-container">
-        <DocumentTitle title={page.title || t('label.article-plural')} />
+        <DocumentTitle title={page.title || t(ARTICLE_PLURAL_LABEL)} />
         {showArticlesEmptyState && (
           <div className="tw:relative tw:flex-1 tw:min-h-0 tw:overflow-hidden tw:rounded-xl">
             <EmptyPlaceholder


### PR DESCRIPTION
## What

Cherry-pick of #31625 to `2.0`. Adds `sortBy` / `sortOrder` query params to `GET /v1/contextCenter/pages/search/hierarchy` so the Context Center left-tree can control ordering (default `updatedAt desc` — newest first), with a stable `fullyQualifiedName` tiebreaker for pagination.

## Cherry-pick

- Clean cherry-pick of the squashed main commit `ae6fc0675123` — no conflicts (8 files).
- Backend built locally against `2.0`: `mvn -DskipTests -DonlyBackend install -pl '!openmetadata-ui'` → **BUILD SUCCESS** (service, integration-tests, java-client all pass).

Original PR: #31625
Fixes open-metadata/openmetadata-collate#4781 (item 1 — article hierarchy sorting).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds validated `sortBy` and `sortOrder` support to Context Center hierarchy search, with `updatedAt`-descending defaults and stable FQN pagination ordering.

- Propagates sort configuration through the REST resource, repository, and Elasticsearch/OpenSearch clients.
- Refreshes the article hierarchy after successful edits so updated pages can move under newest-first ordering.
- Adds integration coverage for invalid parameters and ascending/descending name sorting.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The active-page sorting path should be fixed before merging because pagination can remove the selected page or its ancestors from the reconstructed hierarchy.

Applying updatedAt sorting to the combined roots-and-descendants hit set before pagination breaks the activeFqn guarantee under ordinary bounded requests; the remaining naming issue is non-blocking.

**Files Needing Attention:** openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java, openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java, openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/KnowledgePageHierarchyIT.java
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/resources/knowledge/KnowledgePageResource.java | Adds and validates hierarchy sort parameters, defaulting to updatedAt descending. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java | Applies stable multi-field sorting, but active-page sorting occurs before pagination and can exclude required hierarchy nodes. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java | Mirrors the Elasticsearch implementation and the same active-page pagination defect. |
| openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePageDetailComponent/KnowledgePageDetailComponent.tsx | Notifies the page container after successful article mutations. |
| openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterArticlesPage/ContextCenterArticlesPage.tsx | Forces hierarchy refreshes after saves and consolidates the article translation key. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/KnowledgePageHierarchyIT.java | Adds parameter-validation and name-ordering coverage, with local names that violate repository guidance. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Context Center UI
  participant Resource as KnowledgePageResource
  participant Repo as KnowledgePageRepository
  participant Search as ES/OpenSearch Client
  UI->>Resource: "GET /search/hierarchy<br/>activeFqn, sortBy, sortOrder, offset, limit"
  Resource->>Resource: Validate and build SearchSortFilter
  Resource->>Repo: getHierarchyWithSearchForActivePage(...)
  Repo->>Search: listPageHierarchyForActivePage(...)
  Search->>Search: Query all roots + active-root descendants
  Search->>Search: Sort combined hits, then paginate
  Search->>Search: Reconstruct hierarchy from retained hits
  Search-->>UI: "ResultList<PageHierarchy>"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(contextCenter): support sortBy/sort..."](https://github.com/open-metadata/openmetadata/commit/15ba59cb75d33d2f784c838f5c66bb8e22fe4b37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54762546)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))
- Knowledge Base — [OpenMetadata Service Core: Entities, Resources, Repositories](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-core.md)
- Knowledge Base — [Search Indexing and Event/Notification Sync](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-search-events.md)
- Knowledge Base — [OpenMetadata React UI](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-ui.md)
</details>

<!-- /greptile_comment -->