### PR TITLE
Fixes #31733: apply tag color styling on Data Product and Domain pages (1.13 backport)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/TagChip/TagChip.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/TagChip/TagChip.test.tsx
@@ -1,0 +1,55 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+import TagChip from './TagChip';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('TagChip color styling', () => {
+  it('tints the background and colors the label when tagColor is provided', () => {
+    render(
+      <TagChip
+        data-testid="tags"
+        label="Confidential"
+        labelDataTestId="tag-color-test"
+        tagColor="#ff0000"
+      />
+    );
+
+    expect(screen.getByTestId('tags')).toHaveStyle(
+      'background-color: rgba(255, 0, 0, 0.05)'
+    );
+    expect(screen.getByTestId('tag-color-test')).toHaveStyle({
+      color: '#ff0000',
+    });
+  });
+
+  it('does not apply a tag color when tagColor is absent', () => {
+    render(
+      <TagChip
+        data-testid="tags"
+        label="Plain"
+        labelDataTestId="tag-plain-test"
+      />
+    );
+
+    expect(screen.getByTestId('tags')).not.toHaveStyle(
+      'background-color: rgba(255, 0, 0, 0.05)'
+    );
+    expect(screen.getByTestId('tag-plain-test')).not.toHaveStyle(
+      'color: rgb(255, 0, 0)'
+    );
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/TagChip/TagChip.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/TagChip/TagChip.tsx
@@ -14,6 +14,7 @@
 import { Chip, ChipProps as MuiChipProps, SxProps, Theme } from '@mui/material';
 import { Tag01, XClose } from '@untitledui/icons';
 import { FC, ReactElement } from 'react';
+import { reduceColorOpacity } from '../../../../utils/ColorUtils';
 
 export interface TagChipProps extends Omit<MuiChipProps, 'variant' | 'color'> {
   label: string;
@@ -48,31 +49,33 @@ const TagChip: FC<TagChipProps> = ({
   ) : undefined;
   const chipIcon = icon !== undefined ? icon : defaultIcon;
 
-  const ellipsisStyles = showEllipsis
-    ? {
-        '& .MuiChip-label': {
+  const labelStyles = {
+    ...(showEllipsis
+      ? {
           overflow: 'hidden',
           textOverflow: 'ellipsis',
           whiteSpace: 'nowrap',
           display: 'block',
-        },
-      }
-    : {};
+        }
+      : {}),
+    ...(tagColor ? { color: tagColor } : {}),
+  };
 
   const colorBarStyles = tagColor
     ? {
         position: 'relative' as const,
+        overflow: 'hidden',
         paddingLeft: '12px',
+        backgroundColor: reduceColorOpacity(tagColor, 0.05),
+        borderColor: reduceColorOpacity(tagColor, 0.2),
         '&::before': {
           content: '""',
           position: 'absolute' as const,
           left: 0,
-          top: '50%',
-          transform: 'translateY(-50%)',
-          width: '3px',
-          height: '70%',
+          top: 0,
+          bottom: 0,
+          width: '6px',
           backgroundColor: tagColor,
-          borderRadius: '2px 0 0 2px',
         },
       }
     : {};
@@ -104,12 +107,13 @@ const TagChip: FC<TagChipProps> = ({
       sx={{
         maxWidth,
         minWidth: 0,
-        ...ellipsisStyles,
         ...colorBarStyles,
         ...heightStyles,
+        '& .MuiChip-label': labelStyles,
         '& .MuiChip-icon': {
           flexShrink: 0,
           marginLeft: 0,
+          ...(tagColor ? { color: tagColor } : {}),
         },
         ...sx,
       }}


### PR DESCRIPTION
## Summary

Backport of #31773 to the `1.13` branch, adapted for the MUI-based `TagChip` implementation that exists on 1.13.

**Why a manual backport instead of cherry-pick:** `TagChip` on `1.13` uses MUI `Chip` + `sx` prop, while on `main` it uses a custom Tailwind/Box component. The diff from #31773 does not apply cleanly.

**Changes:**
- Tinted background (`5% opacity`) and colored border (`20% opacity`) derived from `tagColor` via `reduceColorOpacity`
- Full-height accent bar via `::before` pseudo-element (replaces the old 70%-height centered bar)
- Icon and label text colored with `tagColor`
- Merged ellipsis + color label styles into a single `& .MuiChip-label` rule to avoid `sx` spread key collisions
- Added `TagChip.test.tsx` covering colored and default rendering

<img width="510" height="277" alt="Screenshot 2026-08-21 at 8 13 04 AM" src="https://github.com/user-attachments/assets/575c01f6-8546-4c92-8fce-43605b1aa608" />


Fixes #31733

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport updates the MUI-based `TagChip` to derive its background, border, accent, icon, and label colors from `tagColor`.
- Adds tinted background and border styling plus a full-height accent bar.
- Consolidates label ellipsis and color styles under one MUI selector.
- Adds tests for colored and default rendering.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after correcting the non-blocking test-formatting issue that may fail frontend checkstyle.

The tag-color implementation has no established functional regression, while the new test contains one specific formatting violation in an enforced CI path.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/src/components/common/atoms/TagChip/TagChip.test.tsx
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/common/atoms/TagChip/TagChip.tsx | Applies tag-derived color styling while preserving the component's existing size, icon, and caller override behavior; no concrete functional defect was identified. |
| openmetadata-ui/src/main/resources/ui/src/components/common/atoms/TagChip/TagChip.test.tsx | Covers colored and uncolored rendering, but the first test lacks the blank-line separation required by frontend checkstyle. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): apply tag color styling on Data..."](https://github.com/open-metadata/openmetadata/commit/116bff1cb5901edc0d208a5e2f5ed9cf9591a621) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55053888)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))

<!-- /greptile_comment -->