### PR TITLE
[ESLint 2a] Fix @typescript-eslint/no-use-before-define + promote to error

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/eslint.config.mjs
+++ b/openmetadata-ui/src/main/resources/ui/eslint.config.mjs
@@ -176,7 +176,10 @@ export default [
       // TypeScript rules
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/explicit-module-boundary-types': 'off',
-      '@typescript-eslint/no-use-before-define': 'warn',
+      // Cleared to zero and locked by the ESLint-cleanup stack — safe reorders
+      // where possible, documented disables for mutual-recursion / derived-below
+      // cases. Promoted to error so CI blocks any regression.
+      '@typescript-eslint/no-use-before-define': 'error',
       'no-unused-expressions': 'off',
       '@typescript-eslint/no-unused-expressions': [
         'error',

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TestCaseFormDrawer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TestCaseFormDrawer.tsx
@@ -369,6 +369,8 @@ const TestCaseFormDrawer: FC<TestCaseFormDrawerProps> = ({
     testCaseFormBody
   );
 
+  const closeDrawerRef = useRef<() => void>(() => undefined);
+
   const formBody = (
     <HookForm
       form={form}
@@ -386,8 +388,6 @@ const TestCaseFormDrawer: FC<TestCaseFormDrawerProps> = ({
       </div>
     </HookForm>
   );
-
-  const closeDrawerRef = useRef<() => void>(() => undefined);
 
   // Every dismissal path (cancel, X, Escape, backdrop, programmatic close)
   // funnels through the base drawer's onClose, so the parent is notified

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx
@@ -326,6 +326,7 @@ const DomainDetails = ({
       // refresh domain count when assets tab is selected
       fetchDomainAssets();
     }
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define -- derived below from `tabs`
     if (activeKey !== activeTab) {
       if (onActiveTabChange) {
         onActiveTabChange(activeKey as EntityTabs);
@@ -765,6 +766,7 @@ const DomainDetails = ({
         const newFqn = domain.parent
           ? `${domain.parent.fullyQualifiedName}.${newName.trim()}`
           : newName.trim();
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define -- derived below from `tabs`
         navigate(getDomainDetailsPath(newFqn, activeTab));
       }
     } catch {
@@ -908,6 +910,7 @@ const DomainDetails = ({
       handleAssetSave: () => {
         fetchDomainAssets();
         assetTabRef.current?.refreshAssets();
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define -- derived below from `tabs`
         activeTab !== EntityTabs.ASSETS && handleTabChange(EntityTabs.ASSETS);
       },
       setShowAddSubDomainModal: openSubDomainDrawer,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.tsx
@@ -197,6 +197,7 @@ const DomainTreeView = ({
       const firstDomain = selectDomain(domains, resetExpandedItems, domainFqn);
 
       if ((firstDomain?.childrenCount || 0) > 0 && shouldLoadChildren) {
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define -- useCallback defined below
         loadDomains(firstDomain.fullyQualifiedName as string);
       }
     },

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AuditLogsPage/AuditLogsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AuditLogsPage/AuditLogsPage.tsx
@@ -336,6 +336,7 @@ const AuditLogsPage = () => {
       }
 
       if (!cancelled) {
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define -- mutually recursive with pollOnce
         scheduleNextPoll();
       }
     };

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ApplicationUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ApplicationUtils.tsx
@@ -79,6 +79,36 @@ const VECTOR_INDEXABLE_ENTITIES = new Set([
   'topic',
 ]);
 
+/**
+ * Format avg stage latency as a short human string. Returns "—" when no records or no time
+ * has been recorded yet (e.g. fresh job, or stages that haven't reported timing because the
+ * legacy non-distributed path is in use). Below 1 ms shows "<1 ms" rather than rounding to 0.
+ */
+export const formatLatencyAverage = (
+  totalTimeMs?: number,
+  successRecords?: number
+): string => {
+  // No timing recorded yet (legacy non-distributed path) or no records to divide by.
+  // totalTimeMs === 0 with successRecords > 0 is a valid sub-millisecond batch and
+  // falls through to the "<1 ms" branch.
+  if (
+    totalTimeMs === undefined ||
+    successRecords === undefined ||
+    successRecords <= 0
+  ) {
+    return '—';
+  }
+  const avgMs = totalTimeMs / successRecords;
+  if (avgMs < 1) {
+    return '<1 ms';
+  }
+  if (avgMs < 1000) {
+    return `${avgMs.toFixed(1)} ms`;
+  }
+
+  return `${(avgMs / 1000).toFixed(2)} s`;
+};
+
 export const getEntityStatsData = (data: {
   [key: string]: StepStats;
 }): EntityStatsData[] => {
@@ -142,36 +172,6 @@ export const getEntityStatsData = (data: {
   return result.sort((a: EntityStatsData, b: EntityStatsData) =>
     a.name.localeCompare(b.name)
   );
-};
-
-/**
- * Format avg stage latency as a short human string. Returns "—" when no records or no time
- * has been recorded yet (e.g. fresh job, or stages that haven't reported timing because the
- * legacy non-distributed path is in use). Below 1 ms shows "<1 ms" rather than rounding to 0.
- */
-export const formatLatencyAverage = (
-  totalTimeMs?: number,
-  successRecords?: number
-): string => {
-  // No timing recorded yet (legacy non-distributed path) or no records to divide by.
-  // totalTimeMs === 0 with successRecords > 0 is a valid sub-millisecond batch and
-  // falls through to the "<1 ms" branch.
-  if (
-    totalTimeMs === undefined ||
-    successRecords === undefined ||
-    successRecords <= 0
-  ) {
-    return '—';
-  }
-  const avgMs = totalTimeMs / successRecords;
-  if (avgMs < 1) {
-    return '<1 ms';
-  }
-  if (avgMs < 1000) {
-    return `${avgMs.toFixed(1)} ms`;
-  }
-
-  return `${(avgMs / 1000).toFixed(2)} s`;
 };
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CronExpressionUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CronExpressionUtils.ts
@@ -160,6 +160,22 @@ export const getCronDefaultValue = (appName: string) => {
   return initialValue;
 };
 
+export const getDefaultScheduleFromPeriod = (
+  includePeriodOptions: string[]
+) => {
+  if (includePeriodOptions.includes('day')) {
+    return DEFAULT_SCHEDULE_CRON_DAILY;
+  } else if (includePeriodOptions.includes('week')) {
+    return DEFAULT_SCHEDULE_CRON_WEEKLY;
+  } else if (includePeriodOptions.includes('month')) {
+    return DEFAULT_SCHEDULE_CRON_MONTHLY;
+  } else if (includePeriodOptions.includes('hour')) {
+    return DEFAULT_SCHEDULE_CRON_HOURLY;
+  }
+
+  return DEFAULT_SCHEDULE_CRON_DAILY;
+};
+
 export const getDefaultScheduleValue = ({
   defaultSchedule,
   includePeriodOptions,
@@ -180,22 +196,6 @@ export const getDefaultScheduleValue = ({
   }
 
   return getDefaultScheduleFromPeriod(includePeriodOptions);
-};
-
-export const getDefaultScheduleFromPeriod = (
-  includePeriodOptions: string[]
-) => {
-  if (includePeriodOptions.includes('day')) {
-    return DEFAULT_SCHEDULE_CRON_DAILY;
-  } else if (includePeriodOptions.includes('week')) {
-    return DEFAULT_SCHEDULE_CRON_WEEKLY;
-  } else if (includePeriodOptions.includes('month')) {
-    return DEFAULT_SCHEDULE_CRON_MONTHLY;
-  } else if (includePeriodOptions.includes('hour')) {
-    return DEFAULT_SCHEDULE_CRON_HOURLY;
-  }
-
-  return DEFAULT_SCHEDULE_CRON_DAILY;
 };
 
 export const getUpdatedStateFromFormState = <T>(

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomProperty.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomProperty.utils.ts
@@ -87,6 +87,11 @@ const serializeTimeInterval = (
   return isEmptyExtensionValue(interval) ? undefined : interval;
 };
 
+export const hasPopulatedTableRows = (value: unknown) =>
+  isRecord(value) &&
+  Array.isArray(value.rows) &&
+  value.rows.some((row) => isRecord(row) && Object.values(row).some(Boolean));
+
 const serializeTableValue = (raw: unknown): unknown =>
   hasPopulatedTableRows(raw) ? raw : undefined;
 
@@ -216,11 +221,6 @@ export const serializeExtensionValue = (
 export const filterPopulatedTableRows = <T extends Record<string, unknown>>(
   rows: T[]
 ) => rows.filter((row) => Object.values(row).some(Boolean));
-
-export const hasPopulatedTableRows = (value: unknown) =>
-  isRecord(value) &&
-  Array.isArray(value.rows) &&
-  value.rows.some((row) => isRecord(row) && Object.values(row).some(Boolean));
 
 export const getCustomPropertyEntityPathname = (entityType: string) => {
   const entityPathEntries = Object.entries(ENTITY_PATH);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/GlossaryTerm/GlossaryTermWidgetUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/GlossaryTerm/GlossaryTermWidgetUtils.tsx
@@ -83,6 +83,17 @@ const WorkflowHistory = withSuspenseFallback(
   )
 );
 
+const GlossaryTermDomainWidget = () => {
+  const { entityRules } = useGenericContext();
+
+  return (
+    <DomainLabelV2
+      showDomainHeading
+      multiple={entityRules?.canAddMultipleDomains ?? true}
+    />
+  );
+};
+
 export const getGlossaryTermWidgetFromKey = (widgetConfig: WidgetConfig) => {
   if (
     widgetConfig.i.startsWith(GlossaryTermDetailPageWidgetKeys.WORKFLOW_HISTORY)
@@ -118,17 +129,6 @@ export const getGlossaryTermWidgetFromKey = (widgetConfig: WidgetConfig) => {
     <CommonWidgets
       entityType={EntityType.GLOSSARY_TERM}
       widgetConfig={widgetConfig}
-    />
-  );
-};
-
-const GlossaryTermDomainWidget = () => {
-  const { entityRules } = useGenericContext();
-
-  return (
-    <DomainLabelV2
-      showDomainHeading
-      multiple={entityRules?.canAddMultipleDomains ?? true}
     />
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ServiceConnectionDetailsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ServiceConnectionDetailsUtils.tsx
@@ -166,6 +166,7 @@ export const getKeyValues = ({
       }
 
       // Handle special service configurations
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define -- mutually recursive with getKeyValues
       const specialConfig = handleSpecialServiceConfig(
         serviceType,
         key,
@@ -183,6 +184,7 @@ export const getKeyValues = ({
         serviceType === EntityType.DATABASE_SERVICE &&
         key === 'configSource'
       ) {
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define -- mutually recursive with getKeyValues
         const configSource = handleDatabaseConfigSource(
           key,
           value,


### PR DESCRIPTION
## What
**Chunk 2a of the type-safety split.** The original bundled type-safety PR (#30990) covered `no-explicit-any` + `no-non-null-assertion` + `no-use-before-define` (~369 violations). Per the one-rule-per-PR approach, it's being split into per-rule chunks; this is the first (smallest).

Clears all **15** `@typescript-eslint/no-use-before-define` violations and promotes the rule **`warn`→`error`** so CI blocks any regression.

## How (behavior-preserving)
- **6 safe reorders** — hoisted pure helpers (`formatLatencyAverage`, `getDefaultScheduleFromPeriod`, `hasPopulatedTableRows`, `GlossaryTermDomainWidget`, a `useRef`) above their first use; no intervening deps moved.
- **9 documented disables** — `activeTab` (derived below from `tabs`), `loadDomains` (useCallback defined below), and two mutual-recursion pairs (`scheduleNextPoll`/`pollOnce`, `handleSpecialServiceConfig`/`handleDatabaseConfigSource`) — all runtime-safe (referenced only inside callbacks that run after definition), can't be reordered without moving the error.

## Verified
- `no-use-before-define` = **0** across all `src`; the rule is now `error`.
- No new errors introduced. **240 tests pass** across the 12 touched suites.

Closes #31951. Part of epic #30977.

> Note: `main` currently has 10 pre-existing jsx-a11y errors in two test-mock files (from a race with #30989's merge) — fixed separately in #31948, independent of this PR.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR promotes `@typescript-eslint/no-use-before-define` from warning to error after resolving the current violations.
- Reorders pure utilities, a component declaration, and an unconditional ref above their first uses.
- Adds targeted suppressions for deferred callbacks and intentional mutual recursion.
- Makes future violations fail UI lint checks.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the declaration reorders and targeted lint suppressions preserve the existing runtime behavior.

The moved declarations remain pure or unconditional, deferred callbacks cannot execute before initialization in the inspected flows, and no concrete lint, build, or runtime regression remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/eslint.config.mjs | Promotes the TypeScript use-before-definition rule to an error without changing its options. |
| openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TestCaseFormDrawer.tsx | Moves an unconditional drawer callback ref above the JSX closure that captures it, preserving hook and callback behavior. |
| openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx | Documents intentional deferred references to the rendered active tab without changing navigation logic. |
| openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.tsx | Documents the deferred reference between selection handling and the later child-domain loader. |
| openmetadata-ui/src/main/resources/ui/src/pages/AuditLogsPage/AuditLogsPage.tsx | Documents intentional mutual recursion in the self-scheduling export polling loop. |
| openmetadata-ui/src/main/resources/ui/src/utils/ApplicationUtils.tsx | Moves the pure latency formatter above its first invocation without modifying its implementation. |
| openmetadata-ui/src/main/resources/ui/src/utils/CronExpressionUtils.ts | Moves the pure default-schedule helper above its caller without changing schedule selection. |
| openmetadata-ui/src/main/resources/ui/src/utils/CustomProperty.utils.ts | Moves the table-row predicate above serialization code that invokes it, preserving validation semantics. |
| openmetadata-ui/src/main/resources/ui/src/utils/GlossaryTerm/GlossaryTermWidgetUtils.tsx | Moves the glossary domain widget component above the widget factory that references it. |
| openmetadata-ui/src/main/resources/ui/src/utils/ServiceConnectionDetailsUtils.tsx | Documents intentional mutual recursion in service-configuration traversal without altering the traversal. |

</details>

<sub>Reviews (1): Last reviewed commit: ["style(ui): fix @typescript-eslint/no-use..."](https://github.com/open-metadata/openmetadata/commit/73ece11cc72a8a5f6a745525e5c9591af5c09eb8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56210500)</sub>

<!-- /greptile_comment -->