### PR TITLE
Fixes 31916: wait past the Collate job's own 90-minute cap

### DIFF
--- a/.github/workflows/data-access-request-e2e.yml
+++ b/.github/workflows/data-access-request-e2e.yml
@@ -75,7 +75,10 @@ jobs:
 
       - name: Trigger Collate Playwright run & wait
         uses: benc-uk/workflow-dispatch@v1.3.2
-        timeout-minutes: 60
+        # Must stay above wait-timeout-seconds below. The step timeout kills the action
+        # outright, so when it is the smaller of the two the action can never reach its own
+        # wait budget and reports a bare "has timed out" with no downstream conclusion.
+        timeout-minutes: 100
         env:
           SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         with:
@@ -85,6 +88,9 @@ jobs:
           token: ${{ secrets.COLLATE_PAT }}
           wait-for-completion: true
           sync-status: true
-          wait-timeout-seconds: 3660
+          # The Collate job caps itself at timeout-minutes: 90, so waiting past that point is
+          # what guarantees we report its real conclusion instead of giving up first. Successful
+          # runs are 48-60 min today, already at the edge of the previous 61-min budget.
+          wait-timeout-seconds: 5700
           wait-interval-seconds: 60
           inputs: '{ "sha": "${{ env.SHA }}", "event": "${{ github.event_name }}" }'

--- a/.github/workflows/maven-build-collate.yml
+++ b/.github/workflows/maven-build-collate.yml
@@ -82,7 +82,10 @@ jobs:
           persist-credentials: false
       - name: Trigger Collate build & wait
         uses: benc-uk/workflow-dispatch@v1.3.2
-        timeout-minutes: 60
+        # Must stay above wait-timeout-seconds below. The step timeout kills the action
+        # outright, so when it is the smaller of the two the action can never reach its own
+        # wait budget and reports a bare "has timed out" with no downstream conclusion.
+        timeout-minutes: 100
         env:
           SHA: ${{ github.event_name == 'push' && github.event.after || github.event.pull_request.head.sha || github.sha }}
         with:
@@ -97,6 +100,11 @@ jobs:
           token: ${{ secrets.COLLATE_PAT }}
           wait-for-completion: true
           sync-status: true
-          wait-timeout-seconds: 3660
+          # The Collate job caps itself at timeout-minutes: 90, so waiting past that point is
+          # what guarantees we report its real conclusion instead of giving up first. Successful
+          # main builds run 58-68 min, which the previous 61-min budget sat inside: the wait
+          # expired mid-build and failed this check on nearly every PR while the Collate run it
+          # was watching went on to pass.
+          wait-timeout-seconds: 5700
           wait-interval-seconds: 60
           inputs: '{ "sha": "${{ env.SHA }}", "event": "${{ github.event_name }}" }'


### PR DESCRIPTION
### Describe your changes:

Fixes #31916

`maven-collate-ci` fails on nearly every PR with `The action 'Trigger Collate build & wait' has timed out after 60 minutes` — while the Collate build it is watching **passes**. We stop watching too early.

The last 25 successful `OpenMetadata Collate Test` runs on `main` took **57.8–67.7 min (mean 62.5)**, so the 60-minute budget sat *below the mean*. PR #30009 is typical: the check gave up at 18:05:19; Collate run `32586674015` succeeded at 18:08:38 (63m 18s). Same failure today on `main` itself and on four unrelated branches, so it is not branch-specific.

The budget was also **unreachable**. The step's `timeout-minutes: 60` killed the action before its own `wait-timeout-seconds: 3660` (61 min) could expire — so raising the wait alone would have changed nothing, and the action could never report a downstream conclusion, only the bare step-timeout message.

Both Collate-side jobs cap themselves at `timeout-minutes: 90` (`openmetadata-dispatch.yml:40`, `data-access-request-e2e.yml:33`), which gives an exact ceiling to size against rather than a guessed one:

- `wait-timeout-seconds: 5700` (95 min) — past the downstream's own cap, so a genuinely hung build is bounded by that cap and we always report its real conclusion
- `timeout-minutes: 100` — above the wait budget, so the action's timeout governs and emits a meaningful message

`data-access-request-e2e.yml` carries the identical pair. Its downstream runs 48–60 min today — not tipped over yet, but one slow run away — so it gets the same treatment instead of being left to fail the same way next week.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- A Collate build that takes 60–90 min reports its real conclusion (success or failure) on the OpenMetadata PR instead of a spurious wait-timeout failure.
- A Collate build that hangs is still bounded — by the downstream job's own `timeout-minutes: 90`, which we now outlast rather than pre-empt.

#### Unit tests
Not applicable — CI configuration only, no application code.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Verified against real run data rather than by re-running CI:

1. Pulled the last 40 `OpenMetadata Collate Test` runs and computed durations — 25 `main` successes span 57.8–67.7 min, mean 62.5.
2. Confirmed the run dispatched by PR #30009 (`32586674015`) concluded `success` at 63m 18s, ~3 min after our wait expired.
3. Confirmed three `cancelled` runs at 90.3–90.6 min correspond to the Collate job's own `timeout-minutes: 90`, then read that value directly from `openmetadata-dispatch.yml:40` and `data-access-request-e2e.yml:33` to size the new budget exactly.
4. Measured the data-access-request downstream (47.9–59.8 min) to confirm the sibling workflow has the same latent failure.
5. Both changed files parse as valid YAML.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. (No schema changes.)
- [x] For UI changes: I attached a screen recording and/or screenshots above. (No UI changes.)
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above. (CI config only — not unit-testable; verified against production run data instead.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR raises the timeout budgets for two Collate-dispatching CI steps so downstream runs lasting longer than an hour can report their actual conclusions.
- Raises each dispatch step timeout from 60 to 100 minutes.
- Raises each action wait budget from 61 to 95 minutes.
- Documents the relationship between the local wait and the downstream 90-minute job cap.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The timeout fix should be adjusted before merging because a Collate run queued for more than five minutes can still reproduce the missing-conclusion failure.

Both workflows assume a 95-minute end-to-end wait necessarily outlasts a 90-minute job timeout, but the downstream execution cap does not bound queue time before the job starts.

**Files Needing Attention:** .github/workflows/maven-build-collate.yml, .github/workflows/data-access-request-e2e.yml
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/maven-build-collate.yml | Extends the Collate build wait, but the five-minute margin over the downstream job cap does not cover potentially longer queue latency. |
| .github/workflows/data-access-request-e2e.yml | Applies the same timeout change and inherits the insufficient margin between total waiting time and the downstream execution cap. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fixes 31916: wait past the Collate job&#39;s..."](https://github.com/open-metadata/openmetadata/commit/c75724f50fbda59e68a1fcf6754a278c23647d5f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55933454)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->