### PR TITLE
test(playwright): assert the hierarchy dialog, not Ant's modal root

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
@@ -1189,14 +1189,17 @@ export const changeTermHierarchyFromModal = async (
   await page.getByTestId('manage-button').click();
   await page.getByTestId('change-parent-button').click();
 
-  const hierarchyModal = page.locator(
-    '[data-testid="change-parent-hierarchy-modal"]'
-  );
+  // Ant's Modal spreads data-testid onto `.ant-modal-root`, a zero-size wrapper
+  // that never satisfies toBeVisible even while the dialog is on screen — the
+  // dialog itself is the element with a box. Scoping still matters: the bare
+  // `Select Parent` label also matches the control of a hierarchy modal left in
+  // the DOM by an earlier step, and clicking that waits out the whole test on a
+  // hidden element.
+  const hierarchyModal = page
+    .locator('[data-testid="change-parent-hierarchy-modal"]')
+    .getByRole('dialog');
   await expect(hierarchyModal).toBeVisible();
 
-  // Scope to this modal: the page-level label also matches the control of a
-  // hierarchy modal left in the DOM by an earlier step, and the click then waits
-  // out the whole test on a hidden element.
   const parentSelect = hierarchyModal.getByLabel('Select Parent');
   await expect(parentSelect).toBeVisible();
   await expect(parentSelect).toBeEnabled();


### PR DESCRIPTION
Fixes the glossary hierarchy failures in [AUT run 32513179631](https://github.com/open-metadata/openmetadata-nightly/actions/runs/32513179631). Regression from #31894 (mine).

## Cause

`changeTermHierarchyFromModal` waited on `[data-testid="change-parent-hierarchy-modal"]` itself:

```ts
const hierarchyModal = page.locator('[data-testid="change-parent-hierarchy-modal"]');
await expect(hierarchyModal).toBeVisible();
```

`ChangeParentHierarchy.component.tsx` passes that testid to Ant's `<Modal>`, and Ant spreads unrecognised props onto **`.ant-modal-root`** — a `position: fixed`, zero-size container whose children (mask, wrap, dialog) carry the layout. Playwright's visibility check needs a non-empty bounding box, so that element is never visible, open or closed. The assertion could only ever fail, and the 15s timeout was the fastest it could do so:

```
19 × locator resolved to <div class="ant-modal-root" data-testid="change-parent-hierarchy-modal">…</div>
  - unexpected value "hidden"
```

The trace screenshot shows the Change Parent dialog plainly open at the same moment. The code #31894 replaced asserted `[role="dialog"]`, which does have a box.

## Fix

Keep the scoping — the bare `Select Parent` label also matches the control of a hierarchy modal an earlier step left in the DOM, which is what #31894 was addressing — but hang it off the dialog inside the root:

```ts
const hierarchyModal = page
  .locator('[data-testid="change-parent-hierarchy-modal"]')
  .getByRole('dialog');
```

## Blast radius

Deterministic, not flaky — 5 call sites: `GlossaryHierarchy.spec.ts` ×3, `Glossary.spec.ts` ×2.

## Verification

- `tsc --project playwright/tsconfig.json` — no new errors (the two pre-existing `utils/glossary.ts` errors are unchanged).
- `eslint` — 0 errors; the one warning is a pre-existing `waitForSelector` elsewhere in the file.
- `prettier --check` clean.
- `playwright test --list` on `GlossaryHierarchy.spec.ts` — collects fine.
- Not run against a live stack; the nightly is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR fixes glossary hierarchy Playwright failures by asserting the visible dialog inside Ant Design's zero-size modal root while preserving the scope needed to avoid stale controls.
- Changes `changeTermHierarchyFromModal` to locate the descendant with the `dialog` role.
- Keeps parent selection scoped to the intended hierarchy modal.
- Documents why visibility cannot be asserted on `.ant-modal-root`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the locator now targets the visible dialog while retaining the required modal scope.

The single changed helper corrects an invalid visibility target without changing application behavior or weakening the test's protection against stale modal controls.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts | Replaces visibility checks against Ant Design's zero-size modal root with a scoped dialog locator; no actionable defect identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(playwright): assert the hierarchy d..."](https://github.com/open-metadata/openmetadata/commit/2207e7e2f359dc88242327e6e4c2a65303ede591) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55790543)</sub>

<!-- /greptile_comment -->