### PR TITLE
test(ui): narrow the CustomProperties matrix on 1.13, as main already does

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
@@ -18,27 +18,11 @@
  *   StoredProcedure, DashboardDataModel, Metric, Chart,
  *   ApiCollection, ApiEndpoint, DataProduct, Domain, TableColumn.
  *
- * Each entity type has ONE describe.serial block so no two workers can ever run
- * CP create/edit/delete operations for the same entity type simultaneously.
+ * Each entity type has one default-mode describe block so its CP operations
+ * remain sequential without replaying every preceding test on a retry.
  *
  * Entity setup (prepareCustomProperty) is done in beforeAll, not inside tests,
  * so cleanup always runs in afterAll even when a test fails mid-way.
- *
- * That serialisation only holds within this file. `PUT /api/v1/metadata/types/{id}`
- * is read-modify-write on a single global row per entity type, so a spec writing
- * the same row from another worker makes one side's property vanish while the API
- * still answers 200. Two rules keep that from happening:
- *
- *   1. A spec that only *uses* custom properties must read the shared fixtures —
- *      `EntityDataClass.customProperties[entityType][typeKey]` — rather than
- *      create its own. entity-data.setup.ts creates every property type on every
- *      entity type, sequentially, before any test runs.
- *   2. A spec that must create or delete custom properties belongs in this file,
- *      inside the describe.serial for its entity type. The exception is any spec
- *      that Playwright already runs in isolation (the IntakeForm suites have
- *      their own serial project), which cannot overlap with this file by design.
- *
- * Never PUT/PATCH `/api/v1/metadata/types/*` from a spec that runs in parallel.
  */
 
 import { APIRequestContext, expect, test } from '@playwright/test';
@@ -121,7 +105,10 @@ import {
 } from '../../utils/entity';
 import { getEntityFqn } from '../../utils/entityPanel';
 import { navigateToExploreAndSelectEntity } from '../../utils/explore';
