### PR TITLE
chore(ui): support agentLink prop to RunHistoryDrawer

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/RunHistoryDrawer.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/RunHistoryDrawer.component.tsx
@@ -244,6 +244,7 @@ const RunHistoryDrawer: FC<RunHistoryDrawerProps> = ({
           {agentLinkProps && (
             <Button
               color="link-color"
+              data-testid="agent-link-button"
               href={agentLinkProps.href}
               iconTrailing={<LinkExternal02 size={12} />}
               target="_blank">

--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/RunHistoryDrawer.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/RunHistoryDrawer.component.tsx
@@ -19,7 +19,7 @@ import {
   EmptyPlaceholder,
   SlideoutMenu,
 } from '@openmetadata/ui-core-components';
-import { AlignLeft } from '@untitledui/icons';
+import { AlignLeft, LinkExternal02 } from '@untitledui/icons';
 import { isEmpty } from 'lodash';
 import { FC, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -163,6 +163,10 @@ interface RunHistoryDrawerProps {
   onClose: () => void;
   onOpenLogs: (agent: Agent) => void;
   onRun: (agent: Agent) => void;
+  agentLinkProps?: {
+    href: string;
+    label: string;
+  };
 }
 
 const RunHistoryDrawer: FC<RunHistoryDrawerProps> = ({
@@ -174,6 +178,7 @@ const RunHistoryDrawer: FC<RunHistoryDrawerProps> = ({
   onClose,
   onOpenLogs,
   onRun,
+  agentLinkProps,
 }) => {
   const { t } = useTranslation();
   const { isPending, isUnavailable } = useAgentActionAvailability();
@@ -223,19 +228,32 @@ const RunHistoryDrawer: FC<RunHistoryDrawerProps> = ({
           <span className="tw:grid tw:size-9.5 tw:shrink-0 tw:place-items-center tw:rounded-xl tw:bg-tertiary tw:text-fg-secondary">
             <Icon height={18} width={18} />
           </span>
-          <div className="tw:flex-1">
-            <div className="tw:text-md tw:font-bold tw:text-primary tw:leading-none">
+          <div className="tw:flex-1 tw:min-w-0">
+            <div
+              className="tw:text-md tw:font-bold tw:text-primary tw:leading-none tw:truncate"
+              data-testid="agent-name">
               {agent.name}
             </div>
             <div className="tw:text-xs tw:text-quaternary">
               {t('label.run-history-and-details')}
             </div>
           </div>
+          {agentLinkProps && (
+            <Button
+              color="link-color"
+              href={agentLinkProps.href}
+              iconTrailing={<LinkExternal02 size={12} />}
+              target="_blank">
+              {agentLinkProps.label}
+            </Button>
+          )}
           {/* Raw logs and Run now both go through the pipeline service; the run history below
               does not, so the drawer stays useful when those two are closed down. */}
           <Button
-            className="tw:font-semibold tw:after:outline-secondary"
-            color="secondary"
+            className="tw:font-semibold"
+            color={
+              agent.status === 'failed' ? 'secondary-destructive' : 'secondary'
+            }
             data-testid="raw-logs-button"
             iconLeading={<AlignLeft size={15} />}
             isDisabled={isPending || isUnavailable}
@@ -245,8 +263,8 @@ const RunHistoryDrawer: FC<RunHistoryDrawerProps> = ({
           </Button>
           {canRunAgent(agent, permissions) && (
             <Button
-              className="tw:font-semibold tw:text-brand-tertiary tw:after:outline-secondary"
-              color="secondary"
+              className="tw:font-semibold"
+              color="primary"
               data-testid="drawer-run-now-button"
               iconLeading={<PlayIcon height={14} width={14} />}
               isDisabled={isPending || isUnavailable}

--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/RunHistoryDrawer.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/RunHistoryDrawer.component.tsx
@@ -230,10 +230,12 @@ const RunHistoryDrawer: FC<RunHistoryDrawerProps> = ({
             <Icon height={18} width={18} />
           </span>
           <div className="tw:flex-1 tw:min-w-0">
+            {/* The ellipsis tooltip already surfaces the full name on hover, so a
+                native `title` here would only stack an OS-styled duplicate that
+                ignores the theme and fires even when the name is not clipped. */}
             <Typography
               ellipsis={{ rows: 1, tooltip: true }}
               size="text-md"
-              title={agent.name}
               weight="bold">
               {agent.name}
             </Typography>

--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/RunHistoryDrawer.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/RunHistoryDrawer.component.tsx
@@ -231,7 +231,7 @@ const RunHistoryDrawer: FC<RunHistoryDrawerProps> = ({
           </span>
           <div className="tw:flex-1 tw:min-w-0">
             <Typography
-              ellipsis={{ rows: 1 }}
+              ellipsis={{ rows: 1, tooltip: true }}
               size="text-md"
               title={agent.name}
               weight="bold">

--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/RunHistoryDrawer.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/RunHistoryDrawer.component.tsx
@@ -18,6 +18,7 @@ import {
   Card,
   EmptyPlaceholder,
   SlideoutMenu,
+  Typography,
 } from '@openmetadata/ui-core-components';
 import { AlignLeft, LinkExternal02 } from '@untitledui/icons';
 import { isEmpty } from 'lodash';
@@ -229,11 +230,13 @@ const RunHistoryDrawer: FC<RunHistoryDrawerProps> = ({
             <Icon height={18} width={18} />
           </span>
           <div className="tw:flex-1 tw:min-w-0">
-            <div
-              className="tw:text-md tw:font-bold tw:text-primary tw:leading-none tw:truncate"
-              data-testid="agent-name">
+            <Typography
+              ellipsis={{ rows: 1 }}
+              size="text-md"
+              title={agent.name}
+              weight="bold">
               {agent.name}
-            </div>
+            </Typography>
             <div className="tw:text-xs tw:text-quaternary">
               {t('label.run-history-and-details')}
             </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/RunHistoryDrawer.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/RunHistoryDrawer.test.tsx
@@ -251,6 +251,62 @@ describe('RunHistoryDrawer', () => {
     expect(useAgentRuns).toHaveBeenCalledWith(agent.fqn, true, fetchRuns);
   });
 
+  describe('header title', () => {
+    it('should truncate a long agent name and keep it reachable through the ellipsis tooltip', () => {
+      // The header is a fixed-width row shared with the action buttons, so a long
+      // name has to clip rather than push them out. Clipping is only honest while
+      // the full name stays readable, which core Typography delivers by wrapping
+      // the text in a tooltip trigger. Hover itself belongs to core-components
+      // (see its typography.test.tsx); asserting it here would re-test react-aria's
+      // open/close timing rather than this drawer.
+      const longName =
+        'A very long metadata agent name that will not fit the drawer header';
+
+      renderDrawer(undefined, { name: longName });
+
+      const title = screen.getByText(longName);
+
+      expect(title).toHaveClass('tw:truncate');
+      expect(title.closest('button')).toBeInTheDocument();
+    });
+  });
+
+  describe('agent link', () => {
+    const agentLinkProps = {
+      href: '/ai-automations/mysql_service_DescriptionAutomation',
+      label: 'label.view-entity',
+    };
+
+    it('should render no link when the host has no detail page to point at', () => {
+      // OpenMetadata's own agents have nowhere to link, so the header must stay
+      // exactly as it was before the prop existed.
+      renderDrawer();
+
+      expect(screen.queryByTestId('agent-link-button')).not.toBeInTheDocument();
+    });
+
+    it('should render the agent link as an anchor that opens in a new tab', () => {
+      // The drawer sits on top of the page the user came from; navigating in place
+      // would lose the run they were reading.
+      render(
+        <RunHistoryDrawer
+          open
+          agent={agent}
+          agentLinkProps={agentLinkProps}
+          onClose={jest.fn()}
+          onOpenLogs={jest.fn()}
+          onRun={mockOnRun}
+        />
+      );
+
+      const link = screen.getByTestId('agent-link-button');
+
+      expect(link).toHaveAttribute('href', agentLinkProps.href);
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveTextContent(agentLinkProps.label);
+    });
+  });
+
   describe('steps section', () => {
     // The suite-level mock uses mockImplementation; a per-test mockReturnValue would outlive the
     // test and leak into the next one, so restore the default after each.


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?


-->

<img width="726" height="682" alt="Screenshot 2026-08-19 at 10 54 48 PM" src="https://github.com/user-attachments/assets/4edc8a4a-a468-4d31-9148-4b8869b1d787" />

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **UI Enhancements:**
    - Added `agentLinkProps` to `RunHistoryDrawer` for external agent navigation links
    - Updated agent name display with `Typography` component supporting text ellipsis
    - Adjusted button styles and color conditions in `RunHistoryDrawer.component.tsx`

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR extends the run-history drawer with optional agent-detail navigation and improved handling of long agent names.
- Adds an optional external agent link to the drawer header.
- Uses the shared Typography component to truncate long names and expose their full text through a tooltip.
- Adds tests covering title truncation and optional link rendering.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/RunHistoryDrawer.component.tsx | Adds the optional agent link and ellipsis-aware title rendering. |
| openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/RunHistoryDrawer.test.tsx | Covers long-title truncation and the presence, absence, and attributes of the optional agent link. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(ui): drop the redundant native title..."](https://github.com/open-metadata/openmetadata/commit/5174c3d429c7c776023c8ad32261a4260199ad03) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54848561)</sub>

<!-- /greptile_comment -->