### PR TITLE
Fixes 31997: keep required check names on ignored-label CI runs

### DIFF
--- a/.github/workflows/integration-tests-mysql-elasticsearch.yml
+++ b/.github/workflows/integration-tests-mysql-elasticsearch.yml
@@ -461,7 +461,7 @@ jobs:
           report_paths: 'openmetadata-integration-tests/target/failsafe-reports/TEST-*.xml'
 
   integration-tests-mysql-elasticsearch:
-    name: ${{ github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name != 'safe to test' && 'integration-tests-mysql-elasticsearch (ignored label)' || 'integration-tests-mysql-elasticsearch' }}
+    name: integration-tests-mysql-elasticsearch
     needs: [changes, integration-test-build, integration-test-lanes]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/integration-tests-postgres-elasticsearch-redis.yml
+++ b/.github/workflows/integration-tests-postgres-elasticsearch-redis.yml
@@ -478,7 +478,7 @@ jobs:
           report_paths: 'openmetadata-integration-tests/target/failsafe-reports/TEST-*.xml'
 
   integration-tests-postgres-elasticsearch-redis:
-    name: ${{ github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name != 'safe to test' && 'integration-tests-postgres-elasticsearch-redis (ignored label)' || 'integration-tests-postgres-elasticsearch-redis' }}
+    name: integration-tests-postgres-elasticsearch-redis
     needs: [changes, integration-test-build, integration-test-lanes]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/integration-tests-postgres-opensearch.yml
+++ b/.github/workflows/integration-tests-postgres-opensearch.yml
@@ -423,7 +423,7 @@ jobs:
           report_paths: 'openmetadata-integration-tests/target/failsafe-reports/TEST-*.xml'
 
   integration-tests-postgres-opensearch:
-    name: ${{ github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name != 'safe to test' && 'integration-tests-postgres-opensearch (ignored label)' || 'integration-tests-postgres-opensearch' }}
+    name: integration-tests-postgres-opensearch
     needs: [changes, integration-test-build, integration-test-lanes]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -110,30 +110,15 @@ jobs:
       coarse_bundle: ${{ github.event_name == 'workflow_dispatch' && inputs.coarse_bundle || true }}
 
   playwright-summary:
-    # Publish the required check name `playwright-summary` ONLY when the
-    # reusable's gate authorized the run. Every explicit gate skip publishes
-    # a differently-named check so a redundant sibling event cannot satisfy
-    # branch protection before the real pipeline finishes. Gate failures
-    # keep the required name and fail in the guard step below.
-    #
-    # Decision tree (mirrors the reusable's gate outputs verbatim):
-    #   gate succeeded with should_run=true              → 'playwright-summary'
-    #   gate failed                                      → 'playwright-summary'
-    #   labeled event with non-'safe to test' label      → 'playwright-summary (label ignored)'
-    #   gate succeeded with should_run=false             → 'playwright-summary (skipped)'
     name: >-
       ${{
         (
-          needs.playwright.outputs.gate_result != 'success'
+          github.event.action == 'labeled'
+          || needs.playwright.outputs.gate_result != 'success'
           || needs.playwright.outputs.gate_should_run == 'true'
         )
         && 'playwright-summary'
-        || (
-          github.event.action == 'labeled'
-          && github.event.label.name != 'safe to test'
-          && 'playwright-summary (label ignored)'
-          || 'playwright-summary (skipped)'
-        )
+        || 'playwright-summary (skipped)'
       }}
     if: ${{ always() && !cancelled() }}
     needs: [playwright]

--- a/.github/workflows/py-tests-postgres.yml
+++ b/.github/workflows/py-tests-postgres.yml
@@ -37,7 +37,7 @@ jobs:
   # The sole required check for this workflow. Must stay in the caller: inside
   # py-tests-shared.yml it would report as "py-tests-postgres / python / <job>".
   py-tests-status:
