### PR TITLE
ci: fail fast instead of hanging when the apt mirror stalls

### DIFF
--- a/.github/workflows/integration-tests-mysql-elasticsearch.yml
+++ b/.github/workflows/integration-tests-mysql-elasticsearch.yml
@@ -281,7 +281,7 @@ jobs:
             return 1
           }
           apt_retry 240 update
-          apt_retry 300 install -yunixodbc-dev python3-venv librdkafka-dev gcc libsasl2-dev build-essential libssl-dev libffi-dev \
+          apt_retry 300 install -y unixodbc-dev python3-venv librdkafka-dev gcc libsasl2-dev build-essential libssl-dev libffi-dev \
           libevent-dev jq
           sudo make install_antlr_cli
 

--- a/.github/workflows/integration-tests-mysql-elasticsearch.yml
+++ b/.github/workflows/integration-tests-mysql-elasticsearch.yml
@@ -252,21 +252,36 @@ jobs:
           Acquire::https::Timeout "30";
           Acquire::http::No-Cache "true";
           APTCONF
+          # Keep the whole retry budget strictly inside this step's timeout-minutes.
+          # Otherwise the outer deadline truncates a retry and kills the step before
+          # the helper can say why it gave up, which is the failure we're fixing.
+          APT_BUDGET=600
+          APT_DEADLINE=$((SECONDS + APT_BUDGET))
           apt_retry() {
             local limit=$1; shift
-            local i
+            local i remaining
             for i in 1 2 3; do
+              remaining=$((APT_DEADLINE - SECONDS))
+              if [ "$remaining" -le 30 ]; then
+                echo "::error::apt-get $1 gave up: exhausted the ${APT_BUDGET}s apt budget"
+                return 1
+              fi
+              if [ "$limit" -gt "$remaining" ]; then
+                limit=$remaining
+              fi
               if sudo timeout "$limit" apt-get "$@"; then
                 return 0
               fi
-              echo "::warning::apt-get $1 failed or hung (attempt $i/3); retrying in 15s"
-              sleep 15
+              if [ "$i" -lt 3 ]; then
+                echo "::warning::apt-get $1 failed or hung (attempt $i/3); retrying in 10s"
+                sleep 10
+              fi
             done
             echo "::error::apt-get $1 failed after 3 attempts"
             return 1
           }
-          apt_retry 180 update
-          apt_retry 600 install -y unixodbc-dev python3-venv librdkafka-dev gcc libsasl2-dev build-essential libssl-dev libffi-dev \
+          apt_retry 240 update
+          apt_retry 300 install -yunixodbc-dev python3-venv librdkafka-dev gcc libsasl2-dev build-essential libssl-dev libffi-dev \
           libevent-dev jq
           sudo make install_antlr_cli
 

--- a/.github/workflows/integration-tests-mysql-elasticsearch.yml
+++ b/.github/workflows/integration-tests-mysql-elasticsearch.yml
@@ -241,9 +241,32 @@ jobs:
           distribution: 'temurin'
 
       - name: Install Ubuntu dependencies
+        timeout-minutes: 15
         run: |
-          sudo apt-get update
-          sudo apt-get install -y unixodbc-dev python3-venv librdkafka-dev gcc libsasl2-dev build-essential libssl-dev libffi-dev \
+          # The hosted-runner Azure apt mirror intermittently blackholes connections;
+          # apt then falls back to archive.ubuntu.com and can hang forever with no
+          # output, burning the whole job timeout. Bound every fetch and retry.
+          sudo tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'APTCONF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          Acquire::http::No-Cache "true";
+          APTCONF
+          apt_retry() {
+            local limit=$1; shift
+            local i
+            for i in 1 2 3; do
+              if sudo timeout "$limit" apt-get "$@"; then
+                return 0
+              fi
+              echo "::warning::apt-get $1 failed or hung (attempt $i/3); retrying in 15s"
+              sleep 15
+            done
+            echo "::error::apt-get $1 failed after 3 attempts"
+            return 1
+          }
+          apt_retry 180 update
+          apt_retry 600 install -y unixodbc-dev python3-venv librdkafka-dev gcc libsasl2-dev build-essential libssl-dev libffi-dev \
           libevent-dev jq
           sudo make install_antlr_cli
 

--- a/.github/workflows/integration-tests-postgres-elasticsearch-redis.yml
+++ b/.github/workflows/integration-tests-postgres-elasticsearch-redis.yml
@@ -258,9 +258,32 @@ jobs:
           distribution: 'temurin'
 
       - name: Install Ubuntu dependencies
+        timeout-minutes: 15
         run: |
