### PR TITLE
fix(ci): restore 1.13 Playwright shard distribution

### DIFF
--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -189,7 +189,7 @@ jobs:
               --project=DataAssetRulesDisabled \
               --project=Basic \
               --project="Data Insight" \
-              --project=SearchRBAC \
+              --project=SearchRBAC
 
           else
             # Shards 2-6 run common chromium tests equally distributed (5-way sharding)
@@ -197,8 +197,6 @@ jobs:
             echo "🔹 Running common chromium tests on shard ${CHROMIUM_SHARD}/5"
             npx playwright test \
               --project=chromium \
-              --project=IntakeFormCustomPropertyFields \
-              --project=IntakeForm \
               --grep-invert @dataAssetRules \
               --shard=${CHROMIUM_SHARD}/5
           fi
@@ -275,6 +273,45 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: playwright-results-json-${{ matrix.shardIndex }}
+          path: openmetadata-ui/src/main/resources/ui/playwright/output/results.json
+          retention-days: 1
+          if-no-files-found: ignore
+
+      # Intake Form tests mutate global form requirements and must not overlap
+      # projects that create domains or data products. The primary artifacts are
+      # uploaded first because this second Playwright run clears its output paths.
+      - name: Run isolated Intake Form tests
+        id: run-intake-tests
+        if: >-
+          ${{ !cancelled() && matrix.shardIndex == 1 &&
+              (steps.run-tests.outcome == 'success' || steps.run-tests.outcome == 'failure') }}
+        working-directory: openmetadata-ui/src/main/resources/ui/
+        run: npx playwright test --project=IntakeForm
+        env:
+          PLAYWRIGHT_IS_OSS: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Intake Form Playwright report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() && matrix.shardIndex == 1 && steps.run-intake-tests.outcome != 'skipped' }}
+        with:
+          name: playwright-report-1-intake
+          path: openmetadata-ui/src/main/resources/ui/playwright/output/playwright-report
+          retention-days: 5
+
+      - name: Upload Intake Form test results (screenshots, traces)
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() && matrix.shardIndex == 1 && steps.run-intake-tests.outcome != 'skipped' }}
+        with:
+          name: playwright-test-results-1-intake
+          path: openmetadata-ui/src/main/resources/ui/playwright/output/test-results
+          retention-days: 5
+
+      - name: Upload Intake Form results JSON for summary
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() && matrix.shardIndex == 1 && steps.run-intake-tests.outcome != 'skipped' }}
+        with:
+          name: playwright-results-json-1-intake
           path: openmetadata-ui/src/main/resources/ui/playwright/output/results.json
           retention-days: 1
           if-no-files-found: ignore


### PR DESCRIPTION
### Describe your changes:

Follow-up to #31587 and #31835.

The PostgreSQL PR Playwright workflow on `1.13` intends matrix shards 2–6 to execute Chromium shards `1/5` through `5/5`. In [run 32371168076](https://github.com/open-metadata/OpenMetadata/actions/runs/32371168076), matrix shard 2 instead discovered 3,718 tests while shards 3–6 completed without executing their intended test sets.

#### Root cause

PR #31587 added `IntakeFormCustomPropertyFields` and `IntakeForm` to the same sharded command as `chromium`. At that point both projects depended on the Chromium project. Playwright applies `--shard` to primary tests and then includes the full dependency projects, so the first effective shard pulled in the complete Chromium dependency suite and the remaining shards were empty.

PR #31835 corrected the Intake Form dependency graph and the nightly workflows, but the PostgreSQL PR workflow still co-listed the stateful Intake Form projects with Chromium. With the current dependency graph, that layout can also run Intake Form alongside Chromium tests sharing the same database. Intake Form temporarily changes global required-field configuration, which can make parallel domain and data-product creation fail with HTTP 400 responses.

#### What changed

- Keep the existing six-job matrix.
- Keep shards 2–6 as Chromium shards `1/5` through `5/5` and remove the Intake Form projects from that command.
- Run `IntakeForm` as a second, isolated invocation on shard 1. Its project dependency runs `IntakeFormCustomPropertyFields` first.
- Upload shard 1 primary artifacts before starting Intake Form because Playwright clears its output paths for each invocation.
- Upload the Intake Form report, traces, and JSON under unique artifact names so the consolidated summary can include both executions.
- Continue to run Intake Form after an ordinary primary-test failure for complete diagnostics, while avoiding execution when setup never reached the primary test step or the job was cancelled.

#### Why this approach

This preserves the existing runner count and five-way Chromium parallelism, isolates the globally stateful tests from every project that creates domains or data products, and retains diagnostics from both shard 1 invocations. The isolated step only receives OSS mode and the GitHub token; connector credentials remain scoped to the existing primary test step.

This regression is specific to the legacy static `1.13` workflow. The `2.0` branch uses duration-aware shard plans with explicit project/file assignments, and `main` uses the newer reusable dynamic workflow.

#
### Type of change:

- [x] Bug fix

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on the non-obvious test isolation and artifact-ordering constraints.
- [x] JSON Schema migrations are not applicable.

#### Validation

- [x] Parsed the modified workflow as YAML.
- [x] Ran a regression assertion confirming six matrix jobs, isolated shard-1 Intake Form execution, and Chromium shards 2–6 remaining five-way.
- [x] Verified Intake Form runs only after the primary test step was attempted and uploads separate artifacts.
- [x] Ran `git diff --check`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores five-way Chromium sharding in the PostgreSQL Playwright workflow and moves the stateful Intake Form suite into an isolated shard-1 invocation.
- Removes Intake Form projects from Chromium shards 2–6.
- Adds a separate Intake Form execution after shard 1's primary tests.
- Uploads independently named reports, traces, and JSON results for the isolated execution.
- The new execution condition does not actually run after a primary-test failure as intended.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The workflow should not merge until the isolated Intake Form step is made to run after an ordinary primary-test failure as intended.

The new condition does not override GitHub Actions' implicit success gating, causing Intake Form coverage and diagnostics to be skipped whenever shard 1's primary tests fail.

**Files Needing Attention:** .github/workflows/playwright-postgresql-e2e.yml
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/playwright-postgresql-e2e.yml | Restores Chromium shard distribution and isolates Intake Form tests, but the isolated step is skipped when the primary test step fails. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Shard 1 setup] --> B[Primary Playwright tests]
  B -->|success| C[Upload primary artifacts]
  B -->|failure| D[Job failure state]
  C --> E[Run isolated Intake Form]
  D -. implicit success condition blocks step .-> F[Intake Form skipped]
  E --> G[Upload Intake Form artifacts]
  G --> H[Consolidated summary]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): restore Playwright shard distri..."](https://github.com/open-metadata/openmetadata/commit/88ac0937515fb054b7e51e3b2f8c3b65f8af7162) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55453115)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->