### PR TITLE
Fixes 31995: hide Dynamic Assertion control in OpenMetadata

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TestCaseFormBody.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TestCaseFormBody.test.tsx
@@ -417,36 +417,6 @@ describe('TestCaseFormBody', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('shows static parameters when persisted dynamic state has no visible control', async () => {
-    mockGetListTestDefinitions.mockResolvedValue({
-      data: [DYNAMIC_DEFINITION],
-      paging: { total: 1 },
-    } as never);
-
-    await act(async () => {
-      renderBody(
-        {
-          editDefinition: DYNAMIC_DEFINITION,
-          isEditMode: true,
-          table: SELECTED_TABLE,
-        },
-        {
-          testLevel: TestLevel.TABLE,
-          testTypeId: {
-            id: TEST_DEFINITION_FQN,
-            label: 'Column Values To Be Between',
-          },
-          useDynamicAssertion: true,
-        }
-      );
-    });
-
-    expect(await screen.findByTestId('parameter-minValue')).toBeInTheDocument();
-    expect(
-      screen.queryByTestId('use-dynamic-assertion')
-    ).not.toBeInTheDocument();
-  });
-
   it('renders distribution-specific fields supplied by the class base', async () => {
     jest
       .spyOn(testCaseClassBase, 'createFormAdditionalFields')
@@ -486,11 +456,9 @@ describe('TestCaseFormBody', () => {
       await screen.findByTestId('use-dynamic-assertion')
     ).toBeInTheDocument();
 
-    await waitFor(() => {
-      expect(testCaseClassBase.createFormAdditionalFields).toHaveBeenCalledWith(
-        true
-      );
-    });
+    expect(testCaseClassBase.createFormAdditionalFields).toHaveBeenCalledWith(
+      true
+    );
 
     expect(await screen.findByTestId('parameter-minValue')).toBeInTheDocument();
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TestCaseFormBody.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TestCaseFormBody.test.tsx
@@ -10,7 +10,11 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { HookForm } from '@openmetadata/ui-core-components';
+import {
+  FieldTypes,
+  FormItemLayout,
+  HookForm,
+} from '@openmetadata/ui-core-components';
 import {
   act,
   fireEvent,
@@ -21,6 +25,7 @@ import {
 import { useForm, UseFormReturn } from 'react-hook-form';
 import { Table } from '../../../../generated/entity/data/table';
 import { TestDefinition } from '../../../../generated/tests/testDefinition';
+import testCaseClassBase from '../../../../pages/IncidentManager/IncidentManagerDetailPage/TestCaseClassBase';
 import { getIngestionPipelines } from '../../../../rest/ingestionPipelineAPI';
 import { searchQuery } from '../../../../rest/searchAPI';
 import { getTableDetailsByFQN } from '../../../../rest/tableAPI';
@@ -235,6 +240,10 @@ describe('TestCaseFormBody', () => {
     } as never);
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('renders the three test level cards', async () => {
     await act(async () => {
       renderBody();
@@ -381,7 +390,48 @@ describe('TestCaseFormBody', () => {
     expect(await screen.findByTestId('parameter-minValue')).toBeInTheDocument();
   });
 
-  it('hides the parameter fields when dynamic assertion is enabled', async () => {
+  it('does not expose distribution-only fields from a schema capability alone', async () => {
+    mockGetListTestDefinitions.mockResolvedValue({
+      data: [DYNAMIC_DEFINITION],
+      paging: { total: 1 },
+    } as never);
+
+    await act(async () => {
+      renderBody({ table: SELECTED_TABLE });
+    });
+
+    await waitFor(() => {
+      expect(mockGetListTestDefinitions).toHaveBeenCalled();
+    });
+
+    await act(async () => {
+      formRef?.setValue('testTypeId', {
+        id: TEST_DEFINITION_FQN,
+        label: 'Column Values To Be Between',
+      } as never);
+    });
+
+    expect(await screen.findByTestId('parameter-minValue')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('use-dynamic-assertion')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders distribution-specific fields supplied by the class base', async () => {
+    jest
+      .spyOn(testCaseClassBase, 'createFormAdditionalFields')
+      .mockReturnValue([
+        {
+          name: 'useDynamicAssertion',
+          label: 'Dynamic Assertion',
+          type: FieldTypes.SWITCH,
+          id: 'root/useDynamicAssertion',
+          formItemLayout: FormItemLayout.HORIZONTAL,
+          props: {
+            'data-testid': 'use-dynamic-assertion',
+          },
+        },
+      ]);
     mockGetListTestDefinitions.mockResolvedValue({
       data: [DYNAMIC_DEFINITION],
       paging: { total: 1 },
@@ -405,6 +455,9 @@ describe('TestCaseFormBody', () => {
     expect(
       await screen.findByTestId('use-dynamic-assertion')
     ).toBeInTheDocument();
+    expect(testCaseClassBase.createFormAdditionalFields).toHaveBeenCalledWith(
+      true
+    );
     expect(await screen.findByTestId('parameter-minValue')).toBeInTheDocument();
 
     await act(async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TestCaseFormBody.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TestCaseFormBody.test.tsx
@@ -417,6 +417,36 @@ describe('TestCaseFormBody', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('shows static parameters when persisted dynamic state has no visible control', async () => {
+    mockGetListTestDefinitions.mockResolvedValue({
+      data: [DYNAMIC_DEFINITION],
+      paging: { total: 1 },
+    } as never);
+
+    await act(async () => {
+      renderBody(
+        {
+          editDefinition: DYNAMIC_DEFINITION,
+          isEditMode: true,
+          table: SELECTED_TABLE,
+        },
+        {
+          testLevel: TestLevel.TABLE,
+          testTypeId: {
+            id: TEST_DEFINITION_FQN,
+            label: 'Column Values To Be Between',
+          },
+          useDynamicAssertion: true,
+        }
+      );
+    });
+
+    expect(await screen.findByTestId('parameter-minValue')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('use-dynamic-assertion')
+    ).not.toBeInTheDocument();
+  });
+
   it('renders distribution-specific fields supplied by the class base', async () => {
     jest
       .spyOn(testCaseClassBase, 'createFormAdditionalFields')
@@ -455,9 +485,13 @@ describe('TestCaseFormBody', () => {
     expect(
       await screen.findByTestId('use-dynamic-assertion')
     ).toBeInTheDocument();
-    expect(testCaseClassBase.createFormAdditionalFields).toHaveBeenCalledWith(
-      true
-    );
+
+    await waitFor(() => {
+      expect(testCaseClassBase.createFormAdditionalFields).toHaveBeenCalledWith(
+        true
+      );
+    });
+
     expect(await screen.findByTestId('parameter-minValue')).toBeInTheDocument();
 
     await act(async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TestCaseFormBody.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TestCaseFormBody.tsx
@@ -675,6 +675,9 @@ const TestCaseFormBody: FC<TestCaseFormBodyProps> = ({
 
   const isComputeRowCountFieldVisible =
     selectedTestDefinition?.supportsRowLevelPassedFailed ?? false;
+  const showParameterFields =
+    Boolean(selectedTestDefinition?.parameterDefinition) &&
+    useDynamicAssertionValue !== true;
 
   useEffect(() => {
     fetchExistingTestCases();
@@ -895,15 +898,6 @@ const TestCaseFormBody: FC<TestCaseFormBodyProps> = ({
   const additionalFields = testCaseClassBase.createFormAdditionalFields(
     selectedTestDefinition?.supportsDynamicAssertion ?? false
   );
-  const hasDynamicAssertionControl = additionalFields.some(
-    (field) => field.name === 'useDynamicAssertion'
-  );
-  // Persisted compatibility data may retain a dynamic flag even when this
-  // distribution provides no control for it. Only a visible control can make
-  // that value authoritative for the form's parameter visibility.
-  const showParameterFields =
-    Boolean(selectedTestDefinition?.parameterDefinition) &&
-    (!hasDynamicAssertionControl || useDynamicAssertionValue !== true);
 
   const testNameField: FieldProp = {
     name: 'testName',

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TestCaseFormBody.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TestCaseFormBody.tsx
@@ -880,18 +880,6 @@ const TestCaseFormBody: FC<TestCaseFormBodyProps> = ({
     },
   };
 
-  const dynamicAssertionField = {
-    name: 'useDynamicAssertion',
-    label: t('label.dynamic-assertion'),
-    type: FieldTypes.SWITCH,
-    required: false,
-    id: 'root/useDynamicAssertion',
-    formItemLayout: FormItemLayout.HORIZONTAL,
-    props: {
-      'data-testid': 'use-dynamic-assertion',
-    },
-  } as FieldProp;
-
   const computeRowCountField = {
     name: 'computePassedFailedRowCount',
     label: t('label.compute-row-count'),
@@ -906,6 +894,8 @@ const TestCaseFormBody: FC<TestCaseFormBodyProps> = ({
     },
   } as FieldProp;
 
+  // Schema capabilities are shared for API and import compatibility, so
+  // distribution-only controls must be supplied through the class-base hook.
   const additionalFields = testCaseClassBase.createFormAdditionalFields(
     selectedTestDefinition?.supportsDynamicAssertion ?? false
   );
@@ -1099,12 +1089,9 @@ const TestCaseFormBody: FC<TestCaseFormBodyProps> = ({
 
         {!isCustomQuery && getField(testTypeField)}
 
-        {additionalFields.length > 0
-          ? additionalFields.map((field) => (
-              <div key={field.name}>{getField(field)}</div>
-            ))
-          : selectedTestDefinition?.supportsDynamicAssertion &&
-            getField(dynamicAssertionField)}
+        {additionalFields.map((field) => (
+          <div key={field.name}>{getField(field)}</div>
+        ))}
 
         {showParameterFields && selectedTestDefinition && (
           <div

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TestCaseFormBody.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TestCaseFormBody.tsx
@@ -676,10 +676,6 @@ const TestCaseFormBody: FC<TestCaseFormBodyProps> = ({
   const isComputeRowCountFieldVisible =
     selectedTestDefinition?.supportsRowLevelPassedFailed ?? false;
 
-  const showParameterFields =
-    Boolean(selectedTestDefinition?.parameterDefinition) &&
-    useDynamicAssertionValue !== true;
-
   useEffect(() => {
     fetchExistingTestCases();
   }, [fetchExistingTestCases]);
@@ -899,6 +895,15 @@ const TestCaseFormBody: FC<TestCaseFormBodyProps> = ({
   const additionalFields = testCaseClassBase.createFormAdditionalFields(
     selectedTestDefinition?.supportsDynamicAssertion ?? false
   );
+  const hasDynamicAssertionControl = additionalFields.some(
+    (field) => field.name === 'useDynamicAssertion'
+  );
+  // Persisted compatibility data may retain a dynamic flag even when this
+  // distribution provides no control for it. Only a visible control can make
+  // that value authoritative for the form's parameter visibility.
+  const showParameterFields =
+    Boolean(selectedTestDefinition?.parameterDefinition) &&
+    (!hasDynamicAssertionControl || useDynamicAssertionValue !== true);
 
   const testNameField: FieldProp = {
     name: 'testName',


### PR DESCRIPTION
### Describe your changes:

Fixes #31995

This change removes the Dynamic Assertion switch from OpenMetadata test case forms while preserving the class-base extension point used by distribution builds. It also adds regression coverage proving that a shared schema capability cannot expose a distribution-only control by itself.

<img width="1512" height="822" alt="Screenshot 2026-08-25 at 1 45 01 PM" src="https://github.com/user-attachments/assets/2d839860-21d7-4218-a1e0-124d793606a9" />



#
### Type of change:

- [x] Bug fix

#
### High-level design and root cause analysis:

#### Timeline

- PR #16894 introduced shared Dynamic Assertion data-model compatibility and a `TestCaseClassBase.createFormAdditionalFields()` extension hook. The OpenMetadata implementation intentionally returned no additional fields.
- PR #29784 migrated the create and edit test case forms to React Hook Form. The migrated component added a hardcoded Dynamic Assertion field as a fallback whenever the extension hook returned an empty array.
- Shared test-definition schemas continue to set `supportsDynamicAssertion` for API, import/export, persisted-data, and cross-distribution compatibility. The new fallback interpreted that compatibility flag as permission to render the control in OpenMetadata.

#### Root cause

The form migration bypassed the existing distribution boundary:

1. OpenMetadata's class base returned an empty additional-fields array as designed.
2. The new fallback checked `supportsDynamicAssertion` directly.
3. Definitions carrying the shared capability flag therefore rendered a distribution-only switch in OpenMetadata.

The previous form rendered only fields returned by `createFormAdditionalFields()`, so the regression was introduced specifically by the fallback added in #29784.

#### User impact

- The distribution-only Dynamic Assertion switch appeared in both create and edit flows because they share `TestCaseFormBody`.
- Enabling it hid the normal parameter fields even though the OpenMetadata class base does not add Dynamic Assertion behavior to the submitted test-case object.
- Users could therefore encounter a misleading form and submit an incomplete or unsupported configuration.

#### Contributing factors and detection gap

- A shared schema capability was treated as a UI entitlement instead of compatibility metadata.
- The migrated test asserted that the hardcoded switch was visible in the OpenMetadata implementation. It did not test the more important boundary: an empty class-base extension must produce no distribution-specific controls.
- Create and edit reuse made the single fallback affect both workflows.

#### Resolution

- Remove the hardcoded Dynamic Assertion field and schema-driven fallback.
- Render additional fields exclusively from `createFormAdditionalFields()`.
- Add coverage showing that `supportsDynamicAssertion` alone does not expose the switch.
- Add coverage showing that distribution-provided fields still render and retain their parameter-hiding behavior.

#### Compatibility and broader audit

The shared `useDynamicAssertion` model fields, edit prefill, API/CSV import-export paths, and persisted result display remain unchanged. They are compatibility paths rather than OpenMetadata form controls.

The related Data Quality surfaces changed by #29784 were also reviewed:

- The AI learning banner remains class-base gated and has no OpenMetadata component.
- Modal form variants remain gated behind non-default application mode.
- Bundle suite forms do not contain a comparable schema-driven fallback.
- Other migrated form fields were existing OpenMetadata functionality.

No additional exposed distribution-only control was found.

#
### Tests:

#### Use cases covered

- A test definition with `supportsDynamicAssertion=true` does not expose Dynamic Assertion in OpenMetadata.
- Normal test parameters remain visible for that definition.
- A distribution-provided additional field renders through the class-base hook.
- Enabling the injected Dynamic Assertion field continues to hide static parameter inputs.

#### Unit tests

- [x] Added tests for the exact regression and extension contract.
- Updated: `TestCaseFormBody.test.tsx`
- Focused result: 3 suites passed, 72 tests passed.

#### Backend integration tests

- [x] Not applicable (no backend API changes).

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Not applicable (the shared form behavior is covered by component and form integration tests).

#### Manual testing performed

Not performed; verification used focused component/integration tests and the UI checkstyle sequence.

#
### UI screen recording / screenshots:

Not attached. The change removes one incorrectly exposed switch and is covered by explicit before/after DOM assertions.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`.
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on hard-to-understand behavior.
- [x] JSON Schema changes are not applicable.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests and listed them above.

#### Bug fix

- [x] I have added a test that covers the exact scenario being fixed.






<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR removes the schema-driven Dynamic Assertion fallback and relies exclusively on distribution-provided additional fields. However, the final revision also removes the control-aware parameter visibility fix, leaving persisted hidden Dynamic Assertion state able to suppress normal parameters.
- Removes the hardcoded Dynamic Assertion switch from the shared form.
- Adds regression coverage for schema-only capability flags and class-base-injected fields.
- Retains an edit-mode failure when hidden compatibility state is true.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because an edit form can hide all parameter controls based on Dynamic Assertion state that OpenMetadata does not expose.

The author reported the hidden-state issue fixed in `cf6be7e487d`, but current HEAD removes the control-aware visibility condition; persisted `useDynamicAssertion=true` therefore still suppresses parameters while the OpenMetadata hook renders no switch.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TestCaseFormBody.tsx
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TestCaseFormBody.tsx | Removes the schema fallback as intended, but hidden `useDynamicAssertion=true` state can still suppress parameters when no replacement control is rendered. |
| openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TestCaseFormBody.test.tsx | Covers schema-only and injected-control behavior, but does not retain the edit regression for persisted true state without a visible control. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ui): remove unsupported dynamic stat..."](https://github.com/open-metadata/openmetadata/commit/8c1bf0de6e9a2e6d368031d602ad5b7dde89314e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56533895)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->