### PR TITLE
Fixes #24565: Datalake profiler size and created at

### DIFF
--- a/ingestion/src/metadata/profiler/constants.py
+++ b/ingestion/src/metadata/profiler/constants.py
@@ -1,0 +1,23 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Keys of the table-level results a profiler interface returns.
+
+They are shared between the producers (the SQA table metric computers and the pandas interface) and
+the consumer (`Profiler.get_profile`), which maps them onto `TableProfile`.
+"""
+
+ROW_COUNT = "rowCount"
+COLUMN_COUNT = "columnCount"
+COLUMN_NAMES = "columnNames"
+SIZE_IN_BYTES = "sizeInBytes"
+CREATE_DATETIME = "createDateTime"

--- a/ingestion/src/metadata/profiler/interface/pandas/profiler_interface.py
+++ b/ingestion/src/metadata/profiler/interface/pandas/profiler_interface.py
@@ -194,11 +194,17 @@ class PandasProfilerInterface(ProfilerInterface, PandasInterfaceMixin):
         Subclasses of this interface are not always backed by an object store (BurstIQ has no
         `configSource` at all), in which case `get_object_stats` falls back to empty stats.
         """
+        # The schema an object-store table hangs off of is its bucket; without one there is
+        # nothing to look the object up in.
+        database_schema = self.table_entity.databaseSchema
+        if database_schema is None:
+            return {}
+
         try:
             stats = get_object_stats(
                 getattr(self.service_connection_config, "configSource", None),
                 self.client.client,
-                self.table_entity.databaseSchema.name,
+                database_schema.name,
                 self.table_entity.name.root,
             )
         except Exception as exc:

--- a/ingestion/src/metadata/profiler/interface/pandas/profiler_interface.py
+++ b/ingestion/src/metadata/profiler/interface/pandas/profiler_interface.py
@@ -18,7 +18,7 @@ supporting sqlalchemy abstraction layer
 import traceback
 from collections import defaultdict
 from datetime import datetime
-from typing import Callable, Dict, List, Optional, Union  # noqa: UP035
+from typing import Any, Callable, Dict, List, Optional, Union  # noqa: UP035
 
 from sqlalchemy import Column
 
@@ -38,6 +38,7 @@ from metadata.generated.schema.tests.customMetric import CustomMetric
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.mixins.pandas.pandas_mixin import PandasInterfaceMixin
 from metadata.profiler.api.models import ThreadPoolMetrics
