### PR TITLE
test(ui): select tables by shared attributes, not AntD class names

### DIFF
--- a/docs/antd-migration/table.md
+++ b/docs/antd-migration/table.md
@@ -1,0 +1,87 @@
+# Table → TableV2
+
+Sweep guide for replacing the legacy `common/Table/Table` (AntD) with
+`common/Table/TableV2` (`@openmetadata/ui-core-components`). This is the review
+contract for every call-site PR in the sweep.
+
+Written from a parity suite that drives **both** wrappers through the same specs
+(`src/components/common/Table/__tests__/`). Where the table below says a prop
+works, there is a spec proving it works identically on both.
+
+## Prop support
+
+### Works — no call-site change needed
+
+`columns` (`dataIndex`, `key`, `title`, `render`, `width`, `ellipsis`, `fixed`,
+`sorter`, `sortOrder`, `sortDirections`, `filters`, `filterIcon`,
+`filterDropdown`, `onFilter`, `onCell`) · `dataSource` · `rowKey` · `loading`
+(boolean and `{ spinning }`) · `locale.emptyText` · `pagination`
+(`pageSize`, `hideOnSinglePage`, `showSizeChanger`, `pageSizeOptions`,
+`onShowSizeChange`) · `rowSelection` (`type`, `selectedRowKeys`, `onChange`,
+`getCheckboxProps`) · `expandable` (`expandedRowKeys`, `onExpand`,
+`rowExpandable`, `expandedRowRender`, `expandIcon`) · `indentSize` · `onRow`
+(`onClick`, `onDoubleClick`, drag handlers) · `onChange` · `rowClassName` ·
+`footer` · `scroll` · `size` · plus the wrapper's own `containerClassName`,
+`searchProps`, `customPaginationProps`, `defaultVisibleColumns`,
+`staticVisibleColumns`, `extraTableFilters`, `entityType`, `cellClassName`.
+
+### Blocked — the call site must change
+
+| Prop | Why | Do instead |
+|---|---|---|
+| `summary` | React Aria's collection builder discards any table child that is not a Header or Body, so a `tfoot` never reaches the DOM. Drawn outside the table it would not align with the columns | render the total above the table, or add a summary slot to `ui-core-components` first |
+| `components` | no equivalent for custom row/cell renderers | `dragAndDropHooks` for drag rows; a column `render` for custom cells |
+
+Both are **omitted from `TableV2Props`**, so a call site passing them fails to
+compile rather than rendering a table that quietly lost a feature.
+
+### Changed contract
+
+| Prop | Change |
+|---|---|
+| `customPaginationProps` | now **requires** `pagination={false}` alongside it — the parent owns paging and has already fetched exactly this page, so slicing again would drop rows |
+| `size` | AntD `small` → core `compact`, `large` → `md`, unset → `sm`. Note that AntD tables not inside a `TableCard` were previously rendered at `md` because the core `size` prop was inert |
+
+## Test selector contract
+
+Do not select on `.ant-table*`. These hold on **both** wrappers, so a test
+rewritten now keeps passing through the sweep:
+
+| Target | Selector | Notes |
+|---|---|---|
+| row | `[data-row-key]` | AntD's rc-table emits this natively |
+| cell | `td` | |
+| header row | `thead tr` | |
+| expander | `[data-testid="expand-icon"]` | both wrappers emit it |
+| selection control | `input[type="checkbox"]` | radio in single-selection mode |
+| toolbar | `[data-testid="table-toolbar"]` | TableV2 only |
+| column customize | `[data-testid="column-dropdown"]` | both |
+| pager | `[data-testid="pagination"]` | via `NextPrevious` |
+
+No shared hook exists for these — migrate them in the sweep PR that moves the page:
+
+| Target | Legacy | TableV2 |
+|---|---|---|
+| tree depth | `.ant-table-row-level-N` | `data-level` |
+| filter trigger | `.ant-table-filter-trigger` | `[data-testid="filter-trigger"]` |
+| filter dropdown | `.ant-table-filter-dropdown` | `[data-testid="filter-dropdown"]` |
+
+## Per-page checklist
+
+Exercise on the migrated page, not just in unit tests: sorting on every sortable
+column (both directions and off) · column resize and its persistence ·
+pagination including page-size change and the last page after filtering · row
+selection including disabled rows and select-all · expand/collapse at every
+nesting depth · column show/hide and drag reorder in the customize dropdown ·
+fixed columns while horizontally scrolled · column filters · empty, loading and
+error states · dark mode · keyboard navigation and the focus ring.
+
+## Gotchas found during the parity work
+
+- **React Aria strips a row's `onClick`** unless the row is interactive. TableV2
+  handles this internally; do not add your own `onAction` to compensate.
+- **`ts-jest` does not fail on a missing export here** — a passing jest run is
+  not a typecheck. Use `tsc --noEmit`, and compare the error count against the
+  branch point: `main` is not clean (573 errors at time of writing).
+- **`openmetadata-ui` typechecks against `ui-core-components/dist`,** not its
+  source. A core change is invisible until that package is rebuilt.

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.duplicateColumns.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.duplicateColumns.test.tsx
@@ -83,7 +83,7 @@ describe('SampleDataTable with duplicate column names', () => {
     );
 
     const cellTexts = Array.from(
-      container.querySelectorAll('tbody tr.ant-table-row td')
+      container.querySelectorAll('tbody tr[data-row-key] td')
     ).map((cell) => cell.textContent);
 
     expect(cellTexts).toEqual(SAMPLE_ROWS[0]);
@@ -98,7 +98,7 @@ describe('SampleDataTable with duplicate column names', () => {
     fireEvent.click(screen.getByTestId('export-button-details-container'));
 
     const cellTexts = Array.from(
-      container.querySelectorAll('tbody tr.ant-table-row td')
+      container.querySelectorAll('tbody tr[data-row-key] td')
     ).map((cell) => cell.textContent);
     const csvContent = (downloadFile as jest.Mock).mock.calls[0][0] as string;
     const [header, firstDataLine] = csvContent.split('\n');

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.reservedColumns.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.reservedColumns.test.tsx
@@ -103,7 +103,7 @@ describe('SampleDataTable with reserved column names', () => {
       render(<SampleDataTable {...mockProps} />)
     );
 
-    expect(container.querySelectorAll('tbody tr.ant-table-row')).toHaveLength(
+    expect(container.querySelectorAll('tbody tr[data-row-key]')).toHaveLength(
       SAMPLE_ROWS.length
     );
   });
@@ -114,7 +114,7 @@ describe('SampleDataTable with reserved column names', () => {
     );
 
     const rowKeys = Array.from(
-      container.querySelectorAll('tbody tr.ant-table-row')
+      container.querySelectorAll('tbody tr[data-row-key]')
     ).map((row) => row.getAttribute('data-row-key'));
 
     expect(rowKeys.length).toBeGreaterThan(1);

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
@@ -31,7 +31,8 @@
  *                  written against it survives the migration)
  *   data-level     tree depth (TableV2 only; AntD uses .ant-table-row-level-N)
  *   data-testid    table-toolbar, column-dropdown, expand-icon, filter-trigger,
- *                  filter-dropdown, and the table root via the `data-testid` prop
+ *                  filter-dropdown, column-header-content, and the table root
+ *                  via the `data-testid` prop
  *
  * Sorting:
  *  - sorter: (a, b) => number  → applied client-side on full dataset before pagination
@@ -1003,7 +1004,9 @@ const TableV2 = <T extends object>(
                           : {}),
                         ...stickyStyle,
                       }}>
-                      <div className="tw:flex tw:items-center tw:gap-1">
+                      <div
+                        className="tw:flex tw:items-center tw:gap-1"
+                        data-testid="column-header-content">
                         {resolveColumnTitle(colType, propsColumns)}
                         {Boolean(colType.filters || colType.filterDropdown) && (
                           <DialogTrigger

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
@@ -26,6 +26,13 @@
  *  - onCell            → onClick, data-*, colSpan forwarded to the underlying td element
  *  - filterIcon/filterDropdown/onFilter → filter state managed internally; confirm/close close the dropdown
  *
+ * Test contract — these hooks are stable and tests may rely on them:
+ *   data-row-key   on every row (AntD's rc-table emits it too, so a selector
+ *                  written against it survives the migration)
+ *   data-level     tree depth (TableV2 only; AntD uses .ant-table-row-level-N)
+ *   data-testid    table-toolbar, column-dropdown, expand-icon, filter-trigger,
+ *                  filter-dropdown, and the table root via the `data-testid` prop
+ *
  * Sorting:
  *  - sorter: (a, b) => number  → applied client-side on full dataset before pagination
  *  - sorter: true              → visual indicator only; parent must handle via onChange
@@ -1013,7 +1020,8 @@ const TableV2 = <T extends object>(
                               opens. */}
                             <AriaButton
                               aria-label="filter"
-                              className="tw:ml-1 tw:p-0 tw:bg-transparent tw:border-0 tw:cursor-pointer tw:inline-flex tw:items-center">
+                              className="tw:ml-1 tw:p-0 tw:bg-transparent tw:border-0 tw:cursor-pointer tw:inline-flex tw:items-center"
+                              data-testid="filter-trigger">
                               {typeof colType.filterIcon === 'function'
                                 ? colType.filterIcon(
                                     Boolean(filterState[colKey]?.length)
@@ -1024,6 +1032,7 @@ const TableV2 = <T extends object>(
                               <Dialog className="tw:outline-none">
                                 <div
                                   className="tw:bg-primary tw:shadow-lg tw:outline-1 tw:outline-secondary_alt tw:rounded-lg"
+                                  data-testid="filter-dropdown"
                                   style={{ minWidth: '200px' }}>
                                   {typeof colType.filterDropdown === 'function'
                                     ? colType.filterDropdown({

--- a/openmetadata-ui/src/main/resources/ui/src/styles/components/table.less
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/components/table.less
@@ -152,8 +152,11 @@
   }
 }
 
+// Puts a column's filter icon before its title. Both wrappers are matched so
+// the class keeps working as call sites move from AntD to TableV2.
 .align-table-filter-left {
-  .ant-table-filter-column {
+  .ant-table-filter-column,
+  [data-testid='column-header-content'] {
     flex-direction: row-reverse;
     gap: var(--om-space-8);
   }


### PR DESCRIPTION
Fixes [6029](https://github.com/open-metadata/openmetadata-collate/issues/6029)
> Stacked on #31954. Base retargets to `main` once that merges.

Prep for the call-site sweeps, plus the guide those sweeps get reviewed against.

### The selector problem
A test that selects `.ant-table-row` breaks the moment its page moves to TableV2 — which would drop an unrelated red suite into the middle of every sweep PR.

AntD's `rc-table` emits `data-row-key` **natively**, and TableV2 emits it too. So a selector written against it passes on both wrappers and survives the migration. Same for the expander: both render `data-testid="expand-icon"`.

Three suites rewritten (`SampleDataTable` ×2, and `ChildTermsTab` in the Collate repo). All pass against the **legacy** wrapper, which is the point — nothing has migrated yet.

Adds `filter-trigger` / `filter-dropdown` testids to TableV2 so the filter UI has a hook that doesn't depend on AntD's DOM, and lists the stable hooks in the TableV2 header comment.

The parity suite keeps its `.ant-table` selectors — they live in the legacy adapter, which exists precisely to drive the AntD DOM.

### `docs/antd-migration/table.md`
The review contract for every sweep PR: what's supported (with a spec behind each claim), what's blocked and why, the selector table, the per-page checklist, and the gotchas that cost time during the parity work — including that **`ts-jest` does not fail on a missing export here**, so a green jest run is not a typecheck.

### Playwright is deliberately untouched
13 specs reference `.ant-table`. They need a running stack to verify, and rewriting e2e selectors blind is how a suite goes quietly broken. Each moves in the sweep PR for its page, where it can actually be run. The mapping for the three cases with no shared hook (tree depth, filter trigger, filter dropdown) is in the guide.

### Scope correction
An earlier estimate of "39 jest files" was wrong — that grep caught source files using AntD classes for *styling*, which is Phase 6 work, not selectors. The real count is 3.

### Verification
- `SampleDataTable` — 37 tests, `ChildTermsTab` — 10 tests, `common/Table` — 144 tests
- eslint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces AntD-specific selectors in SampleDataTable tests with shared row attributes and adds stable TableV2 filter/header hooks. Major changes:
- Documents TableV2 migration contracts, supported props, selectors, and migration checks.
- Updates duplicate- and reserved-column tests to select rows through `data-row-key`.
- Adds filter trigger, filter dropdown, and header-content test hooks to TableV2.
- Extends filter-title alignment styling to TableV2 headers.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/antd-migration/table.md | Adds the Table-to-TableV2 migration guide, including supported contracts, stable selectors, and validation guidance. |
| openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.duplicateColumns.test.tsx | Replaces AntD row-class selectors with the shared `data-row-key` attribute in duplicate-column assertions. |
| openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.reservedColumns.test.tsx | Uses the shared row-key attribute for row-count and uniqueness assertions. |
| openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx | Adds stable header and filter test hooks without changing the filter interaction flow. |
| openmetadata-ui/src/main/resources/ui/src/styles/components/table.less | Extends filter-icon alignment styling to TableV2 header-content containers. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;feat/tablev2-parity-and-ga..."](https://github.com/open-metadata/openmetadata/commit/7ef2d447d592d02cd4fff6b8a709ce9625b20a1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56217420)</sub>

<!-- /greptile_comment -->