### PR TITLE
refactor(ui): import table types from Table.interface, not AntD

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/APIEndpoint/APIEndpointSchema/APIEndpointSchema.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/APIEndpoint/APIEndpointSchema/APIEndpointSchema.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { Col, Row, Segmented, Tooltip, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import classNames from 'classnames';
 import { cloneDeep, groupBy, isEmpty, isUndefined, uniqBy } from 'lodash';
 import { EntityTags, TagFilterOptions } from 'Models';

--- a/openmetadata-ui/src/main/resources/ui/src/components/APIEndpoint/APIEndpointSchema/APIEndpointSchema.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/APIEndpoint/APIEndpointSchema/APIEndpointSchema.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 import { Col, Row, Segmented, Tooltip, Typography } from 'antd';
-import { ColumnsType } from '../../common/Table/Table.interface';
 import classNames from 'classnames';
 import { cloneDeep, groupBy, isEmpty, isUndefined, uniqBy } from 'lodash';
 import { EntityTags, TagFilterOptions } from 'Models';
@@ -25,6 +24,7 @@ import {
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
+import { ColumnsType } from '../../common/Table/Table.interface';
 
 import {
   HIGHLIGHTED_ROW_SELECTOR,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Classifications/ClassificationDetails/ClassificationDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Classifications/ClassificationDetails/ClassificationDetails.tsx
@@ -15,7 +15,6 @@ import { Box, EmptyPlaceholder } from '@openmetadata/ui-core-components';
 import { Plus, Tag01 } from '@untitledui/icons';
 import { Button, Card, Col, Row, Space, Tooltip, Typography } from 'antd';
 import ButtonGroup from 'antd/lib/button/button-group';
-import { ColumnsType } from '../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { capitalize, isEmpty, isUndefined, toString } from 'lodash';
 import {
@@ -65,6 +64,7 @@ import ManageButton from '../../common/EntityPageInfos/ManageButton/ManageButton
 import Loader from '../../common/Loader/Loader';
 import { NextPreviousProps } from '../../common/NextPrevious/NextPrevious.interface';
 import Table from '../../common/Table/Table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import { GenericProvider } from '../../Customization/GenericProvider/GenericProvider';
 import { DomainLabelV2 } from '../../DataAssets/DomainLabelV2/DomainLabelV2';
 import { OwnerLabelV2 } from '../../DataAssets/OwnerLabelV2/OwnerLabelV2';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Classifications/ClassificationDetails/ClassificationDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Classifications/ClassificationDetails/ClassificationDetails.tsx
@@ -15,7 +15,7 @@ import { Box, EmptyPlaceholder } from '@openmetadata/ui-core-components';
 import { Plus, Tag01 } from '@untitledui/icons';
 import { Button, Card, Col, Row, Space, Tooltip, Typography } from 'antd';
 import ButtonGroup from 'antd/lib/button/button-group';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { capitalize, isEmpty, isUndefined, toString } from 'lodash';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerChildren/ContainerChildren.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerChildren/ContainerChildren.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { Switch, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerChildren/ContainerChildren.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerChildren/ContainerChildren.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 import { Switch, Typography } from 'antd';
-import { ColumnsType } from '../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -31,6 +30,7 @@ import { showErrorToast } from '../../../utils/ToastUtils';
 import ErrorPlaceHolder from '../../common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import { PagingHandlerParams } from '../../common/NextPrevious/NextPrevious.interface';
 import Table from '../../common/Table/Table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import { useGenericContext } from '../../Customization/GenericProvider/GenericContext';
 import { ContainerChildrenProps } from './ContainerChildren.interface';
 import { useContainerChildrenCountSetter } from './ContainerChildrenCountContext';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerDataModel/ContainerDataModel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerDataModel/ContainerDataModel.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { Tooltip, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import {
   cloneDeep,
   groupBy,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerDataModel/ContainerDataModel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerDataModel/ContainerDataModel.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 import { Tooltip, Typography } from 'antd';
-import { ColumnsType } from '../../common/Table/Table.interface';
 import {
   cloneDeep,
   groupBy,
@@ -60,6 +59,7 @@ import CopyLinkButton from '../../common/CopyLinkButton/CopyLinkButton';
 import { EntityAttachmentProvider } from '../../common/EntityDescription/EntityAttachmentProvider/EntityAttachmentProvider';
 import ErrorPlaceHolder from '../../common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import Table from '../../common/Table/Table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import { useGenericContext } from '../../Customization/GenericProvider/GenericContext';
 import { ColumnFilter } from '../../Database/ColumnFilter/ColumnFilter.component';
 import TableDescription from '../../Database/TableDescription/TableDescription.component';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardChartTable/DashboardChartTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardChartTable/DashboardChartTable.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Switch, Typography } from 'antd';
-import { ColumnsType } from '../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { compare, Operation } from 'fast-json-patch';
 import { groupBy, isUndefined, uniqBy } from 'lodash';
@@ -48,6 +47,7 @@ import withSuspenseFallback from '../../AppRouter/withSuspenseFallback';
 import { EntityAttachmentProvider } from '../../common/EntityDescription/EntityAttachmentProvider/EntityAttachmentProvider';
 import ErrorPlaceHolder from '../../common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import Table from '../../common/Table/Table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import { useGenericContext } from '../../Customization/GenericProvider/GenericContext';
 import { ColumnFilter } from '../../Database/ColumnFilter/ColumnFilter.component';
 import TableDescription from '../../Database/TableDescription/TableDescription.component';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardChartTable/DashboardChartTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardChartTable/DashboardChartTable.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Switch, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { compare, Operation } from 'fast-json-patch';
 import { groupBy, isUndefined, uniqBy } from 'lodash';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardVersion/DashboardVersion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardVersion/DashboardVersion.component.tsx
@@ -13,7 +13,6 @@
 
 import Icon from '@ant-design/icons/lib/components/Icon';
 import { Col, Row, Space, Table, Tabs, TabsProps } from 'antd';
-import { ColumnsType } from '../../common/Table/Table.interface';
 import classNames from 'classnames';
 import { FC, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -41,6 +40,7 @@ import { useRequiredParams } from '../../../utils/useRequiredParams';
 import { CustomPropertyTable } from '../../common/CustomPropertyTable/CustomPropertyTable';
 import Description from '../../common/EntityDescription/Description';
 import Loader from '../../common/Loader/Loader';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import TabsLabel from '../../common/TabsLabel/TabsLabel.component';
 import { GenericProvider } from '../../Customization/GenericProvider/GenericProvider';
 import DataAssetsVersionHeader from '../../DataAssets/DataAssetsVersionHeader/DataAssetsVersionHeader';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardVersion/DashboardVersion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardVersion/DashboardVersion.component.tsx
@@ -13,7 +13,7 @@
 
 import Icon from '@ant-design/icons/lib/components/Icon';
 import { Col, Row, Space, Table, Tabs, TabsProps } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import classNames from 'classnames';
 import { FC, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DataModel/DataModels/DataModelsTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DataModel/DataModels/DataModelsTable.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Switch, Typography } from 'antd';
-import { ColumnsType } from '../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import QueryString from 'qs';
@@ -59,6 +58,7 @@ import { showErrorToast } from '../../../../utils/ToastUtils';
 import ErrorPlaceHolder from '../../../common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import { NextPreviousProps } from '../../../common/NextPrevious/NextPrevious.interface';
 import Table from '../../../common/Table/Table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { DataModelTableProps } from './DataModelDetails.interface';
 
 const DataModelTable = ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DataModel/DataModels/DataModelsTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DataModel/DataModels/DataModelsTable.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Switch, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import QueryString from 'qs';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DataModel/DataModels/ModelTab/ModelTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DataModel/DataModels/ModelTab/ModelTab.component.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 import { Typography } from 'antd';
-import { ColumnsType } from '../../../../common/Table/Table.interface';
 import { groupBy, isEmpty, omit, uniqBy } from 'lodash';
 import { EntityTags, TagFilterOptions } from 'Models';
 import { lazy, useCallback, useEffect, useMemo, useState } from 'react';
@@ -53,6 +52,7 @@ import { EntityAttachmentProvider } from '../../../../common/EntityDescription/E
 import FilterTablePlaceHolder from '../../../../common/ErrorWithPlaceholder/FilterTablePlaceHolder';
 import { PagingHandlerParams } from '../../../../common/NextPrevious/NextPrevious.interface';
 import Table from '../../../../common/Table/Table';
+import { ColumnsType } from '../../../../common/Table/Table.interface';
 import { useGenericContext } from '../../../../Customization/GenericProvider/GenericContext';
 import { ColumnFilter } from '../../../../Database/ColumnFilter/ColumnFilter.component';
 import TableDescription from '../../../../Database/TableDescription/TableDescription.component';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DataModel/DataModels/ModelTab/ModelTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DataModel/DataModels/ModelTab/ModelTab.component.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../../common/Table/Table.interface';
 import { groupBy, isEmpty, omit, uniqBy } from 'lodash';
 import { EntityTags, TagFilterOptions } from 'Models';
 import { lazy, useCallback, useEffect, useMemo, useState } from 'react';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ContractQualityFormTab/ContractQualityFormTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ContractQualityFormTab/ContractQualityFormTab.tsx
@@ -13,7 +13,7 @@
 
 import Icon, { DownOutlined } from '@ant-design/icons';
 import { Button, Card, Dropdown, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { toLower } from 'lodash';
 import { lazy, useCallback, useEffect, useMemo, useState } from 'react';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ContractQualityFormTab/ContractQualityFormTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ContractQualityFormTab/ContractQualityFormTab.tsx
@@ -13,7 +13,6 @@
 
 import Icon, { DownOutlined } from '@ant-design/icons';
 import { Button, Card, Dropdown, Typography } from 'antd';
-import { ColumnsType } from '../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { toLower } from 'lodash';
 import { lazy, useCallback, useEffect, useMemo, useState } from 'react';
@@ -45,6 +44,7 @@ import { PagingHandlerParams } from '../../common/NextPrevious/NextPrevious.inte
 import StatusBadge from '../../common/StatusBadge/StatusBadge.component';
 import { StatusType } from '../../common/StatusBadge/StatusBadge.interface';
 import Table from '../../common/Table/Table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import { useGenericContext } from '../../Customization/GenericProvider/GenericContext';
 import { TestLevel } from '../../DataQuality/AddDataQualityTest/components/TestCaseFormV1.interface';
 import './contract-quality-form-tab.less';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ContractSchemaFormTab/ContractScehmaFormTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ContractSchemaFormTab/ContractScehmaFormTab.tsx
@@ -12,7 +12,7 @@
  */
 import Icon from '@ant-design/icons';
 import { Button, Card, Tag, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import { isEmpty, pick, uniqBy } from 'lodash';
 import { Key, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ContractSchemaFormTab/ContractScehmaFormTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ContractSchemaFormTab/ContractScehmaFormTab.tsx
@@ -12,7 +12,6 @@
  */
 import Icon from '@ant-design/icons';
 import { Button, Card, Tag, Typography } from 'antd';
-import { ColumnsType } from '../../common/Table/Table.interface';
 import { isEmpty, pick, uniqBy } from 'lodash';
 import { Key, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -50,6 +49,7 @@ import { getTableExpandableConfig } from '../../../utils/TableUtils';
 import { useRequiredParams } from '../../../utils/useRequiredParams';
 import { PagingHandlerParams } from '../../common/NextPrevious/NextPrevious.interface';
 import AntTable from '../../common/Table/Table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import { useGenericContext } from '../../Customization/GenericProvider/GenericContext';
 import { TableCellRendered } from '../../Database/SchemaTable/SchemaTable.interface';
 import TableTags from '../../Database/TableTags/TableTags.component';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ContractSchemaTable/ContractSchemaTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ContractSchemaTable/ContractSchemaTable.component.tsx
@@ -12,7 +12,7 @@
  */
 import Icon from '@ant-design/icons';
 import { Col, Row, Tag, Typography } from 'antd';
-import { ColumnsType, ColumnType, TablePaginationConfig } from 'antd/lib/table';
+import { ColumnsType, ColumnType, TablePaginationConfig } from '../../common/Table/Table.interface';
 import classNames from 'classnames';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ContractSchemaTable/ContractSchemaTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ContractSchemaTable/ContractSchemaTable.component.tsx
@@ -12,7 +12,6 @@
  */
 import Icon from '@ant-design/icons';
 import { Col, Row, Tag, Typography } from 'antd';
-import { ColumnsType, ColumnType, TablePaginationConfig } from '../../common/Table/Table.interface';
 import classNames from 'classnames';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -27,6 +26,11 @@ import { getContractStatusType } from '../../../utils/DataContract/DataContractU
 import { useRequiredParams } from '../../../utils/useRequiredParams';
 import StatusBadgeV2 from '../../common/StatusBadge/StatusBadgeV2.component';
 import Table from '../../common/Table/Table';
+import {
+  ColumnsType,
+  ColumnType,
+  TablePaginationConfig,
+} from '../../common/Table/Table.interface';
 import './contract-schema.less';
 
 const ContractSchemaTable: React.FC<{

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/TopActiveUsers.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/TopActiveUsers.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Card, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { FC, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/TopActiveUsers.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/TopActiveUsers.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Card, Typography } from 'antd';
-import { ColumnsType } from '../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { FC, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -29,6 +28,7 @@ import { getColumnSorter } from '../../utils/EntitySortUtils';
 import { showErrorToast } from '../../utils/ToastUtils';
 import UserPopOverCard from '../common/PopOverCard/UserPopOverCard';
 import Table from '../common/Table/Table';
+import { ColumnsType } from '../common/Table/Table.interface';
 import PageHeader from '../PageHeader/PageHeader.component';
 import './data-insight-detail.less';
 import { EmptyGraphPlaceholder } from './EmptyGraphPlaceholder';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/TopViewEntities.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/TopViewEntities.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Card, Typography } from 'antd';
-import { ColumnsType } from '../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isUndefined } from 'lodash';
 import { FC, useEffect, useMemo, useState } from 'react';
@@ -27,6 +26,7 @@ import { getDecodedFqn } from '../../utils/StringUtils';
 import { showErrorToast } from '../../utils/ToastUtils';
 import UserPopOverCard from '../common/PopOverCard/UserPopOverCard';
 import Table from '../common/Table/Table';
+import { ColumnsType } from '../common/Table/Table.interface';
 import PageHeader from '../PageHeader/PageHeader.component';
 import './data-insight-detail.less';
 import { EmptyGraphPlaceholder } from './EmptyGraphPlaceholder';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/TopViewEntities.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/TopViewEntities.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Card, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isUndefined } from 'lodash';
 import { FC, useEffect, useMemo, useState } from 'react';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/ColumnFilter/ColumnFilter.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/ColumnFilter/ColumnFilter.component.tsx
@@ -12,7 +12,7 @@
  */
 import { Menu } from 'antd';
 import Checkbox, { CheckboxChangeEvent } from 'antd/lib/checkbox/Checkbox';
-import { FilterDropdownProps } from 'antd/lib/table/interface';
+import { FilterDropdownProps } from '../../common/Table/Table.interface';
 import { startCase } from 'lodash';
 import React from 'react';
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/ColumnFilter/ColumnFilter.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/ColumnFilter/ColumnFilter.component.tsx
@@ -12,9 +12,9 @@
  */
 import { Menu } from 'antd';
 import Checkbox, { CheckboxChangeEvent } from 'antd/lib/checkbox/Checkbox';
-import { FilterDropdownProps } from '../../common/Table/Table.interface';
 import { startCase } from 'lodash';
 import React from 'react';
+import { FilterDropdownProps } from '../../common/Table/Table.interface';
 
 export const ColumnFilter = ({
   setSelectedKeys,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/DatabaseSchema/DatabaseSchemaTable/DatabaseSchemaTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/DatabaseSchema/DatabaseSchemaTable/DatabaseSchemaTable.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { Switch, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { compare } from 'fast-json-patch';
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/DatabaseSchema/DatabaseSchemaTable/DatabaseSchemaTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/DatabaseSchema/DatabaseSchemaTable/DatabaseSchemaTable.tsx
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 import { Switch, Typography } from 'antd';
-import { ColumnsType } from '../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { compare } from 'fast-json-patch';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 
 import { isEmpty } from 'lodash';
 import QueryString from 'qs';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleData.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleData.interface.ts
@@ -10,10 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { ColumnsType } from '../../common/Table/Table.interface';
 import { OperationPermission } from '../../../context/PermissionProvider/PermissionProvider.interface';
 import { EntityType } from '../../../enums/entity.enum';
 import { EntityReference } from '../../../generated/tests/testCase';
+import { ColumnsType } from '../../common/Table/Table.interface';
 
 export type SampleDataType =
   | string

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleData.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleData.interface.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import { OperationPermission } from '../../../context/PermissionProvider/PermissionProvider.interface';
 import { EntityType } from '../../../enums/entity.enum';
 import { EntityReference } from '../../../generated/tests/testCase';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.component.tsx
@@ -23,8 +23,7 @@ import {
   Typography,
 } from 'antd';
 import { ItemType } from 'antd/lib/menu/hooks/useItems';
-import { ColumnsType } from 'antd/lib/table';
-import { ExpandableConfig } from 'antd/lib/table/interface';
+import { ColumnsType, ExpandableConfig } from '../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
 import { groupBy, isEmpty, isEqual, isUndefined, omit } from 'lodash';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.component.tsx
@@ -23,7 +23,6 @@ import {
   Typography,
 } from 'antd';
 import { ItemType } from 'antd/lib/menu/hooks/useItems';
-import { ColumnsType, ExpandableConfig } from '../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
 import { groupBy, isEmpty, isEqual, isUndefined, omit } from 'lodash';
@@ -103,6 +102,10 @@ import { EntityAttachmentProvider } from '../../common/EntityDescription/EntityA
 import FilterTablePlaceHolder from '../../common/ErrorWithPlaceholder/FilterTablePlaceHolder';
 import { PagingHandlerParams } from '../../common/NextPrevious/NextPrevious.interface';
 import Table from '../../common/Table/Table';
+import {
+  ColumnsType,
+  ExpandableConfig,
+} from '../../common/Table/Table.interface';
 import TestCaseStatusSummaryIndicator from '../../common/TestCaseStatusSummaryIndicator/TestCaseStatusSummaryIndicator.component';
 import { useGenericContext } from '../../Customization/GenericProvider/GenericContext';
 import EntityNameModal from '../../Modals/EntityNameModal/EntityNameModal.component';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Directory/DirectoryChildrenTable/DirectoryChildrenTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Directory/DirectoryChildrenTable/DirectoryChildrenTable.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Tooltip, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { toLower } from 'lodash';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Directory/DirectoryChildrenTable/DirectoryChildrenTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Directory/DirectoryChildrenTable/DirectoryChildrenTable.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Tooltip, Typography } from 'antd';
-import { ColumnsType } from '../../../common/Table/Table.interface';
 import { toLower } from 'lodash';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -28,6 +27,7 @@ import { getEntityDetailsPath } from '../../../../utils/RouterUtils';
 import { descriptionTableObject } from '../../../../utils/TableColumn.util';
 import ErrorPlaceHolder from '../../../common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import Table from '../../../common/Table/Table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { useGenericContext } from '../../../Customization/GenericProvider/GenericContext';
 
 function DirectoryChildrenTable() {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Directory/DirectoryVersion/DirectoryVersion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Directory/DirectoryVersion/DirectoryVersion.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Col, Row, Space, Tabs, TabsProps, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
 import { toString } from 'lodash';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Directory/DirectoryVersion/DirectoryVersion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Directory/DirectoryVersion/DirectoryVersion.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Col, Row, Space, Tabs, TabsProps, Typography } from 'antd';
-import { ColumnsType } from '../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
 import { toString } from 'lodash';
@@ -47,6 +46,7 @@ import { CustomPropertyTable } from '../../../common/CustomPropertyTable/CustomP
 import Description from '../../../common/EntityDescription/Description';
 import Loader from '../../../common/Loader/Loader';
 import Table from '../../../common/Table/Table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import TabsLabel from '../../../common/TabsLabel/TabsLabel.component';
 import { GenericProvider } from '../../../Customization/GenericProvider/GenericProvider';
 import DataAssetsVersionHeader from '../../../DataAssets/DataAssetsVersionHeader/DataAssetsVersionHeader';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/File/FileColumnsTable/FileColumnsTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/File/FileColumnsTable/FileColumnsTable.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 import { Tooltip, Typography } from 'antd';
-import { ColumnsType } from '../../../common/Table/Table.interface';
 import classNames from 'classnames';
 import {
   cloneDeep,
@@ -51,6 +50,7 @@ import withSuspenseFallback from '../../../AppRouter/withSuspenseFallback';
 import { EntityAttachmentProvider } from '../../../common/EntityDescription/EntityAttachmentProvider/EntityAttachmentProvider';
 import ErrorPlaceHolder from '../../../common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import Table from '../../../common/Table/Table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { useGenericContext } from '../../../Customization/GenericProvider/GenericContext';
 import { ColumnFilter } from '../../../Database/ColumnFilter/ColumnFilter.component';
 import TableDescription from '../../../Database/TableDescription/TableDescription.component';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/File/FileColumnsTable/FileColumnsTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/File/FileColumnsTable/FileColumnsTable.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { Tooltip, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import classNames from 'classnames';
 import {
   cloneDeep,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/File/FilesTable/FilesTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/File/FilesTable/FilesTable.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 import { Switch, Typography } from 'antd';
-import { ColumnsType } from '../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import QueryString from 'qs';
@@ -44,6 +43,7 @@ import {
 import { showErrorToast } from '../../../../utils/ToastUtils';
 import ErrorPlaceHolder from '../../../common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import Table from '../../../common/Table/Table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { FilesTableProps } from './FilesTable.interface';
 
 function FilesTable({

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/File/FilesTable/FilesTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/File/FilesTable/FilesTable.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { Switch, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import QueryString from 'qs';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetVersion/SpreadsheetVersion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetVersion/SpreadsheetVersion.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Col, Row, Space, Tabs, TabsProps, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
 import { toString } from 'lodash';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetVersion/SpreadsheetVersion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetVersion/SpreadsheetVersion.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Col, Row, Space, Tabs, TabsProps, Typography } from 'antd';
-import { ColumnsType } from '../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
 import { toString } from 'lodash';
@@ -47,6 +46,7 @@ import { CustomPropertyTable } from '../../../common/CustomPropertyTable/CustomP
 import Description from '../../../common/EntityDescription/Description';
 import Loader from '../../../common/Loader/Loader';
 import Table from '../../../common/Table/Table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import TabsLabel from '../../../common/TabsLabel/TabsLabel.component';
 import { GenericProvider } from '../../../Customization/GenericProvider/GenericProvider';
 import DataAssetsVersionHeader from '../../../DataAssets/DataAssetsVersionHeader/DataAssetsVersionHeader';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetsTable/SpreadsheetsTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetsTable/SpreadsheetsTable.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 import { Switch, Typography } from 'antd';
-import { ColumnsType } from '../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import QueryString from 'qs';
@@ -44,6 +43,7 @@ import {
 import { showErrorToast } from '../../../../utils/ToastUtils';
 import ErrorPlaceHolder from '../../../common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import Table from '../../../common/Table/Table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { SpreadsheetsTableProps } from './SpreadsheetsTable.interface';
 
 function SpreadsheetsTable({

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetsTable/SpreadsheetsTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetsTable/SpreadsheetsTable.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { Switch, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import QueryString from 'qs';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/WorkflowsTable/WorkflowsTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/WorkflowsTable/WorkflowsTable.tsx
@@ -10,7 +10,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { ColumnsType } from '../../../common/Table/Table.interface';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
@@ -25,6 +24,7 @@ import { getEntityDetailsPath } from '../../../../utils/RouterUtils';
 import { descriptionTableObject } from '../../../../utils/TableColumn.util';
 import ErrorPlaceHolder from '../../../common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import Table from '../../../common/Table/Table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { useGenericContext } from '../../../Customization/GenericProvider/GenericContext';
 
 function WorkflowsTable() {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/WorkflowsTable/WorkflowsTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/WorkflowsTable/WorkflowsTable.tsx
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetColumnsTable/WorksheetColumnsTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetColumnsTable/WorksheetColumnsTable.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 import { Tooltip, Typography } from 'antd';
-import { ColumnsType } from '../../../common/Table/Table.interface';
 import classNames from 'classnames';
 import {
   cloneDeep,
@@ -55,6 +54,7 @@ import CopyLinkButton from '../../../common/CopyLinkButton/CopyLinkButton';
 import { EntityAttachmentProvider } from '../../../common/EntityDescription/EntityAttachmentProvider/EntityAttachmentProvider';
 import ErrorPlaceHolder from '../../../common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import Table from '../../../common/Table/Table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { useGenericContext } from '../../../Customization/GenericProvider/GenericContext';
 import { ColumnFilter } from '../../../Database/ColumnFilter/ColumnFilter.component';
 import TableDescription from '../../../Database/TableDescription/TableDescription.component';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetColumnsTable/WorksheetColumnsTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetColumnsTable/WorksheetColumnsTable.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { Tooltip, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import classNames from 'classnames';
 import {
   cloneDeep,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/VersionTable/VersionTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/VersionTable/VersionTable.component.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Tooltip } from 'antd';
-import { ColumnsType } from '../../common/Table/Table.interface';
 import { isEmpty, isUndefined } from 'lodash';
 import { Key, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -38,6 +37,7 @@ import { PagingHandlerParams } from '../../common/NextPrevious/NextPrevious.inte
 import RichTextEditorPreviewerV1 from '../../common/RichTextEditor/RichTextEditorPreviewerV1';
 import RichTextEditorPreviewerNew from '../../common/RichTextEditor/RichTextEditorPreviewNew';
 import Table from '../../common/Table/Table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import TagsViewer from '../../Tag/TagsViewer/TagsViewer';
 import { VersionTableProps } from './VersionTable.interfaces';
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/VersionTable/VersionTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/VersionTable/VersionTable.component.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Tooltip } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import { isEmpty, isUndefined } from 'lodash';
 import { Key, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
@@ -32,7 +32,7 @@ import {
   Space,
   Tooltip,
 } from 'antd';
-import { ColumnsType, ExpandableConfig } from 'antd/lib/table/interface';
+import { ColumnsType, ExpandableConfig } from '../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
 import { compare } from 'fast-json-patch';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
@@ -32,7 +32,6 @@ import {
   Space,
   Tooltip,
 } from 'antd';
-import { ColumnsType, ExpandableConfig } from '../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
 import { compare } from 'fast-json-patch';
@@ -116,6 +115,10 @@ import withSuspenseFallback from '../../AppRouter/withSuspenseFallback';
 import Loader from '../../common/Loader/Loader';
 import RichTextEditorPreviewerNew from '../../common/RichTextEditor/RichTextEditorPreviewNew';
 import StatusAction from '../../common/StatusAction/StatusAction';
+import {
+  ColumnsType,
+  ExpandableConfig,
+} from '../../common/Table/Table.interface';
 import Table from '../../common/Table/TableV2';
 import TagButton from '../../common/TagButton/TagButton.component';
 import { useGenericContext } from '../../Customization/GenericProvider/GenericContext';

--- a/openmetadata-ui/src/main/resources/ui/src/components/LineageTable/LineageTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/LineageTable/LineageTable.tsx
@@ -18,7 +18,7 @@ import {
   Card,
   Dropdown,
 } from '@openmetadata/ui-core-components';
-import { ColumnsType } from 'antd/es/table';
+import { ColumnsType } from '../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
 import { isEmpty, map, sortBy } from 'lodash';

--- a/openmetadata-ui/src/main/resources/ui/src/components/LineageTable/LineageTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/LineageTable/LineageTable.tsx
@@ -18,7 +18,6 @@ import {
   Card,
   Dropdown,
 } from '@openmetadata/ui-core-components';
-import { ColumnsType } from '../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
 import { isEmpty, map, sortBy } from 'lodash';
@@ -81,6 +80,7 @@ import NoDataPlaceholder from '../common/ErrorWithPlaceholder/NoDataPlaceholder'
 import { PagingHandlerParams } from '../common/NextPrevious/NextPrevious.interface';
 import { OwnerLabel } from '../common/OwnerLabel/OwnerLabel.component';
 import EntityPopOverCard from '../common/PopOverCard/EntityPopOverCard';
+import { ColumnsType } from '../common/Table/Table.interface';
 import TableV2 from '../common/Table/TableV2';
 import TierTag from '../common/TierTag';
 import TableTags from '../Database/TableTags/TableTags.component';

--- a/openmetadata-ui/src/main/resources/ui/src/components/MlModel/MlModelDetail/MlModelDetail.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MlModel/MlModelDetail/MlModelDetail.component.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Col, Row, Table, Tabs, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import { FC, useCallback, useEffect, useMemo, useState } from 'react';

--- a/openmetadata-ui/src/main/resources/ui/src/components/MlModel/MlModelDetail/MlModelDetail.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MlModel/MlModelDetail/MlModelDetail.component.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Col, Row, Table, Tabs, Typography } from 'antd';
-import { ColumnsType } from '../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import { FC, useCallback, useEffect, useMemo, useState } from 'react';
@@ -63,6 +62,7 @@ import { withActivityFeed } from '../../AppRouter/withActivityFeed';
 import ErrorPlaceHolder from '../../common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import { AlignRightIconButton } from '../../common/IconButtons/EditIconButton';
 import Loader from '../../common/Loader/Loader';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import { GenericProvider } from '../../Customization/GenericProvider/GenericProvider';
 import { DataAssetsHeader } from '../../DataAssets/DataAssetsHeader/DataAssetsHeader.component';
 import { EntityName } from '../../Modals/EntityNameModal/EntityNameModal.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/IngestionRunDetailsModal/IngestionRunDetailsModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/IngestionRunDetailsModal/IngestionRunDetailsModal.tsx
@@ -12,8 +12,7 @@
  */
 
 import { Button, Col, Modal, Row, Typography } from 'antd';
-import { ColumnType } from 'antd/lib/table';
-import { ExpandableConfig } from 'antd/lib/table/interface';
+import { ColumnType, ExpandableConfig } from '../../common/Table/Table.interface';
 import { isArray, startCase } from 'lodash';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/IngestionRunDetailsModal/IngestionRunDetailsModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/IngestionRunDetailsModal/IngestionRunDetailsModal.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Button, Col, Modal, Row, Typography } from 'antd';
-import { ColumnType, ExpandableConfig } from '../../common/Table/Table.interface';
 import { isArray, startCase } from 'lodash';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -25,6 +24,10 @@ import {
 import { formatDateTime } from '../../../utils/date-time/DateTimeUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import Table from '../../common/Table/Table';
+import {
+  ColumnType,
+  ExpandableConfig,
+} from '../../common/Table/Table.interface';
 import ConnectionStepCard from '../../common/TestConnection/ConnectionStepCard/ConnectionStepCard';
 import { IngestionRunDetailsModalProps } from './IngestionRunDetailsModal.interface';
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Pipeline/PipelineTaskTab/PipelineTaskTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Pipeline/PipelineTaskTab/PipelineTaskTab.tsx
@@ -12,7 +12,6 @@
  */
 import Icon from '@ant-design/icons';
 import { Card, Segmented, Typography } from 'antd';
-import { ColumnsType } from '../../common/Table/Table.interface';
 import { groupBy, isEmpty, isUndefined, uniqBy } from 'lodash';
 import { EntityTags, TagFilterOptions } from 'Models';
 import {
@@ -59,6 +58,7 @@ import withSuspenseFallback from '../../AppRouter/withSuspenseFallback';
 import { EntityAttachmentProvider } from '../../common/EntityDescription/EntityAttachmentProvider/EntityAttachmentProvider';
 import { PagingHandlerParams } from '../../common/NextPrevious/NextPrevious.interface';
 import Table from '../../common/Table/Table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import { useGenericContext } from '../../Customization/GenericProvider/GenericContext';
 import { ColumnFilter } from '../../Database/ColumnFilter/ColumnFilter.component';
 import TableDescription from '../../Database/TableDescription/TableDescription.component';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Pipeline/PipelineTaskTab/PipelineTaskTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Pipeline/PipelineTaskTab/PipelineTaskTab.tsx
@@ -12,7 +12,7 @@
  */
 import Icon from '@ant-design/icons';
 import { Card, Segmented, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import { groupBy, isEmpty, isUndefined, uniqBy } from 'lodash';
 import { EntityTags, TagFilterOptions } from 'Models';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Pipeline/PipelineVersion/PipelineVersion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Pipeline/PipelineVersion/PipelineVersion.component.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Col, Row, Space, Table, Tabs, TabsProps } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import classNames from 'classnames';
 import { FC, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Pipeline/PipelineVersion/PipelineVersion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Pipeline/PipelineVersion/PipelineVersion.component.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Col, Row, Space, Table, Tabs, TabsProps } from 'antd';
-import { ColumnsType } from '../../common/Table/Table.interface';
 import classNames from 'classnames';
 import { FC, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -42,6 +41,7 @@ import { CustomPropertyTable } from '../../common/CustomPropertyTable/CustomProp
 import Description from '../../common/EntityDescription/Description';
 import Loader from '../../common/Loader/Loader';
 import RichTextEditorPreviewerV1 from '../../common/RichTextEditor/RichTextEditorPreviewerV1';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import TabsLabel from '../../common/TabsLabel/TabsLabel.component';
 import { GenericProvider } from '../../Customization/GenericProvider/GenericProvider';
 import DataAssetsVersionHeader from '../../DataAssets/DataAssetsVersionHeader/DataAssetsVersionHeader';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppLiveIndexing/AppLiveIndexing.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppLiveIndexing/AppLiveIndexing.component.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppLiveIndexing/AppLiveIndexing.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppLiveIndexing/AppLiveIndexing.component.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 import { Typography } from 'antd';
-import { ColumnsType } from '../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -28,6 +27,7 @@ import { PagingHandlerParams } from '../../../common/NextPrevious/NextPrevious.i
 import StatusBadge from '../../../common/StatusBadge/StatusBadge.component';
 import { StatusType } from '../../../common/StatusBadge/StatusBadge.interface';
 import Table from '../../../common/Table/Table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { AppLiveIndexingProps } from './AppLiveIndexing.interface';
 
 const STATUS_TYPE_MAP: Record<string, StatusType> = {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppLogsViewer/ReindexFailures.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppLogsViewer/ReindexFailures.component.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Drawer, Select, Space, Table, Tooltip, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppLogsViewer/ReindexFailures.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppLogsViewer/ReindexFailures.component.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Drawer, Select, Space, Table, Tooltip, Typography } from 'antd';
-import { ColumnsType } from '../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -22,6 +21,7 @@ import {
 } from '../../../../rest/searchAPI';
 import { formatDateTimeWithTimezone } from '../../../../utils/date-time/DateTimeUtils';
 import { showErrorToast } from '../../../../utils/ToastUtils';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { ReindexFailuresProps } from './ReindexFailures.interface';
 
 const PAGE_SIZE = 20;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppRunsHistory/AppRunsHistory.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppRunsHistory/AppRunsHistory.component.tsx
@@ -12,7 +12,7 @@
  */
 import validator from '@rjsf/validator-ajv8';
 import { Button, Modal, Space, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isNull, noop } from 'lodash';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppRunsHistory/AppRunsHistory.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppRunsHistory/AppRunsHistory.component.tsx
@@ -12,7 +12,6 @@
  */
 import validator from '@rjsf/validator-ajv8';
 import { Button, Modal, Space, Typography } from 'antd';
-import { ColumnsType } from '../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isNull, noop } from 'lodash';
 import {
@@ -62,6 +61,7 @@ import { PagingHandlerParams } from '../../../common/NextPrevious/NextPrevious.i
 import StatusBadge from '../../../common/StatusBadge/StatusBadge.component';
 import { StatusType } from '../../../common/StatusBadge/StatusBadge.interface';
 import Table from '../../../common/Table/Table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import StopScheduleModal from '../../../Modals/StopScheduleRun/StopScheduleRunModal';
 import applicationsClassBase from '../AppDetails/ApplicationsClassBase';
 import AppLogsViewer from '../AppLogsViewer/AppLogsViewer.component';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Bot/BotListV1/BotListV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Bot/BotListV1/BotListV1.component.tsx
@@ -13,7 +13,7 @@
 
 import Icon from '@ant-design/icons/lib/components/Icon';
 import { Button, Col, Row, Space, Switch, Tooltip, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Bot/BotListV1/BotListV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Bot/BotListV1/BotListV1.component.tsx
@@ -13,7 +13,6 @@
 
 import Icon from '@ant-design/icons/lib/components/Icon';
 import { Button, Col, Row, Space, Switch, Tooltip, Typography } from 'antd';
-import { ColumnsType } from '../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -54,6 +53,7 @@ import { PagingHandlerParams } from '../../../common/NextPrevious/NextPrevious.i
 import RichTextEditorPreviewerNew from '../../../common/RichTextEditor/RichTextEditorPreviewNew';
 import Searchbar from '../../../common/SearchBarComponent/SearchBar.component';
 import Table from '../../../common/Table/Table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import TitleBreadcrumb from '../../../common/TitleBreadcrumb/TitleBreadcrumb.component';
 import { TitleBreadcrumbProps } from '../../../common/TitleBreadcrumb/TitleBreadcrumb.interface';
 import PageHeader from '../../../PageHeader/PageHeader.component';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/CustomProperty/CustomPropertyTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/CustomProperty/CustomPropertyTable.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { Button, Space, Tooltip, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import { isArray, isEmpty, isString, isUndefined, startCase } from 'lodash';
 import { FC, Fragment, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/CustomProperty/CustomPropertyTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/CustomProperty/CustomPropertyTable.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 import { Button, Space, Tooltip, Typography } from 'antd';
-import { ColumnsType } from '../../common/Table/Table.interface';
 import { isArray, isEmpty, isString, isUndefined, startCase } from 'lodash';
 import { FC, Fragment, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -28,6 +27,7 @@ import { columnSorter } from '../../../utils/EntitySortUtils';
 import { descriptionTableObject } from '../../../utils/TableColumn.util';
 import ErrorPlaceHolder from '../../common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import Table from '../../common/Table/Table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import ConfirmationModal from '../../Modals/ConfirmationModal/ConfirmationModal';
 import './custom-property-table.less';
 import { CustomPropertyTableProp } from './CustomPropertyTable.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/IngestionListTable.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/IngestionListTable.interface.ts
@@ -12,7 +12,7 @@
  */
 
 import { TableProps } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../../common/Table/Table.interface';
 import { ReactNode } from 'react';
 import { AirflowStatusContextType } from '../../../../../context/AirflowStatusProvider/AirflowStatusProvider.interface';
 import { SORT_ORDER } from '../../../../../enums/common.enum';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/IngestionListTable.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/IngestionListTable.interface.ts
@@ -12,7 +12,6 @@
  */
 
 import { TableProps } from 'antd';
-import { ColumnsType } from '../../../../common/Table/Table.interface';
 import { ReactNode } from 'react';
 import { AirflowStatusContextType } from '../../../../../context/AirflowStatusProvider/AirflowStatusProvider.interface';
 import { SORT_ORDER } from '../../../../../enums/common.enum';
@@ -25,6 +24,7 @@ import {
 import { Paging } from '../../../../../generated/type/paging';
 import { UsePagingInterface } from '../../../../../hooks/paging/usePaging';
 import { PagingHandlerParams } from '../../../../common/NextPrevious/NextPrevious.interface';
+import { ColumnsType } from '../../../../common/Table/Table.interface';
 
 export interface IngestionListTableProps {
   tableContainerClassName?: string;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/IngestionListTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/IngestionListTable.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Skeleton } from 'antd';
-import { ColumnsType } from '../../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
 import { isEmpty, isUndefined } from 'lodash';
@@ -54,6 +53,7 @@ import DeleteModal from '../../../../common/DeleteModal/DeleteModal';
 import RichTextEditorPreviewerNew from '../../../../common/RichTextEditor/RichTextEditorPreviewNew';
 import ButtonSkeleton from '../../../../common/Skeleton/CommonSkeletons/ControlElements/ControlElements.component';
 import Table from '../../../../common/Table/Table';
+import { ColumnsType } from '../../../../common/Table/Table.interface';
 import { SelectedRowDetails } from '../ingestion.interface';
 import { IngestionRecentRuns } from '../IngestionRecentRun/IngestionRecentRuns.component';
 import './ingestion-list-table.less';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/IngestionListTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/IngestionListTable.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Skeleton } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
 import { isEmpty, isUndefined } from 'lodash';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionPipelineList/IngestionPipelineList.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionPipelineList/IngestionPipelineList.component.tsx
@@ -11,8 +11,7 @@
  *  limitations under the License.
  */
 import { Button, Col, Row } from 'antd';
-import { ColumnsType, TableProps } from 'antd/lib/table';
-import { TableRowSelection } from 'antd/lib/table/interface';
+import { ColumnsType, TableProps, TableRowSelection } from '../../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import capitalize from 'lodash/capitalize';
 import isNil from 'lodash/isNil';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionPipelineList/IngestionPipelineList.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionPipelineList/IngestionPipelineList.component.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 import { Button, Col, Row } from 'antd';
-import { ColumnsType, TableProps, TableRowSelection } from '../../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import capitalize from 'lodash/capitalize';
 import isNil from 'lodash/isNil';
@@ -44,6 +43,11 @@ import {
 } from '../../../../../utils/ToastUtils';
 import AirflowMessageBanner from '../../../../common/AirflowMessageBanner/AirflowMessageBanner';
 import { PagingHandlerParams } from '../../../../common/NextPrevious/NextPrevious.interface';
+import {
+  ColumnsType,
+  TableProps,
+  TableRowSelection,
+} from '../../../../common/Table/Table.interface';
 import { ColumnFilter } from '../../../../Database/ColumnFilter/ColumnFilter.component';
 import IngestionListTable from '../IngestionListTable/IngestionListTable';
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Services.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Services.test.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import React, { ReactNode } from 'react';
 import { DISABLED } from '../../../constants/constants';
 import { PAGE_HEADERS } from '../../../constants/PageHeaders.constant';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Services.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Services.test.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { ColumnsType } from '../../common/Table/Table.interface';
 import React, { ReactNode } from 'react';
 import { DISABLED } from '../../../constants/constants';
 import { PAGE_HEADERS } from '../../../constants/PageHeaders.constant';
@@ -23,6 +22,7 @@ import LimitWrapper from '../../../hoc/LimitWrapper';
 import { getServices, searchService } from '../../../rest/serviceAPI';
 import { checkPermission } from '../../../utils/PermissionsUtils';
 import { ListView } from '../../common/ListView/ListView.component';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import Services from './Services';
 
 let isDescription = true;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Services.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Services.tsx
@@ -14,7 +14,6 @@
 import { Button, EmptyPlaceholder } from '@openmetadata/ui-core-components';
 import { Col, Row, Space, Tooltip, Typography } from 'antd';
 import Card from 'antd/lib/card/Card';
-import { ColumnsType, TableProps } from '../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isEmpty, map, startCase } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -68,6 +67,7 @@ import { PagingHandlerParams } from '../../common/NextPrevious/NextPrevious.inte
 import RichTextEditorPreviewerV1 from '../../common/RichTextEditor/RichTextEditorPreviewerV1';
 import RichTextEditorPreviewerNew from '../../common/RichTextEditor/RichTextEditorPreviewNew';
 import ButtonSkeleton from '../../common/Skeleton/CommonSkeletons/ControlElements/ControlElements.component';
+import { ColumnsType, TableProps } from '../../common/Table/Table.interface';
 import { ColumnFilter } from '../../Database/ColumnFilter/ColumnFilter.component';
 import PageHeader from '../../PageHeader/PageHeader.component';
 interface ServicesProps {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Services.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Services.tsx
@@ -14,7 +14,7 @@
 import { Button, EmptyPlaceholder } from '@openmetadata/ui-core-components';
 import { Col, Row, Space, Tooltip, Typography } from 'antd';
 import Card from 'antd/lib/card/Card';
-import { ColumnsType, TableProps } from 'antd/lib/table';
+import { ColumnsType, TableProps } from '../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isEmpty, map, startCase } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/RolesAndPoliciesList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/RolesAndPoliciesList.tsx
@@ -13,7 +13,6 @@
 
 import Icon from '@ant-design/icons/lib/components/Icon';
 import { Button, Tooltip } from 'antd';
-import { ColumnsType } from '../../../common/Table/Table.interface';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
@@ -28,6 +27,7 @@ import {
 } from '../../../../utils/RouterUtils';
 import { descriptionTableObject } from '../../../../utils/TableColumn.util';
 import Table from '../../../common/Table/Table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 
 const ListEntities = ({
   list,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/RolesAndPoliciesList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/RolesAndPoliciesList.tsx
@@ -13,7 +13,7 @@
 
 import Icon from '@ant-design/icons/lib/components/Icon';
 import { Button, Tooltip } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/TeamHierarchy.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/TeamHierarchy.tsx
@@ -12,8 +12,7 @@
  */
 
 import { Button, Modal, Skeleton, Space, Switch, Typography } from 'antd';
-import { ColumnsType, TableProps } from 'antd/lib/table';
-import { ExpandableConfig } from 'antd/lib/table/interface';
+import { ColumnsType, TableProps, ExpandableConfig } from '../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
 import { compare } from 'fast-json-patch';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/TeamHierarchy.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/TeamHierarchy.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Button, Modal, Skeleton, Space, Switch, Typography } from 'antd';
-import { ColumnsType, TableProps, ExpandableConfig } from '../../../common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
 import { compare } from 'fast-json-patch';
@@ -33,6 +32,11 @@ import { showErrorToast, showSuccessToast } from '../../../../utils/ToastUtils';
 import { DraggableBodyRowProps } from '../../../common/Draggable/DraggableBodyRowProps.interface';
 import FilterTablePlaceHolder from '../../../common/ErrorWithPlaceholder/FilterTablePlaceHolder';
 import Table from '../../../common/Table/Table';
+import {
+  ColumnsType,
+  ExpandableConfig,
+  TableProps,
+} from '../../../common/Table/Table.interface';
 import { MovedTeamProps, TeamHierarchyProps } from './team.interface';
 import './teams.less';
 import { TeamHierarchyNameCell } from './TeamsHeaderSection/TeamHierarchyNameCell';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/UserTab/UserTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/UserTab/UserTab.component.tsx
@@ -12,7 +12,7 @@
  */
 import { PlusOutlined } from '@ant-design/icons';
 import { Button, Col, Modal, Space, Tooltip } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../../common/Table/Table.interface';
 import classNames from 'classnames';
 import { isEmpty, orderBy } from 'lodash';
 import QueryString from 'qs';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/UserTab/UserTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/UserTab/UserTab.component.tsx
@@ -12,7 +12,6 @@
  */
 import { PlusOutlined } from '@ant-design/icons';
 import { Button, Col, Modal, Space, Tooltip } from 'antd';
-import { ColumnsType } from '../../../../common/Table/Table.interface';
 import classNames from 'classnames';
 import { isEmpty, orderBy } from 'lodash';
 import QueryString from 'qs';
@@ -56,6 +55,7 @@ import FilterTablePlaceHolder from '../../../../common/ErrorWithPlaceholder/Filt
 import { ManageButtonItemLabel } from '../../../../common/ManageButtonContentItem/ManageButtonContentItem.component';
 import { PagingHandlerParams } from '../../../../common/NextPrevious/NextPrevious.interface';
 import Table from '../../../../common/Table/Table';
+import { ColumnsType } from '../../../../common/Table/Table.interface';
 import { UserSelectableList } from '../../../../common/UserSelectableList/UserSelectableList.component';
 import { useEntityExportModalProvider } from '../../../../Entity/EntityExportModalProvider/EntityExportModalProvider.component';
 import { UserTabProps } from './UserTab.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamImportResult/TeamImportResult.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamImportResult/TeamImportResult.component.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { Space, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePapaParse } from 'react-papaparse';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamImportResult/TeamImportResult.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamImportResult/TeamImportResult.component.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 import { Space, Typography } from 'antd';
-import { ColumnsType } from '../../../common/Table/Table.interface';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePapaParse } from 'react-papaparse';
@@ -21,6 +20,7 @@ import { Status } from '../../../../generated/type/csvImportResult';
 import { parseCSV } from '../../../../utils/EntityImport/EntityImportUtils';
 import RichTextEditorPreviewerNew from '../../../common/RichTextEditor/RichTextEditorPreviewNew';
 import Table from '../../../common/Table/Table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import {
   TeamCSVRecord,
   TeamImportResultProps,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/UserImportResult/UserImportResult.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/UserImportResult/UserImportResult.component.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { Space, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePapaParse } from 'react-papaparse';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/UserImportResult/UserImportResult.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/UserImportResult/UserImportResult.component.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 import { Space, Typography } from 'antd';
-import { ColumnsType } from '../../../common/Table/Table.interface';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePapaParse } from 'react-papaparse';
@@ -21,6 +20,7 @@ import { Status } from '../../../../generated/type/csvImportResult';
 import { parseCSV } from '../../../../utils/EntityImport/EntityImportUtils';
 import RichTextEditorPreviewerNew from '../../../common/RichTextEditor/RichTextEditorPreviewNew';
 import Table from '../../../common/Table/Table';
+import { ColumnsType } from '../../../common/Table/Table.interface';
 import {
   UserCSVRecord,
   UserImportResultProps,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Topic/TopicSchema/TopicSchema.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Topic/TopicSchema/TopicSchema.tsx
@@ -12,11 +12,18 @@
  */
 
 import { Col, Row, Segmented, Tag, Tooltip, Typography } from 'antd';
-import { ColumnsType } from '../../common/Table/Table.interface';
 import classNames from 'classnames';
 import { cloneDeep, groupBy, isEmpty, isUndefined, uniqBy } from 'lodash';
 import { EntityTags, TagFilterOptions } from 'Models';
-import { FC, Key, lazy, useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  FC,
+  Key,
+  lazy,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   HIGHLIGHTED_ROW_SELECTOR,
@@ -65,6 +72,7 @@ import ErrorPlaceHolder from '../../common/ErrorWithPlaceholder/ErrorPlaceHolder
 import RichTextEditorPreviewerV1 from '../../common/RichTextEditor/RichTextEditorPreviewerV1';
 import { EntityDetailWidgetSkeleton } from '../../common/Skeleton/EntityDetailWidgetSkeleton/EntityDetailWidgetSkeleton.component';
 import Table from '../../common/Table/Table';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import ToggleExpandButton from '../../common/ToggleExpandButton/ToggleExpandButton';
 import { useGenericContext } from '../../Customization/GenericProvider/GenericContext';
 import { ColumnFilter } from '../../Database/ColumnFilter/ColumnFilter.component';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Topic/TopicSchema/TopicSchema.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Topic/TopicSchema/TopicSchema.tsx
@@ -12,12 +12,11 @@
  */
 
 import { Col, Row, Segmented, Tag, Tooltip, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
-import { Key } from 'antd/lib/table/interface';
+import { ColumnsType } from '../../common/Table/Table.interface';
 import classNames from 'classnames';
 import { cloneDeep, groupBy, isEmpty, isUndefined, uniqBy } from 'lodash';
 import { EntityTags, TagFilterOptions } from 'Models';
-import { FC, lazy, useCallback, useEffect, useMemo, useState } from 'react';
+import { FC, Key, lazy, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   HIGHLIGHTED_ROW_SELECTOR,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/Table.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/Table.interface.ts
@@ -28,6 +28,7 @@ export type {
   FilterDropdownProps,
   FilterValue,
   SorterResult,
+  SortOrder,
   TableCurrentDataSource,
   TablePaginationConfig,
   TableRowSelection,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/Table.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/Table.interface.ts
@@ -12,6 +12,27 @@
  */
 import { TableProps } from 'antd/lib/table';
 import type { DragAndDropHooks } from 'react-aria-components';
+
+/**
+ * Table types re-exported so this file is the single place that reaches into
+ * AntD's table typings. Call sites import them from here instead, which is what
+ * lets the underlying table be swapped without touching ~100 files: only the
+ * right-hand side of these lines has to change.
+ */
+export type {
+  ColumnGroupType,
+  ColumnsType,
+  ColumnTitle,
+  ColumnType,
+  ExpandableConfig,
+  FilterDropdownProps,
+  FilterValue,
+  SorterResult,
+  TableCurrentDataSource,
+  TablePaginationConfig,
+  TableRowSelection,
+} from 'antd/lib/table/interface';
+export type { TableProps } from 'antd/lib/table';
 import { NextPreviousProps } from '../NextPrevious/NextPrevious.interface';
 import { SearchBarProps } from '../SearchBarComponent/SearchBar.component';
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/Table.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/Table.interface.ts
@@ -12,13 +12,16 @@
  */
 import { TableProps } from 'antd/lib/table';
 import type { DragAndDropHooks } from 'react-aria-components';
+import { NextPreviousProps } from '../NextPrevious/NextPrevious.interface';
+import { SearchBarProps } from '../SearchBarComponent/SearchBar.component';
 
 /**
  * Table types re-exported so this file is the single place that reaches into
- * AntD's table typings. Call sites import them from here instead, which is what
- * lets the underlying table be swapped without touching ~100 files: only the
+ * AntD's table typings. Call sites reference them from here, which is what lets
+ * the underlying table be swapped without touching ~100 files: only the
  * right-hand side of these lines has to change.
  */
+export type { TableProps } from 'antd/lib/table';
 export type {
   ColumnGroupType,
   ColumnsType,
@@ -33,9 +36,6 @@ export type {
   TablePaginationConfig,
   TableRowSelection,
 } from 'antd/lib/table/interface';
-export type { TableProps } from 'antd/lib/table';
-import { NextPreviousProps } from '../NextPrevious/NextPrevious.interface';
-import { SearchBarProps } from '../SearchBarComponent/SearchBar.component';
 
 export interface TableComponentProps<T> extends TableProps<T> {
   containerClassName?: string; // Applied to the table container

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/Table.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/Table.tsx
@@ -19,7 +19,6 @@ import {
   Table as AntdTable,
   Typography,
 } from 'antd';
-import { ColumnsType, ColumnType } from 'antd/es/table';
 import classNames from 'classnames';
 import { isEmpty } from 'lodash';
 import {
@@ -46,10 +45,7 @@ import Loader from '../Loader/Loader';
 import NextPrevious from '../NextPrevious/NextPrevious';
 import Searchbar from '../SearchBarComponent/SearchBar.component';
 import DraggableMenuItem from './DraggableMenu/DraggableMenuItem.component';
-import {
-  TableColumnDropdownList,
-  TableComponentProps,
-} from './Table.interface';
+import { TableColumnDropdownList, TableComponentProps, ColumnsType, ColumnType } from './Table.interface';
 import './table.less';
 
 type TableProps<T extends object> = TableComponentProps<T>;

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/Table.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/Table.tsx
@@ -45,7 +45,12 @@ import Loader from '../Loader/Loader';
 import NextPrevious from '../NextPrevious/NextPrevious';
 import Searchbar from '../SearchBarComponent/SearchBar.component';
 import DraggableMenuItem from './DraggableMenu/DraggableMenuItem.component';
-import { TableColumnDropdownList, TableComponentProps, ColumnsType, ColumnType } from './Table.interface';
+import {
+  ColumnsType,
+  ColumnType,
+  TableColumnDropdownList,
+  TableComponentProps,
+} from './Table.interface';
 import './table.less';
 
 type TableProps<T extends object> = TableComponentProps<T>;

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
@@ -41,14 +41,6 @@ import {
   Typography,
 } from '@openmetadata/ui-core-components';
 import { ChevronDown, ChevronRight } from '@untitledui/icons';
-import type {
-  ColumnType,
-  FilterValue,
-  SorterResult,
-  TableCurrentDataSource,
-  TablePaginationConfig,
-  ColumnsType,
-} from './Table.interface';
 import classNames from 'classnames';
 import { isEmpty, isEqual } from 'lodash';
 import React, {
@@ -81,6 +73,14 @@ import Loader from '../Loader/Loader';
 import NextPrevious from '../NextPrevious/NextPrevious';
 import Searchbar from '../SearchBarComponent/SearchBar.component';
 import DraggableMenuItemV2 from './DraggableMenu/DraggableMenuItemV2.component';
+import type {
+  ColumnsType,
+  ColumnType,
+  FilterValue,
+  SorterResult,
+  TableCurrentDataSource,
+  TablePaginationConfig,
+} from './Table.interface';
 import {
   TableColumnDropdownList,
   TableComponentProps,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
@@ -41,14 +41,14 @@ import {
   Typography,
 } from '@openmetadata/ui-core-components';
 import { ChevronDown, ChevronRight } from '@untitledui/icons';
-import type { ColumnsType } from 'antd/es/table/interface';
 import type {
   ColumnType,
   FilterValue,
   SorterResult,
   TableCurrentDataSource,
   TablePaginationConfig,
-} from 'antd/lib/table/interface';
+  ColumnsType,
+} from './Table.interface';
 import classNames from 'classnames';
 import { isEmpty, isEqual } from 'lodash';
 import React, {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2Utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2Utils.ts
@@ -10,12 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import type { ColumnsType } from 'antd/es/table/interface';
-import type {
-  ColumnType,
-  FilterValue,
-  SortOrder,
-} from 'antd/lib/table/interface';
+import type { ColumnType, FilterValue, SortOrder, ColumnsType } from './Table.interface';
 import { isEmpty } from 'lodash';
 import React, { ReactNode } from 'react';
 import type { FlatRow } from './TableV2.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2Utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2Utils.ts
@@ -10,9 +10,14 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import type { ColumnType, FilterValue, SortOrder, ColumnsType } from './Table.interface';
 import { isEmpty } from 'lodash';
 import React, { ReactNode } from 'react';
+import type {
+  ColumnsType,
+  ColumnType,
+  FilterValue,
+  SortOrder,
+} from './Table.interface';
 import type { FlatRow } from './TableV2.interface';
 
 export function flattenTreeRows<T>(

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useTreeTagFilter.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useTreeTagFilter.ts
@@ -11,10 +11,10 @@
  *  limitations under the License.
  */
 
-import { FilterValue } from '../components/common/Table/Table.interface';
 import { isEmpty } from 'lodash';
 import { TagsData } from 'Models';
 import { useCallback, useMemo, useState } from 'react';
+import { FilterValue } from '../components/common/Table/Table.interface';
 import { TABLE_COLUMNS_KEYS } from '../constants/TableKeys.constants';
 import { getFilteredTagsData } from '../utils/TableTags/TableTags.utils';
 

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useTreeTagFilter.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useTreeTagFilter.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { FilterValue } from 'antd/lib/table/interface';
+import { FilterValue } from '../components/common/Table/Table.interface';
 import { isEmpty } from 'lodash';
 import { TagsData } from 'Models';
 import { useCallback, useMemo, useState } from 'react';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/APICollectionPage/APIEndpointsTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/APICollectionPage/APIEndpointsTab.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Switch, Typography } from 'antd';
-import { ColumnsType } from '../../components/common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import QueryString from 'qs';
@@ -22,6 +21,7 @@ import { Link } from 'react-router-dom';
 import ErrorPlaceHolder from '../../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import { PagingHandlerParams } from '../../components/common/NextPrevious/NextPrevious.interface';
 import TableAntd from '../../components/common/Table/Table';
+import { ColumnsType } from '../../components/common/Table/Table.interface';
 import { useGenericContext } from '../../components/Customization/GenericProvider/GenericContext';
 import { API_COLLECTION_API_ENDPOINTS } from '../../constants/APICollection.constants';
 import { INITIAL_PAGING_VALUE, NO_DATA } from '../../constants/constants';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/APICollectionPage/APIEndpointsTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/APICollectionPage/APIEndpointsTab.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Switch, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../components/common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import QueryString from 'qs';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/KPIList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/KPIList.tsx
@@ -13,7 +13,6 @@
 
 import Icon from '@ant-design/icons/lib/components/Icon';
 import { Button, Tooltip, Typography } from 'antd';
-import { ColumnsType } from '../../components/common/Table/Table.interface';
 import { isUndefined } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -24,6 +23,7 @@ import DeleteModal from '../../components/common/DeleteModal/DeleteModal';
 import ErrorPlaceHolder from '../../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import { PagingHandlerParams } from '../../components/common/NextPrevious/NextPrevious.interface';
 import Table from '../../components/common/Table/Table';
+import { ColumnsType } from '../../components/common/Table/Table.interface';
 import { EmptyGraphPlaceholder } from '../../components/DataInsight/EmptyGraphPlaceholder';
 import {
   INITIAL_PAGING_VALUE,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/KPIList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/KPIList.tsx
@@ -13,7 +13,7 @@
 
 import Icon from '@ant-design/icons/lib/components/Icon';
 import { Button, Tooltip, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../components/common/Table/Table.interface';
 import { isUndefined } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/SchemaTablesTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/SchemaTablesTab.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Switch, Typography } from 'antd';
-import { ColumnsType } from '../../components/common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { compare } from 'fast-json-patch';
 import { isEmpty } from 'lodash';
@@ -24,6 +23,7 @@ import DisplayName from '../../components/common/DisplayName/DisplayName';
 import ErrorPlaceHolder from '../../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import { PagingHandlerParams } from '../../components/common/NextPrevious/NextPrevious.interface';
 import TableAntd from '../../components/common/Table/Table';
+import { ColumnsType } from '../../components/common/Table/Table.interface';
 import { useGenericContext } from '../../components/Customization/GenericProvider/GenericContext';
 import { EntityName } from '../../components/Modals/EntityNameModal/EntityNameModal.interface';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/SchemaTablesTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/SchemaTablesTab.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Switch, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../components/common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { compare } from 'fast-json-patch';
 import { isEmpty } from 'lodash';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/OnlineUsersPage/OnlineUsersPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/OnlineUsersPage/OnlineUsersPage.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Col, Row, Select, Space, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../components/common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import moment from 'moment';
 import { useCallback, useEffect, useMemo, useState } from 'react';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/OnlineUsersPage/OnlineUsersPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/OnlineUsersPage/OnlineUsersPage.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Col, Row, Select, Space, Typography } from 'antd';
-import { ColumnsType } from '../../components/common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import moment from 'moment';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -20,6 +19,7 @@ import { useTranslation } from 'react-i18next';
 import ErrorPlaceHolder from '../../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import FilterTablePlaceHolder from '../../components/common/ErrorWithPlaceholder/FilterTablePlaceHolder';
 import Table from '../../components/common/Table/Table';
+import { ColumnsType } from '../../components/common/Table/Table.interface';
 import TitleBreadcrumb from '../../components/common/TitleBreadcrumb/TitleBreadcrumb.component';
 import { TitleBreadcrumbProps } from '../../components/common/TitleBreadcrumb/TitleBreadcrumb.interface';
 import PageHeader from '../../components/PageHeader/PageHeader.component';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/PoliciesDetailsList.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/PoliciesDetailsList.component.tsx
@@ -13,7 +13,7 @@
 
 import Icon from '@ant-design/icons/lib/components/Icon';
 import { Button, Tooltip } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../components/common/Table/Table.interface';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/PoliciesDetailsList.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/PoliciesDetailsList.component.tsx
@@ -13,12 +13,12 @@
 
 import Icon from '@ant-design/icons/lib/components/Icon';
 import { Button, Tooltip } from 'antd';
-import { ColumnsType } from '../../../components/common/Table/Table.interface';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { ReactComponent as IconRemove } from '../../../assets/svg/ic-remove.svg';
 import Table from '../../../components/common/Table/Table';
+import { ColumnsType } from '../../../components/common/Table/Table.interface';
 import { EntityReference } from '../../../generated/type/entityReference';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesListPage/PoliciesListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesListPage/PoliciesListPage.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Button, Col, Popover, Row, Space, Tag, Tooltip } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../components/common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isEmpty, isUndefined, uniqueId } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesListPage/PoliciesListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesListPage/PoliciesListPage.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Button, Col, Popover, Row, Space, Tag, Tooltip } from 'antd';
-import { ColumnsType } from '../../../components/common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isEmpty, isUndefined, uniqueId } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -23,6 +22,7 @@ import DeleteModal from '../../../components/common/DeleteModal/DeleteModal';
 import ErrorPlaceHolder from '../../../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import { PagingHandlerParams } from '../../../components/common/NextPrevious/NextPrevious.interface';
 import Table from '../../../components/common/Table/Table';
+import { ColumnsType } from '../../../components/common/Table/Table.interface';
 import TitleBreadcrumb from '../../../components/common/TitleBreadcrumb/TitleBreadcrumb.component';
 import { TitleBreadcrumbProps } from '../../../components/common/TitleBreadcrumb/TitleBreadcrumb.interface';
 import PageHeader from '../../../components/PageHeader/PageHeader.component';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesDetailPage/RolesDetailPageList.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesDetailPage/RolesDetailPageList.component.tsx
@@ -13,7 +13,7 @@
 
 import Icon from '@ant-design/icons/lib/components/Icon';
 import { Button, Tooltip } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../components/common/Table/Table.interface';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesDetailPage/RolesDetailPageList.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesDetailPage/RolesDetailPageList.component.tsx
@@ -13,12 +13,12 @@
 
 import Icon from '@ant-design/icons/lib/components/Icon';
 import { Button, Tooltip } from 'antd';
-import { ColumnsType } from '../../../components/common/Table/Table.interface';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { ReactComponent as IconRemove } from '../../../assets/svg/ic-remove.svg';
 import Table from '../../../components/common/Table/Table';
+import { ColumnsType } from '../../../components/common/Table/Table.interface';
 import { EntityReference } from '../../../generated/type/entityReference';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesListPage/RolesListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesListPage/RolesListPage.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Button, Col, Popover, Row, Space, Tag, Tooltip } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../components/common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isEmpty, isUndefined, uniqueId } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesListPage/RolesListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesListPage/RolesListPage.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Button, Col, Popover, Row, Space, Tag, Tooltip } from 'antd';
-import { ColumnsType } from '../../../components/common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isEmpty, isUndefined, uniqueId } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -23,6 +22,7 @@ import DeleteModal from '../../../components/common/DeleteModal/DeleteModal';
 import ErrorPlaceHolder from '../../../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import { PagingHandlerParams } from '../../../components/common/NextPrevious/NextPrevious.interface';
 import Table from '../../../components/common/Table/Table';
+import { ColumnsType } from '../../../components/common/Table/Table.interface';
 import TitleBreadcrumb from '../../../components/common/TitleBreadcrumb/TitleBreadcrumb.component';
 import { TitleBreadcrumbProps } from '../../../components/common/TitleBreadcrumb/TitleBreadcrumb.interface';
 import PageHeader from '../../../components/PageHeader/PageHeader.component';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/SearchIndexDetailsPage/SearchIndexFieldsTable/SearchIndexFieldsTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/SearchIndexDetailsPage/SearchIndexFieldsTable/SearchIndexFieldsTable.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Tooltip, Typography } from 'antd';
-import { ColumnsType, ExpandableConfig } from '../../../components/common/Table/Table.interface';
 import {
   cloneDeep,
   groupBy,
@@ -25,6 +24,10 @@ import {
 import { EntityTags, TagFilterOptions } from 'Models';
 import { lazy, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import {
+  ColumnsType,
+  ExpandableConfig,
+} from '../../../components/common/Table/Table.interface';
 
 import withSuspenseFallback from '../../../components/AppRouter/withSuspenseFallback';
 import CopyLinkButton from '../../../components/common/CopyLinkButton/CopyLinkButton';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/SearchIndexDetailsPage/SearchIndexFieldsTable/SearchIndexFieldsTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/SearchIndexDetailsPage/SearchIndexFieldsTable/SearchIndexFieldsTable.tsx
@@ -12,8 +12,7 @@
  */
 
 import { Tooltip, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
-import { ExpandableConfig } from 'antd/lib/table/interface';
+import { ColumnsType, ExpandableConfig } from '../../../components/common/Table/Table.interface';
 import {
   cloneDeep,
   groupBy,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ServiceDetailsPage/ServiceMainTabContent.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ServiceDetailsPage/ServiceMainTabContent.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Col, Row, Space, Switch, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../components/common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { compare } from 'fast-json-patch';
 import { isEmpty, isUndefined } from 'lodash';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ServiceDetailsPage/ServiceMainTabContent.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ServiceDetailsPage/ServiceMainTabContent.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Col, Row, Space, Switch, Typography } from 'antd';
-import { ColumnsType } from '../../components/common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { compare } from 'fast-json-patch';
 import { isEmpty, isUndefined } from 'lodash';
@@ -33,6 +32,7 @@ import ErrorPlaceHolder from '../../components/common/ErrorWithPlaceholder/Error
 import { PagingHandlerParams } from '../../components/common/NextPrevious/NextPrevious.interface';
 import ResizablePanels from '../../components/common/ResizablePanels/ResizablePanels';
 import Table from '../../components/common/Table/Table';
+import { ColumnsType } from '../../components/common/Table/Table.interface';
 import { GenericProvider } from '../../components/Customization/GenericProvider/GenericProvider';
 import EntityRightPanel from '../../components/Entity/EntityRightPanel/EntityRightPanel';
 import { EntityName } from '../../components/Modals/EntityNameModal/EntityNameModal.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ServiceVersionPage/ServiceVersionMainTabContent.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ServiceVersionPage/ServiceVersionMainTabContent.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Col, Row, Space } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../components/common/Table/Table.interface';
 import { isEmpty, isNil } from 'lodash';
 import { ServiceTypes } from 'Models';
 import { useMemo } from 'react';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ServiceVersionPage/ServiceVersionMainTabContent.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ServiceVersionPage/ServiceVersionMainTabContent.tsx
@@ -12,13 +12,13 @@
  */
 
 import { Col, Row, Space } from 'antd';
-import { ColumnsType } from '../../components/common/Table/Table.interface';
 import { isEmpty, isNil } from 'lodash';
 import { ServiceTypes } from 'Models';
 import { useMemo } from 'react';
 import Description from '../../components/common/EntityDescription/Description';
 import ErrorPlaceHolder from '../../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import Table from '../../components/common/Table/Table';
+import { ColumnsType } from '../../components/common/Table/Table.interface';
 import TagsContainerV2 from '../../components/Tag/TagsContainerV2/TagsContainerV2';
 import { DisplayType } from '../../components/Tag/TagsViewer/TagsViewer.interface';
 import { PAGE_SIZE } from '../../constants/constants';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/StoredProcedure/StoredProcedureTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/StoredProcedure/StoredProcedureTab.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { Switch, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../components/common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import QueryString from 'qs';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/StoredProcedure/StoredProcedureTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/StoredProcedure/StoredProcedureTab.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 import { Switch, Typography } from 'antd';
-import { ColumnsType } from '../../components/common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import QueryString from 'qs';
@@ -21,6 +20,7 @@ import DisplayName from '../../components/common/DisplayName/DisplayName';
 import ErrorPlaceHolder from '../../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import { PagingHandlerParams } from '../../components/common/NextPrevious/NextPrevious.interface';
 import Table from '../../components/common/Table/Table';
+import { ColumnsType } from '../../components/common/Table/Table.interface';
 import {
   INITIAL_PAGING_VALUE,
   INITIAL_TABLE_FILTERS,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/PartitionedKeys/PartitionedKeys.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/PartitionedKeys/PartitionedKeys.component.tsx
@@ -10,11 +10,11 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { ColumnsType } from '../../../components/common/Table/Table.interface';
 import { isEmpty } from 'lodash';
 import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import Table from '../../../components/common/Table/Table';
+import { ColumnsType } from '../../../components/common/Table/Table.interface';
 import WidgetCard from '../../../components/common/WidgetCard/WidgetCard';
 import { useGenericContext } from '../../../components/Customization/GenericProvider/GenericContext';
 import { DetailPageWidgetKeys } from '../../../enums/CustomizeDetailPage.enum';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/PartitionedKeys/PartitionedKeys.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/PartitionedKeys/PartitionedKeys.component.tsx
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../../components/common/Table/Table.interface';
 import { isEmpty } from 'lodash';
 import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/UserListPage/UserListPageV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/UserListPage/UserListPageV1.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Button, Col, Modal, Row, Space, Switch, Tooltip } from 'antd';
-import { ColumnsType } from '../../components/common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { capitalize, isEmpty } from 'lodash';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -25,6 +24,7 @@ import ErrorPlaceHolder from '../../components/common/ErrorWithPlaceholder/Error
 import FilterTablePlaceHolder from '../../components/common/ErrorWithPlaceholder/FilterTablePlaceHolder';
 import { PagingHandlerParams } from '../../components/common/NextPrevious/NextPrevious.interface';
 import Table from '../../components/common/Table/Table';
+import { ColumnsType } from '../../components/common/Table/Table.interface';
 import TitleBreadcrumb from '../../components/common/TitleBreadcrumb/TitleBreadcrumb.component';
 import { TitleBreadcrumbProps } from '../../components/common/TitleBreadcrumb/TitleBreadcrumb.interface';
 import PageHeader from '../../components/PageHeader/PageHeader.component';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/UserListPage/UserListPageV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/UserListPage/UserListPageV1.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Button, Col, Modal, Row, Space, Switch, Tooltip } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../../components/common/Table/Table.interface';
 import { AxiosError } from 'axios';
 import { capitalize, isEmpty } from 'lodash';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ClassificationUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ClassificationUtils.tsx
@@ -17,11 +17,11 @@ import {
   TooltipTrigger,
 } from '@openmetadata/ui-core-components';
 import { Button, Space, Tooltip, Typography } from 'antd';
-import { ColumnsType } from '../components/common/Table/Table.interface';
 import { Link } from 'react-router-dom';
 import { ReactComponent as IconDisableTag } from '../assets/svg/disable-tag.svg';
 import { ReactComponent as EditIcon } from '../assets/svg/edit-new.svg';
 import { ManageButtonItemLabel } from '../components/common/ManageButtonContentItem/ManageButtonContentItem.component';
+import { ColumnsType } from '../components/common/Table/Table.interface';
 import { NO_DATA_PLACEHOLDER } from '../constants/constants';
 import { OperationPermission } from '../context/PermissionProvider/PermissionProvider.interface';
 import { Tag } from '../generated/entity/classification/tag';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ClassificationUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ClassificationUtils.tsx
@@ -17,7 +17,7 @@ import {
   TooltipTrigger,
 } from '@openmetadata/ui-core-components';
 import { Button, Space, Tooltip, Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../components/common/Table/Table.interface';
 import { Link } from 'react-router-dom';
 import { ReactComponent as IconDisableTag } from '../assets/svg/disable-tag.svg';
 import { ReactComponent as EditIcon } from '../assets/svg/edit-new.svg';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomizeColumnUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomizeColumnUtils.tsx
@@ -10,7 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { TableColumnDropdownList, ColumnType } from '../components/common/Table/Table.interface';
+import {
+  ColumnType,
+  TableColumnDropdownList,
+} from '../components/common/Table/Table.interface';
 
 /**
  * Get customizable column details for table dropdown

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomizeColumnUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomizeColumnUtils.tsx
@@ -10,8 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { ColumnType } from 'antd/lib/table';
-import { TableColumnDropdownList } from '../components/common/Table/Table.interface';
+import { TableColumnDropdownList, ColumnType } from '../components/common/Table/Table.interface';
 
 /**
  * Get customizable column details for table dropdown

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.tsx
@@ -13,7 +13,7 @@
 
 import Icon, { CheckOutlined } from '@ant-design/icons';
 import { Typography } from 'antd';
-import type { ColumnsType } from 'antd/es/table';
+import type { ColumnsType } from '../components/common/Table/Table.interface';
 import { isEmpty } from 'lodash';
 import type { LoadingState } from 'Models';
 import { Link } from 'react-router-dom';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.tsx
@@ -13,12 +13,12 @@
 
 import Icon, { CheckOutlined } from '@ant-design/icons';
 import { Typography } from 'antd';
-import type { ColumnsType } from '../components/common/Table/Table.interface';
 import { isEmpty } from 'lodash';
 import type { LoadingState } from 'Models';
 import { Link } from 'react-router-dom';
 import { ReactComponent as MetricIcon } from '../assets/svg/metric.svg';
 import Loader from '../components/common/Loader/Loader';
+import type { ColumnsType } from '../components/common/Table/Table.interface';
 import CustomNodeV1 from '../components/Entity/EntityLineage/CustomNodeV1.component';
 import LoadMoreNode from '../components/Entity/EntityLineage/LoadMoreNode/LoadMoreNode';
 import { NO_DATA_PLACEHOLDER } from '../constants/constants';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ServiceMainTabContentUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ServiceMainTabContentUtils.tsx
@@ -12,10 +12,10 @@
  */
 
 import { Typography } from 'antd';
-import { ColumnsType } from '../components/common/Table/Table.interface';
 import { Operation } from 'fast-json-patch';
 import { ServiceTypes } from 'Models';
 import DisplayName from '../components/common/DisplayName/DisplayName';
+import { ColumnsType } from '../components/common/Table/Table.interface';
 import { EntityName } from '../components/Modals/EntityNameModal/EntityNameModal.interface';
 import { NO_DATA_PLACEHOLDER } from '../constants/constants';
 import { TABLE_COLUMNS_KEYS } from '../constants/TableKeys.constants';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ServiceMainTabContentUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ServiceMainTabContentUtils.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Typography } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../components/common/Table/Table.interface';
 import { Operation } from 'fast-json-patch';
 import { ServiceTypes } from 'Models';
 import DisplayName from '../components/common/DisplayName/DisplayName';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableColumn.util.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableColumn.util.tsx
@@ -11,11 +11,14 @@
  *  limitations under the License.
  */
 import Icon from '@ant-design/icons';
-import { ColumnsType, ColumnType } from '../components/common/Table/Table.interface';
 import classNames from 'classnames';
 import { lazy } from 'react';
 import { ReactComponent as FilterIcon } from '../assets/svg/ic-filter.svg';
 import withSuspenseFallback from '../components/AppRouter/withSuspenseFallback';
+import {
+  ColumnsType,
+  ColumnType,
+} from '../components/common/Table/Table.interface';
 import { TAG_LIST_SIZE } from '../constants/constants';
 import { TABLE_COLUMNS_KEYS } from '../constants/TableKeys.constants';
 import { EntityType } from '../enums/entity.enum';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableColumn.util.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableColumn.util.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import Icon from '@ant-design/icons';
-import { ColumnsType, ColumnType } from 'antd/lib/table';
+import { ColumnsType, ColumnType } from '../components/common/Table/Table.interface';
 import classNames from 'classnames';
 import { lazy } from 'react';
 import { ReactComponent as FilterIcon } from '../assets/svg/ic-filter.svg';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableUtils.tsx
@@ -13,7 +13,7 @@
 
 import Icon from '@ant-design/icons';
 import { Space, Tooltip, Typography } from 'antd';
-import { ExpandableConfig } from 'antd/lib/table/interface';
+import { ExpandableConfig } from '../components/common/Table/Table.interface';
 import classNames from 'classnames';
 import { uniqBy } from 'lodash';
 import { Fragment } from 'react';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableUtils.tsx
@@ -13,7 +13,6 @@
 
 import Icon from '@ant-design/icons';
 import { Space, Tooltip, Typography } from 'antd';
-import { ExpandableConfig } from '../components/common/Table/Table.interface';
 import classNames from 'classnames';
 import { uniqBy } from 'lodash';
 import { Fragment } from 'react';
@@ -62,6 +61,7 @@ import { ReactComponent as IconSortLineThrough } from '../assets/svg/icon-sort-l
 import { ReactComponent as IconSortKey } from '../assets/svg/icon-sort.svg';
 import { ReactComponent as IconUniqueLineThrough } from '../assets/svg/icon-unique-line-through.svg';
 import { ReactComponent as IconUnique } from '../assets/svg/icon-unique.svg';
+import { ExpandableConfig } from '../components/common/Table/Table.interface';
 import { ConstraintTypes } from '../enums/table.enum';
 import {
   ConstraintType,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Users.util.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Users.util.tsx
@@ -12,11 +12,11 @@
  */
 
 import { Popover, Skeleton, Space, Tag, Tooltip } from 'antd';
-import { ColumnsType } from '../components/common/Table/Table.interface';
 import { isEmpty, isUndefined, uniqueId } from 'lodash';
 import { Link } from 'react-router-dom';
 import { ReactComponent as BotIcon } from '../assets/svg/bot.svg';
 import UserPopOverCard from '../components/common/PopOverCard/UserPopOverCard';
+import { ColumnsType } from '../components/common/Table/Table.interface';
 import { TEXT_GREY_MUTED } from '../constants/constants';
 import { EntityReference, User } from '../generated/entity/teams/user';
 import { getEntityName } from './EntityNameUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Users.util.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Users.util.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Popover, Skeleton, Space, Tag, Tooltip } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnsType } from '../components/common/Table/Table.interface';
 import { isEmpty, isUndefined, uniqueId } from 'lodash';
 import { Link } from 'react-router-dom';
 import { ReactComponent as BotIcon } from '../assets/svg/bot.svg';

--- a/tooling/antd-codemods/__tests__/move-named-imports.test.js
+++ b/tooling/antd-codemods/__tests__/move-named-imports.test.js
@@ -1,5 +1,5 @@
 'use strict';
-const { defineInlineTest } = require('jscodeshift/dist/testUtils');
+const { defineInlineTest, runInlineTest } = require('jscodeshift/dist/testUtils');
 const transform = require('../transforms/move-named-imports');
 
 const OPTS = { names: 'Divider,Tag', from: 'antd', to: '@openmetadata/ui-core-components' };
@@ -88,4 +88,56 @@ defineInlineTest(
   `import type { TabsProps } from 'antd';\nimport { Card } from '@openmetadata/ui-core-components';`,
   `import type { TabsProps } from '@openmetadata/ui-core-components';\nimport { Card } from '@openmetadata/ui-core-components';`,
   'does not merge a type-only specifier into an existing value import of the same target module'
+);
+
+// ── --toPath: destination is a file in the repo, not a package ──────────────
+// The specifier has to be recomputed per file: relative depth differs between
+// call sites and there is no `src` resolve root to fall back on. These use
+// runInlineTest rather than defineInlineTest because only the former lets a
+// test supply the file path the specifier is resolved from.
+
+const TO_PATH_OPTS = {
+  names: 'ColumnsType,ColumnType',
+  from: 'antd/lib/table',
+  toPath: 'src/components/common/Table/Table.interface.ts',
+};
+
+const defineToPathTest = (name, path, source, expectedOutput) =>
+  it(name, () => {
+    runInlineTest(transform, TO_PATH_OPTS, { path, source }, expectedOutput);
+  });
+
+defineToPathTest(
+  'writes a sibling specifier as ./',
+  'src/components/common/Table/SomeTable.tsx',
+  `import { ColumnsType } from 'antd/lib/table';`,
+  `import { ColumnsType } from './Table.interface';`
+);
+
+defineToPathTest(
+  'climbs out of nested directories',
+  'src/pages/Deeply/Nested/Page.tsx',
+  `import { ColumnsType } from 'antd/lib/table';`,
+  `import { ColumnsType } from '../../../components/common/Table/Table.interface';`
+);
+
+defineToPathTest(
+  'leaves the destination module itself untouched',
+  'src/components/common/Table/Table.interface.ts',
+  `import { ColumnsType } from 'antd/lib/table';`,
+  `import { ColumnsType } from 'antd/lib/table';`
+);
+
+defineToPathTest(
+  'keeps a default import behind when its named sibling moves',
+  'src/components/common/Table/SomeTable.tsx',
+  `import Table, { ColumnsType } from 'antd/lib/table';`,
+  `import Table from 'antd/lib/table';\nimport { ColumnsType } from './Table.interface';`
+);
+
+defineToPathTest(
+  'keeps a type-only import type-only',
+  'src/components/common/Table/SomeTable.tsx',
+  `import type { ColumnsType } from 'antd/lib/table';`,
+  `import type { ColumnsType } from './Table.interface';`
 );

--- a/tooling/antd-codemods/__tests__/move-named-imports.test.js
+++ b/tooling/antd-codemods/__tests__/move-named-imports.test.js
@@ -141,3 +141,14 @@ defineToPathTest(
   `import type { ColumnsType } from 'antd/lib/table';`,
   `import type { ColumnsType } from './Table.interface';`
 );
+
+// Regression: when every specifier of a type-only import moves into a target
+// that already has a type-only import, the declaration is removed. The second
+// pass of the kind loop used to re-filter a stale collection, whose paths then
+// resolved to the next statement — `path.node.specifiers is not iterable`.
+defineToPathTest(
+  'survives a full type-only move into an existing type-only target',
+  'src/components/common/Table/TableV2Utils.ts',
+  `import type { ColumnsType } from 'antd/lib/table';\nimport type { ColumnType } from './Table.interface';\n\nexport function noop() {}`,
+  `import type { ColumnType, ColumnsType } from './Table.interface';\n\nexport function noop() {}`
+);

--- a/tooling/antd-codemods/transforms/move-named-imports.js
+++ b/tooling/antd-codemods/transforms/move-named-imports.js
@@ -1,10 +1,41 @@
 'use strict';
 
+const path = require('path');
+
+const TS_EXTENSIONS = /\.(tsx?|jsx?)$/;
+
+function stripExtension(filePath) {
+  return path.resolve(filePath).replace(TS_EXTENSIONS, '');
+}
+
+/**
+ * Relative module specifier from `fromFile` to `toPath`, in the form the repo
+ * writes them: extension dropped, and always prefixed with `./` or `../` so it
+ * is never mistaken for a package.
+ */
+function relativeSpecifier(fromFile, toPath) {
+  const rel = path.relative(
+    path.dirname(path.resolve(fromFile)),
+    stripExtension(toPath)
+  );
+
+  return rel.startsWith('.') ? rel : `./${rel}`;
+}
+
 /**
  * Moves named import specifiers from one module to another.
  *
  * jscodeshift -t transforms/move-named-imports.js <path> --parser=tsx \
  *   --names=Divider,Tag --from=antd --to=@openmetadata/ui-core-components
+ *
+ * When the destination is a file inside the repo rather than a package, pass
+ * `--toPath=<path to the module>` instead of `--to`. The specifier is then
+ * computed per file, because a relative import's depth differs from one call
+ * site to the next and no `src` resolve root exists to paper over it.
+ *
+ *   jscodeshift -t transforms/move-named-imports.js <path> --parser=tsx \
+ *     --names=ColumnsType --from=antd/lib/table \
+ *     --toPath=src/components/common/Table/Table.interface.ts
  */
 
 // `path.node.importKind` is 'type' for `import type { ... } from '...'` and
@@ -19,9 +50,19 @@ module.exports = function transformer(file, api, options) {
   const root = j(file.source);
   const names = String(options.names || '').split(',').filter(Boolean);
   const from = options.from || 'antd';
-  const to = options.to;
+  if (options.toPath && !file.path) {
+    throw new Error('--toPath needs a file path to resolve the specifier from');
+  }
+  // The destination module is itself a call site of the `from` module — it is
+  // the one file that must keep importing it.
+  if (options.toPath && stripExtension(file.path) === stripExtension(options.toPath)) {
+    return file.source;
+  }
+  const to = options.toPath
+    ? relativeSpecifier(file.path, options.toPath)
+    : options.to;
   if (!names.length || !to) {
-    throw new Error('--names=<A,B> and --to=<module> are required');
+    throw new Error('--names=<A,B> and one of --to / --toPath are required');
   }
 
   const fromImports = root.find(j.ImportDeclaration, { source: { value: from } });

--- a/tooling/antd-codemods/transforms/move-named-imports.js
+++ b/tooling/antd-codemods/transforms/move-named-imports.js
@@ -77,9 +77,13 @@ module.exports = function transformer(file, api, options) {
   // path's current node, so a declaration already handled by one pass (e.g.
   // replaced in place) is correctly skipped by the other.
   ['type', 'value'].forEach((kind) => {
-    const fromImportsOfKind = fromImports.filter(
-      (path) => importKindOf(path.node) === kind
-    );
+    // Re-query rather than filtering the collection captured above: the first
+    // pass may have removed a declaration (when every specifier moved into an
+    // existing target), after which the stale paths resolve to whatever shifted
+    // into their slot — a `function` node has no `specifiers` and blows up.
+    const fromImportsOfKind = root
+      .find(j.ImportDeclaration, { source: { value: from } })
+      .filter((path) => importKindOf(path.node) === kind);
     if (!fromImportsOfKind.size()) {
       return;
     }

--- a/tooling/antd-codemods/transforms/move-named-imports.js
+++ b/tooling/antd-codemods/transforms/move-named-imports.js
@@ -14,10 +14,12 @@ function stripExtension(filePath) {
  * is never mistaken for a package.
  */
 function relativeSpecifier(fromFile, toPath) {
-  const rel = path.relative(
-    path.dirname(path.resolve(fromFile)),
-    stripExtension(toPath)
-  );
+  // `path.relative` uses the platform separator, so on Windows this would emit
+  // `..\components\...` — a specifier no bundler resolves, written silently.
+  const rel = path
+    .relative(path.dirname(path.resolve(fromFile)), stripExtension(toPath))
+    .split(path.sep)
+    .join('/');
 
   return rel.startsWith('.') ? rel : `./${rel}`;
 }


### PR DESCRIPTION
Fixes [6029](https://github.com/open-metadata/openmetadata-collate/issues/6029)
Independent of #31953 / #31954 — reviewable and mergeable on its own.

Every call site reached directly into `antd/lib/table` or `antd/es/table` for `ColumnsType` and friends, so the table implementation could not be changed without touching all of them. `Table.interface.ts` now re-exports the eleven types in use and is the only file that imports AntD's table typings.

Swapping the underlying table becomes a change to the right-hand side of those re-exports instead of ~100 files.

**Mechanical and type-only — no runtime behaviour changes.** 76 files.

### Two fixes to the shared codemod were needed
1. **`--toPath`** — `move-named-imports` could only write one literal specifier via `--to`, but this destination is a file in the repo and `openmetadata-ui` has no `src` resolve root, so the relative depth differs per call site. `--toPath` computes the specifier per file, skips the destination module itself, and leaves a default import behind when its named sibling moves.
2. **A crash that predates this change** — when every specifier of a declaration moved into an existing target, the declaration was removed, and the second pass of the kind loop re-filtered a *stale* collection whose paths resolved to whatever shifted into the slot (`path.node.specifiers is not iterable`). It now re-queries the AST per pass. This **silently skipped two files** during the bulk run rather than failing loudly — caught only by grepping for what should have been gone.

Both have regression tests; the codemod package is 87/87. Its dependencies were not installed, so all three of its suites were failing before this change — worth a look if CI ever reports that tooling as green.

### Notes
- `Key` is deliberately **not** re-exported — AntD's `Key` is React's, so `TopicSchema` imports it from react directly.
- The census found **103 files and 11 types**, not the 96/4 in the original issue.

### Verification
- `git grep "antd/es/table\|antd/lib/table"` in `src/` → only `Table.interface.ts` itself
- `tsc --noEmit`: **573 errors, identical to `main`** — zero delta
- `eslint` on all 76 changed files: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR centralizes Ant Design table typings behind `Table.interface.ts` and updates UI consumers to use that shared type boundary.
- Re-exports the table types currently used throughout the UI.
- Adds `--toPath` support and stale-AST regression handling to the import-migration codemod.
- Adds regression coverage for relative destinations, default imports, type-only imports, and declaration removal.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/common/Table/Table.interface.ts | Adds the shared type-only Ant Design table export boundary consumed by the migrated UI files. |
| tooling/antd-codemods/transforms/move-named-imports.js | Adds per-file relative destination support, Windows-safe module separators, and fresh AST queries after mutations. |
| tooling/antd-codemods/__tests__/move-named-imports.test.js | Covers relative destination generation, destination exclusion, mixed imports, type-only imports, and the stale-collection regression. |
| openmetadata-ui/src/main/resources/ui/src/components/Topic/TopicSchema/TopicSchema.tsx | Moves table typings to the shared interface and imports the underlying key type directly from React. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ui): stop tw-guard matching a commen..."](https://github.com/open-metadata/openmetadata/commit/34ff88f72f1e318a381cead103b57dc051dbdb57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56210914)</sub>

<!-- /greptile_comment -->