### PR TITLE
fix(playwright): park the pointer before Escape in ports fullscreen test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/InputOutputPorts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/InputOutputPorts.spec.ts
@@ -1530,6 +1530,16 @@ test.describe('Input Output Ports', () => {
         const lineageView = page.getByTestId('ports-lineage-view');
         await expect(lineageView).toHaveCSS('position', 'fixed');
 
+        // The click leaves the pointer hovering the button, whose react-aria
+        // Tooltip opens after a hover delay. An OPEN tooltip installs a
+        // capture-phase document keydown listener that stopPropagation()s
+        // Escape to dismiss itself (layered dismiss — correct UX), so the
+        // fullscreen Escape handler never fires. Whether the delay has
+        // elapsed by the time Escape is pressed depends on CI load — this
+        // was a ~50% merge-queue killer on 2026-08-24. Park the pointer
+        // away from the trigger so Escape always reaches the app.
+        await page.mouse.move(0, 0);
+
         await page.keyboard.press('Escape');
         await expect(lineageView).toHaveCSS('position', 'relative');
       });


### PR DESCRIPTION
## Why — today's #1 merge-queue killer

`InputOutputPorts.spec.ts:1504` ("Exit fullscreen with Escape key") failed in **every classified merge-queue ejection today** (12+ runs, ~50–60% run-failure rate from late morning) with both attempts failing identically: `expected position "relative", received "fixed"` — the Escape never exited fullscreen.

## Root cause — a latent tooltip race, not a code regression

Bisection: the test passed first-attempt (7–9 s) in every full run through Aug 22; no commit in today's onset window touches this page's code path (the two suspects — the a11y sweep #30989 and PageLayout #31709 — were checked file-by-file and are innocuous here). What changed is **timing under Monday's queue load**:

1. The test clicks `toggle-fullscreen-btn` and Playwright leaves the pointer hovering it.
2. The button is wrapped in a react-aria `Tooltip`, which opens after a hover delay.
3. An **open** tooltip installs a **capture-phase document keydown listener** that `stopPropagation()`s Escape to dismiss itself (`@react-aria/tooltip` `useTooltipTrigger` — layered dismiss, correct product UX).
4. So: Escape pressed **before** the delay elapses → reaches the app's fullscreen handler → pass. Escape pressed **after** (slow CI) → swallowed by the tooltip → fail. Retries hit the same timing under the same load → both attempts fail identically.

Product behavior is correct (first Escape closes the topmost layer); the test was pressing Escape while parked on the tooltip trigger.

## Fix

`await page.mouse.move(0, 0)` after the fullscreen assertion, before pressing Escape — the tooltip never opens (or closes), so Escape deterministically reaches the app handler regardless of CI load. Comment in the test documents the capture-phase swallow for the next person.

Verification: mechanism confirmed directly in `@react-aria/tooltip/dist/useTooltipTrigger.mjs` (capture-phase `document.addEventListener('keydown', …, true)` + `e.stopPropagation()` on Escape while open) and matches all observed evidence (trace shows click → assert → Escape with DOM still in fullscreen classes; failures correlate with load, not commits). Not executed locally — the available local backend is SSO-configured and can't run the auth setup; the merge-queue run on this PR is the real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stabilizes the ports fullscreen Playwright test by moving the pointer away from the tooltip trigger before sending Escape.
- Prevents the fullscreen button tooltip from intercepting the Escape key.
- Documents the timing-dependent tooltip interaction that caused merge-queue failures.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the narrowly scoped test change addressing the documented tooltip race.

The pointer is moved away from the fullscreen tooltip trigger before Escape, matching an existing repository technique for dismissing tooltips without altering product behavior.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/InputOutputPorts.spec.ts | Parks the pointer before the Escape action to remove a timing-dependent tooltip interaction; no actionable issues found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(playwright): park the pointer before..."](https://github.com/open-metadata/openmetadata/commit/d6e299bf8a63078ea6556c9f125d39bde30186b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56353116)</sub>

<!-- /greptile_comment -->