### PR TITLE
Fixes #31790: Force sqlparse 0.6.0 in ingestion operator images to clear 4 CVEs

### DIFF
--- a/ingestion/operators/docker/Dockerfile
+++ b/ingestion/operators/docker/Dockerfile
@@ -230,9 +230,46 @@ USER openmetadata
 # build-time only: cx_Oracle and mysqlclient import pkg_resources from their setup.py and
 # 81.0.0 removed it, but once built both import fine against 83+. Leaving 80.x on disk is
 # what keeps scanners reporting CVE-2026-59890.
-# Keep this the LAST pip layer -- a later layer that compiles a package needing
-# pkg_resources would fail here, and the error would not look like a setuptools problem.
+# Keep this the LAST pip layer that can compile anything -- a later layer that builds a
+# package needing pkg_resources would fail here, and the error would not look like a
+# setuptools problem. The sqlparse override below is a pure-Python wheel, so it is exempt.
 RUN pip install --upgrade "setuptools>=83"
+
+# Force sqlparse past two declared ceilings to clear CVE-2026-54284, CVE-2026-59893,
+# CVE-2026-71491 (parser CPU-exhaustion DoS) and CVE-2026-59894 (SQL string breakout in
+# the python/php output formats). All four are fixed only in 0.6.0 -- OSV reports no
+# patched 0.5.x -- so no in-range version is clean and the resolver cannot help us:
+#     collate-sqllineage 2.1.4                     sqlparse==0.5.4
+#     dbt-core (transitive via collate-data-diff)  sqlparse<0.6.0
+# Both ceilings are stale rather than substantive. collate-sqllineage 2.1.5 shipped with
+# sqlparse==0.6.0 and 2.1.6 reverted only the pin to stay co-installable with dbt-core --
+# the two releases are byte-identical apart from the version string, so 0.6.0 is a version
+# upstream already released against. dbt-core's ceiling predates 0.6.0 by nine months and
+# is tracked at https://github.com/dbt-labs/dbt-core/issues/15988. Once that lands, delete
+# this layer and raise the floors in ingestion/setup.py instead.
+#
+# --no-deps because pip would otherwise backtrack on the declared conflict. `pip install`
+# exits 0 while printing the resolver-conflict ERROR, and `pip check` will report the two
+# unsatisfied pins for the life of the image, so the import gate is what actually keeps
+# this honest. It asserts the two things that would otherwise fail silently: that we really
+# got 0.6.x, and that collate-sqllineage's monkeypatch of sqlparse internals still bites.
+# That patch raises MAX_GROUPING_DEPTH/MAX_GROUPING_TOKENS 100x and retypes STRING as a
+# builtin; if a future sqlparse renames either, the patch degrades to a no-op and lineage
+# comes back quietly truncated with nothing failing.
+RUN pip install --no-deps "sqlparse==0.6.0" \
+ && python -W ignore -c "\
+import sqlparse; \
+from sqlparse.engine import grouping; \
+from sqlparse.keywords import KEYWORDS; \
+import collate_sqllineage.core.parser.sqlparse; \
+from collate_sqllineage.core.parser.sqlparse.analyzer import SqlParseLineageAnalyzer; \
+from collate_sqllineage.runner import LineageRunner; \
+assert sqlparse.__version__.startswith('0.6.'), sqlparse.__version__; \
+assert (grouping.MAX_GROUPING_DEPTH, grouping.MAX_GROUPING_TOKENS) == (10000, 1000000), 'sqllineage grouping patch is a no-op'; \
+assert str(KEYWORDS['STRING']) == 'Token.Name.Builtin', 'sqllineage keyword patch is a no-op'; \
+r = LineageRunner('INSERT INTO db.sch.tgt SELECT c FROM db.sch.src', analyzer=SqlParseLineageAnalyzer); \
+assert [str(t) for t in r.source_tables] == ['db.sch.src'], r.source_tables; \
+assert [str(t) for t in r.target_tables] == ['db.sch.tgt'], r.target_tables"
 
 
 # Strip spaCy's bundled test fixture, which scanners misreport as an installed black.

--- a/ingestion/operators/docker/Dockerfile.ci
+++ b/ingestion/operators/docker/Dockerfile.ci
@@ -238,9 +238,46 @@ USER openmetadata
 # build-time only: cx_Oracle and mysqlclient import pkg_resources from their setup.py and
 # 81.0.0 removed it, but once built both import fine against 83+. Leaving 80.x on disk is
 # what keeps scanners reporting CVE-2026-59890.
-# Keep this the LAST pip layer -- a later layer that compiles a package needing
-# pkg_resources would fail here, and the error would not look like a setuptools problem.
+# Keep this the LAST pip layer that can compile anything -- a later layer that builds a
+# package needing pkg_resources would fail here, and the error would not look like a
+# setuptools problem. The sqlparse override below is a pure-Python wheel, so it is exempt.
 RUN pip install --upgrade "setuptools>=83"
