### PR TITLE
ci(playwright): budget = signal, not gate; direct-commit baseline refresh with materiality threshold

### DIFF
--- a/.github/scripts/evaluate_playwright_performance.py
+++ b/.github/scripts/evaluate_playwright_performance.py
@@ -19,6 +19,29 @@ CONVERGENCE_TARGET_NAMES = frozenset(
     }
 )
 
+# Budget targets are SIGNALS, not gates. A budget breach means the pipeline
+# is slower/noisier than the plan promised — someone should look at capacity,
+# the timing baseline, or a runaway spec — but it must never eject a PR from
+# the merge queue when every test passed. Run 32500973433 is the canonical
+# counter-example this classification exists to prevent: chromium-12 finished
+# all 142 tests green, one wedged retry attempt (unbounded on-failure
+# trace/video teardown) pushed execution past the old blocking ceiling, and
+# the PR was ejected with "0 Playwright test failure(s)". Breaches surface
+# via the `Signal Playwright budget breaches` step in
+# playwright-postgresql-e2e.yml (log annotations + job summary + a tracked
+# GitHub issue), not via the required check.
+BUDGET_TARGET_NAMES = frozenset(
+    {
+        "environmentAtMostFiveMinutes",
+        "executionAtMostTwentyFiveMinutes",
+        "shardsAtMostThirtyMinutesBeforeUpload",
+        "flakyRateAtMostPointFivePercent",
+        "retryWorkerTimeAtMostTwoPercent",
+        "staticRequestsPerAppBootBelowOneHundred",
+        "appBootMeasurementIntegrity",
+    }
+)
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
@@ -83,26 +106,36 @@ def aggregate_ranked_counts(
 
 def classify_targets(
     targets: dict[str, bool],
-) -> tuple[dict[str, bool], dict[str, bool]]:
+) -> tuple[dict[str, bool], dict[str, bool], dict[str, bool]]:
     convergence_targets = {
         name: passed
         for name, passed in targets.items()
         if name in CONVERGENCE_TARGET_NAMES
     }
+    budget_targets = {
+        name: passed
+        for name, passed in targets.items()
+        if name in BUDGET_TARGET_NAMES
+    }
+    # Anything neither budget nor convergence still hard-fails --enforce.
+    # The set is intentionally empty today; it exists so a future target
+    # that must eject PRs (e.g. corrupt results artifacts) has a home
+    # without re-plumbing the workflow.
     blocking_targets = {
         name: passed
         for name, passed in targets.items()
-        if name not in CONVERGENCE_TARGET_NAMES
+        if name not in CONVERGENCE_TARGET_NAMES and name not in BUDGET_TARGET_NAMES
     }
 
-    return blocking_targets, convergence_targets
+    return blocking_targets, budget_targets, convergence_targets
 
 
 # Human-readable label + phase-field a target reads, keyed by the target name
-# used in the `targets` dict below. Used to attribute a gate failure to the
+# used in the `targets` dict below. Used to attribute a budget breach to the
 # specific shard(s) that exceeded the threshold (per the phase artifacts) so
