### PR TITLE
Fixes 31799: make BundleSuiteBulkOperations act on its own test cases

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/BundleSuiteBulkOperations.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/BundleSuiteBulkOperations.spec.ts
@@ -20,11 +20,15 @@ import {
   navigateToDataQualityTestCases,
   openAddToExistingBundleSuiteModal,
   openCreateNewBundleSuiteForm,
+  ownedTestCase,
+  OwnedTestCase,
+  searchAndSelectTestCase,
   selectExistingBundleSuite,
   selectTestCasesByCheckbox,
   submitAddToExistingBundleSuite,
   verifyBundleSuitePageLoaded,
   verifyTestCaseSelectionCount,
+  waitForTestCasesToBeIndexed,
 } from '../../../utils/dataQuality';
 import { test } from '../../fixtures/pages';
 
@@ -35,6 +39,11 @@ let table2: TableClass;
 const bundleTestSuite = new BundleTestSuiteClass();
 let bundleSuiteName: string;
 let existingBundleSuiteName: string;
+// Test cases this spec owns. Every test acts on one of these by name rather
+// than on whatever happens to be at the top of the shared, globally sorted
+// Test Cases list -- see `searchAndSelectTestCase`.
+let notNullTestCase: OwnedTestCase;
+let uniqueTestCase: OwnedTestCase;
 
 test.beforeAll(async ({ browser }) => {
   table1 = new TableClass();
@@ -44,15 +53,18 @@ test.beforeAll(async ({ browser }) => {
   await table1.create(apiContext);
   await table2.create(apiContext);
 
+  notNullTestCase = ownedTestCase('test_column_values_not_null');
+  uniqueTestCase = ownedTestCase('test_column_values_unique');
+
   await table1.createTestCase(apiContext, {
-    name: `test_column_values_not_null_${uuid()}`,
+    name: notNullTestCase.name,
     entityLink: `<#E::table::${table1.entityResponseData?.['fullyQualifiedName']}::columns::${table1.entity?.columns[0].name}>`,
     parameterValues: [],
     testDefinition: 'columnValuesToBeNotNull',
   });
 
   await table1.createTestCase(apiContext, {
-    name: `test_column_values_unique_${uuid()}`,
+    name: uniqueTestCase.name,
     entityLink: `<#E::table::${table1.entityResponseData?.['fullyQualifiedName']}::columns::${table1.entity?.columns[0].name}>`,
     parameterValues: [],
     testDefinition: 'columnValuesToBeUnique',
@@ -66,6 +78,13 @@ test.beforeAll(async ({ browser }) => {
   });
 
   await bundleTestSuite.createBundleTestSuite(apiContext);
+
+  // The list page reads from Elasticsearch, so the tests cannot search for
+  // these until they are indexed.
+  await waitForTestCasesToBeIndexed(apiContext, [
+    notNullTestCase,
+    uniqueTestCase,
+  ]);
 
   bundleSuiteName = `bundle_suite_${uuid()}`;
   existingBundleSuiteName =
@@ -83,7 +102,7 @@ test('Create new Bundle Suite with bulk selected test cases', async ({
 }) => {
   await test.step('Navigate and select test case', async () => {
     await navigateToDataQualityTestCases(page);
-    await selectTestCasesByCheckbox(page, 1);
+    await searchAndSelectTestCase(page, notNullTestCase);
     await verifyTestCaseSelectionCount(page, 1);
   });
 
@@ -103,7 +122,7 @@ test('Create new Bundle Suite with bulk selected test cases', async ({
 test('Add test case to existing Bundle Suite', async ({ page }) => {
   await test.step('Navigate and select test case', async () => {
     await navigateToDataQualityTestCases(page);
-    await selectTestCasesByCheckbox(page, 1);
+    await searchAndSelectTestCase(page, uniqueTestCase);
     await verifyTestCaseSelectionCount(page, 1);
   });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
@@ -13,7 +13,7 @@
 import { APIRequestContext, expect, Page, Response } from '@playwright/test';
 import { SidebarItem } from '../constant/sidebar';
 import { TableClass } from '../support/entity/TableClass';
-import { redirectToHomePage } from './common';
+import { redirectToHomePage, uuid } from './common';
 import { waitForAllLoadersToDisappear } from './entity';
 import { sidebarClick } from './sidebar';
 import { submitTestCaseForm } from './testCases';
@@ -350,6 +350,113 @@ export const selectTestCasesByCheckbox = async (
   }
 };
 
+/**
+ * A test case the calling spec created, together with a term that finds it --
+ * and only it -- in the Test Cases list search.
+ */
+export type OwnedTestCase = {
+  name: string;
+  /**
+   * A substring of `name` that is unique across the server. The list search is
+   * Elasticsearch-backed and tokenises names on `_`, so searching a whole
+   * `test_column_values_not_null_<uuid>` name matches *every*
+   * `test_column_values_not_null_*` test case on the server. On a shared server
+   * that is dozens of rows, ranked by relevance rather than exactness, and the
+   * one we want drops off page 1. The uuid segment is the part that narrows it.
+   */
+  searchTerm: string;
+};
+
+/**
+ * Names a test case the calling spec will own, so it can be found again by a
+ * term that cannot collide with another spec's test cases.
+ */
+export const ownedTestCase = (namePrefix: string): OwnedTestCase => {
+  const searchTerm = uuid();
+
+  return { name: `${namePrefix}_${searchTerm}`, searchTerm };
+};
+
+/**
+ * Polls the test case search endpoint until every one of `testCases` is visible
+ * to it.
+ *
+ * The Data Quality > Test Cases list is Elasticsearch-backed, so a test case
+ * created over the API is not immediately findable. Call this after creating
+ * them and before any UI search. Mirrors the query the list page issues
+ * (`q=*term*` + `includeAllTests`) so the poll and the UI agree on what is
+ * visible.
+ */
+export async function waitForTestCasesToBeIndexed(
+  apiContext: APIRequestContext,
+  testCases: OwnedTestCase[]
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        for (const testCase of testCases) {
+          const res = await apiContext.get(
+            `/api/v1/dataQuality/testCases/search/list` +
+              `?q=*${testCase.searchTerm}*&includeAllTests=true&limit=50`
+          );
+
+          if (!res.ok()) {
+            return false;
+          }
+
+          const body = await res.json();
+          const isIndexed = (body.data ?? []).some(
+            (indexed: { name?: string }) => indexed.name === testCase.name
+          );
+
+          if (!isIndexed) {
+            return false;
+          }
+        }
+
+        return true;
+      },
+      { timeout: 45_000, intervals: [1_000, 2_000, 5_000] }
+    )
+    .toBe(true);
+}
+
+/**
+ * Filters the Test Cases list down to `testCase` and ticks its checkbox.
+ *
+ * Always prefer this over `selectTestCasesByCheckbox` when the test goes on to
+ * act on the selection (adding to a Bundle Suite, asserting a suite's contents,
+ * ...). The unfiltered list is sorted by most-recent result descending and is
+ * shared with every other spec running against the same server, so row 1 is
+ * whichever test case some other worker created seconds ago -- and is liable to
+ * be hard-deleted by that worker's cleanup while this test is still using it.
+ * Selecting by name keeps a test on entities it owns and controls the lifetime
+ * of.
+ */
+export const searchAndSelectTestCase = async (
+  page: Page,
+  testCase: OwnedTestCase
+) => {
+  const searchResponse = page.waitForResponse(
+    (res) =>
+      res.url().includes('/api/v1/dataQuality/testCases/search/list') &&
+      res.url().includes(testCase.searchTerm) &&
+      res.status() === 200
+  );
+  await page.getByTestId('searchbar').fill(testCase.searchTerm);
+  await searchResponse;
+
+  const row = page
+    .locator('[data-testid="test-case-table"] tbody tr[data-key]')
+    .filter({ hasText: testCase.name });
+
+  // `searchTerm` is unique, so the filter resolves to exactly one row. Assert it
+  // here rather than relying on `.first()`, so a search that silently returns
+  // the wrong set fails on the search instead of somewhere downstream.
+  await expect(row).toHaveCount(1);
+  await row.locator('label[slot="selection"]').click();
+};
+
 export const verifyTestCaseSelectionCount = async (
   page: Page,
   count: number
@@ -424,7 +531,15 @@ export const submitAddToExistingBundleSuite = async (page: Page) => {
   );
 
   await modal.getByRole('button', { name: 'Add', exact: true }).click();
-  await addResponse;
+  const response = await addResponse;
+
+  // The modal stays open on a rejected add, so without this the failure only
+  // surfaces further down as a confusing "URL never changed" timeout. Surface
+  // the server's reason instead.
+  expect(
+    response.ok(),
+    `Adding test cases to the Bundle Suite failed: ${response.status()} ${await response.text()}`
+  ).toBe(true);
 };
 
 export const verifyBundleSuitePageLoaded = async (


### PR DESCRIPTION
### Describe your changes:

Fixes #31799

`BundleSuiteBulkOperations.spec.ts › Add test case to existing Bundle Suite` failed all three attempts in nightly run [32318370344](https://github.com/open-metadata/openmetadata-nightly/actions/runs/32318370344). It was not an isolated flake: the spec ticked **row 1 of the global Test Cases list**, which is sorted by most-recent result descending. Its own test cases are created without a result, so they can never be row 1 — under CI parallelism (41 workers) row 1 is reliably a test case another worker created seconds ago and is about to hard-delete.

When that worker's cleanup ran (`DELETE /services/databaseServices/...?recursive=true&hardDelete=true`), it cascaded to the test case and removed the `CONTAINS` edge this spec had just created, so the suite read back `tests: []`. When the delete landed slightly earlier, the add was rejected outright with `400 "You are trying to add one or more test cases that do not exist."` Full analysis in #31799.

**The fix:** the two tests that act on their selection now search for a test case the spec created, instead of taking whatever is on top.

```diff
- await selectTestCasesByCheckbox(page, 1);
+ await searchAndSelectTestCase(page, uniqueTestCase);
```

Two details worth calling out:

- **The search term is the uuid segment, not the whole name.** The list search is Elasticsearch-backed and tokenises names on `_`, so `q=*test_column_values_not_null_<uuid>*` matches *every* `test_column_values_not_null_*` test case on the server, ranked by relevance — on a shared server that is dozens of rows and the wanted one drops off page 1. `ownedTestCase()` pairs each name with the segment that actually narrows it (`total=1`). I hit this the hard way: a first version searching by full name passed 9/9 early, then failed 10/12 once enough sibling-named test cases had accumulated. It is documented on the type so it does not get re-introduced.
- **The row assertion is an exact `toHaveCount(1)`**, not `.first()`, so a search that silently returns the wrong set fails on the search rather than somewhere downstream.

Also assert the bulk add response in `submitAddToExistingBundleSuite`. Previously a rejected add left the modal open and only surfaced 15 s later as a confusing "URL never changed" timeout, hiding the server's explanation.

`Bulk selection operations` is deliberately left on `selectTestCasesByCheckbox` — it only asserts selection-UI behaviour and never sends the selected ids to the server, so it is not exposed to this race.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Adding a bulk-selected test case to an existing Bundle Suite while other specs concurrently create and hard-delete test cases against the same server
- Creating a new Bundle Suite from a bulk-selected test case under the same conditions

#### Unit tests
Not applicable — Playwright-only change.

#### Backend integration tests
Not applicable — no backend API changes.

#### Ingestion integration tests
Not applicable — no ingestion changes.

#### Playwright (UI) tests
- [x] Files updated:
  - `openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/BundleSuiteBulkOperations.spec.ts`
  - `openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts`

#### Manual testing performed

Ran against a local server, using a script that reproduces the race: create a foreign test case with a fresh result, wait until it is genuinely indexed **and** sitting at row 1, then hard-delete it 2.5 s later.

1. **Reproduced the original failure first.** The pre-fix spec under that churn failed **4 of 8** with the exact nightly error: `400 "You are trying to add one or more test cases that do not exist."`
2. **Side-by-side, both specs interleaved under one live churn** — same server, same moment: pre-fix **2/6 failed**, fixed **6/6 passed**.
3. Fixed spec, 24 runs (`--repeat-each=8`, all three tests) against a server deliberately polluted with 67+ sibling-named test cases: **24/24 passed**.
4. Fixed spec under churn, 8 runs: **8/8 passed**.
5. Confirmed independently from server state that the right entity is selected — the suites contained `test_column_values_unique_*` / `test_column_values_not_null_*`, while row 1 of the unfiltered list at that moment was an unrelated `tc_tblA`.

`tsc` reports zero errors in both changed files; eslint and prettier clean.

**Not covered:** this has not yet run in the real nightly (41 workers, sharded); the churn is a targeted simulation of one failure mode.

#
### UI screen recording / screenshots:

Not applicable — test-only change.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For UI changes: not applicable, test-only change.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the Bundle Suite bulk-operation tests select test cases created and owned by the spec instead of unstable rows from the shared global list.
- Adds unique owned-test-case names and waits for their search-index visibility.
- Searches for and selects the exact owned row before performing bundle operations.
- Reports rejected bulk-add responses immediately with the server response details.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable defects identified in the changed test flows.

The unique hexadecimal search terms match the UI search semantics, indexing is polled before use, rendered rows are explicitly synchronized, and the bulk response assertion follows the modal’s single-request flow.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/BundleSuiteBulkOperations.spec.ts | Creates uniquely searchable owned test cases, waits for indexing, and uses them in the two tests that submit selected IDs. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts | Adds deterministic test-case indexing and selection helpers and improves bulk-add response diagnostics. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fixes 31799: make BundleSuiteBulkOperati..."](https://github.com/open-metadata/openmetadata/commit/f97e08cc53fd7b19e1327fe6f02ffd00ab10c528) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55048957)</sub>

<!-- /greptile_comment -->