### PR TITLE
Fixes 31912: accept array-encoded testCaseStatus in the DQ dashboard pie IT

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/ui/pages/DataQualityDashboardPage.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/ui/pages/DataQualityDashboardPage.java
@@ -20,6 +20,15 @@ public final class DataQualityDashboardPage extends PageObject {
   public static final String ENTITY_HEALTH_PIE_ID = "healthy-data-assets-pie-chart";
   public static final String DATA_ASSETS_COVERAGE_PIE_ID = "data-assets-coverage-pie-chart";
 
+  /**
+   * The Test Case Result pie still redirects with a scalar {@code testCaseStatus=Failed}, but the
+   * Entity Health pie maps one segment to several statuses and serializes them through
+   * {@code qs.stringify(..., {arrayFormat: 'brackets'})}, which emits {@code testCaseStatus%5B%5D=}.
+   * Both encodings satisfy the contract under test: the click navigated with a status filter.
+   */
+  private static final Pattern TEST_CASES_WITH_STATUS_URL =
+      Pattern.compile("/data-quality/test-cases.*testCaseStatus(%5B%5D|\\[\\])?=");
+
   private DataQualityDashboardPage(final Page page, final UiSession session) {
     super(page, session);
   }
@@ -56,7 +65,7 @@ public final class DataQualityDashboardPage extends PageObject {
 
   /**
    * Click the first available pie chart segment and assert the URL navigates to
-   * {@code /data-quality/test-cases} carrying ANY {@code testCaseStatus=} param.
+   * {@code /data-quality/test-cases} carrying ANY {@code testCaseStatus} param, scalar or array.
    * Recharts only renders segments for non-zero data and the rendering order isn't
    * stable across data shapes, so this method asserts the navigation contract
    * rather than a specific segment-to-status mapping.
@@ -67,9 +76,7 @@ public final class DataQualityDashboardPage extends PageObject {
     PlaywrightAssertions.assertThat(segment)
         .isVisible(new LocatorAssertions.IsVisibleOptions().setTimeout(15_000));
     segment.evaluate("el => el.dispatchEvent(new MouseEvent('click', { bubbles: true }))");
-    page.waitForURL(
-        Pattern.compile("/data-quality/test-cases.*testCaseStatus="),
-        new Page.WaitForURLOptions().setTimeout(20_000));
+    page.waitForURL(TEST_CASES_WITH_STATUS_URL, new Page.WaitForURLOptions().setTimeout(20_000));
     return this;
   }
 


### PR DESCRIPTION
### Describe your changes:

Fixes #31912

I widened the URL pattern that `DataQualityDashboardPage.clickPieChartSegmentExpectsStatusNav` waits on, because #31662 changed the Entity Health pie's redirect encoding and broke `DataQualityDashboardDimensionAndPieReindexUIIT` on every PR that has merged `main` since 2026-08-20.

#31662 turned the Entity Health pie's segment→status mapping from one status per segment into several:

```ts
-export const BINARY_STATUS_PIE_SEGMENT_ORDER: TestCaseStatus[] = [
-  TestCaseStatus.Success,
-  TestCaseStatus.Failed,
+export const BINARY_STATUS_PIE_SEGMENT_ORDER: TestCaseStatus[][] = [
+  [TestCaseStatus.Success, TestCaseStatus.Queued],
+  [TestCaseStatus.Failed, TestCaseStatus.Aborted],
 ];
```

That array is serialized by `getTestCaseListPath` through `qs.stringify(..., { arrayFormat: 'brackets' })`, so the redirect went from `?testCaseStatus=Failed` to `?testCaseStatus%5B%5D=Failed&testCaseStatus%5B%5D=Aborted`. The page object still waited on `Pattern.compile("/data-quality/test-cases.*testCaseStatus=")`, which no longer matches, so `waitForURL` timed out after 20s.

The new URL is intended product behaviour, so this PR updates the test contract rather than the UI. The assertion the test actually makes is "the click navigated to the test-cases route carrying a status filter", so it now accepts the scalar form, the encoded brackets and the decoded brackets.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered

- Clicking a segment of the **Entity Health** pie on `/data-quality/dashboard` navigates to `/data-quality/test-cases` with a multi-status filter (`testCaseStatus[]=Failed&testCaseStatus[]=Aborted`).
- Clicking a segment of the **Test Case Result** pie still navigates with the single-status filter (`testCaseStatus=Failed`) — unchanged by #31662 and still covered by the same pattern.

#### Unit tests

Not applicable — this PR only changes an existing integration test's assertion. `EntityHealthStatusPieChartWidget.test.tsx` already asserts the new URL shape (added in #31662); this change makes the Java IT agree with it.

#### Backend integration tests

- [x] Not applicable (no backend API changes).
- Files updated: `openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/ui/pages/DataQualityDashboardPage.java`

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Not applicable (no UI changes) — the Java Playwright IT `DataQualityDashboardDimensionAndPieReindexUIIT` is what this PR repairs.

#### Manual testing performed

Verification is the `java-playwright-nightly` run on this PR: `ui-it-nightly (elasticsearch)` and `ui-it-nightly (opensearch)` must go green on `DataQualityDashboardDimensionAndPieReindexUIIT.dashboardNavigationSurvivesReindex`, which fails on every other PR built from current `main`.

Diagnosis behind the change (full data in #31912): the workflow checks out `github.event.pull_request.head.sha`, and across the last nine nightly runs every red head contains `e8ee606439` (#31662) and every green head does not — 9/9, including two dependabot PRs that touch no product code.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the Data Quality dashboard integration-test page object so pie-chart navigation waits accept both scalar and bracket-array `testCaseStatus` query parameters.
- Adds a shared URL pattern covering `testCaseStatus=`, `testCaseStatus%5B%5D=`, and `testCaseStatus[]=`.
- Uses the pattern when validating navigation from dashboard pie-chart segments.
- Documents why both scalar and array encodings are valid.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the updated integration-test matcher covers both currently generated status-filter encodings without changing product behavior.

The shared URL pattern preserves scalar status matching while adding the encoded and decoded bracket forms used for multi-status navigation, and no blocking or non-blocking defect remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/ui/pages/DataQualityDashboardPage.java | The revised matcher aligns the Java integration test with scalar and bracket-array status URLs generated by the two dashboard pie charts; no actionable issue was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tests): accept testCaseStatus\[\] in D..."](https://github.com/open-metadata/openmetadata/commit/2991c1b7090d18f9ad09f8ba07c8dce1fbd790e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55843454)</sub>

<!-- /greptile_comment -->