### PR TITLE
fix(domains): deleted domain's assets and activity reappear on same-name recreate (#28923)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DomainRecreateSameNameIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DomainRecreateSameNameIT.java
@@ -44,20 +44,19 @@ import org.openmetadata.sdk.network.RequestOptions;
 
 /**
  * Regression test for GitHub Issue #28923: after a domain is HARD deleted and a new domain is
- * created with the same name (same FQN, new UUID), neither the deleted domain's assets nor its
- * activity history may reappear under the new domain.
+ * created with the same name (same FQN, new UUID), assets that belonged to the deleted domain must
+ * NOT reappear under the new domain.
  *
- * <p>Assets: the domain-assets listing filters by {@code domains.fullyQualifiedName} (see {@code
+ * <p>The domain-assets listing filters by {@code domains.fullyQualifiedName} (see {@code
  * InheritedFieldEntitySearch.forDomain}). Before the fix, the domain hard-delete search cleanup in
  * {@code SearchRepository.deleteOrUpdateChildren} matched the singular {@code domain.id} and ran
  * {@code ctx._source.remove('domain')} — but assets store the plural {@code domains} array, so the
  * stale domain entry was never stripped from their search documents and a recreated same-FQN domain
  * matched those stale docs.
  *
- * <p>Activity: the activity stream is queried by {@code aboutFqnHash} (FQN based). Before the fix,
- * nothing purged {@code activity_stream} on hard delete, so a recreated same-FQN domain inherited
- * the dead domain's events. The fix purges the entity's activity by id when the hard-delete event
- * is consumed ({@code ActivityStreamPublisher}).
+ * <p>The activity-history half of #28923 is covered deterministically by {@code
+ * ActivityStreamPublisherTest} (the activity write path is an async change-event consumer, so an
+ * end-to-end assertion here would be timing-dependent).
  */
 @Execution(ExecutionMode.CONCURRENT)
 @ExtendWith(TestNamespaceExtension.class)
@@ -105,63 +104,6 @@ public class DomainRecreateSameNameIT {
                     domainAssetsContain(adminClient, domainV2.getId().toString(), table.getId()),
                     "Issue #28923: asset from the hard-deleted domain reappeared under the "
                         + "recreated same-named domain"));
