### PR TITLE
Fixes 6093: Preserve masked secrets during configuration updates

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DriveServiceResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DriveServiceResourceIT.java
@@ -24,11 +24,15 @@ import org.openmetadata.schema.security.credentials.GCPValues;
 import org.openmetadata.schema.services.connections.drive.GoogleDriveConnection;
 import org.openmetadata.schema.type.DriveConnection;
 import org.openmetadata.schema.type.EntityHistory;
+import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.models.ListResponse;
+import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.service.secrets.masker.PasswordEntityMasker;
 
 @Execution(ExecutionMode.CONCURRENT)
 public class DriveServiceResourceIT extends BaseServiceIT<DriveService, CreateDriveService> {
+  private static final String DRIVE_SERVICES_ENDPOINT = "/v1/services/driveServices";
 
   {
     supportsListHistoryByTimestamp = true;
@@ -236,6 +240,38 @@ public class DriveServiceResourceIT extends BaseServiceIT<DriveService, CreateDr
     service.setDescription("Updated description");
     DriveService updated = patchEntity(service.getId().toString(), service);
     assertEquals("Updated description", updated.getDescription());
+  }
+
+  @Test
+  void put_driveService_preservesMaskedPrivateKey(TestNamespace ns) {
+    CreateDriveService request = createMinimalRequest(ns);
+    request.setName(ns.prefix("put_preserves_private_key"));
+    DriveService service = createEntity(request);
+    GoogleDriveConnection maskedConnection =
+        JsonUtils.convertValue(service.getConnection().getConfig(), GoogleDriveConnection.class);
+    GCPValues maskedCredentials =
+        JsonUtils.convertValue(maskedConnection.getCredentials().getGcpConfig(), GCPValues.class);
+    assertEquals(PasswordEntityMasker.PASSWORD_MASK, maskedCredentials.getPrivateKey());
+    maskedConnection.setDriveId("updated-drive-id");
+    CreateDriveService update =
+        new CreateDriveService()
+            .withName(service.getName())
+            .withServiceType(DriveServiceType.GoogleDrive)
+            .withConnection(new DriveConnection().withConfig(maskedConnection));
+
+    SdkClients.adminClient()
+        .getHttpClient()
+        .execute(HttpMethod.PUT, DRIVE_SERVICES_ENDPOINT, update, DriveService.class);
+
+    DriveService persisted =
+        SdkClients.ingestionBotClient().driveServices().get(service.getId().toString());
+    GoogleDriveConnection persistedConnection =
+        JsonUtils.convertValue(persisted.getConnection().getConfig(), GoogleDriveConnection.class);
+    GCPValues persistedCredentials =
+        JsonUtils.convertValue(
+            persistedConnection.getCredentials().getGcpConfig(), GCPValues.class);
+    assertEquals("updated-drive-id", persistedConnection.getDriveId());
+    assertEquals("test-private-key", persistedCredentials.getPrivateKey());
   }
 
   @Test

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineResourceIT.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
@@ -67,6 +68,7 @@ import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.models.ListResponse;
 import org.openmetadata.sdk.network.HttpMethod;
 import org.openmetadata.service.resources.services.ingestionpipelines.IngestionPipelineResource;
+import org.openmetadata.service.secrets.masker.PasswordEntityMasker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1316,10 +1318,9 @@ public class IngestionPipelineResourceIT
     assertEquals(
         awsCredentials.getAwsRegion(), actualDbtS3Config.getDbtSecurityConfig().getAwsRegion());
 
-    String maskedSecret = actualDbtS3Config.getDbtSecurityConfig().getAwsSecretAccessKey();
-    assertTrue(
-        maskedSecret == null || maskedSecret.contains("*"),
-        "Secret should be masked for admin user");
+    assertEquals(
+        PasswordEntityMasker.PASSWORD_MASK,
+        actualDbtS3Config.getDbtSecurityConfig().getAwsSecretAccessKey());
 
     IngestionPipeline botPipeline =
         SdkClients.ingestionBotClient().ingestionPipelines().get(pipeline.getId().toString());
@@ -1337,6 +1338,29 @@ public class IngestionPipelineResourceIT
     assertEquals(
         awsCredentials.getAwsSecretAccessKey(),
         botDbtS3Config.getDbtSecurityConfig().getAwsSecretAccessKey());
+
+    actualDbtS3Config.getDbtSecurityConfig().setAwsRegion("us-east-1");
+    actualDbtPipeline.setDbtConfigSource(actualDbtS3Config);
+    SourceConfig maskedSourceConfig = new SourceConfig().withConfig(actualDbtPipeline);
+    ArrayNode patch = JsonUtils.getObjectMapper().createArrayNode();
+    patch
+        .addObject()
+        .put("op", "replace")
+        .put("path", "/sourceConfig")
+        .set("value", JsonUtils.valueToTree(maskedSourceConfig));
+
+    SdkClients.adminClient().ingestionPipelines().patch(pipeline.getId(), patch);
+
+    IngestionPipeline patchedPipeline =
+        SdkClients.ingestionBotClient().ingestionPipelines().get(pipeline.getId());
+    DbtPipeline patchedDbtPipeline =
+        JsonUtils.convertValue(patchedPipeline.getSourceConfig().getConfig(), DbtPipeline.class);
+    DbtS3Config patchedDbtS3Config =
+        JsonUtils.convertValue(patchedDbtPipeline.getDbtConfigSource(), DbtS3Config.class);
+    assertEquals("us-east-1", patchedDbtS3Config.getDbtSecurityConfig().getAwsRegion());
+    assertEquals(
+        awsCredentials.getAwsSecretAccessKey(),
+        patchedDbtS3Config.getDbtSecurityConfig().getAwsSecretAccessKey());
   }
 
   @Test

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/MessagingServiceResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/MessagingServiceResourceIT.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.net.URI;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -449,6 +450,28 @@ public class MessagingServiceResourceIT
 
     KafkaConnection conn = extractKafkaConnection(fetched);
     assertPasswordsNotMasked(conn, "Bot GET by name");