+from metadata.profiler.constants import CREATE_DATETIME, SIZE_IN_BYTES
 from metadata.profiler.interface.profiler_interface import (
     ProfilerInterface,
     ProfilerProcessorStatus,
@@ -48,6 +49,7 @@ from metadata.profiler.processor.metric_filter import MetricFilter
 from metadata.profiler.processor.runner import PandasRunner
 from metadata.sampler.pandas.sampler import DatalakeSampler
 from metadata.utils.datalake.datalake_utils import GenericDataFrameColumnParser
+from metadata.utils.datalake.object_stats import get_object_stats
 from metadata.utils.logger import profiler_interface_registry_logger
 from metadata.utils.sqa_like_column import SQALikeColumn
 
@@ -175,11 +177,44 @@ class PandasProfilerInterface(ProfilerInterface, PandasInterfaceMixin):
             row_dict = {}
             for metric in metrics:
                 row_dict[metric.name()] = metric().df_fn(runner)
+            row_dict.update(self._get_object_stats())
             return row_dict  # noqa: TRY300
         except Exception as exc:
             logger.debug(traceback.format_exc())
             logger.warning(f"Error trying to compute profile for {exc}")
             raise RuntimeError(exc)  # noqa: B904
+
+    def _get_object_stats(self) -> Dict[str, Any]:  # noqa: UP006
+        """Size and creation time of the object backing the table.
+
+        Best effort: a missing `HeadObject` permission must degrade to "no size", never to
+        "no profile", so we swallow the error instead of letting it bubble up to the
+        `RuntimeError` that aborts the whole table.
+
+        Subclasses of this interface are not always backed by an object store (BurstIQ has no
+        `configSource` at all), in which case `get_object_stats` falls back to empty stats.
+        """
+        try:
+            stats = get_object_stats(
+                getattr(self.service_connection_config, "configSource", None),
+                self.client.client,
+                self.table_entity.databaseSchema.name,
+                self.table_entity.name.root,
+            )
+        except Exception as exc:
+            logger.debug(traceback.format_exc())
+            logger.warning(f"Could not fetch object stats for {self.table_entity.name.root}: {exc}")
+            return {}
+
+        # A size of 0 is a real size, hence `is not None` rather than a truthiness check.
+        return {
+            key: value
+            for key, value in (
+                (SIZE_IN_BYTES, stats.size_in_bytes),
+                (CREATE_DATETIME, stats.create_date_time),
+            )
+            if value is not None
+        }
 
     def _compute_static_metrics(
         self,

--- a/ingestion/src/metadata/profiler/interface/pandas/profiler_interface.py
+++ b/ingestion/src/metadata/profiler/interface/pandas/profiler_interface.py
@@ -184,7 +184,7 @@ class PandasProfilerInterface(ProfilerInterface, PandasInterfaceMixin):
             logger.warning(f"Error trying to compute profile for {exc}")
             raise RuntimeError(exc)  # noqa: B904
 
-    def _get_object_stats(self) -> Dict[str, Any]:  # noqa: UP006
+    def _get_object_stats(self) -> dict[str, Any]:
         """Size and creation time of the object backing the table.
 
         Best effort: a missing `HeadObject` permission must degrade to "no size", never to

--- a/ingestion/src/metadata/profiler/orm/functions/table_metric_computer.py
+++ b/ingestion/src/metadata/profiler/orm/functions/table_metric_computer.py
@@ -44,6 +44,13 @@ from metadata.ingestion.source.database.timescale.queries import (
     TIMESCALE_GET_APPROXIMATE_METRICS,
     TIMESCALE_IS_HYPERTABLE,
 )
+from metadata.profiler.constants import (
+    COLUMN_COUNT,
+    COLUMN_NAMES,
+    CREATE_DATETIME,
+    ROW_COUNT,
+    SIZE_IN_BYTES,
+)
 from metadata.profiler.metrics.registry import Metrics
 from metadata.profiler.orm.registry import Dialects
 from metadata.profiler.processor.runner import QueryRunner
@@ -58,12 +65,6 @@ from metadata.utils.logger import profiler_interface_registry_logger
 
 logger = profiler_interface_registry_logger()
 
-
-COLUMN_COUNT = "columnCount"
-COLUMN_NAMES = "columnNames"
-ROW_COUNT = "rowCount"
-SIZE_IN_BYTES = "sizeInBytes"
-CREATE_DATETIME = "createDateTime"
 
 ERROR_MSG = "Schema/Table name not found in table args. Falling back to default computation"
 

--- a/ingestion/src/metadata/profiler/processor/core.py
+++ b/ingestion/src/metadata/profiler/processor/core.py
@@ -44,6 +44,7 @@ from metadata.generated.schema.tests.customMetric import (
 )
 from metadata.generated.schema.type.basic import ProfileSampleType, Timestamp
 from metadata.profiler.api.models import ProfilerResponse, ThreadPoolMetrics
+from metadata.profiler.constants import COLUMN_COUNT, CREATE_DATETIME, SIZE_IN_BYTES
 from metadata.profiler.interface.profiler_interface import ProfilerInterface  # noqa: TC001
 from metadata.profiler.metrics.core import (
     ComposedMetric,
@@ -59,7 +60,6 @@ from metadata.profiler.processor.metric_filter import MetricFilter
 from metadata.utils.logger import profiler_logger
 
 logger = profiler_logger()
-CREATE_DATETIME = "createDateTime"
 
 
 class MissingMetricException(Exception):  # noqa: N818
@@ -516,10 +516,10 @@ class Profiler(Generic[TMetric]):
 
             table_profile = TableProfile(
                 timestamp=self.profile_ts,
-                columnCount=self._table_results.get("columnCount"),
+                columnCount=self._table_results.get(COLUMN_COUNT),
                 rowCount=self._table_results.get(RowCount.name()),
                 createDateTime=raw_create_date,
-                sizeInByte=self._table_results.get("sizeInBytes"),
+                sizeInByte=self._table_results.get(SIZE_IN_BYTES),
                 profileSample=(sample_config.profileSample if sample_config else None),
                 profileSampleType=TableProfileSampleType(
                     sample_config.profileSampleType

--- a/ingestion/src/metadata/sampler/sqlalchemy/sampler.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/sampler.py
@@ -32,11 +32,11 @@ from metadata.generated.schema.type.basic import ProfileSampleType
 from metadata.generated.schema.type.staticSamplingConfig import StaticSamplingConfig
 from metadata.ingestion.connections.session import create_and_bind_thread_safe_session
 from metadata.mixins.sqalchemy.sqa_mixin import SQAInterfaceMixin
+from metadata.profiler.constants import ROW_COUNT
 from metadata.profiler.interface.sqlalchemy.stored_statistics_profiler import Metrics
 from metadata.profiler.orm.functions.modulo import ModuloFn
 from metadata.profiler.orm.functions.random_num import RandomNumFn
 from metadata.profiler.orm.functions.table_metric_computer import (
-    ROW_COUNT,
     table_metric_computer_factory,
 )
 from metadata.profiler.processor.handle_partition import build_partition_predicate

--- a/ingestion/src/metadata/utils/datalake/object_stats.py
+++ b/ingestion/src/metadata/utils/datalake/object_stats.py
@@ -73,8 +73,10 @@ def _(_: S3Config, client: Any, bucket_name: str, key: str) -> ObjectStats:
 
 @get_object_stats.register
 def _(_: GCSConfig, client: Any, bucket_name: str, key: str) -> ObjectStats:
-    # `bucket.blob()` only builds a reference; `get_blob()` is the call that fetches the properties.
-    blob = client.get_bucket(bucket_name).get_blob(key)
+    # `bucket()` only builds a reference, so it needs no `storage.buckets.get` permission --
+    # unlike `get_bucket()`. `get_blob()` then fetches the properties with object-level read access,
+    # which the profiler already holds to read the object itself.
+    blob = client.bucket(bucket_name).get_blob(key)
     if blob is None:
         return ObjectStats()
     return ObjectStats(size_in_bytes=blob.size, create_date_time=_as_utc(blob.time_created))

--- a/ingestion/src/metadata/utils/datalake/object_stats.py
+++ b/ingestion/src/metadata/utils/datalake/object_stats.py
@@ -15,9 +15,9 @@ Storage-level stats of the object backing a Datalake table
 
 from datetime import datetime, timezone
 from functools import singledispatch
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from metadata.generated.schema.entity.services.connections.database.datalake.azureConfig import (
     AzureConfig,
@@ -29,63 +29,75 @@ from metadata.generated.schema.entity.services.connections.database.datalake.s3C
     S3Config,
 )
 
+if TYPE_CHECKING:
+    from azure.storage.blob import BlobServiceClient
+    from google.cloud.storage import Client as GCSStorageClient
+
 
 class ObjectStats(BaseModel):
     """Storage-level stats for a single object backing a Datalake table."""
 
-    size_in_bytes: Optional[int] = None  # noqa: UP045
-    create_date_time: Optional[datetime] = None  # tz-aware UTC  # noqa: UP045
+    size_in_bytes: int | None = None
+    create_date_time: datetime | None = None
 
+    @field_validator("create_date_time")
+    @classmethod
+    def normalize_to_utc(cls, value: datetime | None) -> datetime | None:
+        """Normalize a provider timestamp to timezone-aware UTC.
 
-def _as_utc(value: Optional[datetime]) -> Optional[datetime]:  # noqa: UP045
-    """Normalize a provider timestamp to timezone-aware UTC.
-
-    `Profiler.get_profile` relabels the value with `replace(tzinfo=utc)` rather than converting it,
-    so a non-UTC timestamp leaving this module would end up silently shifted on the profile.
-    """
-    if not value:
-        return None
-    if value.tzinfo is None:
-        return value.replace(tzinfo=timezone.utc)
-    return value.astimezone(timezone.utc)
+        `Profiler.get_profile` relabels the value with `replace(tzinfo=utc)` rather than converting
+        it, so a non-UTC timestamp leaving this model would end up silently shifted on the profile.
+        Validating here rather than at each call site means no provider below can forget.
+        """
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
 
 
 @singledispatch
-def get_object_stats(config_source: Any, client: Any, bucket_name: str, key: str) -> ObjectStats:
+def get_object_stats(config_source: object, client: object, bucket_name: str, key: str) -> ObjectStats:
     """Fetch the size and creation time of the object backing a Datalake table.
 
-    Config sources that are not object stores (e.g. BurstIQ) get empty stats rather than an error.
+    Config sources that are not object stores (e.g. BurstIQ) get empty stats rather than an error,
+    hence the `object` rather than a union of the three supported configs.
     """
     return ObjectStats()
 
 
-@get_object_stats.register
+# The config class is passed to `register` explicitly rather than read off the annotation:
+# `singledispatch` resolves a function's annotations at registration time, which would blow up on
+# the `TYPE_CHECKING`-only client types below.
+@get_object_stats.register(S3Config)
 def _(_: S3Config, client: Any, bucket_name: str, key: str) -> ObjectStats:
+    # boto3 builds its clients at runtime, so `head_object` exists on no static type: `BaseClient`
+    # would type-check the parameter at the cost of an unresolved attribute on the line below.
     response = client.head_object(Bucket=bucket_name, Key=key)
     # S3 exposes no creation time at all. Datalake objects are typically written once, so
     # LastModified is the closest available signal; on overwritten objects it tracks the write time
     # of the current version.
     return ObjectStats(
         size_in_bytes=response.get("ContentLength"),
-        create_date_time=_as_utc(response.get("LastModified")),
+        create_date_time=response.get("LastModified"),
     )
 
 
-@get_object_stats.register
-def _(_: GCSConfig, client: Any, bucket_name: str, key: str) -> ObjectStats:
+@get_object_stats.register(GCSConfig)
+def _(_: GCSConfig, client: "GCSStorageClient", bucket_name: str, key: str) -> ObjectStats:
     # `bucket()` only builds a reference, so it needs no `storage.buckets.get` permission --
     # unlike `get_bucket()`. `get_blob()` then fetches the properties with object-level read access,
     # which the profiler already holds to read the object itself.
     blob = client.bucket(bucket_name).get_blob(key)
     if blob is None:
         return ObjectStats()
-    return ObjectStats(size_in_bytes=blob.size, create_date_time=_as_utc(blob.time_created))
+    return ObjectStats(size_in_bytes=blob.size, create_date_time=blob.time_created)
 
 
-@get_object_stats.register
-def _(_: AzureConfig, client: Any, bucket_name: str, key: str) -> ObjectStats:
+@get_object_stats.register(AzureConfig)
+def _(_: AzureConfig, client: "BlobServiceClient", bucket_name: str, key: str) -> ObjectStats:
     props = client.get_blob_client(container=bucket_name, blob=key).get_blob_properties()
     return ObjectStats(
         size_in_bytes=props.size,
-        create_date_time=_as_utc(props.creation_time or props.last_modified),
+        create_date_time=props.creation_time or props.last_modified,
     )

--- a/ingestion/src/metadata/utils/datalake/object_stats.py
+++ b/ingestion/src/metadata/utils/datalake/object_stats.py
@@ -1,0 +1,89 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Storage-level stats of the object backing a Datalake table
+"""
+
+from datetime import datetime, timezone
+from functools import singledispatch
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+from metadata.generated.schema.entity.services.connections.database.datalake.azureConfig import (
+    AzureConfig,
+)
+from metadata.generated.schema.entity.services.connections.database.datalake.gcsConfig import (
+    GCSConfig,
+)
+from metadata.generated.schema.entity.services.connections.database.datalake.s3Config import (
+    S3Config,
+)
+
+
+class ObjectStats(BaseModel):
+    """Storage-level stats for a single object backing a Datalake table."""
+
+    size_in_bytes: Optional[int] = None  # noqa: UP045
+    create_date_time: Optional[datetime] = None  # tz-aware UTC  # noqa: UP045
+
+
+def _as_utc(value: Optional[datetime]) -> Optional[datetime]:  # noqa: UP045
+    """Normalize a provider timestamp to timezone-aware UTC.
+
+    `Profiler.get_profile` relabels the value with `replace(tzinfo=utc)` rather than converting it,
+    so a non-UTC timestamp leaving this module would end up silently shifted on the profile.
+    """
+    if not value:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+@singledispatch
+def get_object_stats(config_source: Any, client: Any, bucket_name: str, key: str) -> ObjectStats:
+    """Fetch the size and creation time of the object backing a Datalake table.
+
+    Config sources that are not object stores (e.g. BurstIQ) get empty stats rather than an error.
+    """
+    return ObjectStats()
+
+
+@get_object_stats.register
+def _(_: S3Config, client: Any, bucket_name: str, key: str) -> ObjectStats:
+    response = client.head_object(Bucket=bucket_name, Key=key)
+    # S3 exposes no creation time at all. Datalake objects are typically written once, so
+    # LastModified is the closest available signal; on overwritten objects it tracks the write time
+    # of the current version.
+    return ObjectStats(
+        size_in_bytes=response.get("ContentLength"),
+        create_date_time=_as_utc(response.get("LastModified")),
+    )
+
+
+@get_object_stats.register
+def _(_: GCSConfig, client: Any, bucket_name: str, key: str) -> ObjectStats:
+    # `bucket.blob()` only builds a reference; `get_blob()` is the call that fetches the properties.
+    blob = client.get_bucket(bucket_name).get_blob(key)
+    if blob is None:
+        return ObjectStats()
+    return ObjectStats(size_in_bytes=blob.size, create_date_time=_as_utc(blob.time_created))
+
+
+@get_object_stats.register
+def _(_: AzureConfig, client: Any, bucket_name: str, key: str) -> ObjectStats:
+    props = client.get_blob_client(container=bucket_name, blob=key).get_blob_properties()
+    return ObjectStats(
+        size_in_bytes=props.size,
+        create_date_time=_as_utc(props.creation_time or props.last_modified),
+    )

--- a/ingestion/stubs/google/cloud/storage/__init__.pyi
+++ b/ingestion/stubs/google/cloud/storage/__init__.pyi
@@ -1,4 +1,5 @@
 from collections.abc import Iterable, Iterator
+from datetime import datetime
 from typing import Any
 
 from google.auth.credentials import Credentials
@@ -25,5 +26,6 @@ class Bucket:
 class Blob:
     name: str
     size: int | None
+    time_created: datetime | None
     def download_as_bytes(self, **kwargs: Any) -> bytes: ...
     def download_as_string(self, **kwargs: Any) -> bytes: ...

--- a/ingestion/tests/integration/datalake/test_datalake_profiler_e2e.py
+++ b/ingestion/tests/integration/datalake/test_datalake_profiler_e2e.py
@@ -17,6 +17,9 @@ To run this we need OpenMetadata server up and running.
 No sample data is required beforehand
 """
 
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
 import pytest
 
 from metadata.generated.schema.entity.data.table import ColumnProfile, Table
@@ -29,6 +32,8 @@ from metadata.workflow.profiler import ProfilerWorkflow
 from metadata.workflow.workflow_output_handler import WorkflowResultStatus
 
 from .conftest import BUCKET_NAME  # noqa: TID252
+
+PROFILER_TEST_CSV = Path(__file__).parent / "resources" / "profiler_test_.csv"
 
 
 @pytest.fixture(scope="class", autouse=True)
@@ -72,6 +77,19 @@ class TestDatalakeProfilerTestE2E:
 
         assert table_profile.entities
         assert column_profile.entities
+
+        profile = metadata.get_latest_table_profile(
+            f'{ingestion_config["source"]["serviceName"]}.default.{BUCKET_NAME}."profiler_test_.csv"'
+        ).profile
+
+        # Storage level stats, read from the object store rather than computed on the dataframe
+        assert profile.sizeInByte == PROFILER_TEST_CSV.stat().st_size
+        assert profile.createDateTime is not None
+        assert profile.createDateTime.utcoffset() == timedelta(0)
+        assert profile.createDateTime <= datetime.now(timezone.utc)
+        # They are merged into the table metrics, so those must still be there
+        assert profile.rowCount == 3.0
+        assert profile.columnCount == 7.0
 
     def test_values_partitioned_datalake_profiler_workflow(self, metadata, ingestion_config):
         """Test partitioned datalake profiler workflow"""

--- a/ingestion/tests/unit/observability/profiler/pandas/test_burstiq_profiler_interface.py
+++ b/ingestion/tests/unit/observability/profiler/pandas/test_burstiq_profiler_interface.py
@@ -517,3 +517,14 @@ class TestBurstIQProfilerIntegration:
             col_prof = profile_results["columns"][col_name]
             assert col_prof["name"] == col_name
             assert "timestamp" in col_prof
+
+    def test_no_object_store_stats_are_emitted(self):
+        """BurstIQ is not backed by an object store, so the table metrics carry no storage stats."""
+        df_factory = lambda: iter([DF_NORMAL.copy()])  # noqa: E731
+        with _make_interface(df_factory) as interface:
+            all_metrics = _build_all_threadpool_metrics(interface, FULL_TABLE_ENTITY)
+            profile_results = interface.get_all_metrics(all_metrics)
+
+        assert "rowCount" in profile_results["table"]
+        assert "sizeInBytes" not in profile_results["table"]
+        assert "createDateTime" not in profile_results["table"]

--- a/ingestion/tests/unit/observability/profiler/pandas/test_object_stats.py
+++ b/ingestion/tests/unit/observability/profiler/pandas/test_object_stats.py
@@ -35,6 +35,18 @@ KEY = "profiler_test_.csv"
 LAST_MODIFIED = datetime(2026, 8, 20, 10, 30, tzinfo=timezone.utc)
 
 
+class TestObjectStatsModel:
+    """UTC normalization is a property of the model, so no provider branch can forget it"""
+
+    def test_aware_timestamp_is_converted_on_construction(self):
+        aware = datetime(2026, 8, 20, 12, 30, tzinfo=timezone(timedelta(hours=2)))
+
+        assert ObjectStats(create_date_time=aware).create_date_time == LAST_MODIFIED
+
+    def test_naive_timestamp_is_labelled_utc_on_construction(self):
+        assert ObjectStats(create_date_time=datetime(2026, 8, 20, 10, 30)).create_date_time == LAST_MODIFIED
+
+
 class TestS3ObjectStats:
     """S3 (and S3-compatible stores) go through head_object"""
 

--- a/ingestion/tests/unit/observability/profiler/pandas/test_object_stats.py
+++ b/ingestion/tests/unit/observability/profiler/pandas/test_object_stats.py
@@ -1,0 +1,136 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Test the object store stats used by the Datalake profiler
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+from pydantic import BaseModel
+
+from metadata.generated.schema.entity.services.connections.database.datalake.azureConfig import (
+    AzureConfig,
+)
+from metadata.generated.schema.entity.services.connections.database.datalake.gcsConfig import (
+    GCSConfig,
+)
+from metadata.generated.schema.entity.services.connections.database.datalake.s3Config import (
+    S3Config,
+)
+from metadata.utils.datalake.object_stats import ObjectStats, get_object_stats
+
+BUCKET = "my-bucket"
+KEY = "profiler_test_.csv"
+
+LAST_MODIFIED = datetime(2026, 8, 20, 10, 30, tzinfo=timezone.utc)
+
+
+class TestS3ObjectStats:
+    """S3 (and S3-compatible stores) go through head_object"""
+
+    def test_stats_from_head_object(self):
+        client = MagicMock()
+        client.head_object.return_value = {
+            "ContentLength": 1024,
+            "LastModified": LAST_MODIFIED,
+        }
+
+        stats = get_object_stats(S3Config(), client, BUCKET, KEY)
+
+        client.head_object.assert_called_once_with(Bucket=BUCKET, Key=KEY)
+        assert stats.size_in_bytes == 1024
+        assert stats.create_date_time == LAST_MODIFIED
+
+    def test_non_utc_timestamp_is_converted_not_relabelled(self):
+        """A +02:00 timestamp must come back as the same instant in UTC, not the same clock time."""
+        client = MagicMock()
+        client.head_object.return_value = {
+            "ContentLength": 1,
+            "LastModified": datetime(2026, 8, 20, 12, 30, tzinfo=timezone(timedelta(hours=2))),
+        }
+
+        stats = get_object_stats(S3Config(), client, BUCKET, KEY)
+
+        assert stats.create_date_time == LAST_MODIFIED
+        assert stats.create_date_time.utcoffset() == timedelta(0)
+
+    def test_naive_timestamp_is_labelled_utc(self):
+        client = MagicMock()
+        client.head_object.return_value = {
+            "ContentLength": 1,
+            "LastModified": datetime(2026, 8, 20, 10, 30),
+        }
+
+        stats = get_object_stats(S3Config(), client, BUCKET, KEY)
+
+        assert stats.create_date_time == LAST_MODIFIED
+
+    def test_empty_file_keeps_its_zero_size(self):
+        client = MagicMock()
+        client.head_object.return_value = {"ContentLength": 0, "LastModified": LAST_MODIFIED}
+
+        assert get_object_stats(S3Config(), client, BUCKET, KEY).size_in_bytes == 0
+
+
+class TestGCSObjectStats:
+    """GCS exposes a real creation time on the blob"""
+
+    def test_stats_from_blob(self):
+        blob = MagicMock(size=2048, time_created=LAST_MODIFIED)
+        client = MagicMock()
+        client.get_bucket.return_value.get_blob.return_value = blob
+
+        stats = get_object_stats(GCSConfig(), client, BUCKET, KEY)
+
+        client.get_bucket.assert_called_once_with(BUCKET)
+        client.get_bucket.return_value.get_blob.assert_called_once_with(KEY)
+        assert stats.size_in_bytes == 2048
+        assert stats.create_date_time == LAST_MODIFIED
+
+    def test_missing_blob_returns_empty_stats(self):
+        client = MagicMock()
+        client.get_bucket.return_value.get_blob.return_value = None
+
+        assert get_object_stats(GCSConfig(), client, BUCKET, KEY) == ObjectStats()
+
+
+class TestAzureObjectStats:
+    """Azure Blob exposes a creation time, with last_modified as the fallback"""
+
+    def test_stats_from_blob_properties(self):
+        client = MagicMock()
+        props = MagicMock(size=512, creation_time=LAST_MODIFIED, last_modified=None)
+        client.get_blob_client.return_value.get_blob_properties.return_value = props
+
+        stats = get_object_stats(AzureConfig(), client, BUCKET, KEY)
+
+        client.get_blob_client.assert_called_once_with(container=BUCKET, blob=KEY)
+        assert stats.size_in_bytes == 512
+        assert stats.create_date_time == LAST_MODIFIED
+
+    def test_falls_back_to_last_modified(self):
+        client = MagicMock()
+        props = MagicMock(size=512, creation_time=None, last_modified=LAST_MODIFIED)
+        client.get_blob_client.return_value.get_blob_properties.return_value = props
+
+        assert get_object_stats(AzureConfig(), client, BUCKET, KEY).create_date_time == LAST_MODIFIED
+
+
+class TestUnknownConfigSource:
+    def test_unknown_source_returns_empty_stats(self):
+        """Non object store sources (e.g. BurstIQ) get empty stats instead of an error."""
+
+        class NotAnObjectStore(BaseModel):
+            pass
+
+        assert get_object_stats(NotAnObjectStore(), MagicMock(), BUCKET, KEY) == ObjectStats()

--- a/ingestion/tests/unit/observability/profiler/pandas/test_object_stats.py
+++ b/ingestion/tests/unit/observability/profiler/pandas/test_object_stats.py
@@ -88,18 +88,20 @@ class TestGCSObjectStats:
     def test_stats_from_blob(self):
         blob = MagicMock(size=2048, time_created=LAST_MODIFIED)
         client = MagicMock()
-        client.get_bucket.return_value.get_blob.return_value = blob
+        client.bucket.return_value.get_blob.return_value = blob
 
         stats = get_object_stats(GCSConfig(), client, BUCKET, KEY)
 
-        client.get_bucket.assert_called_once_with(BUCKET)
-        client.get_bucket.return_value.get_blob.assert_called_once_with(KEY)
+        # `bucket()`, not `get_bucket()`: the latter would need `storage.buckets.get`
+        client.get_bucket.assert_not_called()
+        client.bucket.assert_called_once_with(BUCKET)
+        client.bucket.return_value.get_blob.assert_called_once_with(KEY)
         assert stats.size_in_bytes == 2048
         assert stats.create_date_time == LAST_MODIFIED
 
     def test_missing_blob_returns_empty_stats(self):
         client = MagicMock()
-        client.get_bucket.return_value.get_blob.return_value = None
+        client.bucket.return_value.get_blob.return_value = None
 
         assert get_object_stats(GCSConfig(), client, BUCKET, KEY) == ObjectStats()
 

--- a/ingestion/tests/unit/observability/profiler/pandas/test_profiler_interface.py
+++ b/ingestion/tests/unit/observability/profiler/pandas/test_profiler_interface.py
@@ -15,7 +15,7 @@ Test SQA Interface
 
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import TestCase, mock
 from unittest.mock import Mock, patch
 from uuid import uuid4
@@ -55,6 +55,7 @@ from metadata.profiler.metrics.static.row_count import RowCount
 from metadata.profiler.processor.default import get_default_metrics
 from metadata.readers.dataframe.models import DatalakeColumnWrapper
 from metadata.sampler.pandas.sampler import DatalakeSampler
+from metadata.utils.datalake.object_stats import ObjectStats
 
 if sys.version_info < (3, 9):  # noqa: UP036
     pytest.skip(
@@ -402,3 +403,92 @@ class PandasInterfaceTest(TestCase):
             assert len(self.datalake_profiler_interface.status.failures) == 1
         finally:
             self.datalake_profiler_interface._get_metric_fn = original_get_metric_fn
+
+
+@pytest.fixture
+def datalake_profiler_interface():
+    """A PandasProfilerInterface over the same fixture data, with the object store client mocked"""
+    import pandas as pd
+
+    with (
+        patch(
+            "metadata.profiler.interface.profiler_interface.get_ssl_connection",
+            return_value=FakeConnection(),
+        ),
+        patch("metadata.sampler.pandas.sampler.get_ssl_connection", return_value=FakeConnection()),
+        patch.object(
+            DatalakeSampler,
+            "get_dataframes",
+            return_value=DatalakeColumnWrapper(
+                dataframes=lambda: iter(
+                    [
+                        PandasInterfaceTest.df1,
+                        pd.concat([PandasInterfaceTest.df2, pd.DataFrame(index=PandasInterfaceTest.df1.index)]),
+                    ]
+                ),
+                columns=None,
+                raw_data=None,
+            ),
+        ),
+        patch.object(DatalakeSampler, "get_client", return_value=Mock()),
+    ):
+        sampler = DatalakeSampler(
+            service_connection_config=DatalakeConnection(configSource={}),
+            ometa_client=None,
+            entity=PandasInterfaceTest.table_entity,
+        )
+        yield PandasProfilerInterface(
+            service_connection_config=DatalakeConnection(configSource={}),
+            ometa_client=None,
+            entity=PandasInterfaceTest.table_entity,
+            source_config=None,
+            sampler=sampler,
+        )
+
+
+class TestPandasObjectStats:
+    """Storage level stats are merged into the table metrics"""
+
+    table_metrics = [  # noqa: RUF012
+        metric
+        for metric in get_default_metrics(Metrics, User)
+        if not metric.is_col_metric() and not metric.is_system_metrics()
+    ]
+
+    def _compute(self, interface):
+        return interface._compute_table_metrics(self.table_metrics, interface.dataset)
+
+    def test_stats_merged_with_table_metrics(self, datalake_profiler_interface):
+        created = datetime(2026, 8, 20, 10, 30, tzinfo=timezone.utc)
+        with patch(
+            "metadata.profiler.interface.pandas.profiler_interface.get_object_stats",
+            return_value=ObjectStats(size_in_bytes=1024, create_date_time=created),
+        ):
+            row = self._compute(datalake_profiler_interface)
+
+        assert row["sizeInBytes"] == 1024
+        assert row["createDateTime"] == created
+        # The stats must be merged next to the metrics, not on top of them
+        assert row[RowCount.name()] == 6
+        assert row["columnCount"] == 10
+
+    def test_stats_failure_does_not_fail_the_profile(self, datalake_profiler_interface):
+        with patch(
+            "metadata.profiler.interface.pandas.profiler_interface.get_object_stats",
+            side_effect=Exception("AccessDenied"),
+        ):
+            row = self._compute(datalake_profiler_interface)
+
+        assert row[RowCount.name()] == 6
+        assert "sizeInBytes" not in row
+        assert "createDateTime" not in row
+
+    def test_empty_stats_are_omitted(self, datalake_profiler_interface):
+        with patch(
+            "metadata.profiler.interface.pandas.profiler_interface.get_object_stats",
+            return_value=ObjectStats(),
+        ):
+            row = self._compute(datalake_profiler_interface)
+
+        assert "sizeInBytes" not in row
+        assert "createDateTime" not in row


### PR DESCRIPTION
> **This pull request was opened by an olivaw agent.** It is an input to review, not an approved change — read the diff, not this description.
>
> Fixes #24565

## What olivaw checked (machine-observed, §8.2/A.1)

- diff: non-empty
- build: not_run
- tests: not_run
- base: `a7242502a4d462d88f4c892f80106c9157f11470`
- head: `4c22aa07972e2c5b540499e3da73d2b9e33eecf3`

**No build or test command is configured for this workspace**, so only the diff's existence was checked. Set `run_config.build_cmd`/`test_cmd` to have olivaw verify its own work.

## What the agent says it did (unverified)

> Done. Committed as `4c22aa07972` on `agent/issue-24565`.
> 
> ## What changed
> 
> **New `ingestion/src/metadata/utils/datalake/object_stats.py`** — `ObjectStats` model plus a `get_object_stats` `@singledispatch` on the Datalake config source: `head_object` for S3, `get_bucket().get_blob()` for GCS, `get_blob_properties()` for Azure (with `creation_time or last_modified`). All timestamps normalized to tz-aware UTC by `_as_utc`, so the `replace(tzinfo=utc)` relabel in `Profiler.get_profile` is a no-op instead of a silent shift. Unknown config sources return empty stats. `LocalConfig` is not registered — `DatalakeConnection._get_client` raises for it, so it would be dead code.
> 
> **`PandasProfilerInterface`** — `_compute_table_metrics` now does `row_dict.update(self._get_object_stats())`. The stat lookup has its own try/except so a missing `s3:HeadObject` degrades to "no size", not "no profile"; `None` values are omitted, but `0` is kept as a real size.
> 
> **New `ingestion/src/metadata/profiler/constants.py`** — the five table-metric keys were defined in `table_metric_computer.py`, redefined in `core.py`, and typed as bare literals in `core.py`'s `TableProfile` construction. Now one module; `core.py`, `table_metric_computer.py`, and `sampler/sqlalchemy/sampler.py` import from it.
> 
> ## Deviations from the spec
> 
> - **BurstIQ needed a guard after all.** The spec asserted `BurstIQConnection.configSource` is simply not an S3/GCS/Azure config; it has no `configSource` field at all, so the plain attribute access would have raised `AttributeError` on every BurstIQ table — caught, but logging a warning per table. Uses `getattr(..., "configSource", None)` instead, which dispatches cleanly to the base. Locked in by a new test in `test_burstiq_profiler_interface.py`.
> - **Skipped the optional §5.6 cleanup** (reimplementing `DataFrameReader._get_file_size_mb` on `get_object_stats`) to keep the change scoped. That latent bug is still there: if no `isinstance` branch matches, the method returns `None` and `json.py:185` does `None > 50.0` → `TypeError`.
> - **No docs change** — the Datalake connector docs aren't in this repo. The S3 `LastModified` approximation is documented in a code comment.
> 
> ## Tests
> 
> 13 new unit tests (9 in `test_object_stats.py`, 3 in `test_profiler_interface.py`, 1 BurstIQ guard). RED-first confirmed: with the source changes stashed, the 3 interface tests fail on `does not have the attribute 'get_object_stats'`.
> 
> `tests/unit/observability/profiler` passes: 517 passed, with 2 failures (`exasol`/`teradata` dialect tests) that are missing-driver failures unrelated to this change — `tests/unit/readers`' 25 failures are likewise identical on a stashed baseline.
> 
> **I could not run the integration test** (`test_datalake_profiler_e2e.py`) — it needs Docker/MinIO and a running OpenMetadata server, neither available here. Its new assertions (`sizeInByte == profiler_test_.csv` on-disk size, UTC `createDateTime`, and `rowCount`/`columnCount` unchanged as the regression guard) are written and the file compiles, but they are unverified.
> 
> The commit used `--no-verify`: pre-commit isn't installed in this clone. I ran the Python half of that gate manually — `ruff check` and `ruff format --check` at the pinned v0.15.12 against `ingestion/pyproject.toml`, both clean.








<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds provider-specific object-stat retrieval so Datalake profiles can include object size and creation time, while centralizing table metric keys.
- Adds S3, GCS, and Azure implementations for retrieving object metadata.
- Merges storage metadata into Pandas table-profile results with best-effort error handling.
- Adds unit and integration coverage for provider responses, metric merging, UTC normalization, and non-object-store profiler interfaces.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because Datalake profiling still cannot resolve the physical storage key for object paths transformed into MD5-derived table names.

For object paths longer than 256 characters, ingestion stores the MD5-derived value in Table.name, while both the dataframe reader and the new object-stat lookup use that catalog name as the provider key instead of the original path.

**Files Needing Attention:** ingestion/src/metadata/profiler/interface/pandas/profiler_interface.py, ingestion/src/metadata/mixins/pandas/pandas_mixin.py
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/utils/datalake/object_stats.py | Introduces provider-dispatched retrieval and UTC normalization for Datalake object size and timestamps. |
| ingestion/src/metadata/profiler/interface/pandas/profiler_interface.py | Merges best-effort object statistics into Pandas table metrics, but the previously reported long-object-key handling remains unresolved. |
| ingestion/src/metadata/profiler/processor/core.py | Replaces duplicated table-profile metric literals with shared constants. |
| ingestion/tests/unit/observability/profiler/pandas/test_object_stats.py | Covers provider-specific object-stat retrieval, missing objects, and timestamp normalization. |
| ingestion/tests/integration/datalake/test_datalake_profiler_e2e.py | Extends the Datalake profiler integration test with size, UTC timestamp, and existing-metric assertions. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  T[Datalake table entity] --> P[Pandas profiler interface]
  P --> M[Compute dataframe metrics]
  P --> S[Fetch object statistics]
  S --> C{Config source}
  C -->|S3| A[HeadObject]
  C -->|GCS| G[Get blob]
  C -->|Azure| Z[Get blob properties]
  M --> R[Table metric results]
  A --> R
  G --> R
  Z --> R
  R --> O[TableProfile]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["refactor(profiler): tighten typing and c..."](https://github.com/open-metadata/openmetadata/commit/49f1e77d9820f299f1792f45b8f6a8e15599e0aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55963872)</sub>

<!-- /greptile_comment -->