### PR TITLE
fix(ui): prevent null crash in Emoji popover on unmount

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/Reactions/Emoji.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/Reactions/Emoji.test.tsx
@@ -110,7 +110,7 @@ describe('Test Emoji Component', () => {
     fireEvent.mouseLeave(emojiButton);
     act(() => jest.runAllTimers());
 
-    expect(queryByTestId('popover-content')).not.toBeVisible();
+    expect(queryByTestId('popover-content')).not.toBeInTheDocument();
   });
 
   it('Should unmount cleanly while tooltip is visible', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/Reactions/Emoji.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/Reactions/Emoji.test.tsx
@@ -110,19 +110,28 @@ describe('Test Emoji Component', () => {
     fireEvent.mouseLeave(emojiButton);
     act(() => jest.runAllTimers());
 
-    expect(queryByTestId('popover-content')).not.toBeInTheDocument();
+    expect(queryByTestId('popover-content')).not.toBeVisible();
   });
 
   it('Should unmount cleanly while tooltip is visible', async () => {
-    // Regression: previously, a controlled `visible` state was not cleared on
-    // unmount, causing Ant Design to call getBoundingClientRect() on a detached
-    // DOM node and crash with "Cannot read properties of null (reading 'left')".
     const { findByTestId, unmount } = render(<Emoji {...mockProps} />);
 
     const emojiButton = await findByTestId('emoji-button');
     fireEvent.mouseEnter(emojiButton);
     await findByTestId('popover-content');
 
+    // Simulate detached-node condition: real browsers return null from
+    // getBoundingClientRect() on a node removed from the layout tree,
+    // which is what caused "Cannot read properties of null (reading 'left')".
+    // jsdom always returns a zero DOMRect, so we mock it explicitly.
+    jest
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockReturnValue(null as unknown as DOMRect);
+
     expect(() => unmount()).not.toThrow();
+
+    // Flush Ant Design's deferred repositioning callbacks to ensure nothing
+    // throws after the trigger node is removed from the DOM.
+    expect(() => act(() => jest.runAllTimers())).not.toThrow();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/Reactions/Emoji.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/Reactions/Emoji.test.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import { User } from '../../../generated/entity/teams/user';
 import { ReactionType } from '../../../generated/type/reaction';
 import Emoji from './Emoji';
@@ -98,5 +98,31 @@ describe('Test Emoji Component', () => {
     fireEvent.click(emojiButton);
 
     expect(onReactionSelect).toHaveBeenCalledWith(mockProps.reaction, 'remove');
+  });
+
+  it('Should hide popover on mouse leave', async () => {
+    const { findByTestId, queryByTestId } = render(<Emoji {...mockProps} />);
+
+    const emojiButton = await findByTestId('emoji-button');
+    fireEvent.mouseEnter(emojiButton);
+    await findByTestId('popover-content');
+
+    fireEvent.mouseLeave(emojiButton);
+    act(() => jest.runAllTimers());
+
+    expect(queryByTestId('popover-content')).not.toBeInTheDocument();
+  });
+
+  it('Should unmount cleanly while tooltip is visible', async () => {
+    // Regression: previously, a controlled `visible` state was not cleared on
+    // unmount, causing Ant Design to call getBoundingClientRect() on a detached
+    // DOM node and crash with "Cannot read properties of null (reading 'left')".
+    const { findByTestId, unmount } = render(<Emoji {...mockProps} />);
+
+    const emojiButton = await findByTestId('emoji-button');
+    fireEvent.mouseEnter(emojiButton);
+    await findByTestId('popover-content');
+
+    expect(() => unmount()).not.toThrow();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/Reactions/Emoji.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/Reactions/Emoji.tsx
@@ -106,6 +106,7 @@ const Emoji: FC<EmojiProps> = ({
 
   return (
     <Popover
+      destroyTooltipOnHide
       content={popoverContent}
       key={reaction}
       trigger="hover"

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/Reactions/Emoji.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/Reactions/Emoji.tsx
@@ -41,7 +41,6 @@ const Emoji: FC<EmojiProps> = ({
   const { currentUser } = useApplicationStore();
   const [reactionType, setReactionType] = useState(reaction);
   const [isClicked, setIsClicked] = useState(false);
-  const [visible, setVisible] = useState(false);
 
   // get reaction object based on current reactionType
   const reactionObject = useMemo(
@@ -109,10 +108,8 @@ const Emoji: FC<EmojiProps> = ({
     <Popover
       content={popoverContent}
       key={reaction}
-      open={visible}
       trigger="hover"
-      zIndex={9999}
-      onOpenChange={setVisible}>
+      zIndex={9999}>
       <Button
         className={classNames(
           'ant-btn-reaction m-r-xss flex-center transparent',
@@ -124,8 +121,7 @@ const Emoji: FC<EmojiProps> = ({
         key={reaction}
         shape="round"
         size="small"
-        onClick={handleEmojiOnClick}
-        onMouseOver={() => setVisible(true)}>
+        onClick={handleEmojiOnClick}>
         {element}
         <span className="text-xs m-l-xs self-center" data-testid="emoji-count">
           {reactionList.length.toLocaleString('en-US', {


### PR DESCRIPTION
### Describe your changes:

I worked on removing the manually controlled `visible` state from the `Emoji` reaction component because when the component unmounted mid-hover (triggered by a `fetchUpdatedThread` re-render), Ant Design's internal `forceUpdate` called `getBoundingClientRect()` on the now-detached DOM node and crashed with `TypeError: Cannot read properties of null (reading 'left')`. Letting `trigger="hover"` own the lifecycle entirely means Ant Design cleans up the pending repositioning Promise on unmount.

https://github.com/user-attachments/assets/c7464972-45e2-4119-86f5-4e127ee93d57


#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Emoji reaction tooltip appears on hover and disappears on mouse leave
- Component unmounts cleanly while its tooltip is visible (regression guard for the Sentry crash)

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Files added/updated: `openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/Reactions/Emoji.test.tsx`
  - Added: "Should hide popover on mouse leave"
  - Added: "Should unmount cleanly while tooltip is visible"

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. Open `/my-data` page with feed items that have emoji reactions
2. Hover over an emoji — tooltip appears showing who reacted
3. Move mouse away — tooltip hides cleanly
4. Click "Add reaction" button — emoji picker opens
5. Hover an emoji and navigate away / trigger a thread reload — no crash

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR removes manually controlled visibility from the emoji reaction popover so Ant Design owns hover and unmount cleanup.
- Enables tooltip destruction when hidden.
- Adds regression coverage for mouse-leave behavior and deferred work after unmount.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/Reactions/Emoji.tsx | Delegates hover visibility to Ant Design and destroys hidden tooltip content to avoid stale popover lifecycle work. |
| openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/Reactions/Emoji.test.tsx | Covers hover dismissal and flushes pending fake-timer work after unmount under a detached-node geometry mock. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test(ui): fix mouse-leave assertion usin..."](https://github.com/open-metadata/openmetadata/commit/74384d27528fb8febce20c2b3877ea510b8ce9a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55157444)</sub>

<!-- /greptile_comment -->