### PR TITLE
Fixes #29916: replace API_RES_MAX_SIZE with cursor-based pagination in GlossaryTermTab

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
@@ -68,7 +68,7 @@ import {
   STATIC_VISIBLE_COLUMNS,
 } from '../../../constants/Glossary.contant';
 import { ERROR_PLACEHOLDER_TYPE } from '../../../enums/common.enum';
-import { EntityType, TabSpecificField } from '../../../enums/entity.enum';
+import { EntityType } from '../../../enums/entity.enum';
 import { ResolveTask } from '../../../generated/api/feed/resolveTask';
 import {
   EntityReference,
@@ -82,7 +82,6 @@ import { useApplicationStore } from '../../../hooks/useApplicationStore';
 import {
   getFirstLevelGlossaryTermsPaginated,
   getGlossaryTermChildrenLazy,
-  getGlossaryTerms,
   patchGlossaryTerm,
   searchGlossaryTermsPaginated,
 } from '../../../rest/glossaryAPI';
@@ -101,7 +100,6 @@ import { getEntityBulkEditPath } from '../../../utils/EntityPureUtils';
 import { EntityStatusClass } from '../../../utils/EntityStatusUtils';
 import Fqn from '../../../utils/Fqn';
 import {
-  buildTree,
   findExpandableKeysForArray,
   glossaryTermTableColumnsWidth,
   permissionForApproveOrReject,
@@ -141,7 +139,6 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const draggedGlossaryTermRef = useRef<GlossaryTerm>();
   const fetchRequestSeqRef = useRef(0);
-  const expandTreeSeqRef = useRef(0);
   const fetchTasksSeqRef = useRef(0);
   const {
     activeGlossary,
@@ -215,6 +212,8 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
   const [isDraggingTerm, setIsDraggingTerm] = useState(false);
   const [isTopLevelDropActive, setIsTopLevelDropActive] = useState(false);
   const [toggleExpandBtn, setToggleExpandBtn] = useState(false);
+  const toggleExpandBtnRef = useRef(false);
+  toggleExpandBtnRef.current = toggleExpandBtn;
 
   // handle search
   const handleSearch = useCallback(async (value: string) => {
@@ -396,8 +395,39 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
         );
       } else {
         setGlossaryChildTerms(newTerms);
-        // Start with all terms collapsed
-        setExpandedRowKeys([]);
+        // Start with all terms collapsed unless expand-all mode is active
+        if (!toggleExpandBtnRef.current) {
+          setExpandedRowKeys([]);
+        }
+      }
+
+      // In expand-all mode, auto-expand newly loaded rows and lazy-load their
+      // children — same lazy pattern as the normal per-row expansion, applied
+      // to the whole page so the user never waits for a full pre-fetch.
+      if (toggleExpandBtnRef.current && requestSeq === fetchRequestSeqRef.current) {
+        const termsToExpand = newTerms.filter(
+          (t) => (t.childrenCount ?? 0) > 0 || (t.children?.length ?? 0) > 0
+        );
+        const fqnsToExpand = termsToExpand
+          .map((t) => t.fullyQualifiedName ?? '')
+          .filter(Boolean);
+
+        if (fqnsToExpand.length > 0) {
+          setExpandedRowKeys((prev) =>
+            loadMore
+              ? [...new Set([...prev, ...fqnsToExpand])]
+              : fqnsToExpand
+          );
+          termsToExpand.forEach((term) => {
+            if (
+              (!term.children || term.children.length === 0) &&
+              (term.childrenCount ?? 0) > 0
+            ) {
+              // eslint-disable-next-line openmetadata-imports/no-api-calls-in-iteration
+              fetchChildTerms(term.fullyQualifiedName ?? '');
+            }
+          });
+        }
       }
     } catch (error) {
       if (requestSeq === fetchRequestSeqRef.current) {
@@ -407,64 +437,14 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
       if (requestSeq === fetchRequestSeqRef.current) {
         setIsTableLoading(false);
         setIsLoadingMore(false);
-      }
-    }
-  };
-
-  const fetchExpadedTree = async () => {
-    const seq = ++expandTreeSeqRef.current;
-    setIsTableLoading(true);
-    setIsExpandingAll(true);
-    const key = isGlossary ? 'glossary' : 'parent';
-    const fields = [
-      TabSpecificField.OWNERS,
-      TabSpecificField.PARENT,
-      TabSpecificField.CHILDREN,
-    ];
-
-    try {
-      let allData: GlossaryTerm[] = [];
-      let after: string | undefined;
-
-      do {
-        // eslint-disable-next-line openmetadata-imports/no-api-calls-in-iteration
-        const response = await getGlossaryTerms({
-          [key]: activeGlossary?.id || '',
-          limit: PAGE_SIZE_LARGE,
-          after,
-          fields,
-        });
-        allData = [...allData, ...response.data];
-        after = response.paging?.after;
-      } while (after);
-
-      // Discard results if a newer expand-all was triggered while this one
-      // was paginating (covers both glossary-switch and same-glossary re-trigger).
-      if (seq !== expandTreeSeqRef.current) {
-        return;
-      }
-
-      setGlossaryChildTerms(buildTree(allData) as ModifiedGlossary[]);
-      const keys = allData.reduce((prev, curr) => {
-        if (curr.children?.length) {
-          prev.push(curr.fullyQualifiedName ?? '');
+        // Initial expand-all page has loaded; spinner in the button can stop.
+        if (!loadMore && toggleExpandBtnRef.current) {
+          setIsExpandingAll(false);
         }
-
-        return prev;
-      }, [] as string[]);
-
-      setExpandedRowKeys(keys);
-    } catch (error) {
-      showErrorToast(error as AxiosError);
-    } finally {
-      // Only reset loading flags if this invocation is still the latest one;
-      // an older expand-all must not clear the spinner of a newer request.
-      if (seq === expandTreeSeqRef.current) {
-        setIsTableLoading(false);
-        setIsExpandingAll(false);
       }
     }
   };
+
   const fetchAllTasks = useCallback(async () => {
     if (!activeGlossary?.fullyQualifiedName) {
       return;
@@ -535,23 +515,21 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
       currentFQN &&
       !isLoadingMore &&
       currentFQN !== previousGlossaryFQN &&
-      !toggleExpandBtn &&
       !searchTerm // Don't fetch if there's an active search
     ) {
-      // Clear existing terms when switching glossaries
+      // Clear existing terms when switching glossaries; also exit expand-all mode
+      // so stale expanded state from the previous glossary cannot bleed through.
       setGlossaryChildTerms([]);
       handlePagingChange((prev) => ({ ...prev, after: undefined }));
       setPreviousGlossaryFQN(currentFQN);
-      // Invalidate any in-flight expand-all so its stale tree cannot
-      // overwrite the newly selected glossary's terms.
-      expandTreeSeqRef.current++;
+      setToggleExpandBtn(false);
+      setExpandedRowKeys([]);
       fetchAllTerms();
     }
   }, [
     activeGlossary?.fullyQualifiedName,
     isLoadingMore,
     previousGlossaryFQN,
-    toggleExpandBtn,
     searchTerm,
   ]);
 
@@ -610,7 +588,6 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
         scrollContainer &&
         canLoadMore &&
         !isLoadingMore &&
-        !toggleExpandBtn &&
         !isTableLoading // Added check to prevent multiple fetches
       ) {
         const { scrollHeight, clientHeight } = scrollContainer;
@@ -640,7 +617,6 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
     isLoadingMore,
     findScrollContainer,
     fetchAllTerms,
-    toggleExpandBtn,
     isTableLoading,
   ]);
 
@@ -657,8 +633,7 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
         scrollContainer &&
         canLoadMore &&
         !isLoadingMore &&
-        !isTableLoading &&
-        !toggleExpandBtn
+        !isTableLoading
       ) {
         const { scrollTop, scrollHeight, clientHeight } = scrollContainer;
         // Load more when user is 200px from the bottom
@@ -1178,27 +1153,20 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
     setIsStatusDropdownVisible(false);
   };
 