+  }
+
+  @Test
+  void patch_messagingServiceConnection_preservesMaskedPasswords(TestNamespace ns) {
+    MessagingService service = createKafkaServiceWithCredentials(ns, "patch_preserves_secrets");
+    KafkaConnection maskedConnection = extractKafkaConnection(service);
+    assertPasswordsMasked(maskedConnection, "Admin create response");
+    maskedConnection.setBootstrapServers("updated:9092");
+    ArrayNode patch = JsonUtils.getObjectMapper().createArrayNode();
+    patch
+        .addObject()
+        .put("op", "replace")
+        .put("path", "/connection/config")
+        .set("value", JsonUtils.valueToTree(maskedConnection));
+
+    SdkClients.adminClient().messagingServices().patch(service.getId(), patch);
+
+    MessagingService persisted =
+        SdkClients.ingestionBotClient().messagingServices().get(service.getId());
+    KafkaConnection persistedConnection = extractKafkaConnection(persisted);
+    assertEquals("updated:9092", persistedConnection.getBootstrapServers());
+    assertPasswordsNotMasked(persistedConnection, "Bot GET after masked PATCH");
   }
 
   /**

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -1296,6 +1296,10 @@ public abstract class EntityRepository<T extends EntityInterface> {
     updated.setChangeDescription(original.getChangeDescription());
   }
 
+  protected T restorePatchSecrets(T original, T updated) {
+    return updated;
+  }
+
   /**
    * This function updates the Elasticsearch indexes wherever the specific entity is present.
    * It is typically invoked when there are changes in the entity that might affect its indexing in Elasticsearch.
@@ -4376,6 +4380,9 @@ public abstract class EntityRepository<T extends EntityInterface> {
     T updated;
     try (var ignored = phase("patchApplyJson")) {
       updated = JsonUtils.applyPatch(original, patch, entityClass);
+    }
+    try (var ignored = phase("patchRestoreSecrets")) {
+      updated = restorePatchSecrets(original, updated);
     }
 
     updated.setUpdatedBy(user);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
@@ -85,6 +85,7 @@ import org.openmetadata.service.resources.services.ingestionpipelines.IngestionP
 import org.openmetadata.service.resources.services.ingestionpipelines.ProgressSseManager;
 import org.openmetadata.service.secrets.SecretsManager;
 import org.openmetadata.service.secrets.SecretsManagerFactory;
+import org.openmetadata.service.secrets.masker.EntityMaskerFactory;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.EntityUtil.Fields;
 import org.openmetadata.service.util.EntityUtil.RelationIncludes;
@@ -510,6 +511,13 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
   public void prepare(IngestionPipeline ingestionPipeline, boolean update) {
     var service = getCachedParentOrLoad(ingestionPipeline.getService(), "", Include.NON_DELETED);
     ingestionPipeline.setService(service.getEntityReference());
+  }
+
+  @Override
+  protected IngestionPipeline restorePatchSecrets(
+      IngestionPipeline original, IngestionPipeline updated) {
+    EntityMaskerFactory.getEntityMasker().unmaskIngestionPipeline(updated, original);
+    return updated;
   }
 
   protected boolean requiresRedeployment(IngestionPipeline original, IngestionPipeline updated) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ServiceEntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ServiceEntityRepository.java
@@ -41,6 +41,7 @@ import org.openmetadata.service.Entity;
 import org.openmetadata.service.search.PropagationDescriptor;
 import org.openmetadata.service.secrets.SecretsManager;
 import org.openmetadata.service.secrets.SecretsManagerFactory;
+import org.openmetadata.service.secrets.masker.EntityMaskerFactory;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.EntityUtil.RelationIncludes;
 
@@ -164,6 +165,21 @@ public abstract class ServiceEntityRepository<
                       service.getName(),
                       serviceType));
     }
+  }
+
+  @Override
+  protected T restorePatchSecrets(T original, T updated) {
+    if (original.getConnection() != null && updated.getConnection() != null) {
+      Object restoredConfig =
+          EntityMaskerFactory.getEntityMasker()
+              .unmaskServiceConnectionConfig(
+                  updated.getConnection().getConfig(),
+                  original.getConnection().getConfig(),
+                  updated.getServiceType().value(),
+                  serviceType);
+      updated.getConnection().setConfig(restoredConfig);
+    }
+    return updated;
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
@@ -239,7 +239,8 @@ public class SystemRepository {
 
   private Settings prepareFetchedSettings(Settings fetchedSettings) {
     if (fetchedSettings.getConfigType() == SettingsType.EMAIL_CONFIGURATION) {
-      SmtpSettings emailConfig = (SmtpSettings) fetchedSettings.getConfigValue();
+      SmtpSettings emailConfig =
+          JsonUtils.convertValue(fetchedSettings.getConfigValue(), SmtpSettings.class);
       if (!nullOrEmpty(emailConfig.getPassword())) {
         emailConfig.setPassword(PasswordEntityMasker.PASSWORD_MASK);
       }
@@ -344,21 +345,8 @@ public class SystemRepository {
 
   @Transaction
   public Response createOrUpdate(Settings setting) {
-    Settings oldValue = getConfigWithKey(setting.getConfigType().toString());
-
-    if (oldValue != null && oldValue.getConfigType().equals(SettingsType.EMAIL_CONFIGURATION)) {
-      SmtpSettings configValue =
-          JsonUtils.convertValue(oldValue.getConfigValue(), SmtpSettings.class);
-      if (configValue != null) {
-        SmtpSettings.Templates templates = configValue.getTemplates();
-        SmtpSettings newConfigValue =
-            JsonUtils.convertValue(setting.getConfigValue(), SmtpSettings.class);
-        if (newConfigValue != null) {
-          newConfigValue.setTemplates(templates);
-          setting.setConfigValue(newConfigValue);
-        }
-      }
-    }
+    Settings oldValue = dao.getConfigWithKey(setting.getConfigType().toString());
+    preserveEmailSettings(setting, oldValue);
 
     try {
       updateSetting(setting);
@@ -366,6 +354,7 @@ public class SystemRepository {
       LOG.error(FAILED_TO_UPDATE_SETTINGS, ex.getMessage());
       return Response.status(500, INTERNAL_SERVER_ERROR_WITH_REASON + ex.getMessage()).build();
     }
+    prepareFetchedSettings(setting);
     if (oldValue == null) {
       return (new RestUtil.PutResponse<>(Response.Status.CREATED, setting, ENTITY_CREATED))
           .toResponse();
@@ -401,6 +390,9 @@ public class SystemRepository {
     if (expectedJson == null) {
       throw EntityNotFoundException.byName(settingName);
     }
+    Settings stored =
+        CollectionDAO.SettingsRowMapper.getSettings(
+            SettingsType.fromValue(settingName), expectedJson);
     Settings original =
         prepareFetchedSettings(
             CollectionDAO.SettingsRowMapper.getSettings(
@@ -409,8 +401,32 @@ public class SystemRepository {
     String jsonString = updated.toString();
     Object updatedConfigValue = JsonUtils.readValue(jsonString, Object.class);
     original.setConfigValue(updatedConfigValue);
+    preserveEmailSettings(original, stored);
     updateSettingIfCurrent(original, expectedJson);
+    prepareFetchedSettings(original);
     return (new RestUtil.PutResponse<>(Response.Status.OK, original, ENTITY_UPDATED)).toResponse();
+  }
+
+  private void preserveEmailSettings(Settings updated, Settings stored) {
+    if (hasStoredEmailSettings(updated, stored)) {
+      SmtpSettings original =
+          decryptEmailSetting(JsonUtils.convertValue(stored.getConfigValue(), SmtpSettings.class));
+      SmtpSettings replacement =
+          JsonUtils.convertValue(updated.getConfigValue(), SmtpSettings.class);
+      replacement.setTemplates(original.getTemplates());
+      if (replacement.getPassword() == null
+          || PasswordEntityMasker.PASSWORD_MASK.equals(replacement.getPassword())) {
+        replacement.setPassword(original.getPassword());
+      }
+      updated.setConfigValue(replacement);
+    }
+  }
+
+  private boolean hasStoredEmailSettings(Settings updated, Settings stored) {
+    return stored != null
+        && stored.getConfigValue() != null
+        && updated.getConfigType() == SettingsType.EMAIL_CONFIGURATION
+        && updated.getConfigValue() != null;
   }
 
   private Response patchGlossaryTermRelationSettings(JsonPatch patch) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/drive/DriveServiceResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/drive/DriveServiceResource.java
@@ -302,7 +302,7 @@ public class DriveServiceResource
       @Context SecurityContext securityContext,
       @Valid CreateDriveService create) {
     DriveService service = getService(create, securityContext.getUserPrincipal().getName());
-    Response response = createOrUpdate(uriInfo, securityContext, service);
+    Response response = createOrUpdate(uriInfo, securityContext, unmask(service));
     decryptOrNullify(securityContext, (DriveService) response.getEntity());
     return response;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/SystemResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/SystemResource.java
@@ -64,10 +64,12 @@ import org.openmetadata.schema.api.configuration.MCPConfiguration;
 import org.openmetadata.schema.api.search.SearchSettings;
 import org.openmetadata.schema.api.security.AuthenticationConfiguration;
 import org.openmetadata.schema.auth.EmailRequest;
+import org.openmetadata.schema.auth.LdapConfiguration;
 import org.openmetadata.schema.configuration.EntityRulesSettings;
 import org.openmetadata.schema.configuration.GlossaryTermRelationSettings;
 import org.openmetadata.schema.configuration.GlossaryTermRelationType;
 import org.openmetadata.schema.configuration.SecurityConfiguration;
+import org.openmetadata.schema.security.client.OidcClientConfig;
 import org.openmetadata.schema.service.configuration.elasticsearch.ElasticSearchConfiguration;
 import org.openmetadata.schema.service.configuration.elasticsearch.NaturalLanguageSearchConfiguration;
 import org.openmetadata.schema.settings.Settings;
@@ -930,6 +932,9 @@ public class SystemResource {
     authorizer.authorizeAdmin(securityContext);
 
     try {
+      SecurityConfiguration originalConfig =
+          SecurityConfigurationManager.getInstance().getCurrentSecurityConfig();
+      preserveMaskedSecuritySecrets(securityConfig, originalConfig);
       AuthenticationConfiguration authConfig = securityConfig.getAuthenticationConfiguration();
 
       // Auto-populate publicKeyUrls for OIDC confidential clients before saving
@@ -955,7 +960,7 @@ public class SystemResource {
       // Reload entire security system
       SecurityConfigurationManager.getInstance().reloadSecuritySystem();
 
-      return Response.ok(securityConfig).build();
+      return Response.ok(getSecurityConfig(securityContext)).build();
     } catch (Exception e) {
       LOG.error("Failed to update security configuration", e);
       throw new RuntimeException("Failed to update security configuration: " + e.getMessage());
@@ -1001,6 +1006,7 @@ public class SystemResource {
       String jsonString = patched.toString();
       SecurityConfiguration updatedConfig =
           JsonUtils.readValue(jsonString, SecurityConfiguration.class);
+      preserveMaskedSecuritySecrets(updatedConfig, currentConfig);
 
       String currentUsername = SecurityUtil.getUserName(securityContext);
       SecurityValidationResponse validationResponse =
@@ -1049,6 +1055,46 @@ public class SystemResource {
       LOG.error("Failed to patch security configuration", e);
       throw new RuntimeException("Failed to patch security configuration: " + e.getMessage());
     }
+  }
+
+  static void preserveMaskedSecuritySecrets(
+      SecurityConfiguration updated, SecurityConfiguration original) {
+    if (updated != null && original != null) {
+      AuthenticationConfiguration updatedAuthentication = updated.getAuthenticationConfiguration();
+      AuthenticationConfiguration originalAuthentication =
+          original.getAuthenticationConfiguration();
+      if (updatedAuthentication != null && originalAuthentication != null) {
+        preserveOidcSecret(updatedAuthentication, originalAuthentication);
+        preserveLdapPassword(updatedAuthentication, originalAuthentication);
+      }
+    }
+  }
+
+  private static void preserveOidcSecret(
+      AuthenticationConfiguration updated, AuthenticationConfiguration original) {
+    OidcClientConfig updatedOidc = updated.getOidcConfiguration();
+    OidcClientConfig originalOidc = original.getOidcConfiguration();
+    if (updatedOidc != null && originalOidc != null) {
+      updatedOidc.setSecret(restoredSecret(updatedOidc.getSecret(), originalOidc.getSecret()));
+    }
+  }
+
+  private static void preserveLdapPassword(
+      AuthenticationConfiguration updated, AuthenticationConfiguration original) {
+    LdapConfiguration updatedLdap = updated.getLdapConfiguration();
+    LdapConfiguration originalLdap = original.getLdapConfiguration();
+    if (updatedLdap != null && originalLdap != null) {
+      updatedLdap.setDnAdminPassword(
+          restoredSecret(updatedLdap.getDnAdminPassword(), originalLdap.getDnAdminPassword()));
+    }
+  }
+
+  private static String restoredSecret(String replacement, String original) {
+    String restored = replacement;
+    if (restored == null || PasswordEntityMasker.PASSWORD_MASK.equals(restored)) {
+      restored = original;
+    }
+    return restored;
   }
 
   @POST

--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/masker/PasswordEntityMasker.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/masker/PasswordEntityMasker.java
@@ -108,7 +108,7 @@ public class PasswordEntityMasker extends EntityMasker {
         Object toUnmaskConfig =
             SecretsUtil.convert(connectionConfig, connectionType, null, serviceType);
         Object originalConvertedConfig =
-            SecretsUtil.convert(connectionConfig, connectionType, null, serviceType);
+            SecretsUtil.convert(originalConnectionConfig, connectionType, null, serviceType);
         Map<String, String> passwordsMap = new HashMap<>();
         buildPasswordsMap(originalConvertedConfig, NEW_KEY, passwordsMap);
         unmaskPasswordFields(toUnmaskConfig, NEW_KEY, passwordsMap);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/SystemRepositoryPatchSettingTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/SystemRepositoryPatchSettingTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.openmetadata.schema.configuration.GlossaryTermRelationSettings;
+import org.openmetadata.schema.email.SmtpSettings;
 import org.openmetadata.schema.settings.Settings;
 import org.openmetadata.schema.settings.SettingsType;
 import org.openmetadata.schema.utils.JsonUtils;
@@ -32,10 +33,15 @@ import org.openmetadata.service.exception.SystemSettingsException;
 import org.openmetadata.service.jdbi3.CollectionDAO.SystemDAO;
 import org.openmetadata.service.migration.MigrationValidationClient;
 import org.openmetadata.service.resources.settings.SettingsCache;
+import org.openmetadata.service.secrets.masker.PasswordEntityMasker;
 
 class SystemRepositoryPatchSettingTest {
   private static final String SETTING_NAME = SettingsType.GLOSSARY_TERM_RELATION_SETTINGS.value();
   private static final String ORIGINAL_JSON = "{\"relationTypes\":[]}";
+  private static final String EMAIL_SETTING_NAME = SettingsType.EMAIL_CONFIGURATION.value();
+  private static final String SMTP_PASSWORD = "smtp-secret";
+  private static final String ORIGINAL_SENDER = "before@example.com";
+  private static final String UPDATED_SENDER = "after@example.com";
 
   private MockedStatic<Entity> entityMock;
   private MockedStatic<MigrationValidationClient> migrationMock;
@@ -219,6 +225,61 @@ class SystemRepositoryPatchSettingTest {
     settingsCacheMock.verifyNoInteractions();
   }
 
+  @Test
+  void patchEmailSettingPreservesMaskedPassword() {
+    String originalJson = JsonUtils.pojoToJson(emailSettings(SMTP_PASSWORD, ORIGINAL_SENDER));
+    when(systemDAO.getConfigJsonWithKey(EMAIL_SETTING_NAME)).thenReturn(originalJson);
+    when(systemDAO.updateSettingsIfCurrent(eq(EMAIL_SETTING_NAME), eq(originalJson), anyString()))
+        .thenReturn(1);
+
+    Response response =
+        systemRepository.patchSetting(
+            EMAIL_SETTING_NAME,
+            Json.createPatchBuilder().replace("/senderMail", UPDATED_SENDER).build());
+
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    ArgumentCaptor<String> updatedJson = ArgumentCaptor.forClass(String.class);
+    verify(systemDAO)
+        .updateSettingsIfCurrent(eq(EMAIL_SETTING_NAME), eq(originalJson), updatedJson.capture());
+    SmtpSettings persisted =
+        SystemRepository.decryptEmailSetting(
+            JsonUtils.readValue(updatedJson.getValue(), SmtpSettings.class));
+    assertEquals(SMTP_PASSWORD, persisted.getPassword());
+    assertEquals(UPDATED_SENDER, persisted.getSenderMail());
+    Settings responseSettings = (Settings) response.getEntity();
+    SmtpSettings responseConfig = (SmtpSettings) responseSettings.getConfigValue();
+    assertEquals(PasswordEntityMasker.PASSWORD_MASK, responseConfig.getPassword());
+  }
+
+  @Test
+  void putEmailSettingPreservesOmittedPassword() {
+    Settings stored =
+        new Settings()
+            .withConfigType(SettingsType.EMAIL_CONFIGURATION)
+            .withConfigValue(emailSettings(SMTP_PASSWORD, ORIGINAL_SENDER));
+    Settings update =
+        new Settings()
+            .withConfigType(SettingsType.EMAIL_CONFIGURATION)
+            .withConfigValue(
+                JsonUtils.readValue(
+                    JsonUtils.pojoToJson(emailSettings(null, UPDATED_SENDER)), Object.class));
+    when(systemDAO.getConfigWithKey(EMAIL_SETTING_NAME)).thenReturn(stored);
+
+    Response response = systemRepository.createOrUpdate(update);
+
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    ArgumentCaptor<String> updatedJson = ArgumentCaptor.forClass(String.class);
+    verify(systemDAO).insertSettings(eq(EMAIL_SETTING_NAME), updatedJson.capture());
+    SmtpSettings persisted =
+        SystemRepository.decryptEmailSetting(
+            JsonUtils.readValue(updatedJson.getValue(), SmtpSettings.class));
+    assertEquals(SMTP_PASSWORD, persisted.getPassword());
+    assertEquals(UPDATED_SENDER, persisted.getSenderMail());
+    Settings responseSettings = (Settings) response.getEntity();
+    SmtpSettings responseConfig = (SmtpSettings) responseSettings.getConfigValue();
+    assertEquals(PasswordEntityMasker.PASSWORD_MASK, responseConfig.getPassword());
+  }
+
   private JsonPatch appendRelationTypePatch() {
     return Json.createPatchBuilder()
         .test("/relationTypes", Json.createArrayBuilder().build())
@@ -241,5 +302,9 @@ class SystemRepositoryPatchSettingTest {
 
   private JsonPatch removeFirstRelationTypePatch() {
     return Json.createPatchBuilder().remove("/relationTypes/0").build();
+  }
+
+  private SmtpSettings emailSettings(String password, String senderMail) {
+    return new SmtpSettings().withPassword(password).withSenderMail(senderMail);
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/system/SystemResourceSecurityConfigTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/system/SystemResourceSecurityConfigTest.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.resources.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.api.security.AuthenticationConfiguration;
+import org.openmetadata.schema.auth.LdapConfiguration;
+import org.openmetadata.schema.configuration.SecurityConfiguration;
+import org.openmetadata.schema.security.client.OidcClientConfig;
+import org.openmetadata.service.secrets.masker.PasswordEntityMasker;
+
+class SystemResourceSecurityConfigTest {
+  private static final String OIDC_SECRET = "oidc-secret";
+  private static final String LDAP_PASSWORD = "ldap-password";
+
+  @Test
+  void preservesMaskedOidcAndLdapSecrets() {
+    SecurityConfiguration original = securityConfiguration(OIDC_SECRET, LDAP_PASSWORD);
+    SecurityConfiguration updated =
+        securityConfiguration(
+            PasswordEntityMasker.PASSWORD_MASK, PasswordEntityMasker.PASSWORD_MASK);
+
+    SystemResource.preserveMaskedSecuritySecrets(updated, original);
+
+    assertEquals(OIDC_SECRET, oidcSecret(updated));
+    assertEquals(LDAP_PASSWORD, ldapPassword(updated));
+  }
+
+  @Test
+  void keepsReplacementOidcAndLdapSecrets() {
+    SecurityConfiguration original = securityConfiguration(OIDC_SECRET, LDAP_PASSWORD);
+    SecurityConfiguration updated = securityConfiguration("new-oidc-secret", "new-ldap-password");
+
+    SystemResource.preserveMaskedSecuritySecrets(updated, original);
+
+    assertEquals("new-oidc-secret", oidcSecret(updated));
+    assertEquals("new-ldap-password", ldapPassword(updated));
+  }
+
+  private SecurityConfiguration securityConfiguration(String oidcSecret, String ldapPassword) {
+    AuthenticationConfiguration authentication =
+        new AuthenticationConfiguration()
+            .withOidcConfiguration(new OidcClientConfig().withSecret(oidcSecret))
+            .withLdapConfiguration(new LdapConfiguration().withDnAdminPassword(ldapPassword));
+    return new SecurityConfiguration().withAuthenticationConfiguration(authentication);
+  }
+
+  private String oidcSecret(SecurityConfiguration configuration) {
+    return configuration.getAuthenticationConfiguration().getOidcConfiguration().getSecret();
+  }
+
+  private String ldapPassword(SecurityConfiguration configuration) {
+    return configuration
+        .getAuthenticationConfiguration()
+        .getLdapConfiguration()
+        .getDnAdminPassword();
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/secrets/masker/TestEntityMasker.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/secrets/masker/TestEntityMasker.java
@@ -37,7 +37,7 @@ import org.openmetadata.schema.utils.JsonUtils;
 
 abstract class TestEntityMasker {
 
-  private static final String PASSWORD = "*********";
+  private static final String PASSWORD = "openmetadata-secret";
 
   protected static final SecurityConfiguration CONFIG = new SecurityConfiguration();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceForm.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceForm.spec.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
+import { APIRequestContext, expect, test } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
 import { PLAYWRIGHT_INGESTION_TAG_OBJ } from '../../constant/config';
@@ -28,7 +28,12 @@ import {
 import { DatabaseServiceClass } from '../../support/entity/service/DatabaseServiceClass';
 import { MessagingServiceClass } from '../../support/entity/service/MessagingServiceClass';
 import { UserClass } from '../../support/user/UserClass';
-import { createNewPage, redirectToHomePage, uuid } from '../../utils/common';
+import {
+  createNewPage,
+  getAuthContext,
+  redirectToHomePage,
+  uuid,
+} from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import { visitServiceDetailsPage } from '../../utils/service';
 import {
@@ -48,6 +53,19 @@ const SERVICE_NAMES = {
 };
 
 const adminUser = new UserClass();
+
+const getIngestionBotToken = async (apiContext: APIRequestContext) => {
+  const botResponse = await apiContext.get('/api/v1/bots/name/ingestion-bot');
+  expect(botResponse.status()).toBe(200);
+  const bot = await botResponse.json();
+  const tokenResponse = await apiContext.get(
+    `/api/v1/users/auth-mechanism/${bot.botUser.id}`
+  );
+  expect(tokenResponse.status()).toBe(200);
+  const token = await tokenResponse.json();
+
+  return token.config.JWTToken as string;
+};
 
 // use the admin user to login
 test.use({ storageState: 'playwright/.auth/admin.json' });
@@ -480,6 +498,63 @@ test.describe(
         await expect(
           page.locator(String.raw`#root\/schemaRegistryTopicSuffixName`)
         ).toHaveValue('');
+      });
+
+      test('should preserve the masked SASL password when the connection is edited', async ({
+        browser,
+        page,
+      }) => {
+        await visitServiceDetailsPage(
+          page,
+          {
+            name: kafkaService.entity.name,
+            type: SERVICE_TYPE.Messaging,
+          },
+          false,
+          false
+        );
+
+        await page.getByRole('tab', { name: 'Connection' }).click();
+        await page.getByTestId('edit-connection-button').click();
+        await waitForAllLoadersToDisappear(page);
+        await waitForServiceConnectionForm(page);
+
+        const bootstrapServers = page.locator(
+          String.raw`#root\/bootstrapServers`
+        );
+        await bootstrapServers.fill('updated-bootstrap:9092');
+        await expect(bootstrapServers).toHaveValue('updated-bootstrap:9092');
+
+        const patchResponse = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/services/messagingServices') &&
+            response.request().method() === 'PATCH'
+        );
+        await page.getByTestId('next-button').click();
+        await page.getByRole('button', { name: 'Save' }).click();
+        expect((await patchResponse).status()).toBe(200);
+
+        const { apiContext, afterAction } = await createNewPage(browser);
+        try {
+          const token = await getIngestionBotToken(apiContext);
+          const ingestionBotContext = await getAuthContext(token);
+          try {
+            const serviceResponse = await ingestionBotContext.get(
+              `/api/v1/services/messagingServices/${kafkaService.entityResponseData['id']}`
+            );
+            expect(serviceResponse.status()).toBe(200);
+            const service = await serviceResponse.json();
+
+            expect(service.connection.config.bootstrapServers).toBe(
+              'updated-bootstrap:9092'
+            );
+            expect(service.connection.config.saslPassword).toBe('admin');
+          } finally {
+            await ingestionBotContext.dispose();
+          }
+        } finally {
+          await afterAction();
+        }
       });
     });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EmailConfiguration.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EmailConfiguration.spec.ts
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
+import { GlobalSettingOptions } from '../../constant/settings';
+import { redirectToHomePage, toastNotification } from '../../utils/common';
+import { settingClick } from '../../utils/sidebar';
+
+const MASKED_PASSWORD = '*********';
+const EMAIL_SETTING = {
+  config_type: 'emailConfiguration',
+  config_value: {
+    emailingEntity: 'OpenMetadata',
+    enableSmtpServer: false,
+    password: MASKED_PASSWORD,
+    senderMail: 'sender@example.com',
+    serverEndpoint: 'smtp.example.com',
+    serverPort: 587,
+    supportUrl: 'https://slack.open-metadata.org',
+    transportationStrategy: 'SMTP',
+    username: 'mailer',
+  },
+};
+
+test.use({ storageState: 'playwright/.auth/admin.json' });
+
+test.describe('Email configuration', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
+  test('does not submit an unchanged masked password', async ({ page }) => {
+    await page.route('**/api/v1/system/settings/emailConfiguration', (route) =>
+      route.fulfill({ json: EMAIL_SETTING })
+    );
+    await page.route('**/api/v1/system/settings', async (route) => {
+      await route.fulfill({
+        json: route.request().postDataJSON(),
+        status: 200,
+      });
+    });
+
+    await redirectToHomePage(page);
+    await settingClick(page, GlobalSettingOptions.EMAIL);
+    await page.getByRole('button', { exact: true, name: 'Edit' }).click();
+
+    await expect(page.getByTestId('password-input')).toHaveValue(
+      MASKED_PASSWORD
+    );
+    await page.getByTestId('emailing-entity-input').fill('Metadata Team');
+
+    const updateResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'PUT' &&
+        response.url().endsWith('/api/v1/system/settings')
+    );
+    await page.getByRole('button', { exact: true, name: 'Save' }).click();
+
+    const response = await updateResponse;
+    expect(response.status()).toBe(200);
+    const payload = response.request().postDataJSON();
+
+    expect(payload.config_value.emailingEntity).toBe('Metadata Team');
+    expect(payload.config_value).not.toHaveProperty('password');
+    await toastNotification(page, 'Email Configuration updated successfully.');
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EmailConfiguration.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EmailConfiguration.spec.ts
@@ -17,13 +17,14 @@ import { GlobalSettingOptions } from '../../constant/settings';
 import { redirectToHomePage, toastNotification } from '../../utils/common';
 import { settingClick } from '../../utils/sidebar';
 
