### PR TITLE
refactor(ui): route the five raw-AntD tables through the common wrapper

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardVersion/DashboardVersion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardVersion/DashboardVersion.component.tsx
@@ -12,7 +12,8 @@
  */
 
 import Icon from '@ant-design/icons/lib/components/Icon';
-import { Col, Row, Space, Table, Tabs, TabsProps } from 'antd';
+import { Col, Row, Space, Tabs, TabsProps } from 'antd';
+import Table from '../../common/Table/Table';
 import { ColumnsType } from 'antd/lib/table';
 import classNames from 'classnames';
 import { FC, useEffect, useMemo, useState } from 'react';

--- a/openmetadata-ui/src/main/resources/ui/src/components/MlModel/MlModelDetail/MlModelDetail.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MlModel/MlModelDetail/MlModelDetail.component.tsx
@@ -11,7 +11,8 @@
  *  limitations under the License.
  */
 
-import { Col, Row, Table, Tabs, Typography } from 'antd';
+import { Col, Row, Tabs, Typography } from 'antd';
+import Table from '../../common/Table/Table';
 import { ColumnsType } from 'antd/lib/table';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Pipeline/PipelineVersion/PipelineVersion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Pipeline/PipelineVersion/PipelineVersion.component.tsx
@@ -11,7 +11,8 @@
  *  limitations under the License.
  */
 
-import { Col, Row, Space, Table, Tabs, TabsProps } from 'antd';
+import { Col, Row, Space, Tabs, TabsProps } from 'antd';
+import Table from '../../common/Table/Table';
 import { ColumnsType } from 'antd/lib/table';
 import classNames from 'classnames';
 import { FC, useEffect, useMemo, useState } from 'react';

--- a/openmetadata-ui/src/main/resources/ui/src/components/SearchSettings/FieldValueBoostList/FieldValueBoostList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SearchSettings/FieldValueBoostList/FieldValueBoostList.tsx
@@ -11,7 +11,8 @@
  *  limitations under the License.
  */
 import Icon from '@ant-design/icons';
-import { Button, Table } from 'antd';
+import { Button } from 'antd';
+import Table from '../../common/Table/Table';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as Delete } from '../../../assets/svg/delete-colored.svg';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppLogsViewer/ReindexFailures.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppLogsViewer/ReindexFailures.component.tsx
@@ -11,7 +11,8 @@
  *  limitations under the License.
  */
 
-import { Drawer, Select, Space, Table, Tooltip, Typography } from 'antd';
+import { Drawer, Select, Space, Tooltip, Typography } from 'antd';
+import Table from '../../../common/Table/Table';
 import { ColumnsType } from 'antd/lib/table';
 import { AxiosError } from 'axios';
 import { useCallback, useEffect, useMemo, useState } from 'react';


### PR DESCRIPTION
Independent of the other TableV2 PRs — based on `main`, merges on its own.

Five components rendered `<Table>` straight from antd, bypassing both `common/Table/Table` and TableV2. That leaves the migration with three doors instead of one: every later sweep would have to handle the wrapper case and the raw case separately. This closes the raw case first.

**Import swap only — no prop changes.**

| File | Columns declare widths? |
|---|---|
| `ReindexFailures.component.tsx` | yes |
| `PipelineVersion.component.tsx` | yes |
| `FieldValueBoostList.tsx` | yes |
| `MlModelDetail.component.tsx` | **no** |
| `DashboardVersion.component.tsx` | **no** |

### Please eyeball these two
The wrapper hardcodes `tableLayout="fixed"`; raw AntD defaults to auto. Where columns declare widths that is a no-op. `MlModelDetail` and `DashboardVersion` declare none — their columns will re-flow to equal width.

Unit tests cannot see this, so I am not claiming it is unchanged: it needs a look at the ML model detail tab and the dashboard version page. If the re-flow is unacceptable, the fix is explicit widths on those columns rather than reverting the wrapper.

### Scope note
The original issue listed 14 files bypassing both wrappers. The real count today is 10 — 5 here, 5 in the Collate repo (open-metadata/openmetadata-collate#6087). The rest have already been migrated.

### Verification
- affected suites: 33 tests passing (1 suite skipped, pre-existing)
- eslint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR routes five UI tables from Ant Design’s raw Table component through the shared Table wrapper without changing their call-site props.

- Migrates dashboard and pipeline version tables.
- Migrates ML model detail and field-value boost tables.
- Migrates the reindex-failures table.
- Introduces the wrapper’s fixed-layout behavior on two tables without explicit column sizing.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking need to confirm or explicitly control fixed-layout sizing for the ML model and dashboard version tables.

The five call sites use wrapper-compatible table props, but two content-heavy tables have no widths or overflow strategy after inheriting the wrapper’s unconditional fixed layout.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/src/components/MlModel/MlModelDetail/MlModelDetail.component.tsx; openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardVersion/DashboardVersion.component.tsx
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardVersion/DashboardVersion.component.tsx | Swaps to the shared wrapper; five widthless columns now use its fixed table layout. |
| openmetadata-ui/src/main/resources/ui/src/components/MlModel/MlModelDetail/MlModelDetail.component.tsx | Swaps two widthless detail tables to the fixed-layout wrapper, including potentially long repository URLs. |
| openmetadata-ui/src/main/resources/ui/src/components/Pipeline/PipelineVersion/PipelineVersion.component.tsx | Import-only migration whose existing column widths constrain the wrapper’s fixed layout. |
| openmetadata-ui/src/main/resources/ui/src/components/SearchSettings/FieldValueBoostList/FieldValueBoostList.tsx | Import-only migration retaining explicit horizontal scrolling and compatible basic table props. |
| openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppLogsViewer/ReindexFailures.component.tsx | Import-only migration retaining sized columns, pagination, loading, and vertical scrolling. |

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(ui): route the five raw-AntD ta..."](https://github.com/open-metadata/openmetadata/commit/ae91920b0710cbf31d4a7e11d86a5df28272906b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56218626)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->