### PR TITLE
fix(ui): visibility handler no longer refreshes when there's nothing to refresh

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.test.tsx
@@ -67,6 +67,35 @@ jest.mock('../../../utils/ToastUtils', () => ({
   showInfoToast: jest.fn(),
 }));
 
+// Default returns a shape that keeps pre-existing tests (which don't touch
+// this mock) working — they call startTokenExpiryTimer during mount, which
+// destructures isExpired/timeoutExpiry from the return value.
+const mockGetOidcToken = jest.fn().mockResolvedValue('');
+const mockExtractDetailsFromToken = jest.fn().mockReturnValue({
+  exp: 0,
+  isExpired: true,
+  timeoutExpiry: 0,
+});
+
+jest.mock('../../../utils/SwTokenStorageUtils', () => {
+  const actual = jest.requireActual('../../../utils/SwTokenStorageUtils');
+
+  return {
+    ...actual,
+    getOidcToken: (...args: unknown[]) => mockGetOidcToken(...args),
+  };
+});
+
+jest.mock('../../../utils/AuthProvider.util', () => {
+  const actual = jest.requireActual('../../../utils/AuthProvider.util');
+
+  return {
+    ...actual,
+    extractDetailsFromToken: (token: string) =>
+      mockExtractDetailsFromToken(token),
+  };
+});
+
 const mockRefreshToken = jest
   .fn()
   .mockImplementation(() => Promise.resolve('newToken'));
