### PR TITLE
fix(ui): route ingestionPipeline entity links to the service agents tab

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtilClassBase.routes.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtilClassBase.routes.test.ts
@@ -1,0 +1,69 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { EntityType } from '../enums/entity.enum';
+import { EntityUtilClassBase } from './EntityUtilClassBase';
+
+/**
+ * EntityUtilClassBase.test.ts mocks the routing helpers, so it can only assert which helper was
+ * called. These cases deliberately use the real helpers and assert the URL a user lands on — the
+ * observable behaviour of an ingestion-pipeline entity link.
+ */
+describe('EntityUtilClassBase ingestion pipeline routes', () => {
+  const entityUtil = new EntityUtilClassBase();
+  const pipelineFqn = 'bigquery-beta.bigquery-beta-1.7047fd1d';
+
+  const linkFor = (serviceCategory?: string, serviceFqn?: string) =>
+    entityUtil.getEntityLink(
+      EntityType.INGESTION_PIPELINE,
+      pipelineFqn,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      serviceCategory,
+      serviceFqn
+    );
+
+  it('returns the service agents tab URL', () => {
+    expect(linkFor('databaseServices', 'bigquery-beta')).toBe(
+      '/service/databaseServices/bigquery-beta/agents'
+    );
+  });
+
+  it('returns the same URL for the singular service entity type', () => {
+    expect(linkFor('databaseService', 'bigquery-beta')).toBe(
+      '/service/databaseServices/bigquery-beta/agents'
+    );
+  });
+
+  it('encodes a service FQN containing a space', () => {
+    expect(linkFor('databaseServices', 'Collate analytics test')).toBe(
+      '/service/databaseServices/Collate%20analytics%20test/agents'
+    );
+  });
+
+  it.each(['Snowflake', 'constructor', 'vishnu-test'])(
+    'never returns a service URL for the non-category %s',
+    (serviceCategory) => {
+      const link = linkFor(serviceCategory, 'bigquery-beta');
+
+      expect(link).not.toContain('/service/');
+      expect(link).toBe(`/table/${pipelineFqn}`);
+    }
+  );
+
+  it('falls back to the table URL without service context', () => {
+    expect(linkFor()).toBe(`/table/${pipelineFqn}`);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtilClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtilClassBase.test.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { EntityType } from '../enums/entity.enum';
+import { EntityTabs, EntityType } from '../enums/entity.enum';
 import { SearchIndex } from '../enums/search.enum';
 import { EntityUtilClassBase } from './EntityUtilClassBase';
 import {
@@ -241,9 +241,7 @@ describe('EntityUtilClassBase', () => {
     expect(getServiceDetailsPath).toHaveBeenCalledWith(fqn, 'securityServices');
   });
 
-  it('should fall through to the default table path for ingestion pipelines', () => {
-    // The logs viewer is now an in-place modal (no route), so ingestion-pipeline
-    // entity links resolve to the default entity path instead of a `/logs` URL.
+  it('should route ingestion pipelines to the owning service agents tab', () => {
     const fqn = 'bigquery-beta.bigquery-beta-1.7047fd1d';
     entityUtil.getEntityLink(
       EntityType.INGESTION_PIPELINE,
@@ -256,6 +254,94 @@ describe('EntityUtilClassBase', () => {
       'bigquery-beta'
     );
 
+    expect(getServiceDetailsPath).toHaveBeenCalledWith(
+      'bigquery-beta',
+      'databaseServices',
+      EntityTabs.AGENTS
+    );
+    expect(getEntityDetailsPath).not.toHaveBeenCalled();
+  });
+
+  it('should fall through to the default table path for ingestion pipelines without service context', () => {
+    // prepareFeedLink and similar callers omit the service category; they must keep the
+    // default behaviour rather than produce a service URL built from a pipeline FQN.
+    const fqn = 'bigquery-beta.bigquery-beta-1.7047fd1d';
+    entityUtil.getEntityLink(EntityType.INGESTION_PIPELINE, fqn);
+
+    expect(getServiceDetailsPath).not.toHaveBeenCalled();
+    expect(getEntityDetailsPath).toHaveBeenCalledWith(
+      EntityType.TABLE,
+      fqn,
+      undefined,
+      undefined
+    );
+  });
+
+  it('should accept the singular service entity type as the category', () => {
+    // Chat markdown links are model-authored and routinely carry the singular entity type
+    // ("databaseService") instead of the plural route segment; both name the same service page.
+    const fqn = 'bigquery-beta.bigquery-beta-1.7047fd1d';
+    entityUtil.getEntityLink(
+      EntityType.INGESTION_PIPELINE,
+      fqn,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'databaseService',
+      'bigquery-beta'
+    );
+
+    expect(getServiceDetailsPath).toHaveBeenCalledWith(
+      'bigquery-beta',
+      'databaseServices',
+      EntityTabs.AGENTS
+    );
+  });
+
+  it.each(['constructor', 'toString', '__proto__', 'hasOwnProperty'])(
+    'should fall through to the default table path for the prototype key %s',
+    (serviceCategory) => {
+      // The category comes from a model-authored href, so a prototype key can reach the
+      // reverse lookup; it must not resolve to a truthy non-category value.
+      const fqn = 'bigquery-beta.bigquery-beta-1.7047fd1d';
+      entityUtil.getEntityLink(
+        EntityType.INGESTION_PIPELINE,
+        fqn,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        serviceCategory,
+        'bigquery-beta'
+      );
+
+      expect(getServiceDetailsPath).not.toHaveBeenCalled();
+      expect(getEntityDetailsPath).toHaveBeenCalledWith(
+        EntityType.TABLE,
+        fqn,
+        undefined,
+        undefined
+      );
+    }
+  );
+
+  it('should fall through to the default table path for an unknown service category', () => {
+    // The category is supplied by the caller (chat markdown links carry one). A value that
+    // is not a real service category would build a route that matches nothing.
+    const fqn = 'bigquery-beta.bigquery-beta-1.7047fd1d';
+    entityUtil.getEntityLink(
+      EntityType.INGESTION_PIPELINE,
+      fqn,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'Snowflake',
+      'bigquery-beta'
+    );
+
+    expect(getServiceDetailsPath).not.toHaveBeenCalled();
     expect(getEntityDetailsPath).toHaveBeenCalledWith(
       EntityType.TABLE,
       fqn,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtilClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtilClassBase.ts
@@ -21,8 +21,9 @@ import {
   ResourceEntity,
   type OperationPermission,
 } from '../context/PermissionProvider/PermissionProvider.interface';
-import { EntityType } from '../enums/entity.enum';
+import { EntityTabs, EntityType } from '../enums/entity.enum';
 import { SearchIndex } from '../enums/search.enum';
+import { ServiceCategoryPlural } from '../enums/service.enum';
 import type { APICollection } from '../generated/entity/data/apiCollection';
 import type { Database } from '../generated/entity/data/database';
 import type { DatabaseSchema } from '../generated/entity/data/databaseSchema';
@@ -102,6 +103,10 @@ import {
 import { ExtraTableDropdownOptions } from './TableDropdownOptions';
 import { getTestSuiteDetailsPath } from './TestSuiteUtils';
 type PatchAPIFunction = (id: string, patch: Operation[]) => Promise<unknown>;
+
+const SERVICE_ROUTE_CATEGORIES: Set<string> = new Set(
+  Object.values(ServiceCategoryPlural)
+);
 
 class EntityUtilClassBase {
   serviceTypeLookupMap: Map<string, string>;
@@ -193,6 +198,28 @@ class EntityUtilClassBase {
     );
   }
 
+  /**
+   * Plural route segment for a caller-supplied service category. Accepts the plural segment
+   * (`databaseServices`) and the singular entity type (`databaseService`) — chat entity links
+   * carry either — and returns undefined for anything that is not a service category.
+   */
+  private getServiceRouteCategory(value?: string): string | undefined {
+    if (!value) {
+      return undefined;
+    }
+
+    if (SERVICE_ROUTE_CATEGORIES.has(value)) {
+      return value;
+    }
+
+    // The value is model-authored, so it can be a prototype key ("constructor") whose lookup
+    // returns a truthy non-category; validate the result rather than the input.
+    const plural =
+      ServiceCategoryPlural[value as keyof typeof ServiceCategoryPlural];
+
+    return SERVICE_ROUTE_CATEGORIES.has(plural) ? plural : undefined;
+  }
+
   public getEntityLink(
     indexType: string,
     fullyQualifiedName: string,
@@ -200,9 +227,11 @@ class EntityUtilClassBase {
     subTab?: string,
     isExecutableTestSuite?: boolean,
     isObservabilityAlert?: boolean,
-    _serviceCategory?: string,
-    _serviceFqn?: string
+    serviceCategory?: string,
+    serviceFqn?: string
   ) {
+    const serviceRouteCategory = this.getServiceRouteCategory(serviceCategory);
+
     switch (indexType) {
       case SearchIndex.TOPIC:
       case EntityType.TOPIC:
@@ -436,6 +465,20 @@ class EntityUtilClassBase {
 
       case EntityType.KNOWLEDGE_PAGE:
         return getKnowledgePagePath(fullyQualifiedName, tab, subTab);
+
+      case EntityType.INGESTION_PIPELINE:
+        // No standalone detail page for a pipeline: route to the owning service's agents
+        // tab. Callers without service context (prepareFeedLink) and unrecognised
+        // categories must fall through, or the URL matches no route.
+        if (serviceFqn && serviceRouteCategory) {
+          return getServiceDetailsPath(
+            serviceFqn,
+            serviceRouteCategory,
+            EntityTabs.AGENTS
+          );
+        }
+
+      // falls through
 
       case SearchIndex.TABLE:
       case EntityType.TABLE:


### PR DESCRIPTION
### Describe your changes:

Fixes #31780

Regression from #29972, which removed the standalone logs-viewer route and with it the `INGESTION_PIPELINE` case in `getEntityLink`.

- **Bug:** every `#ingestionPipeline/...` entity link (chat answers, landing-page cards) fell through to the `TABLE` default and opened `/table/<pipelineFqn>` — a table URL for a pipeline FQN.
- **Fix:** with service context the link now opens the owning service's **Agents** tab; callers without it (e.g. `prepareFeedLink`) keep the old behaviour.
- **Tolerant of the caller's category:** accepts the plural route segment (`databaseServices`) or the singular entity type (`databaseService`); anything that is not a real service category falls through instead of building a dead URL.
- **Tests:** 8 cases on this path, replacing the one that pinned the table fall-through.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Clicking a pipeline entity link in a chat answer opens the owning service's Agents tab instead of a 404 table page.
- A malformed category written by an LLM (`Snowflake`, `constructor`) falls back to the previous behaviour rather than routing to a nonexistent page.

#### Unit tests
- [x] `openmetadata-ui/src/main/resources/ui/src/utils/EntityUtilClassBase.test.ts` — 8 cases: agents-tab route, singular category, missing service context, unknown category, and 4 prototype-key cases (`constructor`, `toString`, `__proto__`, `hasOwnProperty`).

#### Manual testing performed
1. Rebuilt the UI and opened a chat answer containing pipeline links.
2. Confirmed each link opens the service Agents tab; previously `/table/<pipelineFqn>`.

#
### UI screen recording / screenshots:

Not applicable — routing only, no visual change.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This follow-up fixes ingestion-pipeline entity links by routing pipelines with valid service context to the owning service’s Agents tab while preserving the existing fallback without valid context.
- Validates singular and plural service categories before constructing service routes.
- Adds URL-level tests using the real routing helpers, resolving the previous mocked-route coverage concern.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/utils/EntityUtilClassBase.ts | Adds validated service-category normalization and routes ingestion-pipeline links with service context to the Agents tab. |
| openmetadata-ui/src/main/resources/ui/src/utils/EntityUtilClassBase.routes.test.ts | Adds CI-discovered tests against real route helpers and verifies the final user-facing URLs. |
| openmetadata-ui/src/main/resources/ui/src/utils/EntityUtilClassBase.test.ts | Extends mocked-helper unit coverage for service routing, fallback behavior, and malformed categories. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): assert the real ingestionPipel..."](https://github.com/open-metadata/openmetadata/commit/2a9175012052ce19b07dec1b07f7194658ec4f2f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54770607)</sub>

**Context used:**

- Knowledge Base — [OpenMetadata React UI](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-ui.md)

<!-- /greptile_comment -->