### PR TITLE
ci: ping #ci-cleanup when a PR leaves the merge queue

### DIFF
--- a/.github/workflows/merge-queue-dequeue-report.yml
+++ b/.github/workflows/merge-queue-dequeue-report.yml
@@ -47,6 +47,7 @@ jobs:
       PR: ${{ github.event.number || inputs.pr }}
       BASE_REF: ${{ github.event.repository.default_branch }}
       DRY_RUN: ${{ inputs.dry_run == true || vars.MQ_REPORT_DRY_RUN == 'true' }}
+      SLACK_CHANNEL: C0AC5T013V1 # #ci-cleanup
     steps:
       - name: Resolve the dequeue event
         id: event
@@ -104,10 +105,11 @@ jobs:
           # An entry removed while still queued was never built, so it has no
           # merge-group commit and nothing ever ran against it.
           if [ -z "$SHA" ]; then
+            echo "The entry left the queue before it was built, so no checks ran against it." > detail.txt
             {
               echo "### 🚦 Removed from the merge queue — \`$REASON\` ($CREATED)"
               echo
-              echo "The entry left the queue before it was built, so no checks ran against it."
+              cat detail.txt
             } > body.md
           else
             gh api "repos/$GH_REPO/commits/$SHA/check-runs?per_page=100" --paginate \
@@ -124,6 +126,7 @@ jobs:
               | awk '{ out = out (out ? ", " : "") "`" $0 "`" } END { print out }' || true)
 
             : > runs.md
+            : > runs.slack
             cut -f1 failures.tsv | sed 's#/job/.*##' | sort -u | while read -r run; do
               run_name=$(gh api "repos/$GH_REPO/actions/runs/${run##*/}" --jq '.name')
               # Matrix jobs carry every parameter; the first one is the shard id.
@@ -131,27 +134,57 @@ jobs:
                      | sed 's/ (\([^,)]*\)[^)]*)/ (\1)/' \
                      | awk '{ out = out (out ? ", " : "") $0 } END { print out }')
               echo "- [$run_name]($run) — $jobs" >> runs.md
+              # Slack mrkdwn has no []() links; it uses <url|text>.
+              echo "• <$run|$run_name> — $jobs" >> runs.slack
             done
+
+            if [ -s runs.md ]; then
+              if [ -n "$blocked" ]; then
+                echo "Blocked the queue: $blocked" > detail.txt
+              else
+                echo "No required check failed — the entry may have timed out, or been dequeued while a required check was still pending." > detail.txt
+              fi
+            else
+              echo "No failing check on merge-queue commit \`${SHA:0:7}\` — invalidated by an entry ahead in the queue, or a required check timed out." > detail.txt
+            fi
 
             {
               echo "### 🚦 Removed from the merge queue — \`$REASON\` ($CREATED)"
               echo
+              cat detail.txt
               if [ -s runs.md ]; then
-                if [ -n "$blocked" ]; then
-                  echo "Blocked the queue: $blocked"
-                else
-                  echo "No required check failed — the entry may have timed out, or been dequeued while a required check was still pending."
-                fi
                 echo
                 cat runs.md
-              else
-                echo "No failing check on merge-queue commit \`${SHA:0:7}\` — invalidated by an entry ahead in the queue, or a required check timed out."
               fi
             } > body.md
           fi
+
+          # The same report, re-rendered as Slack mrkdwn. jq -Rs escapes the body,
+          # so backticks and newlines from the check names survive as-is.
+          {
+            echo ":rotating_light: *<$GITHUB_SERVER_URL/$GH_REPO/pull/$PR|PR #$PR>* removed from the merge queue — \`$REASON\`"
+            cat detail.txt
+            if [ -s runs.slack ]; then
+              cat runs.slack
+            fi
+          } | jq -Rs --arg channel "$SLACK_CHANNEL" '{channel: $channel, text: .}' > slack.json
 
           if [ "$DRY_RUN" = "true" ]; then
             cat body.md >> "$GITHUB_STEP_SUMMARY"
           else
             gh pr comment "$PR" --body-file body.md
           fi
