### PR TITLE
fix(ci): guard SSO Slack notification step to match main/2.0 behaviour

### DIFF
--- a/.github/workflows/playwright-sso-login-nightly.yml
+++ b/.github/workflows/playwright-sso-login-nightly.yml
@@ -25,6 +25,11 @@ on:
           - okta
           - keycloak-azure-saml
           - all
+      send_slack_notification:
+        description: "Send Slack notification with test results"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -124,7 +129,7 @@ jobs:
           retention-days: 5
 
       - name: Send Slack Notification
-        if: always()
+        if: ${{ always() && (github.event_name == 'schedule' || inputs.send_slack_notification == true) }}
         working-directory: openmetadata-ui/src/main/resources/ui
         env:
           RUN_TITLE: "SSO Login Nightly: ${{ matrix.provider.name }} (${{ github.ref_name }})"


### PR DESCRIPTION
## Summary

- `playwright-slack-report@1.1.113` (now the npm `latest`) introduced `undici@8.10.0` as a dependency, which requires **Node.js >= 22.19.0**
- The 1.13 branch pins node to `v22.17.0` via `.nvmrc`, so the unversioned `npx playwright-slack-report` call fails with `EBADENGINE`
- **main** and **2.0** are unaffected because their `Send Slack Notification` step has a guard that skips it on non-scheduled `workflow_dispatch` runs — 1.13 was missing that guard (`if: always()`)

This PR ports the exact same fix from main/2.0 to 1.13:
1. Add `send_slack_notification: boolean` input to `workflow_dispatch`
2. Change the `Send Slack Notification` `if:` condition from `always()` → `always() && (schedule OR send_slack_notification == true)`

## Test plan

- [ ] Trigger a manual `workflow_dispatch` run on 1.13 without setting `send_slack_notification` — Slack step should be skipped, job passes
- [ ] Trigger with `send_slack_notification: true` — Slack step runs normally
- [ ] Next nightly cron run on 1.13 should also work (scheduled → condition is true, but `playwright-slack-report` will be pinned or upgraded separately if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes Slack reporting opt-in for manually dispatched SSO Playwright runs while preserving notifications for scheduled nightly runs.
- Adds an optional `send_slack_notification` boolean input that defaults to `false`.
- Restricts the Slack notification step to scheduled executions or manual executions that explicitly enable the input.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the workflow guard matches the documented behavior for both scheduled and manually dispatched runs.

Scheduled runs continue executing the notification step, while manual runs execute it only when the newly declared boolean input is enabled; no blocking or independently actionable issue remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/playwright-sso-login-nightly.yml | The new dispatch input and event-aware condition consistently implement the documented opt-in behavior without changing scheduled notification behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): guard SSO Slack notification to..."](https://github.com/open-metadata/openmetadata/commit/695907b467ed16858f2e466d7f26f3a884a74eb1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56203136)</sub>

<!-- /greptile_comment -->