### PR TITLE
test(teams): fix TeamsDragAndDrop on 1.13 (backport #31932)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts
@@ -25,7 +25,7 @@ import {
 } from '../../utils/dragDrop';
 import {
   addTeamHierarchy,
-  hardDeleteTeamByName,
+  hardDeleteTeamsByName,
   visitTeamsPage,
 } from '../../utils/team';
 
@@ -104,16 +104,16 @@ test.describe(
     test.afterAll(async ({ browser }) => {
       const { apiContext, afterAction } = await createNewPage(browser);
 
-      for (const teamName of [
-        teamNameBusiness,
-        teamNameDivision,
-        teamNameDepartment,
-        teamNameGroup,
-      ]) {
-        await hardDeleteTeamByName(apiContext, teamName);
+      try {
+        await hardDeleteTeamsByName(apiContext, [
+          teamNameBusiness,
+          teamNameDivision,
+          teamNameDepartment,
+          teamNameGroup,
+        ]);
+      } finally {
+        await afterAction();
       }
-
-      await afterAction();
     });
 
     test('Add teams in hierarchy', async ({ page }) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts
@@ -12,8 +12,8 @@
  */
 import { expect, test } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
-import { GlobalSettingOptions } from '../../constant/settings';
 import {
+  createNewPage,
   redirectToHomePage,
   toastNotification,
   uuid,
@@ -23,9 +23,11 @@ import {
   dragAndDropElement,
   openDragDropDropdown,
 } from '../../utils/dragDrop';
-import { waitForAllLoadersToDisappear } from '../../utils/entity';
-import { settingClick } from '../../utils/sidebar';
-import { addTeamHierarchy } from '../../utils/team';
+import {
+  addTeamHierarchy,
+  hardDeleteTeamByName,
+  visitTeamsPage,
+} from '../../utils/team';
 
 // use the admin user to login
 test.use({ storageState: 'playwright/.auth/admin.json' });
@@ -89,28 +91,32 @@ test.describe(
   'Teams drag and drop should work properly',
   PLAYWRIGHT_BASIC_TEST_TAG_OBJ,
   () => {
+    // Every test re-enters Settings > Teams, and that landing waits on the
+    // hierarchy table's asset-count aggregation, which grows with the catalog.
+    // On a long-lived deployment the hook alone can outlast the 60s default.
+    test.slow(true);
+
     test.beforeEach(async ({ page }) => {
       await redirectToHomePage(page);
+      await visitTeamsPage(page);
+    });
 
-      const getOrganizationResponse = page.waitForResponse(
-        (response) =>
-          response.url().includes('/api/v1/teams/name/') &&
-          response.status() === 200
-      );
-      const permissionResponse = page.waitForResponse(
-        (response) =>
-          response.url().includes('/api/v1/permissions/team/name/') &&
-          response.status() === 200
-      );
+    test.afterAll(async ({ browser }) => {
+      const { apiContext, afterAction } = await createNewPage(browser);
 
-      await settingClick(page, GlobalSettingOptions.TEAMS);
-      await permissionResponse;
-      await getOrganizationResponse;
-      await waitForAllLoadersToDisappear(page);
+      for (const teamName of [
+        teamNameBusiness,
+        teamNameDivision,
+        teamNameDepartment,
+        teamNameGroup,
+      ]) {
+        await hardDeleteTeamByName(apiContext, teamName);
+      }
+
+      await afterAction();
     });
 
     test('Add teams in hierarchy', async ({ page }) => {
-      test.slow();
       for (const teamDetails of DRAG_AND_DROP_TEAM_DETAILS) {
         await addTeamHierarchy(page, teamDetails);
 
@@ -158,7 +164,6 @@ test.describe(
       test(`Should drag and drop on ${TEAM_TYPE_BY_NAME[droppableTeamName]} team type`, async ({
         page,
       }) => {
-        test.slow();
         // Nested team will be shown once anything is moved under it
         if (index !== 0) {
           await openDragDropDropdown(page, teams[index - 1]);
@@ -182,7 +187,6 @@ test.describe(
     }
 
     test(`Should drag and drop team on table level`, async ({ page }) => {
-      test.slow();
       // Open department team dropdown as it is moved under it from last test
       await openDragDropDropdown(page, teamNameDepartment);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsHierarchy.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsHierarchy.spec.ts
@@ -20,6 +20,7 @@ import {
   addTeamHierarchy,
   getNewTeamDetails,
   searchTeam,
+  visitTeamsPage,
 } from '../../utils/team';
 
 // use the admin user to login
@@ -46,17 +47,7 @@ test.describe(
 
     test.beforeEach(async ({ page }) => {
       await redirectToHomePage(page);
-
-      const getOrganizationResponse = page.waitForResponse(
-        '/api/v1/teams/name/*'
-      );
-      const permissionResponse = page.waitForResponse(
-        '/api/v1/permissions/team/name/*'
-      );
-
-      await settingClick(page, GlobalSettingOptions.TEAMS);
-      await permissionResponse;
-      await getOrganizationResponse;
+      await visitTeamsPage(page);
     });
 
     test('Add teams in hierarchy', async ({ page }) => {
@@ -111,8 +102,6 @@ test.describe(
     });
 
     test('Delete Parent Team', async ({ page }) => {
-      await settingClick(page, GlobalSettingOptions.TEAMS);
-
       await page.getByRole('link', { name: businessTeamName }).click();
 
       await page.click('[data-testid="manage-button"]');

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
@@ -99,42 +99,94 @@ export const visitTeamsPage = async (page: Page) => {
   await waitForAllLoadersToDisappear(page);
 };
 
+interface TeamCleanupFailure {
+  teamName: string;
+  reason: string;
+}
+
 /**
- * Hard-delete a team created through the UI, children included.
+ * Hard-delete one team created through the UI, children included.
+ *
+ * Reports a failure rather than throwing so a caller cleaning up several teams
+ * still attempts the rest — a throw here would leave the remaining teams behind
+ * and recreate the accumulation this cleanup exists to prevent.
  *
  * Specs that build teams through the UI have no entity handle to call
- * `TeamClass.delete` on, so resolve the id by name first.
+ * `TeamClass.delete` on, so the id is resolved by name first. Delete-by-name is
+ * not an option: `TeamResource` pins that route to `recursive=false`, and these
+ * teams are nested by the time cleanup runs.
  *
- * 404 is the one tolerated outcome — the spec may have deleted the team as
- * part of what it asserts, and a recursive delete of its parent takes its
- * children with it. Every other failure is asserted rather than ignored: a
- * cleanup that fails quietly leaves the team behind, and the whole point of
- * calling this is to stop teams accumulating on long-lived deployments.
+ * 404 on the lookup is the one tolerated outcome — the spec may have deleted
+ * the team as part of what it asserts, and a recursive delete of its parent
+ * takes its children with it.
  */
-export const hardDeleteTeamByName = async (
+const hardDeleteTeamByName = async (
   apiContext: APIRequestContext,
   teamName: string
-) => {
-  const teamResponse = await apiContext.get(
-    `/api/v1/teams/name/${encodeURIComponent(teamName)}`
-  );
+): Promise<TeamCleanupFailure | undefined> => {
+  let failure: TeamCleanupFailure | undefined;
 
-  if (teamResponse.status() !== 404) {
-    expect(
-      teamResponse.ok(),
-      `Failed to look up team "${teamName}" for cleanup: ${teamResponse.status()} ${await teamResponse.text()}`
-    ).toBe(true);
-
-    const { id } = await teamResponse.json();
-    const deleteResponse = await apiContext.delete(
-      `/api/v1/teams/${id}?hardDelete=true&recursive=true`
+  try {
+    const teamResponse = await apiContext.get(
+      `/api/v1/teams/name/${encodeURIComponent(teamName)}`
     );
 
-    expect(
-      deleteResponse.ok(),
-      `Failed to clean up team "${teamName}": ${deleteResponse.status()} ${await deleteResponse.text()}`
-    ).toBe(true);
+    if (!teamResponse.ok()) {
+      if (teamResponse.status() !== 404) {
+        failure = {
+          teamName,
+          reason: `lookup returned ${teamResponse.status()} ${await teamResponse.text()}`,
+        };
+      }
+    } else {
+      const { id } = await teamResponse.json();
+      const deleteResponse = await apiContext.delete(
+        `/api/v1/teams/${id}?hardDelete=true&recursive=true`
+      );
+
+      if (!deleteResponse.ok()) {
+        failure = {
+          teamName,
+          reason: `delete returned ${deleteResponse.status()} ${await deleteResponse.text()}`,
+        };
+      }
+    }
+  } catch (error) {
+    failure = { teamName, reason: (error as Error).message };
   }
+
+  return failure;
+};
+
+/**
+ * Hard-delete teams created through the UI, children included.
+ *
+ * Deletes are sequential: a recursive delete takes a team's children with it,
+ * so issuing them in parallel would race the ones already removed. Every name
+ * is attempted before anything is asserted, and the assertion then names every
+ * team that survived — cleanup that fails quietly is what lets teams pile up on
+ * a long-lived deployment in the first place.
+ */
+export const hardDeleteTeamsByName = async (
+  apiContext: APIRequestContext,
+  teamNames: string[]
+) => {
+  const failures: TeamCleanupFailure[] = [];
+
+  for (const teamName of teamNames) {
+    const failure = await hardDeleteTeamByName(apiContext, teamName);
+
+    if (failure) {
+      failures.push(failure);
+    }
+  }
+
+  expect(
+    failures,
+    `Failed to clean up teams: ${failures
+      .map(({ teamName, reason }) => `"${teamName}" (${reason})`)
+      .join(', ')}`
+  ).toEqual([]);
 };
 
 interface SearchTeamOptions {

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
@@ -74,6 +74,55 @@ export const openAddTeamModal = async (
   return addTeamModal;
 };
 
+/**
+ * Land on Settings > Teams with the hierarchy table settled.
+ *
+ * The table spins on its own child-teams fetch plus the per-team asset-count
+ * aggregation, so navigation alone is not enough — a caller that acts right
+ * after the click drags rows that are still being repainted. Wait on the two
+ * calls that gate the first paint, then on the table itself.
+ */
+export const visitTeamsPage = async (page: Page) => {
+  const organizationResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/v1/teams/name/') && response.ok()
+  );
+  const permissionResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/v1/permissions/team/name/') && response.ok()
+  );
+
+  await settingClick(page, GlobalSettingOptions.TEAMS);
+  await Promise.all([permissionResponse, organizationResponse]);
+
+  await expect(page.getByTestId('team-hierarchy-table')).toBeVisible();
+  await waitForAllLoadersToDisappear(page);
+};
+
+/**
+ * Hard-delete a team created through the UI, children included.
+ *
+ * Specs that build teams through the UI have no entity handle to call
+ * `TeamClass.delete` on, so resolve the id by name first. A missing team is not
+ * an error — the spec may have deleted it as part of what it asserts.
+ */
+export const hardDeleteTeamByName = async (
+  apiContext: APIRequestContext,
+  teamName: string
+) => {
+  const teamResponse = await apiContext.get(
+    `/api/v1/teams/name/${encodeURIComponent(teamName)}`
+  );
+
+  if (teamResponse.ok()) {
+    const { id } = await teamResponse.json();
+
+    await apiContext.delete(
+      `/api/v1/teams/${id}?hardDelete=true&recursive=true`
+    );
+  }
+};
+
 interface SearchTeamOptions {
   expectEmptyResults?: boolean;
   expectNotFound?: boolean;

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
@@ -104,7 +104,12 @@ export const visitTeamsPage = async (page: Page) => {
  *
  * Specs that build teams through the UI have no entity handle to call
  * `TeamClass.delete` on, so resolve the id by name first. A missing team is not
- * an error — the spec may have deleted it as part of what it asserts.
+ * an error — the spec may have deleted it as part of what it asserts, and a
+ * recursive delete of its parent may already have taken it.
+ *
+ * A delete that comes back non-ok is asserted rather than ignored: a cleanup
+ * that fails quietly leaves the team behind, and the whole point of calling
+ * this is to stop teams accumulating on long-lived deployments.
  */
 export const hardDeleteTeamByName = async (
   apiContext: APIRequestContext,
@@ -116,10 +121,14 @@ export const hardDeleteTeamByName = async (
 
   if (teamResponse.ok()) {
     const { id } = await teamResponse.json();
-
-    await apiContext.delete(
+    const deleteResponse = await apiContext.delete(
       `/api/v1/teams/${id}?hardDelete=true&recursive=true`
     );
+
+    expect(
+      deleteResponse.ok(),
+      `Failed to clean up team "${teamName}": ${deleteResponse.status()} ${await deleteResponse.text()}`
+    ).toBe(true);
   }
 };
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
@@ -33,6 +33,47 @@ import { settingClick } from './sidebar';
 
 const TEAM_TYPES = ['Department', 'Division', 'Group'];
 
+const ADD_TEAM_MODAL = '[role="dialog"].ant-modal';
+// A success toast self-dismisses after 3.5s; give it a beat past that.
+const TOAST_DISMISS_TIMEOUT = 6_000;
+const MODAL_OPEN_TIMEOUT = 10_000;
+const MODAL_RETRY_TIMEOUT = 60_000;
+
+type AddTeamTrigger = 'add-team' | 'add-placeholder-button';
+
+/**
+ * Click an add-team trigger and return the modal it opens.
+ *
+ * The backend fans async-delete/job notifications out to every socket of the
+ * logged-in user, so a parallel worker's toast can drop over the button in the
+ * window between Playwright's hit-target check and the dispatched click — the
+ * toast swallows the click and the modal never opens. Success toasts carry no
+ * close button, so let them expire and click again; clicking with `force` only
+ * dispatches INTO the toast.
+ */
+export const openAddTeamModal = async (
+  page: Page,
+  trigger: AddTeamTrigger = 'add-team'
+) => {
+  const addButton = page.getByTestId(trigger);
+  const addTeamModal = page.locator(ADD_TEAM_MODAL).last();
+
+  await expect(async () => {
+    await page
+      .getByTestId('alert-bar')
+      .first()
+      .waitFor({ state: 'detached', timeout: TOAST_DISMISS_TIMEOUT })
+      .catch(() => undefined);
+
+    await expect(addButton).toBeEnabled();
+    await addButton.click();
+
+    await expect(addTeamModal).toBeVisible({ timeout: MODAL_OPEN_TIMEOUT });
+  }).toPass({ timeout: MODAL_RETRY_TIMEOUT, intervals: [1_000] });
+
+  return addTeamModal;
+};
+
 interface SearchTeamOptions {
   expectEmptyResults?: boolean;
   expectNotFound?: boolean;
@@ -252,16 +293,12 @@ export const addTeamHierarchy = async (
   index?: number,
   isHierarchy = false
 ) => {
-  const getTeamsResponse = page.waitForResponse('/api/v1/teams*');
+  const addTeamModal = await openAddTeamModal(
+    page,
+    index && index > 0 ? 'add-placeholder-button' : 'add-team'
+  );
 
-  // Fetching the add button and clicking on it
-  if (index && index > 0) {
-    await page.click('[data-testid="add-placeholder-button"]');
-  } else {
-    await page.click('[data-testid="add-team"]');
-  }
-
-  await getTeamsResponse;
+  await expect(page.locator('[data-testid="name"]')).toBeVisible();
 
   // Entering team details
   await validateFormNameFieldInput({
@@ -285,9 +322,30 @@ export const addTeamHierarchy = async (
   await page.locator(descriptionBox).fill(teamDetails.description);
 
   // Saving the created team
-  const saveTeamResponse = page.waitForResponse('/api/v1/teams');
+  const saveTeamResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/v1/teams') &&
+      response.request().method() === 'POST' &&
+      response.ok()
+  );
+  const teamsListResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/v1/teams?parentTeam=') &&
+      response.url().includes('fields=') &&
+      response.request().method() === 'GET'
+  );
   await page.click('[form="add-team-form"]');
   await saveTeamResponse;
+  const teamsListResponseResult = await teamsListResponse;
+
+  expect(teamsListResponseResult.status()).toBe(200);
+  await expect(addTeamModal).toBeHidden({ timeout: 60000 });
+  await waitForAllLoadersToDisappear(page);
+  await expect(
+    page.locator(`[data-row-key="${teamDetails.name}"]`)
+  ).toBeVisible({
+    timeout: 60000,
+  });
 };
 
 export const removeOrganizationPolicyAndRole = async (
@@ -592,7 +650,7 @@ export const executionOnOwnerTeam = async (
 
   await addEmailTeam(page, data.email);
 
-  await page.getByTestId('add-placeholder-button').click();
+  await openAddTeamModal(page, 'add-placeholder-button');
 
   const newTeamData = await createTeam(page);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
@@ -103,13 +103,13 @@ export const visitTeamsPage = async (page: Page) => {
  * Hard-delete a team created through the UI, children included.
  *
  * Specs that build teams through the UI have no entity handle to call
- * `TeamClass.delete` on, so resolve the id by name first. A missing team is not
- * an error — the spec may have deleted it as part of what it asserts, and a
- * recursive delete of its parent may already have taken it.
+ * `TeamClass.delete` on, so resolve the id by name first.
  *
- * A delete that comes back non-ok is asserted rather than ignored: a cleanup
- * that fails quietly leaves the team behind, and the whole point of calling
- * this is to stop teams accumulating on long-lived deployments.
+ * 404 is the one tolerated outcome — the spec may have deleted the team as
+ * part of what it asserts, and a recursive delete of its parent takes its
+ * children with it. Every other failure is asserted rather than ignored: a
+ * cleanup that fails quietly leaves the team behind, and the whole point of
+ * calling this is to stop teams accumulating on long-lived deployments.
  */
 export const hardDeleteTeamByName = async (
   apiContext: APIRequestContext,
@@ -119,7 +119,12 @@ export const hardDeleteTeamByName = async (
     `/api/v1/teams/name/${encodeURIComponent(teamName)}`
   );
 
-  if (teamResponse.ok()) {
+  if (teamResponse.status() !== 404) {
+    expect(
+      teamResponse.ok(),
+      `Failed to look up team "${teamName}" for cleanup: ${teamResponse.status()} ${await teamResponse.text()}`
+    ).toBe(true);
+
     const { id } = await teamResponse.json();
     const deleteResponse = await apiContext.delete(
       `/api/v1/teams/${id}?hardDelete=true&recursive=true`


### PR DESCRIPTION
Backport of #31932 to 1.13, plus the earlier `utils/team.ts` hardening 1.13 never received.

Fixes `TeamsDragAndDrop.spec.ts` on [AUT EKS/RDS MySQL 1.11.13 ➡ 1.13](https://github.com/open-metadata/openmetadata-nightly/actions/runs/32677353331).

## Why this isn't a plain cherry-pick

#31932 cherry-picks cleanly, but on its own it does not make 1.13 green. `git log --oneline origin/main ^origin/1.13 -- playwright/utils/team.ts` shows three commits 1.13 is missing that main and 2.0 both have:

| Commit | PR | main | 2.0 | 1.13 |
|---|---|---|---|---|
| `51ecf4502f` (`team.ts` hunk only) | #25894 Task redesign | ✅ | ✅ | ❌ |
| `b481bcc629` | #30334 Fix flaky team hierarchy creation wait | ✅ | ✅ | ❌ |
| `af609a6237` | #31734 stop the add-team click landing in a toast | ✅ | ✅ | ❌ |

1.13's `addTeamHierarchy` is still the original:

```ts
const saveTeamResponse = page.waitForResponse('/api/v1/teams');
await page.click('[form="add-team-form"]');
await saveTeamResponse;
```

No method or status filter, no wait for the `?parentTeam=…&fields=…` GET that repaints the table, no modal-hidden wait, no row-visible wait — so the helper returns while the table is still refetching. That is the retry-#1/#2 failure at `TeamsDragAndDrop.spec.ts:119`, where `toContainText(description)` runs against a row that hasn't painted.

#25894 is a 500-file redesign, so its `team.ts` hunk is hand-backported rather than cherry-picked. #30334 and #31734 fold in on top.

## Commits

1. `test(teams): backport addTeamHierarchy hardening to 1.13` — the three commits above, `team.ts` only. The delete-modal changes from #29760 / #29851 are deliberately **not** included; 1.13 still ships the radio-based delete modal.
2. `test(teams): stop the teams landing from eating the test budget` — clean cherry-pick of #31932. RCA in that PR.

## Verification

`tsc --noEmit -p playwright/tsconfig.json`, `eslint`, and `prettier --check` are clean on the touched files. The spec itself needs a live deployment and was not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The backport hardens team hierarchy navigation and creation synchronization while adding explicit cleanup for teams created by the drag-and-drop suite.
- Adds retry-aware opening of the add-team modal and waits for the hierarchy table to finish repainting after creation.
- Reuses a settled Teams-page navigation helper across the affected suites.
- Adds recursive post-suite cleanup that aggregates and reports lookup and deletion failures.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the cleanup helper now surfaces both unsuccessful DELETE responses and non-404 lookup failures through its aggregated assertion.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts | Adds synchronized Teams navigation and creation helpers plus cleanup that now reports non-404 lookup failures and unsuccessful DELETE responses. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts | Uses the hardened navigation helper, expands the suite timeout, and performs recursive cleanup after the suite. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsHierarchy.spec.ts | Replaces duplicated Teams-page navigation waits with the shared settled-page helper. |

</details>

<sub>Reviews (4): Last reviewed commit: ["test(teams): attempt every cleanup delet..."](https://github.com/open-metadata/openmetadata/commit/13a88506a33d8d66bcdff5e7ed117514eaaa0991) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56149320)</sub>

<!-- /greptile_comment -->