### PR TITLE
Fix #31756: Propagate tag removal to children on bulk remove from Glossary Term Assets

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
@@ -2118,6 +2118,7 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
     BulkOperationResult result =
         new BulkOperationResult().withStatus(ApiStatus.SUCCESS).withDryRun(dryRun);
     List<BulkResponse> success = new ArrayList<>();
+    List<EntityReference> nonColumnAssets = new ArrayList<>();
 
     if (nullOrEmpty(request.getAssets())) {
       // Nothing to Validate
@@ -2161,7 +2162,15 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
       if (!dryRun) {
         // Update ES
         searchRepository.updateEntity(ref);
+        // Collect for batch propagation to child entities
+        nonColumnAssets.add(ref);
       }
+    }
+
+    // Batch propagate tag removal to child entities (columns, test suites, test cases)
+    if (!dryRun && !nullOrEmpty(nonColumnAssets)) {
+      searchRepository.propagateTagRemovalToChildren(
+          nonColumnAssets, term.getFullyQualifiedName());
     }
 
     return result.withSuccessRequest(success);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -2788,6 +2788,158 @@ public class SearchRepository {
         entityType);
   }
 
+  /**
+   * Propagate tag removal to children of an asset. When a tag is removed from a parent entity
+   * (e.g. a Table) via the Glossary Term Assets tab, the child entities (columns, test suites,
+   * test cases) still hold the Derived tag in their ES docs. This method explicitly removes the
+   * tag from all child ES docs so the cascade is symmetric with the add path.
+   *
+   * @param assetRef the asset whose tag was removed
+   * @param tagFQN the FQN of the tag being removed
+   */
+  public void propagateTagRemovalToChildren(EntityReference assetRef, String tagFQN) {
+    IndexMapping indexMapping = entityIndexMap.get(assetRef.getType());
+    if (indexMapping == null) {
+      return;
+    }
+    List<String> childAliases =
+        filterChildAliasesByCapability(
+            indexMapping, capability -> capability == null || !capability.isTimeSeries());
+    if (nullOrEmpty(childAliases)) {
+      return;
+    }
+    TagLabel removedTag =
+        new TagLabel().withTagFQN(tagFQN).withLabelType(TagLabel.LabelType.DERIVED);
+    String script = generateDeleteTagLabelListScript();
+    Map<String, Object> params = Map.of("tagDeleted", List.of(removedTag));
+    String parentField = assetRef.getType() + ".id";
+    String entityId = assetRef.getId().toString();
+    deferIfFlushScopeActive(
+        () -> {
+          Exception lastException = null;
+          for (int attempt = 0; attempt < 3; attempt++) {
+            try {
+              searchClient.updateChildren(
+                  childAliases,
+                  new ImmutablePair<>(parentField, entityId),
+                  new ImmutablePair<>(script, params));
+              return;
+            } catch (Exception e) {
+              lastException = e;
+              if (attempt < 2) {
+                try {
+                  Thread.sleep((long) Math.pow(2, attempt) * 1000);
+                } catch (InterruptedException ie) {
+                  Thread.currentThread().interrupt();
+                  break;
+                }
+              }
+            }
+          }
+          LOG.error(
+              "Failed to propagate tag removal [{}] from {} [{}] to children after 3 retries",
+              tagFQN,
+              assetRef.getType(),
+              assetRef.getFullyQualifiedName(),
+              lastException);
+          SearchIndexRetryQueue.enqueue(
+              entityId,
+              assetRef.getFullyQualifiedName(),
+              assetRef.getType(),
+              SearchIndexRetryQueue.failureReason(
+                  "propagateTagRemovalToChildren", lastException));
+        },
+        "propagateTagRemovalToChildren",
+        null,
+        null,
+        assetRef.getType());
+  }
+
+  /**
+   * Batch-propagate tag removal to children of multiple assets. Groups assets by entity type
+   * and issues a single update-by-query per type, drastically reducing the number of ES calls
+   * compared to calling the single-asset overload in a loop.
+   *
+   * @param assetRefs the assets whose tag was removed
+   * @param tagFQN the FQN of the tag being removed
+   */
+  public void propagateTagRemovalToChildren(List<EntityReference> assetRefs, String tagFQN) {
+    if (nullOrEmpty(assetRefs)) {
+      return;
+    }
+    Map<String, List<EntityReference>> refsByType =
+        assetRefs.stream().collect(Collectors.groupingBy(EntityReference::getType));
+    refsByType.forEach(
+        (type, refs) -> propagateTagRemovalToChildrenForType(type, refs, tagFQN));
+  }
+
+  private void propagateTagRemovalToChildrenForType(
+      String entityType, List<EntityReference> assetRefs, String tagFQN) {
+    IndexMapping indexMapping = entityIndexMap.get(entityType);
+    if (indexMapping == null) {
+      return;
+    }
+    List<String> childAliases =
+        filterChildAliasesByCapability(
+            indexMapping, capability -> capability == null || !capability.isTimeSeries());
+    if (nullOrEmpty(childAliases)) {
+      return;
+    }
+    TagLabel removedTag =
+        new TagLabel().withTagFQN(tagFQN).withLabelType(TagLabel.LabelType.DERIVED);
+    String script = generateDeleteTagLabelListScript();
+    Map<String, Object> params = Map.of("tagDeleted", List.of(removedTag));
+    String parentField = entityType + ".id";
+    List<String> parentIds =
+        assetRefs.stream().map(ref -> ref.getId().toString()).toList();
+    // Chunk so the terms query never approaches Elasticsearch's index.max_terms_count
+    for (int start = 0; start < parentIds.size(); start += MAX_PARENT_IDS_PER_TERMS_QUERY) {
+      List<String> chunk =
+          List.copyOf(
+              parentIds.subList(
+                  start,
+                  Math.min(start + MAX_PARENT_IDS_PER_TERMS_QUERY, parentIds.size())));
+      deferIfFlushScopeActive(
+          () -> {
+            Exception lastException = null;
+            for (int attempt = 0; attempt < 3; attempt++) {
+              try {
+                searchClient.updateChildren(
+                    childAliases,
+                    parentField,
+                    chunk,
+                    new ImmutablePair<>(script, params));
+                return;
+              } catch (Exception e) {
+                lastException = e;
+                if (attempt < 2) {
+                  try {
+                    Thread.sleep((long) Math.pow(2, attempt) * 1000);
+                  } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break;
+                  }
+                }
+              }
+            }
+            LOG.error(
+                "Failed to propagate tag removal [{}] from {} to children after 3 retries",
+                tagFQN,
+                entityType,
+                lastException);
+            String reason =
+                SearchIndexRetryQueue.failureReason(
+                    "propagateTagRemovalToChildren", lastException);
+            chunk.forEach(
+                id -> SearchIndexRetryQueue.enqueue(id, null, entityType, reason));
+          },
+          "propagateTagRemovalToChildren",
+          null,
+          null,
+          entityType);
+    }
+  }
+
   private void propagateToDomainChildren(
       String domainId, IndexMapping indexMapping, Pair<String, Map<String, Object>> updates)
       throws IOException {
@@ -3419,7 +3571,8 @@ public class SearchRepository {
         if (ctx._source.tags != null && params.tagDeleted != null) {
           for (int i = ctx._source.tags.size() - 1; i >= 0; i--) {
             for (int j = 0; j < params.tagDeleted.size(); j++) {
-              if (ctx._source.tags[i].tagFQN.equalsIgnoreCase(params.tagDeleted[j].tagFQN)) {
+              if (ctx._source.tags[i].tagFQN.equalsIgnoreCase(params.tagDeleted[j].tagFQN)
+                  && ctx._source.tags[i].labelType == 'Derived') {
                 ctx._source.tags.remove(i);
                 break;
               }


### PR DESCRIPTION
Fixes #31756.

Tag propagation cascade delete is not symmetric with add. When a tag is removed from a table via Glossary Term Assets, the derived tags on child entities (columns, test suites, test cases) in Elasticsearch are not cleaned up.

Root cause: bulkRemoveGlossaryToAssets calls searchRepository.updateEntity(ref) which sets changeDescription to null, causing requiresPropagation to return false and child entities not being re-indexed.

Fix: Added propagateTagRemovalToChildren() method in SearchRepository that uses Painless script to clean up derived tags on child entities, and call it from GlossaryTermRepository after bulkRemove and removeTagFromColumn.









<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR removes glossary-term relationships from selected assets and explicitly cleans derived copies from child search documents.
- Batches child cleanup by parent entity type and ID.
- Restricts the Painless deletion predicate to derived labels.
- Adds bounded immediate retries and queues exhausted search updates.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not yet safe to merge because sibling-derived tags can be removed incorrectly and failed child cleanup cannot be replayed from the retry queue.

Table-wide cleanup still lacks provenance needed to distinguish independently retained derived tags, and both cleanup retry paths enqueue only parent identity rather than the removed-tag operation required to update descendants.

**Files Needing Attention:** openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java; openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java | Dispatches batched child cleanup after bulk removals, but column removal still uses table-wide scope that can affect sibling-derived state. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java | Adds derived-only child-tag cleanup and immediate retries, while exhausted retries still lack the operation context required to replay cleanup. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Bulk glossary removal] --> B[Delete tag relationship]
  B --> C[Reindex selected asset or parent table]
  C --> D[Update child documents by parent ID]
  D -->|Success| E[Derived child tags removed]
  D -->|Three failures| F[Enqueue parent retry]
  F --> G[Reindex parent]
  G -. missing removal context .-> H[Child cleanup not replayed]
```
</details>

<sub>Reviews (7): Last reviewed commit: ["fix: add inline exponential-backoff retr..."](https://github.com/open-metadata/openmetadata/commit/25dfb5183ea1d2d80cae5400c84c92c664c5958a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54822834)</sub>

**Context used:**

- Knowledge Base — [Metadata platform service](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/metadata-platform-service.md)
- Knowledge Base — [Metadata entity lifecycle](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/metadata-entity-lifecycle.md)

<!-- /greptile_comment -->