### PR TITLE
Fixes #11571: Preserve custom Glue database names during ingestion

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/glue/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/glue/metadata.py
@@ -188,7 +188,8 @@ class GlueSource(ExternalTableLineageMixin, DatabaseServiceSource):
         for page in self._get_glue_database_and_schemas() or []:
             for schema in page.DatabaseList:
                 try:
-                    if schema.CatalogId != database_name:
+                    # A configured databaseName is an OpenMetadata display name, not a CatalogId.
+                    if not self.service_connection.databaseName and schema.CatalogId != database_name:
                         continue
                     schema_fqn = fqn.build(
                         self.metadata,

--- a/ingestion/tests/unit/topology/database/test_glue.py
+++ b/ingestion/tests/unit/topology/database/test_glue.py
@@ -172,6 +172,29 @@ class GlueUnitTest(TestCase):
         )
         self.assertEqual(list(glue_source_new.get_database_names()), [MOCK_CUSTOM_DB_NAME])
 
+    @patch("metadata.ingestion.source.database.glue.metadata.GlueSource.test_connection")
+    def test_database_schema_names_with_custom_db_name(self, test_connection):
+        test_connection.return_value = False
+        glue_source_new = GlueSource.create(
+            mock_glue_config_db_test["source"],
+            self.config.workflowConfig.openMetadataServerConfig,
+        )
+        glue_source_new.context.get().__dict__["database_service"] = MOCK_DATABASE_SERVICE.name.root
+        glue_source_new.context.get().__dict__["database"] = MOCK_CUSTOM_DB_NAME
+        glue_source_new._get_glue_database_and_schemas = lambda: [
+            DatabasePage(
+                DatabaseList=[
+                    GlueSchema(
+                        CatalogId=MOCK_DATABASE.name.root,
+                        Name="default",
+                        Description="current catalog schema",
+                    )
+                ]
+            )
+        ]
+
+        self.assertEqual(["default"], list(glue_source_new.get_database_schema_names()))
+
     def test_database_schema_names(self):
         assert EXPECTED_DATABASE_SCHEMA_NAMES == list(self.glue_source.get_database_schema_names())  # noqa: SIM300
 


### PR DESCRIPTION
Fixes #11571

### Summary

A configured Glue `databaseName` is an OpenMetadata display name, not necessarily the AWS Glue `CatalogId`. After the catalog filtering change in #26908, schema discovery compared the display name directly with `CatalogId` and silently skipped every schema when a custom name was configured.

This change keeps catalog filtering for the default Catalog ID-based path and skips that comparison only for the documented custom-name path. It adds a regression test covering schema discovery with a custom database name.

### Validation

- `pytest -c ingestion/pyproject.toml ingestion/tests/unit/topology/database/test_glue.py -q` — 10 passed
- `ruff check` on the changed Python files
- `ruff format --check` on the changed Python files
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR allows Glue schema discovery to proceed when the configured OpenMetadata database display name differs from AWS Glue's CatalogId and adds regression coverage for that path.
- Makes CatalogId filtering conditional on databaseName being unset.
- Adds a unit test for schema discovery with a custom database display name.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until custom display names preserve AWS Glue catalog scoping when discovery returns databases from multiple catalogs.

The new truthiness check accepts every CatalogId returned by an unscoped get_databases paginator and emits those schemas beneath one display-named OpenMetadata database.

**Files Needing Attention:** ingestion/src/metadata/ingestion/source/database/glue/metadata.py
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/glue/metadata.py | Fixes custom-name discovery but disables catalog scoping, allowing schemas from other returned Glue catalogs into the same OpenMetadata database. |
| ingestion/tests/unit/topology/database/test_glue.py | Adds regression coverage for a custom display name with one catalog, but does not exercise mixed-CatalogId pages. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Glue get_databases pages] --> B{databaseName configured?}
  B -->|No| C[Keep schemas matching current CatalogId]
  B -->|Yes| D[Accept schemas from every returned CatalogId]
  C --> E[Emit OpenMetadata schemas]
  D --> E
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Glue custom database schema discover..."](https://github.com/open-metadata/openmetadata/commit/dab1c343c33de55556ea4b5667468bd9ee271fb6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55089004)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Ingestion Framework](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/ingestion-framework.md)

<!-- /greptile_comment -->