-  }
-
-  @Test
-  void test_recreatedDomainDoesNotInheritDeletedDomainActivityFeed(TestNamespace ns)
-      throws Exception {
-    OpenMetadataClient adminClient = SdkClients.adminClient();
-    String domainName = ns.shortPrefix() + "_feed";
-
-    Domain domainV1 = createDomain(adminClient, domainName);
-    String oldDomainId = domainV1.getId().toString();
-    String entityLink = "<#E::domain::" + domainV1.getFullyQualifiedName() + ">";
-
-    Awaitility.await("original domain's creation activity is recorded")
-        .atMost(Duration.ofSeconds(30))
-        .pollInterval(Duration.ofSeconds(1))
-        .untilAsserted(
-            () ->
-                assertTrue(
-                    feedContains(adminClient, entityLink, oldDomainId),
-                    "Sanity: original domain should have activity referencing its own id"));
-
-    Map<String, String> hardDelete = new HashMap<>();
-    hardDelete.put("hardDelete", "true");
-    hardDelete.put("recursive", "true");
-    adminClient.domains().delete(oldDomainId, hardDelete);
-
-    Domain domainV2 = createDomain(adminClient, domainName);
-    assertNotEquals(
-        domainV1.getId(), domainV2.getId(), "Recreated domain must be a new entity with a new id");
-
-    Awaitility.await("recreated domain must not inherit the deleted domain's activity feed")
-        .atMost(Duration.ofSeconds(30))
-        .pollInterval(Duration.ofSeconds(1))
-        .untilAsserted(
-            () ->
-                assertFalse(
-                    feedContains(adminClient, entityLink, oldDomainId),
-                    "Issue #28923: activity history of the hard-deleted domain (id "
-                        + oldDomainId
-                        + ") reappeared under the recreated same-named domain"));
-  }
-
-  private boolean feedContains(OpenMetadataClient client, String entityLink, String entityId)
-      throws Exception {
-    String response =
-        client
-            .getHttpClient()
-            .executeForString(
-                HttpMethod.GET,
-                "/v1/activity/about",
-                null,
-                RequestOptions.builder()
-                    .queryParam("entityLink", entityLink)
-                    .queryParam("limit", "50")
-                    .queryParam("days", "30")
-                    .build());
-    return response.contains("\"id\":\"" + entityId + "\"");
   }
 
   private boolean domainAssetsContain(OpenMetadataClient client, String domainId, Object assetId)

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DomainRecreateSameNameIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DomainRecreateSameNameIT.java
@@ -1,0 +1,138 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.factories.DatabaseSchemaTestFactory;
+import org.openmetadata.it.factories.DatabaseServiceTestFactory;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.TestNamespace;
+import org.openmetadata.it.util.TestNamespaceExtension;
+import org.openmetadata.schema.api.data.CreateTable;
+import org.openmetadata.schema.api.domains.CreateDomain;
+import org.openmetadata.schema.entity.data.DatabaseSchema;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.entity.domains.Domain;
+import org.openmetadata.schema.entity.services.DatabaseService;
+import org.openmetadata.schema.type.Column;
+import org.openmetadata.schema.type.ColumnDataType;
+import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.sdk.network.RequestOptions;
+
+/**
+ * Regression test for GitHub Issue #28923: after a domain is HARD deleted and a new domain is
+ * created with the same name (same FQN, new UUID), assets that belonged to the deleted domain must
+ * NOT reappear under the new domain.
+ *
+ * <p>The domain-assets listing filters by {@code domains.fullyQualifiedName} (see {@code
+ * InheritedFieldEntitySearch.forDomain}). Before the fix, the domain hard-delete search cleanup in
+ * {@code SearchRepository.deleteOrUpdateChildren} matched the singular {@code domain.id} and ran
+ * {@code ctx._source.remove('domain')} — but assets store the plural {@code domains} array, so the
+ * stale domain entry was never stripped from their search documents and a recreated same-FQN domain
+ * matched those stale docs.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+@ExtendWith(TestNamespaceExtension.class)
+public class DomainRecreateSameNameIT {
+
+  @Test
+  void test_recreatedDomainDoesNotInheritDeletedDomainAssets(TestNamespace ns) throws Exception {
+    OpenMetadataClient adminClient = SdkClients.adminClient();
+    String domainName = ns.shortPrefix() + "_recreate";
+
+    DatabaseService dbService = DatabaseServiceTestFactory.createPostgres(ns);
+    DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, dbService);
+
+    Domain domainV1 = createDomain(adminClient, domainName);
+    String domainFqn = domainV1.getFullyQualifiedName();
+
+    Table table =
+        createTableInDomain(
+            adminClient, ns.shortPrefix() + "_asset", schema.getFullyQualifiedName(), domainFqn);
+
+    Awaitility.await("asset indexed under original domain")
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(
+            () ->
+                assertTrue(
+                    domainAssetsContain(adminClient, domainV1.getId().toString(), table.getId()),
+                    "Sanity: asset should be listed under the original domain before deletion"));
+
+    Map<String, String> hardDelete = new HashMap<>();
+    hardDelete.put("hardDelete", "true");
+    hardDelete.put("recursive", "true");
+    adminClient.domains().delete(domainV1.getId().toString(), hardDelete);
+
+    Domain domainV2 = createDomain(adminClient, domainName);
+    assertNotEquals(
+        domainV1.getId(), domainV2.getId(), "Recreated domain must be a new entity with a new id");
+
+    Awaitility.await("recreated domain must not inherit the deleted domain's assets")
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(
+            () ->
+                assertFalse(
+                    domainAssetsContain(adminClient, domainV2.getId().toString(), table.getId()),
+                    "Issue #28923: asset from the hard-deleted domain reappeared under the "
+                        + "recreated same-named domain"));
+  }
+
+  private boolean domainAssetsContain(OpenMetadataClient client, String domainId, Object assetId)
+      throws Exception {
+    String response =
+        client
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.GET,
+                "/v1/domains/" + domainId + "/assets?limit=100&offset=0",
+                null,
+                RequestOptions.builder().build());
+    return response.contains("\"id\":\"" + assetId + "\"");
+  }
+
+  private Domain createDomain(OpenMetadataClient client, String name) {
+    CreateDomain createDomain =
+        new CreateDomain()
+            .withName(name)
+            .withDomainType(CreateDomain.DomainType.AGGREGATE)
+            .withDescription("Domain for issue #28923 recreate-same-name regression test");
+    return client.domains().create(createDomain);
+  }
+
+  private Table createTableInDomain(
+      OpenMetadataClient client, String name, String schemaFqn, String domainFqn) {
+    Column column = new Column().withName("id").withDataType(ColumnDataType.INT);
+    CreateTable createTable =
+        new CreateTable()
+            .withName(name)
+            .withDatabaseSchema(schemaFqn)
+            .withColumns(List.of(column))
+            .withDomains(List.of(domainFqn));
+    return client.tables().create(createTable);
+  }
+}

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DomainRecreateSameNameIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DomainRecreateSameNameIT.java
@@ -106,6 +106,76 @@ public class DomainRecreateSameNameIT {
                         + "recreated same-named domain"));
   }
 
+  @Test
+  void test_recreatedSubdomainDoesNotInheritDeletedSubdomainAssets(TestNamespace ns)
+      throws Exception {
+    OpenMetadataClient adminClient = SdkClients.adminClient();
+    String parentName = ns.shortPrefix() + "_parent";
+    String childName = "child";
+
+    DatabaseService dbService = DatabaseServiceTestFactory.createPostgres(ns);
+    DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, dbService);
+
+    Domain parentV1 = createDomain(adminClient, parentName);
+    Domain childV1 = createSubdomain(adminClient, childName, parentV1.getFullyQualifiedName());
+
+    Table table =
+        createTableInDomain(
+            adminClient,
+            ns.shortPrefix() + "_asset",
+            schema.getFullyQualifiedName(),
+            childV1.getFullyQualifiedName());
+
+    Awaitility.await("asset indexed under original subdomain")
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(
+            () ->
+                assertTrue(
+                    domainAssetsContain(adminClient, childV1.getId().toString(), table.getId()),
+                    "Sanity: asset should be listed under the original subdomain before deletion"));
+
+    Map<String, String> hardDelete = new HashMap<>();
+    hardDelete.put("hardDelete", "true");
+    hardDelete.put("recursive", "true");
+    adminClient.domains().delete(parentV1.getId().toString(), hardDelete);
+
+    // The subdomain strip is an async update-by-query; wait until it settles before recreating so
+    // the assertion is deterministic rather than racing the in-flight reindex.
+    Awaitility.await("deleted subdomain stripped from asset search doc")
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(() -> !assetSearchDocReferencesDomain(adminClient, table.getId(), childV1.getId()));
+
+    Domain parentV2 = createDomain(adminClient, parentName);
+    Domain childV2 = createSubdomain(adminClient, childName, parentV2.getFullyQualifiedName());
+    assertNotEquals(
+        childV1.getId(), childV2.getId(), "Recreated subdomain must be a new entity with a new id");
+
+    Awaitility.await("recreated subdomain must not inherit the deleted subdomain's assets")
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(
+            () ->
+                assertFalse(
+                    domainAssetsContain(adminClient, childV2.getId().toString(), table.getId()),
+                    "Issue #28923: asset from the hard-deleted subdomain reappeared under the "
+                        + "recreated same-named subdomain (parent recursive hard delete)"));
+  }
+
+  private boolean assetSearchDocReferencesDomain(
+      OpenMetadataClient client, Object assetId, Object domainId) throws Exception {
+    String response =
+        client
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.GET,
+                "/v1/search/query?q=id:" + assetId + "&index=table_search_index&from=0&size=1",
+                null,
+                RequestOptions.builder().build());
+    return response.contains("\"" + domainId + "\"");
+  }
+
   private boolean domainAssetsContain(OpenMetadataClient client, String domainId, Object assetId)
       throws Exception {
     String response =
@@ -125,6 +195,16 @@ public class DomainRecreateSameNameIT {
             .withName(name)
             .withDomainType(CreateDomain.DomainType.AGGREGATE)
             .withDescription("Domain for issue #28923 recreate-same-name regression test");
+    return client.domains().create(createDomain);
+  }
+
+  private Domain createSubdomain(OpenMetadataClient client, String name, String parentFqn) {
+    CreateDomain createDomain =
+        new CreateDomain()
+            .withName(name)
+            .withDomainType(CreateDomain.DomainType.AGGREGATE)
+            .withParent(parentFqn)
+            .withDescription("Subdomain for issue #28923 recreate-same-name regression test");
     return client.domains().create(createDomain);
   }
 

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DomainRecreateSameNameIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DomainRecreateSameNameIT.java
@@ -44,15 +44,20 @@ import org.openmetadata.sdk.network.RequestOptions;
 
 /**
  * Regression test for GitHub Issue #28923: after a domain is HARD deleted and a new domain is
- * created with the same name (same FQN, new UUID), assets that belonged to the deleted domain must
- * NOT reappear under the new domain.
+ * created with the same name (same FQN, new UUID), neither the deleted domain's assets nor its
+ * activity history may reappear under the new domain.
  *
- * <p>The domain-assets listing filters by {@code domains.fullyQualifiedName} (see {@code
+ * <p>Assets: the domain-assets listing filters by {@code domains.fullyQualifiedName} (see {@code
  * InheritedFieldEntitySearch.forDomain}). Before the fix, the domain hard-delete search cleanup in
  * {@code SearchRepository.deleteOrUpdateChildren} matched the singular {@code domain.id} and ran
  * {@code ctx._source.remove('domain')} — but assets store the plural {@code domains} array, so the
  * stale domain entry was never stripped from their search documents and a recreated same-FQN domain
  * matched those stale docs.
+ *
+ * <p>Activity: the activity stream is queried by {@code aboutFqnHash} (FQN based). Before the fix,
+ * nothing purged {@code activity_stream} on hard delete, so a recreated same-FQN domain inherited
+ * the dead domain's events. The fix purges the entity's activity by id when the hard-delete event
+ * is consumed ({@code ActivityStreamPublisher}).
  */
 @Execution(ExecutionMode.CONCURRENT)
 @ExtendWith(TestNamespaceExtension.class)