-# the merge-queue error and the PR summary are useful without the raw log.
-BLOCKING_TARGET_DETAILS: dict[str, dict[str, Any]] = {
+# the breach annotation, job summary, and tracked issue are useful without
+# the raw log.
+BUDGET_TARGET_DETAILS: dict[str, dict[str, Any]] = {
     # TRANSITIONAL: threshold widened from 300 → 480 s while the
     # `playwright-chromium-deps-v2` apt cache is still populating across
     # branches (a cache miss triggers a real apt install that can take
@@ -117,6 +150,12 @@ BLOCKING_TARGET_DETAILS: dict[str, dict[str, Any]] = {
         "unit": "s",
         "threshold": 480,
     },
+    # The planner packs shards to a 19-minute predicted budget
+    # (COMMON_SHARD_BUDGET_MS in build_playwright_shards.py); 1500 s is that
+    # promise plus tail headroom. The hang-protection `timeout … 30m` wrapper
+    # in playwright-e2e-reusable.yml sits well above this on purpose: a shard
+    # between 25 and 30 minutes breaches the budget (signal) but still
+    # finishes, uploads results, and keeps the run green if tests passed.
     "executionAtMostTwentyFiveMinutes": {
         "label": "Maximum shard execution",
         "phase_field": "executionSeconds",
@@ -135,7 +174,7 @@ BLOCKING_TARGET_DETAILS: dict[str, dict[str, Any]] = {
 def offending_shards(
     phases: list[dict[str, Any]], target_name: str
 ) -> list[dict[str, Any]]:
-    detail = BLOCKING_TARGET_DETAILS.get(target_name)
+    detail = BUDGET_TARGET_DETAILS.get(target_name)
     if not detail:
         return []
     field = detail["phase_field"]
@@ -157,7 +196,7 @@ def offending_shards(
 def describe_failed_target(
     name: str, phases: list[dict[str, Any]]
 ) -> str:
-    detail = BLOCKING_TARGET_DETAILS.get(name)
+    detail = BUDGET_TARGET_DETAILS.get(name)
     shards = offending_shards(phases, name)
     if not detail or not shards:
         return name
@@ -339,16 +378,18 @@ def main() -> None:
             app_boots, ui_scenarios, app_entry_requests
         ),
     }
-    blocking_targets, convergence_targets = classify_targets(targets)
-    failed_target_details = {
+    blocking_targets, budget_targets, convergence_targets = classify_targets(
+        targets
+    )
+    failed_budget_details = {
         name: {
-            "label": BLOCKING_TARGET_DETAILS[name]["label"],
-            "threshold": BLOCKING_TARGET_DETAILS[name]["threshold"],
-            "unit": BLOCKING_TARGET_DETAILS[name]["unit"],
+            "label": BUDGET_TARGET_DETAILS[name]["label"],
+            "threshold": BUDGET_TARGET_DETAILS[name]["threshold"],
+            "unit": BUDGET_TARGET_DETAILS[name]["unit"],
             "offendingShards": offending_shards(phases, name),
         }
-        for name, passed in blocking_targets.items()
-        if not passed and name in BLOCKING_TARGET_DETAILS
+        for name, passed in budget_targets.items()
+        if not passed and name in BUDGET_TARGET_DETAILS
     }
     output = {
         "version": 1,
@@ -358,12 +399,28 @@ def main() -> None:
         "targetsMet": all(targets.values()),
         "blockingTargets": blocking_targets,
         "blockingTargetsMet": all(blocking_targets.values()),
+        "budgetTargets": budget_targets,
+        "budgetTargetsMet": all(budget_targets.values()),
         "convergenceTargets": convergence_targets,
         "convergenceTargetsMet": all(convergence_targets.values()),
-        "failedBlockingTargetDetails": failed_target_details,
+        # Kept for downstream consumers that predate the budget/blocking
+        # split (publish_playwright_pr_comment.cjs schema guard); the
+        # blocking set is empty today so this is always {}.
+        "failedBlockingTargetDetails": {},
+        "failedBudgetTargetDetails": failed_budget_details,
     }
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+
+    # Budget breaches never fail this script — they are surfaced by the
+    # caller (log annotation + job summary + tracked issue). Print them so
+    # the raw log is self-explanatory either way.
+    for name, passed in budget_targets.items():
+        if not passed:
+            print(
+                f"BUDGET BREACH: {describe_failed_target(name, phases)}",
+                flush=True,
+            )
 
     if args.enforce and not output["blockingTargetsMet"]:
         failed = "; ".join(

--- a/.github/scripts/publish_playwright_pr_comment.cjs
+++ b/.github/scripts/publish_playwright_pr_comment.cjs
@@ -582,6 +582,36 @@ module.exports = async function publishPlaywrightPrComment({
     '',
   ];
 
+  // One-line verdict so the author knows at a glance whether the outcome is
+  // on them (test failures), on CI (infrastructure), or informational only
+  // (budget signals on a green run) — see PR #31907's budget/blocking split.
+  const totalTestFailures = totals.failed + shardTotals.lifecycleFailed;
+  const budgetWarnings = (performance?.convergenceWarnings ?? []).filter(
+    (warning) => warning.startsWith('Budget target')
+  );
+  if (totalTestFailures > 0) {
+    lines.push(
+      '❌ **Action needed:** test(s) failed on every attempt against this ' +
+        'PR’s validated commit — see **Genuine Failures** below. These ' +
+        'are test failures, not CI budget or infrastructure issues.'
+    );
+    lines.push('');
+  } else if (run.conclusion !== 'success') {
+    lines.push(
+      '⚙️ **No test failures.** This run failed in CI infrastructure or ' +
+        'reporting (see **Pipeline and setup failures**), not because of ' +
+        'your changes — no test action needed from you.'
+    );
+    lines.push('');
+  } else if (budgetWarnings.length > 0) {
+    lines.push(
+      '✅ All tests passed. The ⚠️ CI time-budget signals below are ' +
+        'pipeline capacity telemetry, **not test failures** — nothing to ' +
+        'fix on this PR.'
+    );
+    lines.push('');
+  }
+
   if (infrastructureIssueCount > 0) {
     lines.push(`### Pipeline and setup failures (${infrastructureIssueCount})`);
     lines.push('');
@@ -639,9 +669,26 @@ module.exports = async function publishPlaywrightPrComment({
         `${metrics.commonShardSkewPercent.toFixed(2)}% common-shard skew`
     );
     lines.push('');
-    if (performance.convergenceWarnings.length > 0) {
+    // Budget breaches and optimization notes travel in the same payload
+    // field (schema is locked across workflow versions); render them under
+    // separate headings so a budget breach is never mistaken for something
+    // the PR author must act on.
+    const optimizationWarnings = performance.convergenceWarnings.filter(
+      (warning) => !warning.startsWith('Budget target')
+    );
+    if (budgetWarnings.length > 0) {
+      lines.push(
+        '⚠️ CI time-budget signals — pipeline capacity telemetry, **not ' +
+          'test failures**, and not caused by this PR:'
+      );
+      for (const warning of budgetWarnings) {
+        lines.push(`- ${escapeMarkdown(warning)}`);
+      }
+      lines.push('');
+    }
+    if (optimizationWarnings.length > 0) {
       lines.push('Optimization targets still in progress:');
-      for (const warning of performance.convergenceWarnings) {
+      for (const warning of optimizationWarnings) {
         lines.push(`- ${escapeMarkdown(warning)}`);
       }
       lines.push('');

--- a/.github/scripts/refresh_timing_baseline.py
+++ b/.github/scripts/refresh_timing_baseline.py
@@ -5,14 +5,18 @@ history artifact produced by a full-mode merge_group run.
 Called from the workflow's `refresh-timing-baseline` job. Normalises the
 reporter's raw schema to the baseline schema the planner reads, preserves
 curated fields on the current baseline (retention pointers and the
-unstable-test-id allowlist), and prints a diff summary useful in the auto-PR
-body.
+unstable-test-id allowlist), and prints a diff summary for the commit body.
 
 Exits:
-  0 — new baseline written OR identical to current (workflow will skip PR)
+  0 — new baseline written OR identical to current (workflow will skip
+      the commit)
   1 — invalid input (missing file, malformed JSON, mode != 'full', etc.)
   2 — drift exceeds --max-drift-percent (safety valve; workflow fails the
       job so a human refreshes manually)
+  3 — change is below --min-materiality-percent (nothing written; the
+      workflow skips the commit). Ordinary run-to-run duration jitter must
+      not produce a main commit per merge_group run — every push to main
+      resets the merge queue, so refreshes have to be rare and meaningful.
 """
 
 from __future__ import annotations
@@ -43,9 +47,17 @@ def parse_args() -> argparse.Namespace:
                         help="Refuse the refresh (exit 2) if more than N%% "
                              "of test-id entries would change. Guards against "
                              "an accidental capture of a broken run.")
+    parser.add_argument("--min-materiality-percent", type=float, default=0.0,
+                        help="Skip the refresh (exit 3) unless the change is "
+                             "material: at least N%% of entries added/removed, "
+                             "or at least N%% with a significant duration "
+                             "shift (>30%% and >5 s). Structural changes "
+                             "(files gained/lost, zero-duration entries "
+                             "recovering) are always material. 0 disables "
+                             "the check.")
     parser.add_argument("--summary", type=Path,
                         help="Optional path to write a human-readable summary "
-                             "for the auto-PR body.")
+                             "for the commit/log output.")
     return parser.parse_args()
 
 
@@ -100,6 +112,15 @@ def compute_diff(current: dict[str, Any], new: dict[str, Any]) -> dict[str, Any]
         1 for k in common
         if abs(cur_by_key[k]["durationMs"] - new_by_key[k]["durationMs"]) > 500
     )
+    # A "significant" shift is one large enough to change how the planner
+    # packs shards: both relatively (>30 %) and absolutely (>5 s) — the
+    # 500 ms `changed_duration` counter above is run-to-run jitter and is
+    # deliberately excluded from materiality.
+    significant_duration_changes = sum(
+        1 for k in common
+        if abs(cur_by_key[k]["durationMs"] - new_by_key[k]["durationMs"])
+        > max(5000, 0.3 * cur_by_key[k]["durationMs"])
+    )
     recovered = sum(
         1 for k in common
         if cur_by_key[k]["durationMs"] == 0 and new_by_key[k]["durationMs"] > 0
@@ -120,6 +141,8 @@ def compute_diff(current: dict[str, Any], new: dict[str, Any]) -> dict[str, Any]
         "added": len(added),
         "removed": len(removed),
         "changed_duration": changed_duration,
+        "significant_duration_changes": significant_duration_changes,
+        "significant_percent": 100.0 * significant_duration_changes / total_entries,
         "recovered": recovered,
         "gained_files": gained_files,
         "lost_files": lost_files,
@@ -134,6 +157,9 @@ def render_summary(diff: dict[str, Any]) -> str:
         f"- entries: {diff['current_entries']} → {diff['new_entries']} "
         f"(+{diff['added']} added, -{diff['removed']} removed)",
         f"- durations changed by > 500 ms: {diff['changed_duration']}",
+        f"- significant shifts (>30% and >5 s): "
+        f"{diff['significant_duration_changes']} "
+        f"({diff['significant_percent']:.1f}%)",
         f"- previously zero → now real: {diff['recovered']}",
         f"- drift: {diff['drift_percent']:.1f}% of test-id entries",
     ]
@@ -180,6 +206,31 @@ def main() -> int:
               f"--max-drift-percent={args.max_drift_percent}; refusing to "
               "auto-refresh. A human should regenerate manually and review.")
         return 2
+
+    if args.min_materiality_percent > 0:
+        structurally_material = (
+            diff["recovered"] > 0
+            or diff["gained_files"]
+            or diff["lost_files"]
+        )
+        percent_material = (
+            diff["drift_percent"] >= args.min_materiality_percent
+            or diff["significant_percent"] >= args.min_materiality_percent
+        )
+        if not structurally_material and not percent_material:
+            skip_note = (
+                f"change below materiality threshold "
+                f"({args.min_materiality_percent:.1f}%): drift "
+                f"{diff['drift_percent']:.1f}%, significant shifts "
+                f"{diff['significant_percent']:.1f}%, nothing structural — "
+                "skipping refresh."
+            )
+            print(skip_note)
+            if args.summary:
+                args.summary.parent.mkdir(parents=True, exist_ok=True)
+                args.summary.write_text(summary + skip_note + "\n",
+                                        encoding="utf-8")
+            return 3
 
     args.output.parent.mkdir(parents=True, exist_ok=True)
     with args.output.open("w", encoding="utf-8") as fh:

--- a/.github/scripts/render_playwright_summary.cjs
+++ b/.github/scripts/render_playwright_summary.cjs
@@ -813,8 +813,14 @@ async function renderPlaywrightSummary({ github, context, core }) {
   }
 
   if (totalFailed > 0 || infrastructureIssues.length > 0) {
+    // Tell the author which kind of red this is: test failures need their
+    // action; infrastructure-only failures explicitly do not.
+    const verdict =
+      totalFailed > 0
+        ? 'test failures — author action needed'
+        : 'no test failures — CI infrastructure/reporting problem, not this change';
     core.setFailed(
-      `${totalFailed} Playwright test failure(s); ${infrastructureIssues.length} CI/reporting failure(s).`
+      `${totalFailed} Playwright test failure(s); ${infrastructureIssues.length} CI/reporting failure(s) (${verdict}).`
     );
   }
 }

--- a/.github/scripts/render_playwright_summary.cjs
+++ b/.github/scripts/render_playwright_summary.cjs
@@ -92,6 +92,8 @@ async function renderPlaywrightSummary({ github, context, core }) {
   const convergenceTargets = performance?.convergenceTargets ?? {};
   const failedBlockingTargetDetails =
     performance?.failedBlockingTargetDetails ?? {};
+  const failedBudgetTargetDetails =
+    performance?.failedBudgetTargetDetails ?? {};
   if (performance) {
     try {
       const workflowRun = await github.rest.actions.getWorkflowRun({
@@ -136,13 +138,16 @@ async function renderPlaywrightSummary({ github, context, core }) {
     );
   }
 
-  // Surface each failed BLOCKING performance target as its own infrastructure
-  // issue — the perf script wrote per-target detail (label, threshold, and
-  // the shards that exceeded) into failedBlockingTargetDetails on the
-  // performance JSON. Without this, the summary previously said only
-  // "1 CI/reporting failure(s)" with no signal on which target or which
-  // shard tripped the gate.
-  for (const [name, detail] of Object.entries(failedBlockingTargetDetails)) {
+  // Surface each failed target with per-target detail (label, threshold,
+  // and the shards that exceeded) from the performance JSON. BLOCKING
+  // targets (empty set today — reserved for corrupt-results style states)
+  // become infrastructure issues and fail the check; BUDGET targets become
+  // non-fatal warnings — a slow-but-green run must stay green (run
+  // 32500973433: all 142 tests passed, one wedged retry teardown pushed the
+  // shard past the old blocking ceiling, PR ejected). Budget breaches are
+  // escalated separately by the `Signal Playwright budget breaches` workflow
+  // step (annotations + tracked issue).
+  const describeTargetDetail = (name, detail) => {
     const label = detail?.label ?? name;
     const threshold = detail?.threshold;
     // Older/malformed payloads may omit `unit`. Guard the space so the
@@ -161,6 +166,16 @@ async function renderPlaywrightSummary({ github, context, core }) {
         }${offending.length > 5 ? ` (+${offending.length - 5} more)` : ''}`
       : '';
     const targetText = Number.isFinite(threshold) ? ` (target ≤ ${threshold}${unitSuffix})` : '';
+    return { label, targetText, shardText };
+  };
+  for (const [name, detail] of Object.entries(failedBudgetTargetDetails)) {
+    const { label, targetText, shardText } = describeTargetDetail(name, detail);
+    convergenceWarnings.push(
+      `Budget target \`${label}\` breached${targetText}${shardText}.`
+    );
+  }
+  for (const [name, detail] of Object.entries(failedBlockingTargetDetails)) {
+    const { label, targetText, shardText } = describeTargetDetail(name, detail);
     addInfrastructureIssue(
       `Playwright performance gate \`${label}\` failed${targetText}${shardText}.`
     );
@@ -471,7 +486,7 @@ async function renderPlaywrightSummary({ github, context, core }) {
   if (performance) {
     const performanceRows = [
       {
-        classification: 'Blocking',
+        classification: 'Budget',
         metric: 'Environment setup',
         observed: `${displayMetric(performanceMetrics.maxEnvironmentSeconds)} s`,
         // Transitional 480 s ceiling while the chromium apt cache is
@@ -481,42 +496,42 @@ async function renderPlaywrightSummary({ github, context, core }) {
         passed: performanceTargets.environmentAtMostFiveMinutes,
       },
       {
-        classification: 'Blocking',
+        classification: 'Budget',
         metric: 'Maximum shard execution',
         observed: `${displayMetric(performanceMetrics.maxExecutionSeconds)} s`,
         target: '≤ 1,500 s',
         passed: performanceTargets.executionAtMostTwentyFiveMinutes,
       },
       {
-        classification: 'Blocking',
+        classification: 'Budget',
         metric: 'Maximum shard-job elapsed before upload',
         observed: `${displayMetric(performanceMetrics.maxElapsedBeforeUploadSeconds)} s`,
         target: '≤ 1,800 s',
         passed: performanceTargets.shardsAtMostThirtyMinutesBeforeUpload,
       },
       {
-        classification: 'Blocking',
+        classification: 'Budget',
         metric: 'Reporting and upload',
         observed: `${displayMetric(performanceMetrics.reportingSeconds)} s`,
         target: '≤ 120 s',
         passed: performanceTargets.reportingAtMostTwoMinutes,
       },
       {
-        classification: 'Blocking',
+        classification: 'Budget',
         metric: 'Flaky test rate',
         observed: `${displayMetric(performanceMetrics.flakyRatePercent)}%`,
         target: '≤ 0.5%',
         passed: performanceTargets.flakyRateAtMostPointFivePercent,
       },
       {
-        classification: 'Blocking',
+        classification: 'Budget',
         metric: 'Retry worker time',
         observed: `${displayMetric(performanceMetrics.retryWorkerPercent)}%`,
         target: '≤ 2%',
         passed: performanceTargets.retryWorkerTimeAtMostTwoPercent,
       },
       {
-        classification: 'Blocking',
+        classification: 'Budget',
         metric: 'Static requests per app boot',
         observed: String(
           displayMetric(performanceMetrics.staticRequestsPerAppBoot)
@@ -525,7 +540,7 @@ async function renderPlaywrightSummary({ github, context, core }) {
         passed: performanceTargets.staticRequestsPerAppBootBelowOneHundred,
       },
       {
-        classification: 'Blocking',
+        classification: 'Budget',
         metric: 'App-boot measurement integrity',
         observed:
           `${displayMetric(performanceMetrics.appBoots)} boots / ` +
@@ -569,7 +584,7 @@ async function renderPlaywrightSummary({ github, context, core }) {
     lines.push('### Performance targets');
     lines.push('');
     lines.push(
-      'Blocking targets enforce CI. Convergence targets remain measured and visible while the suite is optimized.'
+      'Budget targets signal capacity problems without failing the check (see the tracked budget issue). Convergence targets remain measured and visible while the suite is optimized.'
     );
     lines.push('');
     lines.push('| Class | Metric | Observed | Target | Status |');
@@ -588,7 +603,7 @@ async function renderPlaywrightSummary({ github, context, core }) {
   }
 
   if (convergenceWarnings.length > 0) {
-    lines.push('### Performance convergence warnings');
+    lines.push('### Performance budget and convergence warnings');
     lines.push('');
     for (const warning of convergenceWarnings) {
       lines.push(`- ${warning}`);

--- a/.github/scripts/tests/test_playwright_ci_planning.py
+++ b/.github/scripts/tests/test_playwright_ci_planning.py
@@ -1778,9 +1778,12 @@ def test_performance_stability_metrics_include_lifecycle_retries(tmp_path, monke
     assert performance["targets"]["atMostOneAppBootPerUIScenario"] is True
     assert performance["targets"]["appBootMeasurementIntegrity"] is True
     assert "atMostOneAppBootPerAttempt" not in performance["targets"]
-    assert performance["blockingTargetsMet"] is False
+    # Flaky-rate/retry-share breaches are budget signals, not blockers — a
+    # green run stays green (run 32500973433).
+    assert performance["blockingTargetsMet"] is True
+    assert performance["budgetTargetsMet"] is False
     assert performance["convergenceTargetsMet"] is True
-    assert "appBootMeasurementIntegrity" in performance["blockingTargets"]
+    assert "appBootMeasurementIntegrity" in performance["budgetTargets"]
     assert "atMostOneAppBootPerUIScenario" in performance["convergenceTargets"]
     assert metrics["lifecycleFlakyTests"] == 1
     assert metrics["productFlakyRatePercent"] == 0
@@ -1876,7 +1879,13 @@ def test_performance_enforcement_reports_convergence_without_failing(
     }
 
 
-def test_performance_enforcement_still_fails_blocking_targets(tmp_path, monkeypatch):
+def test_environment_overrun_is_budget_breach_not_enforcement_failure(
+    tmp_path, monkeypatch, capsys
+):
+    # Formerly this fixture (481 s > the 480 s env ceiling) raised SystemExit
+    # under --enforce and failed the merge-group check. Environment time is a
+    # BUDGET target now: main() completes, the breach lands in the payload
+    # and stdout for the workflow's budget-signal step.
     evaluator = load_script("evaluate_playwright_performance")
     timing_file = tmp_path / "timing.json"
     request_file = tmp_path / "requests.json"
@@ -1937,12 +1946,18 @@ def test_performance_enforcement_still_fails_blocking_targets(tmp_path, monkeypa
         ],
     )
 
-    with pytest.raises(
-        SystemExit,
-        match="Blocking Playwright performance targets not met: "
-        "environmentAtMostFiveMinutes",
-    ):
-        evaluator.main()
+    evaluator.main()
+
+    captured = capsys.readouterr()
+    assert "BUDGET BREACH" in captured.out
+    assert "environmentAtMostFiveMinutes" in captured.out
+    performance = json.loads(output.read_text())
+    assert performance["blockingTargetsMet"] is True
+    assert performance["budgetTargets"]["environmentAtMostFiveMinutes"] is False
+    assert (
+        "environmentAtMostFiveMinutes"
+        in performance["failedBudgetTargetDetails"]
+    )
 
 
 def test_outcome_classifier_reads_include_matrix():
@@ -2372,11 +2387,12 @@ def test_summary_reconciles_results_and_evaluates_performance_independently():
     assert "specFile.endsWith('.setup.ts')" in summary_helper
     assert "lifecycleFailures" in summary_helper
     assert "lifecycleFlaky" in summary_helper
-    assert ".blockingTargets.reportingAtMostTwoMinutes" in workflow
-    assert ".blockingTargetsMet = ([.blockingTargets[]] | all)" in workflow
+    assert ".budgetTargets.reportingAtMostTwoMinutes" in workflow
+    assert ".budgetTargetsMet = ([.budgetTargets[]] | all)" in workflow
+    assert "Signal Playwright budget breaches" in workflow
     assert "### Performance targets" in summary_helper
-    assert "### Performance convergence warnings" in summary_helper
-    assert "Blocking targets enforce CI" in summary_helper
+    assert "### Performance budget and convergence warnings" in summary_helper
+    assert "Budget targets signal capacity problems" in summary_helper
     assert "convergenceWarnings" in summary_helper
     assert "workflowWallSeconds" in summary_helper
     assert "Full workflow signal wall (to summary)" in summary_helper

--- a/.github/scripts/tests/test_playwright_performance_gate.py
+++ b/.github/scripts/tests/test_playwright_performance_gate.py
@@ -1,20 +1,24 @@
-"""Tests for the Playwright performance-gate script.
+"""Tests for the Playwright performance-budget script.
 
-Focus: the 25-minute execution ceiling introduced with PR #30689's wrapper
-bump, and the shard-level attribution added so gate failures name the
-offending shards instead of surfacing a generic "1 CI/reporting failure(s)"
-banner (run 30736786802 was the trigger)."""
+Focus: timing/flake targets are BUDGET SIGNALS, not gates. A run where every
+test passed must never exit non-zero because a shard ran long — that ejected
+green PRs from the merge queue (run 32500973433: 0 test failures, one wedged
+retry teardown pushed chromium-12 past the old blocking ceiling). Breaches
+are reported in the payload (`failedBudgetTargetDetails`) and stdout for the
+workflow's budget-signal step to surface."""
 
 from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
 
 
 SCRIPTS = Path(__file__).parents[1]
+WORKFLOWS = SCRIPTS.parent / "workflows"
 
 
 def load_script(name: str):
@@ -26,15 +30,72 @@ def load_script(name: str):
     return module
 
 
-def test_execution_target_matches_wrapper_ceiling():
-    # Wrapper is 25m (playwright-e2e-reusable.yml). The gate must
-    # match — the 21m gate was pre-PR-#30689 and marked healthy shards as
-    # failures. If someone changes one without the other, this test fires.
+def test_execution_budget_stays_below_hang_protection_wrapper():
+    # The 1500 s execution target is the BUDGET the planner packs against;
+    # the `timeout … Nm` wrapper in playwright-e2e-reusable.yml is HANG
+    # PROTECTION and must sit well above it — at parity (the old 25m/1500s
+    # pairing) the wrapper killed slow-but-green shards mid-report and
+    # destroyed the results artifact (run 32500973433). If someone tightens
+    # the wrapper back toward the budget, this test fires.
     evaluator = load_script("evaluate_playwright_performance")
-    detail = evaluator.BLOCKING_TARGET_DETAILS["executionAtMostTwentyFiveMinutes"]
+    budget = evaluator.BUDGET_TARGET_DETAILS["executionAtMostTwentyFiveMinutes"]
+    assert budget["threshold"] == 1500
+    assert budget["phase_field"] == "executionSeconds"
 
-    assert detail["threshold"] == 1500
-    assert detail["phase_field"] == "executionSeconds"
+    reusable = (WORKFLOWS / "playwright-e2e-reusable.yml").read_text()
+    match = re.search(
+        r"timeout --signal=TERM --kill-after=30s (\d+)m\s*\\\s*\n\s*npx playwright test",
+        reusable,
+    )
+    assert match, "hang-protection wrapper on the playwright test step not found"
+    wrapper_seconds = int(match.group(1)) * 60
+    assert wrapper_seconds - budget["threshold"] >= 240, (
+        f"wrapper ({wrapper_seconds}s) must leave >= 4 min of headroom above "
+        f"the execution budget ({budget['threshold']}s); a shard between "
+        "budget and wrapper should breach the budget signal, not be killed"
+    )
+
+
+def test_timing_targets_are_budget_not_blocking():
+    # Every timing/flake target belongs to the budget class; the blocking
+    # class is reserved for corrupt-results style states and must be empty
+    # for a normal target set — otherwise budget breaches eject PRs again.
+    evaluator = load_script("evaluate_playwright_performance")
+    targets = {
+        "environmentAtMostFiveMinutes": False,
+        "executionAtMostTwentyFiveMinutes": False,
+        "shardsAtMostThirtyMinutesBeforeUpload": True,
+        "commonShardSkewAtMostFifteenPercent": True,
+        "flakyRateAtMostPointFivePercent": False,
+        "retryWorkerTimeAtMostTwoPercent": True,
+        "requestsPerAttemptBelowTwoHundred": True,
+        "staticRequestsPerAppBootBelowOneHundred": True,
+        "atMostOneAppBootPerUIScenario": True,
+        "appBootMeasurementIntegrity": True,
+    }
+
+    blocking, budget, convergence = evaluator.classify_targets(targets)
+
+    assert blocking == {}
+    assert budget["executionAtMostTwentyFiveMinutes"] is False
+    assert budget["flakyRateAtMostPointFivePercent"] is False
+    assert convergence["commonShardSkewAtMostFifteenPercent"] is True
+
+
+def test_summary_workflow_does_not_enforce():
+    # The caller must not pass --enforce: with the blocking set empty it is
+    # inert, but reintroducing it alongside a reclassification would resurrect
+    # the eject-green-PRs failure mode. Guard the workflow text directly
+    # (comments may mention the flag; executable lines may not).
+    caller = (WORKFLOWS / "playwright-postgresql-e2e.yml").read_text()
+    executable_lines = [
+        line for line in caller.splitlines()
+        if "--enforce" in line and not line.lstrip().startswith("#")
+    ]
+    assert executable_lines == [], (
+        "playwright-postgresql-e2e.yml must not pass --enforce to "
+        f"evaluate_playwright_performance.py: {executable_lines}"
+    )
 
 
 def test_offending_shards_lists_only_phases_over_threshold():
@@ -70,7 +131,7 @@ def test_describe_failed_target_names_top_offenders():
     )
 
     # Names the target label, the threshold, the shard count, and the top-5
-    # offenders — the piece the merge-queue error message previously lacked.
+    # offenders — what the budget annotation and tracked issue surface.
     assert "Maximum shard execution" in message
     assert "target ≤ 1500 s" in message
     assert "exceeded on 7 shard(s)" in message
@@ -78,10 +139,10 @@ def test_describe_failed_target_names_top_offenders():
     assert "(+2 more)" in message
 
 
-def test_enforce_exits_with_detailed_message(tmp_path):
-    # End-to-end: run the script with --enforce against synthetic phase files
-    # that trip the gate. Confirms the exit message carries the per-shard
-    # detail that the summary renderer now surfaces.
+def test_budget_breach_exits_zero_with_detailed_payload(tmp_path):
+    # End-to-end: an over-budget shard must NOT fail the script (even with
+    # --enforce), but must land in failedBudgetTargetDetails and print a
+    # BUDGET BREACH line for the raw log.
     timings = tmp_path / "timings.json"
     requests = tmp_path / "requests.json"
     phase_a = tmp_path / "phase-chromium-01.json"
@@ -90,7 +151,7 @@ def test_enforce_exits_with_detailed_message(tmp_path):
 
     timings.write_text(json.dumps({"tests": [], "lifecycleTests": []}))
     requests.write_text(json.dumps({}))
-    # Below the wrapper (would pass) and above (must trip the gate).
+    # Below the budget (passes) and above (must surface as a breach).
     phase_a.write_text(
         json.dumps(
             {"shardId": "chromium-01", "lane": "chromium",
@@ -121,14 +182,17 @@ def test_enforce_exits_with_detailed_message(tmp_path):
         text=True,
     )
 
-    assert result.returncode == 1, result.stdout + result.stderr
+    assert result.returncode == 0, result.stdout + result.stderr
     combined = result.stdout + result.stderr
-    assert "Blocking Playwright performance targets not met" in combined
+    assert "BUDGET BREACH" in combined
     assert "chromium-02" in combined
     assert "1600 s" in combined
 
     payload = json.loads(output.read_text())
-    detail = payload["failedBlockingTargetDetails"][
+    assert payload["blockingTargetsMet"] is True
+    assert payload["budgetTargetsMet"] is False
+    assert payload["failedBlockingTargetDetails"] == {}
+    detail = payload["failedBudgetTargetDetails"][
         "executionAtMostTwentyFiveMinutes"
     ]
     assert detail["label"] == "Maximum shard execution"
@@ -139,10 +203,10 @@ def test_enforce_exits_with_detailed_message(tmp_path):
 
 
 def test_failed_details_absent_when_phase_targets_pass(tmp_path):
-    # Even when non-phase targets fail (empty requests/timings trip a few of
-    # them), only the phase-attributable targets contribute entries to
-    # `failedBlockingTargetDetails`. This isolates the shard-attribution
-    # payload to the targets that carry per-shard evidence.
+    # Only phase-attributable targets contribute entries to
+    # `failedBudgetTargetDetails` when they actually breach. This isolates
+    # the shard-attribution payload to the targets carrying per-shard
+    # evidence.
     timings = tmp_path / "timings.json"
     requests = tmp_path / "requests.json"
     phase = tmp_path / "phase-chromium-01.json"
@@ -179,5 +243,5 @@ def test_failed_details_absent_when_phase_targets_pass(tmp_path):
         "executionAtMostTwentyFiveMinutes",
         "shardsAtMostThirtyMinutesBeforeUpload",
     ):
-        assert payload["blockingTargets"][target] is True
-    assert payload["failedBlockingTargetDetails"] == {}
+        assert payload["budgetTargets"][target] is True
+    assert payload["failedBudgetTargetDetails"] == {}

--- a/.github/scripts/tests/test_refresh_timing_baseline.py
+++ b/.github/scripts/tests/test_refresh_timing_baseline.py
@@ -203,6 +203,117 @@ def test_main_refuses_when_drift_exceeds_cap(tmp_path):
     assert not output.exists()
 
 
+def test_main_skips_immaterial_change_with_exit_three(tmp_path):
+    # 1 of 20 entries shifts by 600 ms — pure run-to-run jitter. With a 10%
+    # materiality threshold the script must exit 3 and write nothing, so the
+    # workflow skips the main commit (every push to main resets the merge
+    # queue; jitter must not).
+    refresh_script = SCRIPTS / "refresh_timing_baseline.py"
+    history = tmp_path / "history.json"
+    current = tmp_path / "current.json"
+    output = tmp_path / "new.json"
+    summary = tmp_path / "summary.md"
+
+    _write(history, {
+        "mode": "full",
+        "sourceSha": "sha-fresh",
+        "tests": [_fresh_test(f"t{i}", "Pages/A.spec.ts", f"case {i}",
+                              1000 + (600 if i == 0 else 0))
+                  for i in range(20)],
+    })
+    _write(current, {
+        "version": 1, "mode": "full", "sourceRunId": 111,
+        "retainedUnstableTestIds": [],
+        "tests": [_current_test(f"t{i}", "Pages/A.spec.ts", f"case {i}", 1000)
+                  for i in range(20)],
+    })
+
+    result = subprocess.run(
+        [sys.executable, str(refresh_script),
+         "--history", str(history), "--current", str(current),
+         "--output", str(output), "--source-run-id", "42",
+         "--min-materiality-percent", "10",
+         "--summary", str(summary)],
+        capture_output=True, text=True,
+    )
+
+    assert result.returncode == 3, result.stdout + result.stderr
+    assert "materiality" in (result.stdout + result.stderr)
+    assert not output.exists()
+    # The summary still records why the refresh was skipped.
+    assert "materiality" in summary.read_text()
+
+
+def test_main_treats_recovered_zero_duration_as_material(tmp_path):
+    # A single zero→real recovery is below any percentage threshold but MUST
+    # refresh: all-zero entries are the planner-starving bug class that
+    # SIGTERM'd chromium-12 (PR #30812).
+    refresh_script = SCRIPTS / "refresh_timing_baseline.py"
+    history = tmp_path / "history.json"
+    current = tmp_path / "current.json"
+    output = tmp_path / "new.json"
+
+    _write(history, {
+        "mode": "full",
+        "sourceSha": "sha-fresh",
+        "tests": [_fresh_test(f"t{i}", "Pages/A.spec.ts", f"case {i}",
+                              1000 if i else 30000)
+                  for i in range(20)],
+    })
+    _write(current, {
+        "version": 1, "mode": "full", "sourceRunId": 111,
+        "retainedUnstableTestIds": [],
+        "tests": [_current_test(f"t{i}", "Pages/A.spec.ts", f"case {i}",
+                                1000 if i else 0)
+                  for i in range(20)],
+    })
+
+    result = subprocess.run(
+        [sys.executable, str(refresh_script),
+         "--history", str(history), "--current", str(current),
+         "--output", str(output), "--source-run-id", "42",
+         "--min-materiality-percent", "10"],
+        capture_output=True, text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert output.exists()
+
+
+def test_main_treats_significant_shift_share_as_material(tmp_path):
+    # 3 of 20 entries (15%) shift by 20 s (>30% and >5 s) — over a 10%
+    # materiality threshold, so the refresh proceeds.
+    refresh_script = SCRIPTS / "refresh_timing_baseline.py"
+    history = tmp_path / "history.json"
+    current = tmp_path / "current.json"
+    output = tmp_path / "new.json"
+
+    _write(history, {
+        "mode": "full",
+        "sourceSha": "sha-fresh",
+        "tests": [_fresh_test(f"t{i}", "Pages/A.spec.ts", f"case {i}",
+                              30000 if i < 3 else 10000)
+                  for i in range(20)],
+    })
+    _write(current, {
+        "version": 1, "mode": "full", "sourceRunId": 111,
+        "retainedUnstableTestIds": [],
+        "tests": [_current_test(f"t{i}", "Pages/A.spec.ts", f"case {i}", 10000)
+                  for i in range(20)],
+    })
+
+    result = subprocess.run(
+        [sys.executable, str(refresh_script),
+         "--history", str(history), "--current", str(current),
+         "--output", str(output), "--source-run-id", "42",
+         "--min-materiality-percent", "10"],
+        capture_output=True, text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert output.exists()
+
+
 def test_main_rejects_non_full_history(tmp_path):
     refresh_script = SCRIPTS / "refresh_timing_baseline.py"
     history = tmp_path / "history.json"

--- a/.github/workflows/playwright-e2e-reusable.yml
+++ b/.github/workflows/playwright-e2e-reusable.yml
@@ -1155,11 +1155,11 @@ jobs:
     needs:
       [build, cache-keys, detect-changes, plan-playwright, prepare-playwright-fixture]
     runs-on: ubuntu-latest
-    # Budget breakdown: 20 min planner shard target + up to 25 min playwright
-    # timeout wrapper (line ~1090) + ~5-8 min for setup (env, node, browser,
-    # bundle verify) and teardown/artifact upload. 30 min was tight enough
-    # that slow shards were being cancelled by the job clock while playwright
-    # itself still had time on the inner wrapper; 35 gives real headroom.
+    # Budget breakdown: up to 30 min playwright hang-protection wrapper on
+    # the test step + ~5-8 min for setup (env, node, browser, bundle verify)
+    # and teardown/artifact upload. The job clock must clear the inner
+    # wrapper plus setup/teardown so a slow-but-finishing shard is never
+    # cancelled here while playwright still has wrapper time left.
     #
     # This ceiling only works when the sub-budgets it composes actually hold.
     # `Install Playwright Browsers` carries its own `timeout 5m` for exactly
@@ -1167,7 +1167,7 @@ jobs:
     # since `PW_ENVIRONMENT_SECONDS` was recorded before that step ran so the
     # 5-min env blocking gate couldn't fire. Keep those inner timeouts in
     # sync when adjusting this outer ceiling.
-    timeout-minutes: 35
+    timeout-minutes: 40
     if: ${{ !cancelled() && needs.build.result == 'success' && needs.detect-changes.result == 'success' && needs.plan-playwright.result == 'success' && needs.prepare-playwright-fixture.result == 'success' }}
     environment: test
     permissions:
@@ -1456,8 +1456,17 @@ jobs:
           fi
           jq '{shardId, lane, workers, predictedWorkerMs, predictedExecutionMs, testCount, projects, files: (.files | length)}' "$plan_file"
           started_at=$(date +%s)
+          # HANG PROTECTION ONLY — not a budget. The planner packs shards to
+          # ~19 min predicted; the 1500 s execution BUDGET is evaluated (and
+          # signalled, never enforced) by evaluate_playwright_performance.py.
+          # This wrapper exists solely so a truly wedged playwright process
+          # cannot hold the job until the 40-min job clock. It must stay well
+          # above the budget: at the old 25m it killed chromium-12 five
+          # seconds after its last test PASSED (run 32500973433 — one wedged
+          # retry teardown ate 9 min), destroying the results artifact and
+          # ejecting a green PR.
           set +e
-          timeout --signal=TERM --kill-after=30s 25m \
+          timeout --signal=TERM --kill-after=30s 30m \
             npx playwright test "${project_args[@]}" "${files[@]}"
           test_exit=$?
           set -e

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -19,9 +19,10 @@
 #   * `playwright-summary`    — the required PR check + PR-comment
 #                               payload uploader (comment forwarding lives
 #                               in playwright-postgresql-pr-comment.yml).
-#   * `refresh-timing-baseline` — merge_group-only auto-PR that keeps
-#                                 `.github/playwright/timing-baseline.json`
-#                                 fresh from the latest full-mode run.
+#   * `refresh-timing-baseline` — merge_group-only direct commit to main
+#                                 that keeps `.github/playwright/timing-baseline.json`
+#                                 fresh from the latest full-mode run
+#                                 (materiality-gated; see the job comment).
 #
 # Reusable jobs are reported as `<caller-job> / <sub-job>` — GH always
 # prefixes — so a required check named `playwright-summary` could never
@@ -141,6 +142,9 @@ jobs:
     permissions:
       actions: read
       contents: read
+      # For the budget-breach tracked issue (Signal Playwright budget
+      # breaches step below).
+      issues: write
     steps:
       # SECURITY: this job runs `require('./.github/scripts/render_playwright_summary.cjs')`
       # via `actions/github-script` with GITHUB_TOKEN in scope, so whichever tree we
@@ -300,18 +304,18 @@ jobs:
         env:
           EXECUTION_MODE: ${{ needs.playwright.outputs.detect_changes_mode }}
         run: |
-          performance_args=()
-          if [[ "$EXECUTION_MODE" == "full" ]]; then
-            performance_args+=(--enforce)
-          fi
+          # No --enforce: time/flake budget targets are SIGNALS (surfaced by
+          # the "Signal Playwright budget breaches" step below), never a
+          # reason to fail the required check on an otherwise-green run.
+          # Blocking targets (reserved for corrupt-results states; empty
+          # today) would still exit non-zero under --enforce if reintroduced.
           timeout --foreground --signal=TERM --kill-after=30s 2m \
             python3 .github/scripts/evaluate_playwright_performance.py \
               --timing-glob "$RUNNER_TEMP/playwright-timings/**/playwright-timings.json" \
               --request-glob "$RUNNER_TEMP/playwright-timings/**/request-metrics.json" \
               --phase-glob "$RUNNER_TEMP/playwright-timings/**/shard-phases.json" \
               --mode "$EXECUTION_MODE" \
-              --output "$RUNNER_TEMP/playwright-timing-history/playwright-performance.json" \
-              "${performance_args[@]}"
+              --output "$RUNNER_TEMP/playwright-timing-history/playwright-performance.json"
           jq . "$RUNNER_TEMP/playwright-timing-history/playwright-performance.json"
 
       - name: Upload merged Playwright report
@@ -335,19 +339,105 @@ jobs:
           performance="$RUNNER_TEMP/playwright-timing-history/playwright-performance.json"
           [[ -f "$performance" ]] || exit 0
           report_seconds=$(($(date +%s) - PW_REPORT_STARTED_AT))
+          # Reporting duration is a BUDGET target: recorded, surfaced by the
+          # budget-signal step below, but never a reason to fail the check
+          # (it used to exit 1 here on full-mode runs and eject green PRs).
           jq \
             --argjson reportSeconds "$report_seconds" \
             '.metrics.reportingSeconds = $reportSeconds |
              .targets.reportingAtMostTwoMinutes = ($reportSeconds <= 120) |
-             .blockingTargets.reportingAtMostTwoMinutes = ($reportSeconds <= 120) |
+             .budgetTargets.reportingAtMostTwoMinutes = ($reportSeconds <= 120) |
              .targetsMet = ([.targets[]] | all) |
+             .budgetTargetsMet = ([.budgetTargets[]] | all) |
              .blockingTargetsMet = ([.blockingTargets[]] | all) |
              .convergenceTargetsMet = ([.convergenceTargets[]] | all)' \
             "$performance" > "$performance.tmp"
           mv "$performance.tmp" "$performance"
-          if [[ "$EXECUTION_MODE" == "full" && "$report_seconds" -gt 120 ]]; then
-            echo "Playwright reporting and report upload exceeded two minutes" >&2
-            exit 1
+          if [[ "$report_seconds" -gt 120 ]]; then
+            echo "::warning::Playwright reporting and report upload took ${report_seconds}s (budget 120s)"
+          fi
+
+      # THE budget signal. Time/flake budgets no longer fail the required
+      # check (see evaluate_playwright_performance.py — run 32500973433
+      # ejected a PR with zero test failures); instead every breach is:
+      #   * a ::warning annotation on this run,
+      #   * a section in the job summary,
+      #   * an upsert into the tracked issue "Playwright CI over time budget"
+      #     (merge_group full runs only, comment throttled to one per 20 h)
+      # so capacity problems page a human through the issue, not by ejecting
+      # innocent PRs from the merge queue.
+      - name: Signal Playwright budget breaches
+        id: budget-signal
+        if: ${{ always() && needs.playwright.outputs.gate_should_run == 'true' && needs.playwright.outputs.playwright_ci_result != 'skipped' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXECUTION_MODE: ${{ needs.playwright.outputs.detect_changes_mode }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ISSUE_TITLE: "Playwright CI over time budget"
+        run: |
+          performance="$RUNNER_TEMP/playwright-timing-history/playwright-performance.json"
+          [[ -f "$performance" ]] || { echo "No performance payload; nothing to signal."; exit 0; }
+          met=$(jq -r '.budgetTargetsMet // true' "$performance")
+          if [[ "$met" == "true" ]]; then
+            echo "All Playwright budget targets met."
+            exit 0
+          fi
+
+          breached_names=$(jq -r '(.budgetTargets // {}) | to_entries[] | select(.value == false) | .key' "$performance")
+          detail_lines=$(jq -r '
+            (.failedBudgetTargetDetails // {}) | to_entries[] | . as $e |
+            "- **\($e.value.label)**: budget ≤ \($e.value.threshold) \($e.value.unit)" +
+            (if ($e.value.offendingShards | length) > 0
+             then " — exceeded on " + ($e.value.offendingShards | map("`\(.shardId)` (\(.value) \($e.value.unit))") | join(", "))
+             else "" end)' "$performance")
+          # Budget targets without phase attribution (flaky rate, retry
+          # share, boot shape) still need a line each.
+          plain_lines=$(jq -r '
+            (.failedBudgetTargetDetails // {}) as $d |
+            (.budgetTargets // {}) | to_entries[]
+            | select(.value == false and ($d[.key] | not))
+            | "- \(.key)"' "$performance")
+
+          while IFS= read -r name; do
+            [[ -n "$name" ]] && echo "::warning::Playwright budget breach: $name"
+          done <<< "$breached_names"
+
+          {
+            echo "## ⚠️ Playwright budget breaches"
+            echo
+            [[ -n "$detail_lines" ]] && echo "$detail_lines"
+            [[ -n "$plain_lines" ]] && echo "$plain_lines"
+            echo
+            echo "Budget breaches do not fail this check; investigate via the tracked issue."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Tracked issue: only authoritative (merge_group + full) runs feed
+          # it — PR-time targeted runs measure a subset and would be noise.
+          if [[ "${GITHUB_EVENT_NAME}" != "merge_group" || "$EXECUTION_MODE" != "full" ]]; then
+            exit 0
+          fi
+
+          body=$(printf 'Latest breach: [run %s](%s)\n\n%s\n%s\n\nThe merge-queue check stays green on budget breaches; this issue is the signal. Investigate shard packing (`build_playwright_shards.py`), the timing baseline, or runaway specs. Close when runs stay within budget.\n' \
+            "${GITHUB_RUN_ID}" "$RUN_URL" "$detail_lines" "$plain_lines")
+
+          existing=$(gh issue list --state open --search "in:title \"$ISSUE_TITLE\"" \
+            --json number,title --jq --arg t "$ISSUE_TITLE" '[.[] | select(.title == $t)][0].number // empty')
+          if [[ -z "$existing" ]]; then
+            gh issue create --title "$ISSUE_TITLE" --body "$body"
+            echo "Opened budget-breach issue."
+          else
+            # Throttle: at most one comment per 20 h so a breached week does
+            # not bury the issue in per-run comments.
+            last_comment=$(gh issue view "$existing" --json comments \
+              --jq '.comments[-1].createdAt // ""')
+            cutoff=$(date -u -d '20 hours ago' +%FT%TZ)
+            if [[ -z "$last_comment" || "$last_comment" < "$cutoff" ]]; then
+              gh issue comment "$existing" --body "$body"
+              echo "Commented on budget-breach issue #$existing."
+            else
+              echo "Issue #$existing already updated within 20 h; skipping comment."
+            fi
           fi
 
       - name: Upload timing history
@@ -463,15 +553,19 @@ jobs:
           retention-days: 5
           if-no-files-found: ignore
 
-  # Auto-refresh the checked-in timing baseline from every successful
-  # full-mode merge_group run. Without this,
-  # `.github/playwright/timing-baseline.json` only gets updated by hand —
-  # and it drifts fast (see PR #30871 for the 12-day, 23%-dead-title
-  # snapshot that triggered this workflow addition).
+  # Auto-refresh the checked-in timing baseline from successful full-mode
+  # merge_group runs. Without this, `.github/playwright/timing-baseline.json`
+  # only gets updated by hand — and it drifts fast (see PR #30871 for the
+  # 12-day, 23%-dead-title snapshot that triggered this workflow addition).
   #
-  # The step opens/updates a single tracked PR against `main`. A human
-  # still clicks merge — the auto-PR just eliminates the "regenerate the
-  # file" busywork.
+  # COMMITS DIRECTLY TO MAIN (no PR). The previous auto-PR design
+  # deadlocked with the merge queue: the refresh PR had to pass through the
+  # very queue whose activity kept invalidating it, and concurrent refresh
+  # runs raced on the bot branch (`cannot lock ref`, run 32354038772). A
+  # data-only JSON regenerated from a known-good run doesn't need review —
+  # the guards below are the review. `[skip ci]` keeps the push from
+  # burning a CI cycle; note any push to main still resets in-flight
+  # merge-queue entries, which is why the materiality threshold exists.
   #
   # Guards:
   #   * merge_group event only (skip on PR/dispatch — the ci-status
@@ -481,6 +575,12 @@ jobs:
   #   * playwright-summary success only (no partial data on gate failures)
   #   * a drift cap in refresh_timing_baseline.py refuses > 40 % churn as
   #     a safety valve against an accidentally-broken source run
+  #   * a materiality threshold (--min-materiality-percent) skips commits
+  #     for run-to-run jitter — only structural changes (files gained or
+  #     lost, zero-duration entries recovering) or ≥ 10 % of entries
+  #     drifting/shifting significantly produce a commit
+  #   * fetch → regenerate → push retry loop (3 attempts) absorbs races
+  #     with the queue landing merges mid-refresh
   refresh-timing-baseline:
     name: Refresh timing baseline
     needs: [playwright, playwright-summary]
@@ -493,14 +593,18 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
-      pull-requests: write
     steps:
+      # NOTE: pushing to a protected `main` requires the token identity to
+      # be on the branch-protection bypass list. RELEASE_BOT_TOKEN is the
+      # same identity auto-revert-release.yml uses to push release
+      # branches; GITHUB_TOKEN is the fallback for repos where Actions is
+      # allowed to bypass.
       - name: Checkout
         uses: actions/checkout@v7
         with:
           ref: main
           persist-credentials: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Download timing history artifact
         uses: actions/download-artifact@v7
@@ -519,57 +623,59 @@ jobs:
           fi
           echo "history_path=$history" >> "$GITHUB_OUTPUT"
 
-      - name: Build refreshed baseline
-        run: |
-          python3 .github/scripts/refresh_timing_baseline.py \
-            --history "${{ steps.locate.outputs.history_path }}" \
-            --current .github/playwright/timing-baseline.json \
-            --output .github/playwright/timing-baseline.json \
-            --source-run-id "${{ github.run_id }}" \
-            --summary "$RUNNER_TEMP/baseline-refresh-summary.md"
-
-      - name: Skip if baseline unchanged
-        id: diff
-        run: |
-          if git diff --quiet -- .github/playwright/timing-baseline.json; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Push refresh branch and open/update PR
-        if: steps.diff.outputs.changed == 'true'
+      - name: Refresh baseline and commit to main
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HISTORY_PATH: ${{ steps.locate.outputs.history_path }}
           RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          branch="ci/auto-refresh-timing-baseline"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          # Reset the tracked branch to the latest state — a single tracked
-          # PR gets updated across successive runs rather than accumulating
-          # one PR per merge_group. Plain `--force` (not `--force-with-lease`)
-          # because Checkout only fetched `main`, so no remote-tracking ref
-          # exists for this bot-owned branch and a lease would be rejected
-          # with "stale info" on the second and every subsequent run.
-          git checkout -B "$branch"
-          git add .github/playwright/timing-baseline.json
-          git commit -m "chore(playwright): auto-refresh timing baseline from run ${RUN_ID}"
-          git push --force origin "$branch"
 
-          summary_body="$(cat "$RUNNER_TEMP/baseline-refresh-summary.md")"
-          pr_body=$(printf '## Summary\n\nAuto-refreshed from [merge_group run %s](%s).\n\n```\n%s\n```\n\nA human still clicks merge. If this drift looks unreasonable, close the PR — the next successful merge_group run will open a fresh one.\n' "$RUN_ID" "$RUN_URL" "$summary_body")
-          # `.[0].number` on an empty array yields the literal string "null",
-          # not an empty string; the `// empty` fallback turns that into a
-          # real empty string so the -n test below correctly picks the
-          # `gh pr create` branch on the very first run.
-          existing=$(gh pr list --head "$branch" --base main --state open --json number --jq '.[0].number // empty' || echo "")
-          if [[ -n "$existing" ]]; then
-            gh pr edit "$existing" --body "$pr_body"
-            echo "Updated existing PR #$existing"
-          else
-            gh pr create --base main --head "$branch" \
-              --title "chore(playwright): auto-refresh timing-baseline.json" \
-              --body "$pr_body"
-          fi
+          # Regenerate INSIDE the retry loop: each attempt rebuilds the
+          # baseline against the freshly-fetched main, so a queue merge (or
+          # a concurrent refresh run) landing mid-refresh changes the
+          # regeneration input instead of producing a rejected push — the
+          # race that killed the bot-branch design (run 32354038772).
+          for attempt in 1 2 3; do
+            git fetch origin main
+            git reset --hard origin/main
+
+            set +e
+            python3 .github/scripts/refresh_timing_baseline.py \
+              --history "$HISTORY_PATH" \
+              --current .github/playwright/timing-baseline.json \
+              --output .github/playwright/timing-baseline.json \
+              --source-run-id "$RUN_ID" \
+              --min-materiality-percent 10 \
+              --summary "$RUNNER_TEMP/baseline-refresh-summary.md"
+            rc=$?
+            set -e
+
+            if [[ "$rc" -eq 3 ]]; then
+              echo "Change below materiality threshold; skipping refresh commit."
+              exit 0
+            elif [[ "$rc" -ne 0 ]]; then
+              echo "refresh_timing_baseline.py exited $rc" >&2
+              exit "$rc"
+            fi
+
+            if git diff --quiet -- .github/playwright/timing-baseline.json; then
+              echo "Baseline identical to main; nothing to commit."
+              exit 0
+            fi
+
+            git add .github/playwright/timing-baseline.json
+            git commit \
+              -m "chore(playwright): auto-refresh timing baseline from run ${RUN_ID} [skip ci]" \
+              -m "$(cat "$RUNNER_TEMP/baseline-refresh-summary.md")" \
+              -m "Source: ${RUN_URL}"
+            if git push origin HEAD:main; then
+              echo "Baseline refreshed on main (attempt $attempt)."
+              exit 0
+            fi
+            echo "Push rejected (main moved during refresh); retrying." >&2
+          done
+
+          echo "Failed to push refreshed baseline after 3 attempts." >&2
+          exit 1


### PR DESCRIPTION
## Why

[Run 32500973433](https://github.com/open-metadata/OpenMetadata/actions/runs/32500973433) ejected a PR from the merge queue with **zero test failures**: chromium-12 finished all 142 tests green, one wedged retry attempt of `ExplorePageRightPanel:1142` burned 9 minutes (baseline 10 s, test timeout 60 s — the rest is Playwright's **unbounded on-failure trace/video teardown** against a dead browser), and the 25 m wrapper SIGTERM'd playwright **5 seconds after the last test passed**, destroying the results artifact and failing the required check as "0 Playwright test failure(s); 3 CI/reporting failure(s)".

The missing piece: time budgets were wired as **process kills and blocking gates** at merge-group time. No planner can predict a wedged teardown, so this recurs weekly. This PR makes over-budget a **signal**, and reserves run-failure for genuine test failures and unverifiable results.

## Budget signal rework

| Layer | Before | After |
|---|---|---|
| Test-step `timeout` wrapper | 25 m — doubled as budget enforcement, killed slow-but-green shards mid-report | **30 m, hang protection only** (job clock 35→40 m in lock-step) |
| `executionAtMostTwentyFiveMinutes` & friends | blocking gates → check failure → PR ejected | **budget targets**: `::warning` annotations + job-summary section + payload details |
| Reporting > 2 min (full mode) | `exit 1` in the summary job | warning, recorded as budget target |
| Escalation | none (first symptom = red merge_group) | **tracked issue "Playwright CI over time budget"** upserted from merge_group full runs (comment-throttled to 1/20 h) |

`--enforce` semantics are preserved for a reserved *blocking* class (empty today — a home for corrupt-results style states). The PR-comment payload schema is untouched (it crosses workflow versions); budget breaches ride the existing `convergenceWarnings` channel.

## Baseline refresh: direct commit + materiality threshold

The auto-PR approach deadlocked with the merge queue (the refresh PR had to pass through the queue whose activity kept invalidating it) and raced on the bot branch (`cannot lock ref`, run 32354038772). Now:

- **Direct `[skip ci]` commit to main**, regenerated inside a fetch→reset→regenerate→push retry loop (×3) so a concurrent queue merge changes the input instead of rejecting the push.
- **`--min-materiality-percent 10`**: run-to-run jitter never commits (each push to main resets in-flight queue entries). Always material: files gained/lost, zero-duration entries recovering (the planner-starving class from #30812). Material at ≥10%: entry churn or significant duration shifts (>30% and >5 s). The 40% drift safety valve stays.

> ⚠️ **Action needed**: pushing to protected `main` requires the token identity on the bypass list. The job uses `RELEASE_BOT_TOKEN` (same identity `auto-revert-release.yml` pushes with), falling back to `GITHUB_TOKEN`. If neither can bypass main's protection, add the bot to the bypass list or the push will fail with a clear error.

## Tests

`python3 -m pytest .github/scripts/tests/ .github/scripts/test_classify_playwright_outcome.py .github/scripts/test_classify_test_outcome.py` → **146 passed**, including new coverage: budget breach exits 0 with detailed payload; wrapper/budget headroom sync guard (fires if someone re-tightens the wrapper toward the budget); `--enforce` absent from the caller workflow; materiality skip (exit 3, nothing written), zero-recovery always material, significant-shift share material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR converts Playwright performance budgets from blocking gates into non-fatal signals and adds materiality-gated, direct baseline refreshes to `main`.
- Separates budget, convergence, and reserved blocking targets in the performance payload.
- Adds workflow warnings, summaries, and tracked-issue escalation for budget breaches.
- Increases Playwright hang-protection and job timeouts.
- Adds a materiality threshold and retry loop for timing-baseline refresh commits.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not yet safe to merge because budget-breach reporting can still reject the PR-comment payload and fail before updating the tracked issue.

Budget warnings remain incompatible with the publisher’s `convergenceWarnings` contract, and the tracked-issue lookup still invokes `gh issue list --jq` with unsupported jq arguments, leaving both reporting channels broken on reachable budget breaches.

**Files Needing Attention:** .github/scripts/render_playwright_summary.cjs, .github/scripts/publish_playwright_pr_comment.cjs, .github/workflows/playwright-postgresql-e2e.yml
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/scripts/evaluate_playwright_performance.py | Separates budget targets from convergence and reserved blocking targets while preserving detailed breach metadata. |
| .github/scripts/render_playwright_summary.cjs | Renders budget breaches as warnings and updates performance classifications. |
| .github/scripts/publish_playwright_pr_comment.cjs | Adds distinct author-facing verdicts and separates budget telemetry from optimization warnings. |
| .github/scripts/refresh_timing_baseline.py | Adds structural and percentage-based materiality checks before writing a refreshed timing baseline. |
| .github/workflows/playwright-e2e-reusable.yml | Raises the test wrapper to 30 minutes and the containing job timeout to 40 minutes. |
| .github/workflows/playwright-postgresql-e2e.yml | Makes budget breaches non-blocking, adds escalation, and replaces the baseline auto-PR with direct retrying commits. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Playwright shards] --> B[Performance evaluation]
  B --> C{Target class}
  C -->|Budget breach| D[Warning and job summary]
  D --> E[Tracked budget issue]
  C -->|Reserved blocker| F[Required check failure]
  B --> G[Timing history]
  G --> H{Material change?}
  H -->|No| I[Skip refresh]
  H -->|Yes| J[Regenerate against latest main]
  J --> K[Commit and push to main]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["ci(playwright): tell PR authors whether ..."](https://github.com/open-metadata/openmetadata/commit/38eaebaf598c39d9284535bf8d872d7790823401) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55812000)</sub>

<!-- /greptile_comment -->