### PR TITLE
fix(ingestion): handle RootModel fields in _sort_array_entity_fields

### DIFF
--- a/ingestion/src/metadata/ingestion/models/patch_request.py
+++ b/ingestion/src/metadata/ingestion/models/patch_request.py
@@ -18,7 +18,7 @@ import traceback
 from typing import Dict, List, Optional, Tuple  # noqa: UP035
 
 import jsonpatch
-from pydantic import BaseModel
+from pydantic import BaseModel, RootModel
 
 from metadata.ingestion.api.models import Entity, T
 from metadata.ingestion.ometa.mixins.patch_mixin_utils import PatchOperation
@@ -592,6 +592,12 @@ def _sort_array_entity_fields(
             destination_attributes = getattr(destination, field)
             source_attributes = getattr(source, field)
 
+            dest_is_root_model = isinstance(destination_attributes, RootModel)
+            if dest_is_root_model:
+                destination_attributes = destination_attributes.root
+            if isinstance(source_attributes, RootModel):
+                source_attributes = source_attributes.root
+
             source_dict = {_get_attribute_name(attr): attr for attr in (source_attributes or [])}
 
             updated_attributes = []
@@ -615,7 +621,10 @@ def _sort_array_entity_fields(
                 if hasattr(attr, "ordinalPosition"):
                     attr.ordinalPosition = idx + 1
 
-            setattr(destination, field, updated_attributes)
+            if dest_is_root_model:
+                setattr(destination, field, getattr(destination, field).model_copy(update={"root": updated_attributes}))
+            else:
+                setattr(destination, field, updated_attributes)
 
 
 def _remove_change_description(entity: T) -> T:

--- a/ingestion/tests/unit/metadata/ingestion/models/test_patch_request.py
+++ b/ingestion/tests/unit/metadata/ingestion/models/test_patch_request.py
@@ -13,6 +13,7 @@
 Check the JSONPatch operations work as expected
 """
 
+import uuid
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
@@ -234,3 +235,140 @@ class BuildPatchTest(TestCase):
 
             self.assertIn("JsonPatchUpdater exception", str(context.exception))
             self.assertIn("Failed to build patch", str(context.exception))
+
+
+class BuildPatchEntityReferenceListTest(TestCase):
+    def setUp(self):
+        from metadata.generated.schema.entity.data.table import Table
+        from metadata.generated.schema.type.entityReference import EntityReference
+        from metadata.generated.schema.type.entityReferenceList import EntityReferenceList
+
+        self.Table = Table
+        self.EntityReference = EntityReference
+        self.EntityReferenceList = EntityReferenceList
+
+    def _mk_table(self, name):
+        return self.Table(
+            id=str(uuid.uuid4()),
+            name=name,
+            columns=[],
+            fullyQualifiedName=f"svc.db.schema.{name}",
+        )
+
+    def test_empty_to_populated_data_products(self):
+        source = self._mk_table("t1")
+        source.dataProducts = self.EntityReferenceList(root=[])
+
+        dest = source.model_copy(deep=True)
+        dest.dataProducts = self.EntityReferenceList(
+            root=[self.EntityReference(id=str(uuid.uuid4()), type="dataProduct", name="dp1")]
+        )
+
+        result = build_patch(
+            source=source,
+            destination=dest,
+            array_entity_fields=["dataProducts"],
+            skip_on_failure=False,
+        )
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.patch[0]["path"], "/dataProducts")
+        self.assertEqual(len(result.patch[0]["value"]), 1)
+        self.assertEqual(result.patch[0]["value"][0]["name"], "dp1")
+
+    def test_replace_data_products(self):
+        source = self._mk_table("t2")
+        dp_id1, dp_id2 = str(uuid.uuid4()), str(uuid.uuid4())
+        source.dataProducts = self.EntityReferenceList(
+            root=[self.EntityReference(id=dp_id1, type="dataProduct", name="dp1")]
+        )
+
+        dest = source.model_copy(deep=True)
+        dest.dataProducts = self.EntityReferenceList(
+            root=[self.EntityReference(id=dp_id2, type="dataProduct", name="dp2")]
+        )
+
+        result = build_patch(
+            source=source,
+            destination=dest,
+            array_entity_fields=["dataProducts"],
+            skip_on_failure=False,
+        )
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.patch[0]["value"][0]["name"], "dp2")
+
+    def test_same_data_products_no_patch(self):
+        source = self._mk_table("t3")
+        dp_id = str(uuid.uuid4())
+        source.dataProducts = self.EntityReferenceList(
+            root=[self.EntityReference(id=dp_id, type="dataProduct", name="dp1")]
+        )
+
+        dest = source.model_copy(deep=True)
+        dest.dataProducts = self.EntityReferenceList(
+            root=[self.EntityReference(id=dp_id, type="dataProduct", name="dp1")]
+        )
+
+        result = build_patch(
+            source=source,
+            destination=dest,
+            array_entity_fields=["dataProducts"],
+            skip_on_failure=False,
+        )
+        self.assertIsNone(result)
+
+    def test_empty_to_populated_domains(self):
+        source = self._mk_table("t4")
+        source.domains = self.EntityReferenceList(root=[])
+
+        dest = source.model_copy(deep=True)
+        dest.domains = self.EntityReferenceList(
+            root=[self.EntityReference(id=str(uuid.uuid4()), type="domain", name="Analysis")]
+        )
+
+        result = build_patch(
+            source=source,
+            destination=dest,
+            array_entity_fields=["domains"],
+            skip_on_failure=False,
+        )
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.patch[0]["path"], "/domains")
+        self.assertEqual(result.patch[0]["value"][0]["name"], "Analysis")
+
+    def test_both_domains_and_data_products(self):
+        source = self._mk_table("t5")
+        source.domains = self.EntityReferenceList(root=[])
+        source.dataProducts = self.EntityReferenceList(root=[])
+
+        dest = source.model_copy(deep=True)
+        dest.domains = self.EntityReferenceList(
+            root=[self.EntityReference(id=str(uuid.uuid4()), type="domain", name="Analysis")]
+        )
+        dest.dataProducts = self.EntityReferenceList(
+            root=[self.EntityReference(id=str(uuid.uuid4()), type="dataProduct", name="dp1")]
+        )
+
+        result = build_patch(
+            source=source,
+            destination=dest,
+            array_entity_fields=["domains", "dataProducts"],
+            skip_on_failure=False,
+        )
+
+        self.assertIsNotNone(result)
+        paths = {op["path"] for op in result.patch}
+        self.assertIn("/domains", paths)
+        self.assertIn("/dataProducts", paths)
+
+    def test_no_array_entity_fields_still_works(self):
+        source = self._mk_table("t6")
+        dest = source.model_copy(deep=True)
+        dest.dataProducts = self.EntityReferenceList(
+            root=[self.EntityReference(id=str(uuid.uuid4()), type="dataProduct", name="dp1")]
+        )
+
+        result = build_patch(source=source, destination=dest, skip_on_failure=False)
+        self.assertIsNotNone(result)


### PR DESCRIPTION
Fixes #32008

## Problem

`_sort_array_entity_fields` in `patch_request.py` crashes with `AttributeError: 'list' object has no attribute 'root'` when any `EntityReferenceList`-typed field (e.g. `domains`, `dataProducts`) is passed in `array_entity_fields`.

Two issues in the same function:

1. **Iterating a `RootModel` yields tuples, not items** — pydantic v2 `RootModel` iteration yields `(key, value)` tuples, so `_get_attribute_name` and `__dict__` access both fail.
2. **`setattr` with a plain list breaks serialization** — replacing a `RootModel` field with a bare `list` causes subsequent `model_dump_json` calls to crash because pydantic expects the `RootModel` wrapper.

## Fix

In `_sort_array_entity_fields`:
- Extract `.root` before iterating `RootModel` fields
- Re-wrap via `model_copy(update={"root": ...})` instead of setting a bare list

## Tests

Added 6 tests in `BuildPatchEntityReferenceListTest`:
- `test_empty_to_populated_data_products` — the original crash case
- `test_replace_data_products` — swapping one dataProduct for another
- `test_same_data_products_no_patch` — identical values produce no patch
- `test_empty_to_populated_domains` — same pattern for domains
- `test_both_domains_and_data_products` — both fields in one call
- `test_no_array_entity_fields_still_works` — non-arrayEntityFields path unaffected



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates array-entity-field sorting to preserve Pydantic `RootModel` wrappers while sorting their contents.
- Unwraps `RootModel.root` before iterating entity references.
- Re-wraps sorted destination values using `model_copy`.
- Adds coverage for domains, data products, combined fields, replacements, unchanged values, and the default path.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/models/patch_request.py | Preserves RootModel field types while sorting array entity references. |
| ingestion/tests/unit/metadata/ingestion/models/test_patch_request.py | Adds focused regression coverage for EntityReferenceList patch generation without retaining the previously reported redundant docstrings. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ingestion): handle RootModel fields ..."](https://github.com/open-metadata/openmetadata/commit/14f39dc7cf4ee61ae8581d4df45ad4ddfb2303ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56584346)</sub>

<!-- /greptile_comment -->