### PR TITLE
ci: scope spotless to changed Java files via -DspotlessFiles

### DIFF
--- a/.github/workflows/release-branch-validate.yml
+++ b/.github/workflows/release-branch-validate.yml
@@ -46,10 +46,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - name: Checkout with history
+      - name: Checkout with parent
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          # Shallow: just HEAD and HEAD~1. Multi-commit pushes fetch the
+          # older base on demand in the "Determine changed X files" step.
+          fetch-depth: 2
           persist-credentials: false
 
       - name: Determine changed Java files
@@ -61,6 +63,9 @@ jobs:
           if [ -z "${BEFORE}" ] || [ "${BEFORE}" = "0000000000000000000000000000000000000000" ]; then
             BASE=$(git rev-parse HEAD~1)
           else
+            # Multi-commit push: BEFORE may be older than the shallow depth 2
+            # checkout carries, so pull just that one object on demand.
+            git cat-file -e "${BEFORE}" 2>/dev/null || git fetch --depth=1 origin "${BEFORE}"
             BASE="${BEFORE}"
           fi
           CHANGED=$(git diff --name-only --diff-filter=ACMR "${BASE}" HEAD -- '*.java' | tr '\n' ' ')
@@ -115,10 +120,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Checkout with history
+      - name: Checkout with parent
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          # Shallow: just HEAD and HEAD~1. Multi-commit pushes fetch the
+          # older base on demand in the "Determine changed X files" step.
+          fetch-depth: 2
           persist-credentials: false
 
       - name: Determine changed Python files
@@ -130,6 +137,9 @@ jobs:
           if [ -z "${BEFORE}" ] || [ "${BEFORE}" = "0000000000000000000000000000000000000000" ]; then
             BASE=$(git rev-parse HEAD~1)
           else
+            # Multi-commit push: BEFORE may be older than the shallow depth 2
+            # checkout carries, so pull just that one object on demand.
+            git cat-file -e "${BEFORE}" 2>/dev/null || git fetch --depth=1 origin "${BEFORE}"
             BASE="${BEFORE}"
           fi
           # Scope to the two dirs ingestion/Makefile:py_format_check targets.
@@ -176,10 +186,12 @@ jobs:
     env:
       UI_WORKING_DIRECTORY: openmetadata-ui/src/main/resources/ui
     steps:
-      - name: Checkout with history
+      - name: Checkout with parent
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          # Shallow: just HEAD and HEAD~1. Multi-commit pushes fetch the
+          # older base on demand in the "Determine changed X files" step.
+          fetch-depth: 2
           persist-credentials: false
 
       - name: Determine changed UI files
@@ -191,6 +203,9 @@ jobs:
           if [ -z "${BEFORE}" ] || [ "${BEFORE}" = "0000000000000000000000000000000000000000" ]; then
             BASE=$(git rev-parse HEAD~1)
           else
+            # Multi-commit push: BEFORE may be older than the shallow depth 2
+            # checkout carries, so pull just that one object on demand.
+            git cat-file -e "${BEFORE}" 2>/dev/null || git fetch --depth=1 origin "${BEFORE}"
             BASE="${BEFORE}"
           fi
           # Match existing ui-checkstyle: src globs only, exclude generated/**.

--- a/.github/workflows/release-branch-validate.yml
+++ b/.github/workflows/release-branch-validate.yml
@@ -95,25 +95,25 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Run spotless (full tree apply)
-        if: steps.files.outputs.any == 'true'
-        run: mvn -B spotless:apply
-
-      - name: Fail only if changed Java files diverged
+      - name: Run spotless:check on changed Java files only
         if: steps.files.outputs.any == 'true'
         env:
           CHANGED: ${{ steps.files.outputs.changed }}
         run: |
           set -euo pipefail
-          # Guard against baseline drift: only assert on files the push touched.
-          # xargs is used so an empty CHANGED simply exits 0 rather than diffing all.
-          if [ -z "${CHANGED}" ]; then exit 0; fi
-          if [ -n "$(echo ${CHANGED} | xargs git status --porcelain --)" ]; then
-            echo "spotless:apply rewrote files pushed by this commit:"
-            echo ${CHANGED} | xargs git status --porcelain --
-            echo ${CHANGED} | xargs git --no-pager diff --
-            exit 1
-          fi
+          # spotless-maven-plugin accepts a comma-separated list of regexes
+          # matched against absolute file paths. Build one regex per file with
+          # `.` escaped and a `.*` prefix so it survives Maven's absolutization.
+          PATTERNS=""
+          for f in ${CHANGED}; do
+            # Escape regex metacharacters we might see in filenames.
+            ESCAPED=$(printf '%s' "$f" | sed 's/[][().^$+*?|\\]/\\&/g')
+            PATTERNS="${PATTERNS}${PATTERNS:+,}.*${ESCAPED}"
+          done
+          echo "spotless:check regex: ${PATTERNS}"
+          # Baseline drift on other files is intentionally ignored; scope
+          # matches the "Determine changed X files" step above.
+          mvn -B spotless:check "-DspotlessFiles=${PATTERNS}"
 
   python-checkstyle:
     name: Python Checkstyle


