### PR TITLE
fix(glossary): reject field edits to system-defined relation types via generic settings PUT

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationSettingsIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationSettingsIT.java
@@ -518,6 +518,88 @@ public class GlossaryTermRelationSettingsIT {
   @Test
   @ResourceLock(
       value = SharedResourceLocks.GLOSSARY_TERM_RELATION_SETTINGS,
+      mode = ResourceAccessMode.READ_WRITE)
+  void test_systemDefinedRelationTypeFieldCannotBeModified() throws Exception {
+    JsonNode currentSettings = getSettings();
+    ArrayNode relationTypes = (ArrayNode) currentSettings.get("config_value").get("relationTypes");
+
+    boolean toggled = false;
+    boolean originalIsTransitive = false;
+    for (JsonNode type : relationTypes) {
+      if ("partOf".equals(type.get("name").asText())) {
+        JsonNode sys = type.get("isSystemDefined");
+        assertTrue(sys != null && sys.asBoolean(), "'partOf' should be system-defined");
+        originalIsTransitive = type.get("isTransitive").asBoolean();
+        ((ObjectNode) type).put("isTransitive", !originalIsTransitive);
+        toggled = true;
+        break;
+      }
+    }
+    assertTrue(toggled, "'partOf' should exist in default settings");
+
+    ObjectNode modifiedSettings = MAPPER.createObjectNode();
+    modifiedSettings.set("relationTypes", relationTypes);
+    int status = updateSettingsAndGetStatus(modifiedSettings);
+    assertTrue(
+        status >= 400,
+        "Editing a field of system-defined 'partOf' via settings PUT must be rejected. Got: "
+            + status);
+
+    JsonNode after = getSettings();
+    for (JsonNode type : after.get("config_value").get("relationTypes")) {
+      if ("partOf".equals(type.get("name").asText())) {
+        assertEquals(
+            originalIsTransitive,
+            type.get("isTransitive").asBoolean(),
+            "'partOf' isTransitive must be unchanged after a rejected edit");
+      }
+    }
+  }
+
+  @Test
+  @ResourceLock(
+      value = SharedResourceLocks.GLOSSARY_TERM_RELATION_SETTINGS,
+      mode = ResourceAccessMode.READ_WRITE)
+  void test_cannotCreateSystemDefinedRelationTypeViaSettingsPut() throws Exception {
+    String fakeName = "fakeSystem" + System.currentTimeMillis();
+
+    JsonNode currentSettings = getSettings();
+    ArrayNode relationTypes = (ArrayNode) currentSettings.get("config_value").get("relationTypes");
+
+    ObjectNode fakeType = MAPPER.createObjectNode();
+    fakeType.put("name", fakeName);
+    fakeType.put("displayName", "Fake System Type");
+    fakeType.put("isSymmetric", false);
+    fakeType.put("isTransitive", false);
+    fakeType.put("isCrossGlossaryAllowed", true);
+    fakeType.put("category", "associative");
+    fakeType.put("isSystemDefined", true);
+    fakeType.put("color", "#22c55e");
+    fakeType.put("cardinality", "MANY_TO_MANY");
+    relationTypes.add(fakeType);
+
+    ObjectNode newSettings = MAPPER.createObjectNode();
+    newSettings.set("relationTypes", relationTypes);
+    int status = updateSettingsAndGetStatus(newSettings);
+    assertTrue(
+        status >= 400,
+        "Creating a system-defined relation type via settings PUT must be rejected. Got: "
+            + status);
+
+    JsonNode after = getSettings();
+    boolean present = false;
+    for (JsonNode type : after.get("config_value").get("relationTypes")) {
+      if (fakeName.equals(type.get("name").asText())) {
+        present = true;
+        break;
+      }
+    }
+    assertFalse(present, "Fabricated system-defined type must not be persisted");
+  }
+
+  @Test
+  @ResourceLock(
+      value = SharedResourceLocks.GLOSSARY_TERM_RELATION_SETTINGS,
       mode = ResourceAccessMode.READ)
   void test_systemDefinedRelationTypesHaveCorrectDesignSystemColors() throws Exception {
     JsonNode settings = getSettings();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtil.java
@@ -118,6 +118,31 @@ public final class GlossaryTermRelationSettingsUtil {
               + String.join(", ", missingSystemDefinedNames));
     }
 
+    // system-defined is a seeded classification: a settings update must not create a new
+    // system-defined type or promote a custom type to system-defined. Only names already seeded
+    // as system-defined may carry isSystemDefined=true.
+    Set<String> currentSystemDefinedNames = new HashSet<>();
+    for (GlossaryTermRelationType relationType : current.getRelationTypes()) {
+      if (Boolean.TRUE.equals(relationType.getIsSystemDefined())) {
+        currentSystemDefinedNames.add(relationType.getName());
+      }
+    }
+    List<String> illegallySystemDefinedNames = new ArrayList<>();
+    if (updated != null && updated.getRelationTypes() != null) {
+      for (GlossaryTermRelationType relationType : updated.getRelationTypes()) {
+        if (relationType != null
+            && Boolean.TRUE.equals(relationType.getIsSystemDefined())
+            && !currentSystemDefinedNames.contains(relationType.getName())) {
+          illegallySystemDefinedNames.add(relationType.getName());
+        }
+      }
+    }
+    if (!illegallySystemDefinedNames.isEmpty()) {
+      throw new SystemSettingsException(
+          "Cannot create or promote system-defined relation types: "
+              + String.join(", ", illegallySystemDefinedNames));
+    }
+
     // System-defined relation types are immutable: their fields (e.g. isTransitive, color,
     // category) must not be edited. The dedicated relationTypes endpoint and the UI already
     // enforce this; the generic settings PUT is the remaining path that must too.

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtil.java
@@ -91,84 +91,98 @@ public final class GlossaryTermRelationSettingsUtil {
     }
   }
 
