### PR TITLE
fix(security): bump netty to 4.1.137.Final for CVE-2026-59903 (1.13 backport)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -701,10 +701,13 @@
         <artifactId>azure-identity</artifactId>
         <version>1.15.2</version>
       </dependency>
+      <!-- Pin all transitive io.netty:* to one patched line via the BOM (netty-codec-http et al.
+           arrive transitively through reactor-netty-http and others). 4.1.137.Final clears the
+           CorsHandler Vary-header cache-poisoning / info-disclosure issue, CVE-2026-59903. -->
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.1.135.Final</version>
+        <version>4.1.137.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Backport of #31725 to the `1.13` release branch.

## What

Bumps the imported `io.netty:netty-bom` in the root `pom.xml` from **4.1.135.Final → 4.1.137.Final** to remediate **CVE-2026-59903** (MEDIUM, CVSS 6.5) in `netty-codec-http`.

> Note: `1.13` was on `4.1.135.Final` (main was on `4.1.136`), so the cherry-pick had a one-line version-context conflict, resolved to the fixed `4.1.137.Final`. Both `4.1.135` and `4.1.136` are within the affected range `< 4.1.137`.

## Why

`CorsHandler` overwrote an existing `Vary` header with `Vary: Origin`, stripping cache-partitioning headers such as `Authorization`/`Cookie`. Through a shared proxy/reverse-proxy/CDN this enables cache poisoning and disclosure of authenticated content.

- Affected: `netty-codec-http` `< 4.1.137` and `>= 4.2.0, < 4.2.17`
- Fixed: **4.1.137.Final** (4.1.x line) — patched version per the [advisory](https://advisories.gitlab.com/maven/io.netty/netty-codec-http/CVE-2026-59903/)

`netty-codec-http` is pulled transitively (via `reactor-netty-http` and others); bumping the BOM moves the whole `io.netty:*` set onto the patched 4.1.x line. Stays on the existing 4.1.x line (no 4.2 major-line jump).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the imported Netty BOM from 4.1.135.Final to 4.1.137.Final to remediate CVE-2026-59903 while retaining the existing Netty 4.1.x line.
- Pins transitively consumed `io.netty:*` artifacts to the patched BOM release.
- Documents the affected HTTP CORS cache-handling behavior and the purpose of the dependency pin.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or non-blocking defect identified in the dependency update.

The change is a patch-level Netty BOM upgrade on the existing 4.1.x line, and the repository contains no explicit divergent Netty version override or demonstrated incompatible call path.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pom.xml | Bumps the centrally imported Netty BOM to the patched 4.1.137.Final release; no concrete dependency-resolution or compatibility defect was established. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): bump netty to 4.1.137.Fin..."](https://github.com/open-metadata/openmetadata/commit/091250377408a59ec0fe2733c7c18a1c1241b0cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54958348)</sub>

<!-- /greptile_comment -->