### PR TITLE
ci(playwright): don't fail merge-group runs when baseline push is ruleset-blocked

### DIFF
--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -670,8 +670,27 @@ jobs:
               -m "chore(playwright): auto-refresh timing baseline from run ${RUN_ID} [skip ci]" \
               -m "$(cat "$RUNNER_TEMP/baseline-refresh-summary.md")" \
               -m "Source: ${RUN_URL}"
-            if git push origin HEAD:main; then
+            push_rc=0
+            push_output=$(git push origin HEAD:main 2>&1) || push_rc=$?
+            echo "$push_output"
+            if [[ "$push_rc" -eq 0 ]]; then
               echo "Baseline refreshed on main (attempt $attempt)."
+              exit 0
+            fi
+            # A ruleset/branch-protection rejection (GH013: "changes must be
+            # made through the merge queue") is a CONFIGURATION gap, not a
+            # pipeline failure: the token identity is not on main's bypass
+            # list yet. Failing the job here turns every full-mode
+            # merge_group run red and ejects innocent PRs (runs 32750389130,
+            # 32750390655) — the exact failure mode this pipeline exists to
+            # prevent. Surface loudly, skip gracefully.
+            if grep -qE "GH013|rule violations|protected branch" <<< "$push_output"; then
+              echo "::warning::Baseline refresh skipped: push to main rejected by repository ruleset (GH013). Grant the workflow token (RELEASE_BOT_TOKEN or Actions) bypass on main's ruleset to enable auto-refresh."
+              {
+                echo "## ⚠️ Timing-baseline auto-refresh blocked by ruleset"
+                echo
+                echo "The direct push to \`main\` was rejected (GH013). The refresh is skipped — downstream planning keeps using the current baseline. Grant the workflow token bypass on the main ruleset to enable it."
+              } >> "$GITHUB_STEP_SUMMARY"
               exit 0
             fi
             echo "Push rejected (main moved during refresh); retrying." >&2


### PR DESCRIPTION
## Why — urgent follow-up to #31907

The direct-commit baseline refresh from #31907 is being **rejected by main's repository ruleset** (`GH013: Changes must be made through the merge queue`) — the workflow token has no bypass grant yet. The job treated the rejection as "main moved, retry", failed after 3 attempts, and **turned the first two post-merge full-mode merge_group runs red** ([32750389130](https://github.com/open-metadata/OpenMetadata/actions/runs/32750389130), [32750390655](https://github.com/open-metadata/OpenMetadata/actions/runs/32750390655)) with all tests green — the exact failure mode this pipeline work exists to prevent.

## Fix

Detect ruleset/branch-protection rejections (`GH013` / "rule violations" / "protected branch") in the push output and degrade to:
- a `::warning` annotation naming the missing bypass grant,
- a job-summary note,
- graceful `exit 0` — downstream planning keeps using the current baseline.

Genuine push races (main moved mid-refresh) keep the retry loop and still hard-fail after 3 attempts.

## To actually enable auto-refresh (maintainer action)

Grant bypass on the `main` ruleset ("Changes must be made through the merge queue" / "through a pull request" rules) to the identity the job pushes with — `RELEASE_BOT_TOKEN` if configured, else the GitHub Actions app. Until then the refresh job logs a warning and skips; nothing goes red.

## Tests
- YAML validated; all 124 CI-script tests pass (no script changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents timing-baseline refresh failures from blocking otherwise successful merge-group runs when direct pushes to `main` are rejected by repository rules.

- Captures the push exit status and combined output.
- Converts recognized ruleset or branch-protection rejections into a warning and job-summary notice.
- Preserves retries and eventual failure for ordinary push races.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because recognized repository-policy rejections are surfaced without failing merge-group runs, while other push failures still retry and eventually fail.

The changed workflow preserves successful pushes and race retries, and only converts the explicitly intended repository-ruleset rejection path into a warning-backed graceful skip.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/playwright-postgresql-e2e.yml | Adds targeted nonfatal handling for ruleset-blocked baseline pushes while retaining retries for other push failures. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Refresh and commit timing baseline] --> B[Push to main]
  B -->|Success| C[Baseline refreshed]
  B -->|Ruleset or branch protection rejection| D[Emit warning and summary]
  D --> E[Exit successfully with existing baseline]
  B -->|Other push failure| F{Attempts remaining?}
  F -->|Yes| A
  F -->|No| G[Fail refresh job]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci(playwright): don&#39;t fail merge-group r..."](https://github.com/open-metadata/openmetadata/commit/fd20dad135349c3482b2ea95bc5ad5fc2679e2b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56333199)</sub>

<!-- /greptile_comment -->