### PR TITLE
fix(playwright): verify glossary asset count via relation-based filter-count (2.0 backport)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
@@ -1194,7 +1194,19 @@ test.describe('Glossary tests', () => {
       );
       await sidebarClick(page, SidebarItem.GLOSSARY);
       await selectActiveGlossary(page, glossary1.data.displayName);
-      await goToAssetsTab(page, glossaryTerm1.data.displayName, 1);
+      await selectActiveGlossaryTerm(page, glossaryTerm1.data.displayName);
+      await page.getByTestId('assets').click();
+      await page.locator('.ant-tabs-tab-active:has-text("Assets")').waitFor();
+      await expect
+        .poll(async () =>
+          Number(
+            await page
+              .getByTestId('assets')
+              .getByTestId('filter-count')
+              .textContent()
+          )
+        )
+        .toBeGreaterThanOrEqual(1);
       const entityFqn = get(table, 'entityResponseData.fullyQualifiedName');
 
       await expect(


### PR DESCRIPTION
## Summary

Backport of #31801 to the `2.0` branch.

- Replaces `goToAssetsTab(page, glossaryTerm1.data.displayName, 1)` with explicit term selection + Assets tab click + `expect.poll` on the `filter-count` badge
- The poll ensures the test waits for the relation-based count to render before asserting on the assigned table card, fixing the flaky assertion

Both `selectActiveGlossaryTerm` and `goToAssetsTab` were already imported on 2.0 — no import changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport replaces a shared glossary Assets-tab helper with explicit term selection, tab activation, and polling of the relation-based count before checking the assigned table.
- Waits for the Assets tab to become active.
- Polls the count badge until at least one relation appears.
- Preserves the subsequent assigned-table assertion.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with non-blocking improvements recommended to preserve exact relation-count coverage and avoid duplicated selector literals.

The polling reaches the correct numeric count badge and addresses the intended timing issue, but accepting counts above one can conceal inflated relations and the inline sequence adds brittle raw strings.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts | The new polling reduces timing sensitivity, but weakens the exact-count assertion and duplicates raw selector strings. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(playwright): verify glossary asset c..."](https://github.com/open-metadata/openmetadata/commit/3d577d39460d8bebc8a0e1e798347648aa823185) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55062227)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))

<!-- /greptile_comment -->