### PR TITLE
fix(glossary): reject field edits to system-defined relation types via generic settings PUT (#31865) [1.13 backport]

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationSettingsIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationSettingsIT.java
@@ -467,6 +467,88 @@ public class GlossaryTermRelationSettingsIT {
   }
 
   @Test
+  void test_systemDefinedRelationTypeFieldCannotBeModified() throws Exception {
+    synchronized (SETTINGS_LOCK) {
+      JsonNode currentSettings = getSettings();
+      ArrayNode relationTypes =
+          (ArrayNode) currentSettings.get("config_value").get("relationTypes");
+
+      boolean toggled = false;
+      boolean originalIsTransitive = false;
+      for (JsonNode type : relationTypes) {
+        if ("partOf".equals(type.get("name").asText())) {
+          JsonNode sys = type.get("isSystemDefined");
+          assertTrue(sys != null && sys.asBoolean(), "'partOf' should be system-defined");
+          originalIsTransitive = type.get("isTransitive").asBoolean();
+          ((ObjectNode) type).put("isTransitive", !originalIsTransitive);
+          toggled = true;
+          break;
+        }
+      }
+      assertTrue(toggled, "'partOf' should exist in default settings");
+
+      ObjectNode modifiedSettings = MAPPER.createObjectNode();
+      modifiedSettings.set("relationTypes", relationTypes);
+      int status = updateSettingsAndGetStatus(modifiedSettings);
+      assertTrue(
+          status >= 400,
+          "Editing a field of system-defined 'partOf' via settings PUT must be rejected. Got: "
+              + status);
+
+      JsonNode after = getSettings();
+      for (JsonNode type : after.get("config_value").get("relationTypes")) {
+        if ("partOf".equals(type.get("name").asText())) {
+          assertEquals(
+              originalIsTransitive,
+              type.get("isTransitive").asBoolean(),
+              "'partOf' isTransitive must be unchanged after a rejected edit");
+        }
+      }
+    }
+  }
+
+  @Test
+  void test_cannotCreateSystemDefinedRelationTypeViaSettingsPut() throws Exception {
+    synchronized (SETTINGS_LOCK) {
+      String fakeName = "fakeSystem" + System.currentTimeMillis();
+
+      JsonNode currentSettings = getSettings();
+      ArrayNode relationTypes =
+          (ArrayNode) currentSettings.get("config_value").get("relationTypes");
+
+      ObjectNode fakeType = MAPPER.createObjectNode();
+      fakeType.put("name", fakeName);
+      fakeType.put("displayName", "Fake System Type");
+      fakeType.put("isSymmetric", false);
+      fakeType.put("isTransitive", false);
+      fakeType.put("isCrossGlossaryAllowed", true);
+      fakeType.put("category", "associative");
+      fakeType.put("isSystemDefined", true);
+      fakeType.put("color", "#22c55e");
+      fakeType.put("cardinality", "MANY_TO_MANY");
+      relationTypes.add(fakeType);
+
+      ObjectNode newSettings = MAPPER.createObjectNode();
+      newSettings.set("relationTypes", relationTypes);
+      int status = updateSettingsAndGetStatus(newSettings);
+      assertTrue(
+          status >= 400,
+          "Creating a system-defined relation type via settings PUT must be rejected. Got: "
+              + status);
+
+      JsonNode after = getSettings();
+      boolean present = false;
+      for (JsonNode type : after.get("config_value").get("relationTypes")) {
+        if (fakeName.equals(type.get("name").asText())) {
+          present = true;
+          break;
+        }
+      }
+      assertFalse(present, "Fabricated system-defined type must not be persisted");
+    }
+  }
+
+  @Test
   void test_systemDefinedRelationTypesHaveCorrectDesignSystemColors() throws Exception {
     JsonNode settings = getSettings();
     JsonNode relationTypes = settings.get("config_value").get("relationTypes");

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtil.java
@@ -14,13 +14,17 @@
 package org.openmetadata.service.util;
 
 import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import org.openmetadata.schema.configuration.GlossaryTermRelationSettings;
 import org.openmetadata.schema.configuration.GlossaryTermRelationType;
 import org.openmetadata.schema.configuration.RelationCardinality;
+import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.exception.SystemSettingsException;
 
 public final class GlossaryTermRelationSettingsUtil {
@@ -87,32 +91,112 @@ public final class GlossaryTermRelationSettingsUtil {
     }
   }
 
+  /**
+   * Enforces the immutability contract for seeded (system-defined) relation types on the generic
+   * settings-update path. System-defined types cannot be removed or downgraded, no new type may be
+   * flagged as system-defined (create/promote), and an existing system-defined type's fields cannot
+   * be edited. Custom relation types are unaffected. The dedicated relationTypes endpoint and the UI
+   * already enforce this; this covers the remaining generic {@code PUT /system/settings} path.
+   */
   public static void validateSystemDefinedRelationTypesPreserved(
       GlossaryTermRelationSettings current, GlossaryTermRelationSettings updated) {
     if (current == null || current.getRelationTypes() == null) {
       return;
     }
 
-    Set<String> updatedSystemDefinedNames = new HashSet<>();
-    if (updated != null && updated.getRelationTypes() != null) {
-      for (GlossaryTermRelationType relationType : updated.getRelationTypes()) {
-        if (relationType != null && Boolean.TRUE.equals(relationType.getIsSystemDefined())) {
-          updatedSystemDefinedNames.add(relationType.getName());
-        }
+    Map<String, GlossaryTermRelationType> updatedByName = indexByName(updated);
+    validateNoSystemDefinedRemoved(current, updatedByName);
+    validateNoUnsanctionedSystemDefined(current, updated);
+    validateSystemDefinedUnmodified(current, updatedByName);
+  }
+
+  private static Map<String, GlossaryTermRelationType> indexByName(
+      GlossaryTermRelationSettings settings) {
+    Map<String, GlossaryTermRelationType> byName = new HashMap<>();
+    if (settings == null || settings.getRelationTypes() == null) {
+      return byName;
+    }
+    for (GlossaryTermRelationType relationType : settings.getRelationTypes()) {
+      if (relationType != null && relationType.getName() != null) {
+        byName.put(relationType.getName(), relationType);
       }
     }
+    return byName;
+  }
 
-    List<String> missingSystemDefinedNames =
-        current.getRelationTypes().stream()
-            .filter(relationType -> Boolean.TRUE.equals(relationType.getIsSystemDefined()))
-            .map(GlossaryTermRelationType::getName)
-            .filter(name -> !updatedSystemDefinedNames.contains(name))
-            .toList();
-    if (!missingSystemDefinedNames.isEmpty()) {
-      throw new SystemSettingsException(
-          "Cannot delete system-defined relation types: "
-              + String.join(", ", missingSystemDefinedNames));
+  private static void validateNoSystemDefinedRemoved(
+      GlossaryTermRelationSettings current, Map<String, GlossaryTermRelationType> updatedByName) {
+    List<String> removed = new ArrayList<>();
+    for (GlossaryTermRelationType currentType : current.getRelationTypes()) {
+      if (!Boolean.TRUE.equals(currentType.getIsSystemDefined())) {
+        continue;
+      }
+      GlossaryTermRelationType updatedType = updatedByName.get(currentType.getName());
+      if (updatedType == null || !Boolean.TRUE.equals(updatedType.getIsSystemDefined())) {
+        removed.add(currentType.getName());
+      }
     }
+    if (!removed.isEmpty()) {
+      throw new SystemSettingsException(
+          "Cannot delete system-defined relation types: " + String.join(", ", removed));
+    }
+  }
+
+  private static void validateNoUnsanctionedSystemDefined(
+      GlossaryTermRelationSettings current, GlossaryTermRelationSettings updated) {
+    if (updated == null || updated.getRelationTypes() == null) {
+      return;
+    }
+    Set<String> currentSystemDefinedNames = new HashSet<>();
+    for (GlossaryTermRelationType relationType : current.getRelationTypes()) {
+      if (Boolean.TRUE.equals(relationType.getIsSystemDefined())) {
+        currentSystemDefinedNames.add(relationType.getName());
+      }
+    }
+    List<String> unsanctioned = new ArrayList<>();
+    for (GlossaryTermRelationType updatedType : updated.getRelationTypes()) {
+      if (updatedType != null
+          && Boolean.TRUE.equals(updatedType.getIsSystemDefined())
+          && !currentSystemDefinedNames.contains(updatedType.getName())) {
+        unsanctioned.add(updatedType.getName());
+      }
+    }
+    if (!unsanctioned.isEmpty()) {
+      throw new SystemSettingsException(
+          "Cannot create or promote system-defined relation types: "
+              + String.join(", ", unsanctioned));
+    }
+  }
+
+  private static void validateSystemDefinedUnmodified(
+      GlossaryTermRelationSettings current, Map<String, GlossaryTermRelationType> updatedByName) {
+    List<String> modified = new ArrayList<>();
+    for (GlossaryTermRelationType currentType : current.getRelationTypes()) {
+      if (!Boolean.TRUE.equals(currentType.getIsSystemDefined())) {
+        continue;
+      }
+      GlossaryTermRelationType updatedType = updatedByName.get(currentType.getName());
+      if (updatedType != null && isRelationTypeModified(currentType, updatedType)) {
+        modified.add(currentType.getName());
+      }
+    }
+    if (!modified.isEmpty()) {
+      throw new SystemSettingsException(
+          "Cannot modify system-defined relation types: " + String.join(", ", modified));
+    }
+  }
+
+  private static boolean isRelationTypeModified(
+      GlossaryTermRelationType current, GlossaryTermRelationType updated) {
+    // Compare normalized copies so derived cardinality fields (sourceMax/targetMax) don't
+    // register as spurious edits when the stored value predates normalization.
+    GlossaryTermRelationType currentCopy =
+        JsonUtils.deepCopy(current, GlossaryTermRelationType.class);
+    GlossaryTermRelationType updatedCopy =
+        JsonUtils.deepCopy(updated, GlossaryTermRelationType.class);
+    normalize(currentCopy);
+    normalize(updatedCopy);
+    return !JsonUtils.valueToTree(currentCopy).equals(JsonUtils.valueToTree(updatedCopy));
   }
 
   private static RelationCardinality deriveCardinality(Integer sourceMax, Integer targetMax) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtilTest.java
@@ -93,6 +93,109 @@ class GlossaryTermRelationSettingsUtilTest {
                 current, updated));
   }
 
+  @Test
+  void validateSystemDefinedRelationTypesRejectsFieldModification() {
+    GlossaryTermRelationSettings current =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(
+                List.of(relationType("partOf").withIsSystemDefined(true).withIsTransitive(false)));
+    GlossaryTermRelationSettings updated =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(
+                List.of(relationType("partOf").withIsSystemDefined(true).withIsTransitive(true)));
+
+    SystemSettingsException exception =
+        assertThrows(
+            SystemSettingsException.class,
+            () ->
+                GlossaryTermRelationSettingsUtil.validateSystemDefinedRelationTypesPreserved(
+                    current, updated));
+
+    assertEquals("Cannot modify system-defined relation types: partOf", exception.getMessage());
+  }
+
+  @Test
+  void validateSystemDefinedRelationTypesRejectsNewSystemDefinedType() {
+    GlossaryTermRelationSettings current =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(List.of(relationType("partOf").withIsSystemDefined(true)));
+    GlossaryTermRelationSettings updated =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(
+                List.of(
+                    relationType("partOf").withIsSystemDefined(true),
+                    relationType("fakeSys").withIsSystemDefined(true)));
+
+    SystemSettingsException exception =
+        assertThrows(
+            SystemSettingsException.class,
+            () ->
+                GlossaryTermRelationSettingsUtil.validateSystemDefinedRelationTypesPreserved(
+                    current, updated));
+
+    assertEquals(
+        "Cannot create or promote system-defined relation types: fakeSys", exception.getMessage());
+  }
+
+  @Test
+  void validateSystemDefinedRelationTypesRejectsPromotionOfCustomType() {
+    GlossaryTermRelationSettings current =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(
+                List.of(
+                    relationType("partOf").withIsSystemDefined(true),
+                    relationType("dependsOn").withIsSystemDefined(false)));
+    GlossaryTermRelationSettings updated =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(
+                List.of(
+                    relationType("partOf").withIsSystemDefined(true),
+                    relationType("dependsOn").withIsSystemDefined(true)));
+
+    SystemSettingsException exception =
+        assertThrows(
+            SystemSettingsException.class,
+            () ->
+                GlossaryTermRelationSettingsUtil.validateSystemDefinedRelationTypesPreserved(
+                    current, updated));
+
+    assertEquals(
+        "Cannot create or promote system-defined relation types: dependsOn",
+        exception.getMessage());
+  }
+
+  @Test
+  void validateSystemDefinedRelationTypesAllowsCustomTypeModification() {
+    GlossaryTermRelationSettings current =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(
+                List.of(
+                    relationType("dependsOn").withIsSystemDefined(false).withIsTransitive(false)));
+    GlossaryTermRelationSettings updated =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(
+                List.of(
+                    relationType("dependsOn").withIsSystemDefined(false).withIsTransitive(true)));
+
+    // Custom (non system-defined) relation types remain fully editable.
+    GlossaryTermRelationSettingsUtil.validateSystemDefinedRelationTypesPreserved(current, updated);
+  }
+
+  @Test
+  void validateSystemDefinedRelationTypesAllowsUnchangedSystemType() {
+    GlossaryTermRelationSettings current =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(
+                List.of(relationType("partOf").withIsSystemDefined(true).withIsTransitive(false)));
+    GlossaryTermRelationSettings updated =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(
+                List.of(relationType("partOf").withIsSystemDefined(true).withIsTransitive(false)));
+
+    // Re-saving system-defined types unchanged (e.g. alongside a new custom type) must be allowed.
+    GlossaryTermRelationSettingsUtil.validateSystemDefinedRelationTypesPreserved(current, updated);
+  }
+
   private GlossaryTermRelationType relationType(String name) {
     return new GlossaryTermRelationType().withName(name);
   }


### PR DESCRIPTION
Backport of #31865 to the `1.13` branch.

Enforces the immutability contract for seeded (system-defined) glossary relation types on the generic `PUT /v1/system/settings` path: they cannot be edited, renamed, removed, or downgraded, and no new type may be created or promoted to system-defined. Custom relation types remain fully editable.

The service fix and unit tests cherry-picked cleanly from the squashed merge commit `c38c8c0`. The integration test had to be adapted to the `1.13` harness (which uses `synchronized (SETTINGS_LOCK)` blocks rather than the `@ResourceLock` annotations used on `main`); the two new cases are otherwise identical.

Verified on `1.13`: `GlossaryTermRelationSettingsUtilTest` → `Tests run: 9, Failures: 0`; `GlossaryTermRelationSettingsIT` compiles.

Original PR: #31865 · Issue: #31864


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR strengthens glossary relation-type validation on generic system-settings updates so seeded types cannot be edited, removed, downgraded, created, or promoted, while custom types remain editable.
- Indexes submitted relation types and validates preservation of existing system-defined entries.
- Compares normalized copies to distinguish field edits from derived cardinality differences.
- Adds unit and integration coverage for field modification, creation, promotion, and custom-type editing.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge functionally, with a non-blocking repository-convention issue in the new validation helpers and integration tests.

The changed validation is reached after normalization and uniqueness checks and blocks the intended seeded-type mutations; the only accepted concern is conformance of the newly added Java control flow and repeated string literals.

**Files Needing Attention:** openmetadata-service/src/main/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtil.java; openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationSettingsIT.java
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtil.java | Adds comprehensive preservation checks and normalized equality for system-defined relation types; two new helpers use prohibited early-return control flow. |
| openmetadata-service/src/test/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtilTest.java | Adds focused unit coverage for field edits, creation, promotion, unchanged seeded types, and editable custom types. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationSettingsIT.java | Adds synchronized generic-PUT integration cases for seeded-type mutation and fabrication, but repeats a domain name as a prohibited raw equals literal. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  PUT[Generic settings PUT] --> Normalize[Normalize relation settings]
  Normalize --> Unique[Validate unique names]
  Unique --> Preserve[Validate system-defined types]
  Preserve --> Removed{Removed or downgraded?}
  Preserve --> Added{Created or promoted?}
  Preserve --> Modified{Fields modified?}
  Removed -->|Yes| Reject[Reject update]
  Added -->|Yes| Reject
  Modified -->|Yes| Reject
  Removed -->|No| Persist[Persist settings]
  Added -->|No| Persist
  Modified -->|No| Persist
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(glossary): reject field edits to sys..."](https://github.com/open-metadata/openmetadata/commit/abf95ea326106a9be9adbb44c1cd0dc09de2d968) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56193520)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))

<!-- /greptile_comment -->