### PR TITLE
ci: route auto-revert Slack pings to #ci-cleanup

### DIFF
--- a/.github/workflows/auto-revert-release.yml
+++ b/.github/workflows/auto-revert-release.yml
@@ -208,7 +208,7 @@ jobs:
           errors: true
           payload: |
             {
-              "channel": "C03EYBDDX17",
+              "channel": "C0AC5T013V1",
               "text": ":rotating_light: *Auto-revert on `${{ steps.ev.outputs.branch }}`*\n*Reason:* `${{ steps.ev.outputs.name }}` failed — <${{ steps.ev.outputs.url }}|failing run>\n*Reverted commit:* `${{ steps.ev.outputs.sha }}` — ${{ steps.meta.outputs.subject }}\n*Original author:* ${{ steps.meta.outputs.author_name }} <${{ steps.meta.outputs.author_email }}>\n*Revert commit:* `${{ steps.revert.outputs.revert_sha }}`"
             }
 
@@ -226,7 +226,7 @@ jobs:
           errors: true
           payload: |
             {
-              "channel": "C03EYBDDX17",
+              "channel": "C0AC5T013V1",
               "text": ":x: *Auto-revert FAILED on `${{ steps.ev.outputs.branch }}`*\n`${{ steps.ev.outputs.name }}` failed on `${{ steps.ev.outputs.sha }}`, but the automatic revert did not succeed (likely a conflict or push rejection). Manual intervention required.\n*Failing run:* <${{ steps.ev.outputs.url }}|link>\n*Auto-revert run:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
 


### PR DESCRIPTION
### Describe your changes:

The initial channel ID (`C03EYBDDX17`) in `auto-revert-release.yml` was carried over from `py-sonarcloud-nightly.yml`, but that's the ingestion-sonar channel — the release/CI audience for these alerts is `#ci-cleanup` (`C0AC5T013V1`), which is what `merge-queue-dequeue-report.yml:50` already uses. Swap the channel ID in both Slack notify steps (reverted, and revert-failed).

Verified end-to-end during the #31828 live-arm test — the workflow correctly posted to Slack; only the destination channel was wrong.

#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the CONTRIBUTING document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` — small config fix on top of #31828, no separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR redirects both successful and failed auto-revert Slack notifications from the ingestion-sonar channel to the established `#ci-cleanup` channel.
- Updates the channel ID in the successful-revert notification.
- Updates the channel ID in the failed-revert notification.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because both notifications use an established channel already paired with the same Slack action and token.

The change is limited to two matching channel literals, and repository evidence corroborates the replacement as the existing `#ci-cleanup` destination.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/auto-revert-release.yml | Both Slack notification branches now use the repository’s existing `#ci-cleanup` channel ID without changing payload structure or workflow behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: route auto-revert Slack pings to #ci..."](https://github.com/open-metadata/openmetadata/commit/cb7700fd5bc36183281e9922e97d2e990e176645) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55836329)</sub>

<!-- /greptile_comment -->