### PR TITLE
fix(playwright): fix ingestionBotPage execution context race with service worker

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/IngestionBot.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/IngestionBot.spec.ts
@@ -41,15 +41,16 @@ const test = base.extend<{
   ingestionBotPage: async ({ browser }, use) => {
     const { apiContext, afterAction } = await performAdminLogin(browser);
 
-    const page = await browser.newPage();
-    await page.goto('/');
-
     const bot = await apiContext
       .get('/api/v1/bots/name/ingestion-bot')
       .then((response) => response.json());
     const tokenData = await apiContext
       .get(`/api/v1/users/auth-mechanism/${bot.botUser.id}`)
       .then((response) => response.json());
+
+    const page = await browser.newPage();
+    await page.goto('/signin');
+    await page.waitForFunction(() => Boolean(navigator.serviceWorker?.controller));
 
     await setToken(page, tokenData.config.JWTToken);
     await redirectToHomePage(page);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/IngestionBot.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/IngestionBot.spec.ts
@@ -50,7 +50,9 @@ const test = base.extend<{
 
     const page = await browser.newPage();
     await page.goto('/signin');
-    await page.waitForFunction(() => Boolean(navigator.serviceWorker?.controller));
+    await page.waitForFunction(() =>
+      Boolean(navigator.serviceWorker?.controller)
+    );
 
     await setToken(page, tokenData.config.JWTToken);
     await redirectToHomePage(page);


### PR DESCRIPTION
### Describe your changes:

<!-- Fixes #<issue-number> -->

Fixed a race condition in the `ingestionBotPage` Playwright fixture that caused intermittent (and on CI, consistent) failures with `Error: page.evaluate: Execution context was destroyed, most likely because of a navigation.`

**Root cause:** `app-worker.js` calls `self.clients.claim()` during service worker activation, which causes Playwright to destroy and recreate the page's JS execution context. The original fixture called `setToken` (which uses `page.evaluate` to write to IndexedDB) immediately after `page.goto('/')`, racing with this SW activation. On CI/AUT the SW activation takes 60–150ms while the two API calls complete in ~22ms total — so the race was lost on every CI run.

<img width="552" height="262" alt="Screenshot 2026-08-21 at 12 59 16 PM" src="https://github.com/user-attachments/assets/f718db5c-21be-4bdd-b598-974c4c7547ca" />


**Fix:**
- Fetch bot credentials via `apiContext` *before* creating the page, eliminating any overlap between API calls and page navigation.
- Navigate to `/signin` (stable pre-auth page the app won't redirect away from) instead of `/`.
- Wait for `navigator.serviceWorker?.controller` to be truthy before calling `setToken`, ensuring `clients.claim()` has fully completed and the execution context is stable.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- `ingestionBotPage` fixture sets up a browser session as the ingestion-bot user without flaking on CI.

#### Unit tests
- [ ] Not applicable (Playwright fixture change only).

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] The fix is in the Playwright fixture itself (`IngestionBot.spec.ts`). The test exercises the ingestion-bot domain access flow end-to-end.

#### Manual testing performed
1. Ran `yarn playwright:run --grep "Ingestion Bot"` against AUT — previously failing consistently, passes with this fix.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: N/A.
- [x] For UI changes: N/A.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing.



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The fixture now retrieves ingestion-bot credentials before creating its page, opens the stable sign-in route, and waits for service-worker control before writing the token.
- Moves credential API requests ahead of browser-page navigation.
- Synchronizes token injection with service-worker activation.
- Preserves the existing authenticated home-page setup flow.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/IngestionBot.spec.ts | Reorders fixture initialization and adds service-worker synchronization to prevent execution-context destruction during token setup. |

</details>

<sub>Reviews (2): Last reviewed commit: ["lint fix"](https://github.com/open-metadata/openmetadata/commit/6c2e4a82f224009ddf0497b3faa20bcf4fb355cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55474744)</sub>

<!-- /greptile_comment -->