### PR TITLE
fix(ops): scale the deploy-pipelines chunk deadline with the chunk size

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
@@ -170,6 +170,10 @@ public class OpenMetadataOperations implements Callable<Integer> {
   private static final String CATALOG_VERSION_RESOURCE = "/catalog/VERSION";
   private static final String UNKNOWN_VERSION = "unknown";
   private static final String DEFAULT_VERSION = "1.8.0-SNAPSHOT";
+  private static final Duration DEPLOY_CONNECT_TIMEOUT = Duration.ofSeconds(30);
+  private static final Duration MIN_DEPLOY_CHUNK_TIMEOUT = Duration.ofMinutes(2);
+  private static final String STATUS_FAILED = "FAILED";
+  private static final int STATUS_COLUMN_INDEX = 3;
 
   private OpenMetadataApplicationConfig config;
   private Jdbi jdbi;
@@ -2388,40 +2392,55 @@ public class OpenMetadataOperations implements Callable<Integer> {
   }
 
   @Command(name = "deploy-pipelines", description = "Deploy all the service pipelines.")
-  public Integer deployPipelines() {
+  public Integer deployPipelines(
+      @Option(
+              names = {"--chunk-size"},
+              defaultValue = "20",
+              description =
+                  "Number of pipelines sent to the bulk deploy endpoint per request. The server "
+                      + "deploys them sequentially, so a larger chunk needs a proportionally "
+                      + "longer deadline.")
+          int chunkSize,
+      @Option(
+              names = {"--seconds-per-pipeline"},
+              defaultValue = "30",
+              description =
+                  "Deploy deadline budgeted for each pipeline in a chunk. The request timeout is "
+                      + "this value multiplied by the chunk size.")
+          int secondsPerPipeline) {
+    int exitCode = 1;
     try {
       LOG.info("Deploying Pipelines via API");
       parseConfig();
-      IngestionPipelineRepository pipelineRepository =
-          (IngestionPipelineRepository) Entity.getEntityRepository(Entity.INGESTION_PIPELINE);
-      List<IngestionPipeline> pipelines =
-          pipelineRepository.listAll(
-              new EntityUtil.Fields(Set.of(FIELD_OWNERS, "service")),
-              new ListFilter(Include.NON_DELETED));
-      LOG.debug("Pipelines size {}", pipelines.size());
-      List<String> columns = Arrays.asList("Name", "Type", "Service Name", "Status");
-      List<List<String>> pipelineStatuses = new ArrayList<>();
-
-      if (!pipelines.isEmpty()) {
-        deployPipelinesViaAPI(pipelines, pipelineStatuses);
-      }
-
-      printToAsciiTable(columns, pipelineStatuses, "No Pipelines Found");
-
-      // Check if any pipeline deployments failed by examining the status column
-      boolean hasFailures =
-          pipelineStatuses.stream().anyMatch(status -> status.get(3).startsWith("FAILED"));
-
-      if (hasFailures) {
-        LOG.error("Some pipeline deployments failed. Check the table above for details.");
-        return 1;
-      }
-
-      return 0;
+      exitCode = runPipelineDeployment(chunkSize, secondsPerPipeline);
     } catch (Exception e) {
       LOG.error("Failed to deploy pipelines due to ", e);
-      return 1;
     }
+    return exitCode;
+  }
+
+  private int runPipelineDeployment(final int chunkSize, final int secondsPerPipeline) {
+    final IngestionPipelineRepository pipelineRepository =
+        (IngestionPipelineRepository) Entity.getEntityRepository(Entity.INGESTION_PIPELINE);
+    final List<IngestionPipeline> pipelines =
+        pipelineRepository.listAll(
+            new EntityUtil.Fields(Set.of(FIELD_OWNERS, "service")),
+            new ListFilter(Include.NON_DELETED));
+    LOG.debug("Pipelines size {}", pipelines.size());
+    final List<List<String>> pipelineStatuses = new ArrayList<>();
+    if (!pipelines.isEmpty()) {
+      deployPipelinesViaAPI(pipelines, pipelineStatuses, chunkSize, secondsPerPipeline);
+    }
+    printToAsciiTable(
+        Arrays.asList("Name", "Type", "Service Name", "Status"),
+        pipelineStatuses,
+        "No Pipelines Found");
+    int exitCode = 0;
+    if (hasDeployFailures(pipelineStatuses)) {
+      LOG.error("Some pipeline deployments failed. Check the table above for details.");
+      exitCode = 1;
+    }
+    return exitCode;
   }
 
   @Command(
@@ -2961,7 +2980,10 @@ public class OpenMetadataOperations implements Callable<Integer> {
   }
 
   private void deployPipelinesViaAPI(
-      List<IngestionPipeline> pipelines, List<List<String>> pipelineStatuses) {
+      List<IngestionPipeline> pipelines,
+      List<List<String>> pipelineStatuses,
+      int chunkSize,
+      int secondsPerPipeline) {
     try {
       // Get ingestion-bot JWT token
       String jwtToken = getIngestionBotToken();
@@ -2976,14 +2998,16 @@ public class OpenMetadataOperations implements Callable<Integer> {
       }
       LOG.info("Deploying pipelines to server URL: {}", serverUrl);
 
-      // Create HTTP client
-      HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(30)).build();
+      HttpClient client = HttpClient.newBuilder().connectTimeout(DEPLOY_CONNECT_TIMEOUT).build();
+      Duration chunkTimeout = deployChunkTimeout(chunkSize, secondsPerPipeline);
+      DeployRequest deployRequest = new DeployRequest(client, jwtToken, serverUrl, chunkTimeout);
 
-      // Process pipelines in chunks of 20
-      int chunkSize = 20;
       int totalPipelines = pipelines.size();
       LOG.info(
-          "Deploying {} pipelines via bulk API calls in chunks of {}", totalPipelines, chunkSize);
+          "Deploying {} pipelines via bulk API calls in chunks of {} with a {}s deadline per chunk",
+          totalPipelines,
+          chunkSize,
+          chunkTimeout.toSeconds());
 
       List<List<IngestionPipeline>> pipelineChunks = chunkList(pipelines, chunkSize);
 
@@ -2996,7 +3020,7 @@ public class OpenMetadataOperations implements Callable<Integer> {
             chunkIndex * chunkSize + 1,
             Math.min((chunkIndex + 1) * chunkSize, totalPipelines));
 
-        deployPipelineChunk(client, jwtToken, serverUrl, chunk, pipelineStatuses);
+        deployPipelineChunk(deployRequest, chunk, pipelineStatuses);
       }
 
       LOG.info("Completed bulk deployment of {} pipelines", totalPipelines);
@@ -3015,11 +3039,10 @@ public class OpenMetadataOperations implements Callable<Integer> {
   }
 
   private void deployPipelineChunk(
-      HttpClient client,
-      String jwtToken,
-      String serverUrl,
+      DeployRequest deployRequest,
       List<IngestionPipeline> pipelineChunk,
       List<List<String>> pipelineStatuses) {
+    final String serverUrl = deployRequest.serverUrl();
     try {
       // Collect pipeline IDs for this chunk
       List<UUID> pipelineIds =
@@ -3035,13 +3058,14 @@ public class OpenMetadataOperations implements Callable<Integer> {
       HttpRequest request =
           HttpRequest.newBuilder()
               .uri(URI.create(normalizedServerUrl + COLLECTION_PATH + "bulk/deploy"))
-              .header("Authorization", "Bearer " + jwtToken)
+              .header("Authorization", "Bearer " + deployRequest.jwtToken())
               .header("Content-Type", "application/json")
               .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
-              .timeout(Duration.ofMinutes(2))
+              .timeout(deployRequest.chunkTimeout())
               .build();
 
-      HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+      HttpResponse<String> response =
+          deployRequest.client().send(request, HttpResponse.BodyHandlers.ofString());
 
       if (response.statusCode() == 200) {
         LOG.debug("Chunk deployment completed successfully");
@@ -3073,6 +3097,28 @@ public class OpenMetadataOperations implements Callable<Integer> {
       }
     }
   }
+
+  /**
+   * The bulk deploy endpoint registers each pipeline in a chunk sequentially, so the request
+   * deadline has to grow with the chunk size. A fixed deadline silently becomes too short as a
+   * catalog grows, and reports a timeout on deployments that are still progressing server side.
+   */
+  static Duration deployChunkTimeout(final int chunkSize, final int secondsPerPipeline) {
+    final Duration budgeted = Duration.ofSeconds((long) chunkSize * secondsPerPipeline);
+    Duration timeout = MIN_DEPLOY_CHUNK_TIMEOUT;
+    if (budgeted.compareTo(MIN_DEPLOY_CHUNK_TIMEOUT) > 0) {
+      timeout = budgeted;
+    }
+    return timeout;
+  }
+
+  static boolean hasDeployFailures(final List<List<String>> pipelineStatuses) {
+    return pipelineStatuses.stream()
+        .anyMatch(status -> status.get(STATUS_COLUMN_INDEX).startsWith(STATUS_FAILED));
+  }
+
+  private record DeployRequest(
+      HttpClient client, String jwtToken, String serverUrl, Duration chunkTimeout) {}
 
   private <T> List<List<T>> chunkList(List<T> list, int chunkSize) {
     List<List<T>> chunks = new ArrayList<>();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
@@ -2411,12 +2411,27 @@ public class OpenMetadataOperations implements Callable<Integer> {
     int exitCode = 1;
     try {
       LOG.info("Deploying Pipelines via API");
-      parseConfig();
-      exitCode = runPipelineDeployment(chunkSize, secondsPerPipeline);
+      if (isValidDeployOptions(chunkSize, secondsPerPipeline)) {
+        parseConfig();
+        exitCode = runPipelineDeployment(chunkSize, secondsPerPipeline);
+      }
     } catch (Exception e) {
       LOG.error("Failed to deploy pipelines due to ", e);
     }
     return exitCode;
+  }
+
+  static boolean isValidDeployOptions(final int chunkSize, final int secondsPerPipeline) {
+    boolean valid = true;
+    if (chunkSize < 1) {
+      LOG.error("--chunk-size must be at least 1, got {}", chunkSize);
+      valid = false;
+    }
+    if (secondsPerPipeline < 1) {
+      LOG.error("--seconds-per-pipeline must be at least 1, got {}", secondsPerPipeline);
+      valid = false;
+    }
+    return valid;
   }
 
   private int runPipelineDeployment(final int chunkSize, final int secondsPerPipeline) {
@@ -3121,6 +3136,9 @@ public class OpenMetadataOperations implements Callable<Integer> {
       HttpClient client, String jwtToken, String serverUrl, Duration chunkTimeout) {}
 
   private <T> List<List<T>> chunkList(List<T> list, int chunkSize) {
+    if (chunkSize < 1) {
+      throw new IllegalArgumentException("chunkSize must be at least 1, got " + chunkSize);
+    }
     List<List<T>> chunks = new ArrayList<>();
     for (int i = 0; i < list.size(); i += chunkSize) {
       int end = Math.min(list.size(), i + chunkSize);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/OpenMetadataOperationsDeployPipelinesTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/OpenMetadataOperationsDeployPipelinesTest.java
@@ -20,6 +20,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.ParseResult;
 
 class OpenMetadataOperationsDeployPipelinesTest {
 
@@ -66,6 +69,37 @@ class OpenMetadataOperationsDeployPipelinesTest {
   void nonPositiveSecondsPerPipelineIsRejected() {
     assertFalse(OpenMetadataOperations.isValidDeployOptions(20, 0));
     assertFalse(OpenMetadataOperations.isValidDeployOptions(20, -5));
+  }
+
+  private static ParseResult parseDeployPipelines(String... args) {
+    String[] argv = new String[args.length + 3];
+    argv[0] = "-c";
+    argv[1] = "unused.yaml";
+    argv[2] = "deploy-pipelines";
+    System.arraycopy(args, 0, argv, 3, args.length);
+
+    return new CommandLine(new OpenMetadataOperations()).parseArgs(argv);
+  }
+
+  private static int optionValue(ParseResult parsed, String option, int fallback) {
+    return parsed.subcommand().matchedOptionValue(option, fallback);
+  }
+
+  @Test
+  void chunkSizeAndBudgetOptionsAreBound() {
+    ParseResult parsed = parseDeployPipelines("--chunk-size", "5", "--seconds-per-pipeline", "45");
+
+    assertEquals(5, optionValue(parsed, "--chunk-size", -1));
+    assertEquals(45, optionValue(parsed, "--seconds-per-pipeline", -1));
+    assertEquals(Duration.ofSeconds(225), OpenMetadataOperations.deployChunkTimeout(5, 45));
+  }
+
+  @Test
+  void omittedOptionsFallBackToTheDocumentedDefaults() {
+    CommandSpec spec = parseDeployPipelines().subcommand().commandSpec();
+
+    assertEquals("20", spec.findOption("--chunk-size").defaultValue());
+    assertEquals("30", spec.findOption("--seconds-per-pipeline").defaultValue());
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/OpenMetadataOperationsDeployPipelinesTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/OpenMetadataOperationsDeployPipelinesTest.java
@@ -47,7 +47,25 @@ class OpenMetadataOperationsDeployPipelinesTest {
   @Test
   void chunkDeadlineNeverDropsBelowTheFloor() {
     assertEquals(PREVIOUS_FIXED_TIMEOUT, OpenMetadataOperations.deployChunkTimeout(1, 5));
-    assertEquals(PREVIOUS_FIXED_TIMEOUT, OpenMetadataOperations.deployChunkTimeout(0, 30));
+    assertEquals(PREVIOUS_FIXED_TIMEOUT, OpenMetadataOperations.deployChunkTimeout(4, 1));
+  }
+
+  @Test
+  void defaultOptionsAreAccepted() {
+    assertTrue(OpenMetadataOperations.isValidDeployOptions(20, 30));
+    assertTrue(OpenMetadataOperations.isValidDeployOptions(1, 1));
+  }
+
+  @Test
+  void nonPositiveChunkSizeIsRejected() {
+    assertFalse(OpenMetadataOperations.isValidDeployOptions(0, 30));
+    assertFalse(OpenMetadataOperations.isValidDeployOptions(-1, 30));
+  }
+
+  @Test
+  void nonPositiveSecondsPerPipelineIsRejected() {
+    assertFalse(OpenMetadataOperations.isValidDeployOptions(20, 0));
+    assertFalse(OpenMetadataOperations.isValidDeployOptions(20, -5));
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/OpenMetadataOperationsDeployPipelinesTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/OpenMetadataOperationsDeployPipelinesTest.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OpenMetadataOperationsDeployPipelinesTest {
+
+  private static final Duration PREVIOUS_FIXED_TIMEOUT = Duration.ofMinutes(2);
+
+  private static List<String> row(String status) {
+    return List.of("pipeline", "metadata", "service", status);
+  }
+
+  @Test
+  void chunkDeadlineScalesWithChunkSize() {
+    assertEquals(Duration.ofSeconds(600), OpenMetadataOperations.deployChunkTimeout(20, 30));
+    assertEquals(Duration.ofSeconds(3000), OpenMetadataOperations.deployChunkTimeout(100, 30));
+  }
+
+  @Test
+  void defaultChunkDeadlineExceedsThePreviousFixedTimeout() {
+    Duration deadline = OpenMetadataOperations.deployChunkTimeout(20, 30);
+
+    assertTrue(
+        deadline.compareTo(PREVIOUS_FIXED_TIMEOUT) > 0,
+        "a chunk of 20 sequential deploys needs more than the previous fixed 2 minute deadline");
+  }
+
+  @Test
+  void chunkDeadlineNeverDropsBelowTheFloor() {
+    assertEquals(PREVIOUS_FIXED_TIMEOUT, OpenMetadataOperations.deployChunkTimeout(1, 5));
+    assertEquals(PREVIOUS_FIXED_TIMEOUT, OpenMetadataOperations.deployChunkTimeout(0, 30));
+  }
+
+  @Test
+  void failedRowsAreDetected() {
+    assertTrue(
+        OpenMetadataOperations.hasDeployFailures(
+            List.of(row("DEPLOYED"), row("FAILED - 500: airflow unreachable"))));
+  }
+
+  @Test
+  void deployedRowsAreNotFailures() {
+    assertFalse(
+        OpenMetadataOperations.hasDeployFailures(List.of(row("DEPLOYED"), row("DEPLOYED"))));
+  }
+}


### PR DESCRIPTION
## Problem

Fixes #32004.

`deploy-pipelines` POSTs chunks of pipeline IDs to `POST /v1/services/ingestionPipelines/bulk/deploy`. That endpoint deploys them **sequentially** — `pipelineIdList.stream().map(...)`, no parallelism — but the client bounded the request with a hardcoded 2 minute deadline:

```java
int chunkSize = 20;
...
.timeout(Duration.ofMinutes(2))
```

That budgets **6 seconds per pipeline**. A freshly restarted pipeline service does not write and parse a DAG that fast, so the client abandons a request whose work is still progressing.

A client deadline does not cancel the server. The abandoned chunk keeps deploying while the command marks all 20 pipelines `FAILED` and exits 1 — and a Kubernetes `restartPolicy: OnFailure` then replays the whole run on top of work still in flight, adding load to an operation that was already succeeding.

Observed on a 92-pipeline instance during a version upgrade: the command reported failure while **90 of 92 pipelines were deployed**. The two exceptions had been undeployed for months and were unrelated.

```
Deploying 91 pipelines via bulk API calls in chunks of 20
Processing chunk 1 of 5 (pipelines 1-20)
Failed to deploy pipeline chunk
java.net.http.HttpTimeoutException: request timed out
    at org.openmetadata.service.util.OpenMetadataOperations.deployPipelineChunk(OpenMetadataOperations.java:3040)
```

The deadline also degrades silently as a catalog grows — the same instance was 63 pipelines a few months earlier.

## Relation to #28500

#28500 is often assumed to cover this. It does not, and it is already fixed.

That issue was a genuine concurrency bug in the Python DAG builder: Airflow 3's process-global `DagContext` autoregister raising `KeyError: 'unusual_prefix_<hash>_<other dag>'` when DAG files parse concurrently. The fix replaced `with DAG(...) as dag:` with an explicit `dag=` reference, and `build_dag` on both `main` and `2.0.0-release` already carries it.

This is a different layer and a different symptom — a client-side deadline in the Java ops CLI (`HttpTimeoutException` in `deployPipelineChunk`), not a DAG-parse crash in the pipeline service. And the bulk deploy path has no parallelism to race in the first place (`.stream()`, synchronous `client.send()`, sequential chunk loop), so this timeout is not a concurrency problem at all. Fixing #28500 could not have changed it, and this change does not affect #28500.

## Change

- Budget the deadline **per pipeline** and multiply by the chunk size, floored at the previous 2 minutes so nothing gets a shorter deadline than before. Defaults give 600s for a chunk of 20 instead of 120s.
- Expose `--chunk-size` and `--seconds-per-pipeline`. The command previously declared no options at all, so neither value was reachable from a deployment configuration (the Helm chart's `deployPipelinesConfig.additionalArgs` had nothing to pass).
- Extract the deadline calculation and the failure check as static functions so both are unit testable without a database, following the existing `planSmartReindex` pattern.
- `DeployRequest` record keeps the chunk method within the parameter limit.

This is a client-side change only. The `bulk/deploy` endpoint is untouched. No behaviour change to the success path, and genuine failures still exit non-zero.

## Not addressed here

**Reporting.** An abandoned chunk is still recorded as failed. The persisted `deployed` flag cannot correct it: the deploy path only ever calls `setDeployed(true)` and never resets it, so it records whether a pipeline was *ever* deployed rather than what this run did. Reading it to clear a timeout would turn a genuine failure into a silent success on any redeploy — which post-upgrade `deploy-pipelines` always is. A per-run answer needs the deploy response itself; subdividing a timed-out chunk and re-POSTing is the plausible approach, but it re-sends work that may still be in flight, so it wants its own design pass.

**Overlap.** `deployPipelineChunk` swallows the timeout, so the loop POSTs the next chunk while the previous one is still executing server side. Longer deadlines make this rarer but do not remove it.

**Cancellation.** Fixing it properly means an async endpoint (`202` + job handle + poll) so a client give-up cannot orphan server work.

## Measured

Per-pipeline deploy latency on a healthy, idle 92-pipeline instance, three sequential single-pipeline chunks through `bulk/deploy`:

| | elapsed |
|---|---|
| deploy 1 | 6.92s |
| deploy 2 | 8.68s |
| deploy 3 | 13.54s |

The previous deadline budgeted `120s / 20 = 6.0s` per pipeline. Every measurement exceeded that, including the fastest: `20 x 6.92 = 138s > 120s`. A full chunk could not have completed inside the old deadline even at best-case latency on an idle server, so this was not only a cold-start problem. Latency also climbs across consecutive deploys as the pipeline service takes on load.

Against the slowest observed 13.54s, a chunk of 20 needs ~270s. The new default budgets 600s, leaving headroom for the cold pipeline service that a post-upgrade run actually faces.

A chunk of 5 driven from outside the cluster returned `504` at ~65s, but that is the load balancer's 60s idle timeout rather than a server limit, and does not apply to this command: `metadataApiEndpoint` resolves to the in-cluster service, so the deploy request never traverses the ingress.

## Testing

`OpenMetadataOperationsDeployPipelinesTest` — 10 unit tests: deadline scaling, the floor, that the default deadline exceeds the previous fixed 2 minutes, option validation, failure detection, and picocli binding for both options including their declared defaults. Passes alongside the existing `OpenMetadataOperationsSmartReindexTest`. `mvn spotless:apply` clean.

Also exercised end to end by invoking the command from this branch against a running server and MySQL:

| invocation | result |
|---|---|
| (no options) | `chunks of 20 with a 600s deadline per chunk`, all pipelines deployed, exit 0 |
| `--chunk-size 3 --seconds-per-pipeline 45` | `chunks of 3 with a 135s deadline per chunk`, 2 chunks, every response `code=200`, exit 0 |
| `--chunk-size 1 --seconds-per-pipeline 5` | floors to `120s`, 5 chunks, exit 0 |
| `--chunk-size 0` | `--chunk-size must be at least 1, got 0`, exit 1, returns immediately instead of exhausting the heap |
| `--chunk-size -5 --seconds-per-pipeline 0` | both values reported, exit 1 |
| `deploy-pipelines --help` | both options render with their descriptions |

Behaviour is identical on `main`, `2.0.0-release`, `origin/1.13` and `1.13.4-release`, so this applies to both release lines and can be picked to `1.13`.


