### PR TITLE
Fixes 29657: expand object array properties in REST schemas

### DIFF
--- a/ingestion/src/metadata/ingestion/source/api/rest/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/api/rest/metadata.py
@@ -365,7 +365,9 @@ class RestSource(ApiServiceSource):
 
             param_schema = param.get("schema", {})
             param_type = param.get("type") or param_schema.get("type")
-            param_format = param.get("format") or param_schema.get("format")
+            param_format = param.get("format") or (
+                param_schema.get("format") if isinstance(param_schema, dict) else None
+            )
             data_type = self._parse_openapi_type(param_type, param_format)
 
             # Handle array items
@@ -441,6 +443,8 @@ class RestSource(ApiServiceSource):
                         children = self.process_schema_fields(prop_ref, parent_refs)
                     else:
                         logger.debug(f"Skipping object fields inside schema: {prop_ref} to avoid infinite recursion")
+                elif prop_def.get("properties"):
+                    children = self._process_schema_properties(prop_def["properties"], parent_refs)
 
             description = prop_def.get("description")
             description_obj = Markdown(root=description) if description is not None else None

--- a/ingestion/src/metadata/ingestion/source/api/rest/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/api/rest/metadata.py
@@ -37,7 +37,7 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 )
 from metadata.generated.schema.type.apiSchema import APISchema
 from metadata.generated.schema.type.basic import FullyQualifiedEntityName, Markdown
-from metadata.generated.schema.type.schema import DataTypeTopic, FieldModel
+from metadata.generated.schema.type.schema import DataTypeTopic, FieldModel, FieldName
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
@@ -323,7 +323,11 @@ class RestSource(ApiServiceSource):
             logger.warning(f"Error resolving parameter reference: {err}")
             return None
 
