### PR TITLE
ci: auto-revert failing commits on release branches

### DIFF
--- a/.github/workflows/auto-revert-release.yml
+++ b/.github/workflows/auto-revert-release.yml
@@ -13,7 +13,7 @@ name: Auto-revert failing commit on release branch
 
 on:
   workflow_run:
-    workflows: ["Maven Collate Tests"]
+    workflows: ["Release Branch Validate"]
     types: [completed]
   # Manual shim so the revert logic can be exercised on a throwaway release
   # branch (e.g. 9.9.9) before the workflow_run trigger goes live on main.
@@ -28,7 +28,7 @@ on:
       workflow_name:
         description: "Name of the workflow to attribute the failure to"
         required: false
-        default: "Maven Collate Tests (simulated)"
+        default: "Release Branch Validate (simulated)"
       run_url:
         description: "URL to attribute the failure to (defaults to this run)"
         required: false
@@ -74,7 +74,7 @@ jobs:
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             BRANCH="$IN_BRANCH"
             SHA="$IN_SHA"
-            NAME="${IN_NAME:-Maven Collate Tests (simulated)}"
+            NAME="${IN_NAME:-Release Branch Validate (simulated)}"
             URL="${IN_URL:-${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}}"
             DRY="${IN_DRY:-true}"
           else

--- a/.github/workflows/auto-revert-release.yml
+++ b/.github/workflows/auto-revert-release.yml
@@ -1,0 +1,150 @@
+#  Copyright 2021 Collate
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+name: Auto-revert failing commit on release branch
+
+on:
+  workflow_run:
+    workflows: ["Maven Collate Tests"]
+    types: [completed]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: auto-revert-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  auto-revert:
+    # Fire only when the watched build failed on a push (not a PR run, not a re-run of an old build).
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check branch matches release pattern (N.N.N)
+        id: match
+        env:
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          if [[ "$BRANCH" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "match=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "match=false" >> "$GITHUB_OUTPUT"
+            echo "Branch '$BRANCH' is not a release branch; skipping."
+          fi
+
+      - name: Checkout release branch
+        if: steps.match.outputs.match == 'true'
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_BOT_TOKEN }}
+          persist-credentials: true
+
+      - name: Guard — tip advanced, or tip already a bot revert
+        id: guard
+        if: steps.match.outputs.match == 'true'
+        env:
+          FAILING_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          CURRENT_SHA=$(git rev-parse HEAD)
+          if [ "$CURRENT_SHA" != "$FAILING_SHA" ]; then
+            echo "Tip advanced (current=$CURRENT_SHA, failing=$FAILING_SHA); skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          AUTHOR_EMAIL=$(git log -1 --pretty=%ae "$FAILING_SHA")
+          if [ "$AUTHOR_EMAIL" = "release-bot@open-metadata.org" ]; then
+            echo "Tip $FAILING_SHA was authored by the release bot; refusing to revert-a-revert."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Collect commit metadata
+        id: meta
+        if: steps.match.outputs.match == 'true' && steps.guard.outputs.skip == 'false'
+        env:
+          FAILING_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          SUBJECT=$(git log -1 --pretty=%s "$FAILING_SHA")
+          AUTHOR_NAME=$(git log -1 --pretty=%an "$FAILING_SHA")
+          AUTHOR_EMAIL=$(git log -1 --pretty=%ae "$FAILING_SHA")
+          PARENT_COUNT=$(git rev-list --parents -n 1 "$FAILING_SHA" | awk '{print NF-1}')
+          {
+            echo "subject=${SUBJECT}"
+            echo "author_name=${AUTHOR_NAME}"
+            echo "author_email=${AUTHOR_EMAIL}"
+            echo "parents=${PARENT_COUNT}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Revert failing commit
+        id: revert
+        if: steps.match.outputs.match == 'true' && steps.guard.outputs.skip == 'false'
+        env:
+          FAILING_SHA: ${{ github.event.workflow_run.head_sha }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          PARENTS: ${{ steps.meta.outputs.parents }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          RUN_NAME: ${{ github.event.workflow_run.name }}
+        run: |
+          set -euo pipefail
+          git config user.email "release-bot@open-metadata.org"
+          git config user.name "OpenMetadata Release Bot"
+          MSG="Auto-revert: ${FAILING_SHA:0:12} — ${RUN_NAME} failed on ${BRANCH}
+
+          Reverted because \"${RUN_NAME}\" reported failure on ${BRANCH}.
+          Failing run: ${RUN_URL}
+          "
+          if [ "${PARENTS}" -gt 1 ]; then
+            git revert --no-edit -m 1 "$FAILING_SHA"
+          else
+            git revert --no-edit "$FAILING_SHA"
+          fi
+          # Rewrite the auto-generated revert message so it's clearly attributable.
+          git commit --amend -m "$MSG"
+          git push origin "HEAD:${BRANCH}"
+          echo "revert_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Notify Slack — reverted
+        if: steps.match.outputs.match == 'true' && steps.guard.outputs.skip == 'false' && steps.revert.outcome == 'success'
+        continue-on-error: true
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.COLLATE_BOT_SLACK_TOKEN }}
+          errors: true
+          payload: |
+            {
+              "channel": "C03EYBDDX17",
+              "text": ":rotating_light: *Auto-revert on `${{ github.event.workflow_run.head_branch }}`*\n*Reason:* `${{ github.event.workflow_run.name }}` failed — <${{ github.event.workflow_run.html_url }}|failing run>\n*Reverted commit:* `${{ github.event.workflow_run.head_sha }}` — ${{ steps.meta.outputs.subject }}\n*Original author:* ${{ steps.meta.outputs.author_name }} <${{ steps.meta.outputs.author_email }}>\n*Revert commit:* `${{ steps.revert.outputs.revert_sha }}`"
+            }
+
+      - name: Notify Slack — revert failed
+        if: steps.match.outputs.match == 'true' && steps.guard.outputs.skip == 'false' && steps.revert.outcome == 'failure'
+        continue-on-error: true
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.COLLATE_BOT_SLACK_TOKEN }}
+          errors: true
+          payload: |
+            {
+              "channel": "C03EYBDDX17",
+              "text": ":x: *Auto-revert FAILED on `${{ github.event.workflow_run.head_branch }}`*\n`${{ github.event.workflow_run.name }}` failed on `${{ github.event.workflow_run.head_sha }}`, but the automatic revert did not succeed (likely a conflict or push rejection). Manual intervention required.\n*Failing run:* <${{ github.event.workflow_run.html_url }}|link>\n*Auto-revert run:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }

--- a/.github/workflows/auto-revert-release.yml
+++ b/.github/workflows/auto-revert-release.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           ref: ${{ steps.ev.outputs.branch }}
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_BOT_TOKEN }}
+          token: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
           persist-credentials: true
 
       - name: Guard — tip advanced, or tip already a bot revert

