### PR TITLE
test(it): accept multi-select testCaseStatus[] URL in DQ dashboard pie nav (2.0)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/ui/pages/DataQualityDashboardPage.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/ui/pages/DataQualityDashboardPage.java
@@ -56,10 +56,16 @@ public final class DataQualityDashboardPage extends PageObject {
 
   /**
    * Click the first available pie chart segment and assert the URL navigates to
-   * {@code /data-quality/test-cases} carrying ANY {@code testCaseStatus=} param.
+   * {@code /data-quality/test-cases} carrying ANY {@code testCaseStatus} param.
    * Recharts only renders segments for non-zero data and the rendering order isn't
    * stable across data shapes, so this method asserts the navigation contract
    * rather than a specific segment-to-status mapping.
+   *
+   * <p>The status filter is multi-select, so a segment may map to one status
+   * ({@code testCaseStatus=Failed}) or several, which serialize with bracket array
+   * syntax ({@code testCaseStatus[]=Failed&testCaseStatus[]=Aborted}, URL-encoded as
+   * {@code testCaseStatus%5B%5D=}). The pattern accepts the bare, literal-bracket, and
+   * encoded-bracket forms so both single- and multi-status pies satisfy the contract.
    */
   public DataQualityDashboardPage clickPieChartSegmentExpectsStatusNav(final String chartId) {
     final Locator segment =
@@ -68,7 +74,7 @@ public final class DataQualityDashboardPage extends PageObject {
         .isVisible(new LocatorAssertions.IsVisibleOptions().setTimeout(15_000));
     segment.evaluate("el => el.dispatchEvent(new MouseEvent('click', { bubbles: true }))");
     page.waitForURL(
-        Pattern.compile("/data-quality/test-cases.*testCaseStatus="),
+        Pattern.compile("/data-quality/test-cases.*testCaseStatus(%5B%5D|\\[\\])?="),
         new Page.WaitForURLOptions().setTimeout(20_000));
     return this;
   }


### PR DESCRIPTION
2.0 backport of #31880.

## Problem

`DataQualityDashboardDimensionAndPieReindexUIIT.dashboardNavigationSurvivesReindex` fails on the 2.0 nightly with a 20s Playwright timeout at the Entity Health pie step.

## Root cause

PR #31662 (*add multi-select test case status filter*, on both `main` and `2.0`) changed `BINARY_STATUS_PIE_SEGMENT_ORDER` to `TestCaseStatus[][]`. The Entity Health pie now navigates with an array of statuses, serialized as `testCaseStatus[]=Failed&testCaseStatus[]=Aborted` (URL-encoded `testCaseStatus%5B%5D=`), not a bare `testCaseStatus=`. The Java IT page object still waited on the old `testCaseStatus=` regex → `waitForURL` never matched → timeout.

## Fix

Widen the `waitForURL` pattern to accept the bare, literal-bracket, and encoded-bracket forms (`testCaseStatus(%5B%5D|\[\])?=`), mirroring the TS spec change that shipped in #31662. Test-only change.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This test-only backport updates the Data Quality dashboard page object to recognize single- and multi-select test-case status query parameters.
- Accepts bare, literal-bracket, and percent-encoded bracket forms in the navigation URL.
- Documents why Entity Health pie segments may navigate with multiple statuses.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The updated expression accepts the actual encoded multi-status query key while continuing to require the expected test-cases route and status parameter.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/ui/pages/DataQualityDashboardPage.java | Correctly broadens the navigation assertion to match the URL encoding produced for multi-select status filters without weakening the route or required-parameter checks. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(it): accept multi-select testCaseSt..."](https://github.com/open-metadata/openmetadata/commit/87fecc6fa1c7774b6a67f420500640884f158845) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55517357)</sub>

<!-- /greptile_comment -->