-import { setSliderValue } from '../../utils/searchSettingUtils';
+import {
+  openMatchingFieldsPanel,
+  setSliderValue,
+} from '../../utils/searchSettingUtils';
 import {
   settingClick,
   SettingOptionsType,
@@ -272,9 +259,29 @@ const ALL_ENTITIES: CRUDEntity[] = [
 
 ALL_ENTITIES.forEach(({ key, makeInstance }) => {
   const entity = CUSTOM_PROPERTIES_ENTITIES[key];
+  const basicProperties =
+    key === 'entity_table' ? BASIC_PROPERTIES : ['String'];
+  const configProperties = key === 'entity_table' ? CONFIG_PROPERTIES : [];
+  const valuePropertyTypes =
+    key === 'entity_table'
+      ? Object.values(CustomPropertyTypeByName)
+      : [CustomPropertyTypeByName.STRING];
+  const updatePropertyTypes =
+    key === 'entity_table'
+      ? [CustomPropertyTypeByName.STRING, CustomPropertyTypeByName.TABLE_CP]
+      : valuePropertyTypes;
+  const rightPanelPropertyTypes =
+    key === 'entity_table'
+      ? [CustomPropertyTypeByName.STRING]
+      : valuePropertyTypes;
+  const preparedPropertyTypes =
+    key === 'entity_container'
+      ? [CustomPropertyTypeByName.STRING, CustomPropertyTypeByName.HYPERLINK_CP]
+      : valuePropertyTypes;
 
-  test.describe
-    .serial(`Add update and delete custom properties for ${entity.name}`, () => {
+  test.describe(`Add update and delete custom properties for ${entity.name}`, () => {
+    test.describe.configure({ mode: 'default' });
+
     let mainEntity: AssetTypes | OtherTypes = {} as AssetTypes | OtherTypes;
     let responseData:
       | AssetTypes['entityResponseData']
@@ -312,7 +319,10 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
       } else if (makeInstance !== null) {
         mainEntity = makeInstance();
         await mainEntity.create(apiContext);
-        await mainEntity.prepareCustomProperty(apiContext);
+        await mainEntity.prepareCustomProperty(
+          apiContext,
+          preparedPropertyTypes
+        );
 
         if (key === 'entity_table') {
           // Created concurrently: sequential round-trips in this hook
@@ -390,9 +400,7 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
       await redirectToHomePage(page);
     });
 
-    // ── 17 CRUD tests ──────────────────────────────────────────────────────
-
-    BASIC_PROPERTIES.forEach((property) => {
+    basicProperties.forEach((property) => {
       test(property, async ({ page }) => {
         test.slow();
         const propertyName = `cp-${uuid()}-${entity.name}${NAME_SUFFIX}`;
@@ -427,7 +435,7 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
       });
     });
 
-    CONFIG_PROPERTIES.forEach((propertyConfig) => {
+    configProperties.forEach((propertyConfig) => {
       test(propertyConfig.name, async ({ page }) => {
         test.slow();
         const propertyName = `cp-${uuid()}-${entity.name}${NAME_SUFFIX}`;
@@ -482,18 +490,22 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
       });
     });
 
-    // ── Set & Update all CP types (entities with a UI entity page) ──────────
+    // ── Set & Update CP values (entities with a UI entity page) ─────────────
 
     if (makeInstance !== null) {
-      test(`Set & Update all CP types on ${entity.name}`, async ({ page }) => {
-        // 5 minutes timeout since the test handles set->update operation on all
-        // custom property types sequentially
-        test.setTimeout(300000);
-        const properties = Object.values(CustomPropertyTypeByName);
+      const valueCoverageLabel =
+        key === 'entity_table' ? 'all CP types' : 'String CP';
+      const valueCoverageTestTitle =
+        key === 'entity_table'
+          ? `Set all CP types and update representative properties on ${entity.name}`
+          : `Set & Update ${valueCoverageLabel} on ${entity.name}`;
 
-        await test.step('Set all CP types', async () => {
+      test(valueCoverageTestTitle, async ({ page }) => {
+        test.setTimeout(key === 'entity_table' ? 180_000 : 90_000);
+
+        await test.step(`Set ${valueCoverageLabel}`, async () => {
           await mainEntity.visitEntityPage(page);
-          for (const type of properties) {
+          for (const type of valuePropertyTypes) {
             await mainEntity.updateCustomProperty(
               page,
               mainEntity.customPropertyValue[type].property,
@@ -502,9 +514,8 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
           }
         });
 
-        await test.step('Update all CP types', async () => {
-          await mainEntity.visitEntityPage(page);
-          for (const type of properties) {
+        await test.step('Update representative properties', async () => {
+          for (const type of updatePropertyTypes) {
             await mainEntity.updateCustomProperty(
               page,
               mainEntity.customPropertyValue[type].property,
@@ -513,8 +524,8 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
           }
         });
 
-        await test.step('Update all CP types in Right Panel', async () => {
-          for (const [index, type] of properties.entries()) {
+        await test.step('Update a representative property in Right Panel', async () => {
+          for (const [index, type] of rightPanelPropertyTypes.entries()) {
             await updateCustomPropertyInRightPanel({
               page,
               entityName: getEntityDisplayName(responseData),
@@ -3408,6 +3419,8 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
 
         await waitForAllLoadersToDisappear(page);
 
+        await openMatchingFieldsPanel(page);
+
         const customPropertyField = page.getByTestId(
           `field-configuration-panel-extension.${dashboardSearchPropertyName}`
         );
@@ -3535,6 +3548,8 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
 
         await waitForAllLoadersToDisappear(page);
 
+        await openMatchingFieldsPanel(page);
+
         const customPropertyField = page.getByTestId(
           `field-configuration-panel-extension.${pipelineSearchPropertyName}`
         );
@@ -3553,7 +3568,8 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
 
           const data = await createCustomPropertyForEntity(
             apiContext,
-            EntityTypeEndpoint.TableColumn
+            EntityTypeEndpoint.TableColumn,
+            valuePropertyTypes
           );
           testData.customPropertyValue = data.customProperties;
           testData.cleanupUser = data.cleanupUser;
@@ -3575,7 +3591,7 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
           await afterAction();
         });
 
-        for (const type of Object.values(CustomPropertyTypeByName)) {
+        for (const type of valuePropertyTypes) {
           test(`Set ${type} custom property on column and verify in UI`, async ({
             page,
           }) => {
@@ -3727,6 +3743,8 @@ test.describe('Custom property name validation', () => {
     await page.click('[data-testid="add-field-button"]');
   });
 
+  // 1.13 renders this field via FieldTypes.TEXT_MUI, which puts data-testid on the
+  // wrapper rather than the input; main's UT_TEXT renderer puts it on the input itself.
   const nameInput = '[data-testid="name"] input';
   const nameError = '#name_help';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/EntityClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/EntityClass.ts
@@ -22,6 +22,7 @@ import {
 import {
   createCustomPropertyForEntity,
   CustomProperty,
+  CustomPropertyTypeByName,
   setValueForProperty,
   validateValueForProperty,
 } from '../../utils/customProperty';
@@ -102,12 +103,16 @@ export class EntityClass {
     // Override for entity visit
   }
 
-  async prepareCustomProperty(apiContext: APIRequestContext) {
+  async prepareCustomProperty(
+    apiContext: APIRequestContext,
+    propertyTypes?: readonly CustomPropertyTypeByName[]
+  ) {
     // Create custom property only for supported entities
     if (CustomPropertySupportedEntityList.includes(this.endpoint)) {
       const data = await createCustomPropertyForEntity(
         apiContext,
-        this.endpoint
+        this.endpoint,
+        propertyTypes
       );
 
       this.customPropertyValue = data.customProperties;

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
@@ -484,7 +484,10 @@ export const getPropertyValues = (
 
 export const createCustomPropertyForEntity = async (
   apiContext: APIRequestContext,
-  endpoint: EntityTypeEndpoint
+  endpoint: EntityTypeEndpoint,
+  propertyTypes: readonly CustomPropertyTypeByName[] = Object.values(
+    CustomPropertyTypeByName
+  )
 ) => {
   const propertiesResponse = await apiContext.get(
     '/api/v1/metadata/types?category=field&limit=20'
@@ -492,7 +495,7 @@ export const createCustomPropertyForEntity = async (
   const properties = await propertiesResponse.json();
   const propertyList = properties.data.filter(
     (item: { name: CustomPropertyTypeByName }) =>
-      Object.values(CustomPropertyTypeByName).includes(item.name)
+      propertyTypes.includes(item.name)
   );
 
   const entitySchemaResponse = await apiContext.get(

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/searchSettingUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/searchSettingUtils.ts
@@ -124,3 +124,20 @@ export const restoreDefaultSearchSettings = async (page: Page) => {
 
   expect(tableConfig).toEqual(mockEntitySearchConfig);
 };
+
+export const openMatchingFieldsPanel = async (page: Page) => {
+  const firstFieldHeader = page.getByTestId('field-container-header').first();
+
+  const isMatchingFieldsPanelOpen = await firstFieldHeader
+    .isVisible()
+    .catch(() => false);
+
+  if (!isMatchingFieldsPanelOpen) {
+    await page
+      .locator('.ant-collapse-header')
+      .filter({ hasText: 'Matching Fields' })
+      .getByText('Matching Fields')
+      .click();
+    await firstFieldHeader.waitFor({ state: 'visible' });
+  }
+};


### PR DESCRIPTION
## Why

`CustomProperties.spec.ts` is the single largest file in the Playwright suite on 1.13: **476 specs, ~215 test-minutes**. Playwright shards by *file* and cannot split one, so this file alone is **~162% of an ideal shard**. That is what has been timing out the nightly AUT kind lane.

No amount of CI tuning fixes this. More shards, longer step timeouts, and plan regeneration were all tried; the shard-plan generator refuses the file outright — *"68.8% over ideal; maximum allowed is 15%"* — even when handed `--dedicated-file`.

It is not that 1.13's tests are slow. Suite totals are near-identical between branches (**1015 vs 1064 test-minutes**). The problem is **distribution**, and it is confined to this one file.

## What main already does

main solved this by exercising the full property matrix on the **table** entity — the one with the richest custom-property UI — and covering the remaining 18 entities with a representative **String** property. That took the file from 476 specs to **172**.

This ports that narrowing back to 1.13, and lands on exactly **172** specs here too:

| | specs |
|---|---|
| 1.13 today | 476 |
| − per-entity basic/config loops (17 → 1 across 18 non-table entities) | −288 |
| − "Set & Update" and table-column loops (17 → 1) | −16 |
| **result** | **172** — matching main exactly |

`createCustomPropertyForEntity` / `prepareCustomProperty` take an **optional** property-type list that defaults to today's full set, so every other caller is unaffected.

## Deliberately *not* taken from main

Two of main's changes track UI that 1.13 does not have, and were reverted after checking the components on both branches:

- **`const nameInput`** keeps 1.13's `[data-testid="name"] input`. 1.13 renders this field via `FieldTypes.TEXT_MUI`, which puts the testid on a **wrapper**; main's `UT_TEXT` renderer puts it on the **input** itself. Taking main's selector verbatim would have silently broken the name-validation tests.
- **`createNewPage(browser)`** keeps its 1.13 signature, without main's `{ navigate: true }` option.

## On `describe.serial` → default-mode describe

This is not incidental — it is a real part of the fix.

The invariant the old comment protected still holds: `PUT /api/v1/metadata/types/{id}` is read-modify-write on one global row per entity type, so two workers touching the same entity type concurrently can make one side's property vanish while the API still answers `200`. With `fullyParallel: true`, explicitly configuring `mode: 'default'` **still pins the block to a single worker in declaration order**, so that cannot happen.

What it drops is `serial`'s *replay-the-entire-block* behaviour on retry. With `retries: 2`, that replay is a large part of why this file overruns its shard whenever anything inside it fails.

## On `openMatchingFieldsPanel`

A **no-op on 1.13**, verified against the component: 1.13's `activeKey` defaults to `'1'`, which *is* the Matching Fields panel, so it is already open. main added a `'ranking'` panel ahead of it and made that the default, which is why main needs the click. Keeping the helper costs nothing here and keeps the file aligned with main for future cherry-picks.

## Verification

Validated end-to-end on the nightly AUT kind lane, **both database lanes**, against a purpose-built image containing exactly this commit.

**Run: [openmetadata-nightly #32643994995](https://github.com/open-metadata/openmetadata-nightly/actions/runs/32643994995)** — *AUT kind / both 1.11.13 ➡ 1.13-aut-perf*

The AUT lane runs Playwright from a prebuilt image rather than a checkout, so a matching `1.13-aut-perf` branch was cut in each of the four repos the Collate build checks out. Only OpenMetadata carried a change; the other three are byte-identical to their `1.13` tips, so nothing but this commit varies:

| repo | tip | vs its `1.13` |
|---|---|---|
| OpenMetadata | `9fac369e` | +1 commit, 4 files |
| openmetadata-collate | `d27180d1` | identical |
| collate-hybrid-ingestion-runner | `cc29c9fb` | identical |
| ai-platform | `0c1b8b7a` | identical |

The resulting image was `collate/playwright:om-9fac369e-cl-d27180d`, which pins the OpenMetadata side to this commit.

### Result

The file no longer overruns its shard, and for the first time every shard finished.

| | before ([#32618643028](https://github.com/open-metadata/openmetadata-nightly/actions/runs/32618643028), 1.13) | after (this PR) |
|---|---|---|
| slowest shard | killed at the cap | **53.8 min** (mysql) / 54.3 (psql) |
| Playwright phase | 106m 41s | **53m 45s** / 54m 17s |
| lane duration | 116.9 min, failed | 87.9 / 88.3 min |
| tests passed | 4,297 | **5,134** / 5,131 |
| shards reporting a summary | incomplete | **8 / 8**, 0 skipped |

837 more tests actually ran, in half the Playwright wall-clock — the earlier runs were being truncated, so their totals understated the suite.

Per-shard, mysql lane (passed / duration):

```
shard-1  497  40.4m      shard-5  504  42.5m
shard-2  107  39.2m      shard-6  568  49.2m
shard-3  571  53.8m      shard-7  522  44.3m
shard-4  522  50.1m      shard-8  603  51.1m
```

Shard-3 — the one that kept being killed — now lands at 53.8 min against a 75-minute step cap.

### Remaining failures are unrelated

One failure per lane, both in files this PR does not touch:

- mysql — `Domains.spec.ts:795` *Verify domain and subdomain asset count accuracy*: expected `6`, received `0`
- psql — `DashboardWorkflow.spec.ts:74` *Validate Default certification workflow*: `locator.scrollIntoViewIfNeeded`, element not attached to the DOM

Two `CustomProperties.spec.ts:404` entries appear in the failed-attempt list but are reported as **flaky** — they failed once and passed on retry. That is the intended effect of the default-mode describe: only the failing test retries, instead of replaying the whole block.

### Static checks

`tsc` was not run locally (deps not installed in the working clone), so the port was also checked statically:

- All **39** relative imports resolve on 1.13, and every named symbol exists.
- TypeScript is `^5.0.0` on both branches, and `CONFIG_PROPERTIES` is explicitly typed, so the `never[] | T[]` ternaries reduce cleanly.
- The resulting spec count lands on **exactly** main's 172 — the arithmetic check that the narrowing ported completely.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reduces the CustomProperties Playwright matrix by retaining full type coverage for tables and representative String coverage for other entities. It also makes property preparation type-selective, adds a Matching Fields panel helper, and changes entity suites from serial to default scheduling.

- Narrows basic, configured, value-update, and table-column property loops.
- Adds optional property-type selection to shared custom-property setup.
- Avoids whole-suite serial retry replay, but exposes same-entity mutations to full parallel scheduling.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The scheduling change should be fixed before merging because it allows concurrent mutations of the same metadata-type row and can make the reduced suite flaky.

Default-mode tests remain eligible for parallel scheduling in this fully parallel project, while tests within each entity block mutate a shared metadata-type resource that requires sequential access.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts | Narrows the property matrix successfully, but default-mode suites can run same-entity custom-property mutations concurrently under fullyParallel. |
| openmetadata-ui/src/main/resources/ui/playwright/support/entity/EntityClass.ts | Safely forwards an optional readonly property-type list while preserving the existing default behavior. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts | Filters custom-property creation by an optional list and defaults to the complete existing type set. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/searchSettingUtils.ts | Adds a compatible helper that is effectively a no-op for the tested 1.13 default panel state. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Default-mode entity suite] --> B[fullyParallel CI scheduling]
  B --> C[Multiple workers]
  C --> D[Concurrent metadata type PUTs]
  D --> E[Lost custom-property update]
  E --> F[Flaky Playwright failure]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): narrow the CustomProperties ma..."](https://github.com/open-metadata/openmetadata/commit/9fac369e2911c6750248c3c161e7160cf2d5a9f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56009361)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Restore the six-shard Playwright CI layout](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/reverts/revert_26421-20260311-playwright-shard-infrastructure-0814279.md)

<!-- /greptile_comment -->
