### PR TITLE
fix(playwright): skip ports tab click when already active

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
@@ -1677,6 +1677,20 @@ export const navigateToPortsTab = async (page: Page) => {
   const portsTab = page.getByTestId('input_output_ports');
   await portsTab.waitFor({ state: 'visible' });
 
+  // Already on the ports tab: clicking the active tab is a no-op that fires no
+  // /portsView request — waiting on that response would hang until the test
+  // timeout. The selected tab exposes `aria-selected` via its `role="tab"`.
+  const isActive = await page
+    .getByRole('tab', { selected: true })
+    .getByTestId('input_output_ports')
+    .isVisible();
+
+  if (isActive) {
+    await waitForAllLoadersToDisappear(page);
+
+    return;
+  }
+
   const portsViewResponse = page.waitForResponse((response) =>
     response.url().includes('/portsView')
   );


### PR DESCRIPTION
## Describe your changes

`navigateToPortsTab` clicked the Input/Output Ports tab unconditionally and then waited for the `/portsView` response. When the test was already on the ports tab, clicking the active tab is a no-op that fires no request, so the response wait hung until the test timeout.

This guards on the tab's selected state (`getByRole('tab', { selected: true })` scoped to the ports tab) and returns early when the ports tab is already active, reusing the existing `portsTab` locator.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How was this change tested?

Playwright E2E — `InputOutputPorts.spec.ts` exercises `navigateToPortsTab` from callers that are already on the ports tab as well as from other tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The Playwright helper now avoids clicking the Input/Output Ports tab and waiting for a network response when that tab is already selected.
- Detects the selected ports tab through its accessible tab state.
- Waits for existing loaders and returns early when already active.
- Preserves the existing click-and-response behavior when navigation is required.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts | Adds an early return that prevents a Playwright timeout when the ports tab is already active. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix-ports-tab-d..."](https://github.com/open-metadata/openmetadata/commit/5e20dbfda13275d105b4987240dfc5036fcfcec6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55064742)</sub>

<!-- /greptile_comment -->