### PR TITLE
fix(security): bump micrometer to 1.16.7 for CVE-2026-59296 (2.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
     <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
     <testng.version>7.6.1</testng.version>
     <dropwizard-micrometer.version>3.0.0</dropwizard-micrometer.version>
-    <micrometer.version>1.15.12</micrometer.version>
+    <micrometer.version>1.16.7</micrometer.version>
     <json-schema-validator.version>2.0.1</json-schema-validator.version>
     <java-jwt.version>4.4.0</java-jwt.version>
     <jwks-rsa.version>0.22.1</jwks-rsa.version>
@@ -547,14 +547,14 @@
         <version>${dropwizard.version}</version>
       </dependency>
 
-      <!-- For Prometheus support. Pinned to match micrometer-registry-prometheus 1.15.x
-           (pulls client_java 1.3.10); leaving this at 1.3.6 splits the prometheus-metrics
-           family so the 1.3.10 exposition layer calls config APIs absent in 1.3.6
+      <!-- For Prometheus support. Pinned to match micrometer-registry-prometheus 1.16.x
+           (pulls client_java 1.4.3); a mismatched version splits the prometheus-metrics
+           family so one layer calls config APIs absent in the other
            (NoSuchMethodError at runtime). Drives -core/-config across all modules. -->
       <dependency>
         <groupId>io.prometheus</groupId>
         <artifactId>prometheus-metrics-instrumentation-dropwizard</artifactId>
-        <version>1.3.10</version>
+        <version>1.4.3</version>
       </dependency>
 
 


### PR DESCRIPTION
## What

Direct-to-`2.0` companion of #31926. Bump `micrometer` `1.15.12` → `1.16.7` to remediate **CVE-2026-59296**, and bump `prometheus-metrics-instrumentation-dropwizard` `1.3.10` → `1.4.3` in lockstep to keep the prometheus client_java family aligned.

Raised directly against `2.0` (rather than relying on a cherry-pick of #31926) because this is a **two-hunk** pom change and the release is imminent — landing only one hunk on `2.0` would leave the prometheus-metrics family split and cause a runtime `NoSuchMethodError`.

## Why

`micrometer-core 1.15.12` is flagged by [CVE-2026-59296](https://spring.io/security/cve-2026-59296) — metric/log line injection via unsanitized newlines in the StatsD and Logging registries (CWE-74, CVSS 5.9 MEDIUM). The 1.15.x line has **no OSS fix** (`1.15.13` is enterprise-only), so the minimum OSS remediation is `1.16.7`.

`micrometer-registry-prometheus 1.16.x` pulls the prometheus `client_java` family at `1.4.3` (up from `1.3.10`); the `prometheus-metrics-instrumentation-dropwizard` pin keeps that whole family on one version, so it moves to `1.4.3` too.

## Validation (against the 2.0 release commit)

- `dependency:tree`: entire `micrometer-*` family `1.16.7`; entire `prometheus-metrics-*` family uniformly `1.4.3` — no split. (`io.prometheus:simpleclient 0.16.0` is a separate library and is untouched.)
- Compile + install of `openmetadata-service`: `BUILD SUCCESS`. OM uses only stable core micrometer APIs and has zero direct `io.prometheus.metrics.*` imports (only one module even consumes the artifact), so the `1.4.3` jump is purely transitive.
- Runtime scrape smoke test mirroring `MicrometerBundle` (`PrometheusMeterRegistry(DEFAULT)` + JVM/system binders + counter/timer → `.scrape()`): valid Prometheus exposition, **no `NoSuchMethodError`**.

## Scope

Two version lines in the root `pom.xml`. Metrics stack only. StatsD / `LoggingMeterRegistry` (the affected registries) are not used by OpenMetadata — only `micrometer-registry-prometheus` — so the vulnerable path is not reachable in practice; this clears the scanner finding.




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR upgrades Micrometer to 1.16.7 to remediate CVE-2026-59296 while aligning the Prometheus client family.
- Updates the centrally inherited Micrometer version from 1.15.12 to 1.16.7.
- Updates prometheus-metrics-instrumentation-dropwizard from 1.3.10 to 1.4.3 to match Micrometer’s Prometheus dependencies.
- Documents why the Prometheus family must remain version-aligned.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| pom.xml | Aligns the centrally managed Micrometer and Prometheus dependency versions; no blocking issue was identified. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;2.0&#39; into sec/micrometer-c..."](https://github.com/open-metadata/openmetadata/commit/541d3e9eec56bd6de1cceb176db1455cf22cdb8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56125310)</sub>

<!-- /greptile_comment -->