### PR TITLE
fix: retry ingestion requests on HTTP 503

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/client.py
+++ b/ingestion/src/metadata/ingestion/ometa/client.py
@@ -185,7 +185,7 @@ class ClientConfig(ConfigModel):
     retry: Optional[int] = 3  # noqa: UP045
     retry_wait: Optional[int] = 30  # noqa: UP045
     limit_codes: List[int] = [429]  # noqa: RUF012, UP006
-    retry_codes: List[int] = [504]  # noqa: RUF012, UP006
+    retry_codes: List[int] = [503, 504]  # noqa: RUF012, UP006
     auth_token: Optional[Callable] = None  # noqa: UP045
     access_token: Optional[str] = None  # noqa: UP045
     expires_in: Optional[int] = None  # noqa: UP045
@@ -365,7 +365,7 @@ class REST:
         Returns the body json in the 200 status.
 
         When ``raw`` is set, returns the ``Response`` after the same retry/limit
-        decisions (504/429 still retry) instead of the decoded body, so the caller
+        decisions (503/504/429 still retry) instead of the decoded body, so the caller
         can read a status the error handling below would otherwise drop.
         """
         retry_codes = self._retry_codes

--- a/ingestion/src/metadata/ingestion/ometa/client.py
+++ b/ingestion/src/metadata/ingestion/ometa/client.py
@@ -365,7 +365,7 @@ class REST:
         Returns the body json in the 200 status.
 
         When ``raw`` is set, returns the ``Response`` after the same retry/limit
-        decisions (503/504/429 still retry) instead of the decoded body, so the caller
+        decisions (retries on 503/504; 429 triggers limit handling) instead of the decoded body, so the caller
         can read a status the error handling below would otherwise drop.
         """
         retry_codes = self._retry_codes

--- a/ingestion/tests/unit/ometa/test_client_error_messages.py
+++ b/ingestion/tests/unit/ometa/test_client_error_messages.py
@@ -134,6 +134,21 @@ class TestHtmlResponseIsNamed:
         assert client.get("/system/version") is None
 
 
+class TestRetryableServiceUnavailable:
+    def test_503_is_retried_until_the_service_recovers(self):
+        unavailable = _response(503, "upstream unavailable", "text/plain")
+        recovered = _response(200, '{"version":"1.13.1"}')
+        client = REST(ClientConfig(base_url="https://release-1-13.getcollate.io"))
+        client._session = MagicMock()
+        client._session.request.side_effect = [unavailable, recovered]
+
+        with patch("metadata.ingestion.ometa.client.time.sleep"):
+            response = client.get_raw("/system/version", retries=1)
+
+        assert response.status_code == 200
+        assert client._session.request.call_count == 2
+
+
 class TestGetServerVersionErrors:
     """Every failure mode of /system/version must say what to fix."""
 
@@ -228,7 +243,7 @@ class TestGetServerVersionErrors:
         assert "text/yaml" in message
 
     def test_retry_budget_exhausted(self):
-        """`_request` answers None once the 504/429 retries run out."""
+        """`_request` answers None once the 503/504/429 retries run out."""
         client = MagicMock()
         client.get_raw.return_value = None
 

--- a/ingestion/tests/unit/ometa/test_client_error_messages.py
+++ b/ingestion/tests/unit/ometa/test_client_error_messages.py
@@ -243,7 +243,7 @@ class TestGetServerVersionErrors:
         assert "text/yaml" in message
 
     def test_retry_budget_exhausted(self):
-        """`_request` answers None once the 503/504/429 retries run out."""
+        """`_request` answers None once the 503/504 retries run out."""
         client = MagicMock()
         client.get_raw.return_value = None
 


### PR DESCRIPTION
Fixes #31870

## What

Retry ingestion REST requests that receive HTTP 503 Service Unavailable responses. This covers transient pod transitions where the service becomes available again shortly afterward.

## Why

A 503 currently bypasses the ingestion client retry loop, causing the overall ingestion workflow to fail during Kubernetes pod transitions.

## Changes

- Add HTTP 503 to the default retryable status codes alongside 504.
- Add a regression test proving a 503 is retried and succeeds after recovery.

## Testing

- `git diff --check`
- Python compilation via `python -m py_compile`
- `PYTHONPATH=ingestion/src pytest -c ingestion/pyproject.toml -q ingestion/tests/unit/ometa/test_client_error_messages.py`
  - **21 passed**
- Focused regression test for HTTP 503 retry: **passed**

The tests were run with the ingestion virtualenv, generated models, and ANTLR 4.9.2 parser sources available.

## Risk

Low; only the default retry status list changes.





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes HTTP 503 responses retryable by default in the ingestion REST client.
- Adds 503 alongside 504 in the default retry status list.
- Adds a regression test verifying recovery after one transient 503 response.
- Updates retry-related documentation in the client and tests.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/ometa/client.py | Adds HTTP 503 to the existing application-level retry path and updates its documentation. |
| ingestion/tests/unit/ometa/test_client_error_messages.py | Adds focused coverage demonstrating that a transient 503 is retried and the recovered response is returned. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: correct retry budget documentation"](https://github.com/open-metadata/openmetadata/commit/89d15b9056f0d1b0dc0eee4b5df2f6419411a815) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55466832)</sub>

<!-- /greptile_comment -->