### PR TITLE
Fixed context center flaky tests

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArchive.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArchive.spec.ts
@@ -16,7 +16,7 @@ import {
   createNewPage,
   getDefaultAdminAPIContext,
   redirectToHomePage,
-  uuid
+  uuid,
 } from '../../utils/common';
 import {
   ContextCenterFolder,
@@ -33,7 +33,7 @@ import {
   uploadFileViaModal,
   waitForDocumentAbsentFromSearch,
   waitForDocumentInArchive,
-  waitForDocumentPermanentlyDeleted
+  waitForDocumentPermanentlyDeleted,
 } from '../../utils/ContextCenterUtil';
 import { test } from '../fixtures/pages';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArchive.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArchive.spec.ts
@@ -16,7 +16,7 @@ import {
   createNewPage,
   getDefaultAdminAPIContext,
   redirectToHomePage,
-  uuid,
+  uuid
 } from '../../utils/common';
 import {
   ContextCenterFolder,
@@ -27,11 +27,13 @@ import {
   navigateToDocuments,
   openUploadModal,
   revealFolderRow,
+  searchAndGetDocumentRow,
   selectFolderInSidebar,
   softDeleteDocument,
   uploadFileViaModal,
+  waitForDocumentAbsentFromSearch,
   waitForDocumentInArchive,
-  waitForDocumentPermanentlyDeleted,
+  waitForDocumentPermanentlyDeleted
 } from '../../utils/ContextCenterUtil';
 import { test } from '../fixtures/pages';
 
@@ -148,6 +150,12 @@ test.describe('Context Center - Archive Page', () => {
     // ── 9. Search — document NOT visible ────────────────────────────────────
 
     await test.step('searching for the deleted document returns no results', async () => {
+      const { apiContext, afterAction } = await getDefaultAdminAPIContext(
+        browser
+      );
+      await waitForDocumentAbsentFromSearch(apiContext, documentFileName);
+      await afterAction();
+
       const searchInput = getDocumentSearchInput(page);
 
       await expect
@@ -207,9 +215,8 @@ test.describe('Context Center - Archive Page', () => {
 
     await test.step('restored document is visible on the documents page', async () => {
       await navigateToDocuments(page);
-      await expect(
-        page.getByTestId(`document-row-${documentId}`)
-      ).toBeVisible();
+      const documentRow = await searchAndGetDocumentRow(page, documentFileName);
+      await expect(documentRow).toBeVisible();
     });
 
     // ── 13. folder name visible on restored document ───────────────────────────────
@@ -219,46 +226,14 @@ test.describe('Context Center - Archive Page', () => {
       await expect(docRow.getByTestId('document-folder-name')).toBeVisible();
     });
 
-    // ── 14. Document visible in search after restore ──────────────────────────
-
-    await test.step('restored document appears in search results', async () => {
-      const restoredId = documentId;
-      const searchInput = getDocumentSearchInput(page);
-
-      await expect
-        .poll(
-          async () => {
-            const searchResPromise = page.waitForResponse(
-              (res) =>
-                res.url().includes('/api/v1/search/query') &&
-                res.url().includes('index=contextFile')
-            );
-            await searchInput.fill('');
-            await searchInput.fill(documentFileName);
-            await searchResPromise;
-
-            return page
-              .getByTestId(`document-row-${restoredId}`)
-              .isVisible()
-              .catch(() => false);
-          },
-          {
-            intervals: [3000, 5000, 10000],
-            message: `Restored document ${restoredId} not found in search after restore`,
-            timeout: 60000,
-          }
-        )
-        .toBe(true);
-    });
-
-    // ── 15. Soft delete restored document again ───────────────────────────────
+    // ── 14. Soft delete restored document again ───────────────────────────────
 
     await test.step('soft delete the restored document', async () => {
       await navigateToDocuments(page);
       await softDeleteDocument(page, `document-row-${documentId}`);
     });
 
-    // ── 16. Archive page — poll until second delete appears ───────────────────
+    // ── 15. Archive page — poll until second delete appears ───────────────────
 
     await test.step('archive API returns the re-deleted document', async () => {
       const { apiContext, afterAction } = await createNewPage(browser);
@@ -269,7 +244,7 @@ test.describe('Context Center - Archive Page', () => {
       await expect(page.getByTestId(`archive-row-${documentId}`)).toBeVisible();
     });
 
-    // ── 17. Permanently delete ────────────────────────────────────────────────
+    // ── 16. Permanently delete ────────────────────────────────────────────────
 
     await test.step('permanently delete the document from the archive', async () => {
       const archiveRow = page.getByTestId(`archive-row-${documentId}`);
@@ -292,7 +267,7 @@ test.describe('Context Center - Archive Page', () => {
       ).not.toBeVisible();
     });
 
-    // ── 18. Verify NOT in archive (API) ──────────────────────────────────────
+    // ── 17. Verify NOT in archive (API) ──────────────────────────────────────
 
     await test.step('permanently deleted document is absent from the archive API', async () => {
       const { apiContext, afterAction } = await createNewPage(browser);
@@ -300,7 +275,7 @@ test.describe('Context Center - Archive Page', () => {
       await afterAction();
     });
 
-    // ── 19. Verify NOT on documents page ─────────────────────────────────────
+    // ── 18. Verify NOT on documents page ─────────────────────────────────────
 
     await test.step('permanently deleted document is absent from the documents page', async () => {
       await navigateToDocuments(page);
@@ -309,9 +284,15 @@ test.describe('Context Center - Archive Page', () => {
       ).not.toBeVisible();
     });
 
-    // ── 20. Verify NOT in documents search ───────────────────────────────────
+    // ── 19. Verify NOT in documents search ───────────────────────────────────
 
     await test.step('permanently deleted document is absent from documents search', async () => {
+      const { apiContext, afterAction } = await getDefaultAdminAPIContext(
+        browser
+      );
+      await waitForDocumentAbsentFromSearch(apiContext, documentFileName);
+      await afterAction();
+
       const searchInput = getDocumentSearchInput(page);
 
       await expect
@@ -401,7 +382,7 @@ test.describe('Context Center - Folder Delete: file absent from search and archi
     // ── 3. File is visible in the documents list ─────────────────────────────
 
     await test.step('uploaded file is visible with correct folder label', async () => {
-      const docRow = getDocumentRowByName(page, documentFileName);
+      const docRow = await searchAndGetDocumentRow(page, documentFileName);
       await expect(docRow).toBeVisible();
       await expect(docRow.getByTestId('document-folder-name')).toContainText(
         folderName
@@ -410,7 +391,7 @@ test.describe('Context Center - Folder Delete: file absent from search and archi
 
     // ── 4. Soft-delete the folder via API ────────────────────────────────────
 
-    await test.step('soft-delete the folder via API', async () => {
+    await test.step('soft-delete the folder via UI', async () => {
       const folderId = folder.id;
       const folderRow = await revealFolderRow(
         page,
@@ -435,11 +416,24 @@ test.describe('Context Center - Folder Delete: file absent from search and archi
       await page.getByTestId('confirm-button').click();
       const folderDeleteRes = await folderDeleteResPromise;
       expect(folderDeleteRes.status()).toBe(200);
+      const browseResPromise = page.waitForResponse(
+        (res) =>
+          res.url().includes('/api/v1/contextCenter/drive/files') &&
+          !res.url().includes('search')
+      );
+      await getDocumentSearchInput(page).clear();
+      await browseResPromise;
     });
 
     // ── 5. File is absent from documents search ──────────────────────────────
 
     await test.step('file is no longer visible in documents search after folder delete', async () => {
+      const { apiContext, afterAction } = await getDefaultAdminAPIContext(
+        browser
+      );
+      await waitForDocumentAbsentFromSearch(apiContext, documentFileName);
+      await afterAction();
+
       const searchInput = getDocumentSearchInput(page);
 
       await expect

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterDocument.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterDocument.spec.ts
@@ -573,16 +573,6 @@ test.describe('Context Center - Documents Page', () => {
     await waitForAllLoadersToDisappear(page);
     await selectFolderInSidebar(page, folderName);
 
-    const folderSearchResPromise = page.waitForResponse(
-      (res) =>
-        res.url().includes('/api/v1/search/query') &&
-        res.url().includes('index=contextFile')
-    );
-
-    await searchInput.fill(sharedToken);
-    await folderSearchResPromise;
-    await waitForAllLoadersToDisappear(page);
-
     await expect(
       view.locator(`[data-testid="document-row-${inFolderDoc.id}"]`)
     ).toBeVisible();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterMemories.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterMemories.spec.ts
@@ -1368,12 +1368,15 @@ test.describe(
         await expect(dialog).toBeVisible();
 
         await dialog.getByRole('button', { name: /link.*asset/i }).click();
-
+        const searchResPromise = page.waitForResponse(
+          (res) => res.url().includes('/search/query') && res.status() === 200
+        );
         const assetSearch = page
           .getByTestId('picker-popover')
           .getByRole('textbox');
         await expect(assetSearch).toBeVisible();
         await assetSearch.fill(table.name);
+        await searchResPromise;
         await waitForAllLoadersToDisappear(page);
 
         const option = page.getByRole('option', {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/nightly/ContextCenter.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/nightly/ContextCenter.spec.ts
@@ -21,7 +21,6 @@ import {
   expectBulkIdsRequest,
   expectCapturedDownload,
   expectSelectedCount,
-  getDocumentRowByName,
   insertAudioViaUpload,
   insertFileViaUpload,
   insertFileWithUrl,
@@ -33,8 +32,9 @@ import {
   navigateToArticles,
   navigateToDocuments,
   responseMatchesRequestPath,
+  searchAndGetDocumentRow,
   selectDocumentByName,
-  uploadDocument,
+  uploadDocument
 } from '../../utils/ContextCenterUtil';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import { getEditor, waitForAutoSave } from '../../utils/KnowledgeCenter';
@@ -94,7 +94,7 @@ test.describe('Context Center - Download', () => {
 
     await navigateToDocuments(page);
 
-    const targetRow = getDocumentRowByName(page, fileName);
+    const targetRow = await searchAndGetDocumentRow(page, fileName);
     await expect(targetRow).toBeVisible();
 
     const downloadPath = `/api/v1/contextCenter/drive/files/${document.id}/download`;

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/nightly/ContextCenter.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/nightly/ContextCenter.spec.ts
@@ -34,7 +34,7 @@ import {
   responseMatchesRequestPath,
   searchAndGetDocumentRow,
   selectDocumentByName,
-  uploadDocument
+  uploadDocument,
 } from '../../utils/ContextCenterUtil';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import { getEditor, waitForAutoSave } from '../../utils/KnowledgeCenter';

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/ContextCenterUtil.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/ContextCenterUtil.ts
@@ -108,7 +108,7 @@ export const getDocumentRowByName = (page: Page, fileName: string): Locator =>
     .filter({ hasText: fileName });
 
 export const selectDocumentByName = async (page: Page, fileName: string) => {
-  const row = getDocumentRowByName(page, fileName);
+  const row = await searchAndGetDocumentRow(page, fileName);
   await expect(row).toBeVisible();
   await row.scrollIntoViewIfNeeded();
   await row.getByTestId('document-checkbox').click();
@@ -527,6 +527,44 @@ export async function waitForDocumentPermanentlyDeleted(
 
   throw new Error(
     `Document ${documentId} was still present in the archive API after ${timeout}ms`
+  );
+}
+
+export async function waitForDocumentAbsentFromSearch(
+  apiContext: APIRequestContext,
+  documentName: string,
+  timeout = 60_000,
+  interval = 2_000
+) {
+  const start = Date.now();
+
+  while (Date.now() - start < timeout) {
+    const response = await apiContext.get('/api/v1/search/query', {
+      params: {
+        q: documentName,
+        index: 'contextFile',
+        deleted: false
+      },
+    });
+
+    if (!response.ok()) {
+      const body = await response.text();
+      throw new Error(
+        `Unexpected response while polling search for absence of ${documentName}: ${response.status()} ${body}`
+      );
+    }
+
+    const body = await response.json();
+    const hits = body.hits?.hits ?? [];
+    if (hits.length === 0) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+
+  throw new Error(
+    `Document ${documentName} was still present in search results after ${timeout}ms`
   );
 }
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/ContextCenterUtil.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/ContextCenterUtil.ts
@@ -543,7 +543,7 @@ export async function waitForDocumentAbsentFromSearch(
       params: {
         q: documentName,
         index: 'contextFile',
-        deleted: false
+        deleted: false,
       },
     });
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Test stabilization:**
    - Added `waitForDocumentAbsentFromSearch` helper to reliably poll search absence in Playwright tests
    - Replaced synchronous row lookups with `searchAndGetDocumentRow` for robust document retrieval
    - Added API response waits for search queries and file lists to prevent race conditions

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stabilizes Context Center Playwright tests by adding search-index polling, response synchronization, and search-based document-row lookup.
- Adds an API polling helper for confirming that documents disappear from search.
- Uses explicit document searches before interacting with rows.
- Synchronizes tests with relevant search and file-list responses.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/ContextCenterUtil.ts | Adds reusable search-absence polling and routes document selection through search-based row retrieval. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArchive.spec.ts | Reworks archive scenarios to wait for search-index convergence and document-list refreshes. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterDocument.spec.ts | Simplifies synchronization around the folder-selection scenario. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterMemories.spec.ts | Adds response synchronization before locating an asset-picker option. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/nightly/ContextCenter.spec.ts | Uses search-based document retrieval before exercising downloads. |

</details>

<sub>Reviews (2): Last reviewed commit: ["lint fix"](https://github.com/open-metadata/openmetadata/commit/a69d24156f3a4a2cbc28e4acbf03c9d6b6409a6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55100635)</sub>

<!-- /greptile_comment -->