### PR TITLE
fix(ui): make whole Domain and Data Product rows clickable

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx
@@ -173,7 +173,10 @@ const DataProductListPage = ({
               align="center"
               className={NAME_CELL_CLIP_CLASS}
               direction="row"
-              gap={3}>
+              gap={3}
+              onClick={() =>
+                dataProductListing.actionHandlers.onEntityClick?.(entity)
+              }>
               <Avatar size="md" {...getEntityAvatarProps(entity)} />
               <Box className="tw:min-w-0" direction="col">
                 <Typography
@@ -250,7 +253,7 @@ const DataProductListPage = ({
           return null;
       }
     },
-    []
+    [dataProductListing.actionHandlers.onEntityClick]
   );
 
   const selectedDataProductEntities = useMemo(

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx
@@ -23,7 +23,14 @@ import {
 import { Globe01, Package, Plus } from '@untitledui/icons';
 import classNames from 'classnames';
 import { isEmpty } from 'lodash';
-import { FC, ReactNode, useCallback, useMemo, useState } from 'react';
+import {
+  FC,
+  MouseEvent,
+  ReactNode,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { NO_DATA, ROUTES } from '../../constants/constants';
 import { LEARNING_PAGE_IDS } from '../../constants/Learning.constants';
@@ -168,15 +175,18 @@ const DataProductListPage = ({
             entity.name &&
             entity.displayName !== entity.name;
 
+          const handleNameClick = (event: MouseEvent<HTMLDivElement>) => {
+            event.stopPropagation();
+            dataProductListing.actionHandlers.onEntityClick?.(entity);
+          };
+
           return (
             <Box
               align="center"
               className={NAME_CELL_CLIP_CLASS}
               direction="row"
               gap={3}
-              onClick={() =>
-                dataProductListing.actionHandlers.onEntityClick?.(entity)
-              }>
+              onClick={handleNameClick}>
               <Avatar size="md" {...getEntityAvatarProps(entity)} />
               <Box className="tw:min-w-0" direction="col">
                 <Typography

--- a/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/DomainListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/DomainListPage.tsx
@@ -132,7 +132,9 @@ const DomainListPage = ({ renderPageHeader }: DomainListPageProps) => {
   const { renderDomainCard } = useDomainCardTemplates();
 
   const { columns: domainColumns, renderCell: renderDomainCell } =
-    useDomainTableColumns();
+    useDomainTableColumns({
+      onEntityClick: domainListing.actionHandlers.onEntityClick,
+    });
 
   const selectedDomainEntities = useMemo(
     () =>

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.test.tsx
@@ -1,0 +1,79 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { Domain } from '../../../../../generated/entity/domains/domain';
+import { renderDomainNameCell } from './domainFieldRenderers';
+
+jest.mock('@openmetadata/ui-core-components', () => ({
+  Avatar: () => <span data-testid="avatar" />,
+  Box: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+  }) => (
+    <div data-testid="name-cell" onClick={onClick}>
+      {children}
+    </div>
+  ),
+  Typography: ({ children }: { children: ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+
+jest.mock('../../../../../utils/TooltipUtils', () => ({
+  renderBreakableTooltip: (value: string) => value,
+}));
+
+const DOMAIN = {
+  id: 'domain-id',
+  name: 'engineering',
+  displayName: 'Engineering',
+  fullyQualifiedName: 'engineering',
+} as Domain;
+
+describe('renderDomainNameCell', () => {
+  it('navigates once when the name cell is clicked', () => {
+    const onClick = jest.fn();
+
+    render(<>{renderDomainNameCell(DOMAIN, onClick)}</>);
+    fireEvent.click(screen.getByText('Engineering'));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops the click from bubbling to the row so navigation is not duplicated', () => {
+    const onClick = jest.fn();
+    const rowClick = jest.fn();
+
+    render(
+      <div onClick={rowClick}>{renderDomainNameCell(DOMAIN, onClick)}</div>
+    );
+    fireEvent.click(screen.getByText('Engineering'));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(rowClick).not.toHaveBeenCalled();
+  });
+
+  it('does not attach a click handler when no onClick is provided', () => {
+    const rowClick = jest.fn();
+
+    render(<div onClick={rowClick}>{renderDomainNameCell(DOMAIN)}</div>);
+    fireEvent.click(screen.getByText('Engineering'));
+
+    // With no cell handler the click falls through to the row unchanged.
+    expect(rowClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Avatar, Box, Typography } from '@openmetadata/ui-core-components';
-import { ReactNode } from 'react';
+import { MouseEvent, ReactNode } from 'react';
 import { NO_DATA } from '../../../../../constants/constants';
 import { DataProduct } from '../../../../../generated/entity/domains/dataProduct';
 import { Domain } from '../../../../../generated/entity/domains/domain';
@@ -74,13 +74,18 @@ export const renderDomainNameCell = (
 ): ReactNode => {
   const entityName = getEntityName(entity);
 
+  const handleNameClick = (event: MouseEvent<HTMLDivElement>) => {
+    event.stopPropagation();
+    onClick?.();
+  };
+
   return (
     <Box
       align="center"
       className={NAME_CELL_CLIP_CLASS}
       direction="row"
       gap={3}
-      onClick={onClick}>
+      onClick={onClick ? handleNameClick : undefined}>
       <Avatar size="md" {...getEntityAvatarProps(entity)} />
       <Typography
         className={CLIPPED_NAME_CLASS}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.tsx
@@ -69,7 +69,8 @@ export const LIST_EMPTY_STATE_CLASS =
   'tw:flex tw:flex-1 tw:min-h-60 tw:items-center tw:justify-center';
 
 export const renderDomainNameCell = (
-  entity: Domain | DataProduct
+  entity: Domain | DataProduct,
+  onClick?: () => void
 ): ReactNode => {
   const entityName = getEntityName(entity);
 
@@ -78,7 +79,8 @@ export const renderDomainNameCell = (
       align="center"
       className={NAME_CELL_CLIP_CLASS}
       direction="row"
-      gap={3}>
+      gap={3}
+      onClick={onClick}>
       <Avatar size="md" {...getEntityAvatarProps(entity)} />
       <Typography
         className={CLIPPED_NAME_CLASS}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/useDomainTableColumns.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/useDomainTableColumns.test.tsx
@@ -1,0 +1,78 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { fireEvent, render, renderHook, screen } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { Domain } from '../../../../../generated/entity/domains/domain';
+import { useDomainTableColumns } from './useDomainTableColumns';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('@openmetadata/ui-core-components', () => ({
+  Avatar: () => <span data-testid="avatar" />,
+  Box: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+  }) => (
+    <div data-testid="name-cell" onClick={onClick}>
+      {children}
+    </div>
+  ),
+  Typography: ({ children }: { children: ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+
+jest.mock('../../../../../utils/TooltipUtils', () => ({
+  renderBreakableTooltip: (value: string) => value,
+}));
+
+const DOMAIN = {
+  id: 'domain-id',
+  name: 'engineering',
+  displayName: 'Engineering',
+  fullyQualifiedName: 'engineering',
+} as Domain;
+
+describe('useDomainTableColumns', () => {
+  it('routes a name-cell click to onEntityClick with the row entity', () => {
+    const onEntityClick = jest.fn();
+
+    const { result } = renderHook(() =>
+      useDomainTableColumns({ onEntityClick })
+    );
+
+    render(<>{result.current.renderCell(DOMAIN, 'name')}</>);
+    fireEvent.click(screen.getByText('Engineering'));
+
+    expect(onEntityClick).toHaveBeenCalledTimes(1);
+    expect(onEntityClick).toHaveBeenCalledWith(DOMAIN);
+  });
+
+  it('renders the name cell without a click handler when onEntityClick is omitted', () => {
+    const rowClick = jest.fn();
+
+    const { result } = renderHook(() => useDomainTableColumns());
+
+    render(
+      <div onClick={rowClick}>{result.current.renderCell(DOMAIN, 'name')}</div>
+    );
+    fireEvent.click(screen.getByText('Engineering'));
+
+    expect(rowClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/useDomainTableColumns.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/useDomainTableColumns.tsx
@@ -26,11 +26,13 @@ import {
 interface UseDomainTableColumnsOptions {
   nameLabelKey?: string;
   tagSize?: 'sm' | 'lg';
+  onEntityClick?: (entity: Domain) => void;
 }
 
 export const useDomainTableColumns = ({
   nameLabelKey = 'label.domain',
   tagSize = 'sm',
+  onEntityClick,
 }: UseDomainTableColumnsOptions = {}) => {
   const { t } = useTranslation();
 
@@ -49,7 +51,10 @@ export const useDomainTableColumns = ({
     (entity: Domain, columnId: string): ReactNode => {
       switch (columnId) {
         case 'name':
-          return renderDomainNameCell(entity);
+          return renderDomainNameCell(
+            entity,
+            onEntityClick ? () => onEntityClick(entity) : undefined
+          );
         case 'domainType':
           return renderDomainTypeCell(entity);
         case 'owners':
@@ -62,7 +67,7 @@ export const useDomainTableColumns = ({
           return null;
       }
     },
-    [tagSize]
+    [tagSize, onEntityClick]
   );
 
   return { columns, renderCell };


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #31874 

On the Domain and Data Product list pages, clicking a row was supposed to open that item's details page, but clicking on the name (or the area around it) did nothing, so the row felt only partly clickable. 

https://github.com/user-attachments/assets/7e520995-b823-4be5-9e76-f6efd64e071d


https://github.com/user-attachments/assets/2d95ba94-2247-4363-961c-0b39b2d6b788



#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->






<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This follow-up completes the row-click navigation fix for Domain and Data Product listings.
- Routes name-cell clicks through the existing entity navigation handlers.
- Stops name-cell clicks from bubbling to the row and triggering duplicate navigation.
- Adds focused tests for callback routing and propagation behavior.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx | Adds a propagation-safe Data Product name-cell click handler and keeps its callback dependency current. |
| openmetadata-ui/src/main/resources/ui/src/components/DomainListing/DomainListPage.tsx | Supplies the Domain entity navigation callback to the shared table-column renderer. |
| openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.tsx | Makes Domain name cells clickable while preventing the same gesture from reaching row navigation. |
| openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/useDomainTableColumns.tsx | Wires each Domain entity into the optional name-cell navigation callback. |
| openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.test.tsx | Verifies single callback invocation, propagation suppression, and behavior without a cell callback. |
| openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/useDomainTableColumns.test.tsx | Verifies that Domain name-cell clicks receive the correct entity and preserve fallback row handling. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Added unit test for the fix"](https://github.com/open-metadata/openmetadata/commit/00ffda8192da721441f265ea35da7b002c5822d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55498461)</sub>

<!-- /greptile_comment -->