### PR TITLE
test(teams): stop the teams landing from eating the test budget

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts
@@ -91,12 +91,14 @@ test.describe(
   'Teams drag and drop should work properly',
   PLAYWRIGHT_BASIC_TEST_TAG_OBJ,
   () => {
-    // Every test re-enters Settings > Teams, and that landing waits on the
-    // hierarchy table's asset-count aggregation, which grows with the catalog.
-    // On a long-lived deployment the hook alone can outlast the 60s default.
-    test.slow(true);
-
     test.beforeEach(async ({ page }) => {
+      // Marked here rather than in each test body: hook time counts against the
+      // test timeout, and this hook re-enters Settings > Teams, whose landing
+      // waits on the hierarchy table's asset-count aggregation. That grows with
+      // the catalog, so on a long-lived deployment the hook alone can outlast
+      // the 60s default — by the time a test body ran, it would be too late.
+      test.slow();
+
       await redirectToHomePage(page);
       await visitTeamsPage(page);
     });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts
@@ -25,7 +25,7 @@ import {
 } from '../../utils/dragDrop';
 import {
   addTeamHierarchy,
-  hardDeleteTeamByName,
+  hardDeleteTeamsByName,
   visitTeamsPage,
 } from '../../utils/team';
 
@@ -104,16 +104,16 @@ test.describe(
     test.afterAll(async ({ browser }) => {
       const { apiContext, afterAction } = await createNewPage(browser);
 
-      for (const teamName of [
-        teamNameBusiness,
-        teamNameDivision,
-        teamNameDepartment,
-        teamNameGroup,
-      ]) {
-        await hardDeleteTeamByName(apiContext, teamName);
+      try {
+        await hardDeleteTeamsByName(apiContext, [
+          teamNameBusiness,
+          teamNameDivision,
+          teamNameDepartment,
+          teamNameGroup,
+        ]);
+      } finally {
+        await afterAction();
       }
-
-      await afterAction();
     });
 
     test('Add teams in hierarchy', async ({ page }) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts
@@ -12,8 +12,8 @@
  */
 import { expect, test } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
-import { GlobalSettingOptions } from '../../constant/settings';
 import {
+  createNewPage,
   redirectToHomePage,
   toastNotification,
   uuid,
@@ -23,9 +23,11 @@ import {
   dragAndDropElement,
   openDragDropDropdown,
 } from '../../utils/dragDrop';
-import { waitForAllLoadersToDisappear } from '../../utils/entity';
-import { settingClick } from '../../utils/sidebar';
-import { addTeamHierarchy } from '../../utils/team';
+import {
+  addTeamHierarchy,
+  hardDeleteTeamByName,
+  visitTeamsPage,
+} from '../../utils/team';
 
 // use the admin user to login
 test.use({ storageState: 'playwright/.auth/admin.json' });
@@ -89,28 +91,32 @@ test.describe(
   'Teams drag and drop should work properly',
   PLAYWRIGHT_BASIC_TEST_TAG_OBJ,
   () => {
+    // Every test re-enters Settings > Teams, and that landing waits on the
+    // hierarchy table's asset-count aggregation, which grows with the catalog.
+    // On a long-lived deployment the hook alone can outlast the 60s default.
+    test.slow(true);
+
     test.beforeEach(async ({ page }) => {
       await redirectToHomePage(page);
+      await visitTeamsPage(page);
+    });
 
-      const getOrganizationResponse = page.waitForResponse(
-        (response) =>
-          response.url().includes('/api/v1/teams/name/') &&
-          response.status() === 200
-      );
-      const permissionResponse = page.waitForResponse(
-        (response) =>
-          response.url().includes('/api/v1/permissions/team/name/') &&
-          response.status() === 200
-      );
+    test.afterAll(async ({ browser }) => {
+      const { apiContext, afterAction } = await createNewPage(browser);
 
-      await settingClick(page, GlobalSettingOptions.TEAMS);
-      await permissionResponse;
-      await getOrganizationResponse;
-      await waitForAllLoadersToDisappear(page);
+      for (const teamName of [
+        teamNameBusiness,
+        teamNameDivision,
+        teamNameDepartment,
+        teamNameGroup,
+      ]) {
+        await hardDeleteTeamByName(apiContext, teamName);
+      }
+
+      await afterAction();
     });
 
     test('Add teams in hierarchy', async ({ page }) => {
-      test.slow();
       for (const teamDetails of DRAG_AND_DROP_TEAM_DETAILS) {
         await addTeamHierarchy(page, teamDetails);
 
@@ -158,7 +164,6 @@ test.describe(
       test(`Should drag and drop on ${TEAM_TYPE_BY_NAME[droppableTeamName]} team type`, async ({
         page,
       }) => {
-        test.slow();
         // Nested team will be shown once anything is moved under it
         if (index !== 0) {
           await openDragDropDropdown(page, teams[index - 1]);
@@ -182,7 +187,6 @@ test.describe(
     }
 
     test(`Should drag and drop team on table level`, async ({ page }) => {
-      test.slow();
       // Open department team dropdown as it is moved under it from last test
       await openDragDropDropdown(page, teamNameDepartment);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts
@@ -92,13 +92,6 @@ test.describe(
   PLAYWRIGHT_BASIC_TEST_TAG_OBJ,
   () => {
     test.beforeEach(async ({ page }) => {
-      // Marked here rather than in each test body: hook time counts against the
-      // test timeout, and this hook re-enters Settings > Teams, whose landing
-      // waits on the hierarchy table's asset-count aggregation. That grows with
-      // the catalog, so on a long-lived deployment the hook alone can outlast
-      // the 60s default — by the time a test body ran, it would be too late.
-      test.slow();
-
       await redirectToHomePage(page);
       await visitTeamsPage(page);
     });
@@ -119,6 +112,7 @@ test.describe(
     });
 
     test('Add teams in hierarchy', async ({ page }) => {
+      test.slow(true);
       for (const teamDetails of DRAG_AND_DROP_TEAM_DETAILS) {
         await addTeamHierarchy(page, teamDetails);
 
@@ -166,6 +160,7 @@ test.describe(
       test(`Should drag and drop on ${TEAM_TYPE_BY_NAME[droppableTeamName]} team type`, async ({
         page,
       }) => {
+        test.slow(true);
         // Nested team will be shown once anything is moved under it
         if (index !== 0) {
           await openDragDropDropdown(page, teams[index - 1]);
@@ -189,6 +184,7 @@ test.describe(
     }
 
     test(`Should drag and drop team on table level`, async ({ page }) => {
+      test.slow(true);
       // Open department team dropdown as it is moved under it from last test
       await openDragDropDropdown(page, teamNameDepartment);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsHierarchy.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsHierarchy.spec.ts
@@ -19,6 +19,7 @@ import {
   addTeamHierarchy,
   getNewTeamDetails,
   searchTeam,
+  visitTeamsPage,
 } from '../../utils/team';
 
 // use the admin user to login
@@ -45,17 +46,7 @@ test.describe(
 
     test.beforeEach(async ({ page }) => {
       await redirectToHomePage(page);
-
-      const getOrganizationResponse = page.waitForResponse(
-        '/api/v1/teams/name/*'
-      );
-      const permissionResponse = page.waitForResponse(
-        '/api/v1/permissions/team/name/*'
-      );
-
-      await settingClick(page, GlobalSettingOptions.TEAMS);
-      await permissionResponse;
-      await getOrganizationResponse;
+      await visitTeamsPage(page);
     });
 
     test('Add teams in hierarchy', async ({ page }) => {
@@ -110,8 +101,6 @@ test.describe(
     });
 
     test('Delete Parent Team', async ({ page }) => {
-      await settingClick(page, GlobalSettingOptions.TEAMS);
-
       await page.getByRole('link', { name: businessTeamName }).click();
 
       await page.click('[data-testid="manage-button"]');

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
@@ -99,42 +99,94 @@ export const visitTeamsPage = async (page: Page) => {
   await waitForAllLoadersToDisappear(page);
 };
 
+interface TeamCleanupFailure {
+  teamName: string;
+  reason: string;
+}
+
 /**
- * Hard-delete a team created through the UI, children included.
+ * Hard-delete one team created through the UI, children included.
+ *
+ * Reports a failure rather than throwing so a caller cleaning up several teams
+ * still attempts the rest — a throw here would leave the remaining teams behind
+ * and recreate the accumulation this cleanup exists to prevent.
  *
  * Specs that build teams through the UI have no entity handle to call
- * `TeamClass.delete` on, so resolve the id by name first.
+ * `TeamClass.delete` on, so the id is resolved by name first. Delete-by-name is
+ * not an option: `TeamResource` pins that route to `recursive=false`, and these
+ * teams are nested by the time cleanup runs.
  *
- * 404 is the one tolerated outcome — the spec may have deleted the team as
- * part of what it asserts, and a recursive delete of its parent takes its
- * children with it. Every other failure is asserted rather than ignored: a
- * cleanup that fails quietly leaves the team behind, and the whole point of
- * calling this is to stop teams accumulating on long-lived deployments.
+ * 404 on the lookup is the one tolerated outcome — the spec may have deleted
+ * the team as part of what it asserts, and a recursive delete of its parent
+ * takes its children with it.
  */
-export const hardDeleteTeamByName = async (
+const hardDeleteTeamByName = async (
   apiContext: APIRequestContext,
   teamName: string
-) => {
-  const teamResponse = await apiContext.get(
-    `/api/v1/teams/name/${encodeURIComponent(teamName)}`
-  );
+): Promise<TeamCleanupFailure | undefined> => {
+  let failure: TeamCleanupFailure | undefined;
 
-  if (teamResponse.status() !== 404) {
-    expect(
-      teamResponse.ok(),
-      `Failed to look up team "${teamName}" for cleanup: ${teamResponse.status()} ${await teamResponse.text()}`
-    ).toBe(true);
-
-    const { id } = await teamResponse.json();
-    const deleteResponse = await apiContext.delete(
-      `/api/v1/teams/${id}?hardDelete=true&recursive=true`
+  try {
+    const teamResponse = await apiContext.get(
+      `/api/v1/teams/name/${encodeURIComponent(teamName)}`
     );
 
-    expect(
-      deleteResponse.ok(),
-      `Failed to clean up team "${teamName}": ${deleteResponse.status()} ${await deleteResponse.text()}`
-    ).toBe(true);
+    if (!teamResponse.ok()) {
+      if (teamResponse.status() !== 404) {
+        failure = {
+          teamName,
+          reason: `lookup returned ${teamResponse.status()} ${await teamResponse.text()}`,
+        };
+      }
+    } else {
+      const { id } = await teamResponse.json();
+      const deleteResponse = await apiContext.delete(
+        `/api/v1/teams/${id}?hardDelete=true&recursive=true`
+      );
+
+      if (!deleteResponse.ok()) {
+        failure = {
+          teamName,
+          reason: `delete returned ${deleteResponse.status()} ${await deleteResponse.text()}`,
+        };
+      }
+    }
+  } catch (error) {
+    failure = { teamName, reason: (error as Error).message };
   }
+
+  return failure;
+};
+
+/**
+ * Hard-delete teams created through the UI, children included.
+ *
+ * Deletes are sequential: a recursive delete takes a team's children with it,
+ * so issuing them in parallel would race the ones already removed. Every name
+ * is attempted before anything is asserted, and the assertion then names every
+ * team that survived — cleanup that fails quietly is what lets teams pile up on
+ * a long-lived deployment in the first place.
+ */
+export const hardDeleteTeamsByName = async (
+  apiContext: APIRequestContext,
+  teamNames: string[]
+) => {
+  const failures: TeamCleanupFailure[] = [];
+
+  for (const teamName of teamNames) {
+    const failure = await hardDeleteTeamByName(apiContext, teamName);
+
+    if (failure) {
+      failures.push(failure);
+    }
+  }
+
+  expect(
+    failures,
+    `Failed to clean up teams: ${failures
+      .map(({ teamName, reason }) => `"${teamName}" (${reason})`)
+      .join(', ')}`
+  ).toEqual([]);
 };
 
 interface SearchTeamOptions {

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
@@ -74,6 +74,55 @@ export const openAddTeamModal = async (
   return addTeamModal;
 };
 
+/**
+ * Land on Settings > Teams with the hierarchy table settled.
+ *
+ * The table spins on its own child-teams fetch plus the per-team asset-count
+ * aggregation, so navigation alone is not enough — a caller that acts right
+ * after the click drags rows that are still being repainted. Wait on the two
+ * calls that gate the first paint, then on the table itself.
+ */
+export const visitTeamsPage = async (page: Page) => {
+  const organizationResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/v1/teams/name/') && response.ok()
+  );
+  const permissionResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/v1/permissions/team/name/') && response.ok()
+  );
+
+  await settingClick(page, GlobalSettingOptions.TEAMS);
+  await Promise.all([permissionResponse, organizationResponse]);
+
+  await expect(page.getByTestId('team-hierarchy-table')).toBeVisible();
+  await waitForAllLoadersToDisappear(page);
+};
+
+/**
+ * Hard-delete a team created through the UI, children included.
+ *
+ * Specs that build teams through the UI have no entity handle to call
+ * `TeamClass.delete` on, so resolve the id by name first. A missing team is not
+ * an error — the spec may have deleted it as part of what it asserts.
+ */
+export const hardDeleteTeamByName = async (
+  apiContext: APIRequestContext,
+  teamName: string
+) => {
+  const teamResponse = await apiContext.get(
+    `/api/v1/teams/name/${encodeURIComponent(teamName)}`
+  );
+
+  if (teamResponse.ok()) {
+    const { id } = await teamResponse.json();
+
+    await apiContext.delete(
+      `/api/v1/teams/${id}?hardDelete=true&recursive=true`
+    );
+  }
+};
+
 interface SearchTeamOptions {
   expectEmptyResults?: boolean;
   expectNotFound?: boolean;

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
@@ -104,7 +104,12 @@ export const visitTeamsPage = async (page: Page) => {
  *
  * Specs that build teams through the UI have no entity handle to call
  * `TeamClass.delete` on, so resolve the id by name first. A missing team is not
- * an error — the spec may have deleted it as part of what it asserts.
+ * an error — the spec may have deleted it as part of what it asserts, and a
+ * recursive delete of its parent may already have taken it.
+ *
+ * A delete that comes back non-ok is asserted rather than ignored: a cleanup
+ * that fails quietly leaves the team behind, and the whole point of calling
+ * this is to stop teams accumulating on long-lived deployments.
  */
 export const hardDeleteTeamByName = async (
   apiContext: APIRequestContext,
@@ -116,10 +121,14 @@ export const hardDeleteTeamByName = async (
 
   if (teamResponse.ok()) {
     const { id } = await teamResponse.json();
-
-    await apiContext.delete(
+    const deleteResponse = await apiContext.delete(
       `/api/v1/teams/${id}?hardDelete=true&recursive=true`
     );
+
+    expect(
+      deleteResponse.ok(),
+      `Failed to clean up team "${teamName}": ${deleteResponse.status()} ${await deleteResponse.text()}`
+    ).toBe(true);
   }
 };
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
@@ -103,13 +103,13 @@ export const visitTeamsPage = async (page: Page) => {
  * Hard-delete a team created through the UI, children included.
  *
  * Specs that build teams through the UI have no entity handle to call
- * `TeamClass.delete` on, so resolve the id by name first. A missing team is not
- * an error — the spec may have deleted it as part of what it asserts, and a
- * recursive delete of its parent may already have taken it.
+ * `TeamClass.delete` on, so resolve the id by name first.
  *
- * A delete that comes back non-ok is asserted rather than ignored: a cleanup
- * that fails quietly leaves the team behind, and the whole point of calling
- * this is to stop teams accumulating on long-lived deployments.
+ * 404 is the one tolerated outcome — the spec may have deleted the team as
+ * part of what it asserts, and a recursive delete of its parent takes its
+ * children with it. Every other failure is asserted rather than ignored: a
+ * cleanup that fails quietly leaves the team behind, and the whole point of
+ * calling this is to stop teams accumulating on long-lived deployments.
  */
 export const hardDeleteTeamByName = async (
   apiContext: APIRequestContext,
@@ -119,7 +119,12 @@ export const hardDeleteTeamByName = async (
     `/api/v1/teams/name/${encodeURIComponent(teamName)}`
   );
 
-  if (teamResponse.ok()) {
+  if (teamResponse.status() !== 404) {
+    expect(
+      teamResponse.ok(),
+      `Failed to look up team "${teamName}" for cleanup: ${teamResponse.status()} ${await teamResponse.text()}`
+    ).toBe(true);
+
     const { id } = await teamResponse.json();
     const deleteResponse = await apiContext.delete(
       `/api/v1/teams/${id}?hardDelete=true&recursive=true`


### PR DESCRIPTION
## Problem

`TeamsDragAndDrop.spec.ts` fails on the nightly upgrade runs — [AUT EKS/RDS MySQL 1.11.13 ➡ 1.13](https://github.com/open-metadata/openmetadata-nightly/actions/runs/32677353331). The first failure is in `beforeEach`, before any test body runs:

```
Test timeout of 60000ms exceeded while running "beforeEach" hook.
  Expect "toHaveCount" locator('[data-testid="loader"]')   38.0s
  Expect "toHaveCount" locator('[data-testid="loader"]')   19.7s
```

## RCA

The `data-testid="loader"` the hook waits on **is** the teams table's own spinner:

- `TeamHierarchy.tsx` → `loading={isTableLoading || isTeamBasicDataLoading || isSearchLoading}`
- `common/Table/Table.tsx` → `loading={{ indicator: <Loader /> }}`
- `common/Loader/Loader.tsx` → `data-testid="loader"`

`isTeamBasicDataLoading` covers the per-team asset-count aggregation, which scales with the catalog. So the landing is genuinely slow on a loaded deployment — and the hook spent its budget on it twice: `settingClick` already ends in `waitForAllLoadersToDisappear` (30s), and the hook called it a second time. Two 30s waits against a 60s test timeout leaves nothing, the hook times out, and serial mode skips the rest of the file.

Why it degrades over time: this suite creates four `team-ct-test-*` teams and never deletes them (`TeamsHierarchy.spec.ts` deletes its parent team; this one doesn't). The EKS/RDS nightlies reuse a persistent database, so every run leaves four more teams under Organization, growing the aggregation the landing waits on. Matches the result spread — `AUT kind/postgresql` (fresh cluster) passed, both EKS/RDS runs failed.

## Fix

- `utils/team.ts` — new `visitTeamsPage()`: waits the two calls that gate the first paint (with `.ok()` rather than a bare status compare), asserts `team-hierarchy-table`, then waits out loaders. New `hardDeleteTeamByName()` for teams built through the UI, which have no `TeamClass` handle.
- `TeamsDragAndDrop.spec.ts` — `test.slow(true)` at describe level so the landing has headroom (replaces three per-test `test.slow()` calls); hook reduced to `redirectToHomePage` + `visitTeamsPage`; `afterAll` hard-deletes the four teams recursively so the deployment stops accumulating them.
- `TeamsHierarchy.spec.ts` — same hook folded onto `visitTeamsPage` (it had the same shape with looser glob waits); drops a redundant `settingClick` in *Delete Parent Team*, since `beforeEach` already lands there.

## Backport

1.13 additionally lacks the `addTeamHierarchy` hardening that main and 2.0 carry (#25894's `team.ts` hunk, #30334, #31734), which is what fails the retries at `TeamsDragAndDrop.spec.ts:119`. That is handled in the companion 1.13 PR. 2.0 needs only a cherry-pick of this one.

## Verification

`tsc --noEmit -p playwright/tsconfig.json`, `eslint`, and `prettier --check` are clean on the touched files. The spec itself needs a live deployment and was not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)











<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes the Teams Playwright suites wait for the hierarchy page to settle and adds reliable teardown for teams created by the drag-and-drop suite.
- Centralizes Teams-page navigation and readiness checks in `visitTeamsPage`.
- Hard-deletes all generated teams while aggregating cleanup failures.
- Ensures one cleanup failure does not prevent attempts for the remaining teams.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the cleanup now reports unsuccessful lookups and deletes while attempting every team before failing teardown.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts | Uses the shared Teams-page navigation helper and performs failure-reporting cleanup for all generated teams after the serial suite. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsHierarchy.spec.ts | Replaces duplicated navigation waits with the shared helper and removes redundant navigation from the deletion test. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts | Adds settled Teams-page navigation and resilient cleanup helpers that validate responses, continue after individual failures, and assert aggregated failures. |

</details>

<sub>Reviews (6): Last reviewed commit: ["remove unwanted test.slow"](https://github.com/open-metadata/openmetadata/commit/26dc0b9615b99738ef31a956ff0389ef26d2b3b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56149269)</sub>

<!-- /greptile_comment -->