### PR TITLE
Fixes #31794: Resolve current DAR assignee server-side

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataAccessRequestValidationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataAccessRequestValidationIT.java
@@ -14,6 +14,7 @@
 package org.openmetadata.it.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.bootstrap.SharedEntities;
 import org.openmetadata.it.factories.DatabaseSchemaTestFactory;
 import org.openmetadata.it.factories.TableTestFactory;
 import org.openmetadata.it.util.SdkClients;
@@ -140,14 +142,46 @@ public class DataAccessRequestValidationIT {
       String entityType,
       String entityFqn,
       Map<String, Object> payload) {
-    CreateTask request =
-        new CreateTask()
-            .withName(ns.prefix("dar_" + entityType + "_" + UUID.randomUUID()))
-            .withCategory(TaskCategory.DataAccess)
-            .withType(TaskEntityType.DataAccessRequest)
-            .withAbout(entityLink(entityType, entityFqn))
-            .withPayload(payload);
-    return client.tasks().create(request);
+    return client.tasks().create(dataAccessRequest(ns, entityType, entityFqn, payload));
+  }
+
+  private static CreateTask dataAccessRequest(
+      TestNamespace ns, String entityType, String entityFqn, Map<String, Object> payload) {
+    return new CreateTask()
+        .withName(ns.prefix("dar_" + entityType + "_" + UUID.randomUUID()))
+        .withCategory(TaskCategory.DataAccess)
+        .withType(TaskEntityType.DataAccessRequest)
+        .withAbout(entityLink(entityType, entityFqn))
+        .withPayload(payload);
+  }
+
+  @Test
+  void testDarAssignedToCurrentUser_filtersByAuthenticatedPrincipal(TestNamespace ns) {
+    Table table = createTableOnSnowflakeService(ns, baseSnowflakeConnection());
+    String tableFqn = table.getFullyQualifiedName();
+    SharedEntities shared = SharedEntities.get();
+
+    Task user1Task =
+        SdkClients.adminClient()
+            .tasks()
+            .create(
+                dataAccessRequest(ns, "table", tableFqn, dataAccessPayload("FullAccess"))
+                    .withAssignees(List.of(shared.USER1.getFullyQualifiedName())));
+    Task user2Task =
+        SdkClients.user3Client()
+            .tasks()
+            .create(
+                dataAccessRequest(ns, "table", tableFqn, dataAccessPayload("FullAccess"))
+                    .withAssignees(List.of(shared.USER2.getFullyQualifiedName())));
+
+    var assignedToUser1 =
+        SdkClients.user1Client()
+            .tasks()
+            .listDataAccessRequests(
+                Map.of("dataset", tableFqn, "assignedToMe", "true", "limit", "50"));
+    List<UUID> taskIds = assignedToUser1.getData().stream().map(Task::getId).toList();
+    assertTrue(taskIds.contains(user1Task.getId()));
+    assertFalse(taskIds.contains(user2Task.getId()));
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/tasks/TaskResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/tasks/TaskResource.java
@@ -444,6 +444,13 @@ public class TaskResource extends EntityResource<Task, TaskRepository> {
       @Parameter(description = "Filter by assignee user/team id (single UUID).")
           @QueryParam("assigneeId")
           UUID assigneeId,
+      @Parameter(
+              description =
+                  "Filter to tasks assigned to the authenticated user or any of their teams. "
+                      + "When true, this takes precedence over assignee and assigneeId.")
+          @QueryParam("assignedToMe")
+          @DefaultValue("false")
+          boolean assignedToMe,
       @Parameter(description = "Filter by domain FQN") @QueryParam("domain") String domain,
       @Parameter(
               description =
@@ -507,12 +514,7 @@ public class TaskResource extends EntityResource<Task, TaskRepository> {
       validateCsvAgainstAccessType(accessType);
       filter.addQueryParam("accessType", accessType);
     }
-    if (!nullOrEmpty(assignee)) {
-      filter.addQueryParam("assignee", assignee);
-    }
-    if (assigneeId != null) {
-      filter.addQueryParam("assigneeId", assigneeId.toString());
-    }
+    addDataAccessRequestAssigneeFilter(filter, securityContext, assignee, assigneeId, assignedToMe);
     if (!nullOrEmpty(q)) {
       filter.addQueryParam("darSearch", q);
     }
@@ -1373,6 +1375,25 @@ public class TaskResource extends EntityResource<Task, TaskRepository> {
       ListFilter filter, UriInfo uriInfo, SecurityContext securityContext) {
     filter.addQueryParam("visibleAssigneeIds", getCurrentUserAssigneeIds(securityContext));
     filter.addQueryParam("visibleOwnedByIds", getCurrentUserOwnedIds(uriInfo, securityContext));
+  }
+
+  private void addDataAccessRequestAssigneeFilter(
+      ListFilter filter,
+      SecurityContext securityContext,
+      String assignee,
+      UUID assigneeId,
+      boolean assignedToMe) {
+    if (assignedToMe) {
+      // Resolve memberships to immutable IDs so clients cannot omit teams or misquote FQNs.
+      filter.addQueryParam("assigneeIds", getCurrentUserAssigneeIds(securityContext));
+    } else {
+      if (!nullOrEmpty(assignee)) {
+        filter.addQueryParam("assignee", assignee);
+      }
+      if (assigneeId != null) {
+        filter.addQueryParam("assigneeId", assigneeId.toString());
+      }
+    }
   }
 
   private String getCurrentUserAssigneeIds(SecurityContext securityContext) {

--- a/openmetadata-ui/src/main/resources/ui/src/rest/tasksAPI.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/tasksAPI.test.ts
@@ -13,7 +13,12 @@
 
 import { AxiosHeaders, InternalAxiosRequestConfig } from 'axios';
 import { Task } from '../generated/entity/tasks/task';
-import { addTaskComment, deleteTaskComment, editTaskComment } from './tasksAPI';
+import {
+  addTaskComment,
+  deleteTaskComment,
+  editTaskComment,
+  listDataAccessRequests,
+} from './tasksAPI';
 
 let mockCapturedRequest: InternalAxiosRequestConfig | undefined;
 
@@ -92,6 +97,23 @@ describe('tasksAPI comments', () => {
       );
 
       expect(contentType).toBe('application/json');
+    });
+  });
+});
+
+describe('tasksAPI data access requests', () => {
+  beforeEach(() => {
+    mockCapturedRequest = undefined;
+  });
+
+  it('passes the server-resolved current-assignee filter', async () => {
+    await listDataAccessRequests({ assignedToMe: true, status: ['Approved'] });
+
+    expect(mockCapturedRequest?.method).toBe('get');
+    expect(mockCapturedRequest?.url).toBe('/tasks/dataAccessRequests');
+    expect(mockCapturedRequest?.params).toEqual({
+      assignedToMe: true,
+      status: ['Approved'],
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/rest/tasksAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/tasksAPI.ts
@@ -118,6 +118,7 @@ export interface ListDataAccessRequestsParams {
   approver?: string;
   approverId?: string;
   assignee?: string;
+  assignedToMe?: boolean;
   accessType?: DataAccessType | DataAccessType[];
   domain?: string;
   q?: string;


### PR DESCRIPTION
### Describe your changes:

Fixes #31794

The Data Access Request list now accepts `assignedToMe=true` and resolves the authenticated user's ID plus all team IDs on the server. This removes client-side FQN quoting/casing and partial-membership ambiguity from the **My Approvals** query.

The shared UI REST client exposes the new parameter, with a request-boundary unit test. A backend integration test creates DARs for two assignees and verifies that an authenticated user receives only their assigned task.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

The new filter reuses the same server-side identity resolution already used by `/v1/tasks/assigned`. When `assignedToMe=true`, it intentionally takes precedence over the legacy `assignee` and `assigneeId` parameters. Existing callers remain backward compatible.

#
### Tests:

#### Use cases covered

- An authenticated user lists a DAR directly assigned to them.
- A DAR assigned to another user is excluded.
- Existing FQN and ID filters retain their behavior when `assignedToMe` is false.

#### Unit tests

- [x] Added a REST-client parameter test in `tasksAPI.test.ts`.
- `mvn -f openmetadata-service/pom.xml spotless:apply`
- Prettier 2.8.8 on both changed TypeScript files.

#### Backend integration tests

- [x] Added `testDarAssignedToCurrentUser_filtersByAuthenticatedPrincipal` in `DataAccessRequestValidationIT`.
- `mvn -f openmetadata-integration-tests/pom.xml spotless:apply`
- Full CI and a PostgreSQL zero-retry AUT reproduction are pending on this draft.

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- Existing Collate DAR list E2E coverage will be run against an image built from this branch and the dependent Collate PR, with retries disabled.

#### Manual testing performed

- Root cause was captured from strict nightly run https://github.com/open-metadata/openmetadata-nightly/actions/runs/32322104557: the task was `Approved` with the expected assignee, while the PostgreSQL assignee-filtered list returned `paging.total: 0`.

#
### UI screen recording / screenshots:

Not applicable. This PR changes only the REST parameter contract; it does not change visual layout or styling.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code where the identity-resolution choice is non-obvious.
- [x] For JSON Schema changes: not applicable; no schema or migration change.
- [x] For UI changes: not applicable; no visual change.
- [x] I have added tests and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds an `assignedToMe` filter to the Data Access Request listing, resolving the authenticated user and direct team IDs server-side while preserving legacy assignee filters when disabled.
- Routes the new filter through the existing assigned-task identity resolution and repository query.
- Exposes the parameter in the shared TypeScript REST client.
- Adds REST-boundary and backend integration coverage for directly assigned requests.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issues identified.

The new endpoint parameter reuses the established authenticated-user assignee resolution, reaches the existing repository filter with the expected ID representation, and is covered at both the client boundary and backend integration level.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/resources/tasks/TaskResource.java | Adds the authenticated-principal DAR filter using the established assigned-task ID resolution and preserves legacy filters when disabled. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataAccessRequestValidationIT.java | Adds isolated integration coverage proving inclusion of a directly assigned DAR and exclusion of another user’s DAR. |
| openmetadata-ui/src/main/resources/ui/src/rest/tasksAPI.ts | Extends the hand-written DAR request parameter contract with the optional server-resolved filter. |
| openmetadata-ui/src/main/resources/ui/src/rest/tasksAPI.test.ts | Verifies that the shared Axios client forwards `assignedToMe` at the request boundary. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as UI REST Client
  participant API as TaskResource
  participant Identity as User/Team Resolution
  participant Repo as TaskRepository
  participant DB as Relational Database
  UI->>API: "GET /tasks/dataAccessRequests?assignedToMe=true"
  API->>Identity: Resolve authenticated user and direct team IDs
  Identity-->>API: Assignee ID set
  API->>Repo: List DARs with assigneeIds
  Repo->>DB: Query ASSIGNED_TO relationships
  DB-->>Repo: Matching DARs
  Repo-->>UI: Paginated task list
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(data-access): cover current assigne..."](https://github.com/open-metadata/openmetadata/commit/5063714fed720d59a8c2645deddf467578e8d181) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55036100)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [OpenMetadata Service Core: Entities, Resources, Repositories](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-core.md)
- Knowledge Base — [Governance Workflows and Applications in OpenMetadata Service](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-workflows-apps.md)
- Knowledge Base — [OpenMetadata React UI](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-ui.md)
</details>

<!-- /greptile_comment -->