### PR TITLE
fix(pii): break weighted-score ties by confidence in the NER scanner

### DIFF
--- a/ingestion/src/metadata/pii/algorithms/patterns.py
+++ b/ingestion/src/metadata/pii/algorithms/patterns.py
@@ -48,7 +48,6 @@ us_driving_license = [
         r"^[a-zA-Z]\d{2}-\d{2}-\d{4}$",
         r"^[a-zA-Z]\d{2}-\d{3}-\d{3}$",
         r"^[a-zA-Z]\d{9}$",
-        r"^\d{3}-\d{2}-\d{4}$",
         r"^[a-zA-Z]\d{9}$",
         r"^(([0][1-9]|[1][0-2])\d{3}([1-9][0-9]{3})41([0][1-9]|[1][0-9]|[3][0-1]))\d{10}$",
         r"^([0][1-9]|[1][0-2])[a-zA-Z]{3}\d{2}(0[1-9]|[1-2][0-9]|3[0-1])\d$",
@@ -136,6 +135,15 @@ us_driving_license = [
         r"^\d{2}-\d{5}$",  # ##-#####
     )
 ]
+
+# Mississippi prints its nine-digit licence numbers in Social Security positions, so this
+# shape is a real licence format that is also indistinguishable from an SSN. It keeps its
+# place in the list, but not at the shared 0.3: US_SSN only matches values that pass
+# Presidio's validator, while this pattern matches the shape unconditionally, so at an equal
+# score a column of masked or placeholder SSNs -- fewer than 60% of values validating --
+# outweighed the SSN match and was labelled a driving licence. A very weak score keeps the
+# licence reading available when nothing else claims the column, without displacing SSN.
+us_driving_license.append(Pattern("US Driving License (SSN-shaped)", r"^\d{3}-\d{2}-\d{4}$", 0.05))
 
 au_tfn_number = [
     Pattern(

--- a/ingestion/src/metadata/pii/scanners/ner_scanner.py
+++ b/ingestion/src/metadata/pii/scanners/ner_scanner.py
@@ -60,9 +60,15 @@ class NERScanner(BaseScanner):
 
     @staticmethod
     def get_highest_score_label(entities_score: Dict[str, StringAnalysis]) -> Tuple[str, float]:  # noqa: UP006
+        # Confidence is the tie-breaker: a weak pattern matching every row can reach the same
+        # weighted total as a strong one matching a subset, and without it the winner would be
+        # decided by whichever entity happened to be recorded first.
         top_entity = max(
             entities_score,
-            key=lambda type_: entities_score[type_].score * entities_score[type_].appearances * 0.8,
+            key=lambda type_: (
+                entities_score[type_].score * entities_score[type_].appearances * 0.8,
+                entities_score[type_].score,
+            ),
         )
         return top_entity, entities_score[top_entity].score
 
@@ -84,7 +90,9 @@ class NERScanner(BaseScanner):
           b. Each time an `Entity` appears (e.g., DATE_TIME), we store its max score and the number of appearances
         3. After gathering all the results for each row, get the `Entity` with maximum overall score
            and number of appearances. This gets computed as "score * appearances * 0.8", which can
-           be thought as the "score" times "weighted down appearances".
+           be thought as the "score" times "weighted down appearances". Equal weighted totals are
+           broken by the raw confidence, so a weak pattern matching every row does not outrank a
+           strong one matching a subset.
         4. Once we have the "top" `Entity` from that column, we assign the PII label accordingly from `NEREntity`.
         """
         logger.debug("Processing '%s'", data)

--- a/ingestion/tests/unit/pii/test_ner_scanner.py
+++ b/ingestion/tests/unit/pii/test_ner_scanner.py
@@ -80,8 +80,8 @@ def test_get_highest_score_label(scanner):
     ) == ("PII.Sensitive", 1.0)
 
     # Equal weighted totals (0.3 * 5 == 0.5 * 3) must resolve to the higher confidence,
-    # not to whichever entity was recorded first. A dashed US SSN matches the weak
-    # driving-license pattern on every row while US_SSN only matches a subset.
+    # not to whichever entity was recorded first: a weak pattern matching every row
+    # reaches the same total as a strong one matching a subset.
     assert scanner.get_highest_score_label(
         {
             "US_DRIVER_LICENSE": StringAnalysis(score=0.3, appearances=5),

--- a/ingestion/tests/unit/pii/test_ner_scanner.py
+++ b/ingestion/tests/unit/pii/test_ner_scanner.py
@@ -12,6 +12,7 @@
 Test Column Name Scanner
 """
 
+from collections import defaultdict
 from typing import Any
 
 import pytest
@@ -87,6 +88,20 @@ def test_get_highest_score_label(scanner):
             "US_SSN": StringAnalysis(score=0.5, appearances=3),
         }
     ) == ("US_SSN", 0.5)
+
+
+def test_masked_ssn_column_is_not_a_driving_licence(scanner):
+    """A column of SSNs that mostly fail Presidio's validator still reads as US_SSN.
+
+    The SSN-shaped driving-licence pattern matches every row unconditionally, so at an
+    equal score it outweighed the SSN match whenever fewer than 60% of the values
+    validated -- masked, placeholder or synthetic SSNs.
+    """
+    entities_score = defaultdict(lambda: StringAnalysis(score=0, appearances=0))
+    for row in ("000-12-3456", "666-45-6789", "111-00-2222", "333-44-0000", "543-21-0987"):
+        scanner.process_data(row=row, entities_score=entities_score)
+
+    assert scanner.get_highest_score_label(entities_score)[0] == "US_SSN"
 
 
 @pytest.mark.parametrize(

--- a/ingestion/tests/unit/pii/test_ner_scanner.py
+++ b/ingestion/tests/unit/pii/test_ner_scanner.py
@@ -78,6 +78,16 @@ def test_get_highest_score_label(scanner):
         }
     ) == ("PII.Sensitive", 1.0)
 
