### PR TITLE
fix(UI): Added tooltip for the breadcrumb rendering in the hash list component

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/hashtag/HashList.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/hashtag/HashList.test.tsx
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { EditorView } from '@tiptap/pm/view';
 import { SuggestionKeyDownProps, SuggestionProps } from '@tiptap/suggestion';
 import React from 'react';
@@ -247,6 +247,18 @@ describe('HashList', () => {
       const result = ref.current?.onKeyDown(keyDownProps);
 
       expect(result).toBe(false);
+    });
+
+    it('should render breadcrumb tooltip inside the suggestion menu wrapper', async () => {
+      render(<HashList {...mockProps} />);
+
+      fireEvent.mouseEnter(screen.getAllByText('Database/Schema')[0]);
+
+      const tooltip = await screen.findByRole('tooltip');
+
+      expect(document.getElementById('hashtag-viewport')).toContainElement(
+        tooltip
+      );
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/hashtag/HashList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/hashtag/HashList.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { SuggestionProps } from '@tiptap/suggestion';
-import { Space, Typography } from 'antd';
+import { Space, Tooltip, Typography } from 'antd';
 import classNames from 'classnames';
 import { isEmpty } from 'lodash';
 import { forwardRef, useImperativeHandle, useState } from 'react';
@@ -129,9 +129,16 @@ export default forwardRef<
             size={2}
             onClick={() => selectItem(index)}>
             <div className="d-flex flex-wrap">
-              <span className="text-grey-muted truncate w-max-200 text-xss">
-                {breadcrumbsData}
-              </span>
+              <Tooltip
+                getPopupContainer={(triggerNode) =>
+                  triggerNode.closest('.suggestion-menu-wrapper') ||
+                  document.body
+                }
+                title={breadcrumbsData}>
+                <span className="text-grey-muted truncate w-max-200 text-xss">
+                  {breadcrumbsData}
+                </span>
+              </Tooltip>
             </div>
             <Space align="center">
               <div className="w-5" style={{ marginTop: '6px' }}>


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes [29693](https://github.com/open-metadata/OpenMetadata/issues/29693)


https://github.com/user-attachments/assets/b5b4a0c7-3206-484f-9459-e86516890bce


<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds a breadcrumb tooltip to hashtag suggestions and verifies that its overlay is mounted within the suggestion-menu viewport.
- Wraps breadcrumb text in a Tooltip with a custom popup container.
- Adds a hover-based unit test for tooltip placement.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until the Tooltip popup-container callback returns the required `HTMLElement` type.

The new `closest()` callback is inferred to return `Element`, which is incompatible with Ant Design's `HTMLElement` contract and causes the required TypeScript CI check to fail; the remaining findings are non-blocking repository-convention issues.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/hashtag/HashList.tsx; openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/hashtag/HashList.test.tsx
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/hashtag/HashList.tsx | Adds the breadcrumb tooltip, but its popup-container callback has an incompatible return type and the implementation bypasses repository UI conventions. |
| openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/hashtag/HashList.test.tsx | Adds coverage for tooltip placement, with non-blocking raw-string convention violations. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(UI): Added tooltip for the breadcrum..."](https://github.com/open-metadata/openmetadata/commit/25281076f20ca0f70d31742d1f49f917d1312003) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56225866)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))

<!-- /greptile_comment -->