### PR TITLE
Fixes 31740: Enforce caller policies on the Incident Manager listing (1.13 backport) (#31741)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentManagerDomainIsolationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentManagerDomainIsolationIT.java
@@ -17,8 +17,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.openmetadata.it.bootstrap.SharedEntities;
 import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.SharedResourceLocks;
 import org.openmetadata.it.util.TestNamespace;
 import org.openmetadata.it.util.TestNamespaceExtension;
 import org.openmetadata.schema.api.data.CreateDatabase;
@@ -62,6 +65,7 @@ public class IncidentManagerDomainIsolationIT {
   private static final Column COLUMN = new Column().withName("id").withDataType(ColumnDataType.INT);
 
   @Test
+  @ResourceLock(value = SharedResourceLocks.SEARCH_SETTINGS, mode = ResourceAccessMode.READ_WRITE)
   void test_incidentListing_restrictedUserSeesOnlyOwnDomainIncidents(TestNamespace ns)
       throws Exception {
     OpenMetadataClient admin = SdkClients.adminClient();

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentManagerDomainIsolationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentManagerDomainIsolationIT.java
@@ -1,0 +1,292 @@
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.bootstrap.SharedEntities;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.TestNamespace;
+import org.openmetadata.it.util.TestNamespaceExtension;
+import org.openmetadata.schema.api.data.CreateDatabase;
+import org.openmetadata.schema.api.data.CreateDatabaseSchema;
+import org.openmetadata.schema.api.data.CreateTable;
+import org.openmetadata.schema.api.domains.CreateDomain;
+import org.openmetadata.schema.api.search.SearchSettings;
+import org.openmetadata.schema.api.teams.CreateUser;
+import org.openmetadata.schema.api.tests.CreateTestCase;
+import org.openmetadata.schema.api.tests.CreateTestCaseResolutionStatus;
+import org.openmetadata.schema.entity.data.Database;
+import org.openmetadata.schema.entity.data.DatabaseSchema;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.entity.domains.Domain;
+import org.openmetadata.schema.entity.teams.Role;
+import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.settings.Settings;
+import org.openmetadata.schema.settings.SettingsType;
+import org.openmetadata.schema.tests.TestCase;
+import org.openmetadata.schema.tests.type.Severity;
+import org.openmetadata.schema.tests.type.TestCaseResolutionStatusTypes;
+import org.openmetadata.schema.type.Column;
+import org.openmetadata.schema.type.ColumnDataType;
+import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.sdk.models.ListParams;
+import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.sdk.network.RequestOptions;
+
+/**
+ * Regression coverage for the Incident Manager listing RBAC gap: {@code
+ * EntityTimeSeriesRepository#listFromSearchWithOffset} and {@code #listLatestFromSearch} used to
+ * search without a {@code SubjectContext}, so {@code RuleEvaluator#hasDomain}'s list-operation
+ * short-circuit was never backed by search-side filtering and a domain-restricted user saw
+ * incidents from every domain (1.13 backport of the upstream fix for #31740).
+ */
+@Execution(ExecutionMode.CONCURRENT)
+@ExtendWith(TestNamespaceExtension.class)
+public class IncidentManagerDomainIsolationIT {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Column COLUMN = new Column().withName("id").withDataType(ColumnDataType.INT);
+
+  @Test
+  void test_incidentListing_restrictedUserSeesOnlyOwnDomainIncidents(TestNamespace ns)
+      throws Exception {
+    OpenMetadataClient admin = SdkClients.adminClient();
+    Deque<Runnable> cleanup = new ArrayDeque<>();
+    try {
+      String p = ns.shortPrefix();
+      Domain ownDomain = createDomain(admin, p + "_d1", cleanup);
+      Domain foreignDomain = createDomain(admin, p + "_d2", cleanup);
+      DatabaseSchema schema = createShortNamedSchema(admin, p, cleanup);
+      Table ownTable = createTableInDomain(admin, p + "_own", schema, ownDomain, cleanup);
+      Table foreignTable =
+          createTableInDomain(admin, p + "_foreign", schema, foreignDomain, cleanup);
+
+      String testDefinitionFqn =
+          admin
+              .testDefinitions()
+              .list(new ListParams().withLimit(1))
+              .getData()
+              .get(0)
+              .getFullyQualifiedName();
+      String ownIncidentFqn = createIncident(admin, ownTable, p + "_own_tc", testDefinitionFqn);
+      String foreignIncidentFqn =
+          createIncident(admin, foreignTable, p + "_foreign_tc", testDefinitionFqn);
+
+      OpenMetadataClient restricted = createRestrictedUserClient(admin, p, ownDomain, cleanup);
+
+      // Incident listing isolation is driven through search RBAC, which is gated on the global
+      // enableAccessControl setting.
+      boolean originalAccessControl = enableSearchAccessControl(admin);
+      cleanup.push(() -> restoreSearchAccessControl(admin, originalAccessControl));
+
+      Awaitility.await("Incident manager listing honours domain isolation")
+          .atMost(Duration.ofSeconds(90))
+          .pollInterval(Duration.ofSeconds(2))
+          .untilAsserted(
+              () -> {
+                for (boolean latest : new boolean[] {false, true}) {
+                  Set<String> visible = incidentTestCaseFqns(restricted, latest);
+                  assertTrue(
+                      visible.contains(ownIncidentFqn),
+                      "Own-domain incident visible (latest=" + latest + "). Saw: " + visible);
+                  assertFalse(
+                      visible.contains(foreignIncidentFqn),
+                      "Foreign-domain incident hidden (latest=" + latest + "). Saw: " + visible);
+                }
+              });
+    } finally {
+      drain(cleanup);
+    }
+  }
+
+  /** Creates a column-level test case on {@code table} plus an open incident for it. */
+  private String createIncident(
+      OpenMetadataClient admin, Table table, String name, String testDefinitionFqn) {
+    TestCase testCase =
+        admin
+            .testCases()
+            .create(
+                new CreateTestCase()
+                    .withName(name)
+                    .withEntityLink(
+                        "<#E::table::" + table.getFullyQualifiedName() + "::columns::id>")
+                    .withTestDefinition(testDefinitionFqn));
+    admin
+        .testCaseResolutionStatuses()
+        .create(
+            new CreateTestCaseResolutionStatus()
+                .withTestCaseResolutionStatusType(TestCaseResolutionStatusTypes.New)
+                .withTestCaseReference(testCase.getFullyQualifiedName())
+                .withSeverity(Severity.Severity2));
+    return testCase.getFullyQualifiedName();
+  }
+
+  /**
+   * @param latest {@code true} exercises the aggregation branch of the listing, which picks the
+   *     latest status per test case through a different server path than the plain search
+   *     listing. Both must enforce the caller's policies, otherwise {@code latest=true} is a
+   *     trivial bypass.
+   */
+  private Set<String> incidentTestCaseFqns(OpenMetadataClient client, boolean latest)
+      throws Exception {
+    String response =
+        client
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.GET,
+                "/v1/dataQuality/testCases/testCaseIncidentStatus",
+                null,
+                RequestOptions.builder()
+                    .queryParam("limit", "1000")
+                    .queryParam("latest", String.valueOf(latest))
+                    .build());
+    Set<String> fqns = new HashSet<>();
+    for (JsonNode incident : MAPPER.readTree(response).path("data")) {
+      JsonNode reference = incident.path("testCaseReference");
+      if (reference.hasNonNull("fullyQualifiedName")) {
+        fqns.add(reference.get("fullyQualifiedName").asText());
+      }
+    }
+    return fqns;
+  }
+
+  private Domain createDomain(OpenMetadataClient admin, String name, Deque<Runnable> cleanup) {
+    CreateDomain create =
+        new CreateDomain()
+            .withName(name)
+            .withDomainType(CreateDomain.DomainType.AGGREGATE)
+            .withDescription("Incident manager domain isolation test domain");
+    Domain domain = admin.domains().create(create);
+    cleanup.push(() -> admin.domains().delete(domain.getId().toString()));
+    return domain;
+  }
+
+  /**
+   * Creating a test case implicitly creates a test suite whose name is the table's FQN plus a
+   * suffix. Building directly under the shared MySQL service with a short, namespace-derived
+   * prefix keeps the resulting test suite name well inside its column limit.
+   */
+  private DatabaseSchema createShortNamedSchema(
+      OpenMetadataClient admin, String prefix, Deque<Runnable> cleanup) {
+    Database database =
+        admin
+            .databases()
+            .create(
+                new CreateDatabase()
+                    .withName(prefix + "_db")
+                    .withService(SharedEntities.get().MYSQL_SERVICE.getFullyQualifiedName()));
+    cleanup.push(
+        () ->
+            admin
+                .databases()
+                .delete(
+                    database.getId().toString(),
+                    Map.of("recursive", "true", "hardDelete", "true")));
+    return admin
+        .databaseSchemas()
+        .create(
+            new CreateDatabaseSchema()
+                .withName(prefix + "_sch")
+                .withDatabase(database.getFullyQualifiedName()));
+  }
+
+  private Table createTableInDomain(
+      OpenMetadataClient admin,
+      String name,
+      DatabaseSchema schema,
+      Domain domain,
+      Deque<Runnable> cleanup) {
+    CreateTable create =
+        new CreateTable()
+            .withName(name)
+            .withDatabaseSchema(schema.getFullyQualifiedName())
+            .withColumns(List.of(COLUMN))
+            .withDomains(List.of(domain.getFullyQualifiedName()));
+    Table table = admin.tables().create(create);
+    cleanup.push(() -> admin.tables().delete(table.getId()));
+    return table;
+  }
+
+  private OpenMetadataClient createRestrictedUserClient(
+      OpenMetadataClient admin, String prefix, Domain allowedDomain, Deque<Runnable> cleanup) {
+    Role domainOnlyRole = admin.roles().getByName("DomainOnlyAccessRole");
+    String name = prefix + "_restricted";
+    String email = name + "@test.openmetadata.org";
+    CreateUser request =
+        new CreateUser()
+            .withName(name)
+            .withEmail(email)
+            .withDomains(List.of(allowedDomain.getFullyQualifiedName()))
+            .withRoles(List.of(domainOnlyRole.getId()));
+    User user = admin.users().create(request);
+    cleanup.push(() -> admin.users().delete(user.getId()));
+    return SdkClients.createClient(email, email, new String[] {});
+  }
+
+  private boolean enableSearchAccessControl(OpenMetadataClient admin) throws Exception {
+    String settingsJson =
+        admin
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.GET,
+                "/v1/system/settings/" + SettingsType.SEARCH_SETTINGS.value(),
+                null,
+                RequestOptions.builder().build());
+    Settings settings = MAPPER.readValue(settingsJson, Settings.class);
+    SearchSettings searchConfig =
+        MAPPER.convertValue(settings.getConfigValue(), SearchSettings.class);
+    boolean original =
+        Boolean.TRUE.equals(searchConfig.getGlobalSettings().getEnableAccessControl());
+    searchConfig.getGlobalSettings().setEnableAccessControl(true);
+    Settings updated =
+        new Settings().withConfigType(SettingsType.SEARCH_SETTINGS).withConfigValue(searchConfig);
+    admin
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.PUT,
+            "/v1/system/settings",
+            MAPPER.writeValueAsString(updated),
+            RequestOptions.builder().build());
+    return original;
+  }
+
+  private void restoreSearchAccessControl(OpenMetadataClient admin, boolean original) {
+    if (!original) {
+      try {
+        admin
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.PUT,
+                "/v1/system/settings/reset/" + SettingsType.SEARCH_SETTINGS.value(),
+                null,
+                RequestOptions.builder().build());
+      } catch (Exception ignored) {
+        // Best-effort restore.
+      }
+    }
+  }
+
+  private void drain(Deque<Runnable> cleanup) {
+    while (!cleanup.isEmpty()) {
+      try {
+        cleanup.pop().run();
+      } catch (Exception ignored) {
+        // Best-effort teardown; concurrent namespaces keep tests isolated regardless.
+      }
+    }
+  }
+}

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentManagerDomainIsolationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentManagerDomainIsolationIT.java
@@ -148,7 +148,7 @@ public class IncidentManagerDomainIsolationIT {
             .getHttpClient()
             .executeForString(
                 HttpMethod.GET,
-                "/v1/dataQuality/testCases/testCaseIncidentStatus",
+                "/v1/dataQuality/testCases/testCaseIncidentStatus/search/list",
                 null,
                 RequestOptions.builder()
                     .queryParam("limit", "1000")

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/MultiDomainHasDomainIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/MultiDomainHasDomainIT.java
@@ -12,9 +12,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.openmetadata.it.factories.DatabaseSchemaTestFactory;
 import org.openmetadata.it.factories.DatabaseServiceTestFactory;
 import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.SharedResourceLocks;
 import org.openmetadata.it.util.TestNamespace;
 import org.openmetadata.it.util.TestNamespaceExtension;
 import org.openmetadata.schema.api.data.CreateTable;
@@ -62,6 +65,7 @@ public class MultiDomainHasDomainIT {
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   @Test
+  @ResourceLock(value = SharedResourceLocks.SEARCH_SETTINGS, mode = ResourceAccessMode.READ_WRITE)
   void test_searchWithMultipleDomains_hasDomainPolicy(TestNamespace ns) throws Exception {
     OpenMetadataClient adminClient = SdkClients.adminClient();
     String p = ns.shortPrefix();
@@ -175,6 +179,7 @@ public class MultiDomainHasDomainIT {
   }
 
   @Test
+  @ResourceLock(value = SharedResourceLocks.SEARCH_SETTINGS, mode = ResourceAccessMode.READ_WRITE)
   void test_searchWithSingleDomain_hasDomainPolicy(TestNamespace ns) throws Exception {
     OpenMetadataClient adminClient = SdkClients.adminClient();
     String p = ns.shortPrefix();
@@ -253,6 +258,7 @@ public class MultiDomainHasDomainIT {
   }
 
   @Test
+  @ResourceLock(value = SharedResourceLocks.SEARCH_SETTINGS, mode = ResourceAccessMode.READ_WRITE)
   void test_searchWithDomain_canSeeNoDomainAssets(TestNamespace ns) throws Exception {
     OpenMetadataClient adminClient = SdkClients.adminClient();
     String p = ns.shortPrefix();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesRepository.java
@@ -37,6 +37,7 @@ import org.openmetadata.service.search.SearchListFilter;
 import org.openmetadata.service.search.SearchRepository;
 import org.openmetadata.service.search.SearchResultListMapper;
 import org.openmetadata.service.search.SearchSortFilter;
+import org.openmetadata.service.security.policyevaluator.SubjectContext;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.RestUtil;
 
@@ -447,6 +448,29 @@ public abstract class EntityTimeSeriesRepository<T extends EntityTimeSeriesInter
       String q,
       String queryString)
       throws IOException {
+    return listFromSearchWithOffset(
+        fields, searchListFilter, limit, offset, searchSortFilter, q, queryString, null);
+  }
+
+  /**
+   * Same as {@link #listFromSearchWithOffset(EntityUtil.Fields, SearchListFilter, int, int,
+   * SearchSortFilter, String, String)} but evaluates the caller's policies against the search
+   * query, so a listing cannot return time series documents the caller may not read. Domain
+   * conditions such as {@code hasDomain()} can only be enforced here: {@code
+   * RuleEvaluator#hasDomain} short-circuits to {@code true} for list operations because no single
+   * resource is in scope, and relies on this search-side filtering instead. Passing a {@code null}
+   * subject keeps the unfiltered behaviour.
+   */
+  public ResultList<T> listFromSearchWithOffset(
+      EntityUtil.Fields fields,
+      SearchListFilter searchListFilter,
+      int limit,
+      int offset,
+      SearchSortFilter searchSortFilter,
+      String q,
+      String queryString,
+      SubjectContext subjectContext)
+      throws IOException {
     List<T> entityList = new ArrayList<>();
     long total;
 
@@ -455,7 +479,14 @@ public abstract class EntityTimeSeriesRepository<T extends EntityTimeSeriesInter
     if (limit > 0) {
       SearchResultListMapper results =
           searchRepository.listWithOffset(
-              searchListFilter, limit, offset, entityType, searchSortFilter, q, queryString);
+              searchListFilter,
+              limit,
+              offset,
+              entityType,
+              searchSortFilter,
+              q,
+              queryString,
+              subjectContext);
       total = results.getTotal();
       for (Map<String, Object> json : results.getResults()) {
         T entity = setFieldsInternal(readTimeSeriesSource(json), fields);
@@ -467,7 +498,14 @@ public abstract class EntityTimeSeriesRepository<T extends EntityTimeSeriesInter
     } else {
       SearchResultListMapper results =
           searchRepository.listWithOffset(
-              searchListFilter, limit, offset, entityType, searchSortFilter, q, queryString);
+              searchListFilter,
+              limit,
+              offset,
+              entityType,
+              searchSortFilter,
+              q,
+              queryString,
+              subjectContext);
       total = results.getTotal();
       return new ResultList<>(entityList, null, limit, (int) total);
     }
@@ -484,6 +522,28 @@ public abstract class EntityTimeSeriesRepository<T extends EntityTimeSeriesInter
       String sortField,
       String sortType)
       throws IOException {
+    return listLatestFromSearch(
+        fields, contentFilter, groupBy, q, limit, offset, sortField, sortType, null);
+  }
+
+  /**
+   * Subject-aware variant of {@link #listLatestFromSearch(EntityUtil.Fields, SearchListFilter,
+   * String, String, Integer, Integer, String, String)}. The aggregation that picks the latest
+   * document per group must be filtered by the caller's policies too, otherwise {@code
+   * latest=true} bypasses the filtering applied to the plain listing.
+   */
+  @SuppressWarnings("unchecked")
+  public ResultList<T> listLatestFromSearch(
+      EntityUtil.Fields fields,
+      SearchListFilter contentFilter,
+      String groupBy,
+      String q,
+      Integer limit,
+      Integer offset,
+      String sortField,
+      String sortType,
+      SubjectContext subjectContext)
+      throws IOException {
     List<T> entityList = new ArrayList<>();
     SearchListFilter searchListFilter = new SearchListFilter();
     setIncludeSearchFields(searchListFilter);
@@ -492,7 +552,8 @@ public abstract class EntityTimeSeriesRepository<T extends EntityTimeSeriesInter
     SearchAggregation searchAggregation =
         buildComplexAggregation(groupBy, contentFilter, limit, offset, sortField, sortType);
     JsonObject jsonObjResults =
-        searchRepository.aggregate(q, entityType, searchAggregation, searchListFilter);
+        searchRepository.aggregate(
+            q, entityType, searchAggregation, searchListFilter, subjectContext);
 
     Optional<List> jsonObjects =
         JsonUtils.readJsonAtPath(jsonObjResults.toString(), aggregationPath, List.class);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResolutionStatusResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResolutionStatusResource.java
@@ -1,5 +1,7 @@
 package org.openmetadata.service.resources.dqtests;
 
+import static org.openmetadata.service.security.DefaultAuthorizer.getSubjectContext;
+
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -52,6 +54,7 @@ import org.openmetadata.service.security.AuthorizationLogic;
 import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.security.policyevaluator.OperationContext;
 import org.openmetadata.service.security.policyevaluator.ResourceContextInterface;
+import org.openmetadata.service.security.policyevaluator.SubjectContext;
 import org.openmetadata.service.security.policyevaluator.TestCaseResourceContext;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.EntityUtil.Fields;
@@ -473,6 +476,9 @@ public class TestCaseResolutionStatusResource
 
     authorizer.authorizeRequests(securityContext, requests, AuthorizationLogic.ANY);
 
+    // The incident listing carries no single resource, so hasDomain() cannot be evaluated during
+    // authorization above; the caller's policies are enforced on the search query instead.
+    SubjectContext subjectContext = getSubjectContext(securityContext);
     if (latest) {
       // For latest results, use aggregation grouped by test case to get the latest status per test
       // case
@@ -485,10 +491,18 @@ public class TestCaseResolutionStatusResource
           limit,
           offset,
           defaultSortField,
-          sortType);
+          sortType,
+          subjectContext);
     } else {
       return repository.listFromSearchWithOffset(
-          new Fields(null), searchListFilter, limit, offset, searchSortFilter, null, null);
+          new Fields(null),
+          searchListFilter,
+          limit,
+          offset,
+          searchSortFilter,
+          null,
+          null,
+          subjectContext);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/AggregationManagementClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/AggregationManagementClient.java
@@ -68,6 +68,23 @@ public interface AggregationManagementClient {
       throws IOException;
 
   /**
+   * Same as {@link #aggregate(String, String, SearchAggregation, String)} but evaluates the caller's
+   * policies against the aggregation query, so an aggregation cannot surface documents the caller may
+   * not read. Defaults to the subject-less overload, which applies no policy filtering.
+   *
+   * @param subjectContext the caller, used to build the RBAC query
+   */
+  default JsonObject aggregate(
+      String query,
+      String index,
+      SearchAggregation searchAggregation,
+      String filter,
+      SubjectContext subjectContext)
+      throws IOException {
+    return aggregate(query, index, searchAggregation, filter);
+  }
+
+  /**
    * Get entity type counts with aggregation.
    * Returns count of entities grouped by entity type.
    *

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -3244,6 +3244,17 @@ public class SearchRepository {
         query, entityType, searchAggregation, filter.getCondition(entityType));
   }
 
+  public JsonObject aggregate(
+      String query,
+      String entityType,
+      SearchAggregation searchAggregation,
+      SearchListFilter filter,
+      SubjectContext subjectContext)
+      throws IOException {
+    return searchClient.aggregate(
+        query, entityType, searchAggregation, filter.getCondition(entityType), subjectContext);
+  }
+
   public DataQualityReport genericAggregation(
       String query, String index, SearchAggregation aggregationMetadata) throws IOException {
     return searchClient.genericAggregation(query, index, aggregationMetadata);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchAggregationManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchAggregationManager.java
@@ -72,21 +72,24 @@ public class ElasticSearchAggregationManager implements AggregationManagementCli
    * unfiltered.
    */
   private Query applyRbacQuery(Query query, SubjectContext subjectContext) {
-    if (!SearchUtils.shouldApplyRbacConditions(subjectContext, rbacConditionEvaluator)) {
-      return query;
+    Query result = query;
+    if (SearchUtils.shouldApplyRbacConditions(subjectContext, rbacConditionEvaluator)) {
+      OMQueryBuilder rbacQueryBuilder = rbacConditionEvaluator.evaluateConditions(subjectContext);
+      if (rbacQueryBuilder == null) {
+        // Fail closed: policies had to be applied for this caller (access control on, not
+        // admin/bot) but produced no query. Returning the unfiltered query would leak; match
+        // nothing instead.
+        result = Query.of(qb -> qb.matchNone(m -> m));
+      } else {
+        Query rbacQuery = ((ElasticQueryBuilder) rbacQueryBuilder).buildV2();
+        final Query existingQuery = query;
+        result =
+            existingQuery == null
+                ? rbacQuery
+                : Query.of(qb -> qb.bool(b -> b.must(existingQuery).filter(rbacQuery)));
+      }
     }
-    OMQueryBuilder rbacQueryBuilder = rbacConditionEvaluator.evaluateConditions(subjectContext);
-    if (rbacQueryBuilder == null) {
-      // Fail closed: policies had to be applied for this caller (access control on, not admin/bot)
-      // but produced no query. Returning the unfiltered query would leak; match nothing instead.
-      return Query.of(qb -> qb.matchNone(m -> m));
-    }
-    Query rbacQuery = ((ElasticQueryBuilder) rbacQueryBuilder).buildV2();
-    if (query == null) {
-      return rbacQuery;
-    }
-    final Query existingQuery = query;
-    return Query.of(qb -> qb.bool(b -> b.must(existingQuery).filter(rbacQuery)));
+    return result;
   }
 
   private String praseJsonQuery(String jsonQuery) throws JsonProcessingException {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchAggregationManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchAggregationManager.java
@@ -65,6 +65,30 @@ public class ElasticSearchAggregationManager implements AggregationManagementCli
     mapper = new ObjectMapper();
   }
 
+  /**
+   * ANDs the caller's policy conditions into an aggregation query. Aggregations run over whole
+   * indexes, so without this a caller can read documents they are denied on the corresponding
+   * listing. A {@code null} or exempt subject (admin, bot, access control disabled) is left
+   * unfiltered.
+   */
+  private Query applyRbacQuery(Query query, SubjectContext subjectContext) {
+    if (!SearchUtils.shouldApplyRbacConditions(subjectContext, rbacConditionEvaluator)) {
+      return query;
+    }
+    OMQueryBuilder rbacQueryBuilder = rbacConditionEvaluator.evaluateConditions(subjectContext);
+    if (rbacQueryBuilder == null) {
+      // Fail closed: policies had to be applied for this caller (access control on, not admin/bot)
+      // but produced no query. Returning the unfiltered query would leak; match nothing instead.
+      return Query.of(qb -> qb.matchNone(m -> m));
+    }
+    Query rbacQuery = ((ElasticQueryBuilder) rbacQueryBuilder).buildV2();
+    if (query == null) {
+      return rbacQuery;
+    }
+    final Query existingQuery = query;
+    return Query.of(qb -> qb.bool(b -> b.must(existingQuery).filter(rbacQuery)));
+  }
+
   private String praseJsonQuery(String jsonQuery) throws JsonProcessingException {
     JsonNode rootNode = mapper.readTree(jsonQuery);
     String queryToProcess = jsonQuery;
@@ -421,6 +445,22 @@ public class ElasticSearchAggregationManager implements AggregationManagementCli
   public JsonObject aggregate(
       String query, String index, SearchAggregation searchAggregation, String filter)
       throws IOException {
+    return aggregate(query, index, searchAggregation, filter, null);
+  }
+
+  /**
+   * Same as {@link #aggregate(String, String, SearchAggregation, String)} but evaluates the
+   * caller's policies against the aggregation query, so an aggregation cannot surface documents
+   * the caller may not read. A {@code null} or exempt subject leaves the query unfiltered.
+   */
+  @Override
+  public JsonObject aggregate(
+      String query,
+      String index,
+      SearchAggregation searchAggregation,
+      String filter,
+      SubjectContext subjectContext)
+      throws IOException {
     if (!isClientAvailable) {
       LOG.error("ElasticSearch client is not available. Cannot perform aggregation.");
       throw new IOException("ElasticSearch client is not available");
@@ -450,6 +490,7 @@ public class ElasticSearchAggregationManager implements AggregationManagementCli
           parsedQuery = Query.of(q -> q.queryString(qs -> qs.query(query)));
         }
       }
+      parsedQuery = applyRbacQuery(parsedQuery, subjectContext);
 
       Query filterQuery = null;
       if (filter != null && !filter.isEmpty() && !filter.equals("{}")) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java
@@ -548,6 +548,17 @@ public class ElasticSearchClient implements SearchClient {
   }
 
   @Override
+  public JsonObject aggregate(
+      String query,
+      String index,
+      SearchAggregation searchAggregation,
+      String filter,
+      SubjectContext subjectContext)
+      throws IOException {
+    return aggregationManager.aggregate(query, index, searchAggregation, filter, subjectContext);
+  }
+
+  @Override
   public ElasticSearchConfiguration.SearchType getSearchType() {
     return ElasticSearchConfiguration.SearchType.ELASTICSEARCH;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchAggregationManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchAggregationManager.java
@@ -71,21 +71,24 @@ public class OpenSearchAggregationManager implements AggregationManagementClient
    * unfiltered.
    */
   private Query applyRbacQuery(Query query, SubjectContext subjectContext) {
-    if (!SearchUtils.shouldApplyRbacConditions(subjectContext, rbacConditionEvaluator)) {
-      return query;
+    Query result = query;
+    if (SearchUtils.shouldApplyRbacConditions(subjectContext, rbacConditionEvaluator)) {
+      OMQueryBuilder rbacQueryBuilder = rbacConditionEvaluator.evaluateConditions(subjectContext);
+      if (rbacQueryBuilder == null) {
+        // Fail closed: policies had to be applied for this caller (access control on, not
+        // admin/bot) but produced no query. Returning the unfiltered query would leak; match
+        // nothing instead.
+        result = Query.of(qb -> qb.matchNone(m -> m));
+      } else {
+        Query rbacQuery = ((OpenSearchQueryBuilder) rbacQueryBuilder).buildV2();
+        final Query existingQuery = query;
+        result =
+            existingQuery == null
+                ? rbacQuery
+                : Query.of(qb -> qb.bool(b -> b.must(existingQuery).filter(rbacQuery)));
+      }
     }
-    OMQueryBuilder rbacQueryBuilder = rbacConditionEvaluator.evaluateConditions(subjectContext);
-    if (rbacQueryBuilder == null) {
-      // Fail closed: policies had to be applied for this caller (access control on, not admin/bot)
-      // but produced no query. Returning the unfiltered query would leak; match nothing instead.
-      return Query.of(qb -> qb.matchNone(m -> m));
-    }
-    Query rbacQuery = ((OpenSearchQueryBuilder) rbacQueryBuilder).buildV2();
-    if (query == null) {
-      return rbacQuery;
-    }
-    final Query existingQuery = query;
-    return Query.of(qb -> qb.bool(b -> b.must(existingQuery).filter(rbacQuery)));
+    return result;
   }
 
   private String praseJsonQuery(String jsonQuery) throws JsonProcessingException {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchAggregationManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchAggregationManager.java
@@ -64,6 +64,30 @@ public class OpenSearchAggregationManager implements AggregationManagementClient
     mapper = new ObjectMapper();
   }
 
+  /**
+   * ANDs the caller's policy conditions into an aggregation query. Aggregations run over whole
+   * indexes, so without this a caller can read documents they are denied on the corresponding
+   * listing. A {@code null} or exempt subject (admin, bot, access control disabled) is left
+   * unfiltered.
+   */
+  private Query applyRbacQuery(Query query, SubjectContext subjectContext) {
+    if (!SearchUtils.shouldApplyRbacConditions(subjectContext, rbacConditionEvaluator)) {
+      return query;
+    }
+    OMQueryBuilder rbacQueryBuilder = rbacConditionEvaluator.evaluateConditions(subjectContext);
+    if (rbacQueryBuilder == null) {
+      // Fail closed: policies had to be applied for this caller (access control on, not admin/bot)
+      // but produced no query. Returning the unfiltered query would leak; match nothing instead.
+      return Query.of(qb -> qb.matchNone(m -> m));
+    }
+    Query rbacQuery = ((OpenSearchQueryBuilder) rbacQueryBuilder).buildV2();
+    if (query == null) {
+      return rbacQuery;
+    }
+    final Query existingQuery = query;
+    return Query.of(qb -> qb.bool(b -> b.must(existingQuery).filter(rbacQuery)));
+  }
+
   private String praseJsonQuery(String jsonQuery) throws JsonProcessingException {
     JsonNode rootNode = mapper.readTree(jsonQuery);
     String queryToProcess = jsonQuery;
@@ -381,6 +405,22 @@ public class OpenSearchAggregationManager implements AggregationManagementClient
   public JsonObject aggregate(
       String query, String index, SearchAggregation searchAggregation, String filter)
       throws IOException {
+    return aggregate(query, index, searchAggregation, filter, null);
+  }
+
+  /**
+   * Same as {@link #aggregate(String, String, SearchAggregation, String)} but evaluates the
+   * caller's policies against the aggregation query, so an aggregation cannot surface documents
+   * the caller may not read. A {@code null} or exempt subject leaves the query unfiltered.
+   */
+  @Override
+  public JsonObject aggregate(
+      String query,
+      String index,
+      SearchAggregation searchAggregation,
+      String filter,
+      SubjectContext subjectContext)
+      throws IOException {
     if (!isClientAvailable) {
       LOG.error("OpenSearch client is not available. Cannot perform aggregation.");
       throw new IOException("OpenSearch client is not available");
@@ -410,6 +450,7 @@ public class OpenSearchAggregationManager implements AggregationManagementClient
           parsedQuery = Query.of(q -> q.queryString(qs -> qs.query(query)));
         }
       }
+      parsedQuery = applyRbacQuery(parsedQuery, subjectContext);
 
       Query filterQuery = null;
       if (filter != null && !filter.isEmpty() && !filter.equals("{}")) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java
@@ -514,6 +514,17 @@ public class OpenSearchClient implements SearchClient {
   }
 
   @Override
+  public JsonObject aggregate(
+      String query,
+      String index,
+      SearchAggregation searchAggregation,
+      String filter,
+      SubjectContext subjectContext)
+      throws IOException {
+    return aggregationManager.aggregate(query, index, searchAggregation, filter, subjectContext);
+  }
+
+  @Override
   public ElasticSearchConfiguration.SearchType getSearchType() {
     return ElasticSearchConfiguration.SearchType.OPENSEARCH;
   }

--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -96,6 +96,10 @@ export default defineConfig({
         '**/DataAssetRulesDisabled.spec.ts',
         '**/SystemCertificationTags.spec.ts',
         '**/SearchRBAC.spec.ts',
+        // Toggles the global enableAccessControl search setting in beforeAll/afterAll —
+        // same reason SearchRBAC.spec.ts is isolated below; runs in the SearchRBAC
+        // project instead so it never races other chromium tests on that setting.
+        '**/DomainIncidentIsolation.spec.ts',
         '**/SSOLogin.spec.ts',
         // Runs in its own post-chromium project to prevent IntakeForm.spec.ts's
         // per-test beforeEach (which deletes all intake forms) from racing against
@@ -160,11 +164,20 @@ export default defineConfig({
       fullyParallel: true,
     },
     {
+      // Also runs DomainIncidentIsolation.spec.ts (1.13 backport of the #31740 domain-RBAC
+      // fix) — it toggles the same global enableAccessControl setting in beforeAll/afterAll,
+      // so it needs the same isolation from chromium. workers:1 serializes the two spec
+      // files against each other too (a second file here would otherwise be free to run
+      // on a separate worker and race the same setting within this one project).
       name: 'SearchRBAC',
-      testMatch: '**/SearchRBAC.spec.ts',
+      testMatch: [
+        '**/SearchRBAC.spec.ts',
+        '**/DomainIncidentIsolation.spec.ts',
+      ],
       dependencies: ['DataAssetRulesDisabled'],
       use: { ...devices['Desktop Chrome'] },
       teardown: 'entity-data-teardown',
+      workers: 1,
     },
     // Compatibility shim for PR workflows that still pass --project=DomainIsolation.
     // The DomainIsolation E2E suite is not backported to 1.13, so this project intentionally

--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -167,10 +167,8 @@ export default defineConfig({
       teardown: 'entity-data-teardown',
     },
     // Compatibility shim for PR workflows that still pass --project=DomainIsolation.
-    // Only DomainIncidentIsolation.spec.ts has been backported to 1.13 so far (as part of
-    // the #31740 domain-RBAC fix); it runs under the default chromium project instead, since
-    // this shim intentionally matches no tests. The rest of main's DomainIsolation suite
-    // (search/lineage/task/dropdown/listing isolation) is not backported.
+    // The DomainIsolation E2E suite is not backported to 1.13, so this project intentionally
+    // matches no tests while allowing the workflow argument to resolve.
     {
       name: 'DomainIsolation',
       testMatch: [],

--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -167,8 +167,10 @@ export default defineConfig({
       teardown: 'entity-data-teardown',
     },
     // Compatibility shim for PR workflows that still pass --project=DomainIsolation.
-    // The DomainIsolation E2E suite is not backported to 1.13, so this project intentionally
-    // matches no tests while allowing the workflow argument to resolve.
+    // Only DomainIncidentIsolation.spec.ts has been backported to 1.13 so far (as part of
+    // the #31740 domain-RBAC fix); it runs under the default chromium project instead, since
+    // this shim intentionally matches no tests. The rest of main's DomainIsolation suite
+    // (search/lineage/task/dropdown/listing isolation) is not backported.
     {
       name: 'DomainIsolation',
       testMatch: [],

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainIncidentIsolation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainIncidentIsolation.spec.ts
@@ -1,0 +1,228 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { expect, Page, test as base } from '@playwright/test';
+import { SidebarItem } from '../../../constant/sidebar';
+import { Domain } from '../../../support/domain/Domain';
+import { TableClass } from '../../../support/entity/TableClass';
+import { UserClass } from '../../../support/user/UserClass';
+import { performAdminLogin } from '../../../utils/admin';
+import { redirectToHomePage } from '../../../utils/common';
+import {
+  assignDomainOnlyAccess,
+  assignDomainToTable,
+  safeDelete,
+} from '../../../utils/domainIsolationUtils';
+import { waitForAllLoadersToDisappear } from '../../../utils/entity';
+import { seedFailedIncidents } from '../../../utils/incidentManager';
+import { enableDisableSearchRBAC } from '../../../utils/searchRBAC';
+import { sidebarClick } from '../../../utils/sidebar';
+
+// Issue #31740 — the Incident Manager listing is served by the `testCaseIncidentStatus/search/list`
+// endpoint, which never passed the caller's SubjectContext to the search layer. hasDomain() returns
+// true for list operations (no single resource is in scope) and defers to search-side filtering, so
+// without that SubjectContext no domain policy restricted the listing at all.
+//
+// The user under test deliberately has NO domain assigned. A user WITH a domain is not a valid
+// regression guard here: the page sends `domain=<their own domain>` (useIncidentList passes
+// activeDomain unless it is the default), and that caller-supplied filter alone hides foreign
+// incidents even on a server with the bug. With no domain the page sends no `domain` param, so the
+// policy evaluated server-side is the only thing that can filter the list — which is exactly the
+// behaviour this spec protects.
+const adminUser = new UserClass();
+const noDomainUser = new UserClass();
+const tenant = new Domain();
+const restrictedTable = new TableClass();
+const domainlessTable = new TableClass();
+
+let restrictedTestCaseName = '';
+let restrictedTestCaseFqn = '';
+let domainlessTestCaseName = '';
+let domainlessTestCaseFqn = '';
+
+const test = base.extend<{ adminPage: Page; noDomainPage: Page }>({
+  adminPage: async ({ browser }, use) => {
+    const page = await browser.newPage();
+    try {
+      await adminUser.login(page);
+      await use(page);
+    } finally {
+      await page.close();
+    }
+  },
+  noDomainPage: async ({ browser }, use) => {
+    const page = await browser.newPage();
+    try {
+      await noDomainUser.login(page);
+      await use(page);
+    } finally {
+      await page.close();
+    }
+  },
+});
+
+// Returns the test case FQNs the server actually sent to this page. The rendered table is paginated,
+// so a row can be missing from page 1 while still being exposed to the user — asserting only on the
+// DOM would let a real leak pass. Asserting on the payload the page requested closes that gap, and
+// the visible-row assertions below keep the user-facing behaviour covered too.
+const openIncidentManager = async (page: Page): Promise<string[]> => {
+  await redirectToHomePage(page);
+
+  // Matched on URL only. Narrowing the predicate by status would never resolve on an error
+  // response, turning a failing API into an opaque timeout instead of a status assertion.
+  const incidentResponse = page.waitForResponse((response) =>
+    response
+      .url()
+      .includes('/dataQuality/testCases/testCaseIncidentStatus/search/list')
+  );
+  await sidebarClick(page, SidebarItem.INCIDENT_MANAGER);
+  const response = await incidentResponse;
+
+  expect(response.status()).toBe(200);
+
+  await waitForAllLoadersToDisappear(page);
+
+  await expect(page.getByTestId('incident-filter-bar')).toBeVisible();
+
+  const body = await response.json();
+
+  return (body.data ?? []).map(
+    (incident: { testCaseReference?: { fullyQualifiedName?: string } }) =>
+      incident.testCaseReference?.fullyQualifiedName ?? ''
+  );
+};
+
+test.describe(
+  'Domain isolation - incident manager listing',
+  { tag: ['@domain-isolation'] },
+  () => {
+    test.beforeAll(
+      'Setup domain, tables, incidents and users',
+      async ({ browser }) => {
+        // test.slow() does not extend a hook's timeout, so set an explicit budget for creating the
+        // entities and waiting for both incidents to be indexed.
+        test.setTimeout(3 * 60 * 1000);
+
+        const { apiContext, afterAction } = await performAdminLogin(browser);
+
+        try {
+          await Promise.all([
+            adminUser.create(apiContext),
+            noDomainUser.create(apiContext),
+            tenant.create(apiContext),
+            restrictedTable.create(apiContext),
+            domainlessTable.create(apiContext),
+          ]);
+
+          await Promise.all([
+            adminUser.setAdminRole(apiContext),
+            // The role carries the domain policy; the empty domain list is the point of this spec —
+            // the user is subject to hasDomain() but owns no domain, so only domainless assets are
+            // theirs.
+            assignDomainOnlyAccess(apiContext, noDomainUser, []),
+            assignDomainToTable(
+              apiContext,
+              restrictedTable.entityResponseData?.id ?? '',
+              tenant
+            ),
+          ]);
+
+          // The table must carry its domain before the incident is indexed — the incident document
+          // inherits its domains from the test case, which inherits them from the table.
+          // seedFailedIncidents polls until each incident is searchable, so the assertions below
+          // never race Elasticsearch.
+          const [[restrictedTestCase], [domainlessTestCase]] =
+            await Promise.all([
+              seedFailedIncidents({
+                apiContext,
+                table: restrictedTable,
+                count: 1,
+              }),
+              seedFailedIncidents({
+                apiContext,
+                table: domainlessTable,
+                count: 1,
+              }),
+            ]);
+
+          restrictedTestCaseName = restrictedTestCase['name'] as string;
+          restrictedTestCaseFqn = restrictedTestCase[
+            'fullyQualifiedName'
+          ] as string;
+          domainlessTestCaseName = domainlessTestCase['name'] as string;
+          domainlessTestCaseFqn = domainlessTestCase[
+            'fullyQualifiedName'
+          ] as string;
+
+          await enableDisableSearchRBAC(apiContext, true);
+        } finally {
+          await afterAction();
+        }
+      }
+    );
+
+    test.afterAll('Cleanup', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+
+      try {
+        await enableDisableSearchRBAC(apiContext, false);
+
+        // Tables first: the domain is deleted once nothing references it any more.
+        await Promise.all([
+          safeDelete(() => restrictedTable.delete(apiContext)),
+          safeDelete(() => domainlessTable.delete(apiContext)),
+        ]);
+
+        await Promise.all([
+          safeDelete(() => tenant.delete(apiContext)),
+          safeDelete(() => noDomainUser.delete(apiContext)),
+          safeDelete(() => adminUser.delete(apiContext)),
+        ]);
+      } finally {
+        await afterAction();
+      }
+    });
+
+    test('user without a domain cannot see incidents belonging to a domain', async ({
+      noDomainPage,
+    }) => {
+      const listedFqns = await openIncidentManager(noDomainPage);
+
+      await test.step('the domained incident is withheld', async () => {
+        expect(listedFqns).not.toContain(restrictedTestCaseFqn);
+
+        await expect(
+          noDomainPage
+            .getByTestId('test-case-incident-manager-table')
+            .getByRole('link', { name: restrictedTestCaseName })
+        ).toHaveCount(0);
+      });
+
+      await test.step('the domainless incident is still listed', async () => {
+        expect(listedFqns).toContain(domainlessTestCaseFqn);
+
+        await expect(
+          noDomainPage
+            .getByTestId('test-case-incident-manager-table')
+            .getByRole('link', { name: domainlessTestCaseName })
+        ).toBeVisible();
+      });
+    });
+
+    test('admin sees incidents from every domain', async ({ adminPage }) => {
+      const listedFqns = await openIncidentManager(adminPage);
+
+      expect(listedFqns).toContain(restrictedTestCaseFqn);
+      expect(listedFqns).toContain(domainlessTestCaseFqn);
+    });
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainIncidentIsolation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainIncidentIsolation.spec.ts
@@ -91,7 +91,13 @@ const openIncidentManager = async (page: Page): Promise<string[]> => {
 
   await waitForAllLoadersToDisappear(page);
 
-  await expect(page.getByTestId('incident-filter-bar')).toBeVisible();
+  // Confirms the page actually rendered the incident table rather than stalling on a loader
+  // or error state. `incident-filter-bar` (used for this on main) doesn't exist in 1.13's
+  // IncidentManager.component.tsx, so this asserts on the table itself instead — the same
+  // testid the per-row assertions below already rely on.
+  await expect(
+    page.getByTestId('test-case-incident-manager-table')
+  ).toBeVisible();
 
   const body = await response.json();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/domainIsolationUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/domainIsolationUtils.ts
@@ -1,0 +1,125 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { APIRequestContext, Page } from '@playwright/test';
+import { Domain } from '../support/domain/Domain';
+import { UserClass } from '../support/user/UserClass';
+
+// Issue #24180 — the seeded DomainOnlyAccessRole isolates a user to their assigned
+// domains (plus sub-domains and domainless entities). These helpers centralise the
+// role + domain binding and domain assignment used across the isolation specs.
+export const DOMAIN_ONLY_ACCESS_ROLE = 'DomainOnlyAccessRole';
+
+export const assignDomainOnlyAccess = async (
+  apiContext: APIRequestContext,
+  user: UserClass,
+  domains: Domain[]
+) => {
+  const roleResponse = await apiContext.get(
+    `/api/v1/roles/name/${DOMAIN_ONLY_ACCESS_ROLE}`
+  );
+  const domainOnlyRole = await roleResponse.json();
+
+  await user.patch({
+    apiContext,
+    patchData: [
+      {
+        op: 'add',
+        path: '/roles/-',
+        value: {
+          id: domainOnlyRole.id,
+          type: 'role',
+          name: domainOnlyRole.name,
+        },
+      },
+      {
+        op: 'add',
+        path: '/domains',
+        value: domains.map((domain) => ({
+          id: domain.responseData.id,
+          type: 'domain',
+          name: domain.responseData.name,
+          fullyQualifiedName: domain.responseData.fullyQualifiedName,
+        })),
+      },
+    ],
+  });
+};
+
+export const assignDomainToTable = async (
+  apiContext: APIRequestContext,
+  tableId: string,
+  domain: Domain
+) => {
+  await apiContext.patch(`/api/v1/tables/${tableId}`, {
+    data: [
+      {
+        op: 'add',
+        path: '/domains',
+        value: [
+          {
+            id: domain.responseData.id,
+            type: 'domain',
+            name: domain.responseData.name,
+            fullyQualifiedName: domain.responseData.fullyQualifiedName,
+          },
+        ],
+      },
+    ],
+    headers: { 'Content-Type': 'application/json-patch+json' },
+  });
+};
+
+export const safeDelete = async (deleteFn: () => Promise<unknown>) => {
+  try {
+    await deleteFn();
+  } catch (error) {
+    // Best-effort teardown: one failing delete should not block the rest.
+  }
+};
+
+const waitForDomainSearch = (page: Page, domain: Domain) =>
+  page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/v1/search/query') &&
+      response.url().includes(encodeURIComponent(domain.data.name))
+  );
+
+// The admin-facing domain views (navbar dropdown tree and the domains listing page) are
+// server-side paginated over every domain, so a freshly created domain can land off the
+// first page in a busy environment. Searching by name scopes the view to the target
+// domain before asserting, keeping the admin isolation specs deterministic.
+export const searchDomainInDropdownTree = async (
+  page: Page,
+  domain: Domain
+) => {
+  const searchResponse = waitForDomainSearch(page, domain);
+  await page
+    .getByTestId('domain-selectable-tree')
+    .getByTestId('searchbar')
+    .fill(domain.data.name);
+  await searchResponse;
+};
+
+// The domains listing search box rewrites the typed term before issuing the request, so the
+// encoded name is not a substring of the URL. Match the domain search request loosely (by
+// index) instead, mirroring the established selectDomain helper.
+export const searchDomainInListing = async (page: Page, domain: Domain) => {
+  const searchResponse = page.waitForResponse(
+    '/api/v1/search/query?q=*&index=domain*'
+  );
+  await page
+    .getByTestId('page-layout-v1')
+    .getByPlaceholder('Search')
+    .fill(domain.data.name);
+  await searchResponse;
+};

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/domainIsolationUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/domainIsolationUtils.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { APIRequestContext, Page } from '@playwright/test';
+import { APIRequestContext } from '@playwright/test';
 import { Domain } from '../support/domain/Domain';
 import { UserClass } from '../support/user/UserClass';
 
@@ -85,41 +85,4 @@ export const safeDelete = async (deleteFn: () => Promise<unknown>) => {
   } catch (error) {
     // Best-effort teardown: one failing delete should not block the rest.
   }
-};
-
-const waitForDomainSearch = (page: Page, domain: Domain) =>
-  page.waitForResponse(
-    (response) =>
-      response.url().includes('/api/v1/search/query') &&
-      response.url().includes(encodeURIComponent(domain.data.name))
-  );
-
-// The admin-facing domain views (navbar dropdown tree and the domains listing page) are
-// server-side paginated over every domain, so a freshly created domain can land off the
-// first page in a busy environment. Searching by name scopes the view to the target
-// domain before asserting, keeping the admin isolation specs deterministic.
-export const searchDomainInDropdownTree = async (
-  page: Page,
-  domain: Domain
-) => {
-  const searchResponse = waitForDomainSearch(page, domain);
-  await page
-    .getByTestId('domain-selectable-tree')
-    .getByTestId('searchbar')
-    .fill(domain.data.name);
-  await searchResponse;
-};
-
-// The domains listing search box rewrites the typed term before issuing the request, so the
-// encoded name is not a substring of the URL. Match the domain search request loosely (by
-// index) instead, mirroring the established selectDomain helper.
-export const searchDomainInListing = async (page: Page, domain: Domain) => {
-  const searchResponse = page.waitForResponse(
-    '/api/v1/search/query?q=*&index=domain*'
-  );
-  await page
-    .getByTestId('page-layout-v1')
-    .getByPlaceholder('Search')
-    .fill(domain.data.name);
-  await searchResponse;
 };

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
@@ -15,9 +15,84 @@ import { SidebarItem } from '../constant/sidebar';
 import { ResponseDataType } from '../support/entity/Entity.interface';
 import { TableClass } from '../support/entity/TableClass';
 import { redirectToHomePage } from './common';
+import { getCurrentMillis } from './dateTime';
 import { waitForAllLoadersToDisappear } from './entity';
 import { makeRetryRequest } from './serviceIngestion';
 import { sidebarClick } from './sidebar';
+
+/**
+ * Seeds `count` failing test cases on `table`, each of which produces an
+ * incident, WITHOUT deploying or running an ingestion pipeline. A failed test
+ * case result is posted directly via the API, which is what actually creates an
+ * incident — the pipeline is only one way to produce that result.
+ *
+ * Use this for tests that just need incidents to exist (UI, pagination,
+ * filters). It is deterministic and takes seconds, so those tests no longer
+ * depend on Airflow or queue behaviour. Tests that verify pipeline behaviour
+ * (e.g. re-running a pipeline resolves an incident) must still use a real
+ * pipeline via triggerTestSuitePipelineAndWaitForSuccess.
+ *
+ * Returns the created test cases (in creation order).
+ */
+export const seedFailedIncidents = async (data: {
+  apiContext: APIRequestContext;
+  table: TableClass;
+  count: number;
+}): Promise<ResponseDataType[]> => {
+  const { apiContext, table, count } = data;
+  const failTimestamp = getCurrentMillis();
+  const testCases: ResponseDataType[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const testCase = await table.createTestCase(apiContext);
+    await table.addTestCaseResult(apiContext, testCase['fullyQualifiedName'], {
+      result: 'Seeded failing result to create an incident.',
+      testResultValue: [{ name: 'seeded', value: '0' }],
+      testCaseStatus: 'Failed',
+      timestamp: failTimestamp,
+    });
+    testCases.push(testCase);
+  }
+
+  // Wait until ALL seeded incidents are indexed, not just the last — Elasticsearch
+  // indexing is not ordered, so an earlier incident can still be missing when the
+  // last one is searchable, which would under-fill the list and defeat the point.
+  // Polled through /search/list (not the base, DB-backed listing endpoint) since
+  // that is the search-indexed path the Incident Manager page itself reads from.
+  const seededFqns = new Set(
+    testCases.map((testCase) => testCase['fullyQualifiedName'])
+  );
+  await expect
+    .poll(
+      async () => {
+        const response = await apiContext.get(
+          `/api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list?latest=true` +
+            `&startTs=${failTimestamp - 60_000}` +
+            `&endTs=${failTimestamp + 120_000}` +
+            `&limit=${count + 50}`
+        );
+
+        if (!response.ok()) {
+          return 0;
+        }
+
+        const body = await response.json();
+        const indexedFqns = new Set(
+          (body.data ?? []).map(
+            (incident: {
+              testCaseReference?: { fullyQualifiedName?: string };
+            }) => incident.testCaseReference?.fullyQualifiedName
+          )
+        );
+
+        return [...seededFqns].filter((fqn) => indexedFqns.has(fqn)).length;
+      },
+      { timeout: 90_000, intervals: [2_000, 3_000, 5_000] }
+    )
+    .toBeGreaterThanOrEqual(count);
+
+  return testCases;
+};
 
 export const visitProfilerTab = async (page: Page, table: TableClass) => {
   await redirectToHomePage(page);


### PR DESCRIPTION
### Describe your changes:

Fixes #31740

1.13 backport of #31741.

A domain-restricted user saw failed test case incidents from **every** domain on the Incident Manager page. Opening one was correctly blocked, but the listed row already leaked the test case name, the table name and the full FQN.

`RuleEvaluator#hasDomain` short-circuits to `true` for list operations (a listing has no single resource to evaluate the condition against) and defers enforcement to search-side RBAC filtering. The two search-backed listing paths in `EntityTimeSeriesRepository` never received a `SubjectContext`, so that filtering never ran and no policy could restrict the listing — including with `enableSearchAccessControl` on.

This threads the caller's `SubjectContext` through both paths so the existing RBAC search machinery filters the query, same approach as the upstream fix.

#### Not a straight cherry-pick

`8df0bb573d` doesn't apply cleanly to `1.13`:

- `ElasticSearchAggregationManager` / `OpenSearchAggregationManager` have diverged from `main` — 1.13 doesn't have the "ContextMemory" feature main's `aggregate()` wraps queries with (`restrictToOrgWideMemories`). The `SubjectContext`-aware `aggregate()` overload and its `applyRbacQuery` helper are hand-adapted onto 1.13's actual (undiverged) `aggregate()` implementation instead of reusing main's refactor verbatim.
- The upstream PR's `DomainIsolationIT.java` depends on test infrastructure from #24180 that was never backported to `1.13` (the file doesn't exist on this branch). This adds a standalone `IncidentManagerDomainIsolationIT` instead, following the `enableSearchAccessControl`/`restoreSearchAccessControl` + `TestNamespace` pattern already established by `MultiDomainHasDomainIT` on `1.13`.
- All other touched backend files (`EntityTimeSeriesRepository`, `TestCaseResolutionStatusResource`, `SearchRepository`, `AggregationManagementClient`, `ElasticSearchClient`, `OpenSearchClient`) matched `1.13`'s current code closely enough to apply the same change directly.

`TestCaseResolutionStatusResource` on `1.13` has two `GET` listings worth noting since they're easy to conflate: the base path (`repository.list`, DB-backed via `ListFilter`/JDBI — not touched by this fix, and known to silently ignore its own `domain` query param, a separate pre-existing bug out of scope here) and `/search/list` (`repository.listFromSearchWithOffset` / `listLatestFromSearch` — the `SubjectContext`-aware path this fix actually changes, and what the Incident Manager UI page calls).

#### Playwright

Initially left out on the assumption it needed new CI lane wiring, based on a pattern from an unrelated ImportExport-lane investigation on a different branch. That doesn't apply to `1.13`: this branch has no impact-map/path-filter test-selection layer — `playwright-postgresql-e2e.yml` triggers on any non-`paths-ignore`d change and runs the full `chromium` project (the default project, no explicit `testMatch`) across a fixed 6-way shard, so any new spec under `playwright/e2e/Features/**` is picked up automatically. The `DomainIsolation` project in `playwright.config.ts` is an unrelated compatibility shim for `--project=DomainIsolation` invocations and doesn't gate this.

Added `DomainIncidentIsolation.spec.ts` (1.13 port of main's spec), plus its two missing dependencies:
- `utils/domainIsolationUtils.ts` — ported verbatim.
- `incidentManager.ts#seedFailedIncidents` — adapted to poll `/search/list` instead of the base path, since that's the endpoint the spec's assertions and this fix both depend on (polling the base, DB-backed path wouldn't actually confirm Elasticsearch indexing).

The rest of main's `DomainIsolation` suite (search/lineage/task/dropdown/listing isolation) still depends on `#24180` infrastructure not backported to `1.13` and remains out of scope.

#
### Type of change:
- [x] Bug fix

#
### Tests:

#### Backend integration tests
- [x] Added `IncidentManagerDomainIsolationIT#test_incidentListing_restrictedUserSeesOnlyOwnDomainIncidents` in `openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentManagerDomainIsolationIT.java`. Seeds two domains, a domain-restricted user (`DomainOnlyAccessRole`), and incidents in each domain; asserts `/search/list` is filtered for both `latest=false` and `latest=true` — the aggregation path that carried the same gap.

Not yet run against a live server in this session; this is its first execution in CI. It's a standard `*IT.java` under `openmetadata-integration-tests`, picked up automatically by the existing Maven integration-test phase.

#### Playwright (UI) tests
- [x] Added `openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainIncidentIsolation.spec.ts`, ported from main. Runs under the default `chromium` project — no new CI lane needed (see above).

#### Manual testing performed
Verified `mvn compile` / `mvn test-compile` succeed for `openmetadata-service` and `openmetadata-integration-tests`, `mvn spotless:apply` makes no further changes, `yarn tsc:playwright` shows no new type errors from the added/modified files, and `eslint`/`prettier` pass clean on them. Not run against a live server in this session.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable, no schema changes.
- [x] For UI changes: Playwright spec added, see above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

Bug fix:
- [x] I have added a test that covers the exact scenario we are fixing, adapted to what already exists on `1.13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)










<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport threads the authenticated subject through time-series search and aggregation paths so Incident Manager listings honor caller policies.
- Adds subject-aware search and aggregation overloads for Elasticsearch and OpenSearch.
- Passes the request subject from the incident-status resource into both normal and latest-result listings.
- Adds backend and Playwright coverage for domain-isolated incident listings.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResolutionStatusResource.java | Resolves the caller subject and supplies it to both search-backed incident listing branches. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesRepository.java | Adds subject-aware overloads for offset and latest aggregation searches while retaining compatibility overloads. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchAggregationManager.java | Applies the caller's RBAC query to Elasticsearch aggregation requests. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchAggregationManager.java | Applies equivalent caller-policy filtering to OpenSearch aggregation requests. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainIncidentIsolation.spec.ts | Covers Incident Manager visibility for a domain-restricted user through the UI. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentManagerDomainIsolationIT.java | Exercises both normal and latest incident-listing paths with domain-restricted credentials. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as Restricted caller
  participant R as Incident status resource
  participant T as Time-series repository
  participant S as Search repository
  participant A as Search aggregation manager
  U->>R: GET /search/list
  R->>R: Resolve SubjectContext
  alt "latest=false"
    R->>T: listFromSearchWithOffset(..., subject)
    T->>S: listWithOffset(..., subject)
    S-->>U: Policy-filtered incidents
  else "latest=true"
    R->>T: listLatestFromSearch(..., subject)
    T->>S: aggregate(..., subject)
    S->>A: Apply RBAC query
    A-->>U: Policy-filtered latest incidents
  end
```
</details>

<sub>Reviews (6): Last reviewed commit: ["Serialize IT tests that mutate global se..."](https://github.com/open-metadata/openmetadata/commit/f3ba8c97073a2d793715f25db2e8005b59ce94fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56152369)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Metadata platform service](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/metadata-platform-service.md)
- Knowledge Base — [Service API resources](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/service-api-resources.md)
- Knowledge Base — [Platform security and governance](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/platform-security-governance.md)
</details>


<!-- /greptile_comment -->