### PR TITLE
fix(test): prevent flaky OktaSessionRenewalPublic second test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -245,7 +245,7 @@ export default defineConfig({
         '**/SSORenewal.spec.ts',
         '**/SSOSessionLimit.spec.ts',
       ],
-      use: { ...devices['Desktop Chrome'] },
+      use: { ...devices['Desktop Chrome'], trace: 'on' },
       fullyParallel: false,
       workers: 1,
     },

--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -245,7 +245,7 @@ export default defineConfig({
         '**/SSORenewal.spec.ts',
         '**/SSOSessionLimit.spec.ts',
       ],
-      use: { ...devices['Desktop Chrome'], trace: 'on' },
+      use: { ...devices['Desktop Chrome'], trace: 'retain-on-failure' },
       fullyParallel: false,
       workers: 1,
     },

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/OktaSessionRenewalPublic.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/OktaSessionRenewalPublic.spec.ts
@@ -12,6 +12,7 @@
  */
 import { BrowserContext, expect, Page, Request, test } from '@playwright/test';
 import { SSO_ENV } from '../../constant/ssoAuth';
+import { redirectToHomePage } from '../../utils/common';
 import { decodeJwtExp, expireStoredToken } from '../../utils/sessionRenewal';
 import { getProviderHelper, ProviderHelper } from '../../utils/sso-providers';
 import { swapSecurityConfig } from '../../utils/ssoAuth';
@@ -139,6 +140,11 @@ test.describe('Okta Public Session Renewal', { tag: OKTA_PUBLIC_TAGS }, () => {
     const page = userPage!;
 
     await expect(page.getByTestId('dropdown-profile')).toBeVisible();
+
+    // Test 1 ends on the Explore page. Navigating home ensures the subsequent
+    // app-bar-item-explore click is always a real navigation that triggers an
+    // API call, a 401, and the renewal flow we are testing.
+    await redirectToHomePage(page);
 
     // renewToken reaches signInWithRedirect() both from the catch around
     // renewTokens() and from an early return when okta-auth-js holds no tokens.


### PR DESCRIPTION
### Describe your changes:

The `should fall back to interactive login when silent renewal returns login_required` test was intermittently timing out in the Okta SSO suite. The suite runs in serial mode: test 1 ends by clicking `app-bar-item-explore`, leaving the browser on the Explore page. Test 2 then clicks the same sidebar item — but since React Router short-circuits same-path navigation, no API call fires, no 401 is received, and the renewal flow never triggers. The 60 s poll for `interactive-authorize` events times out with 0 hits.

The fix calls `redirectToHomePage` at the start of test 2 so the subsequent Explore click is always a real navigation.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Okta public-client silent-renewal fallback reliably triggers `interactive-authorize` when silent renewal returns `login_required`

#### Unit tests
- [ ] Not applicable (Playwright test fix only).

#### Backend integration tests
- [ ] Not applicable (no backend changes).

#### Ingestion integration tests
- [ ] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Fixed existing spec: `playwright/e2e/Auth/OktaSessionRenewalPublic.spec.ts`

#### Manual testing performed
1. Reviewed CI runs on 2.0 and main — identical code, failure only on runs where test 1 left browser on Explore page.
2. Root cause confirmed via test flow analysis: same-path React Router click = no navigation = no renewal.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR stabilizes the second Okta public-session-renewal test by returning to the home page before navigating to Explore, ensuring the navigation triggers the renewal flow.
- Adds an explicit home-page reset before token expiration and Explore navigation.
- Retains Playwright traces when an SSO test fails.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/OktaSessionRenewalPublic.spec.ts | Resets the shared serial-test page to `/my-data` before installing renewal mocks, expiring the token, and navigating to Explore. |
| openmetadata-ui/src/main/resources/ui/playwright.config.ts | Configures the serial SSO Playwright project to retain traces only for failed tests. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(test): use retain-on-failure trace f..."](https://github.com/open-metadata/openmetadata/commit/3a2443af9237ef9ce13a85729842ed852c7b3e35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55129041)</sub>

<!-- /greptile_comment -->