### PR TITLE
fix: ConditionalAllow permissions treated as false in getOperationPermissions

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/PermissionsUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/PermissionsUtils.ts
@@ -81,7 +81,7 @@ export const getOperationPermissions = (
     (acc: OperationPermission, curr: Permission) => {
       return {
         ...acc,
-        [curr.operation as Operation]: curr.access === Access.Allow,
+        [curr.operation as Operation]: curr.access === Access.Allow || curr.access === Access.ConditionalAllow,
       };
     },
     {} as OperationPermission


### PR DESCRIPTION
### Describe the bug

`getOperationPermissions` in `PermissionsUtils.ts` only checks `Access.Allow` when mapping permissions, treating `Access.ConditionalAllow` as `false`. This causes domain permissions with conditional allow rules to be incorrectly denied at the UI level.

### Root Cause

In `PermissionsUtils.ts` line 84:

```typescript
[curr.operation as Operation]: curr.access === Access.Allow,
```

`Access.ConditionalAllow` evaluates to `false` because it is not equal to `Access.Allow`.

### Fix

```typescript
[curr.operation as Operation]: curr.access === Access.Allow || curr.access === Access.ConditionalAllow,
```

### Related Issue

Closes #31783

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes UI permission mapping so `ConditionalAllow` grants are no longer treated as denied.
- Updates `getOperationPermissions` to recognize both `Allow` and `ConditionalAllow`.
- Preserves backend enforcement of conditions when operations are executed.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The change aligns resource-level UI permission mapping with the existing conditional-access state while entity-aware backend authorization continues to evaluate policy conditions before protected operations.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/utils/PermissionsUtils.ts | Correctly expands the operation-permission mapping to represent conditional grants as available in the UI; no actionable regression was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: ConditionalAllow permissions treate..."](https://github.com/open-metadata/openmetadata/commit/cc2520add21059c286719e75bd650d1b135aed87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55224272)</sub>

<!-- /greptile_comment -->