--- a/.github/workflows/auto-revert-release.yml
+++ b/.github/workflows/auto-revert-release.yml
@@ -15,27 +15,88 @@ on:
   workflow_run:
     workflows: ["Maven Collate Tests"]
     types: [completed]
+  # Manual shim so the revert logic can be exercised on a throwaway release
+  # branch (e.g. 9.9.9) before the workflow_run trigger goes live on main.
+  workflow_dispatch:
+    inputs:
+      head_branch:
+        description: "Release branch to act on (e.g. 9.9.9)"
+        required: true
+      head_sha:
+        description: "Commit SHA to treat as the failing tip"
+        required: true
+      workflow_name:
+        description: "Name of the workflow to attribute the failure to"
+        required: false
+        default: "Maven Collate Tests (simulated)"
+      run_url:
+        description: "URL to attribute the failure to (defaults to this run)"
+        required: false
+        default: ""
+      dry_run:
+        description: "Skip git push and Slack post; log the plan only"
+        required: true
+        type: boolean
+        default: true
 
 permissions:
   contents: write
 
 concurrency:
-  group: auto-revert-${{ github.event.workflow_run.head_branch }}
+  group: auto-revert-${{ github.event.workflow_run.head_branch || github.event.inputs.head_branch }}
   cancel-in-progress: false
 
 jobs:
   auto-revert:
-    # Fire only when the watched build failed on a push (not a PR run, not a re-run of an old build).
+    # Fire on: (a) real build failure on a push, or (b) manual dispatch.
     if: >-