+
+# Force sqlparse past two declared ceilings to clear CVE-2026-54284, CVE-2026-59893,
+# CVE-2026-71491 (parser CPU-exhaustion DoS) and CVE-2026-59894 (SQL string breakout in
+# the python/php output formats). All four are fixed only in 0.6.0 -- OSV reports no
+# patched 0.5.x -- so no in-range version is clean and the resolver cannot help us:
+#     collate-sqllineage 2.1.4                     sqlparse==0.5.4
+#     dbt-core (transitive via collate-data-diff)  sqlparse<0.6.0
+# Both ceilings are stale rather than substantive. collate-sqllineage 2.1.5 shipped with
+# sqlparse==0.6.0 and 2.1.6 reverted only the pin to stay co-installable with dbt-core --
+# the two releases are byte-identical apart from the version string, so 0.6.0 is a version
+# upstream already released against. dbt-core's ceiling predates 0.6.0 by nine months and
+# is tracked at https://github.com/dbt-labs/dbt-core/issues/15988. Once that lands, delete
+# this layer and raise the floors in ingestion/setup.py instead.
+#
+# --no-deps because pip would otherwise backtrack on the declared conflict. `pip install`
+# exits 0 while printing the resolver-conflict ERROR, and `pip check` will report the two
+# unsatisfied pins for the life of the image, so the import gate is what actually keeps
+# this honest. It asserts the two things that would otherwise fail silently: that we really
+# got 0.6.x, and that collate-sqllineage's monkeypatch of sqlparse internals still bites.
+# That patch raises MAX_GROUPING_DEPTH/MAX_GROUPING_TOKENS 100x and retypes STRING as a
+# builtin; if a future sqlparse renames either, the patch degrades to a no-op and lineage
+# comes back quietly truncated with nothing failing.
+RUN pip install --no-deps "sqlparse==0.6.0" \
+ && python -W ignore -c "\
+import sqlparse; \
+from sqlparse.engine import grouping; \
+from sqlparse.keywords import KEYWORDS; \
+import collate_sqllineage.core.parser.sqlparse; \
+from collate_sqllineage.core.parser.sqlparse.analyzer import SqlParseLineageAnalyzer; \
+from collate_sqllineage.runner import LineageRunner; \
+assert sqlparse.__version__.startswith('0.6.'), sqlparse.__version__; \
+assert (grouping.MAX_GROUPING_DEPTH, grouping.MAX_GROUPING_TOKENS) == (10000, 1000000), 'sqllineage grouping patch is a no-op'; \
+assert str(KEYWORDS['STRING']) == 'Token.Name.Builtin', 'sqllineage keyword patch is a no-op'; \
+r = LineageRunner('INSERT INTO db.sch.tgt SELECT c FROM db.sch.src', analyzer=SqlParseLineageAnalyzer); \
+assert [str(t) for t in r.source_tables] == ['db.sch.src'], r.source_tables; \
+assert [str(t) for t in r.target_tables] == ['db.sch.tgt'], r.target_tables"
 
 
 # Strip spaCy's bundled test fixture, which scanners misreport as an installed black.


### PR DESCRIPTION
### Describe your changes:

Fixes #31790

I forced `sqlparse==0.6.0` into `ingestion/operators/docker/Dockerfile` and `Dockerfile.ci` because CVE-2026-54284, CVE-2026-59893, CVE-2026-71491 (parser CPU-exhaustion DoS) and CVE-2026-59894 (string breakout in the `python`/`php` output formats) are fixed **only** in 0.6.0 — OSV reports no patched 0.5.x, so no version inside the declared ranges is clean. Three stale ceilings block the resolver from getting there (`collate-sqllineage 2.1.4` → `sqlparse==0.5.4`, `dbt-core` transitively → `sqlparse<0.6.0`, Airflow constraints → `sqlparse==0.5.5`), and `collate-sqllineage 2.1.5` already shipped against `sqlparse==0.6.0` — 2.1.6 reverted only the pin to stay co-installable with dbt-core, and the two wheels are byte-identical apart from the version string. The override is `pip install --no-deps` as the last pip layer plus a fail-closed import gate, because `pip install` exits 0 while printing the resolver conflict and would otherwise leave a silently-vulnerable image. dbt-core's ceiling is reported upstream at dbt-labs/dbt-core#15988; once it lands this layer goes away and the floors move into `ingestion/setup.py`, which fixes it for PyPI consumers too rather than only our images.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change (2 files, one pip layer each).

The one non-obvious choice worth calling out: the gate asserts that collate-sqllineage's **monkeypatch of sqlparse internals still applies**, not just the version. That patch raises `grouping.MAX_GROUPING_DEPTH`/`MAX_GROUPING_TOKENS` 100×, retypes `KEYWORDS["STRING"]` as `Name.Builtin`, and rewrites the `LATERAL VIEW EXPLODE` `SQL_REGEX` entry. If a future sqlparse renames either grouping global, the patch degrades to a no-op and lineage comes back quietly truncated with **nothing failing** — a version assert alone would not catch that.

