### PR TITLE
fix(ci): replace setup-node yarn cache with explicit restore+retry in ui-checkstyle

### DIFF
--- a/.github/workflows/ui-checkstyle.yml
+++ b/.github/workflows/ui-checkstyle.yml
@@ -139,7 +139,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ~/.cache/yarn
-          key: yarn-pkg-cache-${{ runner.os }}-${{ hashFiles(format('{0}/yarn.lock', env.UI_WORKING_DIRECTORY), format('{0}/yarn.lock', env.CORE_COMPONENTS_WORKING_DIRECTORY)) }}
+          key: yarn-pkg-cache-${{ runner.os }}-${{ hashFiles(format('{0}/yarn.lock', env.UI_WORKING_DIRECTORY)) }}
           restore-keys: |
             yarn-pkg-cache-${{ runner.os }}-
 

--- a/.github/workflows/ui-checkstyle.yml
+++ b/.github/workflows/ui-checkstyle.yml
@@ -124,17 +124,37 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version-file: "${{ env.UI_WORKING_DIRECTORY }}/.nvmrc"
-          cache: yarn
-          cache-dependency-path: |
-            ${{ env.UI_WORKING_DIRECTORY }}/yarn.lock
-            ${{ env.CORE_COMPONENTS_WORKING_DIRECTORY }}/yarn.lock
 
       - name: Install Antlr4 CLI
         run: sudo make install_antlr_cli
 
+      # setup-node's built-in `cache: yarn` is exact-key only — a yarn.lock
+      # change leaves the cache completely cold and exposes installs to transient
+      # registry 5xx. An explicit cache with restore-keys falls back to the most
+      # recent lockfile's cache so a lockfile change only fetches the delta.
+      # RESTORE-ONLY: this workflow runs on PR refs whose exact key is never
+      # reused; saving here would duplicate ~700 MB per run and evict main-scoped
+      # caches. The main-scoped copy is saved by populate-playwright-apt-cache.yml.
+      - name: Restore yarn package cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.cache/yarn
+          key: yarn-pkg-cache-${{ runner.os }}-${{ hashFiles(format('{0}/yarn.lock', env.UI_WORKING_DIRECTORY), format('{0}/yarn.lock', env.CORE_COMPONENTS_WORKING_DIRECTORY)) }}
+          restore-keys: |
+            yarn-pkg-cache-${{ runner.os }}-
+
       - name: Install UI Yarn Packages
         working-directory: ${{ env.UI_WORKING_DIRECTORY }}
-        run: yarn install --frozen-lockfile
+        run: |
+          for attempt in 1 2 3; do
+            yarn install --frozen-lockfile --network-timeout 100000 && break
+            if [[ "$attempt" -eq 3 ]]; then
+              echo "yarn install failed after 3 attempts" >&2
+              exit 1
+            fi
+            echo "::warning::yarn install attempt $attempt failed (registry blip?); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
 
       - name: Get changed src files
         id: changed-src-files
@@ -285,7 +305,16 @@ jobs:
 
       - name: Install Core Components Yarn Packages
         working-directory: ${{ env.CORE_COMPONENTS_WORKING_DIRECTORY }}
-        run: yarn install --frozen-lockfile
+        run: |
+          for attempt in 1 2 3; do
+            yarn install --frozen-lockfile --network-timeout 100000 && break
+            if [[ "$attempt" -eq 3 ]]; then
+              echo "yarn install failed after 3 attempts" >&2
+              exit 1
+            fi
+            echo "::warning::yarn install attempt $attempt failed (registry blip?); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
 
       - name: I18n Sync (core-components)
         id: i18n_core


### PR DESCRIPTION
## Summary

- Replaces `setup-node`'s built-in `cache: yarn` (exact-key only) with an explicit `actions/cache/restore@v5` step that includes `restore-keys` fallback — matching the approach already used in the Playwright workflow
- Wraps both `yarn install` calls in a 3-attempt retry loop with 15/30 s backoff to handle transient registry 5xx errors
- Uses restore-only (not `actions/cache@v5`) to avoid cache-budget blowout on PR/merge-queue ephemeral refs

## Root cause

The failing job ([run 32334620462, job 96321808127](https://github.com/open-metadata/OpenMetadata/actions/runs/32334620462/job/96321808127)) died at the **Install UI Yarn Packages** step. Two compounding problems:

1. **Exact-key cache miss**: `setup-node`'s `cache: yarn` stores the yarn global cache under a key that is the hash of the lockfile. If the `yarn.lock` changes (or if a new PR ref has never been seen before), the cache is a complete miss — yarn re-fetches all ~2000 tarballs from the registry cold.

2. **No retry on registry errors**: yarn v1 does not retry transient HTTP 5xx errors. A single 502 on any one tarball aborts the entire install. This same failure mode took down a Playwright planning job in run 32222855561 and was fixed there; the ui-checkstyle workflow was not updated at the same time.

## How the Playwright fix works (and why it's better)

The Playwright workflow replaced `cache: yarn` with:

```yaml
- name: Restore yarn package cache
  uses: actions/cache/restore@v5        # restore-ONLY — no save
  with:
    path: ~/.cache/yarn
    key: yarn-pkg-cache-${{ runner.os }}-${{ hashFiles('...yarn.lock') }}
    restore-keys: |
      yarn-pkg-cache-${{ runner.os }}-  # partial-match fallback
```

`restore-keys` means: if the exact key misses, fall back to the *most recent* cache entry whose key starts with `yarn-pkg-cache-Linux-`. On a lockfile change, yarn only needs to fetch the *delta* packages — not the full 700 MB corpus.

**Restore-only** is intentional: PR and merge-queue branches produce ephemeral refs whose exact keys are never reused. Saving here produced ~700 MB of duplicate cache entries per run (17.5 GB observed, 49/50 slots on ephemeral refs) and LRU-evicted every `main`-scoped cache within ~30 minutes — which is what turned apparent cache "hits" into cold fetches. The authoritative warm copy is saved exclusively by `populate-playwright-apt-cache.yml` on the main branch.

## Test plan

- [ ] Trigger the UI Checkstyle workflow on a PR that changes `yarn.lock` — confirm the "Install UI Yarn Packages" step no longer fails on a cache miss
- [ ] Confirm the retry loop surfaces a clear warning on a transient failure rather than a silent abort
- [ ] Confirm no new cache entries are saved to the repo cache budget from PR runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces setup-node’s Yarn caching with restore-only prefix fallback and adds retries for both Yarn installs.
- Aligns the restore key with the authoritative cache producer’s UI lockfile key.
- Retries failed installs up to three times with incremental backoff.
- Avoids saving duplicate caches from ephemeral PR and merge-queue refs.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the cache consumer now uses the same UI-lockfile-based key and cache path as the producer.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ui-checkstyle.yml | The revised cache key now matches the producer’s path, OS component, and UI lockfile hash, resolving the previously reported mismatch. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix-workflow-ca..."](https://github.com/open-metadata/openmetadata/commit/21554101e5e974bc58737f8cc40e13bcc97c2ab8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55053602)</sub>

<!-- /greptile_comment -->