### PR TITLE
fix(ingestion): sort ingestion pipelines by displayName (backport #31072 to 1.13)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineSortIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineSortIT.java
@@ -1,0 +1,451 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.factories.DashboardServiceTestFactory;
+import org.openmetadata.it.factories.DatabaseServiceTestFactory;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.TestNamespace;
+import org.openmetadata.it.util.TestNamespaceExtension;
+import org.openmetadata.schema.api.services.ingestionPipelines.CreateIngestionPipeline;
+import org.openmetadata.schema.entity.services.DashboardService;
+import org.openmetadata.schema.entity.services.DatabaseService;
+import org.openmetadata.schema.entity.services.ingestionPipelines.AirflowConfig;
+import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
+import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineType;
+import org.openmetadata.schema.metadataIngestion.DashboardServiceMetadataPipeline;
+import org.openmetadata.schema.metadataIngestion.DatabaseServiceMetadataPipeline;
+import org.openmetadata.schema.metadataIngestion.SourceConfig;
+import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.sdk.exceptions.OpenMetadataException;
+import org.openmetadata.sdk.models.ListParams;
+import org.openmetadata.sdk.models.ListResponse;
+
+/**
+ * Server-side sorting for {@code GET /v1/services/ingestionPipelines} (collate#3919).
+ *
+ * <p>The UI's Name column renders {@code displayName ?? name}, so the list has to be orderable by
+ * that same value. Pipelines created from the UI get a machine-generated {@code name} that bears no
+ * relation to the label the user typed — Automations use {@code
+ * OpenMetadata_application_<random>} — so ordering by the raw {@code name} column is arbitrary on
+ * screen. Every fixture below is therefore seeded so that ascending {@code name} order is the exact
+ * reverse of ascending {@code displayName} order.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+@ExtendWith(TestNamespaceExtension.class)
+public class IngestionPipelineSortIT {
+
+  private static final Date START_DATE = Date.from(Instant.parse("2022-06-10T15:06:47Z"));
+
+  private IngestionPipeline createPipeline(
+      DatabaseService service, String name, String displayName) {
+    return SdkClients.adminClient()
+        .ingestionPipelines()
+        .create(
+            new CreateIngestionPipeline()
+                .withName(name)
+                .withDisplayName(displayName)
+                .withPipelineType(PipelineType.METADATA)
+                .withService(service.getEntityReference())
+                .withSourceConfig(
+                    new SourceConfig()
+                        .withConfig(new DatabaseServiceMetadataPipeline().withIncludeViews(true)))
+                .withAirflowConfig(new AirflowConfig().withStartDate(START_DATE)));
+  }
+
+  private ListParams sortParams(DatabaseService service, String sortOrder, int limit) {
+    return new ListParams()
+        .setService(service.getName())
+        .setLimit(limit)
+        .addQueryParam("sortField", "displayName")
+        .addQueryParam("sortOrder", sortOrder);
+  }
+
+  private ListResponse<IngestionPipeline> listSorted(
+      DatabaseService service, String sortOrder, int limit) {
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    return client.ingestionPipelines().list(sortParams(service, sortOrder, limit));
+  }
+
+  private List<String> displayNamesOf(ListResponse<IngestionPipeline> response) {
+    return response.getData().stream().map(IngestionPipeline::getDisplayName).toList();
+  }
+
+  private List<String> listDisplayNames(DatabaseService service, String sortOrder) {
+    return displayNamesOf(listSorted(service, sortOrder, 50));
+  }
+
+  @Test
+  void test_listSortedByDisplayName_ascending(TestNamespace ns) {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+
+    // name ascending is a-then-z; displayName ascending is the reverse.
+    createPipeline(service, ns.prefix("pipeline-a"), "zzz-" + ns.prefix("last"));
+    createPipeline(service, ns.prefix("pipeline-z"), "aaa-" + ns.prefix("first"));
+
+    assertEquals(
+        List.of("aaa-" + ns.prefix("first"), "zzz-" + ns.prefix("last")),
+        listDisplayNames(service, "asc"));
+  }
+
+  @Test
+  void test_listSortedByDisplayName_descending(TestNamespace ns) {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+
+    createPipeline(service, ns.prefix("pipeline-a"), "aaa-" + ns.prefix("first"));
+    createPipeline(service, ns.prefix("pipeline-z"), "zzz-" + ns.prefix("last"));
+
+    assertEquals(
+        List.of("zzz-" + ns.prefix("last"), "aaa-" + ns.prefix("first")),
+        listDisplayNames(service, "desc"));
+  }
+
+  /**
+   * Regression for the {@code pipelineType} + {@code sortField} combination (collate#3919): the
+   * Automations screen calls this endpoint with {@code pipelineType=application}. The ordered query
+   * used to qualify the pipelineType filter onto the table ({@code
+   * ingestion_pipeline_entity.JSON_UNQUOTE(...)}), which MySQL parses as a routine call and rejects
+   * with HTTP 500. It now reuses the unqualified generated column, matching the default listing.
+   *
+   * <p>NOTE: this reproduces the 500 only on a MySQL backend — the qualified Postgres form ({@code
+   * table.json->>'pipelineType'}) is valid SQL, so against Postgres this passes with or without the
+   * fix. The deterministic, dialect-independent guard is {@code
+   * IngestionPipelineSortConditionTest}; this IT is end-to-end coverage.
+   */
+  @Test
+  void test_listSortedByDisplayName_withPipelineTypeFilter(TestNamespace ns) {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+
+    createPipeline(service, ns.prefix("pipeline-a"), "zzz-" + ns.prefix("last"));
+    createPipeline(service, ns.prefix("pipeline-z"), "aaa-" + ns.prefix("first"));
+
+    ListParams params = sortParams(service, "asc", 50).addQueryParam("pipelineType", "metadata");
+    ListResponse<IngestionPipeline> response =
+        SdkClients.adminClient().ingestionPipelines().list(params);
+
+    assertEquals(
+        List.of("aaa-" + ns.prefix("first"), "zzz-" + ns.prefix("last")), displayNamesOf(response));
+  }
+
+  /** The sort key is COALESCE(NULLIF(displayName,''), name) — it must match getEntityName. */
+  @Test
+  void test_listSortedByDisplayName_fallsBackToNameWhenDisplayNameAbsent(TestNamespace ns) {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+
+    createPipeline(service, ns.prefix("zzz-no-display-name"), null);
+    createPipeline(service, ns.prefix("mmm-pipeline"), "aaa-" + ns.prefix("has-display-name"));
+
+    List<IngestionPipeline> sorted = listSorted(service, "asc", 50).getData();
+
+    // The pipeline without a displayName orders by its name, after "aaa-...".
+    assertEquals(2, sorted.size());
+    assertEquals("aaa-" + ns.prefix("has-display-name"), sorted.get(0).getDisplayName());
+    assertNull(sorted.get(1).getDisplayName());
+    assertEquals(ns.prefix("zzz-no-display-name"), sorted.get(1).getName());
+  }
+
+  /** The cursor is the (displayNameSort, id) tuple, so paging must not duplicate or skip rows. */
+  @Test
+  void test_listSortedByDisplayName_pagesWithoutGapsOrDuplicates(TestNamespace ns) {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+
+    // Creation order is deliberately unrelated to both name and displayName order.
+    createPipeline(service, ns.prefix("pipeline-c"), "bbb-" + ns.prefix("second"));
+    createPipeline(service, ns.prefix("pipeline-a"), "ccc-" + ns.prefix("third"));
+    createPipeline(service, ns.prefix("pipeline-b"), "aaa-" + ns.prefix("first"));
+
+    List<String> expected =
+        List.of(
+            "aaa-" + ns.prefix("first"), "bbb-" + ns.prefix("second"), "ccc-" + ns.prefix("third"));
+
+    ListResponse<IngestionPipeline> firstPage = listSorted(service, "asc", 2);
+    assertEquals(expected.subList(0, 2), displayNamesOf(firstPage));
+    assertNotNull(firstPage.getPaging().getAfter());
+
+    ListResponse<IngestionPipeline> secondPage =
+        SdkClients.adminClient()
+            .ingestionPipelines()
+            .list(sortParams(service, "asc", 2).setAfter(firstPage.getPaging().getAfter()));
+    assertEquals(expected.subList(2, 3), displayNamesOf(secondPage));
+
+    // Walking back from the second page must land on the first page again.
+    ListResponse<IngestionPipeline> backToFirst =
+        SdkClients.adminClient()
+            .ingestionPipelines()
+            .list(sortParams(service, "asc", 2).setBefore(secondPage.getPaging().getBefore()));
+    assertEquals(expected.subList(0, 2), displayNamesOf(backToFirst));
+  }
+
+  /** Without sortField the endpoint must behave exactly as before — ordered by name. */
+  @Test
+  void test_listWithoutSortField_isUnchangedAndOrdersByName(TestNamespace ns) {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+
+    createPipeline(service, ns.prefix("pipeline-a"), "zzz-" + ns.prefix("last"));
+    createPipeline(service, ns.prefix("pipeline-z"), "aaa-" + ns.prefix("first"));
+
+    ListResponse<IngestionPipeline> response =
+        SdkClients.adminClient()
+            .ingestionPipelines()
+            .list(new ListParams().setService(service.getName()).setLimit(50));
+
+    assertEquals(
+        List.of(ns.prefix("pipeline-a"), ns.prefix("pipeline-z")),
+        response.getData().stream().map(IngestionPipeline::getName).toList());
+  }
+
+  /**
+   * Sorting is optional and lenient: an unsupported sortField is ignored rather than rejected, and
+   * the default name-ordered listing is returned. The UI is not expected to send an unsupported
+   * field, so this is a graceful fallback, not a 400.
+   */
+  @Test
+  void test_listWithUnsupportedSortField_fallsBackToDefaultListing(TestNamespace ns) {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+
+    // name ascending is a-then-z; displayName ascending is the reverse.
+    createPipeline(service, ns.prefix("pipeline-a"), "zzz-" + ns.prefix("last"));
+    createPipeline(service, ns.prefix("pipeline-z"), "aaa-" + ns.prefix("first"));
+
+    ListParams params =
+        new ListParams()
+            .setService(service.getName())
+            .setLimit(50)
+            .addQueryParam("sortField", "sourceConfig")
+            .addQueryParam("sortOrder", "asc");
+
+    // Rows come back in the default name order, not displayName order — the field was ignored.
+    assertEquals(
+        List.of(ns.prefix("pipeline-a"), ns.prefix("pipeline-z")),
+        SdkClients.adminClient().ingestionPipelines().list(params).getData().stream()
+            .map(IngestionPipeline::getName)
+            .toList());
+  }
+
+  /** An unrecognised sortOrder defaults to ascending rather than being rejected. */
+  @Test
+  void test_listWithUnsupportedSortOrder_defaultsToAscending(TestNamespace ns) {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+
+    createPipeline(service, ns.prefix("pipeline-a"), "aaa-" + ns.prefix("first"));
+    createPipeline(service, ns.prefix("pipeline-z"), "zzz-" + ns.prefix("last"));
+
+    // "descending" is not the exact token "desc", so it falls through to ascending.
+    assertEquals(
+        List.of("aaa-" + ns.prefix("first"), "zzz-" + ns.prefix("last")),
+        listDisplayNames(service, "descending"));
+  }
+
+  /**
+   * The sort column is deliberately not case-folded, so ordering and the cursor comparison both
+   * inherit the column's own collation. MySQL's {@code utf8mb4_0900_ai_ci} makes {@code 'apple'} and
+   * {@code 'Apple'} compare <em>equal</em>, while PostgreSQL's default collation keeps them
+   * distinct — so on MySQL a whole group of rows shares one sort key and only the {@code id}
+   * tiebreak separates them.
+   *
+   * <p>That is exactly where a keyset walk loses rows. Paging one row at a time across case
+   * variants has to visit every one of them, on either engine, which also pins the reason the cursor
+   * value is carried verbatim: normalising it in Java would make the comparison disagree with the
+   * ORDER BY that produced it.
+   */
+  @Test
+  void test_listSortedByDisplayName_pagesThroughKeysTheCollationTreatsAsEqual(TestNamespace ns) {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+
+    // Distinct strings that differ only in case, so a case-insensitive collation collapses them to
+    // one sort key and the id tiebreak is the only thing keeping the order total.
+    String shared = "-" + ns.prefix("case-probe");
+    List<String> caseVariants = List.of("aa" + shared, "AA" + shared, "Aa" + shared);
+    for (int i = 0; i < caseVariants.size(); i++) {
+      createPipeline(service, ns.prefix("pipeline-" + i), caseVariants.get(i));
+    }
+
+    List<String> walked = new ArrayList<>();
+    String after = null;
+    for (int page = 0; page <= caseVariants.size(); page++) {
+      ListParams params = sortParams(service, "asc", 1);
+      if (after != null) {
+        params.setAfter(after);
+      }
+      ListResponse<IngestionPipeline> result =
+          SdkClients.adminClient().ingestionPipelines().list(params);
+      walked.addAll(displayNamesOf(result));
+      after = result.getPaging().getAfter();
+      if (after == null) {
+        break;
+      }
+    }
+
+    assertNull(after, "keyset walk did not terminate");
+    assertEquals(caseVariants.size(), walked.size(), "keyset walk skipped or repeated a row");
+    assertEquals(Set.copyOf(caseVariants), Set.copyOf(walked));
+  }
+
+  /**
+   * The two listings issue different cursors — {@code (name, id)} unsorted, {@code
+   * (displayNameSort, id)} sorted — and a caller that keeps the cursor across requests can outlive
+   * the sort order that produced it. Feeding one listing the other's cursor has to fail loudly:
+   * both are keyset predicates, so a cursor the query cannot read matches no row and returns an
+   * empty page, which is indistinguishable from having reached the end of the list.
+   */
+  @Test
+  void test_listSortedByDisplayName_rejectsCursorFromTheDefaultListing(TestNamespace ns) {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+
+    createPipeline(service, ns.prefix("pipeline-a"), "zzz-" + ns.prefix("last"));
+    createPipeline(service, ns.prefix("pipeline-z"), "aaa-" + ns.prefix("first"));
+
+    ListResponse<IngestionPipeline> defaultFirstPage =
+        SdkClients.adminClient()
+            .ingestionPipelines()
+            .list(new ListParams().setService(service.getName()).setLimit(1));
+    String defaultCursor = defaultFirstPage.getPaging().getAfter();
+    assertNotNull(defaultCursor);
+
+    ListParams params = sortParams(service, "asc", 1).setAfter(defaultCursor);
+
+    assertThrows(
+        OpenMetadataException.class,
+        () -> SdkClients.adminClient().ingestionPipelines().list(params));
+  }
+
+  /**
+   * {@code serviceType} is the parent service category, which lives in {@code
+   * entity_relationship.fromEntity} rather than on the pipeline row — it is a join, not a plain
+   * condition, so the ordered query has to build it the same way the unordered one does. Without
+   * that the sorted list silently spans every service category while {@code paging.total} stays
+   * filtered. The UI always sends this parameter.
+   */
+  @Test
+  void test_listSortedByDisplayName_honoursServiceTypeFilter(TestNamespace ns) {
+    DatabaseService databaseService = DatabaseServiceTestFactory.createPostgres(ns);
+    DashboardService dashboardService = DashboardServiceTestFactory.createMetabase(ns);
+
+    createPipeline(databaseService, ns.prefix("pipeline-z"), "aaa-" + ns.prefix("db-first"));
+    createPipeline(databaseService, ns.prefix("pipeline-a"), "zzz-" + ns.prefix("db-last"));
+    createDashboardPipeline(dashboardService, ns.prefix("pipeline-m"), ns.prefix("dashboard-one"));
+
+    ListResponse<IngestionPipeline> matching =
+        SdkClients.adminClient()
+            .ingestionPipelines()
+            .list(sortParams(databaseService, "asc", 50).setServiceType("databaseService"));
+
+    assertEquals(
+        List.of("aaa-" + ns.prefix("db-first"), "zzz-" + ns.prefix("db-last")),
+        displayNamesOf(matching));
+    assertEquals(2, matching.getPaging().getTotal());
+
+    // The dashboard service's own pipeline must not leak in under a databaseService filter: the
+    // service name alone matches it, so only an honoured serviceType keeps this empty.
+    ListResponse<IngestionPipeline> contradictory =
+        SdkClients.adminClient()
+            .ingestionPipelines()
+            .list(
+                new ListParams()
+                    .setService(dashboardService.getName())
+                    .setServiceType("databaseService")
+                    .setLimit(50)
+                    .addQueryParam("sortField", "displayName")
+                    .addQueryParam("sortOrder", "asc"));
+
+    assertEquals(List.of(), displayNamesOf(contradictory));
+  }
+
+  /**
+   * {@code displayName} has no maxLength in the schema, and neither the sort expression nor the
+   * cursor truncates. A displayName far longer than the old 256-char cap must still page correctly:
+   * the cursor carries the full value, matching the SQL expression, so no row is skipped.
+   */
+  @Test
+  void test_listSortedByDisplayName_pagesAcrossAnUntruncatedLongDisplayName(TestNamespace ns) {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+
+    String longPrefix = "zzz-" + "x".repeat(300);
+    createPipeline(service, ns.prefix("pipeline-a"), longPrefix + ns.prefix("-long"));
+    createPipeline(service, ns.prefix("pipeline-b"), "aaa-" + ns.prefix("short"));
+
+    ListResponse<IngestionPipeline> firstPage = listSorted(service, "asc", 1);
+    assertEquals(List.of("aaa-" + ns.prefix("short")), displayNamesOf(firstPage));
+    assertNotNull(firstPage.getPaging().getAfter());
+
+    ListResponse<IngestionPipeline> secondPage =
+        SdkClients.adminClient()
+            .ingestionPipelines()
+            .list(sortParams(service, "asc", 1).setAfter(firstPage.getPaging().getAfter()));
+
+    assertEquals(1, secondPage.getData().size());
+    assertEquals(longPrefix + ns.prefix("-long"), secondPage.getData().get(0).getDisplayName());
+  }
+
+  /**
+   * A page can come back empty when the caller holds a valid cursor but every row past it was
+   * deleted meanwhile. Returning a null before-cursor would read as "first page" and dead-end
+   * backward navigation, so the caller's own cursor is echoed instead.
+   */
+  @Test
+  void test_listSortedByDisplayName_echoesCursorWhenPageIsEmpty(TestNamespace ns) {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+
+    createPipeline(service, ns.prefix("pipeline-a"), "aaa-" + ns.prefix("first"));
+    IngestionPipeline second =
+        createPipeline(service, ns.prefix("pipeline-b"), "bbb-" + ns.prefix("second"));
+
+    ListResponse<IngestionPipeline> firstPage = listSorted(service, "asc", 1);
+    String after = firstPage.getPaging().getAfter();
+    assertNotNull(after);
+
+    SdkClients.adminClient()
+        .ingestionPipelines()
+        .delete(second.getId().toString(), Map.of("hardDelete", "true", "recursive", "false"));
+
+    ListResponse<IngestionPipeline> emptyPage =
+        SdkClients.adminClient()
+            .ingestionPipelines()
+            .list(sortParams(service, "asc", 1).setAfter(after));
+
+    assertEquals(List.of(), displayNamesOf(emptyPage));
+    assertEquals(after, emptyPage.getPaging().getBefore());
+  }
+
+  private IngestionPipeline createDashboardPipeline(
+      DashboardService service, String name, String displayName) {
+    return SdkClients.adminClient()
+        .ingestionPipelines()
+        .create(
+            new CreateIngestionPipeline()
+                .withName(name)
+                .withDisplayName(displayName)
+                .withPipelineType(PipelineType.METADATA)
+                .withService(service.getEntityReference())
+                .withSourceConfig(
+                    new SourceConfig().withConfig(new DashboardServiceMetadataPipeline()))
+                .withAirflowConfig(new AirflowConfig().withStartDate(START_DATE)));
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -176,6 +176,7 @@ import org.openmetadata.service.jdbi3.locator.ConnectionAwareSqlBatch;
 import org.openmetadata.service.jdbi3.locator.ConnectionAwareSqlQuery;
 import org.openmetadata.service.jdbi3.locator.ConnectionAwareSqlUpdate;
 import org.openmetadata.service.jdbi3.oauth.OAuthRecords;
+import org.openmetadata.service.resources.databases.DatasourceConfig;
 import org.openmetadata.service.resources.events.subscription.TypedEvent;
 import org.openmetadata.service.resources.feeds.MessageParser.EntityLink;
 import org.openmetadata.service.resources.tags.TagLabelUtil;
@@ -4608,151 +4609,91 @@ public interface CollectionDAO {
       return "fqnHash";
     }
 
-    @Override
-    default int listCount(ListFilter filter) {
-      String condition =
-          "INNER JOIN entity_relationship ON ingestion_pipeline_entity.id = entity_relationship.toId";
+    /**
+     * A pipeline's service category is not a column on the pipeline row — it lives in {@code
+     * entity_relationship.fromEntity} — so the {@code serviceType} filter has to be a join rather
+     * than a {@link ListFilter} condition. Every listing that honours {@code serviceType} shares
+     * this builder so ordered, unordered and count queries can never drift apart on which rows they
+     * consider in scope.
+     *
+     * <p>Always call this before branching on {@code serviceType}: the condition getters register
+     * derived bind parameters on the filter, and the non-serviceType path relies on them too.
+     */
+    default String serviceTypeJoinCondition(ListFilter filter) {
+      StringBuilder condition =
+          new StringBuilder(
+              "INNER JOIN entity_relationship ON ingestion_pipeline_entity.id = entity_relationship.toId");
 
       if (filter.getQueryParam("pipelineType") != null) {
-        String pipelineTypeCondition =
-            String.format(" and %s", filter.getPipelineTypeCondition(null));
-        condition += pipelineTypeCondition;
+        condition.append(String.format(" and %s", filter.getPipelineTypeCondition(null)));
       }
 
       if (filter.getQueryParam("applicationType") != null) {
-        String applicationTypeCondition =
-            String.format(" and %s", filter.getApplicationTypeCondition());
-        condition += applicationTypeCondition;
+        condition.append(String.format(" and %s", filter.getApplicationTypeCondition()));
       }
 
       if (filter.getQueryParam("service") != null) {
-        String serviceCondition = String.format(" and %s", filter.getServiceCondition(null));
-        condition += serviceCondition;
+        condition.append(String.format(" and %s", filter.getServiceCondition(null)));
       }
 
       if (filter.getQueryParam("provider") != null) {
-        String providerCondition =
-            String.format(" and %s", filter.getProviderCondition(getTableName()));
-        condition += providerCondition;
+        condition.append(String.format(" and %s", filter.getProviderCondition(getTableName())));
       }
 
-      Map<String, Object> bindMap = new HashMap<>();
-      String serviceType = filter.getQueryParam("serviceType");
-      String provider = filter.getQueryParam("provider");
-      if (!nullOrEmpty(provider)) {
-        bindMap.put("provider", provider);
-      }
-      if (!nullOrEmpty(serviceType)) {
+      return condition
+          .append(
+              String.format(
+                  " WHERE entity_relationship.fromEntity = :serviceType and entity_relationship.relation = %d",
+                  CONTAINS.ordinal()))
+          .toString();
+    }
 
-        condition =
-            String.format(
-                "%s WHERE entity_relationship.fromEntity = :serviceType and entity_relationship.relation = :relation",
-                condition);
-        bindMap.put("relation", CONTAINS.ordinal());
-        return listIngestionPipelineCount(condition, bindMap, filter.getQueryParams());
+    @Override
+    default int listCount(ListFilter filter) {
+      String condition = serviceTypeJoinCondition(filter);
+      if (nullOrEmpty(filter.getQueryParam("serviceType"))) {
+        return EntityDAO.super.listCount(filter);
       }
-      return EntityDAO.super.listCount(filter);
+      return listIngestionPipelineCount(condition, new HashMap<>(), filter.getQueryParams());
     }
 
     @Override
     default List<String> listAfter(ListFilter filter, int limit, String afterName, String afterId) {
-      String condition =
-          "INNER JOIN entity_relationship ON ingestion_pipeline_entity.id = entity_relationship.toId";
-
-      if (filter.getQueryParam("pipelineType") != null) {
-        String pipelineTypeCondition =
-            String.format(" and %s", filter.getPipelineTypeCondition(null));
-        condition += pipelineTypeCondition;
+      String condition = serviceTypeJoinCondition(filter);
+      if (nullOrEmpty(filter.getQueryParam("serviceType"))) {
+        return EntityDAO.super.listAfter(filter, limit, afterName, afterId);
       }
 
-      if (filter.getQueryParam("applicationType") != null) {
-        String applicationTypeCondition =
-            String.format(" and %s", filter.getApplicationTypeCondition());
-        condition += applicationTypeCondition;
-      }
-
-      if (filter.getQueryParam("service") != null) {
-        String serviceCondition = String.format(" and %s", filter.getServiceCondition(null));
-        condition += serviceCondition;
-      }
-
-      if (filter.getQueryParam("provider") != null) {
-        String providerCondition =
-            String.format(" and %s", filter.getProviderCondition(getTableName()));
-        condition += providerCondition;
-      }
+      condition =
+          String.format(
+              "%s and (ingestion_pipeline_entity.name > :afterName OR (ingestion_pipeline_entity.name = :afterName AND ingestion_pipeline_entity.id > :afterId))  order by ingestion_pipeline_entity.name ASC,ingestion_pipeline_entity.id ASC LIMIT :limit",
+              condition);
 
       Map<String, Object> bindMap = new HashMap<>();
-      String serviceType = filter.getQueryParam("serviceType");
-      String provider = filter.getQueryParam("provider");
-      if (!nullOrEmpty(provider)) {
-        bindMap.put("provider", provider);
-      }
-      if (!nullOrEmpty(serviceType)) {
-
-        condition =
-            String.format(
-                "%s WHERE entity_relationship.fromEntity = :serviceType and entity_relationship.relation = :relation and (ingestion_pipeline_entity.name > :afterName OR (ingestion_pipeline_entity.name = :afterName AND ingestion_pipeline_entity.id > :afterId))  order by ingestion_pipeline_entity.name ASC,ingestion_pipeline_entity.id ASC LIMIT :limit",
-                condition);
-
-        bindMap.put("relation", CONTAINS.ordinal());
-        bindMap.put("afterName", afterName);
-        bindMap.put("afterId", afterId);
-        bindMap.put("limit", limit);
-        return listAfterIngestionPipelineByserviceType(condition, bindMap, filter.getQueryParams());
-      }
-      return EntityDAO.super.listAfter(filter, limit, afterName, afterId);
+      bindMap.put("afterName", afterName);
+      bindMap.put("afterId", afterId);
+      bindMap.put("limit", limit);
+      return listAfterIngestionPipelineByserviceType(condition, bindMap, filter.getQueryParams());
     }
 
     @Override
     default List<String> listBefore(
         ListFilter filter, int limit, String beforeName, String beforeId) {
-      String condition =
-          "INNER JOIN entity_relationship ON ingestion_pipeline_entity.id = entity_relationship.toId";
-
-      if (filter.getQueryParam("pipelineType") != null) {
-        String pipelineTypeCondition =
-            String.format(" and %s", filter.getPipelineTypeCondition(null));
-        condition += pipelineTypeCondition;
+      String condition = serviceTypeJoinCondition(filter);
+      if (nullOrEmpty(filter.getQueryParam("serviceType"))) {
+        return EntityDAO.super.listBefore(filter, limit, beforeName, beforeId);
       }
 
-      if (filter.getQueryParam("applicationType") != null) {
-        String applicationTypeCondition =
-            String.format(" and %s", filter.getApplicationTypeCondition());
-        condition += applicationTypeCondition;
-      }
-
-      if (filter.getQueryParam("service") != null) {
-        String serviceCondition = String.format(" and %s", filter.getServiceCondition(null));
-        condition += serviceCondition;
-      }
-
-      if (filter.getQueryParam("provider") != null) {
-        String providerCondition =
-            String.format(" and %s", filter.getProviderCondition(getTableName()));
-        condition += providerCondition;
-      }
+      condition =
+          String.format(
+              "%s and (ingestion_pipeline_entity.name < :beforeName OR (ingestion_pipeline_entity.name = :beforeName AND ingestion_pipeline_entity.id < :beforeId))  order by ingestion_pipeline_entity.name DESC, ingestion_pipeline_entity.id DESC LIMIT :limit",
+              condition);
 
       Map<String, Object> bindMap = new HashMap<>();
-      String serviceType = filter.getQueryParam("serviceType");
-      String provider = filter.getQueryParam("provider");
-      if (!nullOrEmpty(provider)) {
-        bindMap.put("provider", provider);
-      }
-      if (!nullOrEmpty(serviceType)) {
-        condition =
-            String.format(
-                "%s WHERE entity_relationship.fromEntity = :serviceType and entity_relationship.relation = :relation and (ingestion_pipeline_entity.name < :beforeName OR (ingestion_pipeline_entity.name = :beforeName AND ingestion_pipeline_entity.id < :beforeId))  order by ingestion_pipeline_entity.name DESC, ingestion_pipeline_entity.id DESC LIMIT :limit",
-                condition);
-
-        bindMap.put("relation", CONTAINS.ordinal());
-        bindMap.put("beforeName", beforeName);
-        bindMap.put("beforeId", beforeId);
-        bindMap.put("limit", limit);
-        return listBeforeIngestionPipelineByserviceType(
-            condition, bindMap, filter.getQueryParams());
-      }
-      return EntityDAO.super.listBefore(filter, limit, beforeName, beforeId);
+      bindMap.put("beforeName", beforeName);
+      bindMap.put("beforeId", beforeId);
+      bindMap.put("limit", limit);
+      return listBeforeIngestionPipelineByserviceType(condition, bindMap, filter.getQueryParams());
     }
 
     @SqlQuery("SELECT ingestion_pipeline_entity.json FROM ingestion_pipeline_entity <cond>")
@@ -4773,6 +4714,81 @@ public interface CollectionDAO {
         @Define("cond") String cond,
         @BindMap Map<String, Object> bindings,
         @BindMap Map<String, String> params);
+
+    /**
+     * The {@code <cond>} every displayName-ordered query below is given: the same scope the
+     * unordered listing uses, so ordering the list can never widen or narrow which rows it returns.
+     * Columns stay table-qualified because the serviceType variant joins {@code
+     * entity_relationship}, which has {@code json} and {@code deleted} columns of its own.
+     */
+    default String displayNameSortCondition(ListFilter filter) {
+      // Unqualified: a table prefix on the pipelineType JSON expression reads as a routine call.
+      return nullOrEmpty(filter.getQueryParam("serviceType"))
+          ? filter.getCondition()
+          : serviceTypeJoinCondition(filter);
+    }
+
+    /**
+     * The SQL for the value the Name column renders — {@code displayName} falling back to {@code
+     * name} — sorted inline. No generated column: the pipeline table is small enough (bounded by
+     * services × pipeline types plus automations) that an unindexed sort is instant, and an
+     * expression index can be added later without a schema change if a deployment ever grows.
+     * ORDER BY and the keyset comparison share this same expression, so its collation governs both
+     * and the cursor value is carried verbatim from Java.
+     */
+    default String displayNameSortExpression() {
+      return Boolean.TRUE.equals(DatasourceConfig.getInstance().isMySQL())
+          ? "COALESCE(NULLIF(JSON_UNQUOTE(JSON_EXTRACT(ingestion_pipeline_entity.json, '$.displayName')), ''), ingestion_pipeline_entity.name)"
+          : "COALESCE(NULLIF(ingestion_pipeline_entity.json ->> 'displayName', ''), ingestion_pipeline_entity.name)";
+    }
+
+    @SqlQuery(
+        "SELECT ingestion_pipeline_entity.json FROM ingestion_pipeline_entity <cond> "
+            + "ORDER BY <displayExpr> <order>, ingestion_pipeline_entity.id <order> LIMIT :limit")
+    List<String> listByDisplayName(
+        @BindMap Map<String, ?> params,
+        @Define("cond") String cond,
+        @Define("displayExpr") String displayExpr,
+        @Define("order") String order,
+        @Bind("limit") int limit);
+
+    @SqlQuery(
+        "SELECT ingestion_pipeline_entity.json FROM ingestion_pipeline_entity <cond> "
+            + "AND (<displayExpr> <op> :afterDisplayName "
+            + "OR (<displayExpr> = :afterDisplayName "
+            + "AND ingestion_pipeline_entity.id <op> :afterId)) "
+            + "ORDER BY <displayExpr> <order>, ingestion_pipeline_entity.id <order> LIMIT :limit")
+    List<String> listAfterByDisplayName(
+        @BindMap Map<String, ?> params,
+        @Define("cond") String cond,
+        @Define("displayExpr") String displayExpr,
+        @Define("order") String order,
+        @Define("op") String op,
+        @Bind("limit") int limit,
+        @Bind("afterDisplayName") String afterDisplayName,
+        @Bind("afterId") String afterId);
+
+    // Walks backwards in the reverse direction, then re-sorts the page into the requested order.
+    @SqlQuery(
+        "SELECT json FROM ("
+            + "SELECT <displayExpr> AS sort_key, ingestion_pipeline_entity.id, "
+            + "ingestion_pipeline_entity.json FROM ingestion_pipeline_entity <cond> "
+            + "AND (<displayExpr> <op> :beforeDisplayName "
+            + "OR (<displayExpr> = :beforeDisplayName "
+            + "AND ingestion_pipeline_entity.id <op> :beforeId)) "
+            + "ORDER BY <displayExpr> <reverseOrder>, "
+            + "ingestion_pipeline_entity.id <reverseOrder> LIMIT :limit"
+            + ") last_rows_subquery ORDER BY sort_key <order>, id <order>")
+    List<String> listBeforeByDisplayName(
+        @BindMap Map<String, ?> params,
+        @Define("cond") String cond,
+        @Define("displayExpr") String displayExpr,
+        @Define("order") String order,
+        @Define("reverseOrder") String reverseOrder,
+        @Define("op") String op,
+        @Bind("limit") int limit,
+        @Bind("beforeDisplayName") String beforeDisplayName,
+        @Bind("beforeId") String beforeId);
   }
 
   interface PipelineServiceDAO extends EntityDAO<PipelineService> {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
@@ -13,11 +13,13 @@
 
 package org.openmetadata.service.jdbi3;
 
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.schema.type.EventType.ENTITY_FIELDS_CHANGED;
 import static org.openmetadata.schema.type.EventType.ENTITY_UPDATED;
 import static org.openmetadata.schema.type.Include.ALL;
 import static org.openmetadata.service.Entity.INGESTION_PIPELINE;
 
+import com.google.common.annotations.VisibleForTesting;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 import jakarta.ws.rs.core.UriInfo;
@@ -67,7 +69,9 @@ import org.openmetadata.sdk.PipelineServiceClientInterface;
 import org.openmetadata.sdk.exception.PipelineServiceClientException;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
+import org.openmetadata.service.cache.ListCountCache;
 import org.openmetadata.service.events.lifecycle.EntityLifecycleEventDispatcher;
+import org.openmetadata.service.exception.BadRequestException;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.logstorage.LogStorageInterface;
 import org.openmetadata.service.logstorage.S3LogStorage.LogStreamListener;
@@ -118,6 +122,207 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
     this.supportsSearch = true;
     this.openMetadataApplicationConfig = config;
   }
+
+  private static final String SORT_ORDER_DESC = "desc";
+
+  /** SQL tokens for one scan direction, so the keyset queries never assemble them ad hoc. */
+  private record SortDirection(String order, String reverseOrder, String forward, String backward) {
+    static SortDirection of(boolean ascending) {
+      return ascending
+          ? new SortDirection("ASC", "DESC", ">", "<")
+          : new SortDirection("DESC", "ASC", "<", ">");
+    }
+  }
+
+  /**
+   * When the filter carries {@code sortField=displayName}, list forward ordered by the value the
+   * UI's Name column renders ({@code displayName ?? name}) instead of the raw {@code name}, keeping
+   * keyset pagination. Otherwise the default name-ordered listing applies.
+   *
+   * <p>Overriding this seam — rather than forking the resource's {@code listInternal} — keeps
+   * authorization, the domain filter and cursor validation shared with the normal list, so the two
+   * orderings cannot drift (collate#3919).
+   */
+  @Override
+  public ResultList<IngestionPipeline> listAfter(
+      UriInfo uriInfo, Fields fields, ListFilter filter, int limitParam, String after) {
+    ResultList<IngestionPipeline> result;
+    if (nullOrEmpty(filter.getSortField())) {
+      result = super.listAfter(uriInfo, fields, filter, limitParam, after);
+    } else {
+      result = forwardDisplayNamePage(uriInfo, fields, filter, limitParam, after);
+    }
+    return result;
+  }
+
+  @Override
+  public ResultList<IngestionPipeline> listBefore(
+      UriInfo uriInfo, Fields fields, ListFilter filter, int limitParam, String before) {
+    ResultList<IngestionPipeline> result;
+    if (nullOrEmpty(filter.getSortField())) {
+      result = super.listBefore(uriInfo, fields, filter, limitParam, before);
+    } else {
+      result = beforeDisplayNamePage(uriInfo, fields, filter, limitParam, before);
+    }
+    return result;
+  }
+
+  private boolean isAscending(ListFilter filter) {
+    return !SORT_ORDER_DESC.equalsIgnoreCase(filter.getSortOrder());
+  }
+
+  /** First page (no {@code after}) or a forward page from an {@code after} cursor. */
+  private ResultList<IngestionPipeline> forwardDisplayNamePage(
+      UriInfo uriInfo, Fields fields, ListFilter filter, int limitParam, String after) {
+    int total = ListCountCache.getOrCompute(entityType, filter, () -> dao.listCount(filter));
+    List<IngestionPipeline> entities = new ArrayList<>();
+    String beforeCursor = null;
+    String afterCursor = null;
+    if (limitParam > 0) {
+      SortDirection direction = SortDirection.of(isAscending(filter));
+      entities =
+          hydrateByDisplayName(forwardJsons(filter, direction, limitParam, after), fields, uriInfo);
+      beforeCursor = forwardBeforeCursor(after, entities);
+      if (entities.size() > limitParam) {
+        entities.remove(limitParam);
+        afterCursor = displayNameCursorValue(entities.get(limitParam - 1));
+      }
+    }
+    return getResultList(entities, beforeCursor, afterCursor, total);
+  }
+
+  private List<String> forwardJsons(
+      ListFilter filter, SortDirection direction, int limitParam, String after) {
+    // getCondition registers derived bind params on the filter and the serviceType variant is a
+    // join the plain ListFilter condition cannot express, so resolve the scope once.
+    String condition = ingestionPipelineDAO().displayNameSortCondition(filter);
+    String displayExpr = ingestionPipelineDAO().displayNameSortExpression();
+    List<String> jsons;
+    if (nullOrEmpty(after)) {
+      jsons =
+          ingestionPipelineDAO()
+              .listByDisplayName(
+                  filter.getQueryParams(),
+                  condition,
+                  displayExpr,
+                  direction.order(),
+                  limitParam + 1);
+    } else {
+      DisplayNameCursor cursor = parseDisplayNameCursor(after);
+      jsons =
+          ingestionPipelineDAO()
+              .listAfterByDisplayName(
+                  filter.getQueryParams(),
+                  condition,
+                  displayExpr,
+                  direction.order(),
+                  direction.forward(),
+                  limitParam + 1,
+                  cursor.displayName(),
+                  cursor.id());
+    }
+    return jsons;
+  }
+
+  /** Backward page from a {@code before} cursor; the DAO walks reverse then re-sorts the page. */
+  private ResultList<IngestionPipeline> beforeDisplayNamePage(
+      UriInfo uriInfo, Fields fields, ListFilter filter, int limitParam, String before) {
+    int total = ListCountCache.getOrCompute(entityType, filter, () -> dao.listCount(filter));
+    List<IngestionPipeline> entities = new ArrayList<>();
+    String beforeCursor = null;
+    String afterCursor = null;
+    if (limitParam > 0) {
+      SortDirection direction = SortDirection.of(isAscending(filter));
+      entities =
+          hydrateByDisplayName(beforeJsons(filter, direction, limitParam, before), fields, uriInfo);
+      if (entities.size() > limitParam) {
+        entities.remove(0);
+        beforeCursor = displayNameCursorValue(entities.get(0));
+      }
+      // Empty page = cursor valid but every earlier row was deleted concurrently. Echo the caller's
+      // cursor rather than null, which reads as end-of-pagination. Mirrors listBefore.
+      afterCursor =
+          entities.isEmpty()
+              ? RestUtil.decodeCursor(before)
+              : displayNameCursorValue(entities.get(entities.size() - 1));
+    }
+    return getResultList(entities, beforeCursor, afterCursor, total);
+  }
+
+  private List<String> beforeJsons(
+      ListFilter filter, SortDirection direction, int limitParam, String before) {
+    String condition = ingestionPipelineDAO().displayNameSortCondition(filter);
+    String displayExpr = ingestionPipelineDAO().displayNameSortExpression();
+    DisplayNameCursor cursor = parseDisplayNameCursor(before);
+    return ingestionPipelineDAO()
+        .listBeforeByDisplayName(
+            filter.getQueryParams(),
+            condition,
+            displayExpr,
+            direction.order(),
+            direction.reverseOrder(),
+            direction.backward(),
+            limitParam + 1,
+            cursor.displayName(),
+            cursor.id());
+  }
+
+  private CollectionDAO.IngestionPipelineDAO ingestionPipelineDAO() {
+    return Entity.getCollectionDAO().ingestionPipelineDAO();
+  }
+
+  /**
+   * {@link ResultList} base64-encodes whatever cursor it is handed, so both branches have to yield
+   * the decoded form: {@link #displayNameCursorValue} produces raw JSON, and the echoed cursor
+   * arrived off the wire already encoded.
+   */
+  @VisibleForTesting
+  String forwardBeforeCursor(String after, List<IngestionPipeline> entities) {
+    String beforeCursor = null;
+    if (!nullOrEmpty(after)) {
+      beforeCursor =
+          entities.isEmpty()
+              ? RestUtil.decodeCursor(after)
+              : displayNameCursorValue(entities.get(0));
+    }
+    return beforeCursor;
+  }
+
+  private List<IngestionPipeline> hydrateByDisplayName(
+      List<String> jsons, Fields fields, UriInfo uriInfo) {
+    List<IngestionPipeline> entities = JsonUtils.readObjects(jsons, IngestionPipeline.class);
+    setFieldsInBulk(fields, entities);
+    entities.forEach(entity -> withHref(uriInfo, entity));
+    return entities;
+  }
+
+  @VisibleForTesting
+  DisplayNameCursor parseDisplayNameCursor(String cursor) {
+    Map<String, String> cursorMap = parseCursorMap(RestUtil.decodeCursor(cursor));
+    String displayName = cursorMap.get("displayNameSort");
+    String id = cursorMap.get("id");
+    if (displayName == null || id == null || id.isBlank()) {
+      throw new BadRequestException("Invalid cursor for sortField pagination");
+    }
+    return new DisplayNameCursor(displayName, id);
+  }
+
+  /**
+   * Reproduces the ORDER BY expression — {@code COALESCE(NULLIF(displayName,''), name)} — as the
+   * cursor's sort key. The value is carried verbatim (no truncation and not case-folded), so it
+   * matches the un-truncated SQL expression exactly and comparison stays inside the database.
+   */
+  @VisibleForTesting
+  String displayNameCursorValue(IngestionPipeline pipeline) {
+    String displayName = pipeline.getDisplayName();
+    String sortKey = nullOrEmpty(displayName) ? pipeline.getName() : displayName;
+    return JsonUtils.pojoToJson(
+        Map.of(
+            "displayNameSort", sortKey == null ? "" : sortKey, "id", pipeline.getId().toString()));
+  }
+
+  @VisibleForTesting
+  record DisplayNameCursor(String displayName, String id) {}
 
   @Override
   public void setFullyQualifiedName(IngestionPipeline ingestionPipeline) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ListFilter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ListFilter.java
@@ -26,12 +26,31 @@ public class ListFilter extends Filter<ListFilter> {
   public static final String NULL_PARAM = "null";
   private static final String MCP_EXECUTION_TABLE_NAME = "mcp_execution_entity";
 
+  // Sort metadata is kept off the queryParams map on purpose: ListCountCache hashes queryParams, so
+  // holding these as fields keeps the sorted and unsorted listings on a single count-cache entry.
+  private String sortField;
+  private String sortOrder;
+
   public ListFilter() {
     this(Include.NON_DELETED);
   }
 
   public ListFilter(Include include) {
     this.include = include;
+  }
+
+  public String getSortField() {
+    return sortField;
+  }
+
+  public String getSortOrder() {
+    return sortOrder;
+  }
+
+  public ListFilter withSort(String sortField, String sortOrder) {
+    this.sortField = sortField;
+    this.sortOrder = sortOrder;
+    return this;
   }
 
   public String getCondition(String tableName) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java
@@ -113,6 +113,7 @@ public class IngestionPipelineResource
     extends EntityResource<IngestionPipeline, IngestionPipelineRepository> {
   private IngestionPipelineMapper mapper;
   public static final String COLLECTION_PATH = "/v1/services/ingestionPipelines/";
+  static final String SORT_FIELD_DISPLAY_NAME = "displayName";
   private PipelineServiceClientInterface pipelineServiceClient;
   private OpenMetadataApplicationConfig openMetadataApplicationConfig;
   static final String FIELDS = "owners,followers";
@@ -223,6 +224,15 @@ public class IngestionPipelineResource
     }
   }
 
+  // Sorting is optional and lenient: only `displayName` is supported, and any other value (or none)
+  // falls through to the default name-ordered listing rather than erroring. The repository reads
+  // the
+  // sort off the filter and swaps in the display-name keyset query, so the resource keeps a single
+  // listInternal path — auth, domain filter and cursor validation are shared, not forked.
+  private boolean isDisplayNameSort(String sortField) {
+    return SORT_FIELD_DISPLAY_NAME.equalsIgnoreCase(sortField);
+  }
+
   @GET
   @Valid
   @Operation(
@@ -300,7 +310,26 @@ public class IngestionPipelineResource
               description = "List Ingestion Pipelines by provider..",
               schema = @Schema(implementation = ProviderType.class))
           @QueryParam("provider")
-          ProviderType provider) {
+          ProviderType provider,
+      @Parameter(
+              description =
+                  "Optionally order the list by a field instead of the default `name`. Only "
+                      + "`displayName` is supported — it orders by the effective display name "
+                      + "(`displayName` falling back to `name`), the value clients render. Any other "
+                      + "value (or none) falls through to the default `name` ordering rather than "
+                      + "erroring.",
+              schema = @Schema(type = "string", allowableValues = SORT_FIELD_DISPLAY_NAME))
+          @QueryParam("sortField")
+          String sortField,
+      @Parameter(
+              description = "Direction to apply to `sortField`.",
+              schema =
+                  @Schema(
+                      type = "string",
+                      allowableValues = {"asc", "desc"}))
+          @QueryParam("sortOrder")
+          @DefaultValue("asc")
+          String sortOrder) {
     ListFilter filter =
         new ListFilter(include)
             .addQueryParam("service", serviceParam)
@@ -309,6 +338,9 @@ public class IngestionPipelineResource
             .addQueryParam("testSuite", testSuiteParam)
             .addQueryParam("applicationType", applicationType)
             .addQueryParam("provider", provider == null ? null : provider.value());
+    if (isDisplayNameSort(sortField)) {
+      filter.withSort(SORT_FIELD_DISPLAY_NAME, sortOrder);
+    }
     ResultList<IngestionPipeline> ingestionPipelines =
         super.listInternal(
             uriInfo, securityContext, fieldsParam, filter, limitParam, before, after);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/IngestionPipelineSortConditionTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/IngestionPipelineSortConditionTest.java
@@ -1,0 +1,148 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.openmetadata.schema.type.Relationship.CONTAINS;
+
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.type.Include;
+
+/**
+ * The scope clause shared by every ingestion-pipeline listing.
+ *
+ * <p>{@code serviceType} is the parent service category, which lives in {@code
+ * entity_relationship.fromEntity} rather than on the pipeline row, so it has to be a join rather
+ * than a {@link ListFilter} condition. The count, the unordered page and the displayName-ordered
+ * page all build that join from one method for a reason: if the ordered query considered a different
+ * set of rows than the count, {@code paging.total} would disagree with the rows returned, and the
+ * last page would be silently short.
+ *
+ * <p>The ordered queries append {@code AND (displayNameSort <op> :afterDisplayName OR ...)} directly
+ * onto this string, so it must always terminate in a WHERE clause — an invariant nothing else
+ * enforces, and one that fails as a SQL syntax error only at runtime.
+ */
+class IngestionPipelineSortConditionTest {
+  private static final String TABLE = "ingestion_pipeline_entity";
+  private static final String WHERE = "WHERE ";
+  private static final String CURSOR_PREDICATE =
+      " AND (ingestion_pipeline_entity.displayNameSort > :afterDisplayName)";
+
+  private CollectionDAO.IngestionPipelineDAO dao() {
+    return mock(CollectionDAO.IngestionPipelineDAO.class, CALLS_REAL_METHODS);
+  }
+
+  private ListFilter filterWithServiceType() {
+    return new ListFilter(Include.NON_DELETED).addQueryParam("serviceType", "databaseService");
+  }
+
+  private int countWhereClauses(String sql) {
+    int count = 0;
+    int from = sql.indexOf(WHERE);
+    while (from >= 0) {
+      count++;
+      from = sql.indexOf(WHERE, from + WHERE.length());
+    }
+    return count;
+  }
+
+  @Test
+  void test_serviceTypeJoin_joinsEntityRelationshipAndPinsTheContainsRelation() {
+    String condition = dao().serviceTypeJoinCondition(filterWithServiceType());
+
+    assertTrue(
+        condition.startsWith("INNER JOIN entity_relationship ON " + TABLE + ".id ="),
+        "expected the serviceType filter to be expressed as a join, got: " + condition);
+    // The relation ordinal is inlined rather than bound; if the literal stops matching CONTAINS the
+    // listing silently scopes to the wrong relationship type.
+    assertTrue(
+        condition.endsWith("entity_relationship.relation = " + CONTAINS.ordinal()),
+        "expected the CONTAINS ordinal to be inlined, got: " + condition);
+  }
+
+  /**
+   * The cursor predicate is appended with {@code AND}, so a condition that did not already open a
+   * WHERE clause would produce {@code ... AND (...)} with no WHERE at all.
+   */
+  @Test
+  void test_serviceTypeJoin_terminatesInASingleWhereClauseTheCursorCanExtend() {
+    String composed = dao().serviceTypeJoinCondition(filterWithServiceType()) + CURSOR_PREDICATE;
+
+    assertEquals(1, countWhereClauses(composed), "composed SQL: " + composed);
+    assertTrue(
+        composed.indexOf(WHERE) < composed.indexOf(" AND ("),
+        "cursor predicate must extend the WHERE clause, not precede it: " + composed);
+  }
+
+  @Test
+  void test_displayNameSortCondition_reusesTheServiceTypeJoinVerbatim() {
+    ListFilter filter = filterWithServiceType();
+
+    assertEquals(dao().serviceTypeJoinCondition(filter), dao().displayNameSortCondition(filter));
+  }
+
+  /**
+   * Without {@code serviceType} there is nothing to join, so the ordered listing must fall back to
+   * exactly the condition the unordered listing uses — same rows, different order.
+   */
+  @Test
+  void test_displayNameSortCondition_fallsBackToThePlainFilterConditionWithoutServiceType() {
+    ListFilter filter = new ListFilter(Include.NON_DELETED);
+
+    String condition = dao().displayNameSortCondition(filter);
+
+    assertEquals(filter.getCondition(), condition);
+    assertTrue(condition.startsWith(WHERE), "expected a WHERE clause, got: " + condition);
+    assertEquals(1, countWhereClauses(condition + CURSOR_PREDICATE));
+  }
+
+  /**
+   * Columns stay table-qualified only on the serviceType variant, which joins {@code
+   * entity_relationship} — that table brings its own {@code json} and {@code deleted} columns, so an
+   * unqualified {@code deleted} would be ambiguous and fail at runtime. The plain branch has no join
+   * and must stay unqualified (see the pipelineType regression below).
+   */
+  @Test
+  void test_displayNameSortCondition_qualifiesColumnsOnlyWhenJoiningForServiceType() {
+    String condition = dao().displayNameSortCondition(filterWithServiceType());
+
+    assertTrue(condition.contains(TABLE + "."), "expected qualified columns, got: " + condition);
+  }
+
+  /**
+   * The plain branch sorts a single table, so it must reuse the unqualified {@code getCondition()}
+   * the default listing uses — which resolves {@code pipelineType} against the generated STORED
+   * column. Qualifying it (the old bug) rewrote the filter as {@code
+   * ingestion_pipeline_entity.JSON_UNQUOTE(...)}, which MySQL parses as a routine call and rejects
+   * with "execute command denied ... for routine". The generated column is dialect-safe and indexed.
+   */
+  @Test
+  void test_displayNameSortCondition_filtersPipelineTypeOnTheGeneratedColumnNotJsonExtraction() {
+    ListFilter filter =
+        new ListFilter(Include.NON_DELETED).addQueryParam("pipelineType", "application");
+
+    String condition = dao().displayNameSortCondition(filter);
+
+    assertTrue(
+        condition.contains("pipelineType IN ("),
+        "expected the generated pipelineType column, got: " + condition);
+    assertFalse(
+        condition.contains(TABLE + ".JSON_UNQUOTE"),
+        "must not qualify the JSON extraction onto the table (MySQL routine-call bug): "
+            + condition);
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/IngestionPipelineSortCursorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/IngestionPipelineSortCursorTest.java
@@ -1,0 +1,179 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
+import org.openmetadata.schema.utils.ResultList;
+import org.openmetadata.service.exception.BadRequestException;
+import org.openmetadata.service.jdbi3.IngestionPipelineRepository.DisplayNameCursor;
+import org.openmetadata.service.util.RestUtil;
+
+/**
+ * The keyset cursor for {@code sortField=displayName} carries the value of the SQL sort expression
+ * {@code COALESCE(NULLIF(displayName,''), name)}, so Java has to reproduce it exactly.
+ *
+ * <p>Any disagreement is silent and data-dependent: the cursor is compared against the expression
+ * with {@code >}/{@code =}, so a Java value one character off from the stored one skips or repeats a
+ * row at a page boundary rather than failing. The value is carried whole — the expression is not
+ * length-capped, so the cursor must not truncate either.
+ */
+class IngestionPipelineSortCursorTest {
+  private static final IngestionPipelineRepository repository;
+
+  static {
+    // The real constructor registers the entity with the DAO-backed Entity registry; these helpers
+    // are pure functions of their arguments, so call them on an otherwise-uninitialised instance.
+    repository = mock(IngestionPipelineRepository.class);
+    when(repository.displayNameCursorValue(Mockito.any())).thenCallRealMethod();
+    when(repository.parseDisplayNameCursor(Mockito.anyString())).thenCallRealMethod();
+    when(repository.parseCursorMap(Mockito.nullable(String.class))).thenCallRealMethod();
+    when(repository.forwardBeforeCursor(Mockito.nullable(String.class), Mockito.any()))
+        .thenCallRealMethod();
+  }
+
+  private IngestionPipeline pipeline(String name, String displayName) {
+    return new IngestionPipeline()
+        .withId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+        .withName(name)
+        .withDisplayName(displayName);
+  }
+
+  private String sortKeyOf(IngestionPipeline pipeline) {
+    return repository
+        .parseCursorMap(repository.displayNameCursorValue(pipeline))
+        .get("displayNameSort");
+  }
+
+  @Test
+  void test_sortKey_prefersDisplayNameOverName() {
+    assertEquals("Alpha", sortKeyOf(pipeline("machine-generated-name", "Alpha")));
+  }
+
+  /** {@code NULLIF(displayName,'')} — an empty displayName is not a label, so the name wins. */
+  @Test
+  void test_sortKey_fallsBackToNameWhenDisplayNameIsEmpty() {
+    assertEquals("n2", sortKeyOf(pipeline("n2", "")));
+  }
+
+  /** {@code COALESCE(...)} — the JSON key is absent entirely. */
+  @Test
+  void test_sortKey_fallsBackToNameWhenDisplayNameIsAbsent() {
+    assertEquals("n1", sortKeyOf(pipeline("n1", null)));
+  }
+
+  @Test
+  void test_sortKey_isEmptyWhenNeitherNameNorDisplayNameIsSet() {
+    assertEquals("", sortKeyOf(pipeline(null, null)));
+  }
+
+  /**
+   * The sort key is carried whole — no truncation. The SQL expression is not length-capped either,
+   * so a long displayName's cursor must equal its full value or the keyset comparison skips a row.
+   */
+  @Test
+  void test_sortKey_carriesLongDisplayNamesWhole() {
+    String longName = "a".repeat(300);
+    assertEquals(longName, sortKeyOf(pipeline("machine-name", longName)));
+  }
+
+  @Test
+  void test_cursor_roundTripsThroughTheWireEncoding() {
+    // U+1F600 is a surrogate pair — the full value, emoji included, must survive encode/decode.
+    String longName = "a".repeat(255) + "😀" + "b";
+    IngestionPipeline pipeline = pipeline("n7", longName);
+
+    DisplayNameCursor parsed =
+        repository.parseDisplayNameCursor(
+            RestUtil.encodeCursor(repository.displayNameCursorValue(pipeline)));
+
+    assertEquals(longName, parsed.displayName());
+    assertEquals(pipeline.getId().toString(), parsed.id());
+  }
+
+  /**
+   * A pipeline whose name and displayName are both empty has an empty sort key, which is a legal
+   * cursor value — only a missing key is malformed.
+   */
+  @Test
+  void test_cursor_acceptsAnEmptySortKey() {
+    DisplayNameCursor parsed = repository.parseDisplayNameCursor(cursorOf("\"\"", "\"id-1\""));
+
+    assertEquals("", parsed.displayName());
+    assertEquals("id-1", parsed.id());
+  }
+
+  /**
+   * The unsorted listing issues {@code (name, id)} cursors. Callers persist cursors, so one can
+   * arrive here after the sort order that produced it was lost — it must be rejected rather than
+   * fed to the keyset comparison, where a missing key binds as NULL and quietly matches no row.
+   */
+  @Test
+  void test_cursor_rejectsACursorFromTheDefaultListing() {
+    String defaultListingCursor =
+        RestUtil.encodeCursor("{\"name\":\"some-pipeline\",\"id\":\"id-1\"}");
+
+    assertThrows(
+        BadRequestException.class, () -> repository.parseDisplayNameCursor(defaultListingCursor));
+  }
+
+  /**
+   * A page can come back empty when the cursor was valid but every row past it was deleted
+   * meanwhile; the caller's own cursor is echoed so navigation does not dead-end. {@link ResultList}
+   * base64-encodes every cursor it is handed, and the echoed one arrived off the wire already
+   * encoded — returning it as-is hands the client a double-encoded cursor that no later request can
+   * parse.
+   */
+  @Test
+  void test_emptyPage_echoesACursorTheClientCanUseAgain() {
+    String wireCursor = RestUtil.encodeCursor("{\"displayNameSort\":\"Alpha\",\"id\":\"id-1\"}");
+
+    String echoed = repository.forwardBeforeCursor(wireCursor, List.of());
+
+    assertEquals(
+        wireCursor,
+        new ResultList<>(List.of(), echoed, null, 0).getPaging().getBefore(),
+        "echoed cursor must survive ResultList's encoding unchanged");
+  }
+
+  @Test
+  void test_emptyPage_echoesNothingOnAGenuineFirstPage() {
+    assertNull(repository.forwardBeforeCursor(null, List.of()));
+  }
+
+  @Test
+  void test_cursor_rejectsAMissingOrBlankId() {
+    String noId = cursorOf("\"Alpha\"", null);
+    String blankId = cursorOf("\"Alpha\"", "\"  \"");
+
+    assertThrows(BadRequestException.class, () -> repository.parseDisplayNameCursor(noId));
+    assertThrows(BadRequestException.class, () -> repository.parseDisplayNameCursor(blankId));
+  }
+
+  private String cursorOf(String displayNameSortJson, String idJson) {
+    String json =
+        idJson == null
+            ? String.format("{\"displayNameSort\":%s}", displayNameSortJson)
+            : String.format("{\"displayNameSort\":%s,\"id\":%s}", displayNameSortJson, idJson);
+    return RestUtil.encodeCursor(json);
+  }
+}

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IngestionListNameSorting.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IngestionListNameSorting.spec.ts
@@ -1,0 +1,234 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { expect, Locator, Page, test } from '@playwright/test';
+import { SORT_ORDER } from '../../../src/enums/common.enum';
+import { DatabaseServiceClass } from '../../support/entity/service/DatabaseServiceClass';
+import { performAdminLogin } from '../../utils/admin';
+import { uuid } from '../../utils/common';
+import { waitForAllLoadersToDisappear } from '../../utils/entity';
+
+test.use({ storageState: 'playwright/.auth/admin.json' });
+
+const service = new DatabaseServiceClass();
+
+/**
+ * Regression for collate#3919. The Name column renders `displayName ?? name`, so
+ * it has to sort on that same value. Agents created from the UI get a
+ * machine-generated `name` that carries no relation to the label the user typed
+ * (Automations use `OpenMetadata_application_<random>`), so ordering by the raw
+ * `name` looks arbitrary on screen.
+ *
+ * `name` ascending is deliberately the reverse of `displayName` ascending below,
+ * which is what makes a raw-`name` sorter observably wrong.
+ */
+const token = uuid();
+const firstByDisplayName = `aaa-sort-probe-${token}`;
+const lastByDisplayName = `zzz-sort-probe-${token}`;
+const agents = [
+  { name: `pw-agent-a-${token}`, displayName: lastByDisplayName },
+  { name: `pw-agent-z-${token}`, displayName: firstByDisplayName },
+];
+
+/**
+ * The `chromium` lane has no Airflow/Argo container, so the real status endpoint
+ * returns non-200 and the Pipelines tab renders "Ingestion Scheduler is unable to
+ * respond" instead of the table. Stub that one boundary so `isAirflowAvailable`
+ * is true; every other call the page makes stays real.
+ */
+const stubIngestionSchedulerStatus = (page: Page) =>
+  page.route('**/api/v1/services/ingestionPipelines/status', (route) =>
+    route.fulfill({
+      status: 200,
+      body: JSON.stringify({ code: 200, platform: 'airflow' }),
+    })
+  );
+
+// Only the two agents this spec seeded — the tab lists every database agent.
+const seededRowOrder = async (page: Page) => {
+  const renderedNames = await page
+    .getByTestId('pipeline-name')
+    .allTextContents();
+
+  return renderedNames
+    .map((name) => name.trim())
+    .filter((name) => name.endsWith(token));
+};
+
+// The Name column renders `displayName ?? name`, so the listing response is what the cells should
+// show — and in the order the response returned them.
+const renderedNames = (body: {
+  data?: { displayName?: string; name: string }[];
+}): string[] =>
+  (body.data ?? []).map((pipeline) => pipeline.displayName ?? pipeline.name);
+
+const waitForSortedListing = (page: Page, { cursored = false } = {}) =>
+  page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/v1/services/ingestionPipelines?') &&
+      response.url().includes('sortField=displayName') &&
+      (!cursored || response.url().includes('after=')) &&
+      response.status() === 200
+  );
+
+/**
+ * The Name column's job is to hand ordering to the server and render whatever comes back — sorting
+ * in the browser can only ever reorder the loaded page. So assert both halves of that contract:
+ * the click issues a request carrying the sort params, and the rendered rows mirror that response
+ * in order. Whether the ordering itself is correct is the endpoint's contract, covered by
+ * IngestionPipelineSortIT.
+ */
+const expectSortDelegatedToServer = async (
+  page: Page,
+  nameHeader: Locator,
+  sortOrder: SORT_ORDER
+) => {
+  const sortedResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/v1/services/ingestionPipelines?') &&
+      response.url().includes(`sortField=displayName`) &&
+      response.url().includes(`sortOrder=${sortOrder}`) &&
+      response.status() === 200
+  );
+
+  await nameHeader.click();
+
+  const serverOrder = renderedNames(await (await sortedResponse).json()).filter(
+    (name) => name.endsWith(token)
+  );
+
+  expect(serverOrder).toHaveLength(agents.length);
+
+  await waitForAllLoadersToDisappear(page);
+  await expect.poll(() => seededRowOrder(page)).toEqual(serverOrder);
+};
+
+test.describe('Ingestion agent list Name column sorting', () => {
+  test.beforeAll(async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+
+    await service.create(apiContext);
+
+    await Promise.all(
+      agents.map(async (agent) => {
+        const response = await apiContext.post(
+          '/api/v1/services/ingestionPipelines',
+          {
+            data: {
+              airflowConfig: { scheduleInterval: '0 0 * * *' },
+              displayName: agent.displayName,
+              loggerLevel: 'INFO',
+              name: agent.name,
+              pipelineType: 'metadata',
+              service: {
+                id: service.entityResponseData.id,
+                type: 'databaseService',
+              },
+              sourceConfig: { config: { type: 'DatabaseMetadata' } },
+            },
+          }
+        );
+
+        expect(response.status()).toBe(201);
+      })
+    );
+
+    await afterAction();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+
+    await service.delete(apiContext);
+
+    await afterAction();
+  });
+
+  test('should sort the Name column by the name shown in the cell', async ({
+    page,
+  }) => {
+    test.slow();
+
+    await stubIngestionSchedulerStatus(page);
+
+    await test.step('Open the database agents list', async () => {
+      await page.goto('/settings/services/databases?tab=pipelines');
+      await waitForAllLoadersToDisappear(page);
+
+      await expect(
+        page
+          .getByTestId('pipeline-name')
+          .filter({ hasText: firstByDisplayName })
+      ).toBeVisible();
+      await expect(
+        page.getByTestId('pipeline-name').filter({ hasText: lastByDisplayName })
+      ).toBeVisible();
+    });
+
+    const nameHeader = page.locator('th:has-text("Name")').first();
+
+    await test.step('Sort ascending on Name', async () => {
+      await expect(nameHeader).toBeVisible();
+
+      await expectSortDelegatedToServer(page, nameHeader, SORT_ORDER.ASC);
+    });
+
+    await test.step('Sort descending on Name', async () => {
+      await expectSortDelegatedToServer(page, nameHeader, SORT_ORDER.DESC);
+    });
+  });
+
+  /**
+   * A sorted cursor is a `(displayNameSort, id)` tuple that only the sorted listing can read, and
+   * the cursor outlives a reload because usePaging keeps it in the URL. So the sort order has to
+   * outlive the reload too — replaying that cursor down the default `name`-ordered path matches no
+   * row and renders an empty page.
+   *
+   * `pageSize=1` rather than seeding a full page of agents: the tab lists every database agent, so
+   * the number of rows is not this spec's to control, but the page size is.
+   */
+  test('should keep a sorted page addressable across a reload', async ({
+    page,
+  }) => {
+    test.slow();
+
+    await stubIngestionSchedulerStatus(page);
+
+    await page.goto('/settings/services/databases?tab=pipelines&pageSize=1');
+    await waitForAllLoadersToDisappear(page);
+
+    const sortedFirstPage = waitForSortedListing(page);
+
+    await page.locator('th:has-text("Name")').first().click();
+    await sortedFirstPage;
+    await waitForAllLoadersToDisappear(page);
+
+    const secondPage = waitForSortedListing(page, { cursored: true });
+
+    await page.getByTestId('next').click();
+    await secondPage;
+    await waitForAllLoadersToDisappear(page);
+
+    // Deliberately not asserting *which* agent lands here. The tab lists every database agent, so a
+    // spec running alongside this one can create a row that sorts into the cursor's gap; what the
+    // bug broke is that the page came back at all.
+    const restoredPage = waitForSortedListing(page, { cursored: true });
+
+    await page.reload();
+    await restoredPage;
+    await waitForAllLoadersToDisappear(page);
+
+    // Without the sort order in the URL the reload replayed a (displayNameSort, id) cursor against
+    // the name-ordered listing, which matches no row: an empty table under a "page 2" paginator.
+    await expect(page.getByTestId('pipeline-name')).toHaveCount(1);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/IngestionListTable.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/IngestionListTable.interface.ts
@@ -15,6 +15,7 @@ import { TableProps } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import { ReactNode } from 'react';
 import { AirflowStatusContextType } from '../../../../../context/AirflowStatusProvider/AirflowStatusProvider.interface';
+import { SORT_ORDER } from '../../../../../enums/common.enum';
 import { ServiceCategory } from '../../../../../enums/service.enum';
 import { PipelineType } from '../../../../../generated/api/services/ingestionPipelines/createIngestionPipeline';
 import {
@@ -61,6 +62,14 @@ export interface IngestionListTableProps {
   ) => ReactNode;
   tableClassName?: string;
   searchText?: string;
+  /**
+   * Opt into server-side ordering of the Name column. When `onSortChange` is provided the column
+   * stops comparing rows locally — which can only ever reorder the loaded page — and the caller is
+   * expected to refetch with `sortField=displayName` and this order. Omit both to keep the
+   * client-side comparator.
+   */
+  sortOrder?: SORT_ORDER;
+  onSortChange?: (sortOrder?: SORT_ORDER) => void;
 }
 
 export interface ModifiedIngestionPipeline extends IngestionPipeline {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/IngestionListTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/IngestionListTable.tsx
@@ -31,6 +31,7 @@ import {
   IngestionServicePermission,
   ResourceEntity,
 } from '../../../../../context/PermissionProvider/PermissionProvider.interface';
+import { SORT_ORDER } from '../../../../../enums/common.enum';
 import {
   IngestionPipeline,
   PipelineStatus,
@@ -42,7 +43,7 @@ import {
 } from '../../../../../rest/ingestionPipelineAPI';
 import { getEntityName } from '../../../../../utils/EntityNameUtils';
 import { highlightSearchText } from '../../../../../utils/EntitySearchUtils';
-import { getColumnSorter } from '../../../../../utils/EntitySortUtils';
+import { columnSorter } from '../../../../../utils/EntitySortUtils';
 import { Transi18next } from '../../../../../utils/i18next/LocalUtil';
 import {
   renderNameField,
@@ -68,6 +69,13 @@ import {
 } from './IngestionListTable.interface';
 import IngestionStatusCount from './IngestionStatusCount/IngestionStatusCount';
 import PipelineActions from './PipelineActions/PipelineActions';
+
+// Derived from symbols already in scope rather than imported from antd directly: tw-guard blocks
+// new antd specifiers, and this file's table is legacy AntD that is not being migrated here.
+type AntdSortOrder = ColumnsType<IngestionPipeline>[number]['sortOrder'];
+type AntdTableChangeHandler = NonNullable<
+  NonNullable<IngestionListTableProps['extraTableProps']>['onChange']
+>;
 
 function IngestionListTable({
   tableContainerClassName = '',
@@ -97,6 +105,8 @@ function IngestionListTable({
   customRenderNameField,
   tableClassName,
   searchText,
+  sortOrder,
+  onSortChange,
 }: Readonly<IngestionListTableProps>) {
   const { t } = useTranslation();
   const { theme } = useApplicationStore();
@@ -305,6 +315,44 @@ function IngestionListTable({
     ]
   );
 
+  const isServerSorted = !isUndefined(onSortChange);
+
+  const antdSortOrder = useMemo<AntdSortOrder>(() => {
+    let order: AntdSortOrder = null;
+    if (sortOrder === SORT_ORDER.ASC) {
+      order = 'ascend';
+    } else if (sortOrder === SORT_ORDER.DESC) {
+      order = 'descend';
+    }
+
+    return order;
+  }, [sortOrder]);
+
+  const toSortOrder = (order?: AntdSortOrder): SORT_ORDER | undefined => {
+    let updatedSortOrder: SORT_ORDER | undefined;
+    if (order === 'ascend') {
+      updatedSortOrder = SORT_ORDER.ASC;
+    } else if (order === 'descend') {
+      updatedSortOrder = SORT_ORDER.DESC;
+    }
+
+    return updatedSortOrder;
+  };
+
+  // AntD reports sort, filter and pagination through the same `onChange`. Only the sort action is
+  // ours; everything else stays with the caller's handler, which must still receive every action.
+  const handleTableChange = useCallback<AntdTableChangeHandler>(
+    (pagination, filters, sorter, extra) => {
+      extraTableProps?.onChange?.(pagination, filters, sorter, extra);
+
+      if (extra.action === 'sort' && onSortChange) {
+        const order = Array.isArray(sorter) ? sorter[0]?.order : sorter.order;
+        onSortChange(toSortOrder(order));
+      }
+    },
+    [extraTableProps, onSortChange]
+  );
+
   const tableColumn: ColumnsType<IngestionPipeline> = useMemo(
     () => [
       {
@@ -313,7 +361,13 @@ function IngestionListTable({
         dataIndex: 'name',
         key: 'name',
         fixed: 'left' as FixedType,
-        sorter: getColumnSorter<IngestionPipeline, 'name'>('name'),
+        // Sort on the same value the cell renders (getEntityName), not the raw
+        // `name`: agents created from the UI get a machine-generated name that
+        // has no relation to the label the user sees. `sorter: true` hands
+        // ordering to the server so it spans every page, not just the loaded one.
+        ...(isServerSorted
+          ? { sorter: true, sortOrder: antdSortOrder }
+          : { sorter: columnSorter }),
         render: customRenderNameField ?? renderNameField(searchText),
       },
       ...(showDescriptionCol
@@ -418,6 +472,9 @@ function IngestionListTable({
       pipelineTypeColumnObj,
       recentRunStatuses,
       isIngestionRunsLoading,
+      isLoading,
+      isServerSorted,
+      antdSortOrder,
     ]
   );
 
@@ -476,6 +533,7 @@ function IngestionListTable({
           scroll={data.length > 0 ? { x: 1300 } : undefined}
           size="small"
           {...extraTableProps}
+          onChange={handleTableChange}
         />
       </div>
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionPipelineList/IngestinoPipelineList.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionPipelineList/IngestinoPipelineList.test.tsx
@@ -12,11 +12,15 @@
  */
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { BrowserRouter } from 'react-router-dom';
 import { useAirflowStatus } from '../../../../../context/AirflowStatusProvider/AirflowStatusProvider';
 import { ServiceCategory } from '../../../../../enums/service.enum';
 import { mockIngestionData } from '../../../../../mocks/Ingestion.mock';
 import { mockESIngestionData } from '../../../../../mocks/IngestionListTable.mock';
-import { deployIngestionPipelineById } from '../../../../../rest/ingestionPipelineAPI';
+import {
+  deployIngestionPipelineById,
+  getIngestionPipelines,
+} from '../../../../../rest/ingestionPipelineAPI';
 import { IngestionPipelineList } from './IngestionPipelineList.component';
 
 jest.mock(
@@ -41,24 +45,34 @@ jest.mock('../../../../common/Loader/Loader', () => {
 });
 
 jest.mock('../IngestionListTable/IngestionListTable', () => {
-  return jest.fn().mockImplementation(({ extraTableProps }) => (
-    <div>
-      IngestionListTable
-      <button
-        onClick={() =>
-          extraTableProps.rowSelection.onChange(
-            [
-              mockIngestionData.fullyQualifiedName,
-              mockESIngestionData.fullyQualifiedName,
-            ],
-            [mockIngestionData, mockESIngestionData]
-          )
-        }>
-        rowSelection
-      </button>
-    </div>
-  ));
+  return jest
+    .fn()
+    .mockImplementation(({ extraTableProps, onPageChange, onSortChange }) => (
+      <div>
+        IngestionListTable
+        <button
+          onClick={() =>
+            extraTableProps.rowSelection.onChange(
+              [
+                mockIngestionData.fullyQualifiedName,
+                mockESIngestionData.fullyQualifiedName,
+              ],
+              [mockIngestionData, mockESIngestionData]
+            )
+          }>
+          rowSelection
+        </button>
+        <button onClick={() => onSortChange('asc')}>sortAsc</button>
+        <button onClick={() => onSortChange(undefined)}>sortClear</button>
+        <button
+          onClick={() => onPageChange({ cursorType: 'after', currentPage: 2 })}>
+          nextPage
+        </button>
+      </div>
+    ));
 });
+
+const AFTER_CURSOR = 'eyJkaXNwbGF5TmFtZVNvcnQiOiJBbHBoYSIsImlkIjoiaWQtMSJ9';
 
 jest.mock('../../../../../rest/ingestionPipelineAPI', () => ({
   deployIngestionPipelineById: jest
@@ -67,20 +81,37 @@ jest.mock('../../../../../rest/ingestionPipelineAPI', () => ({
   getIngestionPipelines: jest.fn().mockImplementation(() =>
     Promise.resolve({
       data: [mockIngestionData, mockESIngestionData],
-      paging: { total: 2 },
+      paging: { total: 2, after: AFTER_CURSOR },
     })
   ),
 }));
+
 const mockLocationPathname = '/mock-path';
 
-jest.mock('react-router-dom', () => ({
-  useLocation: jest.fn().mockImplementation(() => ({
-    pathname: mockLocationPathname,
-  })),
-  useNavigate: jest.fn().mockImplementation(() => jest.fn()),
-}));
+const setUrl = (search = '') =>
+  globalThis.history.replaceState({}, '', `${mockLocationPathname}${search}`);
+
+const renderList = async () => {
+  await act(async () => {
+    render(
+      <BrowserRouter>
+        <IngestionPipelineList
+          serviceName={ServiceCategory.DASHBOARD_SERVICES}
+        />
+      </BrowserRouter>
+    );
+  });
+};
+
+const lastRequest = () =>
+  (getIngestionPipelines as jest.Mock).mock.calls.at(-1)?.[0];
 
 describe('IngestionPipelineList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setUrl();
+  });
+
   it('should show loader until get status of airflow', () => {
     (useAirflowStatus as jest.Mock).mockImplementationOnce(() => ({
       isAirflowAvailable: false,
@@ -88,7 +119,11 @@ describe('IngestionPipelineList', () => {
     }));
 
     render(
-      <IngestionPipelineList serviceName={ServiceCategory.DASHBOARD_SERVICES} />
+      <BrowserRouter>
+        <IngestionPipelineList
+          serviceName={ServiceCategory.DASHBOARD_SERVICES}
+        />
+      </BrowserRouter>
     );
 
     expect(screen.getByText('Loader')).toBeInTheDocument();
@@ -101,20 +136,18 @@ describe('IngestionPipelineList', () => {
     }));
 
     render(
-      <IngestionPipelineList serviceName={ServiceCategory.DASHBOARD_SERVICES} />
+      <BrowserRouter>
+        <IngestionPipelineList
+          serviceName={ServiceCategory.DASHBOARD_SERVICES}
+        />
+      </BrowserRouter>
     );
 
     expect(screen.getByText('Airflow not available')).toBeInTheDocument();
   });
 
   it('should not call deployIngestionPipelineById after bulk deploy button click without pipeline selection', async () => {
-    await act(async () => {
-      render(
-        <IngestionPipelineList
-          serviceName={ServiceCategory.DASHBOARD_SERVICES}
-        />
-      );
-    });
+    await renderList();
 
     const bulkDeployButton = screen.getByTestId('bulk-re-deploy-button');
 
@@ -126,13 +159,7 @@ describe('IngestionPipelineList', () => {
   });
 
   it('should call deployIngestionPipelineById after bulk deploy button click after pipeline selection', async () => {
-    await act(async () => {
-      render(
-        <IngestionPipelineList
-          serviceName={ServiceCategory.DASHBOARD_SERVICES}
-        />
-      );
-    });
+    await renderList();
 
     const rowSelection = screen.getByText('rowSelection');
 
@@ -143,5 +170,79 @@ describe('IngestionPipelineList', () => {
     fireEvent.click(bulkDeployButton);
 
     expect(deployIngestionPipelineById).toHaveBeenCalledTimes(2);
+  });
+
+  describe('sort order', () => {
+    it('should send the sort order the URL was restored with alongside the cursor', async () => {
+      // A reload of a sorted page 2. The cursor is a (displayNameSort, id) tuple, so dropping
+      // sortField on restore sends it down the default name-ordered path, which matches no row
+      // and silently renders an empty page.
+      setUrl(
+        `?cursorType=after&cursorValue=${AFTER_CURSOR}&currentPage=2&sortOrder=desc`
+      );
+
+      await renderList();
+
+      expect(lastRequest()).toEqual(
+        expect.objectContaining({
+          paging: { after: AFTER_CURSOR },
+          sortField: 'displayName',
+          sortOrder: 'desc',
+        })
+      );
+    });
+
+    it('should persist the sort order to the URL and drop the stale cursor', async () => {
+      setUrl();
+      await renderList();
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('nextPage'));
+      });
+
+      expect(globalThis.location.search).toContain('cursorValue');
+
+      (getIngestionPipelines as jest.Mock).mockClear();
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('sortAsc'));
+      });
+
+      expect(globalThis.location.search).toContain('sortOrder=asc');
+      expect(globalThis.location.search).not.toContain('cursorValue');
+      // One state change, one request — an intermediate render carrying the new sort with the
+      // stale cursor would both 400 and race the correct request.
+      expect(getIngestionPipelines).toHaveBeenCalledTimes(1);
+      expect(lastRequest()).toEqual(
+        expect.objectContaining({
+          paging: undefined,
+          sortField: 'displayName',
+          sortOrder: 'asc',
+        })
+      );
+    });
+
+    it('should clear the sort order from the URL when sorting is removed', async () => {
+      setUrl('?sortOrder=asc');
+      await renderList();
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('sortClear'));
+      });
+
+      expect(globalThis.location.search).not.toContain('sortOrder');
+      expect(lastRequest()).not.toHaveProperty('sortField');
+    });
+
+    it('should ignore an unsupported sort order in the URL', async () => {
+      // The endpoint rejects anything other than asc/desc, so a hand-edited URL must fall back to
+      // the unsorted listing rather than sending the value straight through.
+      setUrl('?sortOrder=sideways');
+
+      await renderList();
+
+      expect(lastRequest()).not.toHaveProperty('sortField');
+      expect(lastRequest()).not.toHaveProperty('sortOrder');
+    });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionPipelineList/IngestionPipelineList.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionPipelineList/IngestionPipelineList.component.tsx
@@ -10,9 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Button, Col, Row, TablePaginationConfig } from 'antd';
+import { Button, Col, Row } from 'antd';
 import { ColumnsType, TableProps } from 'antd/lib/table';
-import { FilterValue, TableRowSelection } from 'antd/lib/table/interface';
+import { TableRowSelection } from 'antd/lib/table/interface';
 import { AxiosError } from 'axios';
 import capitalize from 'lodash/capitalize';
 import isNil from 'lodash/isNil';
@@ -20,7 +20,10 @@ import map from 'lodash/map';
 import startCase from 'lodash/startCase';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { INITIAL_PAGING_VALUE } from '../../../../../constants/constants';
+import { SORT_FIELD_DISPLAY_NAME } from '../../../../../constants/Ingestions.constant';
 import { useAirflowStatus } from '../../../../../context/AirflowStatusProvider/AirflowStatusProvider';
+import { SORT_ORDER } from '../../../../../enums/common.enum';
 import { EntityType, TabSpecificField } from '../../../../../enums/entity.enum';
 import { ServiceCategory } from '../../../../../enums/service.enum';
 import {
@@ -29,6 +32,7 @@ import {
 } from '../../../../../generated/entity/services/ingestionPipelines/ingestionPipeline';
 import { Paging } from '../../../../../generated/type/paging';
 import { usePaging } from '../../../../../hooks/paging/usePaging';
+import { useTableFilters } from '../../../../../hooks/useTableFilters';
 import {
   deployIngestionPipelineById,
   getIngestionPipelines,
@@ -44,6 +48,14 @@ import Loader from '../../../../common/Loader/Loader';
 import { PagingHandlerParams } from '../../../../common/NextPrevious/NextPrevious.interface';
 import { ColumnFilter } from '../../../../Database/ColumnFilter/ColumnFilter.component';
 import IngestionListTable from '../IngestionListTable/IngestionListTable';
+
+/**
+ * The listing endpoint rejects any `sortOrder` other than `asc`/`desc`, so a value that did not come
+ * from the Name column — a hand-edited URL, or a repeated query param that `qs` parses as an array —
+ * falls back to the unsorted listing instead of being forwarded and 400ing.
+ */
+const toSortOrder = (value?: string): SORT_ORDER | undefined =>
+  Object.values(SORT_ORDER).find((order) => order === value);
 
 export const IngestionPipelineList = ({
   serviceName,
@@ -63,6 +75,20 @@ export const IngestionPipelineList = ({
   const [loading, setLoading] = useState(false);
   const [pipelineTypeFilter, setPipelineTypeFilter] =
     useState<PipelineType[]>();
+
+  // The sort order lives in the URL rather than in component state because the cursor it produces
+  // already does: usePaging persists cursorType/cursorValue as query params, and a sorted cursor is
+  // a (displayNameSort, id) tuple that only the sorted listing can read. Keeping the order in state
+  // meant a reload of page 2 replayed that cursor down the default name-ordered path, which matches
+  // no row and renders an empty page. Same reason back/forward and a shared link now work.
+  const { filters: sortFilters, setFilters: setSortFilters } = useTableFilters<{
+    sortOrder?: string;
+  }>({ sortOrder: undefined });
+
+  const sortOrder = useMemo(
+    () => toSortOrder(sortFilters.sortOrder),
+    [sortFilters.sortOrder]
+  );
 
   const pagingInfo = usePaging();
 
@@ -137,10 +163,12 @@ export const IngestionPipelineList = ({
       paging,
       pipelineType,
       limit,
+      sortOrder,
     }: {
       paging?: Omit<Paging, 'total'>;
       pipelineType?: PipelineType[];
       limit?: number;
+      sortOrder?: SORT_ORDER;
     }) => {
       setLoading(true);
       try {
@@ -153,6 +181,9 @@ export const IngestionPipelineList = ({
           paging,
           pipelineType,
           limit,
+          ...(sortOrder
+            ? { sortField: SORT_FIELD_DISPLAY_NAME, sortOrder }
+            : {}),
         });
 
         setPipelines(data);
@@ -166,13 +197,18 @@ export const IngestionPipelineList = ({
     [serviceName]
   );
 
+  // A new sort order or filter invalidates the cursor the current page was reached with, so the
+  // cursor has to be cleared explicitly — handlePageChange only rewrites the ones it is given.
+  const resetToFirstPage = useCallback(() => {
+    handlePageChange(INITIAL_PAGING_VALUE, {
+      cursorType: null,
+      cursorValue: undefined,
+    });
+  }, [handlePageChange]);
+
   const handlePipelinePageChange = useCallback(
     ({ cursorType, currentPage }: PagingHandlerParams) => {
       if (cursorType) {
-        fetchPipelines({
-          paging: { [cursorType]: paging[cursorType] },
-          limit: pageSize,
-        });
         handlePageChange(
           currentPage,
           { cursorType, cursorValue: paging[cursorType] },
@@ -180,39 +216,62 @@ export const IngestionPipelineList = ({
         );
       }
     },
-    [fetchPipelines, paging, handlePageChange]
+    [paging, handlePageChange, pageSize]
   );
 
+  // Single fetch path. Every input the request depends on — page size, cursor, sort order and the
+  // pipeline type filter — is state this effect reads, so a change to any one of them produces
+  // exactly one request carrying all of the others. Handlers below only move that state; they must
+  // not fetch as well, or a sort would race a request that has forgotten the active filter.
   useEffect(() => {
     if (isAirflowAvailable) {
       const { cursorType, cursorValue } = pagingCursor ?? {};
 
-      if (cursorType && cursorValue) {
-        fetchPipelines({
-          paging: { [cursorType]: cursorValue },
-          limit: pageSize,
-        });
-      } else {
-        fetchPipelines({ limit: pageSize });
-      }
+      fetchPipelines({
+        paging:
+          cursorType && cursorValue ? { [cursorType]: cursorValue } : undefined,
+        pipelineType: pipelineTypeFilter,
+        limit: pageSize,
+        sortOrder,
+      });
     }
-  }, [serviceName, isAirflowAvailable, pageSize, pagingCursor]);
+  }, [
+    fetchPipelines,
+    serviceName,
+    isAirflowAvailable,
+    pageSize,
+    pagingCursor,
+    sortOrder,
+    pipelineTypeFilter,
+  ]);
 
-  const handleTableChange: TableProps<IngestionPipeline>['onChange'] =
-    useCallback(
-      (
-        _pagination: TablePaginationConfig,
-        filters: Record<string, FilterValue | null>
-      ) => {
-        const pipelineType = filters.pipelineType as PipelineType[];
-        setPipelineTypeFilter(pipelineType);
-        fetchPipelines({
-          pipelineType,
-          limit: pageSize,
-        });
-      },
-      [fetchPipelines]
-    );
+  // Params are inferred from the handler type rather than annotated, so the sorter/extra types do
+  // not have to be imported from antd — tw-guard blocks new antd specifiers.
+  const handleTableChange = useCallback<
+    NonNullable<TableProps<IngestionPipeline>['onChange']>
+  >(
+    (_pagination, filters, _sorter, extra) => {
+      // AntD reports sort/filter/pagination through one callback. Reading `filters` on a sort
+      // action saw pipelineType as undefined and silently cleared the active filter.
+      if (extra.action !== 'filter') {
+        return;
+      }
+
+      setPipelineTypeFilter(filters.pipelineType as PipelineType[]);
+      resetToFirstPage();
+    },
+    [resetToFirstPage]
+  );
+
+  const handleSortChange = useCallback(
+    (updatedSortOrder?: SORT_ORDER) => {
+      // Written before resetToFirstPage, not after: both merge into the same query string off the
+      // live URL, and the cursor must be dropped by the later of the two writes.
+      setSortFilters({ sortOrder: updatedSortOrder ?? null });
+      resetToFirstPage();
+    },
+    [resetToFirstPage, setSortFilters]
+  );
 
   const handleRowChange = useCallback(
     (selectedRowKeys: React.Key[], selectedRows: IngestionPipeline[]) => {
@@ -266,7 +325,9 @@ export const IngestionPipelineList = ({
           isLoading={loading}
           pipelineTypeColumnObj={typeColumnObj}
           serviceName={serviceName}
+          sortOrder={sortOrder}
           onPageChange={handlePipelinePageChange}
+          onSortChange={handleSortChange}
         />
       </Col>
     </Row>

--- a/openmetadata-ui/src/main/resources/ui/src/constants/Ingestions.constant.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/Ingestions.constant.ts
@@ -40,3 +40,10 @@ export const PIPELINE_TYPE_LOCALIZATION = {
   [PipelineType.Usage]: 'usage',
   [PipelineType.Application]: 'application',
 };
+
+/**
+ * The only sortField the ingestion pipeline list endpoint accepts. Orders by the effective display
+ * name (`displayName` falling back to `name`) — the value the Name column renders — rather than the
+ * raw `name`, which is machine-generated for UI-created agents.
+ */
+export const SORT_FIELD_DISPLAY_NAME = 'displayName';

--- a/openmetadata-ui/src/main/resources/ui/src/rest/ingestionPipelineAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/ingestionPipelineAPI.ts
@@ -14,6 +14,7 @@
 import { AxiosResponse } from 'axios';
 import { Operation } from 'fast-json-patch';
 import { PagingResponse } from 'Models';
+import { SORT_ORDER } from '../enums/common.enum';
 import {
   CreateIngestionPipeline,
   PipelineType,
@@ -61,6 +62,10 @@ export const getIngestionPipelines = async (data: {
   serviceType?: string;
   limit?: number;
   applicationType?: PipelineType;
+  // Order by the effective display name (`displayName` falling back to `name`) — the value the
+  // Name column renders — instead of the endpoint's default `name` order.
+  sortField?: 'displayName';
+  sortOrder?: SORT_ORDER;
 }) => {
   const { arrQueryFields, serviceFilter, paging, pipelineType, ...rest } = data;
 


### PR DESCRIPTION
Backports #31072 to `1.13`: server-side displayName sort + keyset pagination for the ingestion pipelines list (Name column renders `displayName ?? name`), fixing the MySQL 500 on `pipelineType`+`sortField` by resolving pipelineType against the generated column via the unqualified `getCondition()`.

1.13 adaptations vs main: `setFieldsInBulk` is 2-arg here (dropped the ListFilter overload + unused param); added `nullOrEmpty`/`DatasourceConfig` imports; kept 1.13's run-status props alongside the new sort props in IngestionListTable.

Verified on 1.13 (pre-rebase): service compiles; IngestionPipelineSortConditionTest 6/6; IngestionPipelineSortCursorTest 11/11; IngestionPipelineSortIT 13/13; changed UI files 0 tsc errors.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds server-side effective-display-name sorting and keyset pagination for ingestion pipelines, then wires the UI Name column and URL state to that API.

- Adds dialect-specific display-name ordering, typed cursors, backward pagination, and regression coverage.
- Preserves sorting across pagination, reloads, and shared URLs in the ingestion-list UI.
- The serviceType-specific sorted condition drops the default non-deleted scope, allowing deleted pipelines to reappear when sorting.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until display-name sorting preserves the endpoint's default non-deleted scope for serviceType-filtered requests.

The new UI always combines serviceType with displayName sorting, and that branch replaces the complete ListFilter condition with a join that does not filter deleted rows, so sorting can make soft-deleted pipelines visible again.

**Files Needing Attention:** openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java; openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java | Adds serviceType-aware display-name SQL and keyset queries, but the selected join condition omits the default deleted-row filter. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java | Adds effective-display-name cursor construction and forward/backward pagination; the behavior is well tested, though several helpers exceed repository method-size guidance. |
| openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java | Adds lenient displayName sort parameters while retaining the shared authenticated list path. |
| openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionPipelineList/IngestionPipelineList.component.tsx | Persists sort order in the URL, resets stale cursors on sorting/filtering, and centralizes requests in one effect. |
| openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/IngestionListTable.tsx | Delegates Name sorting to the server while preserving existing table-change handlers and local sorting for other consumers. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineSortIT.java | Adds broad endpoint coverage for ordering, cursors, serviceType filtering, and edge-case display names, but does not cover soft-deleted rows under serviceType sorting. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Ingestion list UI
  participant Resource as IngestionPipelineResource
  participant Repo as IngestionPipelineRepository
  participant DAO as IngestionPipelineDAO
  participant DB as MySQL/PostgreSQL
  UI->>Resource: "GET pipelines?serviceType=...&sortField=displayName&sortOrder=..."
  Resource->>Repo: listAfter/listBefore with ListFilter
  Repo->>DAO: displayNameSortCondition(filter)
  DAO->>DAO: serviceTypeJoinCondition(filter)
  Note over DAO: Complete include/deleted condition is omitted
  Repo->>DAO: display-name keyset query
  DAO->>DB: ORDER BY effective displayName, id
  DB-->>UI: Sorted page may include soft-deleted pipelines
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java`, line 838-855 ([link](https://github.com/open-metadata/openmetadata/blob/65f3c2af7cac55382863126bc06c8718adc5cf27/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java#L838-L855)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Pagination helpers exceed size guidance**

   The new pagination helpers combine count lookup, querying, cursor construction, page trimming, and response creation in methods longer than the repository's focused-method limit; the same pattern continues through `beforeJsons`, while the new Playwright cases also use `test()` instead of the required `it()` convention. Split these responsibilities into focused helpers and apply the repository's test declaration convention to keep this change maintainable and compliant.

   **Context Used:** CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(ingestion): sort ingestion pipelines..."](https://github.com/open-metadata/openmetadata/commit/65f3c2af7cac55382863126bc06c8718adc5cf27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55872182)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))
- Knowledge Base — [OpenMetadata Service Core: Entities, Resources, Repositories](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-core.md)
- Knowledge Base — [OpenMetadata React UI](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-ui.md)
</details>


<!-- /greptile_comment -->