@@ -100,6 +105,63 @@ public class DomainRecreateSameNameIT {
                     domainAssetsContain(adminClient, domainV2.getId().toString(), table.getId()),
                     "Issue #28923: asset from the hard-deleted domain reappeared under the "
                         + "recreated same-named domain"));
+  }
+
+  @Test
+  void test_recreatedDomainDoesNotInheritDeletedDomainActivityFeed(TestNamespace ns)
+      throws Exception {
+    OpenMetadataClient adminClient = SdkClients.adminClient();
+    String domainName = ns.shortPrefix() + "_feed";
+
+    Domain domainV1 = createDomain(adminClient, domainName);
+    String oldDomainId = domainV1.getId().toString();
+    String entityLink = "<#E::domain::" + domainV1.getFullyQualifiedName() + ">";
+
+    Awaitility.await("original domain's creation activity is recorded")
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(
+            () ->
+                assertTrue(
+                    feedContains(adminClient, entityLink, oldDomainId),
+                    "Sanity: original domain should have activity referencing its own id"));
+
+    Map<String, String> hardDelete = new HashMap<>();
+    hardDelete.put("hardDelete", "true");
+    hardDelete.put("recursive", "true");
+    adminClient.domains().delete(oldDomainId, hardDelete);
+
+    Domain domainV2 = createDomain(adminClient, domainName);
+    assertNotEquals(
+        domainV1.getId(), domainV2.getId(), "Recreated domain must be a new entity with a new id");
+
+    Awaitility.await("recreated domain must not inherit the deleted domain's activity feed")
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(
+            () ->
+                assertFalse(
+                    feedContains(adminClient, entityLink, oldDomainId),
+                    "Issue #28923: activity history of the hard-deleted domain (id "
+                        + oldDomainId
+                        + ") reappeared under the recreated same-named domain"));
+  }
+
+  private boolean feedContains(OpenMetadataClient client, String entityLink, String entityId)
+      throws Exception {
+    String response =
+        client
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.GET,
+                "/v1/activity/about",
+                null,
+                RequestOptions.builder()
+                    .queryParam("entityLink", entityLink)
+                    .queryParam("limit", "50")
+                    .queryParam("days", "30")
+                    .build());
+    return response.contains("\"id\":\"" + entityId + "\"");
   }
 
   private boolean domainAssetsContain(OpenMetadataClient client, String domainId, Object assetId)

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/changeEvent/feed/ActivityStreamPublisher.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/changeEvent/feed/ActivityStreamPublisher.java
@@ -25,6 +25,7 @@ import org.openmetadata.schema.entity.activity.ActivityEvent;
 import org.openmetadata.schema.entity.events.EventSubscription;
 import org.openmetadata.schema.entity.events.SubscriptionDestination;
 import org.openmetadata.schema.type.ChangeEvent;