-          sudo apt-get update
-          sudo apt-get install -y unixodbc-dev python3-venv librdkafka-dev gcc libsasl2-dev build-essential libssl-dev libffi-dev \
+          # The hosted-runner Azure apt mirror intermittently blackholes connections;
+          # apt then falls back to archive.ubuntu.com and can hang forever with no
+          # output, burning the whole job timeout. Bound every fetch and retry.
+          sudo tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'APTCONF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          Acquire::http::No-Cache "true";
+          APTCONF
+          apt_retry() {
+            local limit=$1; shift
+            local i
+            for i in 1 2 3; do
+              if sudo timeout "$limit" apt-get "$@"; then
+                return 0
+              fi
+              echo "::warning::apt-get $1 failed or hung (attempt $i/3); retrying in 15s"
+              sleep 15
+            done
+            echo "::error::apt-get $1 failed after 3 attempts"
+            return 1
+          }
+          apt_retry 180 update
+          apt_retry 600 install -y unixodbc-dev python3-venv librdkafka-dev gcc libsasl2-dev build-essential libssl-dev libffi-dev \
           libevent-dev jq
           sudo make install_antlr_cli
 

--- a/.github/workflows/integration-tests-postgres-elasticsearch-redis.yml
+++ b/.github/workflows/integration-tests-postgres-elasticsearch-redis.yml
@@ -269,21 +269,36 @@ jobs:
           Acquire::https::Timeout "30";
           Acquire::http::No-Cache "true";
           APTCONF
+          # Keep the whole retry budget strictly inside this step's timeout-minutes.
+          # Otherwise the outer deadline truncates a retry and kills the step before
+          # the helper can say why it gave up, which is the failure we're fixing.
+          APT_BUDGET=600
+          APT_DEADLINE=$((SECONDS + APT_BUDGET))
           apt_retry() {
             local limit=$1; shift
-            local i
+            local i remaining
             for i in 1 2 3; do
+              remaining=$((APT_DEADLINE - SECONDS))
+              if [ "$remaining" -le 30 ]; then
+                echo "::error::apt-get $1 gave up: exhausted the ${APT_BUDGET}s apt budget"
+                return 1
+              fi
+              if [ "$limit" -gt "$remaining" ]; then
+                limit=$remaining
+              fi
               if sudo timeout "$limit" apt-get "$@"; then
                 return 0
               fi
-              echo "::warning::apt-get $1 failed or hung (attempt $i/3); retrying in 15s"
-              sleep 15
+              if [ "$i" -lt 3 ]; then
+                echo "::warning::apt-get $1 failed or hung (attempt $i/3); retrying in 10s"
+                sleep 10
+              fi
             done
             echo "::error::apt-get $1 failed after 3 attempts"
             return 1
           }
-          apt_retry 180 update
-          apt_retry 600 install -y unixodbc-dev python3-venv librdkafka-dev gcc libsasl2-dev build-essential libssl-dev libffi-dev \
+          apt_retry 240 update
+          apt_retry 300 install -yunixodbc-dev python3-venv librdkafka-dev gcc libsasl2-dev build-essential libssl-dev libffi-dev \
           libevent-dev jq
           sudo make install_antlr_cli
 

--- a/.github/workflows/integration-tests-postgres-elasticsearch-redis.yml
+++ b/.github/workflows/integration-tests-postgres-elasticsearch-redis.yml
@@ -298,7 +298,7 @@ jobs:
             return 1
           }
           apt_retry 240 update
-          apt_retry 300 install -yunixodbc-dev python3-venv librdkafka-dev gcc libsasl2-dev build-essential libssl-dev libffi-dev \
+          apt_retry 300 install -y unixodbc-dev python3-venv librdkafka-dev gcc libsasl2-dev build-essential libssl-dev libffi-dev \
           libevent-dev jq
           sudo make install_antlr_cli
 

--- a/.github/workflows/openmetadata-service-unit-tests.yml
+++ b/.github/workflows/openmetadata-service-unit-tests.yml
@@ -108,21 +108,36 @@ jobs:
           Acquire::https::Timeout "30";
           Acquire::http::No-Cache "true";
           APTCONF
+          # Keep the whole retry budget strictly inside this step's timeout-minutes.
+          # Otherwise the outer deadline truncates a retry and kills the step before
+          # the helper can say why it gave up, which is the failure we're fixing.
+          APT_BUDGET=600
+          APT_DEADLINE=$((SECONDS + APT_BUDGET))
           apt_retry() {
             local limit=$1; shift
-            local i
+            local i remaining
             for i in 1 2 3; do
+              remaining=$((APT_DEADLINE - SECONDS))
+              if [ "$remaining" -le 30 ]; then
+                echo "::error::apt-get $1 gave up: exhausted the ${APT_BUDGET}s apt budget"
+                return 1
+              fi
+              if [ "$limit" -gt "$remaining" ]; then
+                limit=$remaining
+              fi
               if sudo timeout "$limit" apt-get "$@"; then
                 return 0
               fi
-              echo "::warning::apt-get $1 failed or hung (attempt $i/3); retrying in 15s"
-              sleep 15
+              if [ "$i" -lt 3 ]; then
+                echo "::warning::apt-get $1 failed or hung (attempt $i/3); retrying in 10s"
+                sleep 10
+              fi
             done
             echo "::error::apt-get $1 failed after 3 attempts"
             return 1
           }