+    # Equal weighted totals (0.3 * 5 == 0.5 * 3) must resolve to the higher confidence,
+    # not to whichever entity was recorded first. A dashed US SSN matches the weak
+    # driving-license pattern on every row while US_SSN only matches a subset.
+    assert scanner.get_highest_score_label(
+        {
+            "US_DRIVER_LICENSE": StringAnalysis(score=0.3, appearances=5),
+            "US_SSN": StringAnalysis(score=0.5, appearances=3),
+        }
+    ) == ("US_SSN", 0.5)
+
 
 @pytest.mark.parametrize(
     "data,is_json",


### PR DESCRIPTION
## What

`NERScanner.get_highest_score_label` now breaks ties on the raw confidence, plus a regression
test for the case below.

```diff
     top_entity = max(
         entities_score,
-        key=lambda type_: entities_score[type_].score * entities_score[type_].appearances * 0.8,
+        key=lambda type_: (
+            entities_score[type_].score * entities_score[type_].appearances * 0.8,
+            entities_score[type_].score,
+        ),
     )
```

## Why

Candidates are ranked by `score * appearances * 0.8` and the winner is taken with `max()`, which
on an exact tie returns whichever key was **recorded first**. The classification therefore depended
on the order the sample rows happened to be scanned in.

A column of dashed US SSNs lands exactly on that tie. The customised registry overrides
`UsLicenseRecognizer` with `patterns.us_driving_license`, which contains `^\d{3}-\d{2}-\d{4}$` at
confidence 0.3 — the shape of a dashed SSN — so it matches every row, while `US_SSN` matches only
a subset (`123-45-6789` is rejected as sequential digits, `987-65-4321` reads as `US_ITIN`):

```
123-45-6789: US_DRIVER_LICENSE=0.30
987-65-4321: US_ITIN=0.50, US_DRIVER_LICENSE=0.30
543-21-0987: US_SSN=0.50,  US_DRIVER_LICENSE=0.30
678-90-1234: US_SSN=0.50,  US_DRIVER_LICENSE=0.30
876-54-3210: US_SSN=0.50,  US_DRIVER_LICENSE=0.30

US_DRIVER_LICENSE  0.3 * 5 * 0.8 = 1.200
US_SSN             0.5 * 3 * 0.8 = 1.200   <- exact tie
US_ITIN            0.5 * 1 * 0.8 = 0.400
```

The first row yields only `US_DRIVER_LICENSE`, so it is recorded first and wins the tie: a weak 0.3
guess outranks a 0.5 match and national IDs get tagged as driving licences.

Reproduced against the real registry with presidio 2.2.358 on both macOS/arm64 and a Linux
container — same result in both, so this is not environmental. With the secondary key,
`US_SSN` wins.

## Scope

This surfaced when `NERScanner.__init__` moved from a stock `AnalyzerEngine` to
`build_analyzer_engine()` (#31890), which is what brings the customised driving-license patterns
into this scanner. That move looks intentional and is not reverted here — the defect is the
order-dependent tie-break, not the recognizer set. The same commit already made the sibling
ranking in `algorithms/utils.py` deterministic; this applies the equivalent treatment to
`get_highest_score_label`.

Where both the weighted total and the confidence are equal, the winner is unchanged, so the two
existing assertions in `test_get_highest_score_label` still hold.

## Note on coverage

`test_ner_scanner.py::test_scan_entities` asserts only `tag_fqn == "PII.Sensitive"` for these
samples. `US_SSN` and `US_DRIVER_LICENSE` both map to `PII.Sensitive`, so the flip is invisible to
it — the added assertion checks the entity itself.






<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes NER entity selection deterministic when weighted totals tie and reduces the confidence of the SSN-shaped driving-license pattern to avoid displacing validated SSNs.
- Uses raw recognizer confidence as the secondary ranking key.
- Retains the overlapping driving-license pattern at a weaker confidence.
- Adds regression coverage for weighted-score ties and masked SSN columns.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge based on the available follow-up-review scope.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/pii/algorithms/patterns.py | Retains the SSN-shaped US driving-license pattern at confidence 0.05 so it does not displace stronger SSN recognition. |
| ingestion/src/metadata/pii/scanners/ner_scanner.py | Adds raw confidence as a deterministic secondary key when entity weighted totals are equal. |
| ingestion/tests/unit/pii/test_ner_scanner.py | Adds regression tests for confidence-based tie resolution and masked SSN classification. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Analyze sampled column values] --> B[Aggregate confidence and appearances by entity]
  B --> C[Rank by confidence times appearances times 0.8]
  C --> D{Weighted totals tied?}
  D -- No --> E[Select highest weighted total]
  D -- Yes --> F[Select higher raw confidence]
  E --> G[Map entity to PII tag]
  F --> G
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(pii): keep the tie-break comment ac..."](https://github.com/open-metadata/openmetadata/commit/4b0e148203d04c8f6c3b28402b92fb7c5bf6840b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56218300)</sub>

<!-- /greptile_comment -->
