### PR TITLE
MINOR: mark the IOMETE connector as beta in the UI

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/constants/ServiceType.constant.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/ServiceType.constant.ts
@@ -203,6 +203,7 @@ export const BETA_SERVICES = [
   DatabaseServiceType.SapBw4Hana,
   PipelineServiceType.SapBw4HanaPipeline,
   PipelineServiceType.Prefect,
+  DatabaseServiceType.Iomete,
 ];
 
 export const TEST_CONNECTION_INITIAL_MESSAGE =


### PR DESCRIPTION
### Describe your changes:

<!-- REQUIRED: no issue exists for this change yet. Link one here (`Fixes #<issue-number>`) before
     merge — the "Validate PR Metadata" workflow fails without a linked issue that has a >25-word
     description and is added to the **Shipping** project board. -->

I added `DatabaseServiceType.Iomete` to `BETA_SERVICES` in `ServiceType.constant.ts` because the IOMETE database connector is not yet GA and should carry the same "Beta" pill as the other pre-GA connectors. `BETA_SERVICES` is the single source of truth for that badge — its only consumer is `SelectServiceType.tsx`, which renders the pill on each connector card in the Add Service picker — so this one-line addition is the complete change.

#
### Type of change:
- [x] Improvement

#
### High-level design:

N/A — one-line addition to an existing constant list.

#
### Tests:

#### Use cases covered
- Admin opening **Settings → Services → Databases → Add New Service** sees a "Beta" pill on the IOMETE connector card, alongside the existing beta connectors (Dremio, StarRocks, QuestDB, …).
- The pill also shows in the "All" connector view, which spans every service category.

#### Unit tests
Not applicable — no new logic; the change is a new entry in an existing constant array. The rendering branch (`BETA_SERVICES.includes(type)`) is unchanged and already exercised by the existing beta connectors.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
Not applicable — no new UI behaviour, only one more connector matching an existing render branch.

#### Manual testing performed
Not run — this worktree has no `node_modules` under `openmetadata-ui/src/main/resources/ui/`, so the dev server / lint suite could not be started here. Verified statically instead:
1. `DatabaseServiceType.Iomete` is a real generated enum member (`src/generated/entity/services/databaseService.ts`), so the new entry type-checks.
2. `grep -rn "BETA_SERVICES"` across the repo returns exactly one definition and one consumer (`SelectServiceType.tsx:197`), confirming no other list needs the same entry.
3. The `label.beta` i18n key already exists in the locale catalogs, so no `yarn i18n` run is needed.

#
### UI screen recording / screenshots:

TODO — attach a screenshot of the Add Service picker showing the "Beta" pill on the IOMETE card.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` — pending the linked issue.
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above — pending.
- [x] I have commented on my code, particularly in hard-to-understand areas — N/A, no new logic.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed — N/A, no schema change.
- [ ] For UI changes: I attached a screen recording and/or screenshots above — TODO.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above — none applicable, explained above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds IOMETE to the UI’s beta-service list so its connector card displays the existing “Beta” badge in the Add Service picker.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable code issues identified.

The IOMETE enum value matches the service-picker value, remains available in the picker, and the changed list controls only display of the intended beta badge.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/constants/ServiceType.constant.ts | Correctly adds the generated IOMETE database service enum to the list used exclusively for beta-badge rendering. |

</details>

<sub>Reviews (1): Last reviewed commit: ["MINOR: mark the IOMETE connector as beta..."](https://github.com/open-metadata/openmetadata/commit/04e8f1f225bdc0ba9ecf60567b899407367f9290) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55095715)</sub>

**Context used:**

- Knowledge Base — [OpenMetadata React UI](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-ui.md)

<!-- /greptile_comment -->