### PR TITLE
fix(UI): Added tooltip for the breadcrumb rendering in the hash list component

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/hashtag/HashList.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/hashtag/HashList.test.tsx
@@ -249,17 +249,20 @@ describe('HashList', () => {
       expect(result).toBe(false);
     });
 
-    it('should wire the breadcrumb text into a tooltip trigger inside the suggestion menu wrapper', () => {
+    it('should open the breadcrumb tooltip with the full breadcrumb text on focus', () => {
       render(<HashList {...mockProps} />);
 
-      const breadcrumbTrigger = screen
+      const trigger = screen
         .getAllByText('Database/Schema')[0]
-        .closest('[data-rac]');
+        .closest('button') as HTMLElement;
 
-      expect(breadcrumbTrigger).not.toBeNull();
-      expect(document.getElementById('hashtag-viewport')).toContainElement(
-        breadcrumbTrigger as HTMLElement
-      );
+      act(() => {
+        trigger.focus();
+      });
+
+      const tooltip = screen.getByRole('tooltip');
+
+      expect(tooltip).toHaveTextContent('Database/Schema');
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/hashtag/HashList.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/hashtag/HashList.test.tsx
@@ -248,5 +248,18 @@ describe('HashList', () => {
 
       expect(result).toBe(false);
     });
+
+    it('should wire the breadcrumb text into a tooltip trigger inside the suggestion menu wrapper', () => {
+      render(<HashList {...mockProps} />);
+
+      const breadcrumbTrigger = screen
+        .getAllByText('Database/Schema')[0]
+        .closest('[data-rac]');
+
+      expect(breadcrumbTrigger).not.toBeNull();
+      expect(document.getElementById('hashtag-viewport')).toContainElement(
+        breadcrumbTrigger as HTMLElement
+      );
+    });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/hashtag/HashList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/hashtag/HashList.tsx
@@ -10,14 +10,18 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+import {
+  Box,
+  Typography
+} from '@openmetadata/ui-core-components';
 import { SuggestionProps } from '@tiptap/suggestion';
-import { Space, Typography } from 'antd';
 import classNames from 'classnames';
 import { isEmpty } from 'lodash';
 import { forwardRef, useImperativeHandle, useState } from 'react';
 import { isInViewport } from '../../../../utils/BlockEditorPureUtils';
 import { EntityIconSize } from '../../../../utils/EntityIconUtils';
 import searchClassBase from '../../../../utils/SearchClassBase';
+import { renderBreakableTooltip } from '../../../../utils/TooltipUtils';
 import { ExtensionRef, SuggestionItem } from '../../BlockEditor.interface';
 
 export default forwardRef<
@@ -109,9 +113,8 @@ export default forwardRef<
   }));
 
   return (
-    <Space
+    <div
       className="suggestion-menu-wrapper"
-      direction="vertical"
       id="hashtag-viewport">
       {items.map((item, index) => {
         const breadcrumbsData = item.breadcrumbs
@@ -119,33 +122,37 @@ export default forwardRef<
           : '';
 
         return (
-          <Space
-            className={classNames('w-full cursor-pointer hashtag-item', {
+          <button
+            className={classNames('tw:w-full tw:cursor-pointer hashtag-item tw:flex tw:items-start tw:flex-col', {
               'bg-grey-2': index === selectedIndex,
             })}
             data-testid={`hash-mention-${item.label}`}
-            direction="vertical"
             id={`hashtag-item-${item.id}`}
             key={item.id}
-            size={2}
+            type='button'
             onClick={() => selectItem(index)}>
-            <div className="d-flex flex-wrap">
-              <span className="text-grey-muted truncate w-max-200 text-xss">
+            <div className='tw:w-full tw:min-w-0 tw:flex tw:flex-wrap'>
+              <Typography
+                className="tw:text-quaternary tw:block tw:text-left tw:min-w-0"
+                ellipsis={{ tooltip: renderBreakableTooltip(breadcrumbsData) }}
+                size='text-xs'>
                 {breadcrumbsData}
-              </span>
+              </Typography>
             </div>
-            <Space align="center">
+            <Box align="center" className="tw:min-w-0" gap={2}>
               {searchClassBase.getEntityIconWithBg(
                 item.type,
                 EntityIconSize.Size14
               )}
-              <Typography className="truncate w-max-200">
+              <Typography
+                className="tw:block tw:text-left tw:min-w-0"
+                ellipsis={{ tooltip: renderBreakableTooltip(item.label) }}>
                 {item.label}
               </Typography>
-            </Space>
-          </Space>
+            </Box>
+          </button>
         );
       })}
-    </Space>
+    </div>
   );
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/hashtag/HashList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/hashtag/HashList.tsx
@@ -10,10 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import {
-  Box,
-  Typography
-} from '@openmetadata/ui-core-components';
+import { Box, Typography } from '@openmetadata/ui-core-components';
 import { SuggestionProps } from '@tiptap/suggestion';
 import classNames from 'classnames';
 import { isEmpty } from 'lodash';
@@ -113,9 +110,7 @@ export default forwardRef<
   }));
 
   return (
-    <div
-      className="suggestion-menu-wrapper"
-      id="hashtag-viewport">
+    <div className="suggestion-menu-wrapper" id="hashtag-viewport">
       {items.map((item, index) => {
         const breadcrumbsData = item.breadcrumbs
           ? item.breadcrumbs.map((obj: { name: string }) => obj.name).join('/')
@@ -123,19 +118,22 @@ export default forwardRef<
 
         return (
           <button
-            className={classNames('tw:w-full tw:cursor-pointer hashtag-item tw:flex tw:items-start tw:flex-col', {
-              'bg-grey-2': index === selectedIndex,
-            })}
+            className={classNames(
+              'tw:w-full tw:cursor-pointer hashtag-item tw:flex tw:items-start tw:flex-col',
+              {
+                'bg-grey-2': index === selectedIndex,
+              }
+            )}
             data-testid={`hash-mention-${item.label}`}
             id={`hashtag-item-${item.id}`}
             key={item.id}
-            type='button'
+            type="button"
             onClick={() => selectItem(index)}>
-            <div className='tw:w-full tw:min-w-0 tw:flex tw:flex-wrap'>
+            <div className="tw:w-full tw:min-w-0 tw:flex tw:flex-wrap">
               <Typography
                 className="tw:text-quaternary tw:block tw:text-left tw:min-w-0"
                 ellipsis={{ tooltip: renderBreakableTooltip(breadcrumbsData) }}
-                size='text-xs'>
+                size="text-xs">
                 {breadcrumbsData}
               </Typography>
             </div>


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

https://github.com/user-attachments/assets/9fc4b7e8-5fb1-4ad4-a77c-66ab3e4c580a



Fixes #29693 
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates hashtag suggestion rows to use UI-core layout and typography components, adding ellipsis tooltips for breadcrumb and entity-label text.
- Converts each suggestion row into a button.
- Adds breakable tooltip content for truncated breadcrumbs and labels.
- Adds a focus-oriented tooltip test.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/hashtag/HashList.tsx | Replaces Ant Design layout elements with native buttons and UI-core components while adding ellipsis tooltips. |
| openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/hashtag/HashList.test.tsx | Adds coverage for breadcrumb tooltip content during a focus interaction. |

</details>

<sub>Reviews (2): Last reviewed commit: ["addressed gitar comment"](https://github.com/open-metadata/openmetadata/commit/7658c3fca5f6713d2b42c633574d107267cdc64c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56259275)</sub>

<!-- /greptile_comment -->