+  /**
+   * Enforces the immutability contract for seeded (system-defined) relation types on the generic
+   * settings-update path. System-defined types cannot be removed or downgraded, no new type may be
+   * flagged as system-defined (create/promote), and an existing system-defined type's fields cannot
+   * be edited. Custom relation types are unaffected. The dedicated relationTypes endpoint and the UI
+   * already enforce this; this covers the remaining generic {@code PUT /system/settings} path.
+   */
   public static void validateSystemDefinedRelationTypesPreserved(
       GlossaryTermRelationSettings current, GlossaryTermRelationSettings updated) {
     if (current == null || current.getRelationTypes() == null) {
       return;
     }
 
-    Set<String> updatedSystemDefinedNames = new HashSet<>();
-    if (updated != null && updated.getRelationTypes() != null) {
-      for (GlossaryTermRelationType relationType : updated.getRelationTypes()) {
-        if (relationType != null && Boolean.TRUE.equals(relationType.getIsSystemDefined())) {
-          updatedSystemDefinedNames.add(relationType.getName());
-        }
+    Map<String, GlossaryTermRelationType> updatedByName = indexByName(updated);
+    validateNoSystemDefinedRemoved(current, updatedByName);
+    validateNoUnsanctionedSystemDefined(current, updated);
+    validateSystemDefinedUnmodified(current, updatedByName);
+  }
+
+  private static Map<String, GlossaryTermRelationType> indexByName(
+      GlossaryTermRelationSettings settings) {
+    Map<String, GlossaryTermRelationType> byName = new HashMap<>();
+    if (settings == null || settings.getRelationTypes() == null) {
+      return byName;
+    }
+    for (GlossaryTermRelationType relationType : settings.getRelationTypes()) {
+      if (relationType != null && relationType.getName() != null) {
+        byName.put(relationType.getName(), relationType);
       }
     }
+    return byName;
+  }
 
-    List<String> missingSystemDefinedNames =
-        current.getRelationTypes().stream()
-            .filter(relationType -> Boolean.TRUE.equals(relationType.getIsSystemDefined()))
-            .map(GlossaryTermRelationType::getName)
-            .filter(name -> !updatedSystemDefinedNames.contains(name))
-            .toList();
-    if (!missingSystemDefinedNames.isEmpty()) {
-      throw new SystemSettingsException(
-          "Cannot delete system-defined relation types: "
-              + String.join(", ", missingSystemDefinedNames));
+  private static void validateNoSystemDefinedRemoved(
+      GlossaryTermRelationSettings current, Map<String, GlossaryTermRelationType> updatedByName) {
+    List<String> removed = new ArrayList<>();
+    for (GlossaryTermRelationType currentType : current.getRelationTypes()) {
+      if (!Boolean.TRUE.equals(currentType.getIsSystemDefined())) {
+        continue;
+      }
+      GlossaryTermRelationType updatedType = updatedByName.get(currentType.getName());
+      if (updatedType == null || !Boolean.TRUE.equals(updatedType.getIsSystemDefined())) {
+        removed.add(currentType.getName());
+      }
     }
+    if (!removed.isEmpty()) {
+      throw new SystemSettingsException(
+          "Cannot delete system-defined relation types: " + String.join(", ", removed));
+    }
+  }
 
-    // system-defined is a seeded classification: a settings update must not create a new
-    // system-defined type or promote a custom type to system-defined. Only names already seeded
-    // as system-defined may carry isSystemDefined=true.
+  private static void validateNoUnsanctionedSystemDefined(
+      GlossaryTermRelationSettings current, GlossaryTermRelationSettings updated) {
+    if (updated == null || updated.getRelationTypes() == null) {
+      return;
+    }
     Set<String> currentSystemDefinedNames = new HashSet<>();
     for (GlossaryTermRelationType relationType : current.getRelationTypes()) {
       if (Boolean.TRUE.equals(relationType.getIsSystemDefined())) {
         currentSystemDefinedNames.add(relationType.getName());
       }
     }
-    List<String> illegallySystemDefinedNames = new ArrayList<>();
-    if (updated != null && updated.getRelationTypes() != null) {
-      for (GlossaryTermRelationType relationType : updated.getRelationTypes()) {
-        if (relationType != null
-            && Boolean.TRUE.equals(relationType.getIsSystemDefined())
-            && !currentSystemDefinedNames.contains(relationType.getName())) {
-          illegallySystemDefinedNames.add(relationType.getName());
-        }
+    List<String> unsanctioned = new ArrayList<>();
+    for (GlossaryTermRelationType updatedType : updated.getRelationTypes()) {
+      if (updatedType != null
+          && Boolean.TRUE.equals(updatedType.getIsSystemDefined())
+          && !currentSystemDefinedNames.contains(updatedType.getName())) {
+        unsanctioned.add(updatedType.getName());
       }
     }
-    if (!illegallySystemDefinedNames.isEmpty()) {
+    if (!unsanctioned.isEmpty()) {
       throw new SystemSettingsException(
           "Cannot create or promote system-defined relation types: "
-              + String.join(", ", illegallySystemDefinedNames));
+              + String.join(", ", unsanctioned));
     }
+  }
 
-    // System-defined relation types are immutable: their fields (e.g. isTransitive, color,
-    // category) must not be edited. The dedicated relationTypes endpoint and the UI already
-    // enforce this; the generic settings PUT is the remaining path that must too.
-    Map<String, GlossaryTermRelationType> updatedByName = new HashMap<>();
-    if (updated != null && updated.getRelationTypes() != null) {
-      for (GlossaryTermRelationType relationType : updated.getRelationTypes()) {
-        if (relationType != null && relationType.getName() != null) {
-          updatedByName.put(relationType.getName(), relationType);
-        }
-      }
-    }
-
-    List<String> modifiedSystemDefinedNames = new ArrayList<>();
+  private static void validateSystemDefinedUnmodified(
+      GlossaryTermRelationSettings current, Map<String, GlossaryTermRelationType> updatedByName) {
+    List<String> modified = new ArrayList<>();
     for (GlossaryTermRelationType currentType : current.getRelationTypes()) {
       if (!Boolean.TRUE.equals(currentType.getIsSystemDefined())) {
         continue;
       }
       GlossaryTermRelationType updatedType = updatedByName.get(currentType.getName());
       if (updatedType != null && isRelationTypeModified(currentType, updatedType)) {
-        modifiedSystemDefinedNames.add(currentType.getName());
+        modified.add(currentType.getName());
       }
     }
-    if (!modifiedSystemDefinedNames.isEmpty()) {
+    if (!modified.isEmpty()) {
       throw new SystemSettingsException(
-          "Cannot modify system-defined relation types: "
-              + String.join(", ", modifiedSystemDefinedNames));
+          "Cannot modify system-defined relation types: " + String.join(", ", modified));
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtil.java
@@ -14,13 +14,17 @@
 package org.openmetadata.service.util;
 
 import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import org.openmetadata.schema.configuration.GlossaryTermRelationSettings;
 import org.openmetadata.schema.configuration.GlossaryTermRelationType;
 import org.openmetadata.schema.configuration.RelationCardinality;
+import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.exception.SystemSettingsException;
 
 public final class GlossaryTermRelationSettingsUtil {
@@ -113,6 +117,47 @@ public final class GlossaryTermRelationSettingsUtil {
           "Cannot delete system-defined relation types: "
               + String.join(", ", missingSystemDefinedNames));
     }
+
+    // System-defined relation types are immutable: their fields (e.g. isTransitive, color,
+    // category) must not be edited. The dedicated relationTypes endpoint and the UI already
+    // enforce this; the generic settings PUT is the remaining path that must too.
+    Map<String, GlossaryTermRelationType> updatedByName = new HashMap<>();
+    if (updated != null && updated.getRelationTypes() != null) {
+      for (GlossaryTermRelationType relationType : updated.getRelationTypes()) {
+        if (relationType != null && relationType.getName() != null) {
+          updatedByName.put(relationType.getName(), relationType);
+        }
+      }
+    }
+
+    List<String> modifiedSystemDefinedNames = new ArrayList<>();
+    for (GlossaryTermRelationType currentType : current.getRelationTypes()) {
+      if (!Boolean.TRUE.equals(currentType.getIsSystemDefined())) {
+        continue;
+      }
+      GlossaryTermRelationType updatedType = updatedByName.get(currentType.getName());
+      if (updatedType != null && isRelationTypeModified(currentType, updatedType)) {
+        modifiedSystemDefinedNames.add(currentType.getName());
+      }
+    }
+    if (!modifiedSystemDefinedNames.isEmpty()) {
+      throw new SystemSettingsException(
+          "Cannot modify system-defined relation types: "
+              + String.join(", ", modifiedSystemDefinedNames));
+    }
+  }
+
+  private static boolean isRelationTypeModified(
+      GlossaryTermRelationType current, GlossaryTermRelationType updated) {
+    // Compare normalized copies so derived cardinality fields (sourceMax/targetMax) don't
+    // register as spurious edits when the stored value predates normalization.
+    GlossaryTermRelationType currentCopy =
+        JsonUtils.deepCopy(current, GlossaryTermRelationType.class);
+    GlossaryTermRelationType updatedCopy =
+        JsonUtils.deepCopy(updated, GlossaryTermRelationType.class);
+    normalize(currentCopy);
+    normalize(updatedCopy);
+    return !JsonUtils.valueToTree(currentCopy).equals(JsonUtils.valueToTree(updatedCopy));
   }
 
   private static RelationCardinality deriveCardinality(Integer sourceMax, Integer targetMax) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtilTest.java
@@ -115,6 +115,56 @@ class GlossaryTermRelationSettingsUtilTest {
   }
 
   @Test
+  void validateSystemDefinedRelationTypesRejectsNewSystemDefinedType() {
+    GlossaryTermRelationSettings current =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(List.of(relationType("partOf").withIsSystemDefined(true)));
+    GlossaryTermRelationSettings updated =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(
+                List.of(
+                    relationType("partOf").withIsSystemDefined(true),
+                    relationType("fakeSys").withIsSystemDefined(true)));
+
+    SystemSettingsException exception =
+        assertThrows(
+            SystemSettingsException.class,
+            () ->
+                GlossaryTermRelationSettingsUtil.validateSystemDefinedRelationTypesPreserved(
+                    current, updated));
+
+    assertEquals(
+        "Cannot create or promote system-defined relation types: fakeSys", exception.getMessage());
+  }
+
+  @Test
+  void validateSystemDefinedRelationTypesRejectsPromotionOfCustomType() {
+    GlossaryTermRelationSettings current =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(
+                List.of(
+                    relationType("partOf").withIsSystemDefined(true),
+                    relationType("dependsOn").withIsSystemDefined(false)));
+    GlossaryTermRelationSettings updated =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(
+                List.of(
+                    relationType("partOf").withIsSystemDefined(true),
+                    relationType("dependsOn").withIsSystemDefined(true)));
+
+    SystemSettingsException exception =
+        assertThrows(
+            SystemSettingsException.class,
+            () ->
+                GlossaryTermRelationSettingsUtil.validateSystemDefinedRelationTypesPreserved(
+                    current, updated));
+
+    assertEquals(
+        "Cannot create or promote system-defined relation types: dependsOn",
+        exception.getMessage());
+  }
+
+  @Test
   void validateSystemDefinedRelationTypesAllowsCustomTypeModification() {
     GlossaryTermRelationSettings current =
         new GlossaryTermRelationSettings()

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtilTest.java
@@ -93,6 +93,59 @@ class GlossaryTermRelationSettingsUtilTest {
                 current, updated));
   }
 
+  @Test
+  void validateSystemDefinedRelationTypesRejectsFieldModification() {
+    GlossaryTermRelationSettings current =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(
+                List.of(relationType("partOf").withIsSystemDefined(true).withIsTransitive(false)));
+    GlossaryTermRelationSettings updated =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(
+                List.of(relationType("partOf").withIsSystemDefined(true).withIsTransitive(true)));
+
+    SystemSettingsException exception =
+        assertThrows(
+            SystemSettingsException.class,
+            () ->
+                GlossaryTermRelationSettingsUtil.validateSystemDefinedRelationTypesPreserved(
+                    current, updated));
+
+    assertEquals("Cannot modify system-defined relation types: partOf", exception.getMessage());
+  }
+
+  @Test
+  void validateSystemDefinedRelationTypesAllowsCustomTypeModification() {
+    GlossaryTermRelationSettings current =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(
+                List.of(
+                    relationType("dependsOn").withIsSystemDefined(false).withIsTransitive(false)));
+    GlossaryTermRelationSettings updated =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(
+                List.of(
+                    relationType("dependsOn").withIsSystemDefined(false).withIsTransitive(true)));
+
+    // Custom (non system-defined) relation types remain fully editable.
+    GlossaryTermRelationSettingsUtil.validateSystemDefinedRelationTypesPreserved(current, updated);
+  }
+
+  @Test
+  void validateSystemDefinedRelationTypesAllowsUnchangedSystemType() {
+    GlossaryTermRelationSettings current =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(
+                List.of(relationType("partOf").withIsSystemDefined(true).withIsTransitive(false)));
+    GlossaryTermRelationSettings updated =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(
+                List.of(relationType("partOf").withIsSystemDefined(true).withIsTransitive(false)));
+
+    // Re-saving system-defined types unchanged (e.g. alongside a new custom type) must be allowed.
+    GlossaryTermRelationSettingsUtil.validateSystemDefinedRelationTypesPreserved(current, updated);
+  }
+
   private GlossaryTermRelationType relationType(String name) {
     return new GlossaryTermRelationType().withName(name);
   }


### PR DESCRIPTION
## Describe your changes

Fixes #31864.

System-defined glossary relation types (`relatedTo`, `synonym`, `antonym`, `broader`, `narrower`, `partOf`, `hasPart`, `calculatedFrom`, `usedToCalculate`, `seeAlso`; `isSystemDefined: true`) are a **seeded, immutable** classification. Immutability was enforced on two of the three write paths but **not** the third:

| Write path | Enforced immutability before this PR? |
|---|---|
| **UI** — Glossary Term Relations settings page | ✅ edit/delete disabled for system-defined rows |
| **Dedicated API** — `POST/PUT/DELETE /v1/system/settings/glossaryTermRelationSettings/relationTypes[/{name}]` | ✅ create force-sets `isSystemDefined=false`; update/delete reject system-defined |
| **Generic API** — `PUT /v1/system/settings` (whole `glossaryTermRelationSettings` blob) | ❌ **only** blocked *removing* a system-defined type and *duplicate* names |

On the generic path, `SystemResource.validateGlossaryTermRelationSettingsUpdate` → `GlossaryTermRelationSettingsUtil.validateSystemDefinedRelationTypesPreserved` checked only that system-defined **names** were still present. It did not stop editing their fields, nor fabricating/promoting new system-defined types — so an admin could silently bypass the guard the UI and dedicated endpoint enforce.

This PR closes the gap by extending that validation (already invoked on the generic path) to enforce the **full** immutability contract for the seeded types, while leaving custom relation types fully editable.

## Scenario coverage (verified)

All exercised as unit tests / behavior probes against the changed code:

| # | Scenario | Before | After |
|---|---|---|---|
| S1 | Edit a **field** of a system-defined type (`partOf.isTransitive`, `color`, `category`, `description`, `cardinality`, …) | allowed ❌ | **blocked** — `Cannot modify system-defined relation types: <names>` |
| S2 | **Rename** a system-defined type (drop old name, add new) | blocked | **blocked** — `Cannot delete system-defined relation types: <names>` |
| S3 | **Delete** a system-defined type | blocked | **blocked** — `Cannot delete system-defined relation types: <names>` |
| S4 | **Downgrade** a system-defined type (`isSystemDefined` true→false) | blocked | **blocked** — `Cannot delete system-defined relation types: <names>` |
| S5 | **Create** a new type flagged `isSystemDefined: true` | allowed ❌ | **blocked** — `Cannot create or promote system-defined relation types: <names>` |
| S6 | **Promote** an existing custom type to `isSystemDefined: true` | allowed ❌ | **blocked** — `Cannot create or promote system-defined relation types: <names>` |
| S7 | Add a new **custom** type (`isSystemDefined: false`) | allowed | **allowed** ✅ |
| S8 | Edit a **custom** type's fields | allowed | **allowed** ✅ |
| S9 | Delete an unused **custom** type | allowed | **allowed** ✅ (in-use types still blocked by the existing usage check) |
| S10 | **Reorder** relation types, no field change | allowed | **allowed** ✅ |
| S11 | Re-save system-defined types **unchanged** (e.g. alongside a new custom type) | allowed | **allowed** ✅ (normalized comparison, so derived `sourceMax`/`targetMax` don't false-positive) |

Net: on the generic settings PUT, **only already-seeded names may carry `isSystemDefined: true`, they cannot be edited/renamed/removed/downgraded, and no new system-defined type can be created or promoted.** Custom types are unaffected.

## Implementation

`GlossaryTermRelationSettingsUtil.validateSystemDefinedRelationTypesPreserved` split into single-responsibility helpers (index built once):
- `validateNoSystemDefinedRemoved` — delete / rename / downgrade (S2–S4)
- `validateNoUnsanctionedSystemDefined` — create / promote (S5–S6)
- `validateSystemDefinedUnmodified` — field edits, compared on **normalized** copies (S1, S11)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How was this change tested?

**Unit** (`GlossaryTermRelationSettingsUtilTest`, TDD RED→GREEN): rejects field modification of a system-defined type, rejects a new `isSystemDefined:true` type, rejects promoting a custom type; allows custom-type edits and unchanged re-saves. `Tests run: 9, Failures: 0`.

**Integration** (`GlossaryTermRelationSettingsIT`): real `PUT /v1/system/settings` rejects a field edit to a system-defined type and rejects creating a new system-defined type (complements the existing delete-protection IT).

**Live end-to-end** on a fresh instance built from this branch (Postgres + OpenSearch), exercised via the REST API as admin — all scenarios returned HTTP 400 with the expected messages (modify / create / promote / delete) and HTTP 200 for custom-type add; settings baseline preserved after every rejected attempt.


## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR strengthens glossary relation-type validation on the generic settings PUT path so seeded system-defined types cannot be modified, removed, downgraded, fabricated, or promoted.
- Splits system-defined validation into removal, unsanctioned-creation, and modification checks.
- Normalizes relation-type copies before comparing immutable fields.
- Adds unit and integration coverage for rejected mutations and permitted custom-type updates.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtil.java | Extends generic settings validation to enforce removal, promotion, and field-level immutability constraints for system-defined relation types. |
| openmetadata-service/src/test/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtilTest.java | Adds focused unit coverage for immutable system types and editable custom types. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationSettingsIT.java | Adds endpoint-level checks that forbidden system-defined mutations are rejected without persistence. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Generic settings PUT] --> B[Normalize relation settings]
  B --> C[Validate unique names]
  C --> D[Load current settings]
  D --> E[Reject removed or downgraded seeded types]
  E --> F[Reject fabricated or promoted system-defined types]
  F --> G[Reject modified seeded type fields]
  G --> H[Persist validated settings]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["test(glossary): IT coverage for system-d..."](https://github.com/open-metadata/openmetadata/commit/244bbfde421df67f37765e07a49904d2a578281a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55470180)</sub>

<!-- /greptile_comment -->