#
### Tests:

#### Use cases covered
- Ingestion image builds and the lineage/masking/SQL-guard paths keep working on `sqlparse` 0.6.0
- Query-log lineage no longer loses a whole query on `WITH x AS MATERIALIZED (...)`
- `is_safe_sql_query` keeps rejecting forbidden SQL, including the statement shapes 0.6.0 re-tokenizes

#### Unit tests
No new test files. Verification was a **differential test of 0.5.4 vs 0.6.0** in two venvs over 372 SQL statements scraped from our own `ingestion/tests/unit/` corpus, plus 21 targeted cases covering every 0.5.5/0.6.0 changelog entry:

| Probe | Result |
|---|---|
| `is_safe_sql_query` (loaded verbatim from `metadata/utils/helpers.py`) | **0 verdict changes** — 372 corpus + 23 adversarial forbidden-SQL shapes |
| Lineage via `SqlParseLineageAnalyzer` and sqlfluff/ansi — 744 runs | **7 diffs, all improvements** (see below) |
| `mask_query` (real `metadata/ingestion/lineage/masker.py`) | 383 queries, 1 diff, **pre-existing bug not a regression** |
| collate-sqllineage monkeypatch surfaces | All 4 intact; 400-deep and 4000-tuple queries parse to identical token counts |

The 7 lineage differences, all in 0.6.0's favour:
- `WITH x AS MATERIALIZED (...)` no longer dies with `ValueError: too many values to unpack (expected 2)` — under 0.5.4 that query's lineage was lost entirely
- lowercase `as` in `CREATE TABLE t as SELECT f(x) FROM u` now matches uppercase `AS`; 0.5.4 emitted `u.f -> t.f`, a column that does not exist
- the phantom `<default>.materialized` source table is gone
- recovered lineage on a subquery CTAS that previously returned no sources

On `mask_query`: `masker.py` masks `parser._parsed_result`, a single statement, so **any** multi-statement query already loses all but the last one under 0.5.4 (`SELECT 1..; SELECT 2..` → only the 2nd). 0.6.0's corrected splitting merely adds `BEGIN TRANSACTION; …; COMMIT;` to the shapes that hit it. Masking never became weaker — nothing masked before is unmasked after. Related to the closed #19122; not fixed here.

**Not done:** the full `make unit_ingestion` suite was not run under the override — the differential test covers the same code paths but is not a green suite. Worth one CI run against the built image before merge.

#### Backend integration tests
Not applicable — no backend API changes.

#### Ingestion integration tests
Not applicable — no ingestion source changes; this is an image dependency override.

#### Playwright (UI) tests
Not applicable — no UI changes.

#### Manual testing performed
1. Built two venvs with `collate-sqllineage==2.1.4`, forcing `sqlparse==0.6.0` in one via `pip install --no-deps`, and confirmed the install exits 0 while `pip check` reports the unsatisfied pins (no CI job runs `pip check`).
2. Ran the differential harness above in both venvs and diffed the JSON output probe by probe.
3. Verified the build gate is not vacuous: it exits 0 under 0.6.0 and exits 1 with `AssertionError: 0.5.4` under 0.5.4.
4. Simulated Docker's line-continuation join on both Dockerfiles and confirmed each block collapses to a single valid shell command (`sh -n` clean).

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. — N/A, no schema changes
- [ ] For UI changes: I attached a screen recording and/or screenshots above. — N/A, no UI changes
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing — the build-time import gate fails closed if the image ever resolves back to a vulnerable sqlparse or if collate-sqllineage's monkeypatch stops applying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR forces sqlparse 0.6.0 into ingestion operator images to address four vulnerabilities despite stale transitive dependency ceilings.
- Adds the override to production and CI operator images using a final `--no-deps` installation layer.
- Adds build-time assertions for the installed version, collate-sqllineage monkeypatch state, and basic source/target lineage behavior.
- Documents the dependency conflicts and conditions for removing the override.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge based on the reviewed image dependency override and its fail-closed compatibility checks.

No concrete changed-code failure remained after accounting for the pinned collate-sqllineage version, build-time assertions, and the compatibility evidence provided for exercised ingestion paths.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/operators/docker/Dockerfile | Forces sqlparse 0.6.0 in the production ingestion operator image and validates version and lineage compatibility during the build. |
| ingestion/operators/docker/Dockerfile.ci | Mirrors the sqlparse override and fail-closed compatibility gate in the CI ingestion operator image. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Force sqlparse 0.6.0 in the ingestion op..."](https://github.com/open-metadata/openmetadata/commit/b2b5256c20a7ab46ea7afccc61bdff5eb9ca620b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54858734)</sub>

<!-- /greptile_comment -->