### PR TITLE
Fixes #31899: recognize separated Aadhaar numbers

### DIFF
--- a/ingestion/src/metadata/pii/algorithms/presidio_utils.py
+++ b/ingestion/src/metadata/pii/algorithms/presidio_utils.py
@@ -26,6 +26,7 @@ from dateutil import parser
 from presidio_analyzer import (
     AnalyzerEngine,
     EntityRecognizer,
+    Pattern,
     PatternRecognizer,
     RecognizerRegistry,
     RecognizerResult,
@@ -36,6 +37,7 @@ from presidio_analyzer.predefined_recognizers import (
     AuTfnRecognizer,
     CreditCardRecognizer,
     DateRecognizer,
+    InAadhaarRecognizer,
     NhsRecognizer,
     UsBankRecognizer,
     UsLicenseRecognizer,
@@ -228,6 +230,27 @@ def au_tfn_factory(
 ) -> AuTfnRecognizer:
     return AuTfnRecognizer(
         patterns=patterns.au_tfn_number,
+        supported_language=supported_language,
+        context=context,
+    )
+
+
+@recognizer_factories.add(  # pyright: ignore[reportUnknownMemberType, reportUntypedFunctionDecorator]
+    InAadhaarRecognizer
+)
+def in_aadhaar_factory(
+    *,
+    supported_language: str = SUPPORTED_LANG,
+    context: list[str] | None = None,
+) -> InAadhaarRecognizer:
+    return InAadhaarRecognizer(
+        patterns=[
+            Pattern(
+                "AADHAAR",
+                r"(?<![0-9])(?<![0-9]{4}[- ])[0-9]{4}(?:[- ]?[0-9]{4}){2}(?![- ]?[0-9])",
+                0.01,
+            )
+        ],
         supported_language=supported_language,
         context=context,
     )

--- a/ingestion/tests/unit/pii/algorithms/test_feature_extraction.py
+++ b/ingestion/tests/unit/pii/algorithms/test_feature_extraction.py
@@ -10,6 +10,8 @@
 #  limitations under the License.
 from typing import Mapping, Optional  # noqa: UP035
 
+import pytest
+
 from metadata.pii.algorithms.column_patterns import get_pii_column_name_patterns
 from metadata.pii.algorithms.feature_extraction import (
     extract_pii_from_column_names,
@@ -232,12 +234,38 @@ def test_aadhaar_extraction(analyzer):
         "0249-3285-1294",
     ]
     context = ["aadhaar", "govt id", "uidai"]
-    extracted = extract_pii_tags(analyzer, samples, context=context)
+    extracted = extract_pii_tags(
+        analyzer,
+        samples,
+        context=context,
+        recognizer_result_patcher=date_time_patcher,
+    )
     assert get_top_pii_tag(extracted) == PIITag.IN_AADHAAR, (
         PIITag.IN_AADHAAR,
         samples,
         extracted,
     )
+
+
+@pytest.mark.parametrize("sample", ["2161 6729 3627", "8384-2795-9970"])
+def test_aadhaar_extraction_accepts_supported_separators(analyzer, sample):
+    extracted = extract_pii_tags(
+        analyzer,
+        [sample],
+        context=["aadhaar", "govt id", "uidai"],
+    )
+
+    assert get_top_pii_tag(extracted) == PIITag.IN_AADHAAR, extracted
+
+
+def test_aadhaar_extraction_does_not_match_dashed_credit_card(analyzer):
+    extracted = extract_pii_tags(
+        analyzer,
+        ["5105-1051-0510-5100"],
+        context=["card", "number"],
+    )
+
+    assert PIITag.IN_AADHAAR not in extracted
 
 
 def test_indian_passport_extraction(analyzer):


### PR DESCRIPTION
### Describe your changes:

Fixes #31899

Presidio sanitizes Aadhaar separators only after its regex finds a candidate, while the upstream regex matches contiguous digits only. This adds an OpenMetadata recognizer factory whose candidate pattern accepts the existing plain, space-separated, and hyphen-separated formats while preventing partial matches inside 16-digit card numbers.

### Type of change:

- [x] Bug fix

### High-level design:

N/A — small change.

### UI screen recording / screenshots:

Not applicable.

### Checklist:

- [x] I have read the CONTRIBUTING document.
- [x] My PR title is Fixes #31899: recognize separated Aadhaar numbers.
- [x] My PR is linked to GitHub issue #31899.
- [x] I have added tests for the exact separator and card-number boundary scenarios.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an OpenMetadata factory for Presidio's Indian Aadhaar recognizer so candidate detection supports contiguous, space-separated, and hyphen-separated numbers while excluding partial matches inside longer numeric identifiers.
- Registers a custom `InAadhaarRecognizer` candidate pattern with numeric boundaries.
- Adds focused tests for supported separators and dashed credit-card exclusion.
- Aligns the existing Aadhaar extraction test with the result patcher used by production classification.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete changed-code defect identified.

The custom recognizer retains Aadhaar validation while expanding candidate formats, and its boundary checks cover both contiguous surrounding digits and conventionally separated 16-digit card numbers.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/pii/algorithms/presidio_utils.py | Adds a boundary-aware Aadhaar recognizer factory while preserving Presidio's separator sanitization and checksum validation. |
| ingestion/tests/unit/pii/algorithms/test_feature_extraction.py | Adds separator and card-boundary regressions and uses the production date-time patcher in the aggregate Aadhaar test. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pii): recognize separated Aadhaar nu..."](https://github.com/open-metadata/openmetadata/commit/2e0d8e1f1a3dfd141df11b37fcf3d1c0f503b312) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55655476)</sub>

**Context used:**

- Knowledge Base — [Profiler, Data Quality, and PII Classification](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/ingestion-profiler-quality.md)

<!-- /greptile_comment -->