### PR DESCRIPTION
### Describe your changes:

Stacked on #31891. Fixes the timeout-masks-failure hazard we hit while live-testing #31828: `mvn -B spotless:apply` on the whole reactor was slow enough on a cold Maven cache to hit the 20-min `timeout-minutes` cap, which produces `conclusion=cancelled` (not `failure`), which auto-revert-release.yml correctly does not treat as a revertable signal — so broken cherry-picks slip through silently when the runner is slow.

Scope spotless itself to only the changed Java files via `-DspotlessFiles=<regex-list>` (supported by spotless-maven-plugin 2.41.1). Drops the step from ~10-15 min to seconds and eliminates the failure mode.

_Base branch: `ci/shallow-fetch-validate` (from #31891). Merge that first, then rebase this._

#
### Type of change:
- [x] Bug fix

#
### High-level design:

**Regex construction.** For each changed relative path, escape regex metacharacters (`[]().^$+*?|\`), prepend `.*` so the pattern survives Maven's absolute-path resolution, and join with commas. Passed as a single `-DspotlessFiles=<list>` argument.

**`spotless:check` vs `spotless:apply`.** Switched to `check` — fails fast on drift, no in-place edits, no post-run `git status --porcelain` dance. Exit code is authoritative.

**Baseline drift is still ignored.** The regex only matches files the push touched, so pre-existing formatting drift on other files in the release branch is untouched (matches the same scope-of-check principle #31828 established for lint and prettier).

**Alternative considered.** Bumping `timeout-minutes` from 20 → 40. Rejected because it masks the underlying issue (spotless doing 100× the work needed) and doesn't fix cold-cache runs that could still exceed a higher cap.

#
### Tests:

#### Use cases covered
- Single-file broken-Java cherry-pick: `spotless:check` reports the violation, job fails with `conclusion=failure`, auto-revert fires.
- Multi-file broken-Java push: regex list contains all N files, any of them failing triggers `check` to fail.
- No Java changes: existing `steps.files.outputs.any` gate skips the step (unchanged).
- Baseline drift on other Java files: not scanned; only the push's files are asserted (unchanged behavior).

#### Manual testing performed
- Verified `spotless:check -DspotlessFiles=<regex>` is a valid invocation for spotless-maven-plugin 2.41.1 (project version pinned in `pom.xml:162`).
- End-to-end will validate once #31891 + this merge, then a push to `9.9.9` reproduces the live smoke — same delta as before but the Java job now finishes in seconds.

#
### Checklist:
- [x] I have read the CONTRIBUTING document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` — perf/reliability follow-up to #31828, no separate issue.
- [x] I have commented on my code (inline block explaining the regex construction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR limits release-branch Spotless validation to changed Java files, replacing full-tree formatting and post-format diff inspection with a direct scoped check.
- Converts `spotless:apply` followed by `git status` inspection into `spotless:check`.
- Escapes each changed repository-relative Java path and constructs comma-separated absolute-path-compatible patterns.
- Preserves the existing no-Java-change gate and ignores formatting drift outside the pushed files.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with changed Java files still reaching Spotless validation while unrelated baseline drift remains excluded.

Spotless accepts the generated comma-separated regex list, matches each expression against absolute paths, and the workflow escapes repository-relative paths before invoking the non-mutating check goal.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/release-branch-validate.yml | Replaces full-reactor Spotless mutation and diff inspection with a correctly constructed changed-file-only Spotless check; no actionable defect was identified. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Changed Java paths] --> B[Escape regex metacharacters]
  B --> C[Prefix each pattern with .*]
  C --> D[Join patterns with commas]
  D --> E[mvn spotless:check]
  E -->|Formatting clean| F[Validation succeeds]
  E -->|Formatting drift| G[Validation fails]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: scope spotless to changed Java files..."](https://github.com/open-metadata/openmetadata/commit/4e659681e8d406edc2b72b97c207aa0eaf83e693) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55560074)</sub>

<!-- /greptile_comment -->