### PR TITLE
fix(oracle): restore catalog-aware constraint reflection

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/oracle/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/oracle/metadata.py
@@ -58,17 +58,19 @@ from metadata.ingestion.source.database.oracle.queries import (
 )
 from metadata.ingestion.source.database.oracle.utils import (
     _get_col_type,
-    _get_constraint_data,
     denormalize_name,
     get_all_view_definitions,
     get_columns,
+    get_foreign_keys,
     get_indexes_preserve_case,
     get_mview_names,
     get_mview_names_dialect,
+    get_pk_constraint,
     get_table_comment,
     get_table_comment_preserve_case,
     get_table_names,
     get_table_prefix_from_connection,
+    get_unique_constraints,
     get_view_definition,
     get_view_definition_preserve_case,
     get_view_names,
@@ -109,7 +111,9 @@ OracleDialect.get_view_names = get_view_names_dialect
 Inspector.get_all_table_ddls = get_all_table_ddls
 Inspector.get_table_ddl = get_table_ddl
 
-OracleDialect._get_constraint_data = _get_constraint_data
+OracleDialect.get_pk_constraint = get_pk_constraint
+OracleDialect.get_unique_constraints = get_unique_constraints
+OracleDialect.get_foreign_keys = get_foreign_keys
 
 
 class OracleSource(CommonDbSourceService):

--- a/ingestion/src/metadata/ingestion/source/database/oracle/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/oracle/queries.py
@@ -354,7 +354,8 @@ ORACLE_CONSTRAINTS = textwrap.dedent(
             loc.position as loc_pos,
             rem.position as rem_pos,
             ac.search_condition,
-            ac.delete_rule
+            ac.delete_rule,
+            ac.index_name
         FROM {prefix}_CONSTRAINTS{dblink} ac,
             {prefix}_CONS_COLUMNS{dblink} loc,
             {prefix}_CONS_COLUMNS{dblink} rem

--- a/ingestion/src/metadata/ingestion/source/database/oracle/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/oracle/utils.py
@@ -414,6 +414,142 @@ def _get_constraint_data(self, connection, table_name, schema=None, dblink="", *
     return constraint_data  # noqa: RET504
 
 
+def _prepare_constraint_args(self, connection, table_name, schema, **kw):
+    dblink = kw.get("dblink", "")
+    if dblink and not dblink.startswith("@"):
+        dblink = f"@{dblink}"
+
+    if kw.get("oracle_resolve_synonyms", False):
+        rows = list(
+            self._get_synonyms(
+                connection,
+                schema,
+                [table_name],
+                dblink,
+                info_cache=kw.get("info_cache"),
+            )
+        )
+        if rows:
+            row = rows[0]
+            table_name = self.denormalize_name(row.table_name)
+            schema = self.denormalize_name(row.table_owner)
+            if row.db_link:
+                dblink = row.db_link if row.db_link.startswith("@") else f"@{row.db_link}"
+    else:
+        table_name = self.denormalize_name(table_name)
+        schema = self.denormalize_name(schema or self.default_schema_name)
+
+    return table_name, schema, dblink
+
+
+@reflection.cache
+def get_pk_constraint(self, connection, table_name, schema=None, **kw):
+    """Reflect a primary key from the selected Oracle catalog."""
+    table_name, schema, dblink = _prepare_constraint_args(self, connection, table_name, schema, **kw)
+    constraint_data = _get_constraint_data(
+        self,
+        connection,
+        table_name,
+        schema,
+        dblink,
+        info_cache=kw.get("info_cache"),
+    )
+
+    constrained_columns = []
+    constraint_name = None
+    for row in constraint_data:
+        if row[1] == "P":
+            constraint_name = constraint_name or self.normalize_name(row[0])
+            constrained_columns.append(self.normalize_name(row[2]))
+
+    return {"constrained_columns": constrained_columns, "name": constraint_name}
+
+
+@reflection.cache
+def get_unique_constraints(self, connection, table_name, schema=None, **kw):
+    """Reflect unique constraints from the selected Oracle catalog."""
+    table_name, schema, dblink = _prepare_constraint_args(self, connection, table_name, schema, **kw)
+    constraint_data = _get_constraint_data(
+        self,
+        connection,
+        table_name,
+        schema,
+        dblink,
+        info_cache=kw.get("info_cache"),
+    )
+
+    unique_constraints = {}
+    for row in constraint_data:
+        if row[1] != "U":
+            continue
+        constraint_name = self.normalize_name(row[0])
+        index_name = self.normalize_name(row[10])
+        constraint = unique_constraints.setdefault(
+            constraint_name,
+            {
+                "name": constraint_name,
+                "column_names": [],
+                "duplicates_index": constraint_name if index_name == constraint_name else None,
+            },
+        )
+        constraint["column_names"].append(self.normalize_name(row[2]))
+
+    return list(unique_constraints.values())
+
+
+@reflection.cache
+def get_foreign_keys(self, connection, table_name, schema=None, **kw):
+    """Reflect foreign keys from the selected Oracle catalog."""
+    requested_schema = schema
+    table_name, schema, dblink = _prepare_constraint_args(self, connection, table_name, schema, **kw)
+    constraint_data = _get_constraint_data(
+        self,
+        connection,
+        table_name,
+        schema,
+        dblink,
+        info_cache=kw.get("info_cache"),
+    )
+
+    foreign_keys = {}
+    for row in constraint_data:
+        if row[1] != "R":
+            continue
+
+        constraint_name = self.normalize_name(row[0])
+        local_column = self.normalize_name(row[2])
+        remote_table = self.normalize_name(row[3])
+        remote_column = self.normalize_name(row[4])
+        remote_owner = self.normalize_name(row[5])
+
+        if remote_table is None:
+            util.warn(
+                f"Got 'None' querying 'table_name' from {_get_table_prefix(self)}_CONS_COLUMNS{dblink}; "
+                "does the user have proper rights to the table?"
+            )
+            continue
+
+        foreign_key = foreign_keys.setdefault(
+            constraint_name,
+            {
+                "name": constraint_name,
+                "constrained_columns": [],
+                "referred_schema": None,
+                "referred_table": remote_table,
+                "referred_columns": [],
+                "options": {},
+            },
+        )
+        if requested_schema is not None or self.denormalize_name(remote_owner) != schema:
+            foreign_key["referred_schema"] = remote_owner
+        if row[9] != "NO ACTION":
+            foreign_key["options"]["ondelete"] = row[9]
+        foreign_key["constrained_columns"].append(local_column)
+        foreign_key["referred_columns"].append(remote_column)
+
+    return list(foreign_keys.values())
+
+
 # ---------------------------------------------------------------------------
 # Preserve-case variants — bound at instance level only when
 # preserveIdentifierCase=True.  The original functions above are unchanged.

--- a/ingestion/tests/unit/topology/database/test_oracle_constraint_reflection.py
+++ b/ingestion/tests/unit/topology/database/test_oracle_constraint_reflection.py
@@ -1,0 +1,131 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from importlib import import_module
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.dialects.oracle.base import OracleDialect
+
+CONSTRAINT_ROWS = [
+    (
+        "FK_MY_TABLE_PARENT",
+        "R",
+        "PARENT_ID",
+        "PARENT_TABLE",
+        "ID",
+        "PARENT_SCHEMA",
+        1,
+        1,
+        None,
+        "CASCADE",
+        None,
+    ),
+    ("PK_MY_TABLE", "P", "ID", None, None, None, 1, None, None, None, "PK_MY_TABLE"),
+    ("UQ_MY_TABLE_CODE", "U", "CODE", None, None, None, 1, None, None, None, "UQ_MY_TABLE_CODE"),
+    ("UQ_MY_TABLE_CODE", "U", "REGION", None, None, None, 2, None, None, None, "UQ_MY_TABLE_CODE"),
+]
+
+
+def _dialect(prefix: str) -> OracleDialect:
+    import_module("metadata.ingestion.source.database.oracle.metadata")
+    dialect = OracleDialect()
+    dialect.table_prefix = prefix  # type: ignore[attr-defined]
+    return dialect
+
+
+def _connection(rows):
+    connection = MagicMock()
+    connection.execute.return_value.fetchall.return_value = rows
+    return connection
+
+
+@pytest.mark.parametrize("prefix", ["DBA", "ALL"])
+def test_constraint_reflection_uses_configured_catalog(prefix):
+    dialect = _dialect(prefix)
+    connection = _connection(CONSTRAINT_ROWS)
+
+    assert dialect.get_pk_constraint(connection, "my_table", schema="my_schema") == {
+        "constrained_columns": ["id"],
+        "name": "pk_my_table",
+    }
+    assert dialect.get_unique_constraints(connection, "my_table", schema="my_schema") == [
+        {
+            "name": "uq_my_table_code",
+            "column_names": ["code", "region"],
+            "duplicates_index": "uq_my_table_code",
+        }
+    ]
+    assert dialect.get_foreign_keys(connection, "my_table", schema="my_schema") == [
+        {
+            "name": "fk_my_table_parent",
+            "constrained_columns": ["parent_id"],
+            "referred_schema": "parent_schema",
+            "referred_table": "parent_table",
+            "referred_columns": ["id"],
+            "options": {"ondelete": "CASCADE"},
+        }
+    ]
+
+    assert len(connection.execute.call_args_list) == 3
+    for call in connection.execute.call_args_list:
+        query = str(call.args[0])
+        assert f"FROM {prefix}_CONSTRAINTS" in query
+        assert query.count(f"{prefix}_CONS_COLUMNS") == 2
+        assert call.args[1] == {"table_name": "MY_TABLE", "owner": "MY_SCHEMA"}
+
+
+def test_constraint_reflection_returns_empty_defaults():
+    dialect = _dialect("DBA")
+    connection = _connection([])
+
+    assert dialect.get_pk_constraint(connection, "my_table", schema="my_schema") == {
+        "constrained_columns": [],
+        "name": None,
+    }
+    assert dialect.get_unique_constraints(connection, "my_table", schema="my_schema") == []
+    assert dialect.get_foreign_keys(connection, "my_table", schema="my_schema") == []
+
+
+def test_constraint_reflection_resolves_synonym_before_denormalizing():
+    dialect = _dialect("DBA")
+    dialect._get_synonyms = MagicMock(
+        return_value=[
+            SimpleNamespace(
+                table_name="ACTUAL_TABLE",
+                table_owner="ACTUAL_SCHEMA",
+                db_link=None,
+            )
+        ]
+    )
+    connection = _connection(CONSTRAINT_ROWS)
+
+    assert dialect.get_pk_constraint(
+        connection,
+        "alias_table",
+        schema="alias_schema",
+        oracle_resolve_synonyms=True,
+    ) == {
+        "constrained_columns": ["id"],
+        "name": "pk_my_table",
+    }
+    dialect._get_synonyms.assert_called_once_with(
+        connection,
+        "alias_schema",
+        ["alias_table"],
+        "",
+        info_cache=None,
+    )
+    assert connection.execute.call_args.args[1] == {
+        "table_name": "ACTUAL_TABLE",
+        "owner": "ACTUAL_SCHEMA",
+    }


### PR DESCRIPTION
Backports #31676 to 2.0.

This applies catalog-aware Oracle primary-key, unique-constraint, and foreign-key reflection and preserves backing-index metadata.

Focused verification: 4 Oracle constraint-reflection tests passed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restores catalog-aware Oracle constraint reflection by overriding primary-key, unique-constraint, and foreign-key inspection while retaining backing-index metadata.
- Uses the configured Oracle catalog prefix for constraint queries.
- Handles synonym and database-link reflection arguments.
- Adds focused tests for DBA/ALL catalogs, empty results, and synonym resolution.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The pull request appears safe to merge, with no concrete changed-code failure established.

The new reflection methods preserve the expected constraint shapes, route queries through the configured Oracle catalog, and include focused coverage for the principal catalog and synonym paths.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/oracle/metadata.py | Rebinds the three public Oracle constraint-reflection methods to catalog-aware implementations. |
| ingestion/src/metadata/ingestion/source/database/oracle/queries.py | Extends the constraint query with the backing index name needed for unique-constraint metadata. |
| ingestion/src/metadata/ingestion/source/database/oracle/utils.py | Implements catalog-aware PK, unique, and foreign-key reflection with identifier, synonym, and database-link handling. |
| ingestion/tests/unit/topology/database/test_oracle_constraint_reflection.py | Verifies both catalog prefixes, empty reflection results, backing-index metadata, and synonym resolution. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Ingestion as Oracle ingestion
    participant Inspector as SQLAlchemy Inspector
    participant Dialect as Patched OracleDialect
    participant Catalog as Oracle catalog
    Ingestion->>Inspector: Reflect table constraints
    Inspector->>Dialect: get_pk_constraint / get_unique_constraints / get_foreign_keys
    Dialect->>Dialect: Resolve synonym and normalize identifiers
    Dialect->>Catalog: Query configured DBA_ or ALL_ catalog views
    Catalog-->>Dialect: Constraint rows and backing index names
    Dialect-->>Inspector: SQLAlchemy reflection metadata
    Inspector-->>Ingestion: PK, unique, and foreign-key definitions
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(oracle): restore catalog-aware const..."](https://github.com/open-metadata/openmetadata/commit/9494628153406299b5d19d53d52cda09ed252090) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55057400)</sub>

<!-- /greptile_comment -->