### PR TITLE
fix: add domain filter to GlossaryResource list endpoint

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/glossary/GlossaryResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/glossary/GlossaryResource.java
@@ -141,6 +141,9 @@ public class GlossaryResource extends EntityResource<Glossary, GlossaryRepositor
               schema = @Schema(type = "string"))
           @QueryParam("after")
           String after,
+      @Parameter(description = "Filter by domain FQN", schema = @Schema(type = "string"))
+          @QueryParam("domain")
+          String domain,
       @Parameter(
               description = "Include all, deleted, or non-deleted entities.",
               schema = @Schema(implementation = Include.class))
@@ -148,6 +151,13 @@ public class GlossaryResource extends EntityResource<Glossary, GlossaryRepositor
           @DefaultValue("non-deleted")
           Include include) {
     ListFilter filter = new ListFilter(include);
+    if (domain != null) {
+      filter.addQueryParam(
+          "domainId",
+          Entity.getEntityReferenceByName(Entity.DOMAIN, domain, Include.NON_DELETED)
+              .getId()
+              .toString());
+    }
     return super.listInternal(
         uriInfo, securityContext, fieldsParam, filter, limitParam, before, after);
   }


### PR DESCRIPTION
Fixes #31173

Add `@QueryParam("domain")` to `GlossaryResource.list()` and resolve the domain FQN to domain ID in the `ListFilter`.









<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=56494892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; no actionable correctness, security, or repository-rule issues remain.

<details open><summary>Summary</summary>

Adds domain-FQN filtering to the glossary list endpoint and integration coverage for matching, non-matching, and empty domain filters.
- Resolves a supplied domain FQN to a non-deleted domain entity and filters glossaries by its ID.
- Treats a null or empty domain parameter as an omitted filter.
- Refactors the integration coverage into focused tests with shared fixture and listing helpers.
</details>

<sub>Reviews (5) · Last reviewed commit: ["test: split glossary domain-filter IT in..."](https://github.com/open-metadata/openmetadata/commit/16f331d121fdedaae0ea30b82b0010a47137cd77)</sub>

<!-- /greptile_comment -->