### PR TITLE
fix(tests): profile in setUpClass so test_list_entity_profiles has data

### DIFF
--- a/ingestion/tests/integration/profiler/test_sqa_profiler.py
+++ b/ingestion/tests/integration/profiler/test_sqa_profiler.py
@@ -19,7 +19,7 @@ No sample data is required beforehand
 import json
 import time
 from typing import List  # noqa: UP035
-from unittest import TestCase, TestLoader
+from unittest import TestCase
 
 from _openmetadata_testutils.ometa import int_admin_ometa
 from metadata.generated.schema.configuration.profilerConfiguration import (
@@ -39,8 +39,6 @@ from ..integration_base import (  # noqa: TID252
     METADATA_INGESTION_CONFIG_TEMPLATE,
     PROFILER_INGESTION_CONFIG_TEMPLATE,
 )
-
-TestLoader.sortTestMethodsUsing = None  # type: ignore
 
 
 class TestSQAProfiler(TestCase):
@@ -67,9 +65,42 @@ class TestSQAProfiler(TestCase):
                 ingestion_workflow.execute()
                 ingestion_workflow.raise_from_status()
                 ingestion_workflow.stop()
+
+            # Profile here rather than inside a test method. pytest orders TestCase
+            # methods alphabetically, so test_list_entity_profiles runs *before*
+            # test_profiler_workflow and would otherwise assert on profiles that do
+            # not exist yet. It only ever passed because hard-deleted tables used to
+            # leak their profiler rows into the window it queries (issue #27041, fixed
+            # in #31556). Profiles are class fixture data, so they belong here.
+            cls.run_profiler_workflows()
         except Exception as e:
             cls.container_builder.stop_all_containers()
             raise e  # noqa: TRY201
+
+    @classmethod
+    def run_profiler_workflows(cls):
+        """Run the profiler over every container, using the active profiler settings."""
+        for container in cls.container_builder.containers:
+            config = PROFILER_INGESTION_CONFIG_TEMPLATE.format(
+                type=container.connector_type,
+                service_config=container.get_config(),
+                service_name=type(container).__name__,
+            )
+            profiler_workflow = ProfilerWorkflow.create(json.loads(config))
+            profiler_workflow.execute()
+            profiler_workflow.print_status()
+            profiler_workflow.raise_from_status()
+            profiler_workflow.stop()
+
+    def list_profiled_tables(self):
+        """The tables the fixture ingested, across every container."""
+        tables: List[Table] = []  # noqa: UP006
+        for container in self.container_builder.containers:
+            service_name = type(container).__name__
+            cfg = json.loads(container.get_config())
+            db_name = cfg.get("database") or cfg.get("databaseSchema", "default")
+            tables.extend(self.metadata.list_all_entities(Table, params={"database": f"{service_name}.{db_name}"}))
+        return tables
 
     @classmethod
     def tearDownClass(cls):
@@ -93,31 +124,8 @@ class TestSQAProfiler(TestCase):
         cls.metadata.create_or_update_settings(settings)
 
     def test_profiler_workflow(self):
-        """test a simple profiler workflow on a table in each service and validate the profile is created"""
-        for container in self.container_builder.containers:
-            try:
-                config = PROFILER_INGESTION_CONFIG_TEMPLATE.format(
-                    type=container.connector_type,
-                    service_config=container.get_config(),
-                    service_name=type(container).__name__,
-                )
-                profiler_workflow = ProfilerWorkflow.create(
-                    json.loads(config),
-                )
-                profiler_workflow.execute()
-                profiler_workflow.print_status()
-                profiler_workflow.raise_from_status()
-                profiler_workflow.stop()
-            except Exception as e:
-                self.fail(f"Profiler workflow failed for {type(container).__name__} with error {e}")
-
-        tables: List[Table] = []  # noqa: UP006
-        for container in self.container_builder.containers:
-            service_name = type(container).__name__
-            cfg = json.loads(container.get_config())
-            db_name = cfg.get("database") or cfg.get("databaseSchema", "default")
-            tables.extend(self.metadata.list_all_entities(Table, params={"database": f"{service_name}.{db_name}"}))
-        for table in tables:
+        """validate the profile the fixture's profiler run created for a table in each service"""
+        for table in self.list_profiled_tables():
             if table.name.root != "users":
                 continue
             table = self.metadata.get_latest_table_profile(table.fullyQualifiedName)  # noqa: PLW2901
@@ -146,34 +154,10 @@ class TestSQAProfiler(TestCase):
         )
         self.metadata.create_or_update_settings(settings)
 
-        service_names = []
+        # Re-profile so the metric-level settings above take effect.
+        self.run_profiler_workflows()
 
-        for container in self.container_builder.containers:
-            try:
-                service_name = type(container).__name__
-                service_names.append(service_name)
-                config = PROFILER_INGESTION_CONFIG_TEMPLATE.format(
-                    type=container.connector_type,
-                    service_config=container.get_config(),
-                    service_name=service_name,
-                )
-                profiler_workflow = ProfilerWorkflow.create(
-                    json.loads(config),
-                )
-                profiler_workflow.execute()
-                profiler_workflow.print_status()
-                profiler_workflow.raise_from_status()
-                profiler_workflow.stop()
-            except Exception as e:
-                self.fail(f"Profiler workflow failed for {service_name} with error {e}")
-
-        tables: List[Table] = []  # noqa: UP006
-        for container in self.container_builder.containers:
-            sn = type(container).__name__
-            cfg = json.loads(container.get_config())
-            db_name = cfg.get("database") or cfg.get("databaseSchema", "default")
-            tables.extend(self.metadata.list_all_entities(Table, params={"database": f"{sn}.{db_name}"}))
-        for table in tables:
+        for table in self.list_profiled_tables():
             if table.name.root != "users":
                 continue
             table = self.metadata.get_latest_table_profile(table.fullyQualifiedName)  # noqa: PLW2901