+
+      # A dequeue holds up everyone behind it in the queue, so the channel gets
+      # the same report the PR does. Slack must never fail the report, hence
+      # continue-on-error; `errors: true` still surfaces the API error in the log.
+      - name: "Ping #ci-cleanup"
+        if: ${{ steps.event.outputs.reason != '' && env.DRY_RUN != 'true' }}
+        continue-on-error: true
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.COLLATE_BOT_SLACK_TOKEN }}
+          # Keep on — the action discards Slack API errors by default.
+          errors: true
+          payload-file-path: slack.json


### PR DESCRIPTION
### Describe your changes:

Fixes #<issue-number>

<!-- TODO: link an issue before marking ready for review. Same as #30752 / #30755. -->

Follow-up to #30752 and #30755, which report *why* a PR was kicked out of the merge queue — but only on the PR itself, so a queue-blocking failure is visible to its author and to nobody else. This posts the same report to **#ci-cleanup** so the team sees the block as it happens. It reuses `COLLATE_BOT_SLACK_TOKEN` (already a repo secret, used by `py-cli-e2e-tests.yml` and `py-sonarcloud-nightly.yml`) rather than the incoming webhook Collate pings CI errors with, because `SLACK_BACKEND_WEBHOOK` is scoped to the `openmetadata-collate` repo and would have to be re-provisioned here. The report body is factored into `detail.txt` / `runs.slack` so the Slack payload is built from the same data as the PR comment, rendered in Slack mrkdwn (`<url|text>`) instead of GitHub markdown — the PR comment output is byte-identical to before.

#
### Type of change:
- [x] Improvement

#
### High-level design:

N/A — small change, one workflow file.

#
### Tests:

#### Use cases covered
- A PR dequeued after its merge-queue build failed → #ci-cleanup gets the PR link, the dequeue reason, which required check blocked the queue, and one bullet per failing workflow run.
- A PR dequeued before it was ever built (e.g. `MANUAL`) → channel gets the reason with the "never built" explanation, no run links.
- A PR dequeued with no failing check on its queue commit (invalidated by an entry ahead, or a required check timed out) → channel gets that explanation.
- `MQ_REPORT_DRY_RUN` / `workflow_dispatch` dry run → report still goes to the job summary, Slack stays silent.
- Slack API error (bad token, `not_in_channel`, outage) → surfaced in the step log via `errors: true`, job still succeeds via `continue-on-error`.

#### Unit tests
Not applicable — GitHub Actions workflow, no application code. Verified instead by:
- `actionlint .github/workflows/merge-queue-dequeue-report.yml` — clean (it shellchecks the `run` block).
- Extracted the `run` block and executed it against a stubbed `gh` for all three report paths above, confirming `slack.json` is valid JSON with the right `channel` and mrkdwn `text`.
- Diffed `body.md` produced by the old vs. new script across the same three paths — identical in all three, so the existing PR comment does not regress.

#### Backend integration tests
Not applicable — no backend API changes.

#### Ingestion integration tests
Not applicable — no ingestion changes.

#### Playwright (UI) tests
Not applicable — no UI changes.

#### Manual testing performed
The dequeue path cannot be triggered from a fork or a local run, so it was exercised with the harness described above rather than against live Slack. After merge, the first real dequeue is the end-to-end check; if the app is missing from the channel it fails loudly in the step log as `not_in_channel` (fix: `/invite @E2E Tests` in #ci-cleanup) without affecting the PR comment.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` — follows the `ci:` convention of #30752 / #30755 instead.
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Improvement -->
- [x] I have added tests around the new logic.
- [x] For connector/ingestion changes: not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the merge-queue dequeue workflow to post its existing diagnostic report to `#ci-cleanup` while preserving dry-run behavior and preventing Slack failures from failing the reporting job.
- Factors shared dequeue details into reusable files for GitHub and Slack rendering.
- Produces a JSON-escaped Slack `chat.postMessage` payload with links to the PR and failing workflow runs.
- Skips Slack during dry runs and tolerates Slack API failures.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The new notification uses an established Slack action contract, generates its payload on every reachable posting path, preserves dry-run suppression, and isolates Slack API failures from the existing dequeue report.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/merge-queue-dequeue-report.yml | Adds a pinned Slack notification action and shared report rendering without identifying a concrete regression in the supported dequeue paths. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: ping #ci-cleanup when a PR leaves th..."](https://github.com/open-metadata/openmetadata/commit/f114f29c23403806e6e68164c59f1937701e2fc1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55070715)</sub>

<!-- /greptile_comment -->