### PR TITLE
Fixes 30929: Add Data Product as a top-level Explore filter

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreQuickFilters.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreQuickFilters.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import test, { expect } from '@playwright/test';
+import test, { APIRequestContext, expect } from '@playwright/test';
 import { SidebarItem } from '../../constant/sidebar';
 import { DataProduct } from '../../support/domain/DataProduct';
 import { Domain } from '../../support/domain/Domain';
@@ -47,6 +47,38 @@ const tierWithoutAsset = new TagClass({
   classification: 'Tier',
 });
 let user: UserClass;
+
+// Adding an asset to a data product updates the asset's search document
+// asynchronously, and the Data Products dropdown reads its options from that
+// aggregation — so the option only exists once the table doc carries the link.
+const waitForDataProductOnAsset = async (
+  apiContext: APIRequestContext,
+  assetFqn: string,
+  dataProductName: string
+) => {
+  await expect
+    .poll(
+      async () => {
+        const response = await apiContext.get(
+          `/api/v1/search/query?q=${encodeURIComponent(
+            `"${assetFqn}"`
+          )}&index=table&from=0&size=1`
+        );
+
+        if (!response.ok()) {
+          return false;
+        }
+
+        const data = await response.json();
+        const dataProducts: { name?: string }[] =
+          data?.hits?.hits?.[0]?._source?.dataProducts ?? [];
+
+        return dataProducts.some((product) => product.name === dataProductName);
+      },
+      { timeout: 60_000, intervals: [1_000, 2_000, 5_000] }
+    )
+    .toBe(true);
+};
 
 test.beforeAll('Setup pre-requests', async ({ browser }) => {
   test.slow();
@@ -103,6 +135,11 @@ test.beforeAll('Setup pre-requests', async ({ browser }) => {
   await dataProduct.addAssets(apiContext, [
     { id: table.entityResponseData.id, type: 'table' },
   ]);
+  await waitForDataProductOnAsset(
+    apiContext,
+    table.entityResponseData.fullyQualifiedName,
+    dataProduct.data.name
+  );
 
   await afterAction();
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreQuickFilters.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreQuickFilters.spec.ts
@@ -12,6 +12,7 @@
  */
 import test, { expect } from '@playwright/test';
 import { SidebarItem } from '../../constant/sidebar';
+import { DataProduct } from '../../support/domain/DataProduct';
 import { Domain } from '../../support/domain/Domain';
 import { MetricClass } from '../../support/entity/MetricClass';
 import { TableClass } from '../../support/entity/TableClass';
@@ -24,7 +25,11 @@ import {
   redirectToHomePage,
 } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
-import { searchAndClickOnOption, selectNullOption } from '../../utils/explore';
+import {
+  clickUpdateButtonIfVisible,
+  searchAndClickOnOption,
+  selectNullOption,
+} from '../../utils/explore';
 import { sidebarClick } from '../../utils/sidebar';
 
 // use the admin user to login
@@ -32,6 +37,7 @@ test.use({ storageState: 'playwright/.auth/admin.json' });
 test.describe.configure({ mode: 'default' });
 
 const domain = new Domain();
+const dataProduct = new DataProduct([domain]);
 const table = new TableClass();
 const tier = new TagClass({
   classification: 'Tier',
@@ -90,11 +96,20 @@ test.beforeAll('Setup pre-requests', async ({ browser }) => {
       },
     ],
   });
+
+  // The data product is created after the table is patched with its domain so
+  // the asset already belongs to the domain the data product lives in.
+  await dataProduct.create(apiContext);
+  await dataProduct.addAssets(apiContext, [
+    { id: table.entityResponseData.id, type: 'table' },
+  ]);
+
   await afterAction();
 });
 
 test.afterAll('Cleanup', async ({ browser }) => {
   const { apiContext, afterAction } = await createNewPage(browser);
+  await dataProduct.delete(apiContext);
   await user.delete(apiContext);
   await afterAction();
 });
@@ -144,6 +159,10 @@ test('should search for empty or null filters', async ({ page }) => {
     { label: 'Owners', key: 'ownerDisplayName' },
     { label: 'Tag', key: 'tags.tagFQN' },
     { label: 'Domains', key: 'domains.displayName.keyword' },
+    {
+      label: 'Data Products',
+      key: 'dataProducts.displayName.keyword',
+    },
     { label: 'Tier', key: 'tier.tagFQN' },
   ];
 
@@ -201,6 +220,33 @@ test('should search for multiple values along with null filters', async ({
   for (const filter of items) {
     await selectNullOption(page, filter);
   }
+});
+
+test('should filter assets by data product', async ({ page }) => {
+  const filter = {
+    label: 'Data Products',
+    key: 'dataProducts.displayName.keyword',
+    // addAssets overwrites responseData with the bulk-operation report, so the
+    // display name is read from the create payload instead.
+    value: dataProduct.data.displayName,
+  };
+
+  await page.click(`[data-testid="search-dropdown-${filter.label}"]`);
+  await searchAndClickOnOption(page, filter, true);
+  await clickUpdateButtonIfVisible(page);
+  await waitForAllLoadersToDisappear(page);
+
+  await expect(
+    page.getByTestId(`search-dropdown-${filter.label}`)
+  ).toContainText('(1)');
+
+  await expect(
+    page.getByTestId(
+      `table-data-card_${table.entityResponseData.fullyQualifiedName}`
+    )
+  ).toBeVisible();
+
+  await page.getByTestId('clear-all-chips').click();
 });
 
 test('should persist quick filter on global search', async ({ page }) => {

--- a/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
@@ -24,6 +24,11 @@ export const COMMON_DROPDOWN_ITEMS = [
     sourceFields: 'domains.displayName',
   },
   {
+    label: 'label.data-product-plural',
+    key: EntityFields.DATA_PRODUCT,
+    sourceFields: 'dataProducts.displayName',
+  },
+  {
     label: 'label.owner-plural',
     key: EntityFields.OWNERS,
     sourceFields: 'ownerDisplayName',
@@ -59,6 +64,11 @@ export const DATA_ASSET_DROPDOWN_ITEMS = [
     label: 'label.domain-plural',
     key: EntityFields.DOMAINS,
     sourceFields: 'domains.displayName',
+  },
+  {
+    label: 'label.data-product-plural',
+    key: EntityFields.DATA_PRODUCT,
+    sourceFields: 'dataProducts.displayName',
   },
   {
     label: 'label.owner-plural',

--- a/openmetadata-ui/src/main/resources/ui/src/constants/explore.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/explore.constants.ts
@@ -27,6 +27,7 @@ export const MAX_RESULT_HITS = 10000;
 export const SUPPORTED_EMPTY_FILTER_FIELDS = [
   EntityFields.OWNERS,
   EntityFields.DOMAINS,
+  EntityFields.DATA_PRODUCT,
   EntityFields.TIER,
   EntityFields.TAG,
   EntityFields.CERTIFICATION,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SearchClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SearchClassBase.test.ts
@@ -25,6 +25,7 @@ import {
   TAG_DROPDOWN_ITEMS,
   TOPIC_DROPDOWN_ITEMS,
 } from '../constants/AdvancedSearch.constants';
+import { EntityFields } from '../enums/AdvancedSearch.enum';
 import { EntityType } from '../enums/entity.enum';
 import { SearchIndex } from '../enums/search.enum';
 import { Chart } from '../generated/entity/data/chart';
@@ -224,6 +225,21 @@ describe('SearchClassBase', () => {
     expect(databaseItems).toEqual(COMMON_DROPDOWN_ITEMS);
     expect(databaseSchemaItems).toEqual(COMMON_DROPDOWN_ITEMS);
     expect(apiCollectionItems).toEqual(COMMON_DROPDOWN_ITEMS);
+  });
+
+  it('should expose the data product quick filter for asset indices', () => {
+    const dataProductFilter = {
+      label: 'label.data-product-plural',
+      key: EntityFields.DATA_PRODUCT,
+      sourceFields: 'dataProducts.displayName',
+    };
+
+    expect(searchClassBase.getDropDownItems(SearchIndex.TABLE)).toContainEqual(
+      dataProductFilter
+    );
+    expect(
+      searchClassBase.getDropDownItems(SearchIndex.DATA_ASSET)
+    ).toContainEqual(dataProductFilter);
   });
 
   it('should return empty dropdown item based if index not related to explore items', () => {


### PR DESCRIPTION
### Describe your changes:

Fixes #30929

Data Product could only be filtered from Advanced Search. I added it as a top-level Explore quick filter so it sits next to Domain, Owner, Tag and Tier.

- `COMMON_DROPDOWN_ITEMS` and `DATA_ASSET_DROPDOWN_ITEMS` now carry a `label.data-product-plural` entry keyed on `EntityFields.DATA_PRODUCT` (`dataProducts.displayName.keyword`).
- `SUPPORTED_EMPTY_FILTER_FIELDS` gains `DATA_PRODUCT`, so the dropdown also offers the "No Data Products" (`must_not exists`) option like Domain/Tier/Tag do.
- The field is `keyword` with a `lowercase_normalizer` in the index mappings, so the item declares `sourceFields: 'dataProducts.displayName'` — exactly what the Domain filter does — and `getOptionsFromAggregationBucket` recovers the properly cased display name from the aggregation top hit instead of showing the lowercased bucket key.

No backend change is needed: `dataProducts.displayName.keyword` is not in the global aggregation list, and `ExploreQuickFilters` already falls back to `/api/v1/search/aggregate?field=<key>` for any facet the page aggregations don't carry (which is the path every `sourceFields` filter takes anyway, Domain included). Filter application is generic — `getExploreQueryFilterMust` builds the `term` / `must_not exists` clauses from the field key.

https://github.com/user-attachments/assets/f38eac13-4784-469d-b1a6-785da226736c



https://github.com/user-attachments/assets/7d6d9b83-48e0-451f-ab88-69d27dcb7ca7



#
### Type of change:
- [x] New feature

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- On Explore, a user opens the **Data Products** dropdown and sees the data products present in
  the current result scope, with proper casing and counts.
- Selecting a data product narrows results to the assets in it.
- Selecting **No Data Products** returns assets that have no data product assigned.

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Files added/updated: `openmetadata-ui/src/main/resources/ui/src/utils/SearchClassBase.test.ts`
  (asserts the Data Product filter is exposed for the `table` and `dataAsset` indices)

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] I added Playwright E2E tests for UI changes.
- Files added/updated: `openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreQuickFilters.spec.ts`
  - new `should filter assets by data product` test (creates a data product in the fixture domain,
    adds the fixture table to it, filters Explore by it and asserts the asset card)
  - `should search for empty or null filters` now also covers `Data Products`

#### Manual testing performed
Not yet run against a local stack — reviewer-facing verification below is what I ran:
- `npx jest src/utils/SearchClassBase.test.ts src/components/Explore src/components/ExploreV1` → 290 passed, 4 skipped
- `npx jest src/utils/AdvancedSearchUtils src/components/Glossary/GlossaryTerms/tabs src/components/SearchDropdown` → 141 passed
- ESLint + Prettier clean on all changed files; `tsc --noEmit` reports no errors in the changed files

#
### UI screen recording / screenshots:

Pending — will attach a recording of the Data Products dropdown on Explore.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My PR is linked to a GitHub issue via `Fixes #30929` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit + Playwright) and listed them above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds Data Product as a top-level Explore quick filter, including support for filtering assets without an assigned data product.
- Adds the Data Products facet to common and aggregate asset dropdown definitions.
- Enables the empty-value option for the Data Product field.
- Adds unit and Playwright coverage for facet exposure, selection, and empty filtering.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts | Adds the Data Products facet and its display-name source field to common and data-asset quick-filter definitions. |
| openmetadata-ui/src/main/resources/ui/src/constants/explore.constants.ts | Enables the generic empty-value filtering behavior for Data Products. |
| openmetadata-ui/src/main/resources/ui/src/utils/SearchClassBase.test.ts | Verifies that table and aggregate data-asset scopes expose the new quick filter. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreQuickFilters.spec.ts | Adds fixture setup, indexing synchronization, and end-to-end coverage for Data Product filtering. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): wait for the data product link..."](https://github.com/open-metadata/openmetadata/commit/fd74c01af60a754abc26c604fddbb8e57d6b8974) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56166546)</sub>

<!-- /greptile_comment -->