### PR TITLE
fix(ingestion): cap sqlalchemy-vertica below the 1.0 rewrite

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -76,6 +76,9 @@ VERSIONS = {
     "pyathena": "pyathena~=3.25.0",
     "s3fs": "s3fs~=2026.3",
     "sqlalchemy-bigquery": "sqlalchemy-bigquery>=1.15.0",
+    # <1.0: 1.0.0 is a SQLAlchemy-2.0 rewrite (first release since 0.0.5 in 2020) that drops
+    # get_all_table_comments and retypes the dialect methods vertica/metadata.py patches onto it
+    "sqlalchemy-vertica": "sqlalchemy-vertica[vertica-python]>=0.0.5,<1.0",
     "presidio-analyzer": "presidio-analyzer==2.2.358",
     "asammdf": "asammdf>=8.2,<8.8",  # 8.8+ requires chardet>=7, conflicting with the chardet==4.0.0 profiler pin
     "kafka-connect": "kafka-connect-py==0.10.11",
@@ -427,7 +430,7 @@ plugins: Dict[str, Set[str]] = {  # noqa: UP006
     "tableau": {VERSIONS["tableau"], VERSIONS["validators"], VERSIONS["packaging"]},
     "teradata": {VERSIONS["teradata"]},
     "trino": {VERSIONS["trino"], DATA_DIFF["trino"]},
-    "vertica": {"sqlalchemy-vertica[vertica-python]>=0.0.5", DATA_DIFF["vertica"]},
+    "vertica": {VERSIONS["sqlalchemy-vertica"], DATA_DIFF["vertica"]},
     # SDK Data Quality: Required for DataFrame validation (DataFrameValidator)
     # Install with: pip install 'openmetadata-ingestion[pandas]'
     "pandas": {VERSIONS["pandas"], VERSIONS["numpy"]},


### PR DESCRIPTION
## Describe your changes

`sqlalchemy-vertica` published **1.0.1 on 2026-08-24 at 16:03 UTC** — its first release since 0.0.5 in **January 2020**. `ingestion/setup.py` pulled it unpinned via `>=0.0.5`, so CI adopted it silently mid-day and `python / Unit Tests & Static Checks` started failing on **every branch, main included**:

```
ingestion/src/metadata/ingestion/source/database/vertica/metadata.py:254:38 - error: Cannot assign to attribute "get_view_definition" for class "type[VerticaDialect]"
ingestion/src/metadata/ingestion/source/database/vertica/metadata.py:256:36 - error: Cannot assign to attribute "get_table_comment"   for class "type[VerticaDialect]"
```

The break is visible as a clean before/after on one unchanged branch: the 14:23 UTC run resolved 0.0.5 and was green on these lines; the 16:39 UTC run resolved 1.0.1 and was not. No source file changed in between.

**Why it breaks.** 1.0.x is a SQLAlchemy-2.0 rewrite. `sqlalchemy_vertica.base` still exports `VerticaDialect` and `ischema_names`, but the dialect methods are now properly typed, so the monkey-patches at the bottom of `vertica/metadata.py` conflict with the declared signatures. Only 2 of the 5 patches error because `get_all_table_comments` no longer exists upstream at all — assigning a brand-new attribute is unconstrained.

**This is not a hijack.** 0.0.5 and 1.0.1 share the same author (`Luis Villamarin <luis@lv10.me>`) and repo (`github.com/lv10/sqlalchemy-vertica`). It's a legitimate maintainer resuming a dormant project — but adopting a full dialect rewrite should be a deliberate, tested port, not a silent float in CI.

This PR caps at `<1.0` and routes the constraint through the `VERSIONS` dict so it lives alongside the other pins, matching the existing convention (`asammdf`, `tableau`, `snowflake` all carry the same kind of inline justification).

**Follow-up, not in scope here:** port the Vertica connector to the 1.0 dialect and lift the cap. That needs the `get_all_table_comments` removal handled and exercising against a real Vertica instance.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) document.
- [x] My PR title is `fix(ingestion): cap sqlalchemy-vertica below the 1.0 rewrite`
- [x] I have commented on my code, particularly in hard-to-understand areas.

## Manual testing

Constraint resolution verified directly:

```
spec: <1.0,>=0.0.5 | extras: {'vertica-python'}
  0.0.5: ALLOWED
  1.0.0: blocked
  1.0.1: blocked
```

`ruff format --check` and `ruff check` both pass on `setup.py`. The real proof is CI on this PR: static-checks should go green on the two `vertica/metadata.py` lines above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RVJBreyj2UzageZpSyV13

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents the Vertica ingestion extra from resolving the incompatible `sqlalchemy-vertica` 1.0 rewrite.

- Adds a shared `sqlalchemy-vertica[vertica-python]>=0.0.5,<1.0` constraint to `VERSIONS`.
- Updates the Vertica plugin definition to consume the centralized constraint.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the new constraint preserves the previously supported Vertica dialect while excluding the incompatible rewrite.

The Vertica extra continues to install the same dependency and extra through a valid bounded requirement, with no accepted correctness, security, or packaging failures.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/setup.py | Centralizes and caps the Vertica dialect dependency below 1.0 without introducing an actionable packaging or runtime issue. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ingestion): cap sqlalchemy-vertica b..."](https://github.com/open-metadata/openmetadata/commit/1f39c30ec49f2f7f3dd04c7c8c4c822519de295f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56347968)</sub>

<!-- /greptile_comment -->