### PR TITLE
fix(lint): resolve jsx-a11y errors on main from 2 test-mock files (follow-up to #30989)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.test.tsx
@@ -24,7 +24,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
     children: ReactNode;
     onClick?: () => void;
   }) => (
-    <div data-testid="name-cell" onClick={onClick}>
+    <div data-testid="name-cell" role="presentation" onClick={onClick}>
       {children}
     </div>
   ),
@@ -59,7 +59,9 @@ describe('renderDomainNameCell', () => {
     const rowClick = jest.fn();
 
     render(
-      <div onClick={rowClick}>{renderDomainNameCell(DOMAIN, onClick)}</div>
+      <div role="presentation" onClick={rowClick}>
+        {renderDomainNameCell(DOMAIN, onClick)}
+      </div>
     );
     fireEvent.click(screen.getByText('Engineering'));
 
@@ -70,7 +72,11 @@ describe('renderDomainNameCell', () => {
   it('does not attach a click handler when no onClick is provided', () => {
     const rowClick = jest.fn();
 
-    render(<div onClick={rowClick}>{renderDomainNameCell(DOMAIN)}</div>);
+    render(
+      <div role="presentation" onClick={rowClick}>
+        {renderDomainNameCell(DOMAIN)}
+      </div>
+    );
     fireEvent.click(screen.getByText('Engineering'));
 
     // With no cell handler the click falls through to the row unchanged.

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/useDomainTableColumns.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/useDomainTableColumns.test.tsx
@@ -28,7 +28,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
     children: ReactNode;
     onClick?: () => void;
   }) => (
-    <div data-testid="name-cell" onClick={onClick}>
+    <div data-testid="name-cell" role="presentation" onClick={onClick}>
       {children}
     </div>
   ),
@@ -69,7 +69,9 @@ describe('useDomainTableColumns', () => {
     const { result } = renderHook(() => useDomainTableColumns());
 
     render(
-      <div onClick={rowClick}>{result.current.renderCell(DOMAIN, 'name')}</div>
+      <div role="presentation" onClick={rowClick}>
+        {result.current.renderCell(DOMAIN, 'name')}
+      </div>
     );
     fireEvent.click(screen.getByText('Engineering'));
 


### PR DESCRIPTION
## What
Follow-up to #30989 (ESLint 1/10, now merged). That PR promoted the jsx-a11y rules to `error`. Two test files that landed on `main` around the same time — `domainFieldRenderers.test.tsx` and `useDomainTableColumns.test.tsx` — contain clickable-`<div>` mocks that are now **error**-level violations of `jsx-a11y/click-events-have-key-events` + `no-static-element-interactions`.

They slipped through because the merge queue lints **changed files only**, and these two weren't in #30989's diff (they came from `main`), so `main` now has 10 latent lint errors.

## Fix
Add `role="presentation"` to the 5 test-mock divs (behavior-preserving; `fireEvent.click`/`getByText` unaffected). Verified: **0 eslint errors across all of `src`**; both test suites pass (5 tests).

Part of epic #30977.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds presentational roles to clickable test-only wrappers and component mocks, resolving jsx-a11y lint errors without changing application runtime code.

- Updates the `renderDomainNameCell` click-propagation fixtures.
- Updates the `useDomainTableColumns` name-cell mock and row wrapper.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it only adjusts ARIA metadata on test fixtures and no actionable regression was identified.

The changed roles do not alter click handlers, event propagation, text queries, production components, or runtime application behavior.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.test.tsx | Adds presentational roles to three clickable test fixtures while preserving their click-propagation behavior. |
| openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/useDomainTableColumns.test.tsx | Adds presentational roles to the clickable name-cell mock and row wrapper without changing test interactions. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(lint): resolve a11y errors in 2 test..."](https://github.com/open-metadata/openmetadata/commit/cb29897cafe1782c6cc6af4c59374cc7b9947c0a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56205265)</sub>

<!-- /greptile_comment -->