### PR TITLE
Fixes 27040: bind time-series destruction to hard delete, not every delete

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/K8sIngestionPipelineResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/K8sIngestionPipelineResourceIT.java
@@ -29,6 +29,7 @@ import io.kubernetes.client.openapi.models.V1JobList;
 import io.kubernetes.client.util.Config;
 import java.io.StringReader;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
@@ -447,8 +448,12 @@ public class K8sIngestionPipelineResourceIT {
               }
             });
 
-    // Delete pipeline
-    SdkClients.adminClient().ingestionPipelines().delete(pipeline.getId().toString());
+    // Hard delete: tearing the K8s resources down is irreversible, so it is bound to the
+    // irreversible delete. A soft delete leaves them in place so a restore yields a pipeline that
+    // still has its backing CronJob (see SoftDeleteRetentionIT and issue #27040).
+    SdkClients.adminClient()
+        .ingestionPipelines()
+        .delete(pipeline.getId().toString(), Map.of("hardDelete", "true"));
 
     // Verify all resources are cleaned up
     Awaitility.await()

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/SoftDeleteRetentionIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/SoftDeleteRetentionIT.java
@@ -1,0 +1,532 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.bootstrap.SharedEntities;
+import org.openmetadata.it.bootstrap.TestSuiteBootstrap;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.TestNamespace;
+import org.openmetadata.it.util.TestNamespaceExtension;
+import org.openmetadata.schema.api.data.CreateDataContract;
+import org.openmetadata.schema.api.data.CreateDatabase;
+import org.openmetadata.schema.api.data.CreateDatabaseSchema;
+import org.openmetadata.schema.api.data.CreateTable;
+import org.openmetadata.schema.api.services.ingestionPipelines.CreateIngestionPipeline;
+import org.openmetadata.schema.api.tests.CreateTestCase;
+import org.openmetadata.schema.entity.app.App;
+import org.openmetadata.schema.entity.app.AppExtension;
+import org.openmetadata.schema.entity.app.AppMarketPlaceDefinition;
+import org.openmetadata.schema.entity.app.AppRunRecord;
+import org.openmetadata.schema.entity.app.AppSchedule;
+import org.openmetadata.schema.entity.app.AppType;
+import org.openmetadata.schema.entity.app.CreateApp;
+import org.openmetadata.schema.entity.app.CreateAppMarketPlaceDefinitionReq;
+import org.openmetadata.schema.entity.app.NativeAppPermission;
+import org.openmetadata.schema.entity.app.ScheduleTimeline;
+import org.openmetadata.schema.entity.app.ScheduleType;
+import org.openmetadata.schema.entity.app.ScheduledExecutionContext;
+import org.openmetadata.schema.entity.data.DataContract;
+import org.openmetadata.schema.entity.data.Database;
+import org.openmetadata.schema.entity.data.DatabaseSchema;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.entity.datacontract.DataContractResult;
+import org.openmetadata.schema.entity.services.ingestionPipelines.AirflowConfig;
+import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
+import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatus;
+import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatusType;
+import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineType;
+import org.openmetadata.schema.metadataIngestion.DatabaseServiceMetadataPipeline;
+import org.openmetadata.schema.metadataIngestion.SourceConfig;
+import org.openmetadata.schema.tests.TestCase;
+import org.openmetadata.schema.tests.TestCaseParameterValue;
+import org.openmetadata.schema.tests.TestSuite;
+import org.openmetadata.schema.type.Column;
+import org.openmetadata.schema.type.ColumnDataType;
+import org.openmetadata.schema.type.ContractExecutionStatus;
+import org.openmetadata.schema.type.EntityStatus;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.sdk.exceptions.OpenMetadataException;
+import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.sdk.network.RequestOptions;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.jdbi3.DataContractRepository;
+import org.openmetadata.service.jdbi3.IngestionPipelineRepository;
+import org.openmetadata.service.util.FullyQualifiedName;
+
+/**
+ * Regression tests for issue #27040 — a <b>soft</b> delete of an IngestionPipeline, DataContract or
+ * App physically deleted the entity's time series rows, so the subsequent restore brought the
+ * entity back with its whole run/result history gone.
+ *
+ * <p>Time series survival can only be asserted at the row level: a soft-deleted entity's statuses
+ * are not readable through the API anyway, so an API-only check passes even when the rows have
+ * already been destroyed. Each test therefore counts rows directly (mirroring {@code
+ * StaleIncidentStatusIT#softDeleteLeavesRowAndRelationshipIntact}) and then re-reads the history
+ * through the public API after the restore.
+ *
+ * <p>Hard delete keeps destroying the same rows — the paired {@code hardDelete...} tests pin that
+ * down so the fix cannot regress into leaking orphaned time series.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+@ExtendWith(TestNamespaceExtension.class)
+public class SoftDeleteRetentionIT {
+
+  private static final String ENTITY_EXTENSION_TIME_SERIES = "entity_extension_time_series";
+  private static final String APPS_EXTENSION_TIME_SERIES = "apps_extension_time_series";
+  private static final String TEST_APP_CLASS = "org.openmetadata.service.resources.apps.TestApp";
+  private static final String INGESTION_PIPELINES_PATH = "/v1/services/ingestionPipelines/";
+  private static final String APPS_PATH = "/v1/apps/";
+
+  // ===================================================================
+  // IngestionPipeline — entity_extension_time_series / pipelineStatus
+  // ===================================================================
+
+  @Test
+  void ingestionPipelineSoftDeleteKeepsPipelineStatuses(TestNamespace ns) {
+    IngestionPipeline pipeline = createPipeline(ns);
+    String runId = addPipelineStatus(pipeline);
+
+    SdkClients.adminClient().ingestionPipelines().delete(pipeline.getId().toString());
+
+    assertEquals(
+        1,
+        countExtensionRows(
+            pipeline.getFullyQualifiedName(),
+            IngestionPipelineRepository.PIPELINE_STATUS_EXTENSION),
+        "soft delete must not destroy pipeline statuses — restore has to be able to recover them");
+
+    SdkClients.adminClient().ingestionPipelines().restore(pipeline.getId().toString());
+
+    PipelineStatus restored = getPipelineStatus(pipeline, runId);
+    assertEquals(runId, restored.getRunId(), "restored pipeline must still expose its run history");
+    hardDeletePipeline(pipeline);
+  }
+
+  @Test
+  void ingestionPipelineHardDeleteRemovesPipelineStatuses(TestNamespace ns) {
+    IngestionPipeline pipeline = createPipeline(ns);
+    addPipelineStatus(pipeline);
+
+    hardDeletePipeline(pipeline);
+
+    assertEquals(
+        0,
+        countExtensionRows(
+            pipeline.getFullyQualifiedName(),
+            IngestionPipelineRepository.PIPELINE_STATUS_EXTENSION),
+        "hard delete must still purge pipeline statuses");
+  }
+
+  // ===================================================================
+  // DataContract — entity_extension_time_series / dataContractResult
+  // ===================================================================
+
+  @Test
+  void dataContractSoftDeleteKeepsResults(TestNamespace ns) {
+    DataContract contract = createContract(ns, "dc_soft");
+    addContractResult(contract);
+    String contractId = contract.getId().toString();
+
+    SdkClients.adminClient().dataContracts().delete(contractId);
+
+    assertEquals(
+        1,
+        countExtensionRows(
+            contract.getFullyQualifiedName(), DataContractRepository.RESULT_EXTENSION),
+        "soft delete must not destroy data contract results");
+
+    SdkClients.adminClient().dataContracts().restore(contractId);
+
+    DataContractResult latest =
+        SdkClients.adminClient().dataContracts().getLatestResult(contract.getId());
+    assertNotNull(latest, "restored contract must still expose its validation history");
+    hardDeleteContract(contract);
+  }
+
+  @Test
+  void dataContractHardDeleteRemovesResults(TestNamespace ns) {
+    DataContract contract = createContract(ns, "dc_hard");
+    addContractResult(contract);
+
+    hardDeleteContract(contract);
+
+    assertEquals(
+        0,
+        countExtensionRows(
+            contract.getFullyQualifiedName(), DataContractRepository.RESULT_EXTENSION),
+        "hard delete must still purge data contract results");
+  }
+
+  /**
+   * The contract's logical test suite is linked as {@code testSuite CONTAINS dataContract}, so the
+   * normal (from → to) cascade never reaches it and the repository has to drive it explicitly. It
+   * used to be <b>hard</b>-deleted regardless of the delete mode, taking the DQ ingestion pipeline
+   * (and its orchestrator DAG) with it, which a restore could not undo.
+   */
+  @Test
+  void dataContractSoftDeleteKeepsTestSuiteAlive(TestNamespace ns) {
+    DataContract contract = createContractWithQualityExpectations(ns);
+    UUID testSuiteId = contract.getTestSuite().getId();
+    String contractId = contract.getId().toString();
+
+    SdkClients.adminClient().dataContracts().delete(contractId);
+
+    TestSuite suite = getTestSuiteIncludeDeleted(testSuiteId);
+    assertFalse(
+        Boolean.TRUE.equals(suite.getDeleted()),
+        "a reversible contract delete must leave its logical test suite intact to come back to");
+
+    SdkClients.adminClient().dataContracts().restore(contractId);
+
+    DataContract restored = SdkClients.adminClient().dataContracts().get(contractId);
+    assertNotNull(restored.getTestSuite(), "restored contract must still reference its test suite");
+    assertEquals(
+        testSuiteId,
+        restored.getTestSuite().getId(),
+        "restored contract must reference the very same test suite");
+    hardDeleteContract(contract);
+  }
+
+  @Test
+  void dataContractHardDeleteRemovesTestSuite(TestNamespace ns) {
+    DataContract contract = createContractWithQualityExpectations(ns);
+    UUID testSuiteId = contract.getTestSuite().getId();
+
+    hardDeleteContract(contract);
+
+    assertThrows(
+        OpenMetadataException.class,
+        () -> getTestSuiteIncludeDeleted(testSuiteId),
+        "hard delete must still take the contract's logical test suite with it");
+  }
+
+  // ===================================================================
+  // App — apps_extension_time_series / status
+  // ===================================================================
+
+  @Test
+  void appSoftDeleteKeepsRunRecords(TestNamespace ns) {
+    App app = installTestApp(ns, "softDelApp");
+    addAppRunRecord(app);
+
+    deleteApp(app, false);
+
+    assertEquals(
+        1, countAppStatusRows(app.getId()), "soft delete must not destroy application run records");
+
+    restoreApp(app);
+
+    AppRunRecord latest = getLatestAppRun(app);
+    assertNotNull(latest, "restored app must still expose its run history");
+    deleteApp(app, true);
+  }
+
+  @Test
+  void appHardDeleteRemovesRunRecords(TestNamespace ns) {
+    App app = installTestApp(ns, "hardDelApp");
+    addAppRunRecord(app);
+
+    deleteApp(app, true);
+
+    assertEquals(
+        0, countAppStatusRows(app.getId()), "hard delete must still purge application run records");
+  }
+
+  // ===================================================================
+  // Row-level assertions
+  // ===================================================================
+
+  private int countExtensionRows(String entityFqn, String extension) {
+    String entityFqnHash = FullyQualifiedName.buildHash(entityFqn);
+    return TestSuiteBootstrap.getJdbi()
+        .withHandle(
+            handle ->
+                handle
+                    .createQuery(
+                        "SELECT COUNT(*) FROM "
+                            + ENTITY_EXTENSION_TIME_SERIES
+                            + " WHERE entityFQNHash = :entityFqnHash AND extension = :extension")
+                    .bind("entityFqnHash", entityFqnHash)
+                    .bind("extension", extension)
+                    .mapTo(Integer.class)
+                    .one());
+  }
+
+  private int countAppStatusRows(UUID appId) {
+    return TestSuiteBootstrap.getJdbi()
+        .withHandle(
+            handle ->
+                handle
+                    .createQuery(
+                        "SELECT COUNT(*) FROM "
+                            + APPS_EXTENSION_TIME_SERIES
+                            + " WHERE appId = :appId AND extension = :extension")
+                    .bind("appId", appId.toString())
+                    .bind("extension", AppExtension.ExtensionType.STATUS.toString())
+                    .mapTo(Integer.class)
+                    .one());
+  }
+
+  // ===================================================================
+  // IngestionPipeline fixtures
+  // ===================================================================
+
+  private IngestionPipeline createPipeline(TestNamespace ns) {
+    CreateIngestionPipeline request =
+        new CreateIngestionPipeline()
+            .withName(ns.prefix("retention"))
+            .withPipelineType(PipelineType.METADATA)
+            .withService(SharedEntities.get().MYSQL_SERVICE.getEntityReference())
+            .withSourceConfig(
+                new SourceConfig()
+                    .withConfig(new DatabaseServiceMetadataPipeline().withMarkDeletedTables(true)))
+            .withAirflowConfig(new AirflowConfig());
+    return SdkClients.adminClient().ingestionPipelines().create(request);
+  }
+
+  private String addPipelineStatus(IngestionPipeline pipeline) {
+    String runId = UUID.randomUUID().toString();
+    PipelineStatus status =
+        new PipelineStatus()
+            .withPipelineState(PipelineStatusType.SUCCESS)
+            .withRunId(runId)
+            .withTimestamp(System.currentTimeMillis());
+    SdkClients.adminClient()
+        .getHttpClient()
+        .execute(
+            HttpMethod.PUT,
+            INGESTION_PIPELINES_PATH + pipeline.getFullyQualifiedName() + "/pipelineStatus",
+            status,
+            PipelineStatus.class);
+    return runId;
+  }
+
+  private PipelineStatus getPipelineStatus(IngestionPipeline pipeline, String runId) {
+    return SdkClients.adminClient()
+        .getHttpClient()
+        .execute(
+            HttpMethod.GET,
+            INGESTION_PIPELINES_PATH
+                + pipeline.getFullyQualifiedName()
+                + "/pipelineStatus/"
+                + runId,
+            null,
+            PipelineStatus.class);
+  }
+
+  private void hardDeletePipeline(IngestionPipeline pipeline) {
+    HashMap<String, String> params = new HashMap<>();
+    params.put("hardDelete", "true");
+    SdkClients.adminClient().ingestionPipelines().delete(pipeline.getId().toString(), params);
+  }
+
+  // ===================================================================
+  // DataContract fixtures
+  // ===================================================================
+
+  private DataContract createContract(TestNamespace ns, String prefix) {
+    Table table = createTable(ns, prefix);
+    return SdkClients.adminClient()
+        .dataContracts()
+        .create(
+            new CreateDataContract()
+                .withName(ns.prefix(prefix))
+                .withEntity(table.getEntityReference())
+                .withDescription("Soft delete retention guard"));
+  }
+
+  private DataContract createContractWithQualityExpectations(TestNamespace ns) {
+    Table table = createTable(ns, "dc_suite");
+    TestCase testCase =
+        SdkClients.adminClient()
+            .testCases()
+            .create(
+                new CreateTestCase()
+                    .withName(ns.prefix("dc_tc"))
+                    .withEntityLink("<#E::table::" + table.getFullyQualifiedName() + ">")
+                    .withTestDefinition("tableRowCountToBeBetween")
+                    .withParameterValues(
+                        List.of(
+                            new TestCaseParameterValue().withName("minValue").withValue("0"),
+                            new TestCaseParameterValue().withName("maxValue").withValue("100"))));
+
+    DataContract contract =
+        SdkClients.adminClient()
+            .dataContracts()
+            .create(
+                new CreateDataContract()
+                    .withName(ns.prefix("dc_suite"))
+                    .withEntity(table.getEntityReference())
+                    .withEntityStatus(EntityStatus.APPROVED)
+                    .withQualityExpectations(List.of(testCase.getEntityReference()))
+                    .withDescription("Test suite lifecycle guard"));
+    assertNotNull(
+        contract.getTestSuite(), "contract with qualityExpectations must own a logical test suite");
+    return contract;
+  }
+
+  private void addContractResult(DataContract contract) {
+    SdkClients.adminClient()
+        .dataContracts()
+        .addResult(
+            contract.getId(),
+            new DataContractResult()
+                .withDataContractFQN(contract.getFullyQualifiedName())
+                .withTimestamp(System.currentTimeMillis())
+                .withContractExecutionStatus(ContractExecutionStatus.Success)
+                .withResult("Validation passed")
+                .withExecutionTime(42L));
+  }
+
+  private void hardDeleteContract(DataContract contract) {
+    HashMap<String, String> params = new HashMap<>();
+    params.put("hardDelete", "true");
+    SdkClients.adminClient().dataContracts().delete(contract.getId().toString(), params);
+  }
+
+  private TestSuite getTestSuiteIncludeDeleted(UUID testSuiteId) {
+    return SdkClients.adminClient()
+        .getHttpClient()
+        .execute(
+            HttpMethod.GET,
+            "/v1/dataQuality/testSuites/" + testSuiteId + "?include=all",
+            null,
+            TestSuite.class);
+  }
+
+  private Table createTable(TestNamespace ns, String prefix) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    String shortId = ns.uniqueShortId();
+    Database database =
+        client
+            .databases()
+            .create(
+                new CreateDatabase()
+                    .withName(prefix + "Db_" + shortId)
+                    .withService(SharedEntities.get().MYSQL_SERVICE.getFullyQualifiedName()));
+    DatabaseSchema schema =
+        client
+            .databaseSchemas()
+            .create(
+                new CreateDatabaseSchema()
+                    .withName(prefix + "Sc_" + shortId)
+                    .withDatabase(database.getFullyQualifiedName()));
+    return client
+        .tables()
+        .create(
+            new CreateTable()
+                .withName(prefix + "Tb_" + shortId)
+                .withDatabaseSchema(schema.getFullyQualifiedName())
+                .withColumns(
+                    List.of(new Column().withName("id").withDataType(ColumnDataType.BIGINT))));
+  }
+
+  // ===================================================================
+  // App fixtures
+  // ===================================================================
+
+  private App installTestApp(TestNamespace ns, String prefix) {
+    String appName = ns.prefix(prefix);
+    CreateAppMarketPlaceDefinitionReq definitionRequest =
+        new CreateAppMarketPlaceDefinitionReq()
+            .withName(appName)
+            .withDisplayName(appName)
+            .withDescription("App used to guard time series retention on soft delete")
+            .withFeatures("retention guard")
+            .withDeveloper("Test Developer")
+            .withDeveloperUrl("https://www.example.com")
+            .withPrivacyPolicyUrl("https://www.example.com/privacy")
+            .withSupportEmail("support@example.com")
+            .withClassName(TEST_APP_CLASS)
+            .withAppType(AppType.Internal)
+            .withScheduleType(ScheduleType.Scheduled)
+            .withRuntime(new ScheduledExecutionContext().withEnabled(true))
+            .withAppConfiguration(new HashMap<>())
+            .withPermission(NativeAppPermission.All);
+
+    AppMarketPlaceDefinition definition =
+        SdkClients.adminClient()
+            .getHttpClient()
+            .execute(
+                HttpMethod.POST,
+                "/v1/apps/marketplace",
+                definitionRequest,
+                AppMarketPlaceDefinition.class);
+
+    CreateApp createApp =
+        new CreateApp()
+            .withName(definition.getName())
+            .withAppConfiguration(definition.getAppConfiguration())
+            .withAppSchedule(new AppSchedule().withScheduleTimeline(ScheduleTimeline.HOURLY));
+    return SdkClients.adminClient()
+        .getHttpClient()
+        .execute(HttpMethod.POST, "/v1/apps", createApp, App.class);
+  }
+
+  private void addAppRunRecord(App app) {
+    AppRunRecord runRecord =
+        new AppRunRecord()
+            .withAppId(app.getId())
+            .withAppName(app.getName())
+            .withStatus(AppRunRecord.Status.SUCCESS)
+            .withTimestamp(System.currentTimeMillis())
+            .withStartTime(System.currentTimeMillis())
+            .withExtension(AppExtension.ExtensionType.STATUS.toString());
+    Entity.getCollectionDAO()
+        .appExtensionTimeSeriesDao()
+        .insert(JsonUtils.pojoToJson(runRecord), AppExtension.ExtensionType.STATUS.toString());
+  }
+
+  private void deleteApp(App app, boolean hardDelete) {
+    SdkClients.adminClient()
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.DELETE,
+            APPS_PATH + app.getId() + "?hardDelete=" + hardDelete,
+            null,
+            RequestOptions.builder().build());
+  }
+
+  private void restoreApp(App app) {
+    SdkClients.adminClient()
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.PUT,
+            APPS_PATH + "restore",
+            "{\"id\": \"" + app.getId() + "\"}",
+            RequestOptions.builder().build());
+  }
+
+  private AppRunRecord getLatestAppRun(App app) {
+    return SdkClients.adminClient()
+        .getHttpClient()
+        .execute(
+            HttpMethod.GET,
+            APPS_PATH + "name/" + app.getName() + "/runs/latest",
+            null,
+            AppRunRecord.class);
+  }
+}

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/SoftDeleteRetentionIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/SoftDeleteRetentionIT.java
@@ -17,9 +17,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
@@ -68,6 +70,7 @@ import org.openmetadata.schema.type.ContractExecutionStatus;
 import org.openmetadata.schema.type.EntityStatus;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.sdk.exceptions.ApiException;
 import org.openmetadata.sdk.exceptions.OpenMetadataException;
 import org.openmetadata.sdk.network.HttpMethod;
 import org.openmetadata.sdk.network.RequestOptions;