-      github.event.workflow_run.conclusion == 'failure' &&
-      github.event.workflow_run.event == 'push'
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'failure' &&
+       github.event.workflow_run.event == 'push')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Normalize event inputs
+        id: ev
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WR_SHA: ${{ github.event.workflow_run.head_sha }}
+          WR_NAME: ${{ github.event.workflow_run.name }}
+          WR_URL: ${{ github.event.workflow_run.html_url }}
+          IN_BRANCH: ${{ github.event.inputs.head_branch }}
+          IN_SHA: ${{ github.event.inputs.head_sha }}
+          IN_NAME: ${{ github.event.inputs.workflow_name }}
+          IN_URL: ${{ github.event.inputs.run_url }}
+          IN_DRY: ${{ github.event.inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            BRANCH="$IN_BRANCH"
+            SHA="$IN_SHA"
+            NAME="${IN_NAME:-Maven Collate Tests (simulated)}"
+            URL="${IN_URL:-${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}}"
+            DRY="${IN_DRY:-true}"
+          else
+            BRANCH="$WR_BRANCH"
+            SHA="$WR_SHA"
+            NAME="$WR_NAME"
+            URL="$WR_URL"
+            DRY="false"
+          fi
+          echo "Event: $EVENT_NAME | branch=$BRANCH sha=$SHA dry_run=$DRY"
+          {
+            echo "branch=$BRANCH"
+            echo "sha=$SHA"
+            echo "name=$NAME"
+            echo "url=$URL"
+            echo "dry=$DRY"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Check branch matches release pattern (N.N.N)
         id: match
         env:
-          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          BRANCH: ${{ steps.ev.outputs.branch }}
         run: |
           set -euo pipefail
           if [[ "$BRANCH" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -49,7 +110,7 @@ jobs:
         if: steps.match.outputs.match == 'true'
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: ${{ steps.ev.outputs.branch }}
           fetch-depth: 0
           token: ${{ secrets.RELEASE_BOT_TOKEN }}
           persist-credentials: true
@@ -58,7 +119,7 @@ jobs:
         id: guard
         if: steps.match.outputs.match == 'true'
         env:
-          FAILING_SHA: ${{ github.event.workflow_run.head_sha }}
+          FAILING_SHA: ${{ steps.ev.outputs.sha }}
         run: |
           set -euo pipefail
           CURRENT_SHA=$(git rev-parse HEAD)
@@ -79,7 +140,7 @@ jobs:
         id: meta
         if: steps.match.outputs.match == 'true' && steps.guard.outputs.skip == 'false'
         env:
-          FAILING_SHA: ${{ github.event.workflow_run.head_sha }}
+          FAILING_SHA: ${{ steps.ev.outputs.sha }}
         run: |
           set -euo pipefail
           SUBJECT=$(git log -1 --pretty=%s "$FAILING_SHA")
@@ -97,11 +158,12 @@ jobs:
         id: revert
         if: steps.match.outputs.match == 'true' && steps.guard.outputs.skip == 'false'
         env:
-          FAILING_SHA: ${{ github.event.workflow_run.head_sha }}
-          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          FAILING_SHA: ${{ steps.ev.outputs.sha }}
+          BRANCH: ${{ steps.ev.outputs.branch }}
+          RUN_NAME: ${{ steps.ev.outputs.name }}
+          RUN_URL: ${{ steps.ev.outputs.url }}
           PARENTS: ${{ steps.meta.outputs.parents }}
-          RUN_URL: ${{ github.event.workflow_run.html_url }}
-          RUN_NAME: ${{ github.event.workflow_run.name }}
+          DRY_RUN: ${{ steps.ev.outputs.dry }}
         run: |
           set -euo pipefail
           git config user.email "release-bot@open-metadata.org"
@@ -116,13 +178,23 @@ jobs:
           else
             git revert --no-edit "$FAILING_SHA"
           fi
-          # Rewrite the auto-generated revert message so it's clearly attributable.
           git commit --amend -m "$MSG"
-          git push origin "HEAD:${BRANCH}"
-          echo "revert_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          REVERT_SHA=$(git rev-parse HEAD)
+          echo "revert_sha=$REVERT_SHA" >> "$GITHUB_OUTPUT"
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "DRY RUN — would push $REVERT_SHA to origin/$BRANCH; skipping."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+          else
+            git push origin "HEAD:${BRANCH}"
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Notify Slack — reverted
-        if: steps.match.outputs.match == 'true' && steps.guard.outputs.skip == 'false' && steps.revert.outcome == 'success'
+        if: >-
+          steps.match.outputs.match == 'true' &&
+          steps.guard.outputs.skip == 'false' &&
+          steps.revert.outcome == 'success' &&
+          steps.ev.outputs.dry == 'false'
         continue-on-error: true
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
@@ -132,11 +204,15 @@ jobs:
           payload: |
             {
               "channel": "C03EYBDDX17",
-              "text": ":rotating_light: *Auto-revert on `${{ github.event.workflow_run.head_branch }}`*\n*Reason:* `${{ github.event.workflow_run.name }}` failed — <${{ github.event.workflow_run.html_url }}|failing run>\n*Reverted commit:* `${{ github.event.workflow_run.head_sha }}` — ${{ steps.meta.outputs.subject }}\n*Original author:* ${{ steps.meta.outputs.author_name }} <${{ steps.meta.outputs.author_email }}>\n*Revert commit:* `${{ steps.revert.outputs.revert_sha }}`"
+              "text": ":rotating_light: *Auto-revert on `${{ steps.ev.outputs.branch }}`*\n*Reason:* `${{ steps.ev.outputs.name }}` failed — <${{ steps.ev.outputs.url }}|failing run>\n*Reverted commit:* `${{ steps.ev.outputs.sha }}` — ${{ steps.meta.outputs.subject }}\n*Original author:* ${{ steps.meta.outputs.author_name }} <${{ steps.meta.outputs.author_email }}>\n*Revert commit:* `${{ steps.revert.outputs.revert_sha }}`"
             }
 
       - name: Notify Slack — revert failed
-        if: steps.match.outputs.match == 'true' && steps.guard.outputs.skip == 'false' && steps.revert.outcome == 'failure'
+        if: >-
+          steps.match.outputs.match == 'true' &&
+          steps.guard.outputs.skip == 'false' &&
+          steps.revert.outcome == 'failure' &&
+          steps.ev.outputs.dry == 'false'
         continue-on-error: true
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
@@ -146,5 +222,20 @@ jobs:
           payload: |
             {
               "channel": "C03EYBDDX17",
-              "text": ":x: *Auto-revert FAILED on `${{ github.event.workflow_run.head_branch }}`*\n`${{ github.event.workflow_run.name }}` failed on `${{ github.event.workflow_run.head_sha }}`, but the automatic revert did not succeed (likely a conflict or push rejection). Manual intervention required.\n*Failing run:* <${{ github.event.workflow_run.html_url }}|link>\n*Auto-revert run:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": ":x: *Auto-revert FAILED on `${{ steps.ev.outputs.branch }}`*\n`${{ steps.ev.outputs.name }}` failed on `${{ steps.ev.outputs.sha }}`, but the automatic revert did not succeed (likely a conflict or push rejection). Manual intervention required.\n*Failing run:* <${{ steps.ev.outputs.url }}|link>\n*Auto-revert run:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
+
+      - name: Dry-run summary
+        if: steps.ev.outputs.dry == 'true' && steps.revert.outcome == 'success'
+        env:
+          BRANCH: ${{ steps.ev.outputs.branch }}
+          SHA: ${{ steps.ev.outputs.sha }}
+          REVERT_SHA: ${{ steps.revert.outputs.revert_sha }}
+          SUBJECT: ${{ steps.meta.outputs.subject }}
+          AUTHOR: ${{ steps.meta.outputs.author_name }}
+        run: |
+          echo "DRY RUN PLAN"
+          echo "  branch:         $BRANCH"
+          echo "  failing SHA:    $SHA ($AUTHOR — $SUBJECT)"
+          echo "  revert SHA:     $REVERT_SHA (built locally, NOT pushed)"
+          echo "  slack:          suppressed"

--- a/.github/workflows/auto-revert-release.yml
+++ b/.github/workflows/auto-revert-release.yml
@@ -69,6 +69,11 @@ jobs:
           IN_NAME: ${{ github.event.inputs.workflow_name }}
           IN_URL: ${{ github.event.inputs.run_url }}
           IN_DRY: ${{ github.event.inputs.dry_run }}
+          # Safety net for the workflow_run path: unless the repo variable
+          # AUTO_REVERT_DRY_RUN is explicitly set to "false", real failures
+          # only produce a dry-run plan (no push, no Slack). Delete the
+          # variable or set it to "false" to arm real reverts.
+          VAR_DRY: ${{ vars.AUTO_REVERT_DRY_RUN }}
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
@@ -82,7 +87,7 @@ jobs:
             SHA="$WR_SHA"
             NAME="$WR_NAME"
             URL="$WR_URL"
-            DRY="false"
+            DRY="${VAR_DRY:-true}"
           fi
           echo "Event: $EVENT_NAME | branch=$BRANCH sha=$SHA dry_run=$DRY"
           {

--- a/.github/workflows/maven-build-collate.yml
+++ b/.github/workflows/maven-build-collate.yml
@@ -16,6 +16,7 @@ on:
   push:
     branches:
       - main
+      - '[0-9]+.[0-9]+.[0-9]+'
     paths:
       - "openmetadata-service/**"
       - "openmetadata-ui/**"

--- a/.github/workflows/maven-build-collate.yml
+++ b/.github/workflows/maven-build-collate.yml
@@ -16,7 +16,6 @@ on:
   push:
     branches:
       - main
-      - '[0-9]+.[0-9]+.[0-9]+'
     paths:
       - "openmetadata-service/**"
       - "openmetadata-ui/**"

--- a/.github/workflows/release-branch-validate.yml
+++ b/.github/workflows/release-branch-validate.yml
@@ -10,8 +10,16 @@
 #  limitations under the License.
 
 # Gate for auto-revert-release.yml. When a cherry-pick lands on a release
-# branch (N.N.N), this runs the three checkstyles inline. Any failure here
-# is what triggers the auto-revert of the tip commit.
+# branch (N.N.N), this runs the three checkstyles inline on the FILES the
+# push actually touched. Any failure here is what triggers the auto-revert
+# of the tip commit.
+#
+# Scope-of-check note: each job diffs github.event.before..HEAD (falling
+# back to HEAD~1..HEAD on dispatch) and only lints the files in that diff.
+# This is deliberate — running checks against the whole tree would let a
+# pre-existing baseline violation (e.g. from an earlier cherry-pick or a
+# main-side rule bump not yet in this branch) revert an innocent commit
+# and publicly blame its author.
 #
 # Phase 1: hygiene only (spotless / ruff / eslint + prettier). We will
 # broaden this to actual tests/build in a later pass without touching
@@ -38,18 +46,43 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - name: Checkout
+      - name: Checkout with history
         uses: actions/checkout@v7
         with:
+          fetch-depth: 0
           persist-credentials: false
 
+      - name: Determine changed Java files
+        id: files
+        env:
+          BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          if [ -z "${BEFORE}" ] || [ "${BEFORE}" = "0000000000000000000000000000000000000000" ]; then
+            BASE=$(git rev-parse HEAD~1)
+          else
+            BASE="${BEFORE}"
+          fi
+          CHANGED=$(git diff --name-only --diff-filter=ACMR "${BASE}" HEAD -- '*.java' | tr '\n' ' ')
+          echo "base=${BASE}" >> "$GITHUB_OUTPUT"
+          echo "changed=${CHANGED}" >> "$GITHUB_OUTPUT"
+          if [ -z "${CHANGED}" ]; then
+            echo "any=false" >> "$GITHUB_OUTPUT"
+            echo "No Java files changed; skipping spotless."
+          else
+            echo "any=true" >> "$GITHUB_OUTPUT"
+            echo "Changed Java files: ${CHANGED}"
+          fi
+
       - name: Set up JDK 21
+        if: steps.files.outputs.any == 'true'
         uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Cache Maven dependencies
+        if: steps.files.outputs.any == 'true'
         uses: actions/cache@v5
         with:
           path: ~/.m2
@@ -57,39 +90,84 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Run spotless
+      - name: Run spotless (full tree apply)
+        if: steps.files.outputs.any == 'true'
         run: mvn -B spotless:apply
 
-      - name: Fail if spotless would have rewritten files
-        run: git diff --exit-code
+      - name: Fail only if changed Java files diverged
+        if: steps.files.outputs.any == 'true'
+        env:
+          CHANGED: ${{ steps.files.outputs.changed }}
+        run: |
+          set -euo pipefail
+          # Guard against baseline drift: only assert on files the push touched.
+          # xargs is used so an empty CHANGED simply exits 0 rather than diffing all.
+          if [ -z "${CHANGED}" ]; then exit 0; fi
+          if [ -n "$(echo ${CHANGED} | xargs git status --porcelain --)" ]; then
+            echo "spotless:apply rewrote files pushed by this commit:"
+            echo ${CHANGED} | xargs git status --porcelain --
+            echo ${CHANGED} | xargs git --no-pager diff --
+            exit 1
+          fi
 
   python-checkstyle:
     name: Python Checkstyle
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Checkout
+      - name: Checkout with history
         uses: actions/checkout@v7
         with:
+          fetch-depth: 0
           persist-credentials: false
 
+      - name: Determine changed Python files
+        id: files
+        env:
+          BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          if [ -z "${BEFORE}" ] || [ "${BEFORE}" = "0000000000000000000000000000000000000000" ]; then
+            BASE=$(git rev-parse HEAD~1)
+          else
+            BASE="${BEFORE}"
+          fi
+          # Scope to the two dirs ingestion/Makefile:py_format_check targets.
+          CHANGED=$(git diff --name-only --diff-filter=ACMR "${BASE}" HEAD -- 'ingestion/**/*.py' 'openmetadata-airflow-apis/**/*.py' | tr '\n' ' ')
+          echo "changed=${CHANGED}" >> "$GITHUB_OUTPUT"
+          if [ -z "${CHANGED}" ]; then
+            echo "any=false" >> "$GITHUB_OUTPUT"
+            echo "No Python files changed under ingestion/ or openmetadata-airflow-apis/; skipping ruff."
+          else
+            echo "any=true" >> "$GITHUB_OUTPUT"
+            echo "Changed Python files: ${CHANGED}"
+          fi
+
       - name: Set up Python 3.10
+        if: steps.files.outputs.any == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
       - name: Install uv
+        if: steps.files.outputs.any == 'true'
         uses: astral-sh/setup-uv@v7
 
       - name: Install Ruff
+        if: steps.files.outputs.any == 'true'
         run: |
           uv venv env --python 3.10
           uv pip install --python env/bin/python "ruff~=0.15.12"
 
-      - name: Code style check
+      - name: Ruff check + format on changed files
+        if: steps.files.outputs.any == 'true'
+        env:
+          CHANGED: ${{ steps.files.outputs.changed }}
         run: |
+          set -euo pipefail
           source env/bin/activate
-          make py_format_check
+          ruff check --config ingestion/pyproject.toml ${CHANGED}
+          ruff format --check --config ingestion/pyproject.toml ${CHANGED}
 
   ui-checkstyle:
     name: UI Checkstyle
@@ -98,12 +176,43 @@ jobs:
     env:
       UI_WORKING_DIRECTORY: openmetadata-ui/src/main/resources/ui
     steps:
-      - name: Checkout
+      - name: Checkout with history
         uses: actions/checkout@v7
         with:
+          fetch-depth: 0
           persist-credentials: false
 
+      - name: Determine changed UI files
+        id: files
+        env:
+          BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          if [ -z "${BEFORE}" ] || [ "${BEFORE}" = "0000000000000000000000000000000000000000" ]; then
+            BASE=$(git rev-parse HEAD~1)
+          else
+            BASE="${BEFORE}"
+          fi
+          # Match existing ui-checkstyle: src globs only, exclude generated/**.
+          CHANGED=$(git diff --name-only --diff-filter=ACMR "${BASE}" HEAD \
+            -- 'openmetadata-ui/src/main/resources/ui/src/**/*.ts' \
+               'openmetadata-ui/src/main/resources/ui/src/**/*.tsx' \
+               'openmetadata-ui/src/main/resources/ui/src/**/*.js' \
+               'openmetadata-ui/src/main/resources/ui/src/**/*.jsx' \
+               'openmetadata-ui/src/main/resources/ui/src/**/*.json' \
+            ':(exclude)openmetadata-ui/src/main/resources/ui/src/generated/**' \
+            | tr '\n' ' ')
+          echo "changed=${CHANGED}" >> "$GITHUB_OUTPUT"
+          if [ -z "${CHANGED}" ]; then
+            echo "any=false" >> "$GITHUB_OUTPUT"
+            echo "No UI src files changed; skipping eslint + prettier."
+          else
+            echo "any=true" >> "$GITHUB_OUTPUT"
+            echo "Changed UI files: ${CHANGED}"
+          fi
+
       - name: Set up Node
+        if: steps.files.outputs.any == 'true'
         uses: actions/setup-node@v5
         with:
           node-version-file: "${{ env.UI_WORKING_DIRECTORY }}/.nvmrc"
@@ -112,16 +221,29 @@ jobs:
             ${{ env.UI_WORKING_DIRECTORY }}/yarn.lock
 
       - name: Install Antlr4 CLI
+        if: steps.files.outputs.any == 'true'
         run: sudo make install_antlr_cli
 
       - name: Install UI yarn packages
+        if: steps.files.outputs.any == 'true'
         working-directory: ${{ env.UI_WORKING_DIRECTORY }}
         run: yarn install --frozen-lockfile
 
-      - name: ESLint
+      - name: ESLint + Prettier on changed files
+        if: steps.files.outputs.any == 'true'
         working-directory: ${{ env.UI_WORKING_DIRECTORY }}
-        run: yarn lint
-
-      - name: Prettier check
-        working-directory: ${{ env.UI_WORKING_DIRECTORY }}
-        run: yarn pretty:base --check './src/**/*.{js,jsx,ts,tsx,json}'
+        env:
+          CHANGED_ABS: ${{ steps.files.outputs.changed }}
+        run: |
+          set -euo pipefail
+          # Rewrite absolute-repo paths to paths relative to UI_WORKING_DIRECTORY.
+          PREFIX="openmetadata-ui/src/main/resources/ui/"
+          REL=""
+          for f in ${CHANGED_ABS}; do
+            REL="${REL} ${f#${PREFIX}}"
+          done
+          REL="$(echo ${REL} | xargs)"
+          if [ -z "${REL}" ]; then exit 0; fi
+          echo "Linting: ${REL}"
+          yarn lint:base ${REL}
+          yarn pretty:base --check ${REL}

--- a/.github/workflows/release-branch-validate.yml
+++ b/.github/workflows/release-branch-validate.yml
@@ -1,0 +1,127 @@
+#  Copyright 2021 Collate
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Gate for auto-revert-release.yml. When a cherry-pick lands on a release
+# branch (N.N.N), this runs the three checkstyles inline. Any failure here
+# is what triggers the auto-revert of the tip commit.
+#
+# Phase 1: hygiene only (spotless / ruff / eslint + prettier). We will
+# broaden this to actual tests/build in a later pass without touching
+# auto-revert-release.yml — swap the jobs below or replace this workflow.
+
+name: Release Branch Validate
+
+on:
+  push:
+    branches:
+      - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-branch-validate-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  java-checkstyle:
+    name: Java Checkstyle
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Run spotless
+        run: mvn -B spotless:apply
+
+      - name: Fail if spotless would have rewritten files
+        run: git diff --exit-code
+
+  python-checkstyle:
+    name: Python Checkstyle
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install Ruff
+        run: |
+          uv venv env --python 3.10
+          uv pip install --python env/bin/python "ruff~=0.15.12"
+
+      - name: Code style check
+        run: |
+          source env/bin/activate
+          make py_format_check
+
+  ui-checkstyle:
+    name: UI Checkstyle
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      UI_WORKING_DIRECTORY: openmetadata-ui/src/main/resources/ui
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: "${{ env.UI_WORKING_DIRECTORY }}/.nvmrc"
+          cache: yarn
+          cache-dependency-path: |
+            ${{ env.UI_WORKING_DIRECTORY }}/yarn.lock
+
+      - name: Install Antlr4 CLI
+        run: sudo make install_antlr_cli
+
+      - name: Install UI yarn packages
+        working-directory: ${{ env.UI_WORKING_DIRECTORY }}
+        run: yarn install --frozen-lockfile
+
+      - name: ESLint
+        working-directory: ${{ env.UI_WORKING_DIRECTORY }}
+        run: yarn lint
+
+      - name: Prettier check
+        working-directory: ${{ env.UI_WORKING_DIRECTORY }}
+        run: yarn pretty:base --check './src/**/*.{js,jsx,ts,tsx,json}'


### PR DESCRIPTION
### Describe your changes:

Automate reverts on release branches (`N.N.N`) when hygiene validation fails on a direct push (cherry-pick). A new `workflow_run`-triggered workflow watches for the failure, guards against tip-advanced races and bot-authored revert-of-revert loops, reverts the tip, and posts a detailed message to Slack. Rollout is gated behind a repo variable (`AUTO_REVERT_DRY_RUN`) so the first live failures dry-run only.

**Phase 1 scope: hygiene, not correctness.** The gate is a new `Release Branch Validate` workflow that runs **spotless** (Java), **ruff** (Python — ingestion + airflow-apis), and **ESLint + Prettier** (UI) — scoped to only the files touched by the push, so pre-existing baseline drift on the release branch cannot revert an innocent commit. Phase 2 will swap in the actual build/test gate without changing `auto-revert-release.yml`.

_No linked issue — internal CI automation requested directly by a maintainer._

#
### Type of change:
- [x] New feature

#
### High-level design:

**Trigger.** `workflow_run` on `Release Branch Validate` (`types: [completed]`) so revert latency is a few seconds after validation reports failure — no polling, no cron.

**Branch filter.** Regex `^[0-9]+\.[0-9]+\.[0-9]+$` on `workflow_run.head_branch`. Main is untouched.

**Scope-of-check.** Each validation job diffs `github.event.before..HEAD` (falling back to `HEAD~1..HEAD` on dispatch) and lints only that subset. Rationale: running the checks against the whole tree would let a pre-existing baseline violation (e.g. from an earlier cherry-pick or a main-side rule bump not yet in this branch) revert an innocent commit and publicly blame its author.

**Safety guards** (in order):
- Only fires on `conclusion == 'failure' && event == 'push'` — skips PR runs and re-runs of old builds.
- Skips if the branch tip has moved past the failing SHA — a newer commit may already be green; operator decides.
- Skips if the tip was authored by `release-bot@open-metadata.org` — prevents revert-of-revert loops when the underlying regression pre-dates the cherry-pick.
- Handles merge commits with `-m 1` (parent-count check), though cherry-picks are single-parent in practice.

**Staged rollout via `vars.AUTO_REVERT_DRY_RUN`.** Auto path dry-runs by default (prints a "DRY RUN PLAN", no push, no Slack). Setting the repo variable to `"false"` in Settings → Variables arms live reverts; deleting it or setting `"true"` disarms. No code change to flip either way.

**Push permissions.** Uses `secrets.RELEASE_BOT_TOKEN` (a PAT/App token to be added), because `GITHUB_TOKEN` on a `workflow_run` event typically can't bypass branch protection on release branches. Falls back to `GITHUB_TOKEN` for the read-only checkout so dry-runs work before the PAT is provisioned.

**Manual dispatch shim.** `auto-revert-release.yml` also accepts `workflow_dispatch` with `head_branch`, `head_sha`, and `dry_run` inputs so guards (bad-branch / tip-advanced / revert-of-revert / real revert) can be exercised against a throwaway `9.9.9` branch post-merge before arming live reverts.

**Slack.** Reuses the existing `slackapi/slack-github-action` + `secrets.COLLATE_BOT_SLACK_TOKEN` pattern from `py-sonarcloud-nightly.yml`, posting to channel `C03EYBDDX17`. Two payload variants: reverted (SHA, subject, author, revert SHA, failing-run link) and revert-failed (conflict / push rejection → manual intervention).

**Rollout note.** `workflow_run` triggers only fire when the workflow file is on the default branch, so this is inert until merged to `main`. Also requires `RELEASE_BOT_TOKEN` and (to arm) `vars.AUTO_REVERT_DRY_RUN=false` before it can actually push a revert.

#
### Tests:

#### Use cases covered
- A cherry-pick pushed to a `N.N.N` release branch that fails hygiene validation on any file it touches is automatically reverted within seconds of the run failing (once armed), and the team is notified in Slack with the reverted SHA, author, subject, and a link to the failing run.
- If a newer commit lands before the auto-revert runs, the guard skips (no forced revert of a moved tip).
- If the tip is already a bot-authored revert, the guard skips (no infinite loop).
- If the revert itself fails (conflict / push rejection), Slack gets a `revert FAILED` message and a link to the auto-revert run for manual triage.
- Baseline drift (pre-existing spotless / eslint / prettier violations on the release branch) does **not** cause an innocent commit to be reverted, because each check is scoped to files the push actually touched.

#### Unit tests
- Not applicable — GitHub Actions workflow logic, no unit-testable code.

#### Backend integration tests
- Not applicable — no backend API changes.

#### Ingestion integration tests
- Not applicable — no ingestion changes.

#### Playwright (UI) tests
- Not applicable — no UI changes.

#### Manual testing performed
- YAML validated by inspection; branch regex verified against `1.2.3`, `10.0.0`, `main`, `feature/x`.
- End-to-end can only be exercised once merged to `main` (workflow_run requirement, dry-run mode via repo variable, `9.9.9` throwaway branch, dispatch shim for guard cases).

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the CONTRIBUTING document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` — no linked issue; direct CI automation request.
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above — see note above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: N/A.
- [x] For UI changes: N/A.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds a release-branch hygiene validation workflow and a guarded workflow-run consumer that can revert a failing branch tip and notify Slack.
- Runs Java, Python, and UI formatting checks only against files touched by the push.
- Verifies the failing SHA is still the branch tip and avoids bot-authored revert loops.
- Supports dry-run rollout and manual dispatch for operational testing.
</details>

<details open><summary><h3>Confidence Score: 1/5</h3></summary>

The PR does not appear safe to merge until release pushes reliably trigger validation, failed reverts reliably notify operators, and the privileged checkout is pinned immutably.

The replacement release trigger retains the nonmatching regex-style glob, the failed-revert alert remains suppressed after its preceding step fails, and the write-credential checkout still executes through a mutable action tag.

**Files Needing Attention:** .github/workflows/release-branch-validate.yml and .github/workflows/auto-revert-release.yml
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/auto-revert-release.yml | Adds event normalization, release-tip safety guards, dry-run/live revert execution, and Slack result notifications. |
| .github/workflows/release-branch-validate.yml | Adds changed-file-scoped Spotless, Ruff, ESLint, and Prettier validation for release-branch pushes. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Push as Release branch push
  participant Validate as Release Branch Validate
  participant Revert as Auto-revert workflow
  participant Git as Release branch
  participant Slack as Slack
  Push->>Validate: Trigger hygiene checks
  Validate-->>Revert: workflow_run completed with failure
  Revert->>Git: Verify branch and current tip
  alt Dry run
    Revert->>Revert: Build and log revert plan
  else Live mode
    Revert->>Git: Revert failing tip and push
    Revert->>Slack: Post result
  end
```
</details>

<sub>Reviews (5): Last reviewed commit: ["ci: scope release-branch validation to f..."](https://github.com/open-metadata/openmetadata/commit/55756a5d3e5d56f823f76fa922faccf675cb497a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55115614)</sub>

<!-- /greptile_comment -->