### PR TITLE
DO NOT MERGE: probe the Collate ref resolution from #31697

### DIFF
--- a/openmetadata-service/src/test/resources/collate-ci-probe.txt
+++ b/openmetadata-service/src/test/resources/collate-ci-probe.txt
@@ -1,0 +1,3 @@
+Throwaway file to satisfy the maven-build-collate.yml pull_request_target path
+filter (openmetadata-service/**) so the Collate dispatch step runs.
+Delete with the branch.


### PR DESCRIPTION
## DO NOT MERGE — throwaway probe for #31697

Proves the Collate ref resolution in #31697 works, which #31697 itself cannot test.

### Why #31697 can't test itself

1. `maven-build-collate.yml`'s `pull_request_target` paths filter does not include `.github/**`, so a workflow-only diff never triggers the job.
2. `pull_request_target` reads the workflow file from the **base** branch. For #31697 that is `1.13`, which still has the hardcoded `ref: main` — a triggered run would exercise the old code.

### How this PR gets around it

Its base is `1.13-fix/collate-ci-base-branch` — the fix branch itself. So:

- the workflow file comes from the base, i.e. the **fixed** version
- `github.event.pull_request.base.ref` is `1.13-fix/collate-ci-base-branch`
- the throwaway file under `openmetadata-service/**` matches the paths filter, so the job actually runs

### What to look for

The `Trigger Collate build & wait` step should target Collate ref `1.13-fix/collate-ci-base-branch`. The old hardcoded version would target `main` regardless of base.

Collate has no branch of that name, so the step is **expected to fail** with `workflow not found on ref` — and that failure message naming the base branch is the proof. Green would require an identically named Collate branch, which is not worth creating for a probe.

Delete this branch and PR once the log is captured.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This throwaway PR adds an inert test-resource file to match the `openmetadata-service/**` workflow path filter and exercise Collate ref resolution against the PR base branch.
- Adds a three-line CI probe resource.
- Causes the intended `pull_request_target` workflow to run without changing service behavior.
- No actionable defects were identified.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The probe appears safe for its explicitly temporary CI-validation purpose, although the PR is intentionally expected to fail and should not be merged.

The added resource is not parsed or enumerated by tests and has no service runtime effect; its only meaningful behavior is triggering the targeted Collate workflow.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/test/resources/collate-ci-probe.txt | Adds an unreferenced text resource that triggers the intended CI path filter; it introduces no runtime or test behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test: trigger the Collate dispatch path ..."](https://github.com/open-metadata/openmetadata/commit/405d061212df3dbf970e52093d8955229bb11578) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55099117)</sub>

<!-- /greptile_comment -->