### PR TITLE
MINOR - feat(dq): accept multiple testCaseStatus values on testCases/search/list (2.0 backport)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import es.co.elastic.clients.transport.rest5_client.low_level.Request;
@@ -52,6 +53,7 @@ import org.openmetadata.schema.tests.TestCase;
 import org.openmetadata.schema.tests.TestCaseParameterValue;
 import org.openmetadata.schema.tests.TestSuite;
 import org.openmetadata.schema.tests.type.TestCaseResolutionStatusTypes;
+import org.openmetadata.schema.tests.type.TestCaseStatus;
 import org.openmetadata.schema.type.ApiStatus;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.ColumnDataType;
@@ -60,6 +62,7 @@ import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.csv.CsvImportResult;
 import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.exceptions.InvalidRequestException;
 import org.openmetadata.sdk.fluent.builders.TestCaseBuilder;
@@ -5186,6 +5189,138 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
                     "Table-level test should not appear when filtering by columnName");
               }
             });
+  }
+
+  // ===================================================================
+  // TEST CASE STATUS FILTER TESTS (search/list endpoint)
+  // ===================================================================
+
+  @Test
+  void test_searchListByMultipleTestCaseStatuses_matchesAnyOfThem(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Table table = createTable(ns);
+
+    TestCase failedTestCase =
+        createTestCaseWithStatus(client, ns, table, "status_failed", TestCaseStatus.Failed);
+    TestCase abortedTestCase =
+        createTestCaseWithStatus(client, ns, table, "status_aborted", TestCaseStatus.Aborted);
+    TestCase successTestCase =
+        createTestCaseWithStatus(client, ns, table, "status_success", TestCaseStatus.Success);
+
+    String entityLink = String.format("<#E::table::%s>", table.getFullyQualifiedName());
+
+    Awaitility.await("search/list returns test cases matching any of the requested statuses")
+        .atMost(120, TimeUnit.SECONDS)
+        .pollInterval(Duration.ofSeconds(2))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              List<String> names =
+                  searchListTestCaseNames(
+                      client, entityLink, "testCaseStatus=Failed&testCaseStatus=Aborted");
+              assertTrue(
+                  names.contains(failedTestCase.getName()),
+                  "Failed test case must match testCaseStatus=Failed&testCaseStatus=Aborted");
+              assertTrue(
+                  names.contains(abortedTestCase.getName()),
+                  "Aborted test case must match testCaseStatus=Failed&testCaseStatus=Aborted");
+              assertFalse(
+                  names.contains(successTestCase.getName()),
+                  "Success test case must not match testCaseStatus=Failed&testCaseStatus=Aborted");
+            });
+
+    List<String> commaSeparated =
+        searchListTestCaseNames(client, entityLink, "testCaseStatus=Failed,Aborted");
+    assertTrue(
+        commaSeparated.contains(failedTestCase.getName()),
+        "Failed test case must match the comma separated form of the filter");
+    assertTrue(
+        commaSeparated.contains(abortedTestCase.getName()),
+        "Aborted test case must match the comma separated form of the filter");
+    assertFalse(
+        commaSeparated.contains(successTestCase.getName()),
+        "Success test case must not match the comma separated form of the filter");
+
+    List<String> lowerCase =
+        searchListTestCaseNames(client, entityLink, "testCaseStatus=failed&testCaseStatus=aborted");
+    assertTrue(
+        lowerCase.contains(failedTestCase.getName()),
+        "Statuses must be matched case insensitively");
+    assertTrue(
+        lowerCase.contains(abortedTestCase.getName()),
+        "Statuses must be matched case insensitively");
+    assertFalse(
+        lowerCase.contains(successTestCase.getName()),
+        "Case insensitive matching must not widen the filter");
+
+    List<String> singleStatus =
+        searchListTestCaseNames(client, entityLink, "testCaseStatus=Success");
+    assertTrue(
+        singleStatus.contains(successTestCase.getName()),
+        "A single status must keep filtering on that status only");
+    assertFalse(
+        singleStatus.contains(failedTestCase.getName()),
+        "A single status must keep filtering on that status only");
+  }
+
+  @Test
+  void test_searchListByUnknownTestCaseStatus_returnsBadRequest(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Table table = createTable(ns);
+    String entityLink = String.format("<#E::table::%s>", table.getFullyQualifiedName());
+
+    InvalidRequestException exception =
+        assertThrows(
+            InvalidRequestException.class,
+            () ->
+                searchListTestCaseNames(
+                    client, entityLink, "testCaseStatus=Failed&testCaseStatus=NotAStatus"));
+    assertTrue(
+        exception.getMessage().contains("NotAStatus"),
+        "The error must name the invalid status but was: " + exception.getMessage());
+  }
+
+  private TestCase createTestCaseWithStatus(
+      OpenMetadataClient client,
+      TestNamespace ns,
+      Table table,
+      String name,
+      TestCaseStatus status) {
+    TestCase testCase =
+        TestCaseBuilder.create(client)
+            .name(ns.prefix(name))
+            .forTable(table)
+            .testDefinition("tableRowCountToEqual")
+            .parameter("value", "100")
+            .create();
+    client
+        .testCaseResults()
+        .create(
+            testCase.getFullyQualifiedName(),
+            new CreateTestCaseResult()
+                .withTimestamp(System.currentTimeMillis())
+                .withTestCaseStatus(status)
+                .withResult("Result for " + status.value()));
+    return testCase;
+  }
+
+  private List<String> searchListTestCaseNames(
+      OpenMetadataClient client, String entityLink, String statusQuery) {
+    String response =
+        client
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.GET,
+                "/v1/dataQuality/testCases/search/list?" + statusQuery,
+                null,
+                RequestOptions.builder()
+                    .queryParam("entityLink", entityLink)
+                    .queryParam("includeAllTests", "true")
+                    .queryParam("limit", "100")
+                    .build());
+    ResultList<TestCase> results =
+        JsonUtils.readValue(response, new TypeReference<ResultList<TestCase>>() {});
+    return results.getData().stream().map(TestCase::getName).toList();
   }
 
   /**

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
@@ -7,6 +7,7 @@ import static org.openmetadata.schema.type.Include.ALL;
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -35,6 +36,7 @@ import jakarta.ws.rs.core.SecurityContext;
 import jakarta.ws.rs.core.UriInfo;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -344,13 +346,19 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
           @DefaultValue("non-deleted")
           Include include,
       @Parameter(
-              description = "Filter test case by status",
-              schema =
-                  @Schema(
-                      type = "string",
-                      allowableValues = {"Success", "Failed", "Aborted", "Queued"}))
+              description =
+                  "Filter test case by status. Can be repeated or comma separated to filter on "
+                      + "several statuses at once (e.g. `testCaseStatus=Failed&testCaseStatus=Aborted`), "
+                      + "in which case test cases matching any of the statuses are returned. "
+                      + "Values are matched case insensitively",
+              array =
+                  @ArraySchema(
+                      schema =
+                          @Schema(
+                              type = "string",
+                              allowableValues = {"Success", "Failed", "Aborted", "Queued"})))
           @QueryParam("testCaseStatus")
-          String status,
+          List<String> statuses,
       @Parameter(
               description = "Filter for test case type (e.g. column, table, all)",
               schema =
@@ -469,7 +477,7 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
             include,
             !nullOrEmpty(testSuiteId) ? testSuiteId.toString() : null,
             includeAllTests,
-            status,
+            validateTestCaseStatuses(statuses),
             type,
             testPlatforms,
             dataQualityDimension,
@@ -1460,6 +1468,41 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
     if (startTimestamp != null && startTimestamp > endTimestamp) {
       throw new IllegalArgumentException("startTimestamp must be less than endTimestamp");
     }
+  }
+
+  /**
+   * Statuses can be passed as repeated query params and/or as comma separated values. They are
+   * normalized to a single comma separated string of valid {@link TestCaseStatus} values, which the
+   * filter turns into an OR (`terms`) condition.
+   */
+  private static String validateTestCaseStatuses(List<String> statuses) {
+    String joinedStatuses = null;
+    if (!nullOrEmpty(statuses)) {
+      List<String> validStatuses =
+          statuses.stream()
+              .flatMap(status -> Arrays.stream(status.split(",")))
+              .map(String::trim)
+              .filter(status -> !status.isEmpty())
+              .map(TestCaseResource::toTestCaseStatus)
+              .map(TestCaseStatus::value)
+              .distinct()
+              .toList();
+      joinedStatuses = validStatuses.isEmpty() ? null : String.join(",", validStatuses);
+    }
+    return joinedStatuses;
+  }
+
+  /** Matching is case insensitive, the status is normalized to its canonical enum value. */
+  private static TestCaseStatus toTestCaseStatus(String status) {
+    return Arrays.stream(TestCaseStatus.values())
+        .filter(candidate -> candidate.value().equalsIgnoreCase(status))
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    String.format(
+                        "Invalid testCaseStatus '%s'. Allowed values are %s",
+                        status, Arrays.toString(TestCaseStatus.values()))));
   }
 
   private static SearchListFilter buildSearchListFilter(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchListFilter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchListFilter.java
@@ -287,7 +287,7 @@ public class SearchListFilter extends Filter<SearchListFilter> {
     if (testSuiteId != null) conditions.add(getTestSuiteIdCondition(testSuiteId));
 
     if (status != null) {
-      conditions.add(String.format("{\"term\": {\"%s\": \"%s\"}}", FIELD_TEST_CASE_STATUS, status));
+      conditions.add(getTestCaseStatusCondition(status));
     }
 
     if (type != null) conditions.add(getTestCaseTypeCondition(type, "entityLink"));
@@ -398,6 +398,23 @@ public class SearchListFilter extends Filter<SearchListFilter> {
 
   private String escapeDoubleQuotes(String str) {
     return str.replace("\"", "\\\"");
+  }
+
+  /** Comma separated statuses are matched as an OR, a single status still matches exactly. */
+  private String getTestCaseStatusCondition(String status) {
+    List<String> statuses =
+        Arrays.stream(status.split(","))
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .map(this::escapeDoubleQuotes)
+            .toList();
+    String condition = "";
+    if (!statuses.isEmpty()) {
+      String statusList = String.join("\", \"", statuses);
+      condition =
+          String.format("{\"terms\": {\"%s\": [\"%s\"]}}", FIELD_TEST_CASE_STATUS, statusList);
+    }
+    return condition;
   }
 
   private String getTestSuiteIdCondition(String testSuiteId) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/SearchListFilterTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/SearchListFilterTest.java
@@ -32,10 +32,30 @@ public class SearchListFilterTest {
     SearchListFilter searchListFilter = new SearchListFilter();
     searchListFilter.addQueryParam("includeFields", "field1,field2");
     searchListFilter.addQueryParam("excludeFields", "field3,field4");
-    searchListFilter.addQueryParam("testCaseStatus", "failed");
+    searchListFilter.addQueryParam("testCaseStatus", "Failed");
     String actual = searchListFilter.getCondition(Entity.TEST_CASE);
     String expected =
-        "{\"_source\": {\"exclude\": [\"fqnParts\",\"entityType\",\"suggest\",\"field3\",\"field4\"],\n\"include\": [\"field1\",\"field2\"]},\"query\": {\"bool\": {\"filter\": [{\"term\": {\"testCaseResult.testCaseStatus\": \"failed\"}}]}}}";
+        "{\"_source\": {\"exclude\": [\"fqnParts\",\"entityType\",\"suggest\",\"field3\",\"field4\"],\n\"include\": [\"field1\",\"field2\"]},\"query\": {\"bool\": {\"filter\": [{\"terms\": {\"testCaseResult.testCaseStatus\": [\"Failed\"]}}]}}}";
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testMultipleTestCaseStatusesAreMatchedAsOr() {
+    SearchListFilter searchListFilter = new SearchListFilter();
+    searchListFilter.addQueryParam("testCaseStatus", "Failed,Aborted");
+    String actual = searchListFilter.getCondition(Entity.TEST_CASE);
+    String expected =
+        "{\"_source\": {\"exclude\": [\"fqnParts\",\"entityType\",\"suggest\"]},\"query\": {\"bool\": {\"filter\": [{\"terms\": {\"testCaseResult.testCaseStatus\": [\"Failed\", \"Aborted\"]}}]}}}";
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testBlankTestCaseStatusesAreIgnored() {
+    SearchListFilter searchListFilter = new SearchListFilter();
+    searchListFilter.addQueryParam("testCaseStatus", " , ");
+    String actual = searchListFilter.getCondition(Entity.TEST_CASE);
+    String expected =
+        "{\"_source\": {\"exclude\": [\"fqnParts\",\"entityType\",\"suggest\"]},\"query\": {\"match_all\": {}}}";
     assertEquals(expected, actual);
   }
 
@@ -193,7 +213,7 @@ public class SearchListFilterTest {
     assertTrue(
         actual.contains(
             "{\"bool\":{\"should\": [{\"prefix\": {\"entityFQN\": \"service.db.schema.table.\"}},{\"term\": {\"entityFQN\": \"service.db.schema.table\"}}]}}"));
-    assertTrue(actual.contains("{\"term\": {\"testCaseResult.testCaseStatus\": \"Failed\"}}"));
+    assertTrue(actual.contains("{\"terms\": {\"testCaseResult.testCaseStatus\": [\"Failed\"]}}"));
     assertTrue(
         actual.contains(
             "{\"nested\":{\"path\":\"testSuites\",\"query\":{\"term\":{\"testSuites.id\":\"suite-id\"}}}}"));


### PR DESCRIPTION
2.0 backport of #31498 (`5722dfe1`), cherry-picked with `-x`. Clean pick, no conflicts.

## Why this is needed on 2.0

The **UI** half of the multi-select test case status filter — #31662 — was backported to `2.0` (`34ffe490`) but this **backend** half was not. `SearchListFilter.java` on 2.0 has not been touched since July, so it still builds a single-value clause:

```java
// 2.0 today
conditions.add(String.format("{\"term\": {\"%s\": \"%s\"}}", FIELD_TEST_CASE_STATUS, status));
```

When the UI sends `testCaseStatus=Success,Failed`, that term query matches the literal string `"Success,Failed"`, ES returns zero hits, and the test case list renders empty.

This is currently the **only** failing test in the 2.0 AUT nightly, on every lane:

```
Data Quality › TestCase filters @Observability:Data_Quality @ingestion
  src/openmetadata-ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts:966

Error: expect(locator).toBeVisible() failed
  Locator: [data-testid="pw_first_table_column_count_to_be_between_98d64686"]
  Error: element(s) not found
  at verifyFilterTestCase (DataQuality.spec.ts:1064)
  at DataQuality.spec.ts:1295
```

Failing runs (all on build `2.0-202608200745`, failed on the run and both retries — deterministic, not flake):

- kind/MySQL — https://github.com/open-metadata/openmetadata-nightly/actions/runs/32354197217
- kind/PostgreSQL — https://github.com/open-metadata/openmetadata-nightly/actions/runs/32354218190
- EKS/RDS PostgreSQL — run 32354209827

Line 1295 is precisely the assertion #31662 added: select `Success` (list correctly empties), then add `Failed`, and expect the failed test cases back via `testCaseStatus=Success,Failed`.

## Verification

- Cherry-pick applied cleanly onto the current `2.0` tip (`eb149723`), 4 files, +226/−11.
- Post-pick, `getTestCaseCondition()` calls `getTestCaseStatusCondition(status)`, which splits on comma and emits `{"terms": {"testCaseResult.testCaseStatus": ["Success", "Failed"]}}` — the OR semantics the UI expects.
- Every symbol the picked code needs resolves on 2.0: `ArraySchema`, `java.util.Arrays`, `java.util.List`, `TestCaseStatus`, and the static `CommonUtil.nullOrEmpty` are all imported in the file, and `SearchListFilterTest` exists on this branch.
- I did not compile or run the suites locally — the unit test (`SearchListFilterTest`) and integration test (`TestCaseResourceIT`) that came with the pick, plus the 2.0 AUT nightly, are the real verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR backports multi-value test-case status filtering to the search/list endpoint.
- Accepts repeated and comma-separated status parameters, validates them case-insensitively, and normalizes them to canonical enum values.
- Emits an Elasticsearch/OpenSearch terms query so any selected status can match.
- Adds unit and integration coverage for repeated, comma-separated, case-insensitive, single, and invalid status inputs.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge functionally, with only non-blocking Java immutability and comment-policy cleanup requested.

The endpoint validates and canonicalizes status values before constructing the intended terms query, and the accepted concerns are limited to repository style requirements in the newly added Java code.

**Files Needing Attention:** openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java, openmetadata-service/src/main/java/org/openmetadata/service/search/SearchListFilter.java, openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java | Changes the query parameter to a list and validates, canonicalizes, deduplicates, and joins repeated or comma-separated statuses; minor repository-style violations remain. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/SearchListFilter.java | Replaces the single-value term clause with a multi-value terms clause; the behavior is covered, but added declarations and comments violate repository conventions. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java | Adds end-to-end coverage for multi-status OR semantics, case-insensitive values, single values, and invalid values. |
| openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/SearchListFilterTest.java | Updates expected query output and covers multiple and blank status inputs at the filter layer. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI
  participant Resource as TestCaseResource
  participant Filter as SearchListFilter
  participant Search as Elasticsearch/OpenSearch
  UI->>Resource: "GET search/list?testCaseStatus=Failed&testCaseStatus=Aborted"
  Resource->>Resource: Split, trim, validate, normalize
  Resource->>Filter: "testCaseStatus="Failed,Aborted""
  Filter->>Search: terms testCaseResult.testCaseStatus [Failed, Aborted]
  Search-->>UI: Test cases matching either status
```
</details>

<sub>Reviews (1): Last reviewed commit: ["MINOR - feat(dq): accept multiple testCa..."](https://github.com/open-metadata/openmetadata/commit/4a78bd6b3a220f92a0dc76ae757fcd71d6a3aee5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55134553)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))
- Context used - AGENTS.md ([source](https://github.com/open-metadata/openmetadata/blob/main/AGENTS.md))
- Knowledge Base — [OpenMetadata Service Core: Entities, Resources, Repositories](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-core.md)
- Knowledge Base — [Search Indexing and Event/Notification Sync](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-search-events.md)
</details>

<!-- /greptile_comment -->