### PR TITLE
fix(playwright): skip the service worker wait on insecure origins

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/IngestionBot.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/IngestionBot.spec.ts
@@ -50,8 +50,15 @@ const test = base.extend<{
 
     const page = await browser.newPage();
     await page.goto('/signin');
-    await page.waitForFunction(() =>
-      Boolean(navigator.serviceWorker?.controller)
+    // Only localhost/HTTPS are secure contexts, so on the AUT deployments that serve
+    // http:// on a hostname `navigator.serviceWorker` is undefined and the app never
+    // registers a SW -- there is no clients.claim() race to wait out there.
+    await page.waitForFunction(
+      () =>
+        !('serviceWorker' in navigator) ||
+        Boolean(navigator.serviceWorker.controller),
+      undefined,
+      { timeout: 30_000 }
     );
 
     await setToken(page, tokenData.config.JWTToken);


### PR DESCRIPTION
### Describe your changes:

Fixes the one hard failure in nightly AUT run [32490812681](https://github.com/open-metadata/openmetadata-nightly/actions/runs/32490812681) (shard 7, `1 failed`, all 3 retries):

```
[chromium] › playwright/e2e/Flow/IngestionBot.spec.ts:91:3 › Ingestion Bot › Ingestion bot should be able to access domain specific domain

TimeoutError: page.waitForFunction: Timeout 60000ms exceeded.
  51 |     const page = await browser.newPage();
  52 |     await page.goto('/signin');
> 53 |     await page.waitForFunction(() =>
     |                ^
  54 |       Boolean(navigator.serviceWorker?.controller)
```

**Root cause:** #31867 (merged 2026-08-21 10:05 UTC) added an unconditional wait for `navigator.serviceWorker.controller` so `clients.claim()` finishes before `setToken` runs its `page.evaluate`. That is correct on localhost, but `Navigator.serviceWorker` is `[SecureContext]` — it only exists on HTTPS or localhost. The nightly AUT deployments serve the app over plain http on a hostname (`PLAYWRIGHT_TEST_BASE_URL=http://collate.aut-<run-id>-eks-postgresql:8585/`), so:

1. `navigator.serviceWorker` is `undefined` in the page;
2. `src/index.tsx` guards registration on `'serviceWorker' in navigator`, so no worker is ever registered;
3. `controller` never becomes truthy and the fixture burns its full 60s timeout, deterministically.

Local and OSS CI both run against `http://localhost:8585` (a secure context), which is why the change was green there. The same test passed on AUT in the last pre-merge nightly, [32354209827](https://github.com/open-metadata/openmetadata-nightly/actions/runs/32354209827) (`✓ 339 … Ingestion bot should be able to access domain specific domain (2.2m)`).

**Fix:** wait only when the browser actually exposes a service worker, and bound the wait at 30s instead of inheriting the 60s default. `setToken` (`playwright/utils/tokenStorage.ts`) already branches on `isServiceWorkerAvailable()` and falls back to `localStorage`, so the no-worker path needs no wait at all. The `clients.claim()` race #31867 fixed is still covered wherever a worker exists.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- `ingestionBotPage` fixture sets up an ingestion-bot session on both secure (localhost/HTTPS) and insecure (nightly AUT) origins.

#### Unit tests
- [x] Not applicable (Playwright fixture change only).

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] The change is in the Playwright fixture itself (`IngestionBot.spec.ts`).

#### Manual testing performed
1. `npx prettier --check` and `eslint` clean on the file (only the pre-existing `browser.newPage()` warning, which the rule itself documents as expected for multi-user tests).
2. `tsc --project playwright/tsconfig.json --noEmit` reports no new errors — the 3 errors in this file (lines 156/163/173) are pre-existing and unrelated.
3. Verified against the nightly logs above that the wait is the only failing step and that the test passed on the same AUT topology before #31867.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: N/A.
- [x] For UI changes: N/A.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates the ingestion-bot Playwright fixture to avoid waiting for a service-worker controller when the browser does not expose service workers.
- Skips the controller wait on insecure AUT origins.
- Bounds the service-worker readiness wait at 30 seconds.
- Preserves the controller wait for secure origins where service workers are available.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/IngestionBot.spec.ts | Makes ingestion-bot session setup conditional on service-worker availability and adds an explicit readiness timeout. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(playwright): skip the service worker..."](https://github.com/open-metadata/openmetadata/commit/da2a9d25e9eab0bba4d00decaab82b3c0d8a9ad5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55615790)</sub>

<!-- /greptile_comment -->