### PR TITLE
feat(ui): close the TableV2 parity gaps, add a shared parity suite

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
@@ -17,14 +17,11 @@
  * Drop-in replacement for Table.tsx using @openmetadata/ui-core-components.
  * Accepts the same TableComponentProps<T> interface for zero-friction adoption.
  *
- * Unsupported in v1 (accepted but ignored):
- *  - components  (AntD custom cell/header renderers)
- *
- * Not in props type (compile-time error if passed):
- *  - className   → use containerClassName instead
+ * Not in the props type (compile-time error if passed) — see UnsupportedProps:
+ *  - summary, components
  *
  * Partially supported:
- *  - expandable        → tree/nested rows via record.children; expandedRowRender not supported
+ *  - expandable        → tree/nested rows via record.children, plus expandedRowRender
  *  - onRow             → onClick and onDoubleClick are forwarded to the row element
  *  - onCell            → onClick, data-*, colSpan forwarded to the underlying td element
  *  - filterIcon/filterDropdown/onFilter → filter state managed internally; confirm/close close the dropdown
@@ -50,7 +47,7 @@ import type {
   TablePaginationConfig,
 } from 'antd/lib/table/interface';
 import classNames from 'classnames';
-import { isEmpty, isEqual } from 'lodash';
+import { isEmpty, isEqual, noop } from 'lodash';
 import React, {
   forwardRef,
   ReactElement,
@@ -63,6 +60,7 @@ import React, {
   useState,
 } from 'react';
 import {
+  Button as AriaButton,
   ColumnResizer,
   Dialog,
   DialogTrigger,
@@ -98,7 +96,192 @@ import {
   resolveColumnTitle,
 } from './TableV2Utils';
 
-type TableV2Props<T extends object> = TableComponentProps<T>;
+/**
+ * Props AntD's Table accepts that TableV2 cannot honour. Omitting them makes a
+ * call site fail to compile rather than render a table that quietly lost a
+ * feature:
+ *  - `summary`    React Aria's collection builder discards any table child that
+ *                 is not a Header or Body, so a `tfoot` never reaches the DOM,
+ *                 and a summary drawn outside the table would not line up with
+ *                 the columns. Needs a summary slot in ui-core-components.
+ *  - `components` custom row/cell renderers have no equivalent — use
+ *                 `dragAndDropHooks` for drag rows, or a column `render`.
+ */
+type UnsupportedProps = 'summary' | 'components';
+
+type CustomPaginationProps = NonNullable<
+  TableComponentProps<never>['customPaginationProps']
+>;
+
+/**
+ * `customPaginationProps` means the parent owns paging and has already fetched
+ * exactly the rows for this page — internal pagination must be off or the page
+ * gets sliced twice (a 50-row server page rendered as 10). Requiring
+ * `pagination={false}` alongside it makes that intent explicit at every call
+ * site instead of leaving it to convention.
+ */
+type PaginationContract<T> =
+  | {
+      customPaginationProps?: undefined;
+      pagination?: TableComponentProps<T>['pagination'];
+    }
+  | { customPaginationProps: CustomPaginationProps; pagination: false };
+
+type TableV2Props<T extends object> = Omit<
+  TableComponentProps<T>,
+  UnsupportedProps | 'customPaginationProps' | 'pagination'
+> &
+  PaginationContract<T>;
+
+const DEFAULT_PAGE_SIZE = 10;
+const DEFAULT_INDENT_PX = 12;
+const EXPANDER_GUTTER_PX = 16;
+
+/** AntD's size scale mapped onto the core component's. */
+const CORE_SIZE_BY_ANTD_SIZE: Record<string, 'compact' | 'sm' | 'md'> = {
+  small: 'compact',
+  middle: 'sm',
+  large: 'md',
+};
+
+const toCoreSize = (size: TableComponentProps<never>['size']) =>
+  CORE_SIZE_BY_ANTD_SIZE[size ?? 'middle'] ?? 'sm';
+
+/**
+ * Internal pagination is off whenever the parent owns paging, so a server page
+ * is never sliced a second time.
+ */
+const resolveClientPagination = <T,>(
+  pagination: TableComponentProps<T>['pagination'],
+  pageSizeOverride: number | null,
+  hasParentPagination: boolean
+) => {
+  if (pagination === false || hasParentPagination) {
+    return null;
+  }
+  const cfg = (pagination ?? {}) as TablePaginationConfig;
+
+  return {
+    pageSize: pageSizeOverride ?? (cfg.pageSize as number) ?? DEFAULT_PAGE_SIZE,
+    hideOnSinglePage: cfg.hideOnSinglePage ?? false,
+    showSizeChanger: cfg.showSizeChanger ?? false,
+    pageSizeOptions: (cfg.pageSizeOptions ?? []).map(Number),
+    onShowSizeChange: cfg.onShowSizeChange,
+  };
+};
+
+/** Tree depth is drawn as left padding on the cell that carries the expander. */
+const getIndentStyle = (
+  showExpander: boolean,
+  depth: number,
+  indentSize: number | undefined
+): React.CSSProperties =>
+  showExpander
+    ? {
+        paddingLeft: `${
+          EXPANDER_GUTTER_PX + depth * (indentSize ?? DEFAULT_INDENT_PX)
+        }px`,
+      }
+    : {};
+
+const toAriaDirection = (order: 'ascend' | 'descend') =>
+  order === 'descend' ? ('descending' as const) : ('ascending' as const);
+
+/**
+ * React Aria always opens a fresh sort on 'ascending'. AntD lets a column say
+ * which way the first click should go via `sortDirections`, so honour the head
+ * of that list when the sort moves to a different column.
+ */
+const resolveSortDirection = <T,>(
+  column: ColumnType<T> | undefined,
+  isFirstClickOnColumn: boolean,
+  fallback: 'ascending' | 'descending' | null
+) => {
+  const preferred = column?.sortDirections?.[0];
+
+  if (!isFirstClickOnColumn || !preferred) {
+    return fallback;
+  }
+
+  return toAriaDirection(preferred);
+};
+
+/**
+ * `expandedRowRender` draws a detail panel in a row of its own beneath the
+ * record, spanning every column — AntD's shape, rebuilt on the core Row/Cell.
+ */
+const buildExpandedDetailRow = <T extends object>(
+  expandable: TableComponentProps<T>['expandable'],
+  flatRow: FlatRow<T>,
+  isExpanded: boolean,
+  columnCount: number
+) => {
+  const renderDetail = expandable?.expandedRowRender;
+
+  if (!renderDetail || !isExpanded || !flatRow.hasChildren) {
+    return null;
+  }
+
+  return (
+    <UntitledTable.Row
+      id={`${flatRow.rowKey}-expanded`}
+      key={`${flatRow.rowKey}-expanded`}>
+      <UntitledTable.Cell
+        className="tw:py-2 tw:pl-4 tw:pr-2"
+        colSpan={columnCount}>
+        {renderDetail(flatRow.record, flatRow.actualIndex, flatRow.depth, isExpanded)}
+      </UntitledTable.Cell>
+    </UntitledTable.Row>
+  );
+};
+
+/**
+ * Row-level DOM wiring. When `dragAndDropHooks` is supplied React Aria owns drag
+ * and drop, so the call site's native HTML5 drag handlers must not also be
+ * attached — they would fight each other.
+ *
+ * `onAction` is what makes `onClick` work at all: React Aria strips a row's
+ * click handler unless the row is interactive. The empty action marks it
+ * interactive so the call site's handler still receives a real MouseEvent,
+ * without adding a second activation path that would fire it twice.
+ */
+const getRowInteractionProps = (
+  rowHandlers: React.HTMLAttributes<HTMLTableRowElement> & {
+    draggable?: boolean;
+  },
+  hasAriaDragAndDrop: boolean
+) => {
+  const activation = {
+    onAction: rowHandlers.onClick ? noop : undefined,
+    onClick: rowHandlers.onClick,
+    onDoubleClick: rowHandlers.onDoubleClick,
+  };
+
+  if (hasAriaDragAndDrop) {
+    return activation;
+  }
+
+  const {
+    draggable,
+    onDragEnd,
+    onDragEnter,
+    onDragLeave,
+    onDragOver,
+    onDragStart,
+    onDrop,
+  } = rowHandlers;
+
+  return {
+    ...activation,
+    draggable,
+    onDragEnd,
+    onDragEnter,
+    onDragLeave,
+    onDragOver,
+    onDragStart,
+    onDrop,
+  };
+};
 
 const TableV2 = <T extends object>(
   {
@@ -119,6 +302,7 @@ const TableV2 = <T extends object>(
   const [propsColumns, setPropsColumns] = useState<ColumnsType<T>>([]);
   const [columnWidths, setColumnWidths] = useState<Record<string, number>>({});
   const [internalCurrentPage, setInternalCurrentPage] = useState(1);
+  const [pageSizeOverride, setPageSizeOverride] = useState<number | null>(null);
   const [sortState, setSortState] = useState<{
     columnKey: string | null;
     direction: 'ascending' | 'descending' | null;
@@ -151,27 +335,65 @@ const TableV2 = <T extends object>(
 
   const entityKey = useMemo(() => entityType ?? type, [type, entityType]);
 
-  const clientPagination = useMemo(() => {
-    if (rest.pagination === false) {
+  // The props type already requires `pagination={false}` alongside
+  // `customPaginationProps`; this keeps the page intact even when that contract
+  // is bypassed at an untyped boundary.
+  const hasParentPagination = Boolean(customPaginationProps);
+
+  const clientPagination = useMemo(
+    () =>
+      resolveClientPagination(
+        rest.pagination,
+        pageSizeOverride,
+        hasParentPagination
+      ),
+    [rest.pagination, pageSizeOverride, hasParentPagination]
+  );
+
+  /**
+   * Changing the page size invalidates the current page — AntD resets to the
+   * first page, and so must we, or a reader on page 6 of 12 lands past the end
+   * of a now-shorter list.
+   */
+  const handlePageSizeChange = useCallback(
+    (size: number) => {
+      setPageSizeOverride(size);
+      setInternalCurrentPage(1);
+      clientPagination?.onShowSizeChange?.(1, size);
+    },
+    [clientPagination]
+  );
+
+  /**
+   * A column carrying `sortOrder` drives the sort, exactly as in AntD — the
+   * prop is controlled by the parent and outranks whatever the user last
+   * clicked. Falls back to the internal (uncontrolled) state when no column
+   * declares one.
+   */
+  const controlledSort = useMemo(() => {
+    const idx = propsColumns.findIndex((c) => (c as ColumnType<T>).sortOrder);
+    if (idx === -1) {
       return null;
     }
-    const cfg = (rest.pagination ?? {}) as TablePaginationConfig;
+    const col = propsColumns[idx] as ColumnType<T>;
 
     return {
-      pageSize: (cfg.pageSize as number) ?? 10,
-      hideOnSinglePage: cfg.hideOnSinglePage ?? false,
+      columnKey: String(col.key ?? col.dataIndex ?? idx),
+      direction: toAriaDirection(col.sortOrder === 'descend' ? 'descend' : 'ascend'),
     };
-  }, [rest.pagination]);
+  }, [propsColumns]);
+
+  const effectiveSort = controlledSort ?? sortState;
 
   const sortedDataSource = useMemo((): T[] => {
     const data = (rest.dataSource ?? []) as T[];
-    if (!sortState.columnKey || !sortState.direction) {
+    if (!effectiveSort.columnKey || !effectiveSort.direction) {
       return data;
     }
     const col = propsColumns.find((c, idx) => {
       const key = String(c.key ?? (c as ColumnType<T>).dataIndex ?? idx);
 
-      return key === sortState.columnKey;
+      return key === effectiveSort.columnKey;
     }) as ColumnType<T> | undefined;
 
     if (!col?.sorter || typeof col.sorter !== 'function') {
@@ -180,8 +402,8 @@ const TableV2 = <T extends object>(
     const compareFn = col.sorter as (a: T, b: T) => number;
     const sorted = [...data].sort((a, b) => compareFn(a, b));
 
-    return sortState.direction === 'descending' ? sorted.reverse() : sorted;
-  }, [rest.dataSource, sortState, propsColumns]);
+    return effectiveSort.direction === 'descending' ? sorted.reverse() : sorted;
+  }, [rest.dataSource, effectiveSort, propsColumns]);
 
   const filteredDataSource = useMemo((): T[] => {
     const activeFilters = Object.entries(filterState).filter(
@@ -344,6 +566,25 @@ const TableV2 = <T extends object>(
     return rest.rowSelection.type === 'radio' ? 'single' : 'multiple';
   }, [rest.rowSelection]);
 
+  /**
+   * AntD blocks selection per row through `getCheckboxProps().disabled`, leaving
+   * the row itself interactive. `disabledBehavior="selection"` is React Aria's
+   * equivalent: the row keeps focus and row actions, only selection is refused.
+   */
+  const disabledRowKeys = useMemo((): Set<string> | undefined => {
+    const getCheckboxProps = rest.rowSelection?.getCheckboxProps;
+    if (!getCheckboxProps) {
+      return undefined;
+    }
+
+    return new Set(
+      filteredDataSource
+        .map((record, index) => ({ key: getRowKey(record, index), record }))
+        .filter(({ record }) => getCheckboxProps(record).disabled)
+        .map(({ key }) => key)
+    );
+  }, [rest.rowSelection, filteredDataSource, getRowKey]);
+
   const handleSelectionChange = useCallback(
     (keys: AriaSelection) => {
       if (!rest.rowSelection?.onChange) {
@@ -386,7 +627,17 @@ const TableV2 = <T extends object>(
   const handleSortChange = useCallback(
     (descriptor: AriaSortDescriptor) => {
       const newKey = descriptor.column ? String(descriptor.column) : null;
-      const newDirection = descriptor.direction ?? null;
+      const clickedColumn = propsColumns.find((c, idx) => {
+        const key = String(c.key ?? (c as ColumnType<T>).dataIndex ?? idx);
+
+        return key === newKey;
+      }) as ColumnType<T> | undefined;
+
+      const newDirection = resolveSortDirection(
+        clickedColumn,
+        sortState.columnKey !== newKey,
+        descriptor.direction ?? null
+      );
       setSortState({ columnKey: newKey, direction: newDirection });
 
       if (!rest.onChange) {
@@ -412,9 +663,9 @@ const TableV2 = <T extends object>(
           columnKey: String(descriptor.column ?? ''),
           field: String(descriptor.column ?? ''),
           order:
-            descriptor.direction === 'ascending'
+            newDirection === 'ascending'
               ? 'ascend'
-              : descriptor.direction === 'descending'
+              : newDirection === 'descending'
               ? 'descend'
               : null,
         } as SorterResult<T>,
@@ -430,6 +681,7 @@ const TableV2 = <T extends object>(
       rest.dataSource,
       internalCurrentPage,
       clientPagination,
+      sortState.columnKey,
     ]
   );
 
@@ -496,6 +748,19 @@ const TableV2 = <T extends object>(
     }
   }, [dataSourceLength, clientPagination, internalCurrentPage]);
 
+  /** NextPrevious renders its page-size dropdown only when handed a handler. */
+  const sizeChangerProps = useMemo(() => {
+    if (!clientPagination?.showSizeChanger) {
+      return {};
+    }
+    const { pageSizeOptions } = clientPagination;
+
+    return {
+      onShowSizeChange: handlePageSizeChange,
+      ...(pageSizeOptions.length ? { pageSizeOptions } : {}),
+    };
+  }, [clientPagination, handlePageSizeChange]);
+
   // ─── Flat rows (tree data flattened with depth tracking) ──────────────────
 
   const flatRows = useMemo<FlatRow<T>[]>(() => {
@@ -515,12 +780,27 @@ const TableV2 = <T extends object>(
       });
     }
 
-    return flattenTreeRows(
+    const rows = flattenTreeRows(
       pagedDataSource,
       getRowKey,
       expandedKeys,
       rest.expandable.rowExpandable as ((r: T) => boolean) | undefined
     );
+
+    // With `expandedRowRender` the detail panel is the child, so a row is
+    // expandable even though it carries no `children` array — which is all
+    // `flattenTreeRows` looks at.
+    if (!rest.expandable.expandedRowRender) {
+      return rows;
+    }
+    const rowExpandable = rest.expandable.rowExpandable as
+      | ((r: T) => boolean)
+      | undefined;
+
+    return rows.map((row) => ({
+      ...row,
+      hasChildren: rowExpandable ? rowExpandable(row.record) : true,
+    }));
   }, [
     pagedDataSource,
     rest.expandable,
@@ -636,7 +916,9 @@ const TableV2 = <T extends object>(
             <UntitledTable
               stickyHeader
               aria-label="data-table"
-              className={rest.resizableColumns ? 'tw:table-fixed' : undefined}
+              className={classNames(rest.className, {
+                'tw:table-fixed': rest.resizableColumns,
+              })}
               containerStyle={
                 scroll?.y
                   ? {
@@ -645,6 +927,8 @@ const TableV2 = <T extends object>(
                     }
                   : undefined
               }
+              disabledBehavior="selection"
+              disabledKeys={disabledRowKeys}
               dragAndDropHooks={dragAndDropHooks}
               selectedKeys={
                 rest.rowSelection?.selectedRowKeys
@@ -653,12 +937,12 @@ const TableV2 = <T extends object>(
               }
               selectionBehavior={rest.rowSelection ? 'toggle' : undefined}
               selectionMode={selectionMode}
-              size={rest.size === 'small' ? 'sm' : 'md'}
+              size={toCoreSize(rest.size)}
               sortDescriptor={
-                sortState.columnKey && sortState.direction
+                effectiveSort.columnKey && effectiveSort.direction
                   ? {
-                      column: sortState.columnKey,
-                      direction: sortState.direction,
+                      column: effectiveSort.columnKey,
+                      direction: effectiveSort.direction,
                     }
                   : undefined
               }
@@ -703,16 +987,22 @@ const TableV2 = <T extends object>(
                             onOpenChange={(isOpen) =>
                               setOpenFilterKey(isOpen ? colKey : null)
                             }>
-                            <Button
+                            {/*
+                              `DialogTrigger` opens its popover through a React
+                              Aria `PressResponder`, which only reaches a React
+                              Aria pressable child. A core `Button` here is not
+                              one — it warns "PressResponder was rendered
+                              without a pressable child" and the dropdown never
+                              opens. */}
+                            <AriaButton
                               aria-label="filter"
-                              className="tw:ml-1 tw:p-0 tw:bg-transparent tw:border-0 tw:cursor-pointer tw:inline-flex tw:items-center"
-                              color="tertiary">
+                              className="tw:ml-1 tw:p-0 tw:bg-transparent tw:border-0 tw:cursor-pointer tw:inline-flex tw:items-center">
                               {typeof colType.filterIcon === 'function'
                                 ? colType.filterIcon(
                                     Boolean(filterState[colKey]?.length)
                                   )
                                 : colType.filterIcon ?? null}
-                            </Button>
+                            </AriaButton>
                             <Popover placement="bottom right">
                               <Dialog className="tw:outline-none">
                                 <div
@@ -767,13 +1057,19 @@ const TableV2 = <T extends object>(
                     </div>
                   )
                 }>
-                {flatRows.map((flatRow) => {
+                {flatRows.flatMap((flatRow) => {
                   const { record, actualIndex, depth, hasChildren, rowKey } =
                     flatRow;
                   const rowHandlers = rest.onRow?.(record, actualIndex) ?? {};
                   const isExpanded = expandedKeys.has(rowKey);
+                  const detailRow = buildExpandedDetailRow(
+                    rest.expandable,
+                    flatRow,
+                    isExpanded,
+                    propsColumns.length
+                  );
 
-                  return (
+                  return [
                     <UntitledTable.Row
                       className={classNames(
                         'tw:group tw:transition-colors tw:hover:bg-secondary tw:data-[selected]:bg-secondary',
@@ -783,33 +1079,12 @@ const TableV2 = <T extends object>(
                       )}
                       data-level={depth}
                       data-row-key={rowKey}
-                      draggable={
-                        dragAndDropHooks
-                          ? undefined
-                          : (rowHandlers.draggable as boolean | undefined)
-                      }
                       id={rowKey}
                       key={rowKey}
-                      onClick={rowHandlers.onClick}
-                      onDoubleClick={rowHandlers.onDoubleClick}
-                      onDragEnd={
-                        dragAndDropHooks ? undefined : rowHandlers.onDragEnd
-                      }
-                      onDragEnter={
-                        dragAndDropHooks ? undefined : rowHandlers.onDragEnter
-                      }
-                      onDragLeave={
-                        dragAndDropHooks ? undefined : rowHandlers.onDragLeave
-                      }
-                      onDragOver={
-                        dragAndDropHooks ? undefined : rowHandlers.onDragOver
-                      }
-                      onDragStart={
-                        dragAndDropHooks ? undefined : rowHandlers.onDragStart
-                      }
-                      onDrop={
-                        dragAndDropHooks ? undefined : rowHandlers.onDrop
-                      }>
+                      {...getRowInteractionProps(
+                        rowHandlers,
+                        Boolean(dragAndDropHooks)
+                      )}>
                       {propsColumns.map((col, colIdx) => {
                         const colType = col as ColumnType<T>;
                         const cellKey = String(
@@ -858,9 +1133,11 @@ const TableV2 = <T extends object>(
                                   }
                                 : {}),
                               ...stickyStyle,
-                              ...(showExpandInCell
-                                ? { paddingLeft: `${16 + depth * 12}px` }
-                                : {}),
+                              ...getIndentStyle(
+                                Boolean(showExpandInCell),
+                                depth,
+                                rest.indentSize
+                              ),
                               ...cellHandlerProps.style,
                             }}>
                             <div
@@ -925,8 +1202,9 @@ const TableV2 = <T extends object>(
                           </UntitledTable.Cell>
                         );
                       })}
-                    </UntitledTable.Row>
-                  );
+                    </UntitledTable.Row>,
+                    detailRow,
+                  ].filter(Boolean);
                 })}
               </UntitledTable.Body>
             </UntitledTable>
@@ -943,6 +1221,12 @@ const TableV2 = <T extends object>(
           );
         })()}
       </div>
+
+      {rest.footer && (
+        <div className="tw:px-4 tw:py-2 tw:text-sm tw:text-tertiary">
+          {rest.footer(pagedDataSource)}
+        </div>
+      )}
 
       {customPaginationProps && customPaginationProps.showPagination ? (
         <div>
@@ -962,6 +1246,7 @@ const TableV2 = <T extends object>(
             pagingHandler={({ currentPage }) =>
               setInternalCurrentPage(currentPage)
             }
+            {...sizeChangerProps}
           />
         </div>
       ) : null}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
@@ -300,6 +300,26 @@ const getRowInteractionProps = (
   };
 };
 
+/**
+ * Stable, unique React Aria column ids.
+ *
+ * AntD tolerates two columns sharing a `key` — it renders both. React Aria uses
+ * the id as a collection key, so a duplicate collapses the column while the row
+ * still renders a cell for it, and the table throws "Cell count must match
+ * column count". Suffixing repeats keeps such a table rendering instead.
+ */
+const getColumnIds = <T,>(columns: ColumnsType<T>): string[] => {
+  const seen = new Map<string, number>();
+
+  return columns.map((col, idx) => {
+    const base = String(col.key ?? (col as ColumnType<T>).dataIndex ?? idx);
+    const count = seen.get(base) ?? 0;
+    seen.set(base, count + 1);
+
+    return count === 0 ? base : `${base}-${count}`;
+  });
+};
+
 const TableV2 = <T extends object>(
   {
     loading,
@@ -778,6 +798,8 @@ const TableV2 = <T extends object>(
     };
   }, [clientPagination, handlePageSizeChange]);
 
+  const columnIds = useMemo(() => getColumnIds(propsColumns), [propsColumns]);
+
   // ─── Flat rows (tree data flattened with depth tracking) ──────────────────
 
   const flatRows = useMemo<FlatRow<T>[]>(() => {
@@ -972,7 +994,7 @@ const TableV2 = <T extends object>(
                   const rowHeaderColumn = colType as ColumnType<T> & {
                     isRowHeader?: boolean;
                   };
-                  const colKey = String(col.key ?? colType.dataIndex ?? colIdx);
+                  const colKey = columnIds[colIdx];
                   const colWidth =
                     columnWidths[colKey] ??
                     (colType.width as number | undefined);
@@ -1108,9 +1130,7 @@ const TableV2 = <T extends object>(
                       )}>
                       {propsColumns.map((col, colIdx) => {
                         const colType = col as ColumnType<T>;
-                        const cellKey = String(
-                          col.key ?? colType.dataIndex ?? colIdx
-                        );
+                        const cellKey = columnIds[colIdx];
                         const stickyStyle = getColumnStickyStyle(
                           colType.fixed,
                           1

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
@@ -245,24 +245,32 @@ const buildExpandedDetailRow = <T extends object>(
  * interactive so the call site's handler still receives a real MouseEvent,
  * without adding a second activation path that would fire it twice.
  */
-interface RowInteractionProps
-  extends Pick<
-    React.HTMLAttributes<HTMLElement>,
-    | 'onClick'
-    | 'onDoubleClick'
-    | 'onDragEnd'
-    | 'onDragEnter'
-    | 'onDragLeave'
-    | 'onDragOver'
-    | 'onDragStart'
-    | 'onDrop'
-  > {
-  onAction?: () => void;
+/**
+ * Derived from the row component's own props rather than from
+ * `HTMLAttributes`: React Aria's Row types several of these itself, so a
+ * hand-written shape drifts from what the component actually accepts.
+ */
+type RowInteractionProps = Pick<
+  React.ComponentProps<typeof UntitledTable.Row>,
+  | 'draggable'
+  | 'onAction'
+  | 'onClick'
+  | 'onDoubleClick'
+  | 'onDragEnd'
+  | 'onDragEnter'
+  | 'onDragLeave'
+  | 'onDragOver'
+  | 'onDragStart'
+  | 'onDrop'
+>;
+
+/** What AntD's `onRow` hands back. */
+type AntdRowHandlers = React.HTMLAttributes<HTMLElement> & {
   draggable?: boolean;
-}
+};
 
 const getRowInteractionProps = (
-  rowHandlers: React.HTMLAttributes<HTMLElement> & { draggable?: boolean },
+  rowHandlers: AntdRowHandlers,
   hasAriaDragAndDrop: boolean
 ): RowInteractionProps => {
   const activation = {
@@ -1074,7 +1082,8 @@ const TableV2 = <T extends object>(
                 {flatRows.flatMap((flatRow) => {
                   const { record, actualIndex, depth, hasChildren, rowKey } =
                     flatRow;
-                  const rowHandlers = rest.onRow?.(record, actualIndex) ?? {};
+                  const rowHandlers = (rest.onRow?.(record, actualIndex) ??
+                    {}) as AntdRowHandlers;
                   const isExpanded = expandedKeys.has(rowKey);
                   const detailRow = buildExpandedDetailRow(
                     rest.expandable,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
@@ -245,12 +245,26 @@ const buildExpandedDetailRow = <T extends object>(
  * interactive so the call site's handler still receives a real MouseEvent,
  * without adding a second activation path that would fire it twice.
  */
+interface RowInteractionProps
+  extends Pick<
+    React.HTMLAttributes<HTMLElement>,
+    | 'onClick'
+    | 'onDoubleClick'
+    | 'onDragEnd'
+    | 'onDragEnter'
+    | 'onDragLeave'
+    | 'onDragOver'
+    | 'onDragStart'
+    | 'onDrop'
+  > {
+  onAction?: () => void;
+  draggable?: boolean;
+}
+
 const getRowInteractionProps = (
-  rowHandlers: React.HTMLAttributes<HTMLTableRowElement> & {
-    draggable?: boolean;
-  },
+  rowHandlers: React.HTMLAttributes<HTMLElement> & { draggable?: boolean },
   hasAriaDragAndDrop: boolean
-) => {
+): RowInteractionProps => {
   const activation = {
     onAction: rowHandlers.onClick ? noop : undefined,
     onClick: rowHandlers.onClick,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
@@ -264,13 +264,8 @@ type RowInteractionProps = Pick<
   | 'onDrop'
 >;
 
-/** What AntD's `onRow` hands back. */
-type AntdRowHandlers = React.HTMLAttributes<HTMLElement> & {
-  draggable?: boolean;
-};
-
 const getRowInteractionProps = (
-  rowHandlers: AntdRowHandlers,
+  rowHandlers: RowInteractionProps,
   hasAriaDragAndDrop: boolean
 ): RowInteractionProps => {
   const activation = {
@@ -1082,8 +1077,11 @@ const TableV2 = <T extends object>(
                 {flatRows.flatMap((flatRow) => {
                   const { record, actualIndex, depth, hasChildren, rowKey } =
                     flatRow;
+                  // AntD types `onRow`'s return as HTMLAttributes<any>, while
+                  // React Aria's Row types several of the same handlers itself.
+                  // This is the boundary between the two, narrowed once.
                   const rowHandlers = (rest.onRow?.(record, actualIndex) ??
-                    {}) as AntdRowHandlers;
+                    {}) as RowInteractionProps;
                   const isExpanded = expandedKeys.has(rowKey);
                   const detailRow = buildExpandedDetailRow(
                     rest.expandable,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/__tests__/Table.parity.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/__tests__/Table.parity.test.tsx
@@ -1,0 +1,57 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { fireEvent, screen, within } from '@testing-library/react';
+import Table from '../Table';
+import { ParityAdapter, runTableParitySuite } from './tableParity.shared';
+
+/** Control access for the legacy antd DOM. Assertions stay in the shared suite. */
+const antdAdapter: ParityAdapter = {
+  activate: (element) => fireEvent.click(element),
+  clickNextPage: () => {
+    fireEvent.click(
+      document.querySelector('.ant-pagination-next button') as HTMLElement
+    );
+  },
+  getIndentPx: (label) => {
+    const row = screen
+      .getAllByRole('row')
+      .find((candidate) => within(candidate).queryByText(label));
+    const indent = (row as HTMLElement).querySelector(
+      '.ant-table-row-indent'
+    ) as HTMLElement | null;
+
+    return indent ? parseFloat(indent.style.paddingLeft || '0') : 0;
+  },
+  openFilter: () => {
+    fireEvent.click(
+      document.querySelector('.ant-table-filter-trigger') as HTMLElement
+    );
+  },
+  queryPageSizeControl: () => document.querySelector('.ant-pagination-options'),
+  getSelectAllControl: () =>
+    document.querySelector(
+      'thead .ant-table-selection input[type="checkbox"]'
+    ) as HTMLElement | null,
+  queryPager: () => document.querySelector('.ant-pagination'),
+  toggleExpander: (label) => {
+    const row = screen
+      .getAllByRole('row')
+      .find((candidate) => within(candidate).queryByText(label));
+    fireEvent.click(
+      within(row as HTMLElement).getByTestId('expand-icon')
+    );
+  },
+};
+
+runTableParitySuite('Table (legacy)', Table, antdAdapter);

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/__tests__/TableV2.parity.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/__tests__/TableV2.parity.test.tsx
@@ -1,0 +1,121 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { ComponentType } from 'react';
+import TableV2 from '../TableV2';
+import { ParityAdapter, runTableParitySuite } from './tableParity.shared';
+
+/**
+ * react-aria's `usePress` listens on pointer events, not `click`, so a bare
+ * `fireEvent.click` never activates a core Button/MenuItem in jsdom.
+ */
+const press = (element: HTMLElement) => {
+  fireEvent.pointerDown(element, { button: 0, pointerId: 1, pointerType: 'mouse' });
+  fireEvent.pointerUp(element, { button: 0, pointerId: 1, pointerType: 'mouse' });
+  fireEvent.click(element);
+};
+
+/** Control access for the ui-core-components DOM. Assertions stay in the shared suite. */
+const coreAdapter: ParityAdapter = {
+  activate: (element) => press(element),
+  clickNextPage: () => {
+    fireEvent.click(screen.getByTestId('next'));
+  },
+  getIndentPx: (label) => {
+    const row = screen
+      .getAllByRole('row')
+      .find((candidate) => within(candidate).queryByText(label));
+    const cell = (row as HTMLElement).querySelector(
+      'td, th'
+    ) as HTMLElement | null;
+
+    return cell ? parseFloat(cell.style.paddingLeft || '0') : 0;
+  },
+  openFilter: () => {
+    press(screen.getByLabelText('filter'));
+  },
+  queryPageSizeControl: () =>
+    screen.queryByTestId('page-size-selection-dropdown'),
+  getSelectAllControl: () =>
+    document.querySelector(
+      'thead input[type="checkbox"]'
+    ) as HTMLElement | null,
+  queryPager: () => screen.queryByTestId('pagination'),
+  toggleExpander: (label) => {
+    const row = screen
+      .getAllByRole('row')
+      .find((candidate) => within(candidate).queryByText(label));
+    fireEvent.click(within(row as HTMLElement).getByTestId('expand-icon'));
+  },
+};
+
+runTableParitySuite('TableV2', TableV2, coreAdapter);
+
+/**
+ * Not a parity spec — an intentional divergence from legacy. `customPaginationProps`
+ * now *requires* `pagination={false}` in the props type, so the pair can only be
+ * mismatched at an untyped boundary. The runtime short-circuit is the backstop for
+ * that case: AntD would slice the page a second time, TableV2 must not.
+ */
+describe('TableV2 — parent-owned pagination', () => {
+  const rows = Array.from({ length: 12 }, (_, i) => ({
+    count: i,
+    name: `row-${String(i).padStart(2, '0')}`,
+  }));
+
+  const columns = [
+    { dataIndex: 'name', key: 'name', title: 'Name' },
+    { dataIndex: 'count', key: 'count', title: 'Count' },
+  ];
+
+  const customPaginationProps = {
+    currentPage: 1,
+    pageSize: 50,
+    paging: { total: 120 },
+    pagingHandler: jest.fn(),
+    showPagination: true,
+  };
+
+  it('renders every row the parent supplied rather than slicing to a page size', () => {
+    render(
+      <TableV2
+        columns={columns}
+        customPaginationProps={customPaginationProps}
+        dataSource={rows}
+        pagination={false}
+        rowKey="name"
+      />
+    );
+
+    expect(screen.getAllByRole('row')).toHaveLength(rows.length + 1);
+  });
+
+  it('still refuses to slice when the pagination contract is bypassed untyped', () => {
+    // Mirrors a JS call site, or a `tableProps` spread that TypeScript cannot
+    // narrow — the case the props type cannot catch.
+    const UntypedTable = TableV2 as unknown as ComponentType<
+      Record<string, unknown>
+    >;
+    render(
+      <UntypedTable
+        columns={columns}
+        customPaginationProps={customPaginationProps}
+        dataSource={rows}
+        rowKey="name"
+      />
+    );
+
+    expect(screen.getAllByRole('row')).toHaveLength(rows.length + 1);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/__tests__/tableParity.shared.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/__tests__/tableParity.shared.tsx
@@ -1,0 +1,712 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * Behavioural parity suite shared by `Table` (legacy, antd) and `TableV2`
+ * (ui-core-components).
+ *
+ * The contract: every assertion here is implementation-independent — it checks
+ * *what the user sees or gets called back with*, never a framework class name.
+ * Where a control's DOM genuinely differs by design (the pager, the expander),
+ * the difference is confined to the `ParityAdapter` the runner supplies; the
+ * assertion around it stays shared.
+ *
+ * A spec that cannot be made green against legacy `Table` is a wrong spec, not
+ * a legacy bug — drop it rather than "fix" it.
+ */
+
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { ColumnsType } from 'antd/lib/table';
+import { ComponentType, ReactNode } from 'react';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import { useApplicationStore } from '../../../../hooks/useApplicationStore';
+import { usePersistentStorage } from '../../../../hooks/currentUserStore/useCurrentUserStore';
+
+export interface ParityRow {
+  name: string;
+  count: number;
+  children?: ParityRow[];
+}
+
+export interface ParityAdapter {
+  /** Advance the pager one page. */
+  clickNextPage: () => void;
+  /** Toggle the expander on the row whose first cell reads `label`. */
+  toggleExpander: (label: string) => void;
+  /** The header "select all" control, or null when the impl renders none. */
+  getSelectAllControl: () => HTMLElement | null;
+  /** The built-in pager element, or null when none is rendered. */
+  queryPager: () => HTMLElement | null;
+  /** The built-in pager's page-size control, or null when none is rendered. */
+  queryPageSizeControl: () => HTMLElement | null;
+  /** Left indentation, in px, applied to a tree row's first cell. */
+  getIndentPx: (label: string) => number;
+  /** Open the column filter dropdown for the column titled `columnTitle`. */
+  openFilter: (columnTitle: string) => void;
+  /**
+   * Activate a control the way this implementation expects. antd listens on
+   * `click`; react-aria's `usePress` listens on pointer events, so a bare click
+   * never fires. Activation mechanics differ by design — the assertions around
+   * them do not.
+   */
+  activate: (element: HTMLElement) => void;
+}
+
+export const PARITY_ROWS: ParityRow[] = [
+  { count: 3, name: 'charlie' },
+  { count: 1, name: 'alpha' },
+  { count: 2, name: 'bravo' },
+];
+
+export const TREE_ROWS: ParityRow[] = [
+  {
+    children: [{ count: 10, name: 'child-one' }],
+    count: 1,
+    name: 'parent-one',
+  },
+  { count: 2, name: 'parent-two' },
+];
+
+const nameColumn: ColumnsType<ParityRow>[number] = {
+  dataIndex: 'name',
+  key: 'name',
+  title: 'Name',
+};
+
+const countColumn: ColumnsType<ParityRow>[number] = {
+  dataIndex: 'count',
+  key: 'count',
+  title: 'Count',
+};
+
+export const BASE_COLUMNS: ColumnsType<ParityRow> = [nameColumn, countColumn];
+
+/**
+ * First data cell of a row. antd renders `<td role="cell">`; react-aria renders
+ * `<td role="rowheader">` for the row-header column and `role="gridcell"` after
+ * it — so the lookup is structural, not role-based.
+ */
+const firstCell = (row: HTMLElement): HTMLElement | null =>
+  row.querySelector('td, th:not([scope])');
+
+/** Row labels in render order, ignoring the header row. */
+const renderedNames = (): string[] =>
+  screen
+    .getAllByRole('row')
+    .slice(1)
+    .map((row) => firstCell(row)?.textContent?.trim() ?? '')
+    .filter(Boolean);
+
+export const runTableParitySuite = (
+  suiteName: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TableComponent: ComponentType<any>,
+  adapter: ParityAdapter
+) => {
+  // Both column-customize menus are react-dnd draggables, so every render needs
+  // a drag-drop context — the same wrapper the real pages provide.
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <DndProvider backend={HTML5Backend}>{children}</DndProvider>
+  );
+
+  const renderTable = (props: Record<string, unknown> = {}) =>
+    render(
+      <TableComponent
+        columns={BASE_COLUMNS}
+        dataSource={PARITY_ROWS}
+        pagination={false}
+        rowKey="name"
+        {...props}
+      />,
+      { wrapper }
+    );
+
+  // The column-visibility preference is a persisted zustand store keyed by the
+  // signed-in user. Without a current user every write is a no-op, so the
+  // customize-columns specs would exercise a path production never takes; and
+  // without the reset one spec's selection leaks into the next.
+  beforeEach(() => {
+    useApplicationStore.setState({
+      currentUser: { id: 'parity-user-id', name: 'parity-user' },
+    });
+    usePersistentStorage.setState({ preferences: {} });
+  });
+
+  describe(`${suiteName} — render`, () => {
+    it('renders one row per record', () => {
+      renderTable();
+
+      expect(renderedNames()).toEqual(['charlie', 'alpha', 'bravo']);
+    });
+
+    it('renders every column title', () => {
+      renderTable();
+
+      expect(screen.getByText('Name')).toBeInTheDocument();
+      expect(screen.getByText('Count')).toBeInTheDocument();
+    });
+
+    it('renders custom render() output in place of the raw value', () => {
+      renderTable({
+        columns: [
+          { ...nameColumn, render: (value: string) => `<${value}>` },
+          countColumn,
+        ],
+      });
+
+      expect(screen.getByText('<alpha>')).toBeInTheDocument();
+    });
+
+    it('passes value, record and row index to render()', () => {
+      const render_ = jest.fn().mockReturnValue('cell');
+      renderTable({ columns: [{ ...nameColumn, render: render_ }, countColumn] });
+
+      expect(render_).toHaveBeenCalledWith('charlie', PARITY_ROWS[0], 0);
+      expect(render_).toHaveBeenCalledWith('bravo', PARITY_ROWS[2], 2);
+    });
+
+    it('shows locale.emptyText when there is no data', () => {
+      renderTable({ dataSource: [], locale: { emptyText: 'nothing here' } });
+
+      expect(screen.getByText('nothing here')).toBeInTheDocument();
+    });
+
+    it('shows a loader while loading', () => {
+      renderTable({ loading: true });
+
+      expect(screen.getByTestId('loader')).toBeInTheDocument();
+    });
+
+    it('accepts the object form of loading', () => {
+      renderTable({ loading: { spinning: true } });
+
+      expect(screen.getByTestId('loader')).toBeInTheDocument();
+    });
+  });
+
+  describe(`${suiteName} — sorting`, () => {
+    const sortedColumns: ColumnsType<ParityRow> = [
+      { ...nameColumn, sorter: (a, b) => a.name.localeCompare(b.name) },
+      countColumn,
+    ];
+
+    it('sorts ascending on the first header click', () => {
+      renderTable({ columns: sortedColumns });
+      fireEvent.click(screen.getByText('Name'));
+
+      expect(renderedNames()).toEqual(['alpha', 'bravo', 'charlie']);
+    });
+
+    it('sorts descending on the second header click', () => {
+      renderTable({ columns: sortedColumns });
+      fireEvent.click(screen.getByText('Name'));
+      fireEvent.click(screen.getByText('Name'));
+
+      expect(renderedNames()).toEqual(['charlie', 'bravo', 'alpha']);
+    });
+
+    it('honours a controlled sortOrder without any interaction', () => {
+      renderTable({
+        columns: [{ ...sortedColumns[0], sortOrder: 'descend' }, countColumn],
+      });
+
+      expect(renderedNames()).toEqual(['charlie', 'bravo', 'alpha']);
+    });
+
+    it('leaves order untouched and reports the sorter when sorter is true', () => {
+      const onChange = jest.fn();
+      renderTable({
+        columns: [{ ...nameColumn, sorter: true }, countColumn],
+        onChange,
+      });
+      fireEvent.click(screen.getByText('Name'));
+
+      expect(renderedNames()).toEqual(['charlie', 'alpha', 'bravo']);
+      expect(onChange).toHaveBeenCalled();
+      expect(onChange.mock.calls[0][2]).toEqual(
+        expect.objectContaining({ order: 'ascend' })
+      );
+    });
+  });
+
+  describe(`${suiteName} — pagination`, () => {
+    const many = Array.from({ length: 12 }, (_, i) => ({
+      count: i,
+      name: `row-${String(i).padStart(2, '0')}`,
+    }));
+
+    it('renders every row when pagination is false', () => {
+      renderTable({ dataSource: many, pagination: false });
+
+      expect(renderedNames()).toHaveLength(12);
+    });
+
+    it('limits the page to pageSize', () => {
+      renderTable({ dataSource: many, pagination: { pageSize: 5 } });
+
+      expect(renderedNames()).toHaveLength(5);
+      expect(renderedNames()[0]).toBe('row-00');
+    });
+
+    it('shows the next page when the pager advances', () => {
+      renderTable({ dataSource: many, pagination: { pageSize: 5 } });
+      act(() => adapter.clickNextPage());
+
+      expect(renderedNames()[0]).toBe('row-05');
+    });
+
+    it('hides the pager for a single page when hideOnSinglePage is set', () => {
+      renderTable({
+        dataSource: PARITY_ROWS,
+        pagination: { hideOnSinglePage: true, pageSize: 10 },
+      });
+
+      expect(adapter.queryPager()).toBeNull();
+    });
+
+    it('renders the pager when there is more than one page', () => {
+      renderTable({ dataSource: many, pagination: { pageSize: 5 } });
+
+      expect(adapter.queryPager()).not.toBeNull();
+    });
+  });
+
+  describe(`${suiteName} — selection`, () => {
+    it('renders a checkbox per row plus the select-all control', () => {
+      renderTable({ rowSelection: { onChange: jest.fn() } });
+
+      expect(screen.getAllByRole('checkbox')).toHaveLength(
+        PARITY_ROWS.length + 1
+      );
+    });
+
+    it('reports the selected key and record', () => {
+      const onChange = jest.fn();
+      renderTable({ rowSelection: { onChange } });
+      const rowCheckbox = within(screen.getAllByRole('row')[1]).getByRole(
+        'checkbox'
+      );
+      fireEvent.click(rowCheckbox);
+
+      expect(onChange).toHaveBeenCalled();
+      expect(onChange.mock.calls[0][0]).toEqual(['charlie']);
+      expect(onChange.mock.calls[0][1]).toEqual([PARITY_ROWS[0]]);
+    });
+
+    // AntD renders `input[type=radio]`; React Aria keeps checkbox semantics for
+    // table selection and swaps only the visual. The contract that matters to a
+    // user is the same either way: one row at a time, and no select-all.
+    it('replaces the previous pick when the selection type is radio', () => {
+      const onChange = jest.fn();
+      renderTable({ rowSelection: { onChange, type: 'radio' } });
+      const rows = screen.getAllByRole('row').slice(1);
+      fireEvent.click(rows[0].querySelector('input') as HTMLElement);
+      fireEvent.click(rows[1].querySelector('input') as HTMLElement);
+
+      expect(onChange.mock.calls.at(-1)?.[0]).toEqual(['alpha']);
+    });
+
+    it('offers no select-all control when the selection type is radio', () => {
+      renderTable({ rowSelection: { onChange: jest.fn(), type: 'radio' } });
+
+      expect(document.querySelector('thead input')).toBeNull();
+    });
+
+    it('disables the control for rows blocked by getCheckboxProps', () => {
+      renderTable({
+        rowSelection: {
+          getCheckboxProps: (record: ParityRow) => ({
+            disabled: record.name === 'alpha',
+          }),
+          onChange: jest.fn(),
+        },
+      });
+      const alphaRow = screen
+        .getAllByRole('row')
+        .find((row) => within(row).queryByText('alpha'));
+
+      expect(within(alphaRow as HTMLElement).getByRole('checkbox')).toBeDisabled();
+    });
+
+    it('selects every row on the current page from the select-all control', () => {
+      const onChange = jest.fn();
+      renderTable({ rowSelection: { onChange } });
+      const selectAll = adapter.getSelectAllControl();
+      fireEvent.click(selectAll as HTMLElement);
+
+      expect(onChange.mock.calls[0][0]).toEqual([
+        'charlie',
+        'alpha',
+        'bravo',
+      ]);
+    });
+  });
+
+  describe(`${suiteName} — expandable`, () => {
+    it('hides child rows until the parent is expanded', () => {
+      renderTable({ dataSource: TREE_ROWS, expandable: {} });
+
+      expect(renderedNames()).toEqual(['parent-one', 'parent-two']);
+    });
+
+    it('reveals child rows when the parent is expanded', () => {
+      renderTable({ dataSource: TREE_ROWS, expandable: {} });
+      act(() => adapter.toggleExpander('parent-one'));
+
+      expect(renderedNames()).toEqual([
+        'parent-one',
+        'child-one',
+        'parent-two',
+      ]);
+    });
+
+    it('honours controlled expandedRowKeys', () => {
+      renderTable({
+        dataSource: TREE_ROWS,
+        expandable: { expandedRowKeys: ['parent-one'] },
+      });
+
+      expect(renderedNames()).toContain('child-one');
+    });
+
+    it('calls onExpand with the new state and the record', () => {
+      const onExpand = jest.fn();
+      renderTable({ dataSource: TREE_ROWS, expandable: { onExpand } });
+      act(() => adapter.toggleExpander('parent-one'));
+
+      expect(onExpand).toHaveBeenCalledWith(true, TREE_ROWS[0]);
+    });
+  });
+
+  describe(`${suiteName} — column extras`, () => {
+    it('renders a footer', () => {
+      renderTable({ footer: () => 'footer-content' });
+
+      expect(screen.getByText('footer-content')).toBeInTheDocument();
+    });
+
+    it('forwards onRow click and double click', () => {
+      const onClick = jest.fn();
+      const onDoubleClick = jest.fn();
+      renderTable({ onRow: () => ({ onClick, onDoubleClick }) });
+      const firstRow = screen.getAllByRole('row')[1];
+      fireEvent.click(firstRow);
+      fireEvent.doubleClick(firstRow);
+
+      expect(onClick).toHaveBeenCalled();
+      expect(onDoubleClick).toHaveBeenCalled();
+    });
+
+    it('forwards onCell props to the rendered cell', () => {
+      renderTable({
+        columns: [
+          { ...nameColumn, onCell: () => ({ 'data-testid': 'tagged-cell' }) },
+          countColumn,
+        ],
+      });
+
+      expect(screen.getAllByTestId('tagged-cell')).toHaveLength(
+        PARITY_ROWS.length
+      );
+    });
+
+    it('applies a fixed column as sticky', () => {
+      renderTable({ columns: [{ ...nameColumn, fixed: 'left' }, countColumn] });
+      const cell = firstCell(screen.getAllByRole('row')[1]);
+
+      expect(cell).toHaveStyle({ position: 'sticky' });
+    });
+  });
+
+  describe(`${suiteName} — container`, () => {
+    it('applies containerClassName to the outer container', () => {
+      const { container } = renderTable({ containerClassName: 'outer-marker' });
+
+      expect(container.querySelector('.outer-marker')).toBeInTheDocument();
+    });
+
+    it('applies className somewhere in the rendered output', () => {
+      const { container } = renderTable({ className: 'inner-marker' });
+
+      expect(container.querySelector('.inner-marker')).toBeInTheDocument();
+    });
+  });
+
+  describe(`${suiteName} — search and custom pagination`, () => {
+    it('renders the searchbar when searchProps is given', () => {
+      renderTable({ searchProps: { onSearch: jest.fn() } });
+
+      expect(screen.getByTestId('searchbar')).toBeInTheDocument();
+    });
+
+    it('renders custom pagination when showPagination is true', () => {
+      renderTable({
+        customPaginationProps: {
+          currentPage: 1,
+          pageSize: 10,
+          paging: { total: 30 },
+          pagingHandler: jest.fn(),
+          showPagination: true,
+        },
+      });
+
+      expect(screen.getByTestId('pagination')).toBeInTheDocument();
+    });
+
+    it('hides custom pagination when showPagination is false', () => {
+      renderTable({
+        customPaginationProps: {
+          currentPage: 1,
+          pageSize: 10,
+          paging: { total: 30 },
+          pagingHandler: jest.fn(),
+          showPagination: false,
+        },
+      });
+
+      expect(screen.queryByTestId('pagination')).not.toBeInTheDocument();
+    });
+  });
+
+  describe(`${suiteName} — pagination, round 2`, () => {
+    const many = Array.from({ length: 12 }, (_, i) => ({
+      count: i,
+      name: `row-${String(i).padStart(2, '0')}`,
+    }));
+
+    it('offers a page-size control when showSizeChanger is set', () => {
+      renderTable({
+        dataSource: many,
+        pagination: { pageSize: 5, showSizeChanger: true },
+      });
+
+      expect(adapter.queryPageSizeControl()).not.toBeNull();
+    });
+
+    it('falls back to page 1 when the data shrinks below the current page', () => {
+      const { rerender } = renderTable({
+        dataSource: many,
+        pagination: { pageSize: 5 },
+      });
+      act(() => adapter.clickNextPage());
+
+      expect(renderedNames()[0]).toBe('row-05');
+
+      rerender(
+        <TableComponent
+          columns={BASE_COLUMNS}
+          dataSource={many.slice(0, 3)}
+          pagination={{ pageSize: 5 }}
+          rowKey="name"
+        />
+      );
+
+      expect(renderedNames()).toEqual(['row-00', 'row-01', 'row-02']);
+    });
+
+    it('renders the shared page-size control for customPaginationProps', () => {
+      renderTable({
+        customPaginationProps: {
+          currentPage: 1,
+          onShowSizeChange: jest.fn(),
+          pageSize: 10,
+          pageSizeOptions: [10, 25, 50],
+          paging: { total: 30 },
+          pagingHandler: jest.fn(),
+          showPagination: true,
+        },
+      });
+
+      expect(
+        screen.getByTestId('page-size-selection-dropdown')
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe(`${suiteName} — expandable, round 2`, () => {
+    it('renders expandedRowRender output when the row is expanded', () => {
+      renderTable({
+        expandable: {
+          expandedRowKeys: ['charlie'],
+          expandedRowRender: (record: ParityRow) => (
+            <span>{`detail-${record.name}`}</span>
+          ),
+        },
+      });
+
+      expect(screen.getByText('detail-charlie')).toBeInTheDocument();
+    });
+
+    it('omits the expander for rows rowExpandable rejects', () => {
+      renderTable({
+        expandable: {
+          expandedRowRender: (record: ParityRow) => <span>{record.name}</span>,
+          rowExpandable: () => false,
+        },
+      });
+
+      expect(screen.queryAllByTestId('expand-icon')).toHaveLength(0);
+    });
+
+    it('widens child indentation as indentSize grows', () => {
+      const { unmount } = renderTable({
+        dataSource: TREE_ROWS,
+        expandable: { expandedRowKeys: ['parent-one'] },
+      });
+      const defaultIndent = adapter.getIndentPx('child-one');
+      unmount();
+
+      renderTable({
+        dataSource: TREE_ROWS,
+        expandable: { expandedRowKeys: ['parent-one'] },
+        indentSize: 48,
+      });
+
+      expect(adapter.getIndentPx('child-one')).toBeGreaterThan(defaultIndent);
+    });
+  });
+
+  describe(`${suiteName} — sorting, round 2`, () => {
+    it('starts descending when sortDirections lists descend first', () => {
+      renderTable({
+        columns: [
+          {
+            ...nameColumn,
+            sortDirections: ['descend', 'ascend'],
+            sorter: (a: ParityRow, b: ParityRow) => a.name.localeCompare(b.name),
+          },
+          countColumn,
+        ],
+      });
+      fireEvent.click(screen.getByText('Name'));
+
+      expect(renderedNames()).toEqual(['charlie', 'bravo', 'alpha']);
+    });
+  });
+
+  describe(`${suiteName} — column filters`, () => {
+    const filterColumns = [
+      {
+        ...nameColumn,
+        filterDropdown: ({ confirm }: { confirm: () => void }) => (
+          <button data-testid="filter-apply" onClick={() => confirm()}>
+            apply
+          </button>
+        ),
+        filterIcon: () => <span data-testid="filter-icon">f</span>,
+        onFilter: (value: unknown, record: ParityRow) =>
+          record.name === String(value),
+      },
+      countColumn,
+    ];
+
+    it('renders the custom filter icon', () => {
+      renderTable({ columns: filterColumns });
+
+      expect(screen.getByTestId('filter-icon')).toBeInTheDocument();
+    });
+
+    it('opens the custom filter dropdown', () => {
+      renderTable({ columns: filterColumns });
+      act(() => adapter.openFilter('Name'));
+
+      expect(screen.getByTestId('filter-apply')).toBeInTheDocument();
+    });
+  });
+
+  describe(`${suiteName} — customize columns`, () => {
+    const customizeProps = {
+      defaultVisibleColumns: ['name'],
+      entityType: 'parityTest',
+      staticVisibleColumns: ['name'],
+    };
+
+    it('renders the customize control when both column lists are given', () => {
+      renderTable(customizeProps);
+
+      expect(screen.getByTestId('column-dropdown')).toBeInTheDocument();
+    });
+
+    it('hides a column that is neither static nor default-visible', () => {
+      renderTable(customizeProps);
+
+      expect(
+        screen.queryByRole('columnheader', { hidden: true, name: /Count/ })
+      ).not.toBeInTheDocument();
+    });
+
+    it('lists the hideable columns in the dropdown', () => {
+      renderTable(customizeProps);
+      act(() => adapter.activate(screen.getByTestId('column-dropdown')));
+
+      expect(screen.getByTestId('column-menu-item-count')).toBeInTheDocument();
+    });
+
+    it('reveals a column when it is selected in the dropdown', () => {
+      renderTable(customizeProps);
+      act(() => adapter.activate(screen.getByTestId('column-dropdown')));
+      // Both menu items put the testid on the drag container and the toggle on
+      // the button inside it.
+      act(() =>
+        adapter.activate(
+          within(screen.getByTestId('column-menu-item-count')).getByRole(
+            'button'
+          )
+        )
+      );
+
+      // `hidden: true` because a react-aria popover marks the rest of the page
+      // `aria-hidden` while it is open, and the flag outlives the menu in jsdom.
+      // The assertion is about column visibility, not aria state.
+      expect(
+        screen.getByRole('columnheader', { hidden: true, name: /Count/ })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe(`${suiteName} — selection, round 2`, () => {
+    it('reflects controlled selectedRowKeys as checked', () => {
+      renderTable({
+        rowSelection: { onChange: jest.fn(), selectedRowKeys: ['alpha'] },
+      });
+      const alphaRow = screen
+        .getAllByRole('row')
+        .find((row) => within(row).queryByText('alpha'));
+
+      expect(
+        within(alphaRow as HTMLElement).getByRole('checkbox')
+      ).toBeChecked();
+    });
+  });
+
+  describe(`${suiteName} — fixed columns, round 2`, () => {
+    // NOTE: the *offset* of the second fixed column cannot be asserted here —
+    // antd computes it from measured widths, which jsdom reports as 0, so
+    // legacy yields `left: 0px` too. TableV2's hardcoded `left: 0` for every
+    // left-fixed column stays a review/visual item (plan ref C1).
+    it('keeps every column fixed to the same side sticky', () => {
+      renderTable({
+        columns: [
+          { ...nameColumn, fixed: 'left', width: 150 },
+          { ...countColumn, fixed: 'left', width: 120 },
+        ],
+        scroll: { x: 800 },
+      });
+      const cells = screen.getAllByRole('row')[1].querySelectorAll('td, th');
+
+      expect(cells[0]).toHaveStyle({ position: 'sticky' });
+      expect(cells[1]).toHaveStyle({ position: 'sticky' });
+    });
+  });
+};

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/__tests__/tableParity.shared.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/__tests__/tableParity.shared.tsx
@@ -433,6 +433,22 @@ export const runTableParitySuite = (
     });
   });
 
+  describe(`${suiteName} — duplicate column keys`, () => {
+    // AntD renders both columns; React Aria uses the key as a collection id, so
+    // a duplicate used to collapse the column and throw on the cell count.
+    it('renders every column even when two share a key', () => {
+      renderTable({
+        columns: [
+          nameColumn,
+          { ...countColumn, key: 'name' },
+        ],
+      });
+      const cells = screen.getAllByRole('row')[1].querySelectorAll('td, th');
+
+      expect(cells).toHaveLength(2);
+    });
+  });
+
   describe(`${suiteName} — container`, () => {
     it('applies containerClassName to the outer container', () => {
       const { container } = renderTable({ containerClassName: 'outer-marker' });

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/__tests__/tableParity.shared.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/__tests__/tableParity.shared.tsx
@@ -138,7 +138,11 @@ export const runTableParitySuite = (
   // without the reset one spec's selection leaks into the next.
   beforeEach(() => {
     useApplicationStore.setState({
-      currentUser: { id: 'parity-user-id', name: 'parity-user' },
+      currentUser: {
+        email: 'parity-user@open-metadata.org',
+        id: 'parity-user-id',
+        name: 'parity-user',
+      },
     });
     usePersistentStorage.setState({ preferences: {} });
   });


### PR DESCRIPTION
> Stacked on #31953 — review that first. Base will retarget to `main` once it merges.

`TableV2` is documented as a drop-in replacement for the legacy `Table`, but silently dropped a number of props. This adds a suite that drives **both** wrappers through the same specs, and fixes everything it found red.

### The suite is the point
Every spec runs against legacy `Table` first. A spec that cannot go green there is a **wrong spec, not a legacy bug** — three specs were corrected that way during the run, and one "bug" turned out not to exist at all (the customize dropdown does re-show a hidden column; a React Aria popover marks the page `aria-hidden` and the flag outlived the menu in jsdom).

DOM differences that are genuine design choices — which element the pager is, how a control is activated — live in a per-wrapper adapter. The assertions stay shared.

### Fixed
| Prop | Was |
|---|---|
| `onRow` `onClick` | never fired. React Aria strips a row's click handler unless the row is interactive; an empty `onAction` marks it interactive so the handler gets a real `MouseEvent`, with no second activation path |
| column filter dropdown | **could not open at all** — `DialogTrigger` reaches its child through a `PressResponder`, and the child was a core `Button` rather than a React Aria pressable |
| `className` | accepted by the props type, dropped at render |
| controlled `sortOrder` | ignored |
| `rowSelection.getCheckboxProps` | ignored — rows meant to be unselectable were selectable. Mapped to `disabledKeys` + `disabledBehavior="selection"` |
| `sortDirections`, `indentSize`, `footer`, `expandedRowRender` | unimplemented |
| page-size changer | never appeared — `showSizeChanger` / `pageSizeOptions` / `onShowSizeChange` now reach the internal pager, and changing size resets to page one |

### Deliberately not implemented
`summary` and `components` are **removed from `TableV2Props`**, so passing them fails to compile rather than rendering a table that quietly lost a feature. React Aria's collection builder discards any table child that is not a Header or Body, so a `tfoot` never reaches the DOM — and a summary drawn outside the table would not line up with the columns, which is worse than not drawing it. `TeamHierarchy` uses `components` and will fail to compile when it migrates; that is intended.

`customPaginationProps` now requires `pagination={false}` in the type, since it means the parent already fetched exactly this page. A runtime short-circuit backstops untyped call sites.

### Verification
- 144 tests in `src/components/common/Table` (includes the pre-existing `Table.test.tsx` and DraggableMenu suites)
- adopter suites (Glossary, Metrics, LineageTable, ListView) — 110 tests
- `tsc --noEmit`: **573 errors, identical to `main`** — zero delta (note: `main` is not clean; zero is unreachable)
- `eslint`: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

TableV2 gains broader compatibility with the legacy Table API and a shared parity suite that runs equivalent behavior checks against both wrappers.
- Adds controlled sorting, page-size controls, footer and expanded-row rendering, indentation, row interactions, filter activation, class forwarding, and per-row selection disabling.
- Introduces shared parity tests with implementation-specific adapters for Ant Design and React Aria DOM behavior.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because expanded child rows marked disabled by `getCheckboxProps` can still be selected.

The disabled-key set is built from top-level `filteredDataSource` records, while expanded descendants are introduced only in `flatRows`; consequently, disabled child keys never reach the table’s `disabledKeys` selection guard.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx | Expands TableV2’s legacy compatibility across sorting, pagination, selection, expansion, filtering, and row interaction behavior. |
| openmetadata-ui/src/main/resources/ui/src/components/common/Table/__tests__/tableParity.shared.tsx | Defines the shared behavioral contract exercised against both table wrappers. |
| openmetadata-ui/src/main/resources/ui/src/components/common/Table/__tests__/Table.parity.test.tsx | Supplies the Ant Design adapter for the shared parity suite. |
| openmetadata-ui/src/main/resources/ui/src/components/common/Table/__tests__/TableV2.parity.test.tsx | Supplies the React Aria adapter and parent-owned pagination coverage for TableV2. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): keep TableV2 working when two c..."](https://github.com/open-metadata/openmetadata/commit/6405dbd4b9a7b357c4219f2d18fb2d43b22650ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56210806)</sub>

<!-- /greptile_comment -->