-          apt_retry 180 update
-          apt_retry 600 install -y unixodbc-dev python3-venv librdkafka-dev gcc libsasl2-dev build-essential libssl-dev libffi-dev \
+          apt_retry 240 update
+          apt_retry 300 install -yunixodbc-dev python3-venv librdkafka-dev gcc libsasl2-dev build-essential libssl-dev libffi-dev \
           librdkafka-dev unixodbc-dev libevent-dev jq
           sudo make install_antlr_cli
 

--- a/.github/workflows/openmetadata-service-unit-tests.yml
+++ b/.github/workflows/openmetadata-service-unit-tests.yml
@@ -137,7 +137,7 @@ jobs:
             return 1
           }
           apt_retry 240 update
-          apt_retry 300 install -yunixodbc-dev python3-venv librdkafka-dev gcc libsasl2-dev build-essential libssl-dev libffi-dev \
+          apt_retry 300 install -y unixodbc-dev python3-venv librdkafka-dev gcc libsasl2-dev build-essential libssl-dev libffi-dev \
           librdkafka-dev unixodbc-dev libevent-dev jq
           sudo make install_antlr_cli
 

--- a/.github/workflows/openmetadata-service-unit-tests.yml
+++ b/.github/workflows/openmetadata-service-unit-tests.yml
@@ -97,9 +97,32 @@ jobs:
           distribution: "temurin"
 
       - name: Install Ubuntu dependencies
+        timeout-minutes: 15
         run: |
-          sudo apt-get update
-          sudo apt-get install -y unixodbc-dev python3-venv librdkafka-dev gcc libsasl2-dev build-essential libssl-dev libffi-dev \
+          # The hosted-runner Azure apt mirror intermittently blackholes connections;
+          # apt then falls back to archive.ubuntu.com and can hang forever with no
+          # output, burning the whole job timeout. Bound every fetch and retry.
+          sudo tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'APTCONF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          Acquire::http::No-Cache "true";
+          APTCONF
+          apt_retry() {
+            local limit=$1; shift
+            local i
+            for i in 1 2 3; do
+              if sudo timeout "$limit" apt-get "$@"; then
+                return 0
+              fi
+              echo "::warning::apt-get $1 failed or hung (attempt $i/3); retrying in 15s"
+              sleep 15
+            done
+            echo "::error::apt-get $1 failed after 3 attempts"
+            return 1
+          }
+          apt_retry 180 update
+          apt_retry 600 install -y unixodbc-dev python3-venv librdkafka-dev gcc libsasl2-dev build-essential libssl-dev libffi-dev \
           librdkafka-dev unixodbc-dev libevent-dev jq
           sudo make install_antlr_cli
 


### PR DESCRIPTION
### Describe your changes:

Fixes #<issue-number>

<!-- TODO: link an issue — `PR Metadata Validation` requires one, added to the
     **Shipping** project with Status / Source / Priority / Domain / Release set. -->

The hosted-runner Azure apt mirror intermittently blackholes connections. When it does, `apt-get
update` logs `Ign:` for every `azure.archive.ubuntu.com` index, falls back to `archive.ubuntu.com`,
and then hangs indefinitely with **no output at all**. The step never returns, so the job burns its
entire `timeout-minutes` budget before GitHub kills it — and a job killed by its own timeout is
reported with conclusion **`cancelled`**, which reads like a human pressed the cancel button.

