### PR TITLE
fix(ui): pass fields when fetching KnowledgePage in Explore summary panel (#31838) (2.0 cherry-pick)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
@@ -76,6 +76,7 @@ import {
 import { waitForSearchIndexed } from '../../utils/polling';
 import { sidebarClick } from '../../utils/sidebar';
 import { test } from '../fixtures/pages';
+import { navigateToKCEntity } from '../Utils/ExplorePageRightPanelUtils';
 import {
   runAdvancedBlocksTest,
   runContentPersistenceTest,
@@ -393,6 +394,57 @@ test.describe('Context Center Articles', () => {
         page.getByTestId('search-error-placeholder')
       ).not.toBeVisible();
     });
+  });
+
+  test('Article tags added on the article page are visible in the Explore right-panel summary', async ({
+    page,
+    browser,
+  }) => {
+    const { apiContext: setupContext, afterAction: setupAfterAction } =
+      await createNewPage(browser);
+    const article = await createArticleViaApi(setupContext, {
+      displayName: `CC Tag Panel Article ${uuid()}`,
+      name: `cc_tag_panel_article_${uuid()}`,
+    });
+    await setupAfterAction();
+
+    const tagDisplayName = 'Article';
+    const tagFqn = 'KnowledgeCenter.Article';
+
+    try {
+      await test.step('Add tag to article via the article page', async () => {
+        await navigateToArticle(page, article.fullyQualifiedName);
+        await updateTags(page, { tag: tagDisplayName, tagFqn });
+      });
+
+      await test.step('Wait for search index to reflect the update', async () => {
+        const { apiContext, afterAction } = await getApiContext(page);
+        await waitForSearchIndexed(
+          apiContext,
+          article.fullyQualifiedName,
+          'page'
+        );
+        await afterAction();
+      });
+
+      await test.step('Verify tag is visible in Explore right-panel summary', async () => {
+        await navigateToKCEntity(page, article.displayName);
+
+        const summaryPanel = page.locator(
+          '[data-testid="entity-summary-panel-container"]'
+        );
+        await expect(
+          summaryPanel
+            .locator('.tags-section, [class*="tags"]')
+            .getByText(tagDisplayName)
+        ).toBeVisible();
+      });
+    } finally {
+      const { apiContext: cleanupContext, afterAction: cleanupAfterAction } =
+        await createNewPage(browser);
+      await deleteArticleByFqn(cleanupContext, article.fullyQualifiedName);
+      await cleanupAfterAction();
+    }
   });
 
   test('Quick link lifecycle validates, creates, edits, and deletes from card', async ({

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityByFqnUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityByFqnUtils.test.ts
@@ -18,6 +18,7 @@ import * as apiCollectionsAPI from '../rest/apiCollectionsAPI';
 import * as apiEndpointsAPI from '../rest/apiEndpointsAPI';
 import * as databaseAPI from '../rest/databaseAPI';
 import * as glossaryAPI from '../rest/glossaryAPI';
+import * as knowledgeCenterAPI from '../rest/knowledgeCenterAPI';
 import * as serviceAPI from '../rest/serviceAPI';
 import * as tableAPI from '../rest/tableAPI';
 import * as testAPI from '../rest/testAPI';
@@ -26,6 +27,7 @@ import { getEntityByFqnUtil } from './EntityByFqnUtils';
 jest.mock('../rest/tableAPI');
 jest.mock('../rest/databaseAPI');
 jest.mock('../rest/glossaryAPI');
+jest.mock('../rest/knowledgeCenterAPI');
 jest.mock('../rest/serviceAPI');
 jest.mock('../rest/alertsAPI');
 jest.mock('../rest/apiCollectionsAPI');
@@ -233,6 +235,48 @@ describe('EntityByFqnUtils', () => {
 
       expect(alertsAPI.getAlertsFromName).toHaveBeenCalledWith(mockFqn);
       expect(result).toEqual(mockEventSubData);
+    });
+
+    it('should fetch KNOWLEDGE_PAGE entity forwarding the requested fields', async () => {
+      const mockPageData = { id: '1', name: 'test-article' };
+      (knowledgeCenterAPI.getKnowledgePageByFqn as jest.Mock).mockResolvedValue(
+        mockPageData
+      );
+
+      const result = await getEntityByFqnUtil(
+        EntityType.KNOWLEDGE_PAGE,
+        mockFqn,
+        mockFields
+      );
+
+      expect(knowledgeCenterAPI.getKnowledgePageByFqn).toHaveBeenCalledWith(
+        mockFqn,
+        {
+          fields: mockFields,
+        }
+      );
+      expect(result).toEqual(mockPageData);
+    });
+
+    it('should fetch KNOWLEDGE_CENTER entity forwarding the requested fields', async () => {
+      const mockPageData = { id: '1', name: 'test-article' };
+      (knowledgeCenterAPI.getKnowledgePageByFqn as jest.Mock).mockResolvedValue(
+        mockPageData
+      );
+
+      const result = await getEntityByFqnUtil(
+        EntityType.KNOWLEDGE_CENTER,
+        mockFqn,
+        mockFields
+      );
+
+      expect(knowledgeCenterAPI.getKnowledgePageByFqn).toHaveBeenCalledWith(
+        mockFqn,
+        {
+          fields: mockFields,
+        }
+      );
+      expect(result).toEqual(mockPageData);
     });
 
     it('should return null for unknown entity type', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityByFqnUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityByFqnUtils.ts
@@ -213,7 +213,7 @@ export const getEntityByFqnUtil = (
 
     case EntityType.KNOWLEDGE_PAGE:
     case EntityType.KNOWLEDGE_CENTER:
-      return getKnowledgePageByFqn(entityFQN);
+      return getKnowledgePageByFqn(entityFQN, { fields });
 
     default:
       return null;


### PR DESCRIPTION
Cherry-pick of #31838 (merge commit 8d271cefe6561fc98bc54df862aed08fd322e902) onto `2.0`.

## What
On the Explore page, a Context Center article (KnowledgePage) showed "No Tags assigned" (and no owners/domains) in the right-side summary panel even though the article had tags. `getEntityByFqnUtil`'s `KNOWLEDGE_PAGE` / `KNOWLEDGE_CENTER` branch dropped the `fields` argument, so the panel fetched `/contextCenter/pages/name/{fqn}` without `fields=tags`. The one-line fix forwards `fields`.

## Contents (identical to main merge)
- `EntityByFqnUtils.ts` — forward `fields` to `getKnowledgePageByFqn`
- `EntityByFqnUtils.test.ts` — unit tests (fields forwarded for both cases)
- `ContextCenterArticles.spec.ts` — Playwright E2E asserting the tag shows in the Explore summary panel

Cherry-pick applied cleanly (no conflicts); diff is byte-identical to the source commit.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This cherry-pick forwards requested fields when fetching Knowledge Page and Knowledge Center entities, allowing Explore’s summary panel to receive tags, owners, and domains.
- Passes the existing `fields` argument to `getKnowledgePageByFqn`.
- Adds unit coverage for both affected entity types.
- Adds an end-to-end regression test confirming an article tag appears in Explore’s summary panel.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the production change preserving existing optional-field behavior while fixing the missing Knowledge Page metadata.

The REST helper accepts optional field parameters, undefined values are omitted during query serialization, and defined summary-panel fields are now forwarded with unit and end-to-end regression coverage.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/utils/EntityByFqnUtils.ts | Correctly forwards optional requested fields to the established Knowledge Page REST helper without changing requests when fields is undefined. |
| openmetadata-ui/src/main/resources/ui/src/utils/EntityByFqnUtils.test.ts | Adds focused unit coverage verifying fields forwarding for Knowledge Page and Knowledge Center entity types. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts | Adds end-to-end coverage for displaying an article’s assigned tag in the Explore summary panel. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Explore as Explore Summary Panel
  participant Utility as getEntityByFqnUtil
  participant REST as Knowledge Center API
  Explore->>Utility: Fetch KnowledgePage with owners,domains,tags
  Utility->>REST: "getKnowledgePageByFqn(fqn, { fields })"
  REST-->>Utility: KnowledgePage including requested fields
  Utility-->>Explore: Render tags, owners, and domains
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): pass fields when fetching Knowl..."](https://github.com/open-metadata/openmetadata/commit/65be704acdc52c539b31262b2b644aa8fee1fd64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55422799)</sub>

<!-- /greptile_comment -->