### PR TITLE
fix: add getParentEntity to QueryRepository for isOwner() policy evaluation

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/QueryRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/QueryRepository.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
+import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.entity.data.Query;
 import org.openmetadata.schema.entity.services.DatabaseService;
 import org.openmetadata.schema.entity.teams.User;
@@ -190,6 +191,14 @@ public class QueryRepository extends EntityRepository<Query> {
     return queryEntity == null
         ? Collections.emptyList()
         : findFrom(queryEntity.getId(), Entity.QUERY, Relationship.USES, USER);
+  }
+
+  @Override
+  public EntityInterface getParentEntity(Query entity, String fields) {
+    if (entity.getService() == null) {
+      return null;
+    }
+    return Entity.getEntity(entity.getService(), fields, Include.ALL);
   }
 
   @Override


### PR DESCRIPTION
Add getParentEntity override to QueryRepository for isOwner() policy evaluation. Fixes #31717

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes a Query’s DatabaseService available as its parent during ownership-policy evaluation.
- Adds a `QueryRepository.getParentEntity` override.
- Resolves the service with the requested fields and `Include.ALL`.
- Returns no parent when the Query has no service reference.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The implementation appears safe to merge, with the non-blocking concern that the fixed ownership-policy behavior lacks regression coverage.

The new override follows established service-parent lookup behavior and its reachable failure paths are handled, but the policy change is not protected by a focused test.

**Files Needing Attention:** openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/QueryRepository.java
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/QueryRepository.java | Adds the intended DatabaseService parent lookup for Query policy evaluation, but does not add the required regression coverage. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add getParentEntity method to Query..."](https://github.com/open-metadata/openmetadata/commit/d510569c02e2287f925adf51aa6b14a02b49fea7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56497132)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))

<!-- /greptile_comment -->