### PR TITLE
Fixes 31859: discard an Explore filter search that resolves after its dropdown closed

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ExploreDiscovery.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ExploreDiscovery.spec.ts
@@ -257,8 +257,12 @@ test.describe('Explore Assets Discovery', () => {
 
     // The user should not be visible in the owners filter when the deleted switch is off
     await page.click('[data-testid="search-dropdown-Owners"]');
+    // Match on the typed value: opening the dropdown fires its own aggregation
+    // for the same field, and a glob matching both races ahead of the search.
     const searchResOwner = page.waitForResponse(
-      `/api/v1/search/aggregate?index=dataAsset&field=ownerDisplayName*deleted=false*`
+      `/api/v1/search/aggregate?index=dataAsset&field=ownerDisplayName&value=*${encodeURIComponent(
+        user.responseData.displayName
+      )}*deleted=false*`
     );
 
     await page.fill(
@@ -281,7 +285,9 @@ test.describe('Explore Assets Discovery', () => {
     await page.click('[data-testid="search-dropdown-Domains"]');
 
     const searchResDomain = page.waitForResponse(
-      `/api/v1/search/aggregate?index=dataAsset&field=domains.displayName.keyword*deleted=false*`
+      `/api/v1/search/aggregate?index=dataAsset&field=domains.displayName.keyword&value=*${encodeURIComponent(
+        domain.responseData.displayName
+      )}*deleted=false*`
     );
 
     await page.fill(
@@ -317,8 +323,11 @@ test.describe('Explore Assets Discovery', () => {
     const ownerSearchText = user.responseData.displayName.toLowerCase();
     await page.click('[data-testid="search-dropdown-Owners"]');
 
+    // Match on the typed value, not the dropdown's own initial aggregation.
     const searchResOwner = page.waitForResponse(
-      `/api/v1/search/aggregate?index=dataAsset&field=ownerDisplayName*deleted=true*`
+      `/api/v1/search/aggregate?index=dataAsset&field=ownerDisplayName&value=*${encodeURIComponent(
+        ownerSearchText
+      )}*deleted=true*`
     );
 
     await page.fill('[data-testid="search-input"]', ownerSearchText);
@@ -356,7 +365,9 @@ test.describe('Explore Assets Discovery', () => {
     await page.click('[data-testid="search-dropdown-Domains"]');
 
     const searchResDomain = page.waitForResponse(
-      `/api/v1/search/aggregate?index=dataAsset&field=domains.displayName.keyword*deleted=true*`
+      `/api/v1/search/aggregate?index=dataAsset&field=domains.displayName.keyword&value=*${encodeURIComponent(
+        domainSearchText
+      )}*deleted=true*`
     );
 
     await page.fill('[data-testid="search-input"]', domainSearchText);

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.test.tsx
@@ -643,6 +643,45 @@ describe('ExploreQuickFilters component', () => {
   });
 
   describe('Error handling', () => {
+    it('should not report an error for a request that was superseded', async () => {
+      const { showErrorToast } = require('../../utils/ToastUtils');
+      let rejectStale = (_reason?: unknown): void => undefined;
+      mockGetAggregationOptions
+        .mockImplementationOnce(
+          () =>
+            new Promise((_resolve, reject) => {
+              rejectStale = reject;
+            })
+        )
+        .mockResolvedValueOnce({
+          data: {
+            aggregations: {
+              'sterms#service.name': {
+                buckets: [{ key: 'fresh-option', doc_count: 1 }],
+              },
+            },
+          },
+        });
+
+      render(<ExploreQuickFilters {...mockProps} />);
+
+      fireEvent.click(screen.getByTestId('onSearch-columns.name'));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('onSearch-service.name'));
+      });
+
+      await act(async () => {
+        rejectStale(new Error('Stale Error'));
+      });
+
+      expect(showErrorToast).not.toHaveBeenCalled();
+
+      expect(screen.getByTestId('option-service.name-0')).toHaveTextContent(
+        'fresh-option'
+      );
+    });
+
     it('should handle API errors gracefully when fetching initial options', async () => {
       const { showErrorToast } = require('../../utils/ToastUtils');
       mockGetAggregationOptions.mockRejectedValue(new Error('API Error'));

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.test.tsx
@@ -62,6 +62,7 @@ jest.mock('../SearchDropdown/SearchDropdown', () => ({
   default: ({
     options,
     searchKey,
+    isSuggestionsLoading,
     onChange,
     onSearch,
     onGetInitialOptions,
@@ -97,6 +98,9 @@ jest.mock('../SearchDropdown/SearchDropdown', () => ({
       </span>
       <span data-testid={`selected-count-${searchKey}`}>
         {selectedKeys?.length ?? 0}
+      </span>
+      <span data-testid={`suggestions-loading-${searchKey}`}>
+        {isSuggestionsLoading ? 'true' : 'false'}
       </span>
       {options.map((option, index) => (
         <div data-testid={`option-${searchKey}-${index}`} key={option.key}>
@@ -1053,6 +1057,102 @@ describe('ExploreQuickFilters component', () => {
       );
 
       expect(screen.getByTestId('extra-action')).toBeInTheDocument();
+    });
+  });
+
+  describe('Stale responses', () => {
+    const aggregationResponse = (key: string, bucketKey: string) => ({
+      data: {
+        aggregations: {
+          [`sterms#${key}`]: {
+            buckets: [{ key: bucketKey, doc_count: 1 }],
+          },
+        },
+      },
+    });
+
+    it('should ignore a response that resolves after another dropdown searched', async () => {
+      let resolveStale = (_value: unknown): void => undefined;
+      mockGetAggregationOptions
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveStale = resolve;
+            })
+        )
+        .mockResolvedValueOnce(
+          aggregationResponse('service.name', 'fresh-option')
+        );
+
+      render(<ExploreQuickFilters {...mockProps} />);
+
+      fireEvent.click(screen.getByTestId('onSearch-columns.name'));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('onSearch-service.name'));
+      });
+
+      expect(screen.getByTestId('option-service.name-0')).toHaveTextContent(
+        'fresh-option'
+      );
+
+      await act(async () => {
+        resolveStale(aggregationResponse('columns.name', 'stale-option'));
+      });
+
+      expect(screen.getByTestId('option-service.name-0')).toHaveTextContent(
+        'fresh-option'
+      );
+
+      expect(
+        screen.queryByTestId('option-service.name-1')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should not strand the loader when a static field supersedes a pending fetch', async () => {
+      let resolveStale = (_value: unknown): void => undefined;
+      mockGetAggregationOptions.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveStale = resolve;
+          })
+      );
+
+      const staticField: ExploreQuickFilterField = {
+        label: 'Tier',
+        key: 'tier.tagFQN',
+        value: undefined,
+        options: [{ key: 'Tier.Tier1', label: 'Tier1' }],
+      };
+
+      render(
+        <ExploreQuickFilters
+          {...mockProps}
+          fields={[...mockFields, staticField]}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('onSearch-columns.name'));
+
+      expect(
+        screen.getByTestId('suggestions-loading-tier.tagFQN')
+      ).toHaveTextContent('true');
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('onGetInitialOptions-tier.tagFQN'));
+      });
+
+      await act(async () => {
+        resolveStale(aggregationResponse('columns.name', 'stale-option'));
+      });
+
+      expect(
+        screen.getByTestId('suggestions-loading-tier.tagFQN')
+      ).toHaveTextContent('false');
+
+      expect(screen.getByTestId('option-tier.tagFQN-0')).toHaveTextContent(
+        'Tier1'
+      );
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
@@ -269,7 +269,9 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
         sourceFields
       );
     } catch (error) {
-      showErrorToast(error as AxiosError);
+      if (isLatestOptionsRequest(requestId)) {
+        showErrorToast(error as AxiosError);
+      }
     } finally {
       if (isLatestOptionsRequest(requestId)) {
         setIsOptionsLoading(false);
@@ -345,7 +347,9 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
         )
       );
     } catch (error) {
-      showErrorToast(error as AxiosError);
+      if (isLatestOptionsRequest(requestId)) {
+        showErrorToast(error as AxiosError);
+      }
     } finally {
       if (isLatestOptionsRequest(requestId)) {
         setIsOptionsLoading(false);

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
@@ -15,7 +15,7 @@ import { Space } from 'antd';
 import { AxiosError } from 'axios';
 import { isEmpty, isEqual, uniqWith } from 'lodash';
 import Qs from 'qs';
-import { FC, useCallback, useMemo, useState } from 'react';
+import { FC, useCallback, useMemo, useRef, useState } from 'react';
 import { EntityFields } from '../../enums/AdvancedSearch.enum';
 import { SearchIndex } from '../../enums/search.enum';
 import useCustomLocation from '../../hooks/useCustomLocation/useCustomLocation';
@@ -98,6 +98,14 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
   const location = useCustomLocation();
   const [options, setOptions] = useState<SearchDropdownOption[]>();
   const [isOptionsLoading, setIsOptionsLoading] = useState<boolean>(false);
+
+  // Every dropdown writes into this one `options` state, so only the newest
+  // fetch may write — otherwise a late response repaints the dropdown that
+  // opened after it with the previous field's values.
+  const optionsRequestIdRef = useRef(0);
+  const startOptionsRequest = () => ++optionsRequestIdRef.current;
+  const isLatestOptionsRequest = (requestId: number) =>
+    requestId === optionsRequestIdRef.current;
   const { queryFilter } = useAdvanceSearch();
   const { isNLPActive } = useSearchStore();
   const getStaticOptions = useCallback(
@@ -169,6 +177,7 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
   const fetchDefaultOptions = async (
     index: SearchIndex | SearchIndex[],
     key: string,
+    requestId: number,
     fieldSearchIndex?: SearchIndex,
     fieldSearchKey?: string,
     sourceFields?: string
@@ -213,6 +222,10 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
         res.data.aggregations[`sterms#${searchKeyToUse}`]?.buckets ?? [];
     }
 
+    if (!isLatestOptionsRequest(requestId)) {
+      return;
+    }
+
     setOptions(
       addEntityTypeIcons(
         key,
@@ -234,9 +247,12 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
     fieldSearchKey?: string,
     sourceFields?: string
   ) => {
+    const requestId = startOptionsRequest();
     const staticOptions = getStaticOptions(key);
     if (staticOptions) {
       setOptions(addEntityTypeIcons(key, staticOptions));
+      // Owns the newest request, so no in-flight fetch will clear the loader.
+      setIsOptionsLoading(false);
 
       return;
     }
@@ -247,6 +263,7 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
       await fetchDefaultOptions(
         index,
         key,
+        requestId,
         fieldSearchIndex,
         fieldSearchKey,
         sourceFields
@@ -254,7 +271,9 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
     } catch (error) {
       showErrorToast(error as AxiosError);
     } finally {
-      setIsOptionsLoading(false);
+      if (isLatestOptionsRequest(requestId)) {
+        setIsOptionsLoading(false);
+      }
     }
   };
 
@@ -265,6 +284,7 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
     fieldSearchKey?: string,
     sourceFields?: string
   ) => {
+    const requestId = startOptionsRequest();
     const staticOptions = getStaticOptions(key);
     if (staticOptions) {
       const filteredOptions = value
@@ -273,6 +293,8 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
           )
         : staticOptions;
       setOptions(addEntityTypeIcons(key, filteredOptions));
+      // Owns the newest request, so no in-flight fetch will clear the loader.
+      setIsOptionsLoading(false);
 
       return;
     }
@@ -304,6 +326,11 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
 
       const buckets =
         res.data.aggregations[`sterms#${searchKeyToUse}`]?.buckets ?? [];
+
+      if (!isLatestOptionsRequest(requestId)) {
+        return;
+      }
+
       setOptions(
         addEntityTypeIcons(
           key,
@@ -320,7 +347,9 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
     } catch (error) {
       showErrorToast(error as AxiosError);
     } finally {
-      setIsOptionsLoading(false);
+      if (isLatestOptionsRequest(requestId)) {
+        setIsOptionsLoading(false);
+      }
     }
   };
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx
@@ -79,6 +79,15 @@ const QuickFilterDropdown: FC<QuickFilterDropdownProps> = ({
     debouncedOnSearch.cancel();
   }, [pathname, debouncedOnSearch]);
 
+  // A queued search must not resolve into a closed dropdown: consumers share
+  // one options state, so it would repaint whichever dropdown opened next.
+  // Keyed on the open flag to cover every close path (Escape, Close, Update).
+  useEffect(() => {
+    if (!isOpen) {
+      debouncedOnSearch.cancel();
+    }
+  }, [isOpen, debouncedOnSearch]);
+
   useEffect(() => {
     setNullOptionSelected(
       selectedKeys.some((item) => item.key === NULL_OPTION_KEY)

--- a/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/SearchDropdown.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/SearchDropdown.test.tsx
@@ -13,6 +13,7 @@
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { debounce } from 'lodash';
 import { act } from 'react';
 import SearchDropdown from './SearchDropdown';
 import { SearchDropdownProps } from './SearchDropdown.interface';
@@ -402,6 +403,31 @@ describe('Search DropDown Component', () => {
     const noOwnerCheckbox = await screen.findByTestId('no-option-checkbox');
 
     expect(noOwnerCheckbox).toBeInTheDocument();
+  });
+
+  it('Should cancel a pending search when the dropdown is closed', async () => {
+    render(<SearchDropdown {...mockProps} />);
+
+    const trigger = await screen.findByTestId('search-dropdown-Owner');
+    const { cancel } = (debounce as jest.Mock).mock.results.at(-1)?.value ?? {};
+
+    await act(async () => {
+      userEvent.click(trigger);
+    });
+
+    expect(await screen.findByTestId('drop-down-menu')).toBeInTheDocument();
+
+    const cancelCallsWhileOpen = cancel.mock.calls.length;
+
+    await act(async () => {
+      fireEvent.click(await screen.findByTestId('close-btn'));
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('drop-down-menu')).not.toBeInTheDocument()
+    );
+
+    expect(cancel.mock.calls.length).toBeGreaterThan(cancelCallsWhileOpen);
   });
 
   it('Should send null option in payload if selected', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/SearchDropdown.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/SearchDropdown.tsx
@@ -264,6 +264,15 @@ const SearchDropdown: FC<SearchDropdownProps> = ({
     debouncedOnSearch.cancel();
   }, [pathname, debouncedOnSearch]);
 
+  // A queued search must not resolve into a closed dropdown: consumers share
+  // one options state, so it would repaint whichever dropdown opened next.
+  // Keyed on the open flag to cover every close path (Escape, Close, Update).
+  useEffect(() => {
+    if (!isDropDownOpen) {
+      debouncedOnSearch.cancel();
+    }
+  }, [isDropDownOpen, debouncedOnSearch]);
+
   // Handle null option change
   const handleNullOptionChange = (checked: boolean) => {
     setNullOptionSelected(checked);


### PR DESCRIPTION
### Describe your changes:

Fixes #31859

The Explore filter dropdowns share a single `options` state in `ExploreQuickFilters`, and the search input is debounced by 500 ms in both `SearchDropdown` and `QuickFilterDropdown`. That debounce was cancelled only on unmount and on a pathname change — not when the dropdown closed. A search typed in one filter could therefore resolve after that filter was closed and overwrite the shared state, repainting whichever dropdown opened next with the previous field's options and counts.

Three changes:

- **`SearchDropdown.tsx` / `QuickFilterDropdown.tsx`** — cancel the pending search from an effect keyed on the open flag, so every close path is covered. Doing it in `onOpenChange` was not enough: `Close` and `Update` call `setIsDropDownOpen(false)` directly and never reach that handler.
- **`ExploreQuickFilters.tsx`** — each options fetch takes a monotonic ticket and only the newest may write `options` / clear the loader, so an out-of-order response cannot overwrite a newer field's list. Static-option fields (e.g. Tier) clear the loader themselves, since no in-flight fetch is left to do it on their behalf.
- **`ExploreDiscovery.spec.ts`** — the aggregation waits (`field=ownerDisplayName*deleted=true*`) matched the dropdown's own initial-options request as well as the typed search, so the test resolved on the wrong response and raced ahead of the request it had queued. They now match on the typed value.


Before:


https://github.com/user-attachments/assets/0858a677-4e3b-43bd-930a-732d4a1d2428


After:


https://github.com/user-attachments/assets/7cea5260-9489-412e-95d4-868206b409f6



#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- A user types in the Owners filter, closes it within 500 ms and opens Domains: the Domains menu shows domain options, not owner options.
- The same holds when the dropdown is closed via `Close` or `Update` rather than `Escape`.
- Two option requests resolving out of order leave the newest field's options on screen.
- A static-option field (Tier) opened while another field's fetch is in flight does not strand the dropdown loader.

#### Unit tests
- [x] Added tests for the changed logic. Each was confirmed to fail with its fix reverted.
- Files updated:
  - `src/components/SearchDropdown/SearchDropdown.test.tsx` — cancels the pending search when the dropdown closes.
  - `src/components/Explore/ExploreQuickFilters.test.tsx` — ignores a response that resolves after another dropdown searched; does not strand the loader when a static field supersedes a pending fetch.
- `yarn test src/components/Explore src/components/SearchDropdown` → 17 suites, 304 passed.
- Wider regression sweep over every `SearchDropdown` / `ExploreQuickFilters` consumer (TableQueries, OntologyExplorer, DataQuality, AuditLog, LearningResources, DataInsight, ExploreV1, AssetsTabs, AssetSelectionModal, CustomControls, atoms/filters) → 67 suites, 957 passed.
- `npx tsc --noEmit` output is byte-identical to the pre-change baseline.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Updated `playwright/e2e/Flow/ExploreDiscovery.spec.ts` (existing coverage; the waits were matching the wrong response).
- The full E2E run has not been executed locally — the AUT run is the verification for that half.

#### Manual testing performed
Not performed for this PR; the race was diagnosed from the failing run's trace (network + action timeline), and each fix is covered by a unit test that fails without it.

#
### UI screen recording / screenshots:

Not applicable — no visual change; the fix removes a wrong-content repaint.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For UI changes: no recording needed (no visual change).
- [x] I have added tests and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