@@ -201,13 +185,17 @@ class TestSQAProfiler(TestCase):
         self.assertTrue(hasattr(profiles_all, "total"))
         self.assertTrue(hasattr(profiles_all, "entities"))
 
-        if profiles_all.entities:
-            first = profiles_all.entities[0]
-            self.assertIsInstance(first, EntityProfile)
-            self.assertIsNotNone(first.id)
-            self.assertIsNotNone(first.entityReference)
-            self.assertIsNotNone(first.timestamp)
-            self.assertIsNotNone(first.profileData)
+        # Assert rather than guard: setUpClass profiles every container, so an empty
+        # window is a real failure. Skipping it here only pushed the failure two lines
+        # down, hiding whether the unfiltered listing was empty too.
+        self.assertGreater(len(profiles_all.entities), 0)
+
+        first = profiles_all.entities[0]
+        self.assertIsInstance(first, EntityProfile)
+        self.assertIsNotNone(first.id)
+        self.assertIsNotNone(first.entityReference)
+        self.assertIsNotNone(first.timestamp)
+        self.assertIsNotNone(first.profileData)
 
         profiles_table = get_profiles(Table, start_ts, end_ts, ProfileTypeEnum.table)
         self.assertGreater(len(profiles_table.entities), 0)


### PR DESCRIPTION
Fixes the `py-tests` / `py-tests-postgres` **shard-2** failure that is currently blocking the merge queue for every PR that touches ingestion.

```
FAILED tests/integration/profiler/test_sqa_profiler.py::TestSQAProfiler::test_list_entity_profiles
>       self.assertGreater(len(profiles_table.entities), 0)
E       AssertionError: 0 not greater than 0
```

## Root cause

`test_list_entity_profiles` runs **first** in its class — before the two tests that create the profiles it asserts on. pytest orders `unittest.TestCase` methods alphabetically (`l` < `p`), and the module-level `TestLoader.sortTestMethodsUsing = None` intended to force definition order **only affects unittest’s own loader**; pytest collects `TestCase` methods itself and ignores it.

Verified against an unmodified checkout — with that line present, collection still yields:

```
TestSQAProfiler::test_list_entity_profiles          <-- runs first
TestSQAProfiler::test_profiler_workflow
TestSQAProfiler::test_profiler_workflow_w_globale_config
```

The CI artifacts agree: the junit XML records `test_list_entity_profiles` executing first, with the other two passing afterwards.

## Why it passed until 2026-08-20

The test asserts on a **global 24-hour window across every table** rather than on data it owns. Hard-deleted tables used to leak their profiler rows into that window, so unrelated tests earlier in the shard left behind enough data to satisfy it.

#31556 fixed that leak (issue #27041). The server log from a failing run shows the new purge doing exactly its job:

```
INFO o.o.s.j.TableRepository - Purged 10 profiler row(s) for hard-deleted table
     docker_test_mssql_2b436f53_mssql_pytds.AdventureWorksLT2022.dbo.ErrorLog
```

26 such purges in a single run. With the leak gone, the window is genuinely empty when the listing test runs, and a test that was always logically broken finally started reporting it. **#31556 is correct and should not be reverted.**

## Why it looked branch-specific

PRs that do not touch ingestion skip the integration matrix entirely and report green. Across ~40 recent `py-tests-postgres` runs, every "pass" had `python / Integration Tests` **skipped**, and every run that actually executed it failed. So the queue looks healthy while rejecting all ingestion PRs — currently `fix/expat-cve-2026-72522`, `fix/airflow-3.3.1-cve`, `taipei`, `pr-31761` and `ayush-shah/ingestion-source-config-type`.

## The change

- Run the profiler in `setUpClass` via a new `run_profiler_workflows()` helper, so profiles are class fixture data and no test depends on another’s ordering. This also removes one redundant profiler run.
- Extract `list_profiled_tables()`, which was duplicated across both workflow tests.
- Drop the ineffective `TestLoader.sortTestMethodsUsing` hack rather than leave code that looks like it controls ordering.
- Turn `if profiles_all.entities:` into an assertion. That guard swallowed an empty *unfiltered* listing and hid which of the two calls was empty — the one signal needed to diagnose this.

`test_profiler_workflow_w_globale_config` still re-profiles itself, since it must run after changing the global metric settings.

## Verification

- `ruff check` clean, `ruff format` clean.
- Collection order confirmed before and after.
- The endpoint itself was verified healthy against a server running this same code (`/v1/entity/profiles/table` returned 6 table + 37 column profiles), confirming the API is fine and the defect is purely test ordering.

Full integration run is on CI — it needs Docker testcontainers plus a live server.



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Moves the initial profiler execution into class setup so profile-listing tests have deterministic fixture data regardless of test order.
- Extracts reusable profiler execution and profiled-table listing helpers.
- Keeps the global-settings test’s explicit re-profiling step.
- Replaces the conditional unfiltered-profile check with a required non-empty assertion.
- Removes the ineffective unittest loader-order override.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/tests/integration/profiler/test_sqa_profiler.py | Establishes profile data during class setup and consolidates duplicated profiler-test helpers without an eligible follow-up defect. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/profiler-te..."](https://github.com/open-metadata/openmetadata/commit/f2eea00777537d12dd14e12308b34dc31bf6ed75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55518325)</sub>

<!-- /greptile_comment -->