### PR TITLE
fix(playwright): gate deleted-entity dropdown assertions on search-index consistency

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExplorePageRightPanel.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExplorePageRightPanel.spec.ts
@@ -158,6 +158,13 @@ test.describe('Right Panel Test Suite', () => {
 
   test.describe('Explore page right panel tests', () => {
     test.describe('Overview panel CRUD and Removal operations', () => {
+      // Nightly EKS/RDS infra runs every test body in this group at 72-84 s
+      // (run 32560604531 in openmetadata-nightly; PR infra ~45 s) — genuine
+      // remote-server latency, uniform across all 10 tests. Budget for that
+      // infra explicitly instead of the old suite-wide test.slow(true),
+      // which tripled EVERY test in the file and let failures grind for
+      // minutes. Applies to all tests in this describe only.
+      test.setTimeout(120_000);
       const crudEntityMap = {
         table: new TableClass(),
         dashboard: new DashboardClass(),

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExplorePageRightPanel.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExplorePageRightPanel.spec.ts
@@ -31,7 +31,7 @@ import { ClassificationClass } from '../../support/tag/ClassificationClass';
 import { TagClass } from '../../support/tag/TagClass';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
-import { uuid } from '../../utils/common';
+import { uuid, waitForDeletionFromSearchIndex } from '../../utils/common';
 import { getCurrentMillis } from '../../utils/dateTime';
 import {
   getEntityDisplayName,
@@ -1075,6 +1075,18 @@ test.describe('Right Panel Test Suite', () => {
               await overview.shouldShowOwner(deletedUser.getUserDisplayName());
 
               await deletedUser.delete(apiContext);
+              // The owner dropdown is search-backed and index deletion is
+              // eventually consistent — gate on the index before asserting
+              // absence, or the dropdown can still return the deleted user.
+              await waitForDeletionFromSearchIndex(
+                apiContext,
+                deletedUser.getUserDisplayName(),
+                'user',
+                [
+                  deletedUser.getUserDisplayName(),
+                  deletedUser.responseData.name,
+                ]
+              );
               await adminPage.reload();
               await rightPanel.waitForPanelVisible();
 
@@ -1126,6 +1138,14 @@ test.describe('Right Panel Test Suite', () => {
 
               await deletedTag.delete(apiContext);
               await deletedClassification.delete(apiContext);
+              // Gate on index deletion propagating before asserting absence
+              // in the search-backed tag dropdown (eventual consistency).
+              await waitForDeletionFromSearchIndex(
+                apiContext,
+                deletedTagDisplayName,
+                'tag',
+                [deletedTagDisplayName]
+              );
               await adminPage.reload();
               await rightPanel.waitForPanelVisible();
 
@@ -1174,6 +1194,14 @@ test.describe('Right Panel Test Suite', () => {
 
               await deletedGlossaryTerm.delete(apiContext);
               await deletedGlossary.delete(apiContext);
+              // Gate on index deletion propagating before asserting absence
+              // in the search-backed term dropdown (eventual consistency).
+              await waitForDeletionFromSearchIndex(
+                apiContext,
+                deletedTermDisplayName,
+                'glossaryTerm',
+                [deletedTermDisplayName]
+              );
               await adminPage.reload();
               await rightPanel.waitForPanelVisible();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExplorePageRightPanel.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExplorePageRightPanel.spec.ts
@@ -114,7 +114,12 @@ const testTier = 'Tier1';
 test.describe('Right Panel Test Suite', () => {
   // Setup test data and page objects
   test.beforeAll(async ({ browser }) => {
-    test.slow(true); // 5 minutes
+    // Explicit hook budget for the 9 sequential entity creations. Do NOT
+    // use test.slow(true) here: combined with the (now removed) suite-wide
+    // beforeEach slow, stacked tripled budgets let a single failing attempt
+    // grind for 9 minutes before reporting (hook 3m + nested hook 3m + test
+    // 3m — run 32500973433) instead of failing fast.
+    test.setTimeout(120_000);
     const { apiContext, afterAction } = await performAdminLogin(browser);
 
     try {
@@ -130,11 +135,6 @@ test.describe('Right Panel Test Suite', () => {
     } finally {
       await afterAction();
     }
-  });
-
-  // No need for explicit beforeEach instantiation as fixtures handle it
-  test.beforeEach(async () => {
-    test.slow(true);
   });
 
   // Cleanup test data
@@ -372,7 +372,8 @@ test.describe('Right Panel Test Suite', () => {
       };
 
       test.beforeAll(async ({ browser }) => {
-        test.slow(true);
+        // Bounded hook budget — see the suite-level beforeAll comment.
+        test.setTimeout(120_000);
         const { apiContext, afterAction } = await performAdminLogin(browser);
         try {
           await Promise.all(
@@ -1476,7 +1477,8 @@ test.describe('Right Panel Test Suite', () => {
       };
 
       test.beforeAll(async ({ browser }) => {
-        test.slow(true);
+        // Bounded hook budget — see the suite-level beforeAll comment.
+        test.setTimeout(120_000);
         const { apiContext, afterAction } = await performAdminLogin(browser);
         try {
           await Promise.all(

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -1053,13 +1053,22 @@ export const waitForDeletionFromSearchIndex = async (
           )}&index=${searchIndex}&from=0&size=10`
         );
 
+        // This poll resolves on `false` ("entity gone"), the OPPOSITE
+        // polarity of verifyDomainPropagation — so a transient search error
+        // must read as "still present" (keep polling), never as an empty
+        // result set, or a single flaky 5xx would pass the gate against a
+        // stale index.
+        if (!response.ok()) {
+          return true;
+        }
+
         const hits: {
           _source?: {
             name?: string;
             displayName?: string;
             fullyQualifiedName?: string;
           };
-        }[] = response.ok() ? (await response.json())?.hits?.hits ?? [] : [];
+        }[] = (await response.json())?.hits?.hits ?? [];
 
         return hits.some((hit) =>
           matchNames.some(

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -1027,6 +1027,54 @@ export const verifyDomainPropagation = async (
   await expect(entityCard).toContainText(domain.displayName);
 };
 
+/**
+ * Wait for a hard-deleted entity to disappear from the search index.
+ *
+ * Search-index deletion is eventually consistent: a selection dropdown
+ * queried immediately after `DELETE /api/v1/...?hardDelete=true` can still
+ * return the deleted entity and fail a `not.toBeVisible()` assertion (the
+ * ExplorePageRightPanel deleted-entity flake family — run 32500973433).
+ * Gate on the search API no longer returning the entity before asserting
+ * its absence in the UI, mirroring how verifyDomainPropagation gates on
+ * presence.
+ */
+export const waitForDeletionFromSearchIndex = async (
+  apiContext: APIRequestContext,
+  searchTerm: string,
+  searchIndex: string,
+  matchNames: string[]
+) => {
+  await expect
+    .poll(
+      async () => {
+        const response = await apiContext.get(
+          `/api/v1/search/query?q=${encodeURIComponent(
+            searchTerm
+          )}&index=${searchIndex}&from=0&size=10`
+        );
+
+        const hits: {
+          _source?: {
+            name?: string;
+            displayName?: string;
+            fullyQualifiedName?: string;
+          };
+        }[] = response.ok() ? (await response.json())?.hits?.hits ?? [] : [];
+
+        return hits.some((hit) =>
+          matchNames.some(
+            (name) =>
+              hit._source?.name === name ||
+              hit._source?.displayName === name ||
+              hit._source?.fullyQualifiedName === name
+          )
+        );
+      },
+      { timeout: 30_000, intervals: [1_000, 2_000, 3_000, 5_000] }
+    )
+    .toBe(false);
+};
+
 export const replaceAllSpacialCharWith_ = (text: string) => {
   return text.replaceAll(/[&/\\#, +()$~%.'":*?<>{}]/g, '_');
 };


### PR DESCRIPTION
## Why

The `Overview panel - Deleted entity verification` family in `ExplorePageRightPanel.spec.ts` has flaked at four different lines (`:1048`, `:1092`, `:1142`, `:1532`). On [run 32500973433](https://github.com/open-metadata/OpenMetadata/actions/runs/32500973433) the `:1142` first attempt failed after a **9-minute** slot and pushed the shard past its wall clock — ejecting a PR with zero genuine test failures.

Two independent defects, both fixed here:

### 1. Flake root cause: racing the search index (commit bfa5bbf)

Each test hard-deletes a user/tag/glossary term via API, reloads, and asserts absence from a **search-backed** dropdown after a **single** search query. Elasticsearch delete propagation is eventually consistent; under CI load the query still returns the deleted entity → `not.toBeVisible()` fails → retry passes once the index catches up.

Fix: new `waitForDeletionFromSearchIndex` helper (inverse of the existing `verifyDomainPropagation` gate) polls `/api/v1/search/query` until the deleted entity disappears from the `user`/`tag`/`glossaryTerm` index (all three deletes are `hardDelete=true`, so the poll converges), then the existing UI verification runs once. Poll bounded at 30 s, typically converges in seconds.

### 2. Fail-fast: the 9-minute failure was stacked tripled timeouts (commit f65365f)

The suite ran **every** test at 180 s via a blanket `test.beforeEach(() => test.slow(true))`, and tripled its `beforeAll` hooks with `test.slow(true)` too. A failing attempt on a fresh worker ground through tripled top-level hook + tripled nested hook + tripled test body ≈ **3 × 180 s = the 9-minute slot** before reporting anything.

Evidence (timing-history artifacts from 6 recent full merge_group runs): 244/251 tests in this spec finish in ≤ 21 s at p95, max true body ~45 s — the 60 s default is generous. The >55 s slots are `beforeAll` time attributed to worker-first tests, which has its own separate hook budget and never needed the *test* timeout tripled.

- Blanket `beforeEach` slow **removed** → tests fail at the 60 s default.
- `test.slow(true)` in the three `beforeAll` hooks → explicit `test.setTimeout(120_000)` hook budget (hook-scoped; bounds a wedged setup at 2 min).
- Targeted per-test `test.slow()` opt-ins (lineage/data-quality tests building real data inline) unchanged.

**Worst-case failing slot: ~9 min → 60 s (typical) / ~3 min (worker-first incl. hook budgets).**


## Nightly infra cross-check (EKS/RDS)

Verified against [openmetadata-nightly run 32560604531](https://github.com/open-metadata/openmetadata-nightly/actions/runs/32560604531) (EKS/RDS MySQL, remote server) so the timeout change cannot regress there:

- Spec-wide on nightly: median 12.5 s, p95 23.5 s, deleted-entity family max 24 s — comfortable at the 60 s default.
- **Exception found and handled**: every test body in `Overview panel CRUD and Removal operations` runs 72–84 s on nightly (~45 s on PR infra) — uniform across all 10 tests, i.e. genuine remote-server latency. That describe gets an explicit `test.setTimeout(120_000)` (nightly max × 1.4) instead of relying on the old suite-wide 3× slow.

## Tests

- ESLint + Prettier clean; `tsc` reports no errors in changed files.
- Test-only change; the affected tests run in the Playwright PR pipeline itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes deleted-entity Playwright checks wait for search-index convergence and replaces blanket timeout multiplication with bounded, scope-specific budgets.
- Polls the search API before checking deleted users, tags, and glossary terms in dropdowns.
- Treats non-successful search responses as “keep polling,” preventing errors from masquerading as deletion.
- Restores default test timeouts while retaining explicit budgets for expensive hooks and the slower CRUD group.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts | The deletion poll now handles non-2xx responses with the correct inverse-poll polarity, fully addressing the prior finding. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExplorePageRightPanel.spec.ts | Deleted-entity checks now wait for index consistency, and timeout overrides are narrowed to documented slow scopes. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(playwright): treat search errors as ..."](https://github.com/open-metadata/openmetadata/commit/d01043e766a818446a738f1d6f521e750e55ccf5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55822854)</sub>

<!-- /greptile_comment -->