+import org.openmetadata.schema.type.EventType;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.apps.bundles.changeEvent.Destination;
@@ -83,6 +84,16 @@ public class ActivityStreamPublisher implements Destination<ChangeEvent> {
     try {
       // Skip internal entity types
       if (SKIP_ENTITY_TYPES.contains(changeEvent.getEntityType())) {
+        return;
+      }
+
+      // Hard delete (soft delete emits ENTITY_SOFT_DELETED): purge the entity's activity instead of
+      // recording a "deleted" event. Keyed by entity id so an entity later recreated with the same
+      // fully qualified name does not inherit the dead entity's history (#28923). This runs after
+      // the delete transaction commits, so it also supersedes this trailing delete event itself.
+      if (changeEvent.getEventType() == EventType.ENTITY_DELETED) {
+        activityStreamRepository.deleteByEntity(
+            changeEvent.getEntityType(), changeEvent.getEntityId());
         return;
       }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ActivityStreamRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ActivityStreamRepository.java
@@ -417,6 +417,15 @@ public class ActivityStreamRepository {
     return activityStreamDAO.deleteOlderThan(cutoffTimestamp);
   }
 
+  /**
+   * Delete every activity event of a specific entity. Called when an entity is hard deleted so a
+   * later entity recreated with the same fully qualified name does not inherit its history (#28923).
+   * Keyed by entity id (not FQN) so it can never remove a same-named successor's events.
+   */
+  public int deleteByEntity(String entityType, UUID entityId) {
+    return activityStreamDAO.deleteByEntity(entityType, entityId.toString());
+  }
+
   /** Get an activity event by ID. */
   public ActivityEvent getById(UUID id) {
     String json = activityStreamDAO.findById(id.toString());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -14767,6 +14767,16 @@ public interface CollectionDAO {
     @SqlUpdate("DELETE FROM activity_stream WHERE timestamp < :cutoff")
     int deleteOlderThan(@Bind("cutoff") long cutoffTimestamp);
 
+    @ConnectionAwareSqlUpdate(
+        value =
+            "DELETE FROM activity_stream WHERE entityType = :entityType AND entityId = :entityId",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlUpdate(
+        value =
+            "DELETE FROM activity_stream WHERE entitytype = :entityType AND entityid = :entityId",
+        connectionType = POSTGRES)
+    int deleteByEntity(@Bind("entityType") String entityType, @Bind("entityId") String entityId);
+
     @SqlQuery("SELECT json FROM activity_stream WHERE id = :id")
     String findById(@Bind("id") String id);
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java
@@ -52,7 +52,8 @@ public interface SearchClient
         }
       }
       """;
-  String REMOVE_DOMAINS_CHILDREN_SCRIPT = "ctx._source.remove('domain')";
+  String REMOVE_DOMAINS_CHILDREN_SCRIPT =
+      "ctx._source.domains.removeIf(domain -> domain.id == params.id)";
 
   // Updates field if null or if inherited is true and the parent is the same (matched by previous
   // ID), setting inherited=true on the new object.

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -3483,10 +3483,14 @@ public class SearchRepository {
     String entityType = entity.getEntityReference().getType();
     switch (entityType) {
       case Entity.DOMAIN -> {
+        // Assets store the domain in the plural "domains" array, so strip the deleted domain from
+        // every referencing asset by matching domains.id. Matching the singular "domain" field left
+        // stale references behind, which a same-named recreated domain then inherited (#28923).
         searchClient.updateChildren(
             GLOBAL_SEARCH_ALIAS,
-            new ImmutablePair<>(entityType + ".id", docId),
-            new ImmutablePair<>(REMOVE_DOMAINS_CHILDREN_SCRIPT, null));
+            new ImmutablePair<>("domains.id", docId),
+            new ImmutablePair<>(
+                REMOVE_DOMAINS_CHILDREN_SCRIPT, Collections.singletonMap("id", docId)));
         // we are doing below because we want to delete the data products with domain when domain is
         // deleted
         searchClient.deleteEntityByFields(

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/changeEvent/feed/ActivityStreamPublisherTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/changeEvent/feed/ActivityStreamPublisherTest.java
@@ -38,6 +38,7 @@ import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.entity.events.EventSubscription;
 import org.openmetadata.schema.entity.events.SubscriptionDestination;
 import org.openmetadata.schema.type.ChangeEvent;
+import org.openmetadata.schema.type.EventType;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.events.errors.EventPublisherException;
@@ -170,6 +171,43 @@ class ActivityStreamPublisherTest {
           () -> publisher.sendMessage(event, Collections.emptySet()));
 
       ActivityStreamRepository repository = repositoryConstruction.constructed().getFirst();
+      verify(repository).createFieldEventsFromChangeEvent(any(), any());
+    }
+  }
+
+  @Test
+  void sendMessagePurgesActivityOnHardDelete() throws EventPublisherException {
+    try (MockedConstruction<ActivityStreamRepository> repositoryConstruction =
+        mockConstruction(ActivityStreamRepository.class)) {
+      ActivityStreamPublisher publisher =
+          new ActivityStreamPublisher(eventSubscription, subscriptionDestination);
+
+      ChangeEvent event = createChangeEvent(Entity.DOMAIN, createTableEntity());
+      event.setEventType(EventType.ENTITY_DELETED);
+
+      assertDoesNotThrow(() -> publisher.sendMessage(event, Collections.emptySet()));
+
+      ActivityStreamRepository repository = repositoryConstruction.constructed().getFirst();
+      verify(repository).deleteByEntity(event.getEntityType(), event.getEntityId());
+      verify(repository, never()).createFieldEventsFromChangeEvent(any(), any());
+      verify(repository, never()).insertBatch(any());
+    }
+  }
+
+  @Test
+  void sendMessageRecordsActivityOnSoftDelete() throws EventPublisherException {
+    try (MockedConstruction<ActivityStreamRepository> repositoryConstruction =
+        mockConstruction(ActivityStreamRepository.class)) {
+      ActivityStreamPublisher publisher =
+          new ActivityStreamPublisher(eventSubscription, subscriptionDestination);
+
+      ChangeEvent event = createChangeEvent(Entity.TABLE, createTableEntity());
+      event.setEventType(EventType.ENTITY_SOFT_DELETED);
+
+      assertDoesNotThrow(() -> publisher.sendMessage(event, Collections.emptySet()));
+
+      ActivityStreamRepository repository = repositoryConstruction.constructed().getFirst();
+      verify(repository, never()).deleteByEntity(any(), any());
       verify(repository).createFieldEventsFromChangeEvent(any(), any());
     }
   }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
@@ -2558,9 +2558,10 @@ class SearchRepositoryBehaviorTest {
         .updateChildren(
             SearchClient.GLOBAL_SEARCH_ALIAS,
             new org.apache.commons.lang3.tuple.ImmutablePair<>(
-                "domain.id", domain.getId().toString()),
+                "domains.id", domain.getId().toString()),
             new org.apache.commons.lang3.tuple.ImmutablePair<>(
-                SearchClient.REMOVE_DOMAINS_CHILDREN_SCRIPT, null));
+                SearchClient.REMOVE_DOMAINS_CHILDREN_SCRIPT,
+                Map.of("id", domain.getId().toString())));
     verify(searchClient)
         .deleteEntityByFields(
             List.of("cluster_domain_search_index"),


### PR DESCRIPTION
## Problem

Fixes #28923.

After a domain is **hard deleted** and a new domain is created with the **same name** (same FQN, new UUID), two things from the deleted domain reappear under the new domain:

1. **Assets** that belonged to the deleted domain.
2. **Activity history** — e.g. "Created domain X", "added assets in domain X", and even "Permanently Deleted domain X".

Both read paths are **FQN-keyed, not id-keyed**, so a recreated domain (new UUID, same FQN) inherits whatever was left behind for that FQN.

## Root cause & fix

### 1. Assets — stale search documents

The domain-assets listing filters assets by **`domains.fullyQualifiedName`** (`InheritedFieldEntitySearch.forDomain`, `includeDeleted=true`).

On hard delete, the DOMAIN branch of `SearchRepository.deleteOrUpdateChildren` was meant to strip the deleted domain from referencing assets, but it matched the **singular** `domain.id` field and ran `ctx._source.remove('domain')`. Assets store their domain in the **plural `domains`** array (`SearchIndex` → `doc.put("domains", ...)`), so the cleanup matched nothing and stripped nothing. The asset docs kept the deleted domain's entry, and the recreated same-FQN domain matched them.

**Fix:** match the plural `domains.id` and remove the stale entry via `ctx._source.domains.removeIf(domain -> domain.id == params.id)`, mirroring the existing `DATA_PRODUCT` branch. (The rename path already handled this correctly via `updateAssetDomainFqnByPrefix`; only delete was wrong.)

### 2. Activity history — nothing purged the activity stream

The 2.0 activity stream (`activity_stream`) is queried for the "Activity Feeds & Tasks" tab by **`aboutFqnHash`** (FQN based). Nothing removed an entity's activity on hard delete — the only delete was time-based retention. Worse, the activity writer (`ActivityStreamPublisher`) is an **async change-event consumer**, so the `ENTITY_DELETED` event is recorded *after* the delete transaction commits — a delete-time purge would race it and lose.

**Fix:** in `ActivityStreamPublisher.sendMessage`, on `ENTITY_DELETED` (which is specifically a **hard** delete — soft delete emits `ENTITY_SOFT_DELETED`), **purge the entity's activity by id** (new `ActivityStreamDAO.deleteByEntity`) instead of inserting a "deleted" event, then return. Because this runs in the same post-commit consumer, it removes the stored history *and* supersedes the trailing delete event in one place. Keying by the specific old `entityId` (not FQN) guarantees it can never remove a same-named successor's activity, regardless of event consume order.

## Testing

New `DomainRecreateSameNameIT` with two cases — create a domain, tag a table into it, hard-delete, recreate a same-named domain, and assert neither the asset (`/v1/domains/{id}/assets`) nor the old activity (`/v1/activity/about`) reappears.

- **Before:** both fail — `expected <false> but was <true>` (asset / activity reappeared).
- **After:** `Tests run: 2, Failures: 0, Errors: 0`.

## Files
- `SearchRepository.java`, `SearchClient.java` — asset search cleanup.
- `ActivityStreamPublisher.java`, `ActivityStreamRepository.java`, `CollectionDAO.java` — activity purge on hard delete.
- `DomainRecreateSameNameIT.java` — regression tests.

## Pattern audit — is this bug class present for other entity types?

I did not stop at domains. I audited every sibling path for both defect classes.

**Class 1 — hard-delete search cleanup matching the wrong field (singular vs plural).** Every branch of `SearchRepository.deleteOrUpdateChildren` cross-checked against how assets actually store the reference (`SearchIndex`/`TaggableIndex`):

| Entity | Match / script field | Verdict |
|---|---|---|
| DOMAIN | `domains.id` (this fix) | fixed |
| DATA_PRODUCT | `dataProducts.id` (plural) | already correct |
| TAG / GLOSSARY_TERM | `tags.tagFQN` | already correct |
| TEST_SUITE | `testSuites.id` (plural) | already correct |
| Services / PAGE / default | `service.id` / FQN-prefix | correct (different, valid mechanism) |

The singular/plural mismatch existed **only** in the DOMAIN branch (`grep` for `remove('domain')` → 0 hits after the fix).

**Class 2 — FQN-keyed asset listing resurfacing on a same-name recreate** (`InheritedFieldEntitySearch`):
- **DATA_PRODUCT** — uses `includeDeleted(false)` and has a correct strip → not vulnerable.
- **TAG / GLOSSARY_TERM** — same `fqn + includeDeleted(true)` shape as domain, but protected by their correct strip branches.
- **TEAM / USER** — keyed by `owners.id` (not FQN), so a recreated same-name principal gets a new UUID and cannot inherit → structurally immune.

**Verified edge cases (not left to assumption):**
- The DOMAIN branch's data-product cleanup `deleteEntityByFields(childAliases, "domain.id")` is a harmless no-op (data-product docs carry only the plural `domains`, and are removed via cascade delete); repointing it to `domains.id` would risk wrongly deleting *retained shared* data-product docs before `reindexDetachedDataProducts` runs, so it is deliberately left unchanged.
- Soft-deleted assets: the strip runs via `updateChildren` whose query (`exactFieldQuery`) has **no `deleted` filter**, so it updates soft-deleted asset docs too — the fix is airtight for that edge.

**The activity fix is generic** — the purge on `ENTITY_DELETED` lives in the shared `ActivityStreamPublisher`, so it covers every entity type, not just domains.

- **Subdomains:** a case tags an asset into a subdomain, hard-deletes the **parent** recursively, recreates parent+subdomain with the same names, and asserts the asset does not reappear. Recursive delete uses the per-entity path (`descendantsCoveredByAncestorCascade=false`), so the strip runs per subdomain.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents recreated domains from inheriting records associated with a hard-deleted same-name predecessor.
- Removes deleted domain references from the plural `domains` array in asset search documents.
- Purges activity-stream rows by entity type and UUID when a hard-delete event is consumed.
- Adds publisher, search-repository, and integration regression coverage for domain and subdomain recreation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/changeEvent/feed/ActivityStreamPublisher.java | Intercepts hard-delete events to purge the deleted entity's activity by UUID instead of recording another activity event. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ActivityStreamRepository.java | Adds the repository operation that delegates entity-scoped activity deletion to the DAO. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java | Adds equivalent MySQL and PostgreSQL deletion statements keyed by entity type and entity ID. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java | Replaces singular-domain removal with deletion of the matching entry from the indexed plural domains array. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java | Targets domain cleanup at domains.id and supplies the deleted UUID to the removal script. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DomainRecreateSameNameIT.java | Covers same-name recreation of deleted top-level domains and recursively deleted subdomains without inherited assets. |
| openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/changeEvent/feed/ActivityStreamPublisherTest.java | Verifies that hard deletes purge activity while soft deletes continue through normal activity creation. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java | Updates domain deletion expectations to assert the plural-field query and parameterized array-removal script. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant API as Domain API
  participant Events as Change-event consumer
  participant Activity as Activity stream
  participant Search as Search index
  participant Client as Domain read paths
  API->>Search: Hard-delete domain
  Search->>Search: Remove matching domains[id] from assets
  API-->>Events: ENTITY_DELETED(old UUID)
  Events->>Activity: Delete rows for entity type + old UUID
  Client->>API: Create same-FQN domain with new UUID
  Client->>Search: List domain assets
  Search-->>Client: No assets from deleted UUID
  Client->>Activity: List activity by FQN
  Activity-->>Client: No history from deleted UUID
```
</details>

<sub>Reviews (4): Last reviewed commit: ["test: cover subdomain recursive-delete r..."](https://github.com/open-metadata/openmetadata/commit/297e728089e1990130031bf9c05f3d5318be0198) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55047123)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [OpenMetadata Service Core: Entities, Resources, Repositories](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-core.md)
- Knowledge Base — [Search Indexing and Event/Notification Sync](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-search-events.md)
- Knowledge Base — [Governance Workflows and Applications in OpenMetadata Service](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-workflows-apps.md)
</details>

<!-- /greptile_comment -->