-const MASKED_PASSWORD = '*********';
+// Playwright keeps non-generated app constants local to avoid importing the app dependency graph.
+const MASKED_PASSWORD_VALUE = '*********';
 const EMAIL_SETTING = {
   config_type: 'emailConfiguration',
   config_value: {
     emailingEntity: 'OpenMetadata',
     enableSmtpServer: false,
-    password: MASKED_PASSWORD,
+    password: MASKED_PASSWORD_VALUE,
     senderMail: 'sender@example.com',
     serverEndpoint: 'smtp.example.com',
     serverPort: 587,
@@ -52,7 +53,7 @@ test.describe('Email configuration', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
     await page.getByRole('button', { exact: true, name: 'Edit' }).click();
 
     await expect(page.getByTestId('password-input')).toHaveValue(
-      MASKED_PASSWORD
+      MASKED_PASSWORD_VALUE
     );
     await page.getByTestId('emailing-entity-input').fill('Metadata Team');
 

--- a/openmetadata-ui/src/main/resources/ui/src/constants/Secrets.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/Secrets.constants.ts
@@ -1,0 +1,14 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+export const MASKED_PASSWORD_VALUE = '*********';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/EditEmailConfigPage/EditEmailConfigPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/EditEmailConfigPage/EditEmailConfigPage.component.tsx
@@ -24,6 +24,7 @@ import {
   GlobalSettingOptions,
   GlobalSettingsMenuCategory,
 } from '../../constants/GlobalSettings.constants';
+import { MASKED_PASSWORD_VALUE } from '../../constants/Secrets.constants';
 import {
   EMAIL_CONFIG_SERVICE_CATEGORY,
   OPEN_METADATA,
@@ -38,6 +39,15 @@ import {
 } from '../../rest/settingConfigAPI';
 import { getSettingPath } from '../../utils/RouterUtils';
 import { showErrorToast, showSuccessToast } from '../../utils/ToastUtils';
+
+const withoutMaskedPassword = (configValues: SMTPSettings) => {
+  const updateValues = { ...configValues };
+  if (updateValues.password === MASKED_PASSWORD_VALUE) {
+    delete updateValues.password;
+  }
+
+  return updateValues;
+};
 
 function EditEmailConfigPage() {
   const navigate = useNavigate();
@@ -106,7 +116,7 @@ function EditEmailConfigPage() {
         setIsSaveLoading(true);
         const settingsConfigData: Settings = {
           config_type: SettingType.EmailConfiguration,
-          config_value: configValues,
+          config_value: withoutMaskedPassword(configValues),
         };
         await updateSettingsConfig(settingsConfigData);
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/EditEmailConfigPage/EditEmailConfigPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/EditEmailConfigPage/EditEmailConfigPage.test.tsx
@@ -12,6 +12,8 @@
  */
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MASKED_PASSWORD_VALUE } from '../../constants/Secrets.constants';
+import { SettingType } from '../../generated/settings/settings';
 import EditEmailConfigPage from './EditEmailConfigPage.component';
 
 const ERROR = 'ERROR';
@@ -19,6 +21,12 @@ const ENTITY_FETCH_ERROR = 'server.entity-fetch-error';
 const ENTITY_UPDATING_ERROR = 'server.entity-updating-error';
 const UPDATE_ENTITY_SUCCESS = 'server.update-entity-success';
 const ACTIVE_FIELD = 'activeField';
+const EMAIL_CONFIG = {
+  password: MASKED_PASSWORD_VALUE,
+  senderMail: 'before@example.com',
+  serverEndpoint: 'smtp.example.com',
+  serverPort: 587,
+};
 
 jest.mock('../../components/common/ServiceDocPanel/ServiceDocPanel', () =>
   jest.fn(({ activeField }) => (
@@ -50,16 +58,22 @@ jest.mock(
 jest.mock(
   '../../components/Settings/Email/EmailConfigForm/EmailConfigForm.component',
   () =>
-    jest.fn().mockImplementation(({ onCancel, onFocus, onSubmit }) => (
-      <>
-        EmailConfigForm
-        <button onClick={onCancel}>Cancel EmailConfigForm</button>
-        <button onClick={() => onFocus({ target: { id: ACTIVE_FIELD } })}>
-          Focus EmailConfigForm
-        </button>
-        <button onClick={onSubmit}>Submit EmailConfigForm</button>
-      </>
-    ))
+    jest
+      .fn()
+      .mockImplementation(
+        ({ emailConfigValues, onCancel, onFocus, onSubmit }) => (
+          <>
+            EmailConfigForm
+            <button onClick={onCancel}>Cancel EmailConfigForm</button>
+            <button onClick={() => onFocus({ target: { id: ACTIVE_FIELD } })}>
+              Focus EmailConfigForm
+            </button>
+            <button onClick={() => onSubmit(emailConfigValues)}>
+              Submit EmailConfigForm
+            </button>
+          </>
+        )
+      )
 );
 
 const mockNavigate = jest.fn();
@@ -70,10 +84,7 @@ jest.mock('react-router-dom', () => ({
 
 const mockGetSettingsConfigFromConfigType = jest.fn().mockResolvedValue({
   data: {
-    config_value: {
-      customLogoUrlPath: 'https://custom-logo.png',
-      customMonogramUrlPath: 'https://custom-monogram.png',
-    },
+    config_value: EMAIL_CONFIG,
   },
 });
 
@@ -83,7 +94,7 @@ jest.mock('../../rest/settingConfigAPI', () => ({
   getSettingsConfigFromConfigType: jest.fn(() =>
     mockGetSettingsConfigFromConfigType()
   ),
-  updateSettingsConfig: jest.fn(() => mockUpdateSettingsConfig()),
+  updateSettingsConfig: jest.fn((...args) => mockUpdateSettingsConfig(...args)),
 }));
 
 jest.mock('../../utils/RouterUtils', () => ({
@@ -107,6 +118,10 @@ const mockProps = {
 };
 
 describe('EditEmailConfigPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should contain all necessary elements', async () => {
     await act(async () => {
       render(<EditEmailConfigPage {...mockProps} />);
@@ -186,6 +201,31 @@ describe('EditEmailConfigPage', () => {
         ERROR,
         ENTITY_UPDATING_ERROR
       );
+    });
+  });
+
+  it('does not submit the masked password sentinel', async () => {
+    render(<EditEmailConfigPage {...mockProps} />);
+
+    await screen.findByText('EmailConfigForm');
+    await act(async () => {
+      userEvent.click(
+        screen.getByRole('button', {
+          name: 'Submit EmailConfigForm',
+        })
+      );
+    });
+
+    await waitFor(() => expect(mockUpdateSettingsConfig).toHaveBeenCalled());
+    const submittedSettings = mockUpdateSettingsConfig.mock.calls[0][0];
+
+    expect(submittedSettings).toEqual({
+      config_type: SettingType.EmailConfiguration,
+      config_value: {
+        senderMail: EMAIL_CONFIG.senderMail,
+        serverEndpoint: EMAIL_CONFIG.serverEndpoint,
+        serverPort: EMAIL_CONFIG.serverPort,
+      },
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ServiceConnectionUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ServiceConnectionUtils.ts
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 import { cloneDeep, isNil, reduce } from 'lodash';
+import { MASKED_PASSWORD_VALUE } from '../constants/Secrets.constants';
 import { SERVICE_FILTER_PATTERN_FIELDS } from '../constants/ServiceConnection.constants';
 import {
   ADVANCED_PROPERTIES,
@@ -307,7 +308,7 @@ export const SECRET_FIELD_PREFIX = 'secret:';
  * the real value, so an unmodified field on an edit form must not be treated
  * as a plaintext value missing the secret prefix.
  */
-export const MASKED_PASSWORD_VALUE = '*********';
+export { MASKED_PASSWORD_VALUE };
 
 type JsonObject = Record<string, Record<string, unknown>>;
 


### PR DESCRIPTION
### Describe your changes:

Fixes open-metadata/openmetadata-collate#6093

Preserves stored secrets when edit forms return masked placeholders, adds generic post-PATCH restoration for service connections and ingestion pipelines, and hardens SMTP, OIDC, LDAP, and Drive update paths. The email UI now omits unchanged masked passwords while the backend remains authoritative and API responses stay masked.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

- Restore secrets immediately after applying JSON Patch through an entity-repository hook specialized by service and ingestion-pipeline repositories.
- Preserve settings secrets from the raw stored configuration before encryption, while centralizing the UI mask sentinel and omitting it from SMTP updates.
- No schema, migration, API-contract, or rollout changes.

#
### Tests:

#### Use cases covered

- Editing non-secret SMTP fields preserves the stored password.
- Patching Kafka and DBT S3 configurations with masked credentials preserves their real secrets.
- Updating Google Drive with a masked private key preserves the stored key.
- Updating security settings preserves unchanged OIDC and LDAP secrets.

#### Unit tests

- [x] Added unit coverage for masker behavior, SMTP PUT/PATCH, security settings, and email request payloads.
- Files added/updated: `PasswordEntityMaskerTest`, `SystemRepositoryPatchSettingTest`, `SystemResourceSecurityConfigTest`, `EditEmailConfigPage.test.tsx`, and `ServiceConnectionUtils.test.ts`.
- Focused result: 23 backend and 68 UI tests passed.

#### Backend integration tests

- [x] Added integration coverage in `DriveServiceResourceIT`, `MessagingServiceResourceIT`, and `IngestionPipelineResourceIT`.
- Focused Testcontainers result: 3 tests passed; the 11-module reactor completed successfully.

#### Ingestion integration tests

- [x] Not applicable (no connector changes).

#### Playwright (UI) tests

- [x] Added SMTP payload and Kafka secret-preservation scenarios in `EmailConfiguration.spec.ts` and `ServiceForm.spec.ts`.

#### Manual testing performed

Targeted SMTP and Kafka Playwright scenarios passed against the local application stack.

#
### UI screen recording / screenshots:

Not applicable — this is a non-visual payload and secret-preservation change covered by Playwright request and persisted-value assertions.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`.
- [x] My PR is linked to a GitHub issue via the fully qualified `Fixes` reference above.
- [x] I have commented on my code where non-obvious behavior requires explanation.
- [x] No JSON Schema changes or migration scripts are required.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added tests that cover the exact bug and representative platform-wide secret update paths.






<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR preserves stored secrets when configuration updates contain masked placeholders or omit unchanged credentials.
- Adds a post-PATCH secret-restoration hook for service connections and ingestion pipelines.
- Preserves SMTP, OIDC, LDAP, and Google Drive credentials across configuration updates.
- Centralizes the frontend password-mask sentinel and omits unchanged masked SMTP passwords from update payloads.
- Adds backend, integration, unit, and Playwright coverage for representative secret-preservation paths.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java | Introduces a repository extension point that restores secrets immediately after JSON Patch application. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ServiceEntityRepository.java | Restores masked fields in patched service connection configurations from the original entity. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java | Restores masked fields in patched ingestion-pipeline configurations. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java | Preserves stored SMTP templates and unchanged passwords while keeping response values masked. |
| openmetadata-service/src/main/java/org/openmetadata/service/resources/system/SystemResource.java | Preserves unchanged OIDC and LDAP credentials during security configuration PUT and PATCH operations. |
| openmetadata-service/src/main/java/org/openmetadata/service/secrets/masker/PasswordEntityMasker.java | Corrects service-connection restoration to source original password values from the original configuration. |
| openmetadata-service/src/main/java/org/openmetadata/service/resources/services/drive/DriveServiceResource.java | Unmasks Drive service updates before persistence so masked private keys retain their stored values. |
| openmetadata-ui/src/main/resources/ui/src/pages/EditEmailConfigPage/EditEmailConfigPage.component.tsx | Removes the unchanged password-mask sentinel from SMTP update requests. |
| openmetadata-ui/src/main/resources/ui/src/constants/Secrets.constants.ts | Centralizes the frontend masked-password sentinel used by configuration update logic. |
| openmetadata-ui/src/main/resources/ui/src/utils/ServiceConnectionUtils.ts | Re-exports the centralized password-mask sentinel for existing service connection consumers. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Client[Client edit form] --> Payload[Update with masked or omitted secret]
  Payload --> Patch[Apply PUT or JSON Patch]
  Stored[Stored configuration] --> Restore[Restore unchanged secrets]
  Patch --> Restore
  Restore --> Persist[Encrypt and persist configuration]
  Persist --> Response[Return masked API response]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into harshach/fix-is..."](https://github.com/open-metadata/openmetadata/commit/b3a8f820e3108668c7dd1ffa791d03a3291d6f08) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56365652)</sub>

<!-- /greptile_comment -->