### PR TITLE
fix(search): fail reindex status when search cluster is degraded

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
@@ -1136,6 +1136,10 @@ public class SystemRepository {
     boolean reindexNeeded() {
       return !stalePending.isEmpty() || !missingIndexes.isEmpty();
     }
+
+    boolean passed() {
+      return driftComputed && !reindexNeeded() && clusterHealthy;
+    }
   }
 
   static ReindexStatus classifyReindexStatus(
@@ -1270,8 +1274,7 @@ public class SystemRepository {
     StepValidation result;
     if (searchRepository.getSearchClient().isClientAvailable()) {
       SearchReindexStatus status = computeSearchReindexStatus(searchRepository);
-      boolean healthy = status.driftComputed() && !status.reindexNeeded();
-      result = step.withPassed(healthy).withMessage(buildReindexStatusMessage(status));
+      result = step.withPassed(status.passed()).withMessage(buildReindexStatusMessage(status));
     } else {
       result =
           step.withPassed(Boolean.TRUE).withMessage("Skipped: search instance is not reachable.");

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
@@ -1268,18 +1268,25 @@ public class SystemRepository {
   }
 
   private StepValidation getReindexStatusValidation() {
-    StepValidation step =
-        new StepValidation().withDescription(ValidationStepDescription.SEARCH_REINDEX.key);
     SearchRepository searchRepository = Entity.getSearchRepository();
     StepValidation result;
     if (searchRepository.getSearchClient().isClientAvailable()) {
-      SearchReindexStatus status = computeSearchReindexStatus(searchRepository);
-      result = step.withPassed(status.passed()).withMessage(buildReindexStatusMessage(status));
+      result = buildReindexStepValidation(computeSearchReindexStatus(searchRepository));
     } else {
       result =
-          step.withPassed(Boolean.TRUE).withMessage("Skipped: search instance is not reachable.");
+          new StepValidation()
+              .withDescription(ValidationStepDescription.SEARCH_REINDEX.key)
+              .withPassed(Boolean.TRUE)
+              .withMessage("Skipped: search instance is not reachable.");
     }
     return result;
+  }
+
+  static StepValidation buildReindexStepValidation(SearchReindexStatus status) {
+    return new StepValidation()
+        .withDescription(ValidationStepDescription.SEARCH_REINDEX.key)
+        .withPassed(status.passed())
+        .withMessage(buildReindexStatusMessage(status));
   }
 
   private SearchReindexStatus computeSearchReindexStatus(SearchRepository searchRepository) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/SystemRepositoryReindexStatusTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/SystemRepositoryReindexStatusTest.java
@@ -109,6 +109,34 @@ class SystemRepositoryReindexStatusTest {
   }
 
   @Test
+  void degradedClusterFailsEvenWhenNoReindexNeeded() {
+    SearchReindexStatus status =
+        new SearchReindexStatus(List.of(), 0, List.of(), List.of(), false, true);
+    assertFalse(status.passed());
+  }
+
+  @Test
+  void cleanUpToDateHealthyClusterPasses() {
+    SearchReindexStatus status =
+        new SearchReindexStatus(List.of(), 0, List.of(), List.of(), true, true);
+    assertTrue(status.passed());
+  }
+
+  @Test
+  void reindexNeededFailsEvenWhenClusterHealthy() {
+    SearchReindexStatus status =
+        new SearchReindexStatus(List.of("dashboard"), 0, List.of(), List.of(), true, true);
+    assertFalse(status.passed());
+  }
+
+  @Test
+  void driftComputeFailureFailsEvenWhenClusterHealthy() {
+    SearchReindexStatus status =
+        new SearchReindexStatus(List.of(), 0, List.of(), List.of(), true, false);
+    assertFalse(status.passed());
+  }
+
+  @Test
   void driftComputeFailureIsNotReportedAsUpToDate() {
     SearchReindexStatus status =
         new SearchReindexStatus(List.of(), 0, List.of(), List.of(), true, false);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/SystemRepositoryReindexStatusTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/SystemRepositoryReindexStatusTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.system.StepValidation;
 import org.openmetadata.search.IndexMapping;
 import org.openmetadata.service.jdbi3.SystemRepository.ReindexStatus;
 import org.openmetadata.service.jdbi3.SystemRepository.SearchReindexStatus;
@@ -109,31 +110,34 @@ class SystemRepositoryReindexStatusTest {
   }
 
   @Test
-  void degradedClusterFailsEvenWhenNoReindexNeeded() {
+  void degradedClusterFailsStepEvenWhenNoReindexNeeded() {
     SearchReindexStatus status =
         new SearchReindexStatus(List.of(), 0, List.of(), List.of(), false, true);
-    assertFalse(status.passed());
+    StepValidation step = SystemRepository.buildReindexStepValidation(status);
+    assertFalse(step.getPassed());
+    assertTrue(step.getMessage().toLowerCase().contains("degraded"));
   }
 
   @Test
-  void cleanUpToDateHealthyClusterPasses() {
+  void cleanUpToDateHealthyClusterPassesStep() {
     SearchReindexStatus status =
         new SearchReindexStatus(List.of(), 0, List.of(), List.of(), true, true);
-    assertTrue(status.passed());
+    StepValidation step = SystemRepository.buildReindexStepValidation(status);
+    assertTrue(step.getPassed());
   }
 
   @Test
-  void reindexNeededFailsEvenWhenClusterHealthy() {
+  void reindexNeededFailsStepEvenWhenClusterHealthy() {
     SearchReindexStatus status =
         new SearchReindexStatus(List.of("dashboard"), 0, List.of(), List.of(), true, true);
-    assertFalse(status.passed());
+    assertFalse(SystemRepository.buildReindexStepValidation(status).getPassed());
   }
 
   @Test
-  void driftComputeFailureFailsEvenWhenClusterHealthy() {
+  void driftComputeFailureFailsStepEvenWhenClusterHealthy() {
     SearchReindexStatus status =
         new SearchReindexStatus(List.of(), 0, List.of(), List.of(), true, false);
-    assertFalse(status.passed());
+    assertFalse(SystemRepository.buildReindexStepValidation(status).getPassed());
   }
 
   @Test


### PR DESCRIPTION
## Summary

The **Search Reindex Status** step in `/system/validate` reported a degraded (red) OpenSearch/Elasticsearch cluster only as a message warning while leaving `passed=true`. The UI (`OmHealthPage`) paints any `passed=true` as green, so operators saw a green **"Success"** checkmark directly above the text **"WARNING: search cluster health is degraded."** — contradictory.

Observed on sandbox when the cluster hit the disk flood-stage block.

Fixes #32012
<img width="1626" height="463" alt="image" src="https://github.com/user-attachments/assets/83c4d870-629a-4baf-bc43-695060bfbccd" />


## Change

- Add `SearchReindexStatus.passed()` = `driftComputed && !reindexNeeded() && clusterHealthy`.
- `getReindexStatusValidation()` now sets the step's `passed` from `status.passed()` instead of `driftComputed() && !reindexNeeded()`, so a degraded cluster fails the step.

Cluster health is unchanged elsewhere: `getSearchHealthStatus()` maps **green/yellow → healthy**, **only red (unassigned primary) → degraded**, so single-node yellow clusters are unaffected.

Reverses the intentional "non-failing warning" behavior from #28856 — confirmed with the original author, who asked to flip it to red.

## Test

### Unit

`SystemRepositoryReindexStatusTest` — 4 new cases (degraded→fail, clean+healthy→pass, reindex-needed→fail, drift-fail→fail), asserting on the observable `StepValidation` (passed + message), not the predicate in isolation. Full class: `Tests run: 15, Failures: 0, Errors: 0, Skipped: 0`. `spotless:check` clean.

### Manual (live, against Elasticsearch on `:9200`)

Verified the step's `passed` flips **solely** on cluster health, with no reindex-drift confound.

1. Build the branch and start the server. Log in and get a token for `GET /api/v1/system/status`.
2. Force the search cluster **red** — create an index with 0 replicas pinned to a nonexistent node, so its primary can never allocate:
   ```bash
   curl -X PUT localhost:9200/force_red_test -H 'Content-Type: application/json' \
     -d '{"settings":{"number_of_replicas":0,"index.routing.allocation.require._name":"no-such-node"}}'
   # cluster health -> red (1 unassigned primary)
   ```
   (Only **red** is degraded — `getSearchHealthStatus` maps green/yellow → healthy — so a yellow cluster will not reproduce it.)
3. Hit `GET /api/v1/system/status` and read the **Search Reindex Status** step in each state:

   | Cluster | `passed` | message tail |
   |---|---|---|
   | healthy | `true` (green) | `...Cluster healthy.` |
   | red | `false` (red) | `...WARNING: search cluster health is degraded.` |

   Same message except the cluster clause — cluster health is the only thing that flips the badge. On `main` (pre-fix) the red case still returns `passed=true` → green Success next to the warning.
4. UI: **Settings → Preferences → Health Check** (`/settings/om-health`) → Search Reindex Status card renders red/Failed with the degraded warning in the error log.
5. Cleanup: `curl -X DELETE localhost:9200/force_red_test`.





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes Search Reindex Status fail when drift cannot be computed, reindexing is needed, or the search cluster is degraded.
- Adds a shared predicate requiring computed drift, no required reindex, and healthy cluster state.
- Builds the validation result from that predicate while preserving unreachable-search behavior.
- Adds coverage for degraded, healthy, stale, and drift-failure status combinations.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java | Centralizes the reindex-step pass condition and includes cluster health in the validation result. |
| openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/SystemRepositoryReindexStatusTest.java | Adds assertions for the validation result across degraded, healthy, reindex-needed, and drift-failure status combinations. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Compute search reindex status] --> B{Drift computed?}
  B -- No --> F[Validation fails]
  B -- Yes --> C{Reindex needed?}
  C -- Yes --> F
  C -- No --> D{Cluster healthy?}
  D -- No --> F
  D -- Yes --> P[Validation passes]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(search): assert reindex StepValidat..."](https://github.com/open-metadata/openmetadata/commit/cc60dc4da2e0bc4dd281499ab5ad7b22b0deb535) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56549210)</sub>

<!-- /greptile_comment -->