This happened on 2026-08-19 to three separate workflows on the same commit (PR #31715). Every one of
them died on the identical line, 83–95 minutes after it was printed, without executing a single test:

```
21:34:52  Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease     ← Azure mirror dead
21:34:53  Hit:2 https://archive.ubuntu.com/ubuntu noble InRelease          ← fell back upstream
21:34:54  Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
             ⋮  (83 minutes of silence)
22:58:03  ##[error]The operation was canceled.
```

Affected runs: [32303539887](https://github.com/open-metadata/OpenMetadata/actions/runs/32303539887)
(MySQL+ES), [32303539943](https://github.com/open-metadata/OpenMetadata/actions/runs/32303539943)
(PostgreSQL+ES+Redis), [32303539608](https://github.com/open-metadata/OpenMetadata/actions/runs/32303539608)
(Service Unit Tests). All three passed on re-run with no code change, confirming it was purely the mirror.

**What changed** — in the `Install Ubuntu dependencies` step of those three workflows:

- Each `apt-get` invocation is wrapped in `timeout(1)` (240s for `update`, 300s for `install`) and
  retried up to 3 times, so a stalled mirror is killed rather than waited on forever.
- All apt work shares an explicit `APT_BUDGET` of 600s, and **each attempt is clamped to the budget
  remaining**. The budget sits strictly inside the step's `timeout-minutes: 15`, so the outer
  deadline can never truncate a retry — a give-up always gets to print *why*.
- `Acquire::Retries`, `Acquire::http::Timeout` and `Acquire::https::Timeout` are set so apt itself
  gives up on a dead connection instead of blocking.
- `timeout-minutes: 15` remains as a backstop for anything else in the step that hangs, leaving 300s
  of headroom for `make install_antlr_cli` after the apt budget is spent.

Worst case is now 600s of apt work ending in an explicit `::error::` that names apt as the culprit,
instead of 90 minutes of silence surfaced as a misleading `cancelled`.

> The budget/clamp in the second bullet came out of @greptile-apps' review — the first revision used
> a 40-minute worst case (`3×180s` update + `3×600s` install) under a 15-minute step deadline, so the
> step would have been hard-killed mid-retry with no diagnostic, reintroducing the very failure this
> PR removes. Good catch.

This is a CI-reliability change only — no product code, no schema, no API surface is touched.

#
### Type of change:
- [x] Improvement

#
### High-level design:

N/A — small change, 3 files, CI-only.

#
### Tests:

#### Use cases covered
- A CI job whose apt mirror stalls fails within the 600s budget with a diagnostic `::error::`,
  instead of hanging for the full 90-minute job timeout and reporting a misleading `cancelled`.
- A transient (non-persistent) apt failure is retried and the job proceeds normally.
- A *combined* slow-update-then-stalled-install still finishes inside the budget and still emits the
  diagnostic, rather than being hard-killed by the step deadline mid-retry.

#### Unit tests
Not applicable — this is workflow YAML, not application code. Validated instead by:

- **YAML parse** of all three workflows; each contains exactly one patched `Install Ubuntu
  dependencies` step, no bare `sudo apt-get update` remains, and — asserted mechanically —
  `APT_BUDGET` is strictly less than `timeout-minutes × 60` in every file (600s vs 900s).
- **`bash -n`** clean on each extracted `run:` script.
- **Behavioral test of the `apt_retry` helper (13/13 passing)**, with `sudo`/`timeout` stubbed to
  emulate a hang (exit 124) against a virtual clock, so deadline behaviour is exercised without
  waiting in real time:
  - succeeds on the first try → rc=0, 1 attempt
  - recovers on the third attempt → rc=0, 3 attempts
  - gives up after 3 consecutive hangs → rc=1, 3 attempts
  - combined `update` + `install` worst case lands at exactly 600s of the 600s budget
  - no individual attempt is ever allowed to exceed the remaining budget
  - starting with the budget already spent → rc=1, 0 attempts, explicit `::error::` still printed
  - `set -e` aborts the step on give-up rather than silently continuing to the next command

Not verified: `actionlint` was not available in the dev environment, so this is YAML + shell syntax
+ behavior validation rather than a full Actions lint.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. Pulled the raw logs for all four cancelled jobs across the three runs and confirmed the identical
   hang signature and the 90-minute job-timeout boundary in each.
2. Confirmed the sibling lanes in the same run finished successfully, ruling out a
   `cancel-in-progress` concurrency cancellation as the cause.
3. Re-ran all three workflows unchanged — all green on attempt 2, confirming an infra flake.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [x] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Improvement -->
- [x] I have added tests around the new logic.
- [x] For connector/ingestion changes: I updated the documentation. <!-- N/A -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds bounded apt retries and a shared deadline to prevent stalled package mirrors from consuming the full CI job timeout.
- Limits apt update and install attempts with explicit connection and command timeouts.
- Shares a 600-second apt budget across retries while retaining a 15-minute step backstop.
- Applies the same fail-fast behavior to the MySQL integration, PostgreSQL integration, and service unit-test workflows.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/integration-tests-mysql-elasticsearch.yml | Adds bounded apt retries and fixes the install argument while keeping apt execution within the step deadline. |
| .github/workflows/integration-tests-postgres-elasticsearch-redis.yml | Applies the corrected shared-budget apt retry logic to the PostgreSQL integration workflow. |
| .github/workflows/openmetadata-service-unit-tests.yml | Applies the corrected shared-budget apt retry logic to service unit-test dependency installation. |

</details>

<sub>Reviews (3): Last reviewed commit: ["ci: restore the space in \`apt-get instal..."](https://github.com/open-metadata/openmetadata/commit/d98e8fd0a3e3c347b40320286b33c07a92274815) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55001427)</sub>

<!-- /greptile_comment -->