### PR TITLE
fix: migrate KnowledgePage approval task from FeedRepository to TaskRepository

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KnowledgePageRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KnowledgePageRepository.java
@@ -17,7 +17,6 @@ import static org.openmetadata.service.governance.workflows.Workflow.UPDATED_BY_
 import static org.openmetadata.service.util.EntityUtil.entityReferenceMatch;
 import static org.openmetadata.service.util.EntityUtil.getId;
 
-import jakarta.json.JsonPatch;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import java.util.ArrayList;
@@ -33,7 +32,6 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.jdbi.v3.core.Jdbi;
 import org.openmetadata.schema.EntityInterface;
-import org.openmetadata.schema.api.feed.CloseTask;
 import org.openmetadata.schema.api.feed.ResolveTask;
 import org.openmetadata.schema.attachments.Asset;
 import org.openmetadata.schema.attachments.AssetType;
@@ -60,7 +58,6 @@ import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.governance.workflows.WorkflowHandler;
-import org.openmetadata.service.resources.feeds.MessageParser;
 import org.openmetadata.service.resources.knowledge.KnowledgePageResource;
 import org.openmetadata.service.search.PropagationDescriptor;
 import org.openmetadata.service.search.SearchSortFilter;
@@ -70,7 +67,6 @@ import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.EntityUtil.RelationIncludes;
 import org.openmetadata.service.util.FullyQualifiedName;
 import org.openmetadata.service.util.RestUtil;
-import org.openmetadata.service.util.WebsocketNotificationHandler;
 
 @Slf4j
 @Repository
@@ -631,6 +627,16 @@ public class KnowledgePageRepository extends EntityRepository<Page> {
     }
 
     @Override
+    public void updateReviewers() {
+      super.updateReviewers();
+      if (original.getReviewers() != null
+          && updated.getReviewers() != null
+          && !original.getReviewers().equals(updated.getReviewers())) {
+        updateTaskWithNewReviewers(updated);
+      }
+    }
+
+    @Override
     public void entitySpecificUpdate(boolean consolidatingChanges) {
       // Update Related Terms
       updateRelatedEntities(original, updated);
@@ -751,31 +757,17 @@ public class KnowledgePageRepository extends EntityRepository<Page> {
   }
 
   protected void updateTaskWithNewReviewers(Page page) {
-    try {
-      MessageParser.EntityLink about =
-          new MessageParser.EntityLink(KNOWLEDGE_PAGE_ENTITY, page.getFullyQualifiedName());
-      FeedRepository feedRepository = Entity.getFeedRepository();
-      Thread originalTask =
-          feedRepository.getTask(about, TaskType.RequestApproval, TaskStatus.Open);
-      page =
-          Entity.getEntityByName(
-              KNOWLEDGE_PAGE_ENTITY,
-              page.getFullyQualifiedName(),
-              "id,fullyQualifiedName,reviewers",
-              Include.ALL);
-
-      Thread updatedTask = JsonUtils.deepCopy(originalTask, Thread.class);
-      updatedTask.getTask().withAssignees(new ArrayList<>(page.getReviewers()));
-      JsonPatch patch = JsonUtils.getJsonPatch(originalTask, updatedTask);
-      RestUtil.PatchResponse<Thread> thread =
-          feedRepository.patchThread(null, originalTask.getId(), updatedTask.getUpdatedBy(), patch);
-
-      // Send WebSocket Notification
-      WebsocketNotificationHandler.handleTaskNotification(thread.entity());
-    } catch (EntityNotFoundException e) {
-      // Task may not be present
-      LOG.debug("Task not found for page {}", page.getFullyQualifiedName());
-    }
+    page =
+        Entity.getEntityByName(
+            KNOWLEDGE_PAGE_ENTITY,
+            page.getFullyQualifiedName(),
+            "id,fullyQualifiedName,reviewers",
+            Include.ALL);
+    TaskRepository taskRepository = (TaskRepository) Entity.getEntityRepository(Entity.TASK);
+    taskRepository.updateApprovalTaskAssignees(
+        page.getFullyQualifiedName(),
+        new ArrayList<>(page.getReviewers()),
+        page.getUpdatedBy());
   }
 
   @Override
@@ -838,25 +830,14 @@ public class KnowledgePageRepository extends EntityRepository<Page> {
   }
 
   private void closeApprovalTask(Page entity, String comment) {
-    MessageParser.EntityLink about =
-        new MessageParser.EntityLink(KNOWLEDGE_PAGE_ENTITY, entity.getFullyQualifiedName());
-    FeedRepository feedRepository = Entity.getFeedRepository();
-
-    // Skip closing tasks if updatedBy is null (e.g., during tests)
     if (entity.getUpdatedBy() == null) {
       LOG.debug(
           "Skipping task closure for page {} - updatedBy is null", entity.getFullyQualifiedName());
       return;
     }
-
-    // Close User Tasks
-    try {
-      Thread taskThread = feedRepository.getTask(about, TaskType.RequestApproval, TaskStatus.Open);
-      feedRepository.closeTask(
-          taskThread, entity.getUpdatedBy(), new CloseTask().withComment(comment));
-    } catch (EntityNotFoundException ex) {
-      LOG.info("No approval task found for page {}", entity.getFullyQualifiedName());
-    }
+    TaskRepository taskRepository = (TaskRepository) Entity.getEntityRepository(Entity.TASK);
+    taskRepository.closeApprovalTaskForEntity(
+        entity.getFullyQualifiedName(), entity.getUpdatedBy(), comment);
   }
 
   public static void checkUpdatedByReviewer(Page page, String updatedBy) {


### PR DESCRIPTION
Fixes #31687

Migrate `updateTaskWithNewReviewers()` and `closeApprovalTask()` from the legacy FeedRepository path to the Task entity API. Also add `updateReviewers()` override to detect reviewer changes and reassign approval tasks.



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR migrates KnowledgePage approval-task closure and reviewer reassignment from the legacy feed-thread repository to TaskRepository.
- Adds reviewer-change handling that updates approval-task assignees.
- Closes approval tasks through the Task entity API using the page FQN.
- Removes legacy feed patching, closure, and WebSocket-notification code.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge based on the currently established behavior.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KnowledgePageRepository.java | Migrates approval-task reassignment and closure to TaskRepository; no new eligible follow-up finding was established. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[KnowledgePage update] --> B{Change type}
  B -->|Reviewers changed| C[Update reviewer relationships]
  C --> D[TaskRepository updates approval assignees]
  B -->|Approved, rejected, or draft| E[TaskRepository finds open Approval task by page FQN]
  E --> F[Close approval task]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: migrate KnowledgePage approval task..."](https://github.com/open-metadata/openmetadata/commit/87b3556b7bc58f47c6d7e61916f08cbf60c04353) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56495191)</sub>

**Context used:**

- Knowledge Base — [Metadata platform service](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/metadata-platform-service.md)
- Knowledge Base — [Metadata entity lifecycle](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/metadata-entity-lifecycle.md)

<!-- /greptile_comment -->