-    name: ${{ github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name != 'safe to test' && 'py-tests-status (ignored label)' || 'py-tests-status' }}
+    name: py-tests-status
     needs: python
     if: ${{ always() && !github.event.pull_request.draft && (github.event_name != 'pull_request_target' || github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
     runs-on: ubuntu-latest

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -41,7 +41,7 @@ jobs:
   # The sole required check for this workflow. Must stay in the caller: inside
   # py-tests-shared.yml it would report as "py-tests / python / <job>".
   py-tests-status:
-    name: ${{ github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name != 'safe to test' && 'py-tests-status (ignored label)' || 'py-tests-status' }}
+    name: py-tests-status
     needs: python
     if: ${{ always() && !github.event.pull_request.draft && (github.event_name != 'pull_request_target' || github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Describe your changes:

Fixes #31997

Adding **any** label to an open PR permanently strands its required checks on
`Expected — Waiting for status to be reported`, even though every check already reported green on
the same head SHA (observed on #31989).

A label fires a second `pull_request_target` run on the same SHA. In that run the gate jobs of the
integration-test and py-tests workflows are skipped by their `if:`, and **GitHub Actions does not
evaluate `${{ }}` inside `name:` for a job that never starts** — it publishes the raw expression
text as the check-run name. From run `32772736464`:

```
Integration Test Lane (${{ matrix.lane.name }})                                   skipped
github.event_name == 'pull_request_target' && ... || 'integration-tests-mysql...' skipped
```

The required context is therefore absent from the newest check suite and the merge box waits for it
forever. `java-checkstyle`, `py-checkstyle`, `ui-checkstyle` and `ui-coverage` are unaffected
because they use static `name:` values — a skipped job still publishes the required name with a
`skipped` conclusion, which branch protection accepts.

This PR makes the five gate jobs use that same static name. The `if:` is untouched, so the
ignored-label behaviour (do not re-run the suite) is unchanged; only the published check name is.

`playwright-summary` hit the same wall for a different reason: its job always runs, so its
expression does evaluate, but it deliberately renamed itself to `playwright-summary (label
ignored)`. That rename exists to stop the redundant `pull_request_target` twin of a same-repo PR
from satisfying branch protection while the real `pull_request` run is still compiling. A `labeled`
event cannot cause that race — it fires after the authoritative run and starts no pipeline of its
own — so this PR keeps `(skipped)` for the twin race and publishes the required name on labeled
events.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

Six workflow files, one job name each.

| File | Job | Change |
|---|---|---|
| `integration-tests-mysql-elasticsearch.yml` | `integration-tests-mysql-elasticsearch` | dynamic `name:` → static literal |
| `integration-tests-postgres-opensearch.yml` | `integration-tests-postgres-opensearch` | dynamic `name:` → static literal |
| `integration-tests-postgres-elasticsearch-redis.yml` | `integration-tests-postgres-elasticsearch-redis` | dynamic `name:` → static literal |
| `py-tests.yml` | `py-tests-status` | dynamic `name:` → static literal |
| `py-tests-postgres.yml` | `py-tests-status` | dynamic `name:` → static literal |
| `playwright-postgresql-e2e.yml` | `playwright-summary` | drop the `(label ignored)` branch, keep `(skipped)` |

Of these, `integration-tests-mysql-elasticsearch`, `integration-tests-postgres-opensearch`,
`py-tests-status` and `playwright-summary` are required contexts in the `merge-rules` ruleset;
`integration-tests-postgres-elasticsearch-redis` is not, but carried the identical dead expression
and produced the same unreadable check name.

**Alternatives rejected**

- *Drop `labeled` from `types:`* — fork PRs need the `safe to test` label to authorize a run.
- *Make the gate jobs always run and exit 0 on an ignored label* — same synthetic-pass semantics as
  a `skipped` conclusion, but burns a runner on every label event and is a larger change.
- *Give `playwright-summary` a static name too* — that would remove the `(skipped)` rename, which
  is real protection against the same-repo `pull_request` / `pull_request_target` twin race
  documented in the job.

**Not changed**: `playwright-knowledge-graph-postgresql-e2e.yml` uses the same `(label ignored)`
rename, but `Playwright RDF (Knowledge Graph + Ontology)` is not a required context, so it has no
stuck state today. Worth aligning if it is ever promoted to required.

#
### Tests:

#### Use cases covered

- Adding a non-`safe to test` label to an open PR no longer strands `integration-tests-*`,
  `py-tests-status` or `playwright-summary` on `Expected — Waiting for status to be reported`.
- Adding `safe to test` still authorizes a full run of all five workflows.
- The same-repo `pull_request` / `pull_request_target` twin race stays covered: on
  `opened` / `synchronize` the redundant twin still publishes `playwright-summary (skipped)`.

#### Unit tests

Not applicable — CI workflow definitions only.

#### Backend integration tests

Not applicable — no backend API changes.

#### Ingestion integration tests

Not applicable — no ingestion changes.

#### Playwright (UI) tests

Not applicable — no UI changes.

#### Manual testing performed

1. `actionlint` on all six files — no new findings (the two pre-existing `SC2016` infos at
   `playwright-postgresql-e2e.yml:380` are untouched).
2. `yaml.safe_load` on all six files, asserting the resolved job names:
   ```
   integration-tests-mysql-elasticsearch.yml            -> integration-tests-mysql-elasticsearch
   integration-tests-postgres-opensearch.yml            -> integration-tests-postgres-opensearch
   integration-tests-postgres-elasticsearch-redis.yml   -> integration-tests-postgres-elasticsearch-redis
   py-tests.yml                                         -> py-tests-status
   py-tests-postgres.yml                                -> py-tests-status
   playwright-postgresql-e2e.yml                        -> ${{ (labeled || gate_result != success || gate_should_run) && 'playwright-summary' || 'playwright-summary (skipped)' }}
   ```
3. **This PR cannot self-test the five `pull_request_target` workflows**: that event always runs the
   workflow definition from the *base* branch, so labeling this PR still exercises `main`'s broken
   version. Only `playwright-summary` (which also runs under `pull_request`) picks up the new
   definition here. End-to-end verification of the rest happens on the first labeled PR after this
   merges.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. (No schema changes.)
- [x] For UI changes: I attached a screen recording and/or screenshots above. (No UI changes.)
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above. (Not applicable — CI config only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the integration and Python gate-job names static and changes Playwright labeled-event naming so required contexts continue to appear after label-triggered runs.
- Replaces dynamic ignored-label names for three integration gates and two Python gates.
- Publishes `playwright-summary` for labeled events while retaining `playwright-summary (skipped)` for other declined runs.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR does not appear safe to merge because ignored-label runs can still satisfy required CI contexts without successful execution of the authoritative tests.

The current Python jobs publish skipped checks under their sole required name, while Playwright publishes a successful required summary after its gate declines; these paths leave the previously reported required-check bypass outstanding.

**Files Needing Attention:** .github/workflows/py-tests.yml, .github/workflows/py-tests-postgres.yml, .github/workflows/playwright-postgresql-e2e.yml, and the changed integration workflow gates
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/py-tests.yml | Makes the sole Python required-check name static while retaining the ignored-label condition that skips its gate job. |
| .github/workflows/py-tests-postgres.yml | Applies the same static required-name behavior to the PostgreSQL Python workflow. |
| .github/workflows/playwright-postgresql-e2e.yml | Makes every labeled event publish `playwright-summary`, including declined-gate runs that complete successfully without Playwright execution. |
| .github/workflows/integration-tests-mysql-elasticsearch.yml | Replaces the ignored-label-specific gate name with the static integration required context. |
| .github/workflows/integration-tests-postgres-opensearch.yml | Replaces the ignored-label-specific gate name with the static integration required context. |
| .github/workflows/integration-tests-postgres-elasticsearch-redis.yml | Makes the non-required integration gate name static for consistency. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  L[Label added to PR] --> T[pull_request_target workflow]
  T --> G{Gate authorizes tests?}
  G -->|No| S[Skip tests or run no-op summary]
  S --> R[Publish required static check name]
  G -->|Yes| X[Run test pipeline]
  X --> R
```
</details>

<sub>Reviews (2): Last reviewed commit: ["ci: keep required check names on ignored..."](https://github.com/open-metadata/openmetadata/commit/1b4731b9d9cc9c2345384fb77a139f906fd9af24) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56536169)</sub>

<!-- /greptile_comment -->