### PR TITLE
fix(ci): dedicated shard for IntakeFormCustomPropertyFields; drop non-existent IntakeForm project

### DIFF
--- a/.github/workflows/mysql-nightly-e2e.yml
+++ b/.github/workflows/mysql-nightly-e2e.yml
@@ -88,16 +88,24 @@ jobs:
               --project=DataAssetRulesEnabled \
               --project=DataAssetRulesDisabled
 
+          elif [ "${{ matrix.shardIndex }}" -eq "2" ]; then
+            echo "🔹 Running IntakeFormCustomPropertyFields on shard 2"
+
+            # IntakeFormCustomPropertyFields depends on the chromium project and
+            # is fullyParallel: false. Co-listing it with chromium under --shard
+            # collapses distribution onto shard 1/N and leaves the other shards
+            # empty, so it must run on its own matrix slot.
+            npx playwright test \
+              --project=IntakeFormCustomPropertyFields
+
           else
-            # Shards 2-7 handle chromium tests (7 shards total)
-            CHROMIUM_SHARD=$(( ${{ matrix.shardIndex }} - 1 ))
-            echo "🔹 Running all tests (excluding DataAssetRules) on chromium shard ${CHROMIUM_SHARD}/5"
+            # Shards 3-8 handle chromium tests (6 shards total)
+            CHROMIUM_SHARD=$(( ${{ matrix.shardIndex }} - 2 ))
+            echo "🔹 Running all tests (excluding DataAssetRules) on chromium shard ${CHROMIUM_SHARD}/6"
             npx playwright test \
               --project=chromium \
-              --project=IntakeFormCustomPropertyFields \
-              --project=IntakeForm \
               --grep-invert @dataAssetRules \
-              --shard=${CHROMIUM_SHARD}/7
+              --shard=${CHROMIUM_SHARD}/6
           fi
 
         env:

--- a/.github/workflows/postgresql-nightly-e2e.yml
+++ b/.github/workflows/postgresql-nightly-e2e.yml
@@ -88,16 +88,24 @@ jobs:
               --project=DataAssetRulesEnabled \
               --project=DataAssetRulesDisabled
 
+          elif [ "${{ matrix.shardIndex }}" -eq "2" ]; then
+            echo "🔹 Running IntakeFormCustomPropertyFields on shard 2"
+
+            # IntakeFormCustomPropertyFields depends on the chromium project and
+            # is fullyParallel: false. Co-listing it with chromium under --shard
+            # collapses distribution onto shard 1/N and leaves the other shards
+            # empty, so it must run on its own matrix slot.
+            npx playwright test \
+              --project=IntakeFormCustomPropertyFields
+
           else
-            # Shards 2-7 handle chromium tests (7 shards total)
-            CHROMIUM_SHARD=$(( ${{ matrix.shardIndex }} - 1 ))
-            echo "🔹 Running all tests (excluding DataAssetRules) on chromium shard ${CHROMIUM_SHARD}/5"
+            # Shards 3-8 handle chromium tests (6 shards total)
+            CHROMIUM_SHARD=$(( ${{ matrix.shardIndex }} - 2 ))
+            echo "🔹 Running all tests (excluding DataAssetRules) on chromium shard ${CHROMIUM_SHARD}/6"
             npx playwright test \
               --project=chromium \
-              --project=IntakeFormCustomPropertyFields \
-              --project=IntakeForm \
               --grep-invert @dataAssetRules \
-              --shard=${CHROMIUM_SHARD}/7
+              --shard=${CHROMIUM_SHARD}/6
           fi
 
         env:


### PR DESCRIPTION
## Summary

- After #31796 bumped the nightly Postgres Playwright matrix from 6 → 8 (denominator 5 → 7), 6 of 7 chromium shards ran **zero** tests and finished in ~11 s each (see run 32333583778 shards 3-8). Only shard 2 (`--shard=1/7`) got any work.
- Root cause: co-listing `--project=chromium --project=IntakeFormCustomPropertyFields` under `--shard`. `IntakeFormCustomPropertyFields` depends on the entire `chromium` project and is `fullyParallel: false`, so Playwright collapses distribution onto shard 1/N. The same interaction was already visible on the 5-shard config as shard 2 timing out at 194 min.
- Additional bug: `--project=IntakeForm` does not exist on 1.13 (only `IntakeFormCustomPropertyFields` was added by #30910). Playwright silently accepted the unknown project name.

## Fix

Split the workload so every matrix slot does real work:

| Shard | Command |
|-------|---------|
| 1     | `--project=setup --project=DataAssetRulesEnabled --project=DataAssetRulesDisabled` |
| 2     | `--project=IntakeFormCustomPropertyFields` (own slot; runs `chromium` as its dep serially) |
| 3-8   | `--project=chromium --grep-invert @dataAssetRules --shard=X/6` |

Also drops the invalid `--project=IntakeForm`.

## Test plan

- [ ] Trigger the workflow via `workflow_dispatch` on `1.13`
- [ ] Confirm each of shards 3-8 reports a non-empty test set and non-trivial duration
- [ ] Confirm shard 2 runs `IntakeFormCustomPropertyFields.spec.ts` end-to-end (its `chromium` dep will run there too)
- [ ] Confirm merge-reports job succeeds and Slack summary reflects all shards

## Related

- #31796 (the shard bump that surfaced this)
- #30910 (introduced `IntakeFormCustomPropertyFields` project)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR separates the serial IntakeForm custom-property project from the regular Chromium shards in both nightly database workflows.
- Reserves matrix slot 1 for DataAssetRules projects.
- Reserves slot 2 for IntakeFormCustomPropertyFields and its declared dependencies.
- Distributes the remaining Chromium suite across slots 3–8 using a consistent six-shard denominator.
- Removes the nonexistent IntakeForm project selection.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because both workflows consistently map all eight matrix slots to valid Playwright project selections and shard indices.

The MySQL and PostgreSQL workflows apply matching branch logic, use shard values 1/6 through 6/6 for slots 3–8, and intentionally isolate the dependency-heavy IntakeFormCustomPropertyFields project.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/mysql-nightly-e2e.yml | Adds a dedicated IntakeFormCustomPropertyFields matrix slot and redistributes the remaining MySQL Chromium workload across six correctly numbered shards. |
| .github/workflows/postgresql-nightly-e2e.yml | Applies the same dedicated-project and six-shard layout to the PostgreSQL nightly workflow while removing the invalid IntakeForm project. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  M[Eight-slot nightly matrix] --> S1[Slot 1]
  M --> S2[Slot 2]
  M --> S3[Slots 3–8]
  S1 --> D[Setup and DataAssetRules projects]
  S2 --> I[IntakeFormCustomPropertyFields]
  I --> CDEP[Setup and Chromium dependencies]
  S3 --> C[Chromium excluding dataAssetRules]
  C --> SH[Six shards: 1/6 through 6/6]
  D --> R[Upload blob report]
  I --> R
  SH --> R
  R --> MR[Merge reports and publish summary]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): apply same shard fix to MySQL n..."](https://github.com/open-metadata/openmetadata/commit/f83f9509a674cf58bdd330e2acebf6f1774fee7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55074611)</sub>

<!-- /greptile_comment -->