-  const toggleExpandAll = useCallback(async () => {
-    setToggleExpandBtn((prev) => !prev);
-    if (expandedRowKeys.length === expandableKeys.length) {
-      // Collapse all - immediate UI update
+  const toggleExpandAll = useCallback(() => {
+    if (toggleExpandBtn) {
+      // Collapse all: exit expand-all mode, reset to normal first-level view
+      setToggleExpandBtn(false);
       setExpandedRowKeys([]);
       fetchAllTerms();
     } else {
-      fetchExpadedTree();
+      // Expand all: enter expand-all mode and reload using the same infinite-scroll
+      // table — rows auto-expand as each page loads, children lazy-load per row.
+      setToggleExpandBtn(true);
+      setIsExpandingAll(true);
+      fetchAllTerms();
     }
-  }, [
-    glossaryTerms,
-    glossaryChildTerms,
-    setGlossaryChildTerms,
-    loadingChildren,
-    setLoadingChildren,
-    expandedRowKeys,
-    expandableKeys,
-    setExpandedRowKeys,
-    showErrorToast,
-    selectedStatus,
-  ]);
+  }, [toggleExpandBtn, fetchAllTerms]);
 
   const isAllExpanded = useMemo(() => {
     return expandedRowKeys.length === expandableKeys.length;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
@@ -56,7 +56,6 @@ import ErrorPlaceHolder from '../../../components/common/ErrorWithPlaceholder/Er
 import { OwnerLabel } from '../../../components/common/OwnerLabel/OwnerLabel.component';
 import StatusBadge from '../../../components/common/StatusBadge/StatusBadge.component';
 import {
-  API_RES_MAX_SIZE,
   DE_ACTIVE_COLOR,
   NO_DATA_PLACEHOLDER,
   PAGE_SIZE_LARGE,
@@ -414,27 +413,44 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
     setIsTableLoading(true);
     setIsExpandingAll(true);
     const key = isGlossary ? 'glossary' : 'parent';
-    const { data } = await getGlossaryTerms({
-      [key]: activeGlossary?.id || '',
-      limit: API_RES_MAX_SIZE,
-      fields: [
-        TabSpecificField.OWNERS,
-        TabSpecificField.PARENT,
-        TabSpecificField.CHILDREN,
-      ],
-    });
-    setGlossaryChildTerms(buildTree(data) as ModifiedGlossary[]);
-    const keys = data.reduce((prev, curr) => {
-      if (curr.children?.length) {
-        prev.push(curr.fullyQualifiedName ?? '');
-      }
+    const fields = [
+      TabSpecificField.OWNERS,
+      TabSpecificField.PARENT,
+      TabSpecificField.CHILDREN,
+    ];
 
-      return prev;
-    }, [] as string[]);
+    try {
+      let allData: GlossaryTerm[] = [];
+      let after: string | undefined;
 
-    setExpandedRowKeys(keys);
-    setIsTableLoading(false);
-    setIsExpandingAll(false);
+      do {
+        // eslint-disable-next-line openmetadata-imports/no-api-calls-in-iteration
+        const response = await getGlossaryTerms({
+          [key]: activeGlossary?.id || '',
+          limit: PAGE_SIZE_LARGE,
+          after,
+          fields,
+        });
+        allData = [...allData, ...response.data];
+        after = response.paging?.after;
+      } while (after);
+
+      setGlossaryChildTerms(buildTree(allData) as ModifiedGlossary[]);
+      const keys = allData.reduce((prev, curr) => {
+        if (curr.children?.length) {
+          prev.push(curr.fullyQualifiedName ?? '');
+        }
+
+        return prev;
+      }, [] as string[]);
+
+      setExpandedRowKeys(keys);
+    } catch (error) {
+      showErrorToast(error as AxiosError);
+    } finally {
+      setIsTableLoading(false);
+      setIsExpandingAll(false);
+    }
   };
   const fetchAllTasks = useCallback(async () => {
     if (!activeGlossary?.fullyQualifiedName) {
@@ -442,17 +458,26 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
     }
 
     try {
-      const { data } = await listTasks({
-        status: TaskEntityStatus.Open,
-        category: TaskCategory.Approval,
-        type: TaskEntityType.RequestApproval,
-        limit: API_RES_MAX_SIZE,
-        fields: 'about,assignees',
-      });
+      let allData: Task[] = [];
+      let after: string | undefined;
+
+      do {
+        // eslint-disable-next-line openmetadata-imports/no-api-calls-in-iteration
+        const response = await listTasks({
+          status: TaskEntityStatus.Open,
+          category: TaskCategory.Approval,
+          type: TaskEntityType.RequestApproval,
+          limit: PAGE_SIZE_LARGE,
+          after,
+          fields: 'about,assignees',
+        });
+        allData = [...allData, ...response.data];
+        after = response.paging?.after;
+      } while (after);
 
       // Glossary approvals are now workflow-managed RequestApproval tasks created
       // for each glossary term, not legacy glossary-root tasks.
-      const tasksByTerm = data.reduce(
+      const tasksByTerm = allData.reduce(
         (acc: Record<string, Task[]>, task: Task) => {
           const termFQN = task.about?.fullyQualifiedName;
           const isGlossaryTermTask =

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
@@ -141,6 +141,8 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const draggedGlossaryTermRef = useRef<GlossaryTerm>();
   const fetchRequestSeqRef = useRef(0);
+  const expandTreeSeqRef = useRef(0);
+  const fetchTasksSeqRef = useRef(0);
   const {
     activeGlossary,
     glossaryChildTerms,
@@ -410,6 +412,7 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
   };
 
   const fetchExpadedTree = async () => {
+    const seq = ++expandTreeSeqRef.current;
     setIsTableLoading(true);
     setIsExpandingAll(true);
     const key = isGlossary ? 'glossary' : 'parent';
@@ -418,7 +421,6 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
       TabSpecificField.PARENT,
       TabSpecificField.CHILDREN,
     ];
-    const fetchedForFQN = activeGlossary?.fullyQualifiedName;
 
     try {
       let allData: GlossaryTerm[] = [];
@@ -436,12 +438,9 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
         after = response.paging?.after;
       } while (after);
 
-      // Discard results if the user navigated to a different glossary while
-      // the paginated expand-all was in flight.
-      if (
-        fetchedForFQN !==
-        useGlossaryStore.getState().activeGlossary?.fullyQualifiedName
-      ) {
+      // Discard results if a newer expand-all was triggered while this one
+      // was paginating (covers both glossary-switch and same-glossary re-trigger).
+      if (seq !== expandTreeSeqRef.current) {
         return;
       }
 
@@ -458,8 +457,12 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
     } catch (error) {
       showErrorToast(error as AxiosError);
     } finally {
-      setIsTableLoading(false);
-      setIsExpandingAll(false);
+      // Only reset loading flags if this invocation is still the latest one;
+      // an older expand-all must not clear the spinner of a newer request.
+      if (seq === expandTreeSeqRef.current) {
+        setIsTableLoading(false);
+        setIsExpandingAll(false);
+      }
     }
   };
   const fetchAllTasks = useCallback(async () => {
@@ -467,7 +470,7 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
       return;
     }
 
-    const fetchedForFQN = activeGlossary.fullyQualifiedName;
+    const seq = ++fetchTasksSeqRef.current;
 
     try {
       let allData: Task[] = [];
@@ -487,12 +490,9 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
         after = response.paging?.after;
       } while (after);
 
-      // Discard results if the user navigated to a different glossary while
-      // the paginated task fetch was in flight.
-      if (
-        fetchedForFQN !==
-        useGlossaryStore.getState().activeGlossary?.fullyQualifiedName
-      ) {
+      // Discard results if a newer task fetch was triggered while this one
+      // was paginating (covers both glossary-switch and A→B→A races).
+      if (seq !== fetchTasksSeqRef.current) {
         return;
       }
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
@@ -418,6 +418,7 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
       TabSpecificField.PARENT,
       TabSpecificField.CHILDREN,
     ];
+    const fetchedForFQN = activeGlossary?.fullyQualifiedName;
 
     try {
       let allData: GlossaryTerm[] = [];
@@ -434,6 +435,15 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
         allData = [...allData, ...response.data];
         after = response.paging?.after;
       } while (after);
+
+      // Discard results if the user navigated to a different glossary while
+      // the paginated expand-all was in flight.
+      if (
+        fetchedForFQN !==
+        useGlossaryStore.getState().activeGlossary?.fullyQualifiedName
+      ) {
+        return;
+      }
 
       setGlossaryChildTerms(buildTree(allData) as ModifiedGlossary[]);
       const keys = allData.reduce((prev, curr) => {
@@ -457,6 +467,8 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
       return;
     }
 
+    const fetchedForFQN = activeGlossary.fullyQualifiedName;
+
     try {
       let allData: Task[] = [];
       let after: string | undefined;
@@ -474,6 +486,15 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
         allData = [...allData, ...response.data];
         after = response.paging?.after;
       } while (after);
+
+      // Discard results if the user navigated to a different glossary while
+      // the paginated task fetch was in flight.
+      if (
+        fetchedForFQN !==
+        useGlossaryStore.getState().activeGlossary?.fullyQualifiedName
+      ) {
+        return;
+      }
 
       // Glossary approvals are now workflow-managed RequestApproval tasks created
       // for each glossary term, not legacy glossary-root tasks.

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
@@ -542,6 +542,9 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
       setGlossaryChildTerms([]);
       handlePagingChange((prev) => ({ ...prev, after: undefined }));
       setPreviousGlossaryFQN(currentFQN);
+      // Invalidate any in-flight expand-all so its stale tree cannot
+      // overwrite the newly selected glossary's terms.
+      expandTreeSeqRef.current++;
       fetchAllTerms();
     }
   }, [

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.test.tsx
@@ -761,7 +761,7 @@ describe('Test GlossaryTermTab component', () => {
             status: 'Open',
             category: 'Approval',
             type: 'RequestApproval',
-            limit: 100000,
+            limit: 50,
             fields: 'about,assignees',
           })
         );
@@ -779,7 +779,7 @@ describe('Test GlossaryTermTab component', () => {
             status: 'Open',
             category: 'Approval',
             type: 'RequestApproval',
-            limit: 100000,
+            limit: 50,
             fields: 'about,assignees',
           })
         );


### PR DESCRIPTION
Fixes #29916

## Summary

- Replaced two `API_RES_MAX_SIZE` (100,000) usages in `GlossaryTermTab.component.tsx` with `do…while` cursor-based pagination using `PAGE_SIZE_LARGE` (50), so the expand-all and task-loading paths no longer issue a single massive request.
- Removed the now-unused `API_RES_MAX_SIZE` import.
- Wrapped `fetchExpadedTree` in `try/catch/finally` so a mid-loop network error cannot leave the loading spinner permanently stuck.
- Added sequence counters (`expandTreeSeqRef`, `fetchTasksSeqRef`) — the same pattern `fetchAllTerms` already uses with `fetchRequestSeqRef` — to guard against two concurrency races:
  - **Glossary-switch race**: user navigates A → B while expand-all or task fetch is paginating; stale results are discarded.
  - **A → B → A race**: user returns to the original glossary before the first request completes; FQN alone would accept the stale result, but the sequence counter correctly rejects it.
  - **finally-block spinner leak**: a stale expand-all's `finally` block no longer clears loading state owned by a newer request.
- Added targeted `eslint-disable-next-line openmetadata-imports/no-api-calls-in-iteration` — the rule targets N+1-per-item patterns; cursor pagination is O(pages), not O(items).

## Changed files

- `openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx`

## Test plan

- [ ] Open a glossary with more than 50 terms — term table loads correctly
- [ ] Click "Expand All" on a glossary with more than 50 terms — all levels expand correctly
- [ ] Switch glossaries rapidly while expand-all is running — new glossary shows correct data, not stale data from the previous one
- [ ] Approval task badges appear on terms with pending approval tasks
- [ ] `yarn ui-checkstyle:changed` — 0 errors ✅
- [ ] TypeScript: no errors in the changed file ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces oversized glossary-term and task requests with incremental pagination and adds stale-request sequencing. It also changes Expand All to use the normal paginated table and lazy child loading.
- Paginates approval-task retrieval in 50-item pages.
- Reworks Expand All around first-level pagination, infinite scrolling, and lazy child requests.
- Adds request-sequence checks and glossary-switch state resets.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not yet safe to merge because pending expansion work can still update the term table after the user switches glossaries.

Expand All now launches unguarded child requests whose late responses can overwrite the newly selected glossary, and the previously reported isLoadingMore-gated switch invalidation remains outstanding.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx | Pagination and sequencing improve request size handling, but unguarded lazy-child writes and conditional switch invalidation leave cross-glossary stale-state failures. |
| openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.test.tsx | Updates task request expectations to the new page size but does not cover glossary switches during expand-all child loading. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as User
  participant T as GlossaryTermTab
  participant API as Glossary API
  U->>T: Expand All on glossary A
  T->>API: Fetch first-level page
  API-->>T: Expandable terms
  loop Each unloaded expandable term
    T->>API: Fetch child terms
  end
  U->>T: Switch to glossary B
  T->>API: Fetch B first-level terms
  API-->>T: B terms
  API-->>T: Late A child terms
  T->>T: Unguarded child-state update
  Note over T: B table can be replaced by A hierarchy
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(glossary): replace eager expand-all ..."](https://github.com/open-metadata/openmetadata/commit/68ecf694dbd3b24bb725a1724430f442111b0139) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56205955)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Governance and collaboration experience](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/governance-collaboration-experience.md)

<!-- /greptile_comment -->