@@ -571,5 +600,136 @@ describe('Test axios response interceptor', () => {
     expect(mockRefreshToken).toHaveBeenCalled();
     expect(mockAxios).toHaveBeenCalledWith(mockError.config);
     expect(result).toEqual({ data: 'ok' });
+  });
+});
+
+// Regression tests for the visibility handler. Before this branch every
+// visibilitychange event fired tokenService.refreshToken() when the stored
+// token was empty or lacked an `exp` claim — hitting the IdP on every tab
+// focus for a signed-out session or an opaque token. The handler now
+// early-returns in both cases, and only near-expiry / expired tokens
+// trigger a refresh.
+describe('AuthProvider visibility handler', () => {
+  const ConsumerComponent = () => <div>ConsumerComponent</div>;
+  const WrapperComponent = () => (
+    <AuthProvider childComponentType={ConsumerComponent}>
+      <ConsumerComponent />
+    </AuthProvider>
+  );
+
+  const fireTabVisible = async () => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    });
+    await act(async () => {
+      fireEvent(document, new Event('visibilitychange'));
+    });
+    // Let the handler's async chain resolve
+    // (getOidcToken → extractDetailsFromToken → branch).
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  };
+
+  beforeEach(() => {
+    mockRefreshToken.mockReset();
+    mockRefreshToken.mockResolvedValue('newToken');
+    mockGetOidcToken.mockReset();
+    mockGetOidcToken.mockResolvedValue('');
+    mockExtractDetailsFromToken.mockReset();
+    mockExtractDetailsFromToken.mockReturnValue({
+      exp: 0,
+      isExpired: true,
+      timeoutExpiry: 0,
+    });
+  });
+
+  it('does NOT call refreshToken when there is no token in storage', async () => {
+    mockGetOidcToken.mockResolvedValue('');
+
+    await act(async () => {
+      render(<WrapperComponent />);
+    });
+    // Clear counts from mount-time work so the visibility-event assertion
+    // only reflects the handler under test.
+    mockRefreshToken.mockClear();
+
+    await fireTabVisible();
+
+    expect(mockRefreshToken).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call refreshToken when the token has no exp claim', async () => {
+    mockGetOidcToken.mockResolvedValue('opaque-token');
+    mockExtractDetailsFromToken.mockReturnValue({
+      exp: undefined,
+      isExpired: false,
+      timeoutExpiry: 0,
+    });
+
+    await act(async () => {
+      render(<WrapperComponent />);
+    });
+    mockRefreshToken.mockClear();
+
+    await fireTabVisible();
+
+    expect(mockRefreshToken).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call refreshToken when the token is fresh (outside the pre-expiry buffer)', async () => {
+    mockGetOidcToken.mockResolvedValue('fresh-jwt');
+    mockExtractDetailsFromToken.mockReturnValue({
+      exp: Math.floor(Date.now() / 1000) + 600,
+      isExpired: false,
+      timeoutExpiry: 540_000,
+    });
+
+    await act(async () => {
+      render(<WrapperComponent />);
+    });
+    mockRefreshToken.mockClear();
+
+    await fireTabVisible();
+
+    expect(mockRefreshToken).not.toHaveBeenCalled();
+  });
+
+  it('DOES call refreshToken when the token has expired', async () => {
+    mockGetOidcToken.mockResolvedValue('expired-jwt');
+    mockExtractDetailsFromToken.mockReturnValue({
+      exp: Math.floor(Date.now() / 1000) - 60,
+      isExpired: true,
+      timeoutExpiry: 0,
+    });
+
+    await act(async () => {
+      render(<WrapperComponent />);
+    });
+    mockRefreshToken.mockClear();
+
+    await fireTabVisible();
+
+    expect(mockRefreshToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('DOES call refreshToken when the token is within the pre-expiry buffer', async () => {
+    mockGetOidcToken.mockResolvedValue('near-expiry-jwt');
+    mockExtractDetailsFromToken.mockReturnValue({
+      exp: Math.floor(Date.now() / 1000) + 30,
+      isExpired: false,
+      timeoutExpiry: 0,
+    });
+
+    await act(async () => {
+      render(<WrapperComponent />);
+    });
+    mockRefreshToken.mockClear();
+
+    await fireTabVisible();
+
+    expect(mockRefreshToken).toHaveBeenCalledTimes(1);
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.test.tsx
@@ -679,6 +679,29 @@ describe('AuthProvider visibility handler', () => {
     expect(mockRefreshToken).not.toHaveBeenCalled();
   });
 
+  it('does NOT call refreshToken for an opaque/undecodable token (jwt-decode threw)', async () => {
+    // When jwt-decode throws, extractDetailsFromToken falls through to
+    // {exp: 0, isExpired: true, timeoutExpiry: 0}. Naïvely ordering
+    // `if (isExpired)` first would fire refresh on every focus for an
+    // opaque token. The invalid-exp guard MUST come before the isExpired
+    // branch. (Greptile P1 on #31819)
+    mockGetOidcToken.mockResolvedValue('not-a-jwt');
+    mockExtractDetailsFromToken.mockReturnValue({
+      exp: 0,
+      isExpired: true,
+      timeoutExpiry: 0,
+    });
+
+    await act(async () => {
+      render(<WrapperComponent />);
+    });
+    mockRefreshToken.mockClear();
+
+    await fireTabVisible();
+
+    expect(mockRefreshToken).not.toHaveBeenCalled();
+  });
+
   it('does NOT call refreshToken when the token is fresh (outside the pre-expiry buffer)', async () => {
     mockGetOidcToken.mockResolvedValue('fresh-jwt');
     mockExtractDetailsFromToken.mockReturnValue({

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
@@ -525,9 +525,8 @@ export const AuthProvider = ({
         if (!token) {
           return;
         }
-        const { exp, isExpired, timeoutExpiry } = extractDetailsFromToken(
-          token
-        );
+        const { exp, isExpired, timeoutExpiry } =
+          extractDetailsFromToken(token);
         if (isExpired) {
           const newToken = await tokenService.current?.refreshToken();
           // Post-refresh reauth: if the user was bounced to signin by an

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
@@ -527,6 +527,17 @@ export const AuthProvider = ({
         }
         const { exp, isExpired, timeoutExpiry } =
           extractDetailsFromToken(token);
+        // A missing / non-positive `exp` means the token is opaque, not a
+        // JWT at all, or spec-violating. extractDetailsFromToken returns
+        // `isExpired: true` for the jwt-decode-throws branch AND
+        // `isExpired: false, timeoutExpiry: 0` for the isNil(exp) branch —
+        // neither is signal we can act on, so leave the token in place and
+        // let the next real 401 drive a refresh via the axios interceptor.
+        // MUST come before the isExpired branch — otherwise opaque tokens
+        // would fire refresh() on every tab focus.
+        if (typeof exp !== 'number' || exp <= 0) {
+          return;
+        }
         if (isExpired) {
           const newToken = await tokenService.current?.refreshToken();
           // Post-refresh reauth: if the user was bounced to signin by an
@@ -540,17 +551,9 @@ export const AuthProvider = ({
 
           return;
         }
-        // A missing / non-positive `exp` (opaque token, non-JWT, or spec-
-        // violating id_token) has no usable expiry — the previous shorthand
-        // `timeoutExpiry <= 0` treated it the same as near-expiry and fired
-        // the renewer on every focus. Leave it alone; the next real 401
-        // will drive a refresh via the axios interceptor.
-        if (typeof exp !== 'number' || exp <= 0) {
-          return;
-        }
         // Only near-expiry (within the pre-expiry buffer) should proactively
         // refresh here. `timeoutExpiry === 0` exactly captures that case
-        // once we've ruled out `!exp` above.
+        // once we've ruled out invalid exp above.
         if (isNumber(timeoutExpiry) && timeoutExpiry <= 0) {
           const newToken = await tokenService.current?.refreshToken();
           if (newToken && !useApplicationStore.getState().isAuthenticated) {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
@@ -509,8 +509,8 @@ export const AuthProvider = ({
 
   // When the tab becomes visible after being backgrounded, browsers may have
   // throttled or suspended the proactive renewal timer. Check token freshness
-  // immediately and refresh if expired, or reschedule the timer with the
-  // correct remaining time.
+  // immediately and refresh only when the token is actually stale; otherwise
+  // just reschedule the timer with the correct remaining time.
   useEffect(() => {
     const handleVisibilityChange = async () => {
       if (document.visibilityState !== 'visible') {
@@ -518,21 +518,17 @@ export const AuthProvider = ({
       }
       try {
         const token = await getOidcToken();
-        const { isExpired, timeoutExpiry } = extractDetailsFromToken(token);
-
-        // eslint-disable-next-line no-console
-        console.debug(
-          '[VisibilityHandler] token length:',
-          token?.length,
-          'isExpired:',
-          isExpired,
-          'timeoutExpiry:',
-          timeoutExpiry,
-          'hasTokenService:',
-          !!tokenService.current
+        // No token in storage (user is on /signin, or just logged out).
+        // Firing tokenService.refreshToken() here would still invoke the
+        // renewer (e.g. OIDC signinSilent → hidden iframe to the IdP) on
+        // every tab focus — pure IdP-side noise for a signed-out session.
+        if (!token) {
+          return;
+        }
+        const { exp, isExpired, timeoutExpiry } = extractDetailsFromToken(
+          token
         );
-
-        if (isExpired || timeoutExpiry <= 0) {
+        if (isExpired) {
           const newToken = await tokenService.current?.refreshToken();
           // Post-refresh reauth: if the user was bounced to signin by an
           // earlier failed call, a successful refresh must re-run the
@@ -542,12 +538,32 @@ export const AuthProvider = ({
           if (newToken && !useApplicationStore.getState().isAuthenticated) {
             await getLoggedInUserDetails();
           }
-        } else {
-          startTokenExpiryTimer();
+
+          return;
         }
-      } catch (error) {
-        // eslint-disable-next-line no-console
-        console.error('[VisibilityHandler] error:', error);
+        // A missing / non-positive `exp` (opaque token, non-JWT, or spec-
+        // violating id_token) has no usable expiry — the previous shorthand
+        // `timeoutExpiry <= 0` treated it the same as near-expiry and fired
+        // the renewer on every focus. Leave it alone; the next real 401
+        // will drive a refresh via the axios interceptor.
+        if (typeof exp !== 'number' || exp <= 0) {
+          return;
+        }
+        // Only near-expiry (within the pre-expiry buffer) should proactively
+        // refresh here. `timeoutExpiry === 0` exactly captures that case
+        // once we've ruled out `!exp` above.
+        if (isNumber(timeoutExpiry) && timeoutExpiry <= 0) {
+          const newToken = await tokenService.current?.refreshToken();
+          if (newToken && !useApplicationStore.getState().isAuthenticated) {
+            await getLoggedInUserDetails();
+          }
+
+          return;
+        }
+        startTokenExpiryTimer();
+      } catch {
+        // Storage read errors fall through: the next real 401 will drive
+        // the refresh via the axios interceptor.
       }
     };
 


### PR DESCRIPTION
## Summary

Stops \`tokenService.refreshToken()\` from firing on every tab focus when there's nothing to refresh — the current behavior on main hits the IdP on every visibility change while the user is signed out (or holds an opaque token), which surfaces as \`/auth/refresh\` (or a hidden \`signinSilent\` iframe) calls in the Network tab and unnecessary IdP-side load.

### Root cause

\`handleVisibilityChange\` used the shorthand:
\`\`\`ts
if (isExpired || timeoutExpiry <= 0) {
  await tokenService.current?.refreshToken();
}
\`\`\`

\`extractDetailsFromToken\` returns \`{isExpired:true, timeoutExpiry:0}\` for **empty tokens** (signed-out) and \`{isExpired:false, timeoutExpiry:0}\` for **tokens without an \`exp\` claim**. Both fell into the refresh branch.

### The fix

- **No token in storage** → early return. No IdP call.
- **Expired token** → refresh (unchanged).
- **Missing / non-positive \`exp\`** → early return; the next real 401 drives the refresh via the axios interceptor.
- **Near-expiry** (within the 60s pre-expiry buffer, \`exp\` confirmed valid) → refresh.
- **Otherwise** → reschedule the proactive timer.

Also drops the noisy \`[VisibilityHandler]\` \`console.debug\` that fired on every focus and made real refresh calls hard to spot in the console.

### Relationship to the AuthCoordinator refactor PR

The AuthCoordinator refactor PR (#31675) already carries this fix as part of the larger cleanup + full Jest coverage (\`AuthCoordinator.test.ts › tab visibility gating\`). Shipping this as a targeted hotfix on \`main\` unblocks users on the current release while the refactor is under review.

## Test plan

- [x] \`npx tsc --noEmit\` — no new errors (pre-existing MSAL / AuthProviderUtil issues untouched)
- [x] \`yarn test --testPathPattern=components/Auth/AuthProviders\` — 28/28 pass
- [x] \`yarn lint:base\` on \`AuthProvider.tsx\` — 0 errors
- [ ] Manual: sign out → toggle tabs → verify Network tab shows no \`/auth/refresh\` call
- [ ] Manual: sign in with a fresh token (>1min lifetime) → toggle tabs → verify no \`/auth/refresh\` call
- [ ] Manual: let token drift into last 60s of lifetime → toggle tabs → verify one \`/auth/refresh\` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents the tab-visibility handler from initiating token renewal when storage has no usable expiring token.
- Returns immediately for absent, opaque, undecodable, or non-positive-expiry tokens.
- Preserves renewal for expired and near-expiry JWTs and reschedules the proactive timer for fresh JWTs.
- Adds regression coverage for the visibility-handler branches and removes focus-time debug logging.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx | Reorders token validation so unusable expiry metadata is rejected before expired and near-expiry refresh branches, fully addressing the prior opaque-token finding. |
| openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.test.tsx | Adds focused regression coverage for absent, opaque, malformed, fresh, expired, and near-expiry token states. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ui): visibility handler skips refres..."](https://github.com/open-metadata/openmetadata/commit/422793386c81bdeaa91784d2122f734db4292197) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55088853)</sub>

**Context used:**

- Knowledge Base — [OpenMetadata React UI](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-ui.md)

<!-- /greptile_comment -->