### PR TITLE
Fixes 31799: make BundleSuiteBulkOperations act on its own test cases [1.13]

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/BundleSuiteBulkOperations.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/BundleSuiteBulkOperations.spec.ts
@@ -20,11 +20,15 @@ import {
   navigateToDataQualityTestCases,
   openAddToExistingBundleSuiteModal,
   openCreateNewBundleSuiteForm,
+  ownedTestCase,
+  OwnedTestCase,
+  searchAndSelectTestCase,
   selectExistingBundleSuite,
   selectTestCasesByCheckbox,
   submitAddToExistingBundleSuite,
   verifyBundleSuitePageLoaded,
   verifyTestCaseSelectionCount,
+  waitForTestCasesToBeIndexed,
 } from '../../../utils/dataQuality';
 import { test } from '../../fixtures/pages';
 
@@ -35,6 +39,11 @@ let table2: TableClass;
 const bundleTestSuite = new BundleTestSuiteClass();
 let bundleSuiteName: string;
 let existingBundleSuiteName: string;
+// Test cases this spec owns. Every test acts on one of these by name rather
+// than on whatever happens to be at the top of the shared, globally sorted
+// Test Cases list -- see `searchAndSelectTestCase`.
+let notNullTestCase: OwnedTestCase;
+let uniqueTestCase: OwnedTestCase;
 
 test.beforeAll(async ({ browser }) => {
   table1 = new TableClass();
@@ -44,15 +53,18 @@ test.beforeAll(async ({ browser }) => {
   await table1.create(apiContext);
   await table2.create(apiContext);
 
+  notNullTestCase = ownedTestCase('test_column_values_not_null');
+  uniqueTestCase = ownedTestCase('test_column_values_unique');
+
   await table1.createTestCase(apiContext, {
-    name: `test_column_values_not_null_${uuid()}`,
+    name: notNullTestCase.name,
     entityLink: `<#E::table::${table1.entityResponseData?.['fullyQualifiedName']}::columns::${table1.entity?.columns[0].name}>`,
     parameterValues: [],
     testDefinition: 'columnValuesToBeNotNull',
   });
 
   await table1.createTestCase(apiContext, {
-    name: `test_column_values_unique_${uuid()}`,
+    name: uniqueTestCase.name,
     entityLink: `<#E::table::${table1.entityResponseData?.['fullyQualifiedName']}::columns::${table1.entity?.columns[0].name}>`,
     parameterValues: [],
     testDefinition: 'columnValuesToBeUnique',
@@ -66,6 +78,13 @@ test.beforeAll(async ({ browser }) => {
   });
 
   await bundleTestSuite.createBundleTestSuite(apiContext);
+
+  // The list page reads from Elasticsearch, so the tests cannot search for
+  // these until they are indexed.
+  await waitForTestCasesToBeIndexed(apiContext, [
+    notNullTestCase,
+    uniqueTestCase,
+  ]);
 
   bundleSuiteName = `bundle_suite_${uuid()}`;
   existingBundleSuiteName =
@@ -83,7 +102,7 @@ test('Create new Bundle Suite with bulk selected test cases', async ({
 }) => {
   await test.step('Navigate and select test case', async () => {
     await navigateToDataQualityTestCases(page);
-    await selectTestCasesByCheckbox(page, 1);
+    await searchAndSelectTestCase(page, notNullTestCase);
     await verifyTestCaseSelectionCount(page, 1);
   });
 
@@ -103,7 +122,7 @@ test('Create new Bundle Suite with bulk selected test cases', async ({
 test('Add test case to existing Bundle Suite', async ({ page }) => {
   await test.step('Navigate and select test case', async () => {
     await navigateToDataQualityTestCases(page);
-    await selectTestCasesByCheckbox(page, 1);
+    await searchAndSelectTestCase(page, uniqueTestCase);
     await verifyTestCaseSelectionCount(page, 1);
   });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
@@ -13,7 +13,7 @@
 import { APIRequestContext, expect, Page, Response } from '@playwright/test';
 import { SidebarItem } from '../constant/sidebar';
 import { TableClass } from '../support/entity/TableClass';
-import { redirectToHomePage } from './common';
+import { redirectToHomePage, uuid } from './common';
 import { waitForAllLoadersToDisappear } from './entity';
 import { sidebarClick } from './sidebar';
 import { submitTestCaseForm } from './testCases';
@@ -280,6 +280,113 @@ export const selectTestCasesByCheckbox = async (
   }
 };
 
+/**
+ * A test case the calling spec created, together with a term that finds it --
+ * and only it -- in the Test Cases list search.
+ */
+export type OwnedTestCase = {
+  name: string;
+  /**
+   * A substring of `name` that is unique across the server. The list search is
+   * Elasticsearch-backed and tokenises names on `_`, so searching a whole
+   * `test_column_values_not_null_<uuid>` name matches *every*
+   * `test_column_values_not_null_*` test case on the server. On a shared server
+   * that is dozens of rows, ranked by relevance rather than exactness, and the
+   * one we want drops off page 1. The uuid segment is the part that narrows it.
+   */
+  searchTerm: string;
+};
+
+/**
+ * Names a test case the calling spec will own, so it can be found again by a
+ * term that cannot collide with another spec's test cases.
+ */
+export const ownedTestCase = (namePrefix: string): OwnedTestCase => {
+  const searchTerm = uuid();
+
+  return { name: `${namePrefix}_${searchTerm}`, searchTerm };
+};
+
+/**
+ * Polls the test case search endpoint until every one of `testCases` is visible
+ * to it.
+ *
+ * The Data Quality > Test Cases list is Elasticsearch-backed, so a test case
+ * created over the API is not immediately findable. Call this after creating
+ * them and before any UI search. Mirrors the query the list page issues
+ * (`q=*term*` + `includeAllTests`) so the poll and the UI agree on what is
+ * visible.
+ */
+export async function waitForTestCasesToBeIndexed(
+  apiContext: APIRequestContext,
+  testCases: OwnedTestCase[]
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        for (const testCase of testCases) {
+          const res = await apiContext.get(
+            `/api/v1/dataQuality/testCases/search/list` +
+              `?q=*${testCase.searchTerm}*&includeAllTests=true&limit=50`
+          );
+
+          if (!res.ok()) {
+            return false;
+          }
+
+          const body = await res.json();
+          const isIndexed = (body.data ?? []).some(
+            (indexed: { name?: string }) => indexed.name === testCase.name
+          );
+
+          if (!isIndexed) {
+            return false;
+          }
+        }
+
+        return true;
+      },
+      { timeout: 45_000, intervals: [1_000, 2_000, 5_000] }
+    )
+    .toBe(true);
+}
+
+/**
+ * Filters the Test Cases list down to `testCase` and ticks its checkbox.
+ *
+ * Always prefer this over `selectTestCasesByCheckbox` when the test goes on to
+ * act on the selection (adding to a Bundle Suite, asserting a suite's contents,
+ * ...). The unfiltered list is sorted by most-recent result descending and is
+ * shared with every other spec running against the same server, so row 1 is
+ * whichever test case some other worker created seconds ago -- and is liable to
+ * be hard-deleted by that worker's cleanup while this test is still using it.
+ * Selecting by name keeps a test on entities it owns and controls the lifetime
+ * of.
+ */
+export const searchAndSelectTestCase = async (
+  page: Page,
+  testCase: OwnedTestCase
+) => {
+  const searchResponse = page.waitForResponse(
+    (res) =>
+      res.url().includes('/api/v1/dataQuality/testCases/search/list') &&
+      res.url().includes(testCase.searchTerm) &&
+      res.status() === 200
+  );
+  await page.getByTestId('searchbar').fill(testCase.searchTerm);
+  await searchResponse;
+
+  const row = page.locator('tr[data-row-key]').filter({
+    hasText: testCase.name,
+  });
+
+  // `searchTerm` is unique, so the filter resolves to exactly one row. Assert it
+  // here rather than relying on `.first()`, so a search that silently returns
+  // the wrong set fails on the search instead of somewhere downstream.
+  await expect(row).toHaveCount(1);
+  await row.locator('input[type="checkbox"]').check();
+};
+
 export const verifyTestCaseSelectionCount = async (
   page: Page,
   count: number
@@ -350,7 +457,15 @@ export const submitAddToExistingBundleSuite = async (page: Page) => {
   );
 
   await modal.getByRole('button', { name: 'Add', exact: true }).click();
-  await addResponse;
+  const response = await addResponse;
+
+  // The modal stays open on a rejected add, so without this the failure only
+  // surfaces further down as a confusing "URL never changed" timeout. Surface
+  // the server's reason instead.
+  expect(
+    response.ok(),
+    `Adding test cases to the Bundle Suite failed: ${response.status()} ${await response.text()}`
+  ).toBe(true);
 };
 
 export const verifyBundleSuitePageLoaded = async (


### PR DESCRIPTION
### Describe your changes:

Fixes #31799

Cherry-pick of #31800 (`main`) onto `1.13`, **with the row/checkbox locators ported to this branch** — see the caveat below.

`BundleSuiteBulkOperations.spec.ts › Add test case to existing Bundle Suite` ticked **row 1 of the global Test Cases list**, which is sorted by most-recent result descending. The spec's own test cases are created without a result, so they can never be row 1 — under CI parallelism row 1 is reliably a test case another worker created seconds ago and is about to hard-delete. When that cleanup ran (`?recursive=true&hardDelete=true`), it cascaded to the test case and removed the `CONTAINS` edge this spec had just created, so the suite read back `tests: []`. When the delete landed earlier, the add was rejected with `400 "You are trying to add one or more test cases that do not exist."` Full analysis in #31799.

The two tests that act on their selection now search for a test case the spec created:

```diff
- await selectTestCasesByCheckbox(page, 1);
+ await searchAndSelectTestCase(page, uniqueTestCase);
```

The search term is the uuid segment, not the whole name — the list search is Elasticsearch-backed and tokenises on `_`, so a full `<prefix>_<uuid>` name matches every `<prefix>_*` test case on the server and the wanted one ranks off page 1.

> [!IMPORTANT]
> **This is not a clean pick, even though git applied it without conflict.**
> `1.13` still renders the Test Cases list with the **antd table**, whereas `main`/`2.0` use the core `Table`. The cherry-pick merged textually but would have been silently wrong — the new helper would have looked for `tr[data-key]` + `label[slot="selection"]`, neither of which exists here. `searchAndSelectTestCase` therefore uses `tr[data-row-key]` + `input[type="checkbox"]`.check() on this branch, matching this branch's own `selectTestCasesByCheckbox`. Worth a careful look during review.
>
> The `data-testid="searchbar"` the helper types into does exist on `1.13` (via `common/SearchBarComponent`), and this same page is already driven that way by `dataQuality.ts` — so that part needed no change.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — cherry-pick with a locator port.

#
### Tests:

#### Use cases covered
- Adding a bulk-selected test case to an existing Bundle Suite while other specs concurrently create and hard-delete test cases against the same server
- Creating a new Bundle Suite from a bulk-selected test case under the same conditions

#### Unit tests
Not applicable — Playwright-only change.

#### Backend integration tests
Not applicable — no backend API changes.

#### Ingestion integration tests
Not applicable — no ingestion changes.

#### Playwright (UI) tests
- [x] Files updated:
  - `openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/BundleSuiteBulkOperations.spec.ts`
  - `openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts`

#### Manual testing performed

The behavioural validation was done on the `main` PR (#31800): the pre-fix spec was made to fail 4/8 under a script reproducing the race, and interleaved under one live churn the old spec failed 2/6 while the fixed spec passed 6/6; the fixed spec passed 24/24 unchurned and 8/8 under churn.

**That run-time evidence does not fully transfer to this branch**, because the ported locators are branch-specific and were not exercised against a `1.13` server locally. What was verified here:

- The ported locators match this branch's own working idiom in `selectTestCasesByCheckbox` (`tr[data-row-key]` + `input[type="checkbox"]`.check()).
- `data-testid="searchbar"` is present on this branch's Test Cases page and already used by `dataQuality.ts:157`.
- `@playwright/test` is `1.57.0` on both branches, so no API-compatibility gap in `expect.poll` / `Locator.filter` / `APIResponse.ok()`.
- `tsc` reports zero errors in both changed files; eslint and prettier clean.

Please let CI exercise this one before merging rather than relying on the `main` validation alone.

#
### UI screen recording / screenshots:

Not applicable — test-only change.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For UI changes: not applicable, test-only change.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR stabilizes Bundle Suite bulk-operation Playwright coverage by selecting test cases owned by the spec rather than globally sorted rows.

- Assigns each actionable test case a unique searchable UUID segment.
- Polls the Elasticsearch-backed endpoint until created cases are indexed.
- Searches for and selects the exact antd table row before performing bundle operations.
- Surfaces failed bulk-add API responses at the operation that caused them.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code defect identified.

The new polling request matches the branch's Test Cases search contract, the selection helper uses the table structure already used on this branch, and each mutating test targets a distinct UUID-named resource it created.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/BundleSuiteBulkOperations.spec.ts | Creates uniquely identifiable test cases, waits for indexing, and selects the exact owned case in both state-mutating scenarios. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts | Adds ownership, indexing, and exact-selection helpers using branch-appropriate antd locators, plus an immediate bulk-add response assertion. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fixes 31799: make BundleSuiteBulkOperati..."](https://github.com/open-metadata/openmetadata/commit/a7a02a97b01f8255d8c1718538a8a6c9f89c1a65) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55057069)</sub>

<!-- /greptile_comment -->

> [!NOTE]
> **Why `skip-pr-checks` is applied.** `Validate PR Metadata` resolves same-repo links through GitHub's `closingIssuesReferences`, which GitHub only populates for PRs targeting the **default branch**. A backport targeting a release branch therefore cannot satisfy it from the description, no matter how the `Fixes #` line is written — every current release-branch PR hits this (e.g. #31808, #31807). The issue is #31799 and is linked from the `main` PR #31800.