@@ -75,6 +78,8 @@ import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.DataContractRepository;
 import org.openmetadata.service.jdbi3.IngestionPipelineRepository;
 import org.openmetadata.service.util.FullyQualifiedName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Regression tests for issue #27040 — a <b>soft</b> delete of an IngestionPipeline, DataContract or
@@ -94,11 +99,39 @@ import org.openmetadata.service.util.FullyQualifiedName;
 @ExtendWith(TestNamespaceExtension.class)
 public class SoftDeleteRetentionIT {
 
+  private static final Logger LOG = LoggerFactory.getLogger(SoftDeleteRetentionIT.class);
+
   private static final String ENTITY_EXTENSION_TIME_SERIES = "entity_extension_time_series";
   private static final String APPS_EXTENSION_TIME_SERIES = "apps_extension_time_series";
   private static final String TEST_APP_CLASS = "org.openmetadata.service.resources.apps.TestApp";
   private static final String INGESTION_PIPELINES_PATH = "/v1/services/ingestionPipelines/";
   private static final String APPS_PATH = "/v1/apps/";
+  private static final String MARKETPLACE_PATH = "/v1/apps/marketplace";
+  private static final String HARD_DELETE_PARAM = "hardDelete";
+  private static final Map<String, String> HARD_DELETE = Map.of(HARD_DELETE_PARAM, "true");
+  private static final Map<String, String> RECURSIVE_HARD_DELETE =
+      Map.of(HARD_DELETE_PARAM, "true", "recursive", "true");
+  private static final int NOT_FOUND = 404;
+
+  /**
+   * Teardown for everything a test created, newest first. Registered at creation time rather than
+   * run at the end of each test so that an assertion failing mid-test still cleans up: these suites
+   * share one cluster and {@code NamespaceCleanup} has no mapping for ingestionPipeline, database or
+   * application, so a leaked fixture would sit there for every later test to trip over.
+   */
+  private final List<Runnable> fixtureCleanups = new ArrayList<>();
+
+  @AfterEach
+  void removeFixtures() {
+    for (Runnable cleanup : fixtureCleanups.reversed()) {
+      try {
+        cleanup.run();
+      } catch (OpenMetadataException alreadyGone) {
+        LOG.debug("Fixture already removed by the test itself: {}", alreadyGone.getMessage());
+      }
+    }
+    fixtureCleanups.clear();
+  }
 
   // ===================================================================
   // IngestionPipeline — entity_extension_time_series / pipelineStatus
@@ -122,7 +155,6 @@ public class SoftDeleteRetentionIT {
 
     PipelineStatus restored = getPipelineStatus(pipeline, runId);
     assertEquals(runId, restored.getRunId(), "restored pipeline must still expose its run history");
-    hardDeletePipeline(pipeline);
   }
 
   @Test
@@ -163,7 +195,6 @@ public class SoftDeleteRetentionIT {
     DataContractResult latest =
         SdkClients.adminClient().dataContracts().getLatestResult(contract.getId());
     assertNotNull(latest, "restored contract must still expose its validation history");
-    hardDeleteContract(contract);
   }
 
   @Test
@@ -207,7 +238,6 @@ public class SoftDeleteRetentionIT {
         testSuiteId,
         restored.getTestSuite().getId(),
         "restored contract must reference the very same test suite");
-    hardDeleteContract(contract);
   }
 
   @Test
