### PR TITLE
fix(playwright): use createAdminApiContext in IngestionListNameSorting hooks on 1.13

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IngestionListNameSorting.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IngestionListNameSorting.spec.ts
@@ -13,7 +13,7 @@
 import { expect, Locator, Page, test } from '@playwright/test';
 import { SORT_ORDER } from '../../../src/enums/common.enum';
 import { DatabaseServiceClass } from '../../support/entity/service/DatabaseServiceClass';
-import { performAdminLogin } from '../../utils/admin';
+import { createAdminApiContext } from '../../utils/admin';
 import { uuid } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 
@@ -113,8 +113,8 @@ const expectSortDelegatedToServer = async (
 };
 
 test.describe('Ingestion agent list Name column sorting', () => {
-  test.beforeAll(async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
+  test.beforeAll(async () => {
+    const { apiContext, afterAction } = await createAdminApiContext();
 
     await service.create(apiContext);
 
@@ -145,8 +145,8 @@ test.describe('Ingestion agent list Name column sorting', () => {
     await afterAction();
   });
 
-  test.afterAll(async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
+  test.afterAll(async () => {
+    const { apiContext, afterAction } = await createAdminApiContext();
 
     await service.delete(apiContext);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/admin.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/admin.ts
@@ -32,8 +32,10 @@ export const authenticateAdminPage = async (page: Page) => {
 };
 
 export const performAdminLogin = async (browser: Browser) => {
+  const admin = new AdminClass();
   const page = await browser.newPage();
-  await authenticateAdminPage(page);
+  await admin.login(page);
+  await redirectToHomePage(page);
 
   const token = await getToken(page);
   const apiContext = await getAuthContext(token);

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/admin.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/admin.ts
@@ -32,10 +32,8 @@ export const authenticateAdminPage = async (page: Page) => {
 };
 
 export const performAdminLogin = async (browser: Browser) => {
-  const admin = new AdminClass();
   const page = await browser.newPage();
-  await admin.login(page);
-  await redirectToHomePage(page);
+  await authenticateAdminPage(page);
 
   const token = await getToken(page);
   const apiContext = await getAuthContext(token);


### PR DESCRIPTION
The `beforeAll` and `afterAll` hooks in this spec only need an API token to create/delete test data. They never actually need a browser window at all.

So instead of calling `performAdminLogin(browser)` (which opens a browser), we now call `createAdminApiContext()` (which just makes a direct API call to get a token). No browser = no redirect problem.

**Only this one spec file is changed.** No shared utilities are touched.