-    def _parse_openapi_type(self, openapi_type: Optional[object]) -> DataTypeTopic:  # noqa: UP045
+    def _parse_openapi_type(
+        self,
+        openapi_type: Optional[object],  # noqa: UP045
+        openapi_format: Optional[object] = None,  # noqa: UP045
+    ) -> DataTypeTopic:
         """
         Parse OpenAPI type string to DataTypeTopic enum.
         Shared type conversion logic used across the codebase.
@@ -337,6 +341,11 @@ class RestSource(ApiServiceSource):
 
         if not openapi_type:
             return DataTypeTopic.UNKNOWN
+
+        if openapi_type.lower() == "number" and isinstance(openapi_format, str):
+            normalized_format = openapi_format.upper()
+            if normalized_format in {"FLOAT", "DOUBLE"}:
+                return DataTypeTopic[normalized_format]
 
         # Handle INTEGER -> INT conversion
         normalized_type = "INT" if openapi_type.upper() == "INTEGER" else openapi_type.upper()
@@ -354,14 +363,10 @@ class RestSource(ApiServiceSource):
             if not param_name:
                 return None
 
-            # Get type from parameter (Swagger 2.0 format)
-            param_type = param.get("type")
-
-            # Get type from schema (OpenAPI 3.0 format)
-            if not param_type and "schema" in param:
-                param_type = param["schema"].get("type")
-
-            data_type = self._parse_openapi_type(param_type)
+            param_schema = param.get("schema", {})
+            param_type = param.get("type") or param_schema.get("type")
+            param_format = param.get("format") or param_schema.get("format")
+            data_type = self._parse_openapi_type(param_type, param_format)
 
             # Handle array items
             children = None
@@ -369,7 +374,7 @@ class RestSource(ApiServiceSource):
                 items = param.get("items") or param.get("schema", {}).get("items")
                 if items:
                     item_type = items.get("type")
-                    child_data_type = self._parse_openapi_type(item_type)
+                    child_data_type = self._parse_openapi_type(item_type, items.get("format"))
                     children = [FieldModel(name="item", dataType=child_data_type)]
 
             return FieldModel(
@@ -382,33 +387,79 @@ class RestSource(ApiServiceSource):
             logger.warning(f"Error converting parameter to field: {err}")
             return None
 
+    def _process_array_items(
+        self,
+        items: dict,
+        parent_refs: List[str],  # noqa: UP006
+    ) -> Optional[List[FieldModel]]:  # noqa: UP006, UP045
+        if not items:
+            return None
+
+        items_ref = items.get("$ref")
+        if items_ref:
+            if items_ref in parent_refs:
+                logger.debug(f"Skipping array fields inside schema: {items_ref} to avoid infinite recursion")
+                return None
+
+            logger.debug(f"Processing array fields inside schema: {items_ref}")
+            children = self.process_schema_fields(items_ref, parent_refs)
+            logger.debug(f"Completed processing array fields inside schema: {items_ref}")
+            return children
+
+        properties = items.get("properties", {})
+        if properties:
+            return self._process_schema_properties(properties, parent_refs)
+
+        return [
+            FieldModel(
+                name=FieldName(root="item"),
+                dataType=self._parse_openapi_type(items.get("type"), items.get("format")),
+            )
+        ]
+
+    def _process_schema_properties(
+        self,
+        properties: dict,
+        parent_refs: List[str],  # noqa: UP006
+    ) -> List[FieldModel]:  # noqa: UP006
+        fields = []
+        for prop_name, prop_def in properties.items():
+            prop_type = prop_def.get("type")
+            children = None
+            data_type_display = None
+
+            if prop_type:
+                data_type = self._parse_openapi_type(prop_type, prop_def.get("format"))
+                if data_type == DataTypeTopic.ARRAY:
+                    children = self._process_array_items(prop_def.get("items", {}), parent_refs)
+            else:
+                data_type = DataTypeTopic.UNKNOWN
+                data_type_display = "OBJECT"
+                prop_ref = prop_def.get("$ref")
+                if prop_ref:
+                    if prop_ref not in parent_refs:
+                        children = self.process_schema_fields(prop_ref, parent_refs)
+                    else:
+                        logger.debug(f"Skipping object fields inside schema: {prop_ref} to avoid infinite recursion")
+
+            description = prop_def.get("description")
+            description_obj = Markdown(root=description) if description is not None else None
+            fields.append(
+                FieldModel(
+                    name=prop_name,
+                    dataType=data_type,
+                    dataTypeDisplay=data_type_display,
+                    children=children,
+                    description=description_obj,
+                )
+            )
+
+        return fields
+
     def _process_inline_schema(self, properties: dict) -> Optional[APISchema]:  # noqa: UP045
         """Process inline schema properties (schemas without $ref)"""
         try:
-            fields = []
-            for prop_name, prop_def in properties.items():
-                prop_type = prop_def.get("type")
-
-                data_type = self._parse_openapi_type(prop_type)
-
-                # Handle array items
-                children = None
-                if data_type == DataTypeTopic.ARRAY:
-                    items = prop_def.get("items", {})
-                    if items:
-                        item_type = items.get("type")
-                        child_data_type = self._parse_openapi_type(item_type)
-                        children = [FieldModel(name="item", dataType=child_data_type)]
-
-                fields.append(
-                    FieldModel(
-                        name=prop_name,
-                        dataType=data_type,
-                        children=children,
-                        description=prop_def.get("description"),
-                    )
-                )
-
+            fields = self._process_schema_properties(properties, [])
             return APISchema(schemaFields=fields) if fields else None
         except Exception as err:
             logger.warning(f"Error processing inline schema: {err}")
@@ -499,76 +550,14 @@ class RestSource(ApiServiceSource):
                 return None
 
             parent_refs.append(schema_ref)
-            if self._parse_openapi_type(schema_fields.get("type")) == DataTypeTopic.ARRAY:
-                items_ref = schema_fields.get("items", {}).get("$ref")
-                if items_ref and items_ref not in parent_refs:
-                    fetched_fields = self.process_schema_fields(items_ref, parent_refs)
-                    parent_refs.pop()
-                    return fetched_fields
+            try:
+                if self._parse_openapi_type(schema_fields.get("type")) == DataTypeTopic.ARRAY:
+                    return self._process_array_items(schema_fields.get("items", {}), parent_refs) or []
 
-            fetched_fields = []
-            for key, val in schema_fields.get("properties", {}).items():
-                dtype = val.get("type")
-                if dtype:
-                    parsed_dtype = self._parse_openapi_type(dtype)
-                    children = None
-                    if parsed_dtype.value == DataTypeTopic.ARRAY.value:
-                        # If field of array type then parse children
-                        children_ref = val.get("items", {}).get("$ref")
-                        if children_ref:
-                            # check infinite recursion by checking pre-processed schemas(parent_refs)
-                            if children_ref not in parent_refs:
-                                logger.debug(f"Processing array fields inside schema: {children_ref}")
-                                children = self.process_schema_fields(children_ref, parent_refs)
-                                logger.debug(f"Completed processing array fields inside schema: {children_ref}")
-                            else:
-                                logger.debug(
-                                    f"Skipping array fields inside schema: {children_ref} to avoid infinite recursion"
-                                )
-                    # Extract description if available
-                    description = val.get("description")
-                    description_obj = Markdown(root=description) if description is not None else None
-
-                    fetched_fields.append(
-                        FieldModel(
-                            name=key,
-                            dataType=parsed_dtype,
-                            children=children,
-                            description=description_obj,
-                        )
-                    )
-                else:
-                    # If type of field is not defined then check for sub-schema
-                    # Check if it's `object` type field
-                    children = None
-                    if val.get("$ref"):
-                        # check infinite recursion by checking pre-processed schemas(parent_refs)
-                        if val.get("$ref") not in parent_refs:
-                            children = self.process_schema_fields(val.get("$ref"), parent_refs)
-                        else:
-                            logger.debug(
-                                f"Skipping object fields inside schema: {val.get('$ref')} to avoid infinite recursion"
-                            )
-                    # Extract description if available
-                    description = val.get("description")
-                    description_obj = Markdown(root=description) if description is not None else None
-
-                    fetched_fields.append(
-                        FieldModel(
-                            name=key,
-                            dataType=DataTypeTopic.UNKNOWN,
-                            dataTypeDisplay="OBJECT",
-                            children=children,
-                            description=description_obj,
-                        )
-                    )
-            if parent_refs and (schema_ref in parent_refs):
+                return self._process_schema_properties(schema_fields.get("properties", {}), parent_refs)
+            finally:
                 parent_refs.pop()
-            return fetched_fields  # noqa: TRY300
         except Exception as err:
             warning = f"Error while processing schema fields: {err}"
             logger.warning(warning)
-            if parent_refs and (schema_ref in parent_refs):
-                parent_refs.pop()
-                logger.debug(f"Popping {schema_ref} from parent_refs due to processing error")
         return None

--- a/ingestion/tests/unit/topology/api/test_rest.py
+++ b/ingestion/tests/unit/topology/api/test_rest.py
@@ -794,6 +794,21 @@ class TestRest:
         assert result.description.root == "Page number"
         assert result.children is None
 
+    @pytest.mark.parametrize("schema", [None, "invalid"])
+    def test_convert_parameter_to_field_uses_top_level_type_with_non_object_schema(self, schema):
+        param = {
+            "in": "query",
+            "name": "page",
+            "type": "integer",
+            "schema": schema,
+        }
+
+        result = self.rest_source._convert_parameter_to_field(param)
+
+        assert result is not None
+        assert result.name.root == "page"
+        assert result.dataType == DataTypeTopic.INT
+
     def test_convert_parameter_to_field_openapi_3(self):
         """Test converting OpenAPI 3.0 parameter to FieldModel"""
         param = {
@@ -1222,6 +1237,33 @@ class TestRest:
         assert result is not None
         assert len(result.schemaFields) == 1
         assert result.schemaFields[0].dataType == DataTypeTopic.UNKNOWN
+
+    def test_process_inline_schema_expands_untyped_object_properties(self):
+        properties = {
+            "metadata": {
+                "description": "Nested metadata",
+                "properties": {
+                    "identifier": {
+                        "type": "integer",
+                        "description": "Metadata identifier",
+                    }
+                },
+            }
+        }
+
+        result = self.rest_source._process_inline_schema(properties)
+
+        assert result is not None
+        assert result.schemaFields is not None
+        metadata_field = result.schemaFields[0]
+        assert metadata_field.dataType == DataTypeTopic.UNKNOWN
+        assert metadata_field.dataTypeDisplay == "OBJECT"
+        assert metadata_field.description == Markdown(root="Nested metadata")
+        assert metadata_field.children is not None
+        assert len(metadata_field.children) == 1
+        assert metadata_field.children[0].name.root == "identifier"
+        assert metadata_field.children[0].dataType == DataTypeTopic.INT
+        assert metadata_field.children[0].description == Markdown(root="Metadata identifier")
 
     def test_schema_helpers_handle_invalid_input(self):
         assert self.rest_source._process_array_items({}, []) is None

--- a/ingestion/tests/unit/topology/api/test_rest.py
+++ b/ingestion/tests/unit/topology/api/test_rest.py
@@ -408,6 +408,45 @@ MOCK_RESPONSE_NESTED_DATA_REF = {
 
 MOCK_RESPONSE_NO_SCHEMA = {"responses": {"200": {"description": "successful operation"}}}
 
+MOCK_RESPONSE_INLINE_OBJECT_ARRAY = {
+    "responses": {
+        "200": {
+            "description": "successful operation",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "order_list": {
+                                "type": "array",
+                                "description": "List of orders",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "order_id": {
+                                            "type": "integer",
+                                            "description": "Order ID",
+                                        },
+                                        "order_amount": {
+                                            "type": "number",
+                                            "format": "double",
+                                            "description": "Order amount in USD",
+                                        },
+                                        "order_status": {
+                                            "type": "string",
+                                            "description": "Order status",
+                                        },
+                                    },
+                                },
+                            }
+                        },
+                    }
+                }
+            },
+        }
+    }
+}
+
 # Canned OpenAPI document fed to the source instead of fetching the live
 # petstore URL declared in mock_rest_config, so the collection tests stay
 # hermetic and deterministic (no network).
@@ -466,12 +505,49 @@ class TestRest:
         ]
         assert collections == expected_collections
 
+    def test_get_api_collections_parses_schema_variants(self):
+        self.rest_source.connection = object()
+        schema = {
+            "tags": [{}, {"name": "known"}],
+            "paths": {"/new": {"get": {"tags": ["new"]}}},
+        }
+
+        with patch(
+            "metadata.ingestion.source.api.rest.metadata.parse_openapi_schema",
+            return_value=schema,
+        ):
+            collections = list(self.rest_source.get_api_collections())
+
+        assert {collection.name.root for collection in collections} == {
+            "known",
+            "default",
+            "new",
+        }
+
+        with patch(
+            "metadata.ingestion.source.api.rest.metadata.parse_openapi_schema",
+            side_effect=RuntimeError("invalid schema"),
+        ):
+            assert list(self.rest_source.get_api_collections()) == []
+
     def test_yield_api_collection(self):
         """test yield api collections"""
         # deepcopy: yield_api_collection sets collection.url in place, which would
         # otherwise mutate the shared module-level MOCK_COLLECTIONS fixture.
         collection_request = list(self.rest_source.yield_api_collection(deepcopy(MOCK_COLLECTIONS[0])))
         assert collection_request == EXPECTED_COLLECTION_REQUEST
+
+    def test_yield_api_collection_returns_error(self):
+        with patch.object(
+            self.rest_source,
+            "_generate_collection_url",
+            side_effect=RuntimeError("invalid collection"),
+        ):
+            result = list(self.rest_source.yield_api_collection(deepcopy(MOCK_COLLECTIONS[0])))
+
+        assert len(result) == 1
+        assert result[0].left is not None
+        assert "invalid collection" in result[0].left.error
 
     def test_all_collections(self):
         collections = list(self.rest_source.get_api_collections())
@@ -491,10 +567,44 @@ class TestRest:
         collection_url = self.rest_source._generate_collection_url("store")
         assert collection_url == MOCK_STORE_URL
 
+    def test_url_helpers_use_fallbacks(self):
+        connection_config = self.rest_source.config.serviceConnection.root.config
+        assert self.rest_source._get_fallback_url() is None
+
+        connection_config.docURL = AnyUrl("https://example.com/#")
+        assert str(self.rest_source._generate_collection_url("store")) == "https://example.com/#/store"
+
+        connection_config.docURL = None
+        assert self.rest_source._generate_collection_url("store") is None
+
+        collection = deepcopy(MOCK_SINGLE_COLLECTION)
+        collection.url = None
+        assert self.rest_source._generate_endpoint_url(collection, MOCK_SINGLE_ENDPOINT) is None
+
+    def test_url_helpers_recover_from_errors(self):
+        with patch(
+            "metadata.ingestion.source.api.rest.metadata.clean_uri",
+            side_effect=RuntimeError("invalid URL"),
+        ):
+            assert self.rest_source._generate_collection_url("store") is None
+
+        with patch(
+            "metadata.ingestion.source.api.rest.metadata.AnyUrl",
+            side_effect=RuntimeError("invalid URL"),
+        ):
+            assert self.rest_source._generate_endpoint_url(MOCK_SINGLE_COLLECTION, MOCK_SINGLE_ENDPOINT) is None
+
     def test_generate_endpoint_url(self):
         """test generate endpoint url"""
         endpoint_url = self.rest_source._generate_endpoint_url(MOCK_SINGLE_COLLECTION, MOCK_SINGLE_ENDPOINT)
         assert endpoint_url == MOCK_STORE_ORDER_URL
+
+    def test_endpoint_helpers_handle_invalid_input(self):
+        self.rest_source.json_response = {"paths": None}
+
+        assert self.rest_source._filter_collection_endpoints(MOCK_SINGLE_COLLECTION) is None
+        assert self.rest_source._prepare_endpoint_data("/store", "get", None, MOCK_SINGLE_COLLECTION) is None
+        assert self.rest_source._get_api_request_method("unsupported") is None
 
     def test_collection_filter_pattern(self):
         """test collection filter pattern"""
@@ -801,6 +911,40 @@ class TestRest:
         assert page_field.dataType == DataTypeTopic.INT
         assert page_field.description.root == "Page number"
 
+    def test_get_request_schema_resolves_parameter_references(self):
+        parameter = {
+            "in": "query",
+            "name": "limit",
+            "type": "integer",
+        }
+        self.rest_source.json_response = {"parameters": {"Limit": parameter}}
+        info = {
+            "parameters": [
+                {"$ref": "#/parameters/Limit"},
+                {"$ref": "#/parameters/Missing"},
+            ]
+        }
+
+        result = self.rest_source._get_request_schema(info)
+
+        assert result is not None
+        assert result.schemaFields is not None
+        assert [field.name.root for field in result.schemaFields] == ["limit"]
+
+    def test_resolve_parameter_ref_variants(self):
+        parameter = {"in": "query", "name": "limit", "type": "integer"}
+
+        self.rest_source.json_response = {"parameters": {"Limit": parameter}}
+        assert self.rest_source._resolve_parameter_ref("#/parameters/Limit") == parameter
+
+        self.rest_source.json_response = {"components": {"parameters": {"Limit": parameter}}}
+        assert self.rest_source._resolve_parameter_ref("#/parameters/Limit") == parameter
+
+        self.rest_source.json_response = {}
+        assert self.rest_source._resolve_parameter_ref("#/parameters/Limit") is None
+        assert self.rest_source._resolve_parameter_ref("invalid") is None
+        assert self.rest_source._resolve_parameter_ref(1) is None
+
     def test_get_request_schema_openapi_3_query_parameters(self):
         """Test extracting request schema from OpenAPI 3.0 query parameters"""
         result = self.rest_source._get_request_schema(MOCK_QUERY_PARAMETERS_OPENAPI_3)
@@ -980,6 +1124,10 @@ class TestRest:
         result = self.rest_source._parse_openapi_type("BOOLEAN")
         assert result == DataTypeTopic.BOOLEAN
 
+    @pytest.mark.parametrize("openapi_type", [[], ""])
+    def test_parse_openapi_type_empty_values(self, openapi_type):
+        assert self.rest_source._parse_openapi_type(openapi_type) == DataTypeTopic.UNKNOWN
+
     def test_process_schema_fields_with_nullable_type(self):
         self.rest_source.json_response = {
             "components": {
@@ -1075,6 +1223,17 @@ class TestRest:
         assert len(result.schemaFields) == 1
         assert result.schemaFields[0].dataType == DataTypeTopic.UNKNOWN
 
+    def test_schema_helpers_handle_invalid_input(self):
+        assert self.rest_source._process_array_items({}, []) is None
+        assert self.rest_source._process_inline_schema({"field": None}) is None
+        assert self.rest_source._convert_parameter_to_field({"name": "field", "schema": None}) is None
+        assert self.rest_source._get_response_schema(None) is None
+
+        self.rest_source.json_response = {}
+        schema_ref = "#/components/schemas/Missing"
+        assert self.rest_source._resolve_schema_ref(schema_ref) is None
+        assert self.rest_source.process_schema_fields(schema_ref) is None
+
     def test_get_response_schema_inline_properties(self):
         """Test _get_response_schema handles inline schemas without $ref"""
         self.rest_source.json_response = {}
@@ -1099,6 +1258,84 @@ class TestRest:
 
         assert result is not None
         assert len(result.schemaFields) == 2
+
+    def test_get_response_schema_inline_object_array_properties(self):
+        self.rest_source.json_response = {}
+
+        result = self.rest_source._get_response_schema(MOCK_RESPONSE_INLINE_OBJECT_ARRAY)
+
+        assert result is not None
+        assert result.schemaFields is not None
+        assert len(result.schemaFields) == 1
+
+        order_list = result.schemaFields[0]
+        assert order_list.name.root == "order_list"
+        assert order_list.dataType == DataTypeTopic.ARRAY
+        assert order_list.description == Markdown(root="List of orders")
+        assert order_list.children is not None
+        assert [child.name.root for child in order_list.children] == [
+            "order_id",
+            "order_amount",
+            "order_status",
+        ]
+        assert [child.dataType for child in order_list.children] == [
+            DataTypeTopic.INT,
+            DataTypeTopic.DOUBLE,
+            DataTypeTopic.STRING,
+        ]
+        assert [child.description.root for child in order_list.children] == [
+            "Order ID",
+            "Order amount in USD",
+            "Order status",
+        ]
+
+    def test_get_response_schema_referenced_inline_object_array_properties(self):
+        schema = deepcopy(
+            MOCK_RESPONSE_INLINE_OBJECT_ARRAY["responses"]["200"]["content"]["application/json"]["schema"]
+        )
+        self.rest_source.json_response = {"components": {"schemas": {"Orders": schema}}}
+        info = {
+            "responses": {"200": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/Orders"}}}}}
+        }
+
+        result = self.rest_source._get_response_schema(info)
+
+        assert result is not None
+        assert result.schemaFields is not None
+        order_list = result.schemaFields[0]
+        assert order_list.dataType == DataTypeTopic.ARRAY
+        assert order_list.description == Markdown(root="List of orders")
+        assert order_list.children is not None
+        assert [child.name.root for child in order_list.children] == [
+            "order_id",
+            "order_amount",
+            "order_status",
+        ]
+        assert [child.dataType for child in order_list.children] == [
+            DataTypeTopic.INT,
+            DataTypeTopic.DOUBLE,
+            DataTypeTopic.STRING,
+        ]
+        assert [child.description.root for child in order_list.children] == [
+            "Order ID",
+            "Order amount in USD",
+            "Order status",
+        ]
+
+    def test_process_inline_schema_number_formats(self):
+        properties = {
+            "float_amount": {"type": "number", "format": "float"},
+            "double_amount": {"type": "number", "format": "double"},
+        }
+
+        result = self.rest_source._process_inline_schema(properties)
+
+        assert result is not None
+        assert result.schemaFields is not None
+        assert [field.dataType for field in result.schemaFields] == [
+            DataTypeTopic.FLOAT,
+            DataTypeTopic.DOUBLE,
+        ]
 
     def test_get_response_schema_201_fallback(self):
         """Test _get_response_schema falls back to 201 when 200 not found"""


### PR DESCRIPTION
### Describe your changes:

Fixes #29657

The REST/OpenAPI connector now expands properties declared under an array's inline `items.type: object` schema. Instead of emitting a synthetic `item: UNKNOWN` child, it emits the ordered item properties with their OpenMetadata types and descriptions. The same behavior now applies when the parent schema is resolved through `$ref`.

The root cause was duplicated schema-property parsing: inline response schemas only inspected `items.type`, while referenced parent schemas only expanded `items.$ref`. Both paths now use shared property and array-item parsing. Primitive arrays keep the existing synthetic `item` child, and `$ref` cycle protection remains in place. OpenAPI `type: number` fields with `format: float` or `format: double` now map to `FLOAT` and `DOUBLE`.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

- Added connector-local `_process_schema_properties` and `_process_array_items` helpers used by both inline and `$ref`-resolved schemas.
- Inline object-array properties are returned directly as the array field's children, matching referenced-object-array behavior.
- Array item `$ref` values continue through `process_schema_fields`, preserving `parent_refs` cycle detection.
- Primitive array items still produce the existing `item` child.
- No public API, JSON Schema, generated model, backend, database, migration, or UI changes are required.

#
### Tests:

#### Use cases covered

- An inline response schema with `order_list.items.type: object` emits ordered `order_id: INT`, `order_amount: DOUBLE`, and `order_status: STRING` children.
- The array and child descriptions from the issue's schema are preserved.
- A component-referenced parent schema containing the same inline object array produces equivalent children.
- OpenAPI `number` formats `float` and `double` map to `FLOAT` and `DOUBLE`.
- Existing primitive-array placeholder behavior and circular `$ref` protection remain covered.

#### Unit tests

- [x] I added unit tests for the new/changed logic.
- File updated: `ingestion/tests/unit/topology/api/test_rest.py`
- `python -m pytest tests/unit/topology/api/test_rest.py -v` — 85 passed.
- `python -m pytest tests/unit/topology/api -q` — 107 passed.
- Module coverage: 95.45% for `metadata.ingestion.source.api.rest.metadata` (90% gate passed).
- RED verification before implementation: the three new regression cases failed on the `item: UNKNOWN` placeholder, missing referenced children, and unknown float/double types.

#### Backend integration tests

- [x] Not applicable — no backend API or service changes.
- Files added/updated: N/A.

#### Ingestion integration tests

- [x] Not applicable — this is deterministic OpenAPI schema parsing covered by connector unit tests; no external service behavior changed.
- Files added/updated: N/A.

#### Playwright (UI) tests

- [x] Not applicable — no UI changes.
- Files added/updated: N/A.

#### Manual testing performed

Replayed both parser shapes directly through the deterministic regression fixtures:

1. `source .dev-env.local.sh`
2. `cd ingestion`
3. Run `python -m pytest tests/unit/topology/api/test_rest.py::TestRest::test_get_response_schema_inline_object_array_properties -v`.
4. Run `python -m pytest tests/unit/topology/api/test_rest.py::TestRest::test_get_response_schema_referenced_inline_object_array_properties -v`.
5. Confirm both paths return `order_list` as `ARRAY` with direct `order_id`, `order_amount`, and `order_status` children, including their expected types and descriptions.

Additional validation:

- `make py_format` — passed.
- `make py_format_check` — passed.
- `make static-checks` — passed with 0 errors (repository baseline warnings only).

#
### UI screen recording / screenshots:

Not applicable — no UI changes.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`.
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] The parsing flow is expressed through focused helpers; no additional explanatory comments are required.
- [x] Not applicable — no JSON Schema or migration changes.
- [x] Not applicable — no UI changes or screenshots required.
- [x] I have added tests and listed them above.

#### Bug fix

- [x] I have added a test that covers the exact scenario we are fixing.




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR centralizes REST/OpenAPI schema-property and array-item parsing so inline object arrays and referenced schemas produce typed child fields consistently.
- Expands inline object-array properties while preserving descriptions and property order.
- Adds float and double format handling for OpenAPI number fields.
- Preserves primitive-array placeholders and circular-reference protection.
- Adds regression coverage for schema parsing and the previously reported nullable/non-object parameter-schema case.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported parameter-schema issue is covered by guarded format access and top-level type short-circuiting.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/api/rest/metadata.py | Introduces shared schema helpers and safely preserves a valid top-level parameter type when the optional schema value is null or non-object. |
| ingestion/tests/unit/topology/api/test_rest.py | Adds regression tests for inline object arrays, referenced schemas, numeric formats, cycle handling, and parameter-schema variants. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Address REST schema review feedback"](https://github.com/open-metadata/openmetadata/commit/44c02c0620243e5d6d3c66261d4bdf5d6e80ce4b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56581537)</sub>

<!-- /greptile_comment -->