@@ -217,10 +247,15 @@ public class SoftDeleteRetentionIT {
 
     hardDeleteContract(contract);
 
-    assertThrows(
-        OpenMetadataException.class,
-        () -> getTestSuiteIncludeDeleted(testSuiteId),
-        "hard delete must still take the contract's logical test suite with it");
+    ApiException notFound =
+        assertThrows(
+            ApiException.class,
+            () -> getTestSuiteIncludeDeleted(testSuiteId),
+            "hard delete must still take the contract's logical test suite with it");
+    assertEquals(
+        NOT_FOUND,
+        notFound.getStatusCode(),
+        "the suite must be gone, not merely unreadable — got: " + notFound.getMessage());
   }
 
   // ===================================================================
@@ -241,7 +276,6 @@ public class SoftDeleteRetentionIT {
 
     AppRunRecord latest = getLatestAppRun(app);
     assertNotNull(latest, "restored app must still expose its run history");
-    deleteApp(app, true);
   }
 
   @Test
@@ -304,7 +338,9 @@ public class SoftDeleteRetentionIT {
                 new SourceConfig()
                     .withConfig(new DatabaseServiceMetadataPipeline().withMarkDeletedTables(true)))
             .withAirflowConfig(new AirflowConfig());
-    return SdkClients.adminClient().ingestionPipelines().create(request);
+    IngestionPipeline pipeline = SdkClients.adminClient().ingestionPipelines().create(request);
+    fixtureCleanups.add(() -> hardDeletePipeline(pipeline));
+    return pipeline;
   }
 
   private String addPipelineStatus(IngestionPipeline pipeline) {
@@ -338,9 +374,7 @@ public class SoftDeleteRetentionIT {
   }
 
   private void hardDeletePipeline(IngestionPipeline pipeline) {
-    HashMap<String, String> params = new HashMap<>();
-    params.put("hardDelete", "true");
-    SdkClients.adminClient().ingestionPipelines().delete(pipeline.getId().toString(), params);
+    SdkClients.adminClient().ingestionPipelines().delete(pipeline.getId().toString(), HARD_DELETE);
   }
 
   // ===================================================================
@@ -402,9 +436,7 @@ public class SoftDeleteRetentionIT {
   }
 
   private void hardDeleteContract(DataContract contract) {
-    HashMap<String, String> params = new HashMap<>();
-    params.put("hardDelete", "true");
-    SdkClients.adminClient().dataContracts().delete(contract.getId().toString(), params);
+    SdkClients.adminClient().dataContracts().delete(contract.getId().toString(), HARD_DELETE);
   }
 
   private TestSuite getTestSuiteIncludeDeleted(UUID testSuiteId) {
@@ -427,6 +459,9 @@ public class SoftDeleteRetentionIT {
                 new CreateDatabase()
                     .withName(prefix + "Db_" + shortId)
                     .withService(SharedEntities.get().MYSQL_SERVICE.getFullyQualifiedName()));
+    // The database cascade takes the schema, the table and the table's data contract with it.
+    fixtureCleanups.add(
+        () -> client.databases().delete(database.getId().toString(), RECURSIVE_HARD_DELETE));
     DatabaseSchema schema =
         client
             .databaseSchemas()
@@ -464,7 +499,7 @@ public class SoftDeleteRetentionIT {
             .withAppType(AppType.Internal)
             .withScheduleType(ScheduleType.Scheduled)
             .withRuntime(new ScheduledExecutionContext().withEnabled(true))
-            .withAppConfiguration(new HashMap<>())
+            .withAppConfiguration(Map.of())
             .withPermission(NativeAppPermission.All);
 
     AppMarketPlaceDefinition definition =
@@ -472,18 +507,22 @@ public class SoftDeleteRetentionIT {
             .getHttpClient()
             .execute(
                 HttpMethod.POST,
-                "/v1/apps/marketplace",
+                MARKETPLACE_PATH,
                 definitionRequest,
                 AppMarketPlaceDefinition.class);
+    fixtureCleanups.add(() -> hardDelete(MARKETPLACE_PATH + "/" + definition.getId()));
 
     CreateApp createApp =
         new CreateApp()
             .withName(definition.getName())
             .withAppConfiguration(definition.getAppConfiguration())
             .withAppSchedule(new AppSchedule().withScheduleTimeline(ScheduleTimeline.HOURLY));
-    return SdkClients.adminClient()
-        .getHttpClient()
-        .execute(HttpMethod.POST, "/v1/apps", createApp, App.class);
+    App app =
+        SdkClients.adminClient()
+            .getHttpClient()
+            .execute(HttpMethod.POST, "/v1/apps", createApp, App.class);
+    fixtureCleanups.add(() -> deleteApp(app, true));
+    return app;
   }
 
   private void addAppRunRecord(App app) {
@@ -505,7 +544,17 @@ public class SoftDeleteRetentionIT {
         .getHttpClient()
         .executeForString(
             HttpMethod.DELETE,
-            APPS_PATH + app.getId() + "?hardDelete=" + hardDelete,
+            APPS_PATH + app.getId() + "?" + HARD_DELETE_PARAM + "=" + hardDelete,
+            null,
+            RequestOptions.builder().build());
+  }
+
+  private void hardDelete(String path) {
+    SdkClients.adminClient()
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.DELETE,
+            path + "?" + HARD_DELETE_PARAM + "=true",
             null,
             RequestOptions.builder().build());
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/AppRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/AppRepository.java
@@ -261,17 +261,6 @@ public class AppRepository extends EntityRepository<App> {
     }
   }
 
-  @Override
-  protected void postDelete(App entity, boolean hardDelete) {
-    super.postDelete(entity, hardDelete);
-    // Delete the status stored in the app extension
-    // Note that we don't want to delete the LIMITS, since we want to keep them
-    // between different app installations
-    daoCollection
-        .appExtensionTimeSeriesDao()
-        .delete(entity.getId().toString(), AppExtension.ExtensionType.STATUS.toString());
-  }
-
   public final List<App> listAll() {
     List<String> jsons = dao.listAfterWithOffset(Integer.MAX_VALUE, 0);
     List<App> entities = new ArrayList<>();
@@ -537,6 +526,12 @@ public class AppRepository extends EntityRepository<App> {
     return JsonUtils.readValue(result.get(0), clazz);
   }
 
+  /**
+   * Reached exclusively from {@code cleanup()}, which the delete path runs on the hard-delete
+   * branch only — so an app's run history survives a (reversible) soft delete and comes back with
+   * the app on restore. LIMITS extensions are deliberately left in place: they are meant to carry
+   * over between installations of the same app.
+   */
   @Override
   protected void entitySpecificCleanup(App app) {
     // Remove the Pipelines for Application
@@ -544,6 +539,9 @@ public class AppRepository extends EntityRepository<App> {
     pipelineRef.forEach(
         reference ->
             Entity.deleteEntity("admin", reference.getType(), reference.getId(), true, true));
+    daoCollection
+        .appExtensionTimeSeriesDao()
+        .delete(app.getId().toString(), AppExtension.ExtensionType.STATUS.toString());
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataContractRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataContractRepository.java
@@ -258,7 +258,7 @@ public class DataContractRepository extends EntityRepository<DataContract> {
    */
   @Override
   protected void hardDeleteAdditionalChildren(UUID id, String updatedBy) {
-    deleteContractTestSuite(findContractTestSuite(find(id, Include.ALL)));
+    deleteContractTestSuite(findContractTestSuite(find(id, Include.ALL)), updatedBy);
   }
 
   private TestSuite findContractTestSuite(DataContract dataContract) {
@@ -266,12 +266,16 @@ public class DataContractRepository extends EntityRepository<DataContract> {
         dataContract.getTestSuite(), TEST_SUITE_LIFECYCLE_FIELDS, Include.ALL);
   }
 
-  /** No-op when the contract never owned a suite — it must never be created on a delete path. */
-  private void deleteContractTestSuite(TestSuite testSuite) {
+  /**
+   * No-op when the contract never owned a suite — it must never be created on a delete path.
+   * {@code deletedBy} is the operator the delete came in as, so the suite's audit trail credits
+   * them rather than a hard-coded system user.
+   */
+  private void deleteContractTestSuite(TestSuite testSuite, String deletedBy) {
     if (testSuite != null) {
       TestSuiteRepository testSuiteRepository =
           (TestSuiteRepository) Entity.getEntityRepository(Entity.TEST_SUITE);
-      testSuiteRepository.deleteLogicalTestSuite(ADMIN_USER_NAME, testSuite, true);
+      testSuiteRepository.deleteLogicalTestSuite(deletedBy, testSuite, true);
       testSuiteRepository.deleteFromSearch(testSuite, true);
     }
   }
@@ -898,7 +902,7 @@ public class DataContractRepository extends EntityRepository<DataContract> {
 
       // If we had a test suite from older tests, but we removed them, we can delete the suite
       if (nullOrEmpty(dataContract.getQualityExpectations())) {
-        deleteContractTestSuite(findContractTestSuite(dataContract));
+        deleteContractTestSuite(findContractTestSuite(dataContract), dataContract.getUpdatedBy());
         dataContract.setTestSuite(null);
         return null;
       }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataContractRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataContractRepository.java
@@ -106,6 +106,10 @@ public class DataContractRepository extends EntityRepository<DataContract> {
   public static final String RESULT_SCHEMA = "dataContractResult";
   public static final String RESULT_EXTENSION_KEY = "id";
 
+  // deleteLogicalTestSuite walks the suite's tests and pipelines, so both have to be hydrated
+  // before it runs.
+  private static final String TEST_SUITE_LIFECYCLE_FIELDS = "tests,pipelines";
+
   private final TestSuiteMapper testSuiteMapper = new TestSuiteMapper();
   private final IngestionPipelineMapper ingestionPipelineMapper;
   @Getter @Setter private PipelineServiceClientInterface pipelineServiceClient;
@@ -229,16 +233,47 @@ public class DataContractRepository extends EntityRepository<DataContract> {
     postCreateOrUpdate(updated);
   }
 
+  /**
+   * Contract results are destroyed only on hard delete: {@code entitySpecificCleanup} is reached
+   * exclusively from {@code cleanup()}, which the delete path runs on the hard-delete branch only.
+   */
   @Override
-  protected void postDelete(DataContract dataContract, boolean hardDelete) {
-    super.postDelete(dataContract, hardDelete);
-    if (!nullOrEmpty(dataContract.getQualityExpectations())) {
-      deleteTestSuite(dataContract);
-    }
-    // Clean status
+  protected void entitySpecificCleanup(DataContract dataContract) {
     daoCollection
         .entityExtensionTimeSeriesDao()
         .delete(dataContract.getFullyQualifiedName(), RESULT_EXTENSION);
+  }
+
+  /**
+   * The logical test suite is linked as {@code testSuite --CONTAINS--> dataContract}, i.e. the
+   * contract is the <i>target</i> of the edge, so the delete cascade — which walks from → to —
+   * never reaches it and the repository has to drive it explicitly. Destroying the suite (and, via
+   * {@code deleteLogicalTestSuite}, its DQ ingestion pipeline) is irreversible, so it belongs on
+   * the hard-delete hook only: a soft-deleted contract keeps a working suite to come back to.
+   *
+   * <p>Deliberately no soft-delete/restore counterpart. That same {@code testSuite CONTAINS
+   * dataContract} edge makes the contract a restore-cascade <i>child</i> of the suite, and
+   * {@code bulkRestoreSubtree} runs {@code restoreAdditionalChildren} unconditionally — so a
+   * contract → suite restore hook and the suite → contract cascade would call each other forever.
+   */
+  @Override
+  protected void hardDeleteAdditionalChildren(UUID id, String updatedBy) {
+    deleteContractTestSuite(findContractTestSuite(find(id, Include.ALL)));
+  }
+
+  private TestSuite findContractTestSuite(DataContract dataContract) {
+    return Entity.getEntityOrNull(
+        dataContract.getTestSuite(), TEST_SUITE_LIFECYCLE_FIELDS, Include.ALL);
+  }
+
+  /** No-op when the contract never owned a suite — it must never be created on a delete path. */
+  private void deleteContractTestSuite(TestSuite testSuite) {
+    if (testSuite != null) {
+      TestSuiteRepository testSuiteRepository =
+          (TestSuiteRepository) Entity.getEntityRepository(Entity.TEST_SUITE);
+      testSuiteRepository.deleteLogicalTestSuite(ADMIN_USER_NAME, testSuite, true);
+      testSuiteRepository.deleteFromSearch(testSuite, true);
+    }
   }
 
   private void postCreateOrUpdate(DataContract dataContract) {
@@ -863,7 +898,7 @@ public class DataContractRepository extends EntityRepository<DataContract> {
 
       // If we had a test suite from older tests, but we removed them, we can delete the suite
       if (nullOrEmpty(dataContract.getQualityExpectations())) {
-        deleteTestSuite(dataContract);
+        deleteContractTestSuite(findContractTestSuite(dataContract));
         dataContract.setTestSuite(null);
         return null;
       }
@@ -929,14 +964,6 @@ public class DataContractRepository extends EntityRepository<DataContract> {
     }
   }
 
-  private void deleteTestSuite(DataContract dataContract) {
-    TestSuiteRepository testSuiteRepository =
-        (TestSuiteRepository) Entity.getEntityRepository(Entity.TEST_SUITE);
-    TestSuite testSuite = getOrCreateTestSuite(dataContract);
-    testSuiteRepository.deleteLogicalTestSuite(ADMIN_USER_NAME, testSuite, true);
-    testSuiteRepository.deleteFromSearch(testSuite, true);
-  }
-
   private TestSuite getOrCreateTestSuite(DataContract dataContract) {
     String testSuiteName = getTestSuiteName(dataContract);
     TestSuiteRepository testSuiteRepository =
@@ -945,7 +972,7 @@ public class DataContractRepository extends EntityRepository<DataContract> {
     // Check if test suite already exists
     if (contractHasTestSuite(dataContract)) {
       return Entity.getEntityOrNull(
-          dataContract.getTestSuite(), "tests,pipelines", Include.NON_DELETED);
+          dataContract.getTestSuite(), TEST_SUITE_LIFECYCLE_FIELDS, Include.NON_DELETED);
     } else {
       // Create new test suite
       LOG.debug(
@@ -1157,7 +1184,8 @@ public class DataContractRepository extends EntityRepository<DataContract> {
               dataContract.getFullyQualifiedName()));
     }
     TestSuite testSuite =
-        Entity.getEntity(dataContract.getTestSuite(), "tests,pipelines", Include.NON_DELETED);
+        Entity.getEntity(
+            dataContract.getTestSuite(), TEST_SUITE_LIFECYCLE_FIELDS, Include.NON_DELETED);
 
     if (nullOrEmpty(testSuite.getPipelines())) {
       throw DataContractValidationException.byMessage(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
@@ -726,11 +726,6 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
     return new IngestionPipelineUpdater(original, updated, operation);
   }
 
-  @Override
-  protected void postDelete(IngestionPipeline entity, boolean hardDelete) {
-    postDelete(entity, hardDelete, false);
-  }
-
   /**
    * Removing the DAG from the orchestrator is irreversible, so it must only happen when the entity
    * itself is going away for good. A soft delete is reversible and {@code restoreEntity} has no way
@@ -739,10 +734,22 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
    * the runner happened to be down. The accepted trade-off is that nothing pauses the DAG either,
    * so a soft-deleted pipeline keeps running on schedule and recording statuses until it is
    * restored or hard-deleted; pausing it would need a restore-time redeploy hook that does not
-   * exist yet. Stays in {@code postDelete} rather than moving to {@link #entitySpecificCleanup}
-   * because it is a blocking remote call that must not run inside the real transaction
-   * {@code cleanup()} opens, and because {@code forceDelete} threads
-   * {@code allowUnavailableRunner} through here and reads back the skip flag.
+   * exist yet.
+   *
+   * <p>The teardown stays here rather than moving to {@link #entitySpecificCleanup} (where the
+   * pipeline's time series went) because it is a blocking remote call that must not run inside the
+   * real transaction {@code cleanup()} opens, and because {@code forceDelete} threads
+   * {@code allowUnavailableRunner} through the overload below and reads back the skip flag.
+   */
+  @Override
+  protected void postDelete(IngestionPipeline entity, boolean hardDelete) {
+    postDelete(entity, hardDelete, false);
+  }
+
+  /**
+   * Variant of {@link #postDelete(IngestionPipeline, boolean)} for {@code forceDelete}: tolerates an
+   * unreachable ingestion runner when {@code allowUnavailableRunner} is set and reports back whether
+   * the runner cleanup was skipped, so the caller can warn about the DAG left behind.
    */
   private boolean postDelete(
       IngestionPipeline entity, boolean hardDelete, boolean allowUnavailableRunner) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
@@ -731,12 +731,33 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
     postDelete(entity, hardDelete, false);
   }
 
+  /**
+   * Removing the DAG from the orchestrator is irreversible, so it must only happen when the entity
+   * itself is going away for good. A soft delete is reversible and {@code restoreEntity} has no way
+   * to redeploy, so tearing the runner down there left a restored pipeline with no backing DAG —
+   * and, with {@code allowUnavailableRunner=false}, failed the whole soft delete outright whenever
+   * the runner happened to be down. Stays in {@code postDelete} rather than moving to
+   * {@link #entitySpecificCleanup} because it is a remote call that must not run inside the
+   * {@code cleanup()} transaction, and because {@code forceDelete} threads
+   * {@code allowUnavailableRunner} through here and reads back the skip flag.
+   */
   private boolean postDelete(
       IngestionPipeline entity, boolean hardDelete, boolean allowUnavailableRunner) {
     super.postDelete(entity, hardDelete);
-    boolean wasRunnerCleanupSkipped = deleteDeployedPipeline(entity, allowUnavailableRunner);
-    deletePipelineStatuses(entity);
+    boolean wasRunnerCleanupSkipped = false;
+    if (hardDelete) {
+      wasRunnerCleanupSkipped = deleteDeployedPipeline(entity, allowUnavailableRunner);
+    }
     return wasRunnerCleanupSkipped;
+  }
+
+  /**
+   * Pipeline run history is destroyed only on hard delete: {@code entitySpecificCleanup} is reached
+   * exclusively from {@code cleanup()}, which the delete path runs on the hard-delete branch only.
+   */
+  @Override
+  protected void entitySpecificCleanup(IngestionPipeline entity) {
+    deletePipelineStatuses(entity);
   }
 
   protected boolean deleteDeployedPipeline(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
@@ -736,9 +736,12 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
    * itself is going away for good. A soft delete is reversible and {@code restoreEntity} has no way
    * to redeploy, so tearing the runner down there left a restored pipeline with no backing DAG —
    * and, with {@code allowUnavailableRunner=false}, failed the whole soft delete outright whenever
-   * the runner happened to be down. Stays in {@code postDelete} rather than moving to
-   * {@link #entitySpecificCleanup} because it is a remote call that must not run inside the
-   * {@code cleanup()} transaction, and because {@code forceDelete} threads
+   * the runner happened to be down. The accepted trade-off is that nothing pauses the DAG either,
+   * so a soft-deleted pipeline keeps running on schedule and recording statuses until it is
+   * restored or hard-deleted; pausing it would need a restore-time redeploy hook that does not
+   * exist yet. Stays in {@code postDelete} rather than moving to {@link #entitySpecificCleanup}
+   * because it is a blocking remote call that must not run inside the real transaction
+   * {@code cleanup()} opens, and because {@code forceDelete} threads
    * {@code allowUnavailableRunner} through here and reads back the skip flag.
    */
   private boolean postDelete(

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/IngestionPipelineRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/IngestionPipelineRepositoryTest.java
@@ -55,12 +55,8 @@ class IngestionPipelineRepositoryTest {
   @Test
   void deleteDeployedPipelineReportsSkippedCleanupForUnavailableRunner() {
     IngestionPipeline pipeline = createBasicPipeline();
-    PipelineServiceClientInterface pipelineServiceClient =
-        mock(PipelineServiceClientInterface.class);
-    doThrow(new IngestionRunnerUnavailableException("runner unavailable"))
-        .when(pipelineServiceClient)
-        .deletePipeline(pipeline);
-    IngestionPipelineRepository cleanupRepository = repositoryWithClient(pipelineServiceClient);
+    IngestionPipelineRepository cleanupRepository =
+        repositoryWithClient(unavailableRunnerClient(pipeline));
 
     boolean wasRunnerCleanupSkipped = cleanupRepository.deleteDeployedPipeline(pipeline, true);
 
@@ -112,6 +108,48 @@ class IngestionPipelineRepositoryTest {
     boolean wasRunnerCleanupSkipped = cleanupRepository.deleteDeployedPipeline(pipeline, true);
 
     assertFalse(wasRunnerCleanupSkipped);
+  }
+
+  /**
+   * A runner that is down is the observable channel for whether the teardown was attempted at all:
+   * with {@code allowUnavailableRunner=false} — the mode every delete but {@code forceDelete} uses
+   * — {@code deleteDeployedPipeline} propagates {@link IngestionRunnerUnavailableException}, so the
+   * exception surfaces exactly when {@code postDelete} reaches the orchestrator and stays silent
+   * when it does not. The two tests below therefore pin both halves of the {@code hardDelete} guard
+   * through {@code postDelete} itself rather than through {@code deleteDeployedPipeline}, which the
+   * other tests in this class call directly and which would keep passing if the guard were dropped.
+   */
+  @Test
+  void postDeleteLeavesTheDeployedPipelineAloneOnSoftDelete() {
+    IngestionPipeline pipeline = createBasicPipeline();
+    IngestionPipelineRepository cleanupRepository =
+        repositoryWithClient(unavailableRunnerClient(pipeline));
+
+    assertDoesNotThrow(
+        () -> cleanupRepository.postDelete(pipeline, false),
+        "A soft delete is reversible and restore cannot redeploy, so it must not touch the "
+            + "orchestrator — nor fail when the orchestrator is unreachable");
+  }
+
+  @Test
+  void postDeleteTearsDownTheDeployedPipelineOnHardDelete() {
+    IngestionPipeline pipeline = createBasicPipeline();
+    IngestionPipelineRepository cleanupRepository =
+        repositoryWithClient(unavailableRunnerClient(pipeline));
+
+    assertThrows(
+        IngestionRunnerUnavailableException.class,
+        () -> cleanupRepository.postDelete(pipeline, true),
+        "A hard delete must still remove the DAG from the orchestrator");
+  }
+
+  private PipelineServiceClientInterface unavailableRunnerClient(IngestionPipeline pipeline) {
+    PipelineServiceClientInterface pipelineServiceClient =
+        mock(PipelineServiceClientInterface.class);
+    doThrow(new IngestionRunnerUnavailableException("runner unavailable"))
+        .when(pipelineServiceClient)
+        .deletePipeline(pipeline);
+    return pipelineServiceClient;
   }
 
   private IngestionPipelineRepository repositoryWithClient(


### PR DESCRIPTION
### Describe your changes:

Fixes #27040

**This is silent, irrecoverable data loss.** A *soft* delete of an `IngestionPipeline`, `DataContract`
or `App` physically deleted the entity's time series rows. `restoreEntity` only flips the `deleted`
flag — there is no time-series reinstatement — so the entity came back with its entire run/result
history gone, permanently, with no error shown to the user.

`EntityRepository.postDelete(T entity, boolean hardDelete)` receives the flag and the base
implementation guards on it correctly. Three subclasses received the flag and ignored it:

| Repository | Ran unconditionally in `postDelete` |
|---|---|
| `IngestionPipelineRepository` | `deleteDeployedPipeline(...)` + `deletePipelineStatuses(...)` |
| `DataContractRepository` | `deleteTestSuite(...)` + `entityExtensionTimeSeriesDao().delete(fqn, RESULT_EXTENSION)` |
| `AppRepository` | `appExtensionTimeSeriesDao().delete(id, ExtensionType.STATUS)` |

Two irreversible side effects rode along on the same unguarded path, both listed in the issue:

1. **The deployed DAG was destroyed on a soft delete.** `restoreEntity` has no way to redeploy, so a
   restore produced a live-looking pipeline with no backing DAG. Worse, with
   `allowUnavailableRunner=false` — the mode every delete except `forceDelete` uses — a plain soft
   delete **threw** `IngestionRunnerUnavailableException` and failed the whole request whenever the
   ingestion runner happened to be down.
2. **`DataContractRepository.deleteTestSuite` hardcoded `hardDelete=true` *and* resolved the suite via
   `getOrCreateTestSuite`** — so soft-deleting a contract hard-deleted its logical test suite, which
   hard-deleted that suite's DQ ingestion pipeline and its DAG; and on a contract that had no suite,
   it **created one on the delete path purely in order to delete it**.

**Blast radius — stated precisely, not oversold.** `postDelete` is called from the three public delete
entry points and from the *bulk hard delete* chunk. `bulkSoftDeleteSubtree` never calls it, so this
fired on a **direct** soft delete of the entity — **not** when it was cascade-soft-deleted as a child
of its service or table.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

**Move time-series destruction to a seat that is hard-delete-only by construction, rather than adding
a conditional that a future edit can drop.**

`EntityRepository`'s private `delete(...)` reaches `cleanup(updated)` **only** on the hard-delete
branch. `cleanup` is `protected final` and dispatches to the overridable `entitySpecificCleanup`.
Putting the destructive work there means it *cannot* run on a soft delete — there is no `if` to
forget, and the guarantee is structural. The bulk hard-delete path is covered for free: the base
`bulkEntitySpecificCleanup` loops `entitySpecificCleanup(deletedBy, entity)` over the batch.

This follows the idiom established by `8e5c21dee6` ("Fixes 27060: delete test case results once on
hard delete…") for `TestCaseRepository`. No `bulkEntitySpecificCleanup` override was added here,
unlike `TestCaseRepository`: that override exists purely to collapse N async dispatches into one,
whereas these hooks issue a single synchronous `DELETE` each, so an override would be a byte-for-byte
duplicate of the base loop.

**`deleteDeployedPipeline` deliberately stays in `postDelete`, behind an `if (hardDelete)` guard.**
Two reasons it does not belong in `entitySpecificCleanup`:
- it is a **blocking remote call**, and `cleanup()` opens a real
  `Entity.getJdbi().inTransaction(...)`; holding a DB transaction open across an HTTP round-trip to
  the orchestrator is exactly what you don't want. (Note `EntityRepository`'s `@Transaction`
  annotations are the JDBI SQL-object annotation on a plain class and are inert — `cleanup()`'s is
  the real one.)
- `forceDelete` threads `allowUnavailableRunner` through this method and reads back its `boolean`
  return to warn about a DAG left behind; `entitySpecificCleanup` returns `void`.

**`DataContractRepository`'s test-suite teardown moved to `hardDeleteAdditionalChildren`**, the
documented hook for related entities the cascade cannot reach — the edge is
`testSuite --CONTAINS--> dataContract`, i.e. the contract is the *target*, so the from→to walk never
reaches the suite. This mirrors `DashboardRepository`'s handling of charts. `getOrCreateTestSuite` on
the delete path is replaced by a lookup that no-ops when there is no suite.

**Deliberately no soft-delete/restore counterpart for the test suite.** That was implemented, proved
harmful, and reverted: the same `CONTAINS` edge makes the contract a restore-cascade *child* of the
suite, `restoreChildren` runs before the parent's own `deleted` flag flips, and `bulkRestoreSubtree`
runs `restoreAdditionalChildren` unconditionally — so a contract→suite restore hook and the
suite→contract cascade call each other forever. It surfaced as a 302 s client timeout on
`PUT /v1/dataContracts/restore`. The reason is recorded in the JavaDoc so nobody re-adds it.

**Accepted behavioural consequence, stated honestly.** A soft-deleted pipeline now keeps a live DAG
that nothing pauses — it will keep running on schedule and recording statuses until it is restored or
hard-deleted — and a soft-deleted contract keeps its test suite and DQ pipeline. This is the
deliberate trade-off: everything irreversible is now bound to hard delete. It also **aligns direct
soft delete with the cascade behaviour that already existed on `main`**, where soft-deleting a service
left every child pipeline's DAG running because `bulkSoftDeleteSubtree` never called `postDelete`.
Pausing instead of leaving it running would need a restore-time redeploy hook that does not exist
today (`PipelineServiceClientInterface.toggleIngestion` is the obvious primitive) — that is new
behaviour, not this bug fix.

No schema change, no migration.

*Related but not addressed here:* `AppResource.delete`/`deleteAppAsync` and `UserRepository.postDelete`
run comparable unguarded work on soft delete, and `AppRepository.entitySpecificCleanup` still
hard-codes `"admin"` for its pipeline teardown. All pre-existing and out of scope for this issue.

#
### Tests:

#### Use cases covered

- Soft-deleting an ingestion pipeline keeps its `pipelineStatus` history; restoring it makes the runs
  readable again through `GET /v1/services/ingestionPipelines/{fqn}/pipelineStatus/{runId}`.
- Soft-deleting a data contract keeps its `dataContractResult` history; restoring it makes
  `GET /v1/dataContracts/{id}/results/latest` work again.
- Soft-deleting an app keeps its run records; restoring it makes
  `GET /v1/apps/name/{name}/runs/latest` work again.
- Soft-deleting a data contract leaves its logical test suite intact and still referenced by the
  contract after restore.
- Hard delete still purges all of the above, and still tears the DAG down.
- A soft delete no longer fails when the ingestion runner is unreachable.

#### Unit tests

- [x] I added unit tests for the new/changed logic.
- Files updated: `openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/IngestionPipelineRepositoryTest.java`
  — 2 new tests (`postDeleteLeavesTheDeployedPipelineAloneOnSoftDelete`,
  `postDeleteTearsDownTheDeployedPipelineOnHardDelete`). They exist because the DAG-teardown guard has
  **no runnable integration coverage** (see NOT VERIFIED below), so without them collapsing
  `postDelete` to `super.postDelete(...); return false;` would orphan a DAG against every hard-deleted
  pipeline with the whole suite still green. They assert *behaviour*, not interactions: the stubbed
  runner throws on `deletePipeline`, so whether the exception propagates out of `postDelete` is the
  observable signal that the orchestrator was reached. `PipelineServiceClientInterface` is a true
  external boundary, which is what CLAUDE.md sanctions mocking.
- Result: `Tests run: 66, Failures: 0, Errors: 0, Skipped: 0` across the touched and adjacent classes
  (`IngestionPipelineRepositoryTest` 24/24, `EntityRepositoryRestoreTest`, `TestSuiteRepositoryTest`,
  `TestCaseRepositoryTest`, `AppRepositoryStorageStrippingTest`, `DataContractFieldSupportTest`,
  `IngestionPipelineStatusIndexTest`).
- **Coverage — real numbers, below the 90% target.** JaCoCo line coverage on the three changed classes
  from the `openmetadata-service` unit-test run:
  `IngestionPipelineRepository` **13.9%** (95/684), `AppRepository` **3.3%** (9/272),
  `DataContractRepository` **0.0%** (0/826).
  These are genuinely low and I am not dressing them up: these repositories are almost entirely
  covered by `openmetadata-integration-tests`, which runs in a separate module against a live server
  and is **not instrumented by this JaCoCo run**, so the figures measure the unit-test slice only, not
  the real coverage of the changed behaviour. The changed hooks themselves are exercised by the 2 unit
  tests plus the 8 integration tests below. Raising the module-level unit figure would mean unit-testing
  repositories that this codebase deliberately tests through integration tests.

#### Backend integration tests

- [x] I added integration tests in `openmetadata-integration-tests/`.
- File added: `openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/SoftDeleteRetentionIT.java` (8 tests).
- The retention assertions use **raw JDBI row counts** against `entity_extension_time_series` /
  `apps_extension_time_series`. This is required, not a stylistic choice: a soft-deleted entity's
  statuses aren't readable through the API anyway, so an API-level check passes even when the rows
  have already been destroyed. Each test then re-reads the history through the public API after the
  restore.
- Four tests fail without the fix (`expected: <1> but was: <0>` on the row counts, and a 404 on the
  hard-deleted test suite). **The four paired hard-delete tests pass both pre- and post-fix by
  design** — they are regression guards against over-correcting into leaked orphan rows, not RED
  evidence for the bug.
- Result: `Tests run: 8, Failures: 0, Errors: 0, Skipped: 0`.
- Regression: `DataContractResourceIT,TestSuiteResourceIT,DataContractPermissionIT` →
  `Tests run: 600, Failures: 0, Errors: 0, Skipped: 45`.
- `K8sIngestionPipelineResourceIT.test_deletePipeline_withK8sBackend` encoded the old behaviour (it
  soft-deleted, then asserted the CronJob/ConfigMap were gone). Updated to hard-delete — same
  assertions, correct delete mode. **No assertion was weakened.**

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Not applicable (no UI changes).

#### Manual testing performed ✅

Run against a local stack. `entityFQNHash` is **not** `md5('<fqn>')` — `FullyQualifiedName.buildHash`
splits the FQN and MD5s each segment, so join on the entity's own stored `fqnHash` instead.

**A — IngestionPipeline**

1. Create a database service and a metadata ingestion agent on it. Note the pipeline id and FQN.
2. `PUT /v1/services/ingestionPipelines/<fqn>/pipelineStatus` with
   `{"runId":"manual-1","pipelineState":"success","timestamp":1700000000000}`; confirm
   `GET .../pipelineStatus/manual-1` → 200. Record the baseline:
   ```sql
   SELECT fqnHash FROM ingestion_pipeline_entity WHERE id = '<pipelineId>';  -- keep this
   SELECT COUNT(*) FROM entity_extension_time_series eets
     JOIN ingestion_pipeline_entity ipe ON eets.entityFQNHash = ipe.fqnHash
    WHERE ipe.id = '<pipelineId>'
      AND eets.extension = 'ingestionPipeline.pipelineStatus';               -- 1
   ```
3. Stop the ingestion runner, then soft delete: `DELETE /v1/services/ingestionPipelines/<id>` → **200**
   (before: an `IngestionRunnerUnavailableException` error).
4. Re-run the count → still **1** (before: 0). Confirm the DAG is **still present** in the
   orchestrator (before: deleted).
5. `PUT /v1/services/ingestionPipelines/restore` `{"id":"<id>"}` → 200, then
   `GET .../pipelineStatus/manual-1` → 200 with `runId: manual-1` (before: 404).
6. `DELETE /v1/services/ingestionPipelines/<id>?hardDelete=true`, then using the saved hash:
   `SELECT COUNT(*) FROM entity_extension_time_series WHERE entityFQNHash = '<fqnHash>' AND extension = 'ingestionPipeline.pipelineStatus'` → **0**, and the DAG is gone.

**B — DataContract**

1. Create a data contract on a table with at least one quality expectation. Note the contract id and
   `testSuite.id`.
2. `PUT /v1/dataContracts/<id>/results` with a `Success` result; confirm
   `GET /v1/dataContracts/<id>/results/latest` → 200. Record the baseline:
   ```sql
   SELECT fqnHash FROM data_contract_entity WHERE id = '<contractId>';       -- keep this
   SELECT COUNT(*) FROM entity_extension_time_series eets
     JOIN data_contract_entity dce ON eets.entityFQNHash = dce.fqnHash
    WHERE dce.id = '<contractId>'
      AND eets.extension = 'dataContract.dataContractResult';                -- 1
   ```
3. Soft delete `DELETE /v1/dataContracts/<id>`; re-run the count → still **1** (before: 0).
4. `GET /v1/dataQuality/testSuites/<testSuiteId>?include=all` → **200**, not deleted
   (before: 404 — the suite and its DQ pipeline had been hard-deleted).
5. `PUT /v1/dataContracts/restore` `{"id":"<id>"}` → 200; `GET /v1/dataContracts/<id>/results/latest`
   → 200 with the result from step 2 (before: gone).
6. `DELETE /v1/dataContracts/<id>?hardDelete=true` → the test suite 404s and the row count via the
   saved hash → **0**.
7. On a contract with **no** quality expectations, soft delete and confirm no test suite is created —
   `SELECT COUNT(*) FROM test_suite WHERE name LIKE '%<contractName>%'` stays 0 (before:
   `getOrCreateTestSuite` created one on the delete path).

**C — App**

1. Install an app and let it run once; `GET /v1/apps/name/<appName>/runs/latest` → 200.
2. Soft delete `DELETE /v1/apps/<id>`;
   `SELECT COUNT(*) FROM apps_extension_time_series WHERE appId = '<id>' AND extension = 'status'`
   → **≥ 1** (before: 0).
3. `PUT /v1/apps/restore` `{"id":"<id>"}` → 200; `GET /v1/apps/name/<appName>/runs/latest` → 200 with
   the pre-delete run (before: "no status found").
4. `DELETE /v1/apps/<id>?hardDelete=true` → the count goes to 0 while `extension = 'limits'` rows are
   untouched.

**NOT VERIFIED — please weigh these in review:**

- **End-to-end DAG/CronJob teardown.** The two unit tests prove `postDelete` calls the orchestrator on
  hard delete and not on soft delete; they do not prove the real K8s/Airflow client then removes the
  CronJob. That assertion lives in `K8sIngestionPipelineResourceIT`, which is `@Disabled` in the repo
  (`"Flaky: pipelineServiceClient is null in CI"`), so my edit to it is unverified by a run.
- **The `updatedBy` audit-trail threading.** `hardDeleteAdditionalChildren` now credits the real
  operator instead of a hard-coded `ADMIN_USER_NAME` when deleting the contract's test suite. Every IT
  authenticates as `admin`, so no automated test can tell the two apart — this is covered by manual
  step B only.

#
### UI screen recording / screenshots:

Not applicable — backend-only change (`openmetadata-service` + `openmetadata-integration-tests`), no
UI files touched.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: N/A — no schema change, so no migration is needed.
- [x] For UI changes: N/A — no UI changes.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing (`SoftDeleteRetentionIT`,
      which references issue #27040 in its class JavaDoc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR binds irreversible ingestion-pipeline, data-contract, and app cleanup to hard deletion while preserving time-series history and related resources across soft delete and restore.
- Moves pipeline-status, contract-result, and app-run deletion into hard-delete-only cleanup hooks.
- Guards deployed-pipeline teardown so soft deletion does not remove the orchestrator DAG.
- Moves logical test-suite teardown to the data contract’s hard-delete child hook and avoids creating suites during deletion.
- Adds unit and integration coverage for soft-delete retention and hard-delete cleanup.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no actionable changed-code defects were identified.

The revised lifecycle hooks preserve reversible state on soft delete while the direct and bulk hard-delete flows still invoke the required time-series, DAG, and logical-suite cleanup before entity storage is removed.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java | Restricts orchestrator teardown and pipeline-status deletion to hard-delete paths while preserving force-delete runner handling. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataContractRepository.java | Retains contract results and logical test suites on soft delete, resolving and deleting existing suites only during irreversible lifecycle operations. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/AppRepository.java | Moves app status-history deletion into the hard-delete-only entity cleanup hook. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/SoftDeleteRetentionIT.java | Adds database-level and restored-API assertions for soft-delete retention plus paired hard-delete cleanup checks. |
| openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/IngestionPipelineRepositoryTest.java | Verifies that soft deletion avoids the external runner while hard deletion still attempts DAG teardown. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/K8sIngestionPipelineResourceIT.java | Updates Kubernetes teardown coverage to request hard deletion explicitly. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  D[Delete entity] --> H{Hard delete?}
  H -->|No| S[Mark entity deleted]
  S --> R[Retain time-series history and related runtime resources]
  R --> X[Restore can expose retained history]
  H -->|Yes| C[Run hard-delete cleanup]
  C --> T[Delete time-series rows]
  C --> P[Remove deployed ingestion DAG]
  C --> Q[Delete contract logical test suite]
  C --> E[Delete entity relationships and storage]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fixes 27040: move the postDelete contrac..."](https://github.com/open-metadata/openmetadata/commit/fa999e6e8159bcca8fc8b3db8c2a6224290a5aef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55283584)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [OpenMetadata Service Core: Entities, Resources, Repositories](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-core.md)
- Knowledge Base — [Governance Workflows and Applications in OpenMetadata Service](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-workflows-apps.md)
- Knowledge Base — [OpenMetadata Airflow APIs: Deploying and Triggering Ingestion Pipelines as DAGs](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-airflow-apis.md)
</details>

<!-- /greptile_comment -->