### PR TITLE
fix(playwright): poll the asset card count in the Domains asset-count test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
@@ -869,12 +869,10 @@ test.describe('Domains', () => {
         const countText = await assetCountElement.textContent();
         const displayedCount = Number.parseInt(countText ?? '0', 10);
         const totalCount = domainAssets.length + subDomainAssets.length;
-        const assetCards = await page
-          .locator('[data-testid*="table-data-card_"]')
-          .count();
+        const assetCards = page.locator('[data-testid*="table-data-card_"]');
 
         expect(displayedCount).toBe(totalCount);
-        expect(assetCards).toBe(totalCount);
+        await expect(assetCards).toHaveCount(totalCount);
       });
 
       await test.step('Verify subdomain asset count matches displayed cards', async () => {
@@ -909,12 +907,10 @@ test.describe('Domains', () => {
         const countText = await assetCountElement.textContent();
         const displayedCount = Number.parseInt(countText ?? '0', 10);
 
-        const assetCards = await page
-          .locator('[data-testid*="table-data-card_"]')
-          .count();
+        const assetCards = page.locator('[data-testid*="table-data-card_"]');
 
         expect(displayedCount).toBe(subDomainAssets.length);
-        expect(assetCards).toBe(subDomainAssets.length);
+        await expect(assetCards).toHaveCount(subDomainAssets.length);
       });
     } finally {
       await subDomain?.delete(apiContext);


### PR DESCRIPTION
## Problem

`playwright/e2e/Pages/Domains.spec.ts` → **Verify domain and subdomain asset count accuracy** fails on `1.13` while passing on `main` and `2.0`. All three attempts failed in the 1.13 nightly, but not on the same step:

| Attempt | Failing step | Assertion |
|---|---|---|
| retry 0 | subdomain step | `expect(assetCards).toBe(3)` → got `0` |
| retry 1 | domain step | `expect(assetCards).toBe(6)` → got `0` |
| retry 2 | domain step | `expect(assetCards).toBe(6)` → got `0` |

Retry 0 found all 6 cards on the domain step before failing on the subdomain step. Same locator, same code path, different result per attempt — this is a race, not a stale selector and not a product bug.

## Root cause

Both verify steps read the card count as a snapshot:

```ts
const assetCards = await page.locator('[data-testid*="table-data-card_"]').count();
expect(assetCards).toBe(totalCount);
```

`Locator.count()` does not auto-wait, and `expect(number).toBe(...)` does not poll. The count is frozen at whatever the DOM held at that instant, with no retry.

The only synchronization before it is `waitForAllLoadersToDisappear`, which is:

```ts
await expect(page.locator('[data-testid="loader"]')).toHaveCount(0, { timeout });
```

That waits for a loader to **vanish** — it never waits for one to **appear**. `assetsTab.click()` resolves as soon as the click is dispatched, and until React commits the `AssetsTabs` mount (which is when `isLoading === true` first renders `data-testid="loader"`) the DOM holds zero loaders. The assertion is satisfied immediately, so the helper provides no synchronization at all and `.count()` runs against a list that has not painted yet.

### Why the neighbouring assertion always passes

`expect(displayedCount).toBe(...)` passed on every attempt, because the two assertions read from independent sources:

- **the tab badge** — `DomainDetails.component.tsx`'s own `fetchAssetCount()`, a `searchQuery({ pageSize: 0 })` fired on domain load, warm long before the Assets tab is clicked;
- **the card list** — a separate search that `AssetsTabs.component.tsx` issues when it mounts on tab activation.

So a correct badge says nothing about whether the list has rendered. That split is exactly what lets `displayedCount === 6` coexist with `assetCards === 0`.

## Fix

Hold a `Locator` instead of a number and assert with `toHaveCount`, which re-queries until the expect timeout so the in-flight `AssetsTabs` search can resolve:

```diff
- const assetCards = await page
-   .locator('[data-testid*="table-data-card_"]')
-   .count();
+ const assetCards = page.locator('[data-testid*="table-data-card_"]');

  expect(displayedCount).toBe(totalCount);
- expect(assetCards).toBe(totalCount);
+ await expect(assetCards).toHaveCount(totalCount);
```

Applied to both verify steps.

## This is a missing backport

`main` and `2.0` already use this exact form. They got it via `26e0940362` (#29635, 2026-07-11) — I diffed that commit against its parent to confirm it is what flipped both call sites. `git merge-base --is-ancestor 26e0940362 origin/1.13` reports **not an ancestor**, which is why only 1.13 fails.

Both verify steps in this PR are now identical to `origin/main`, verified with a direct `diff` of the two regions.

## Verification

- `prettier --check` clean on the file (prettier 2.8.8, as pinned).
- Both changed steps `diff` clean against `origin/main`.
- Not run locally: the spec needs a live server plus Elasticsearch, so the fix is verified by source-level reasoning against this branch's `AssetsTabs` / `DomainDetails` components rather than by a green local run. The 1.13 nightly is the real confirmation.

`displayedCount` is intentionally left as a snapshot read — that is what `main` does, and it is not what failed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stabilizes the Domains asset-count Playwright test by replacing snapshot card counts with Playwright’s polling `toHaveCount` assertion.
- Keeps each card locator live while the asynchronous asset list renders.
- Applies the polling assertion to both domain and subdomain verification steps.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it narrowly improves synchronization in two existing Playwright assertions without changing application behavior.

The live locators re-query the same existing card selector until the expected count is rendered, addressing the documented asynchronous list-rendering race while preserving the test’s established expectations.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts | Replaces two race-prone snapshot counts with bounded polling assertions; no actionable regression was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(playwright): poll the asset card cou..."](https://github.com/open-metadata/openmetadata/commit/a15cb7ebb69b05c614e194b905b4db91c7e98b38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56144698)</sub>

<!-- /greptile_comment -->