### PR TITLE
Fixes 31740: Enforce caller policies on the Incident Manager listing (#31741) [2.0 backport]

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DomainIsolationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DomainIsolationIT.java
@@ -19,17 +19,23 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
+import org.openmetadata.it.bootstrap.SharedEntities;
 import org.openmetadata.it.factories.DatabaseSchemaTestFactory;
 import org.openmetadata.it.factories.DatabaseServiceTestFactory;
 import org.openmetadata.it.util.SdkClients;
 import org.openmetadata.it.util.SharedResourceLocks;
 import org.openmetadata.it.util.TestNamespace;
 import org.openmetadata.it.util.TestNamespaceExtension;
+import org.openmetadata.schema.api.data.CreateDatabase;
+import org.openmetadata.schema.api.data.CreateDatabaseSchema;
 import org.openmetadata.schema.api.data.CreateTable;
 import org.openmetadata.schema.api.domains.CreateDomain;
 import org.openmetadata.schema.api.lineage.AddLineage;
 import org.openmetadata.schema.api.search.SearchSettings;
 import org.openmetadata.schema.api.teams.CreateUser;
+import org.openmetadata.schema.api.tests.CreateTestCase;
+import org.openmetadata.schema.api.tests.CreateTestCaseResolutionStatus;
+import org.openmetadata.schema.entity.data.Database;
 import org.openmetadata.schema.entity.data.DatabaseSchema;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.entity.domains.Domain;
@@ -37,10 +43,14 @@ import org.openmetadata.schema.entity.services.DatabaseService;
 import org.openmetadata.schema.entity.teams.Role;
 import org.openmetadata.schema.settings.Settings;
 import org.openmetadata.schema.settings.SettingsType;
+import org.openmetadata.schema.tests.TestCase;
+import org.openmetadata.schema.tests.type.Severity;
+import org.openmetadata.schema.tests.type.TestCaseResolutionStatusTypes;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.ColumnDataType;
 import org.openmetadata.schema.type.EntitiesEdge;
 import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.network.HttpMethod;
 import org.openmetadata.sdk.network.RequestOptions;
 
@@ -218,6 +228,106 @@ public class DomainIsolationIT {
   // also carries a baseline role, which the bare DomainOnlyAccessRole strips). The UI task list is
   // additionally exercised by playwright DomainIsolation/DomainTaskIsolation.spec.ts.
 
+  @Test
+  void test_incidents_restrictedUserSeesOnlyOwnDomain(TestNamespace ns) throws Exception {
+    OpenMetadataClient admin = SdkClients.adminClient();
+    Deque<Runnable> cleanup = new ArrayDeque<>();
+    try {
+      String p = ns.shortPrefix();
+      Domain ownDomain = createDomain(admin, p + "_d1", cleanup);
+      Domain foreignDomain = createDomain(admin, p + "_d2", cleanup);
+      DatabaseSchema schema = createShortNamedSchema(admin, p, cleanup);
+      Table ownTable = createTable(admin, p + "_own", schema, ownDomain, cleanup);
+      Table foreignTable = createTable(admin, p + "_foreign", schema, foreignDomain, cleanup);
+
+      String testDefinitionFqn =
+          admin
+              .testDefinitions()
+              .list(new ListParams().withLimit(1))
+              .getData()
+              .get(0)
+              .getFullyQualifiedName();
+      String ownIncidentFqn = createIncident(admin, ownTable, p + "_own_tc", testDefinitionFqn);
+      String foreignIncidentFqn =
+          createIncident(admin, foreignTable, p + "_foreign_tc", testDefinitionFqn);
+
+      OpenMetadataClient restricted = createRestrictedUserClient(admin, p, ownDomain, cleanup);
+
+      // Incident listing isolation is driven through search RBAC, which is gated on the global
+      // enableAccessControl setting.
+      boolean originalAccessControl = enableSearchAccessControl(admin);
+      cleanup.push(() -> restoreSearchAccessControl(admin, originalAccessControl));
+
+      Awaitility.await("Incident manager listing honours domain isolation")
+          .atMost(Duration.ofSeconds(90))
+          .pollInterval(Duration.ofSeconds(2))
+          .untilAsserted(
+              () -> {
+                for (boolean latest : new boolean[] {false, true}) {
+                  Set<String> visible = incidentTestCaseFqns(restricted, latest);
+                  assertTrue(
+                      visible.contains(ownIncidentFqn),
+                      "Own-domain incident visible (latest=" + latest + "). Saw: " + visible);
+                  assertFalse(
+                      visible.contains(foreignIncidentFqn),
+                      "Foreign-domain incident hidden (latest=" + latest + "). Saw: " + visible);
+                }
+              });
+    } finally {
+      drain(cleanup);
+    }
+  }
+
+  /** Creates a column-level test case on {@code table} plus an open incident for it. */
+  private String createIncident(
+      OpenMetadataClient admin, Table table, String name, String testDefinitionFqn) {
+    TestCase testCase =
+        admin
+            .testCases()
+            .create(
+                new CreateTestCase()
+                    .withName(name)
+                    .withEntityLink(
+                        "<#E::table::" + table.getFullyQualifiedName() + "::columns::id>")
+                    .withTestDefinition(testDefinitionFqn));
+    admin
+        .testCaseResolutionStatuses()
+        .create(
+            new CreateTestCaseResolutionStatus()
+                .withTestCaseResolutionStatusType(TestCaseResolutionStatusTypes.New)
+                .withTestCaseReference(testCase.getFullyQualifiedName())
+                .withSeverity(Severity.Severity2));
+    return testCase.getFullyQualifiedName();
+  }
+
+  /**
+   * @param latest {@code true} exercises the aggregation branch of the listing, which picks the
+   *     latest status per test case through a different server path than the plain search listing.
+   *     Both must enforce the caller's policies, otherwise {@code latest=true} is a trivial bypass.
+   */
+  private Set<String> incidentTestCaseFqns(OpenMetadataClient client, boolean latest)
+      throws Exception {
+    String response =
+        client
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.GET,
+                "/v1/dataQuality/testCases/testCaseIncidentStatus/search/list",
+                null,
+                RequestOptions.builder()
+                    .queryParam("limit", "1000")
+                    .queryParam("latest", String.valueOf(latest))
+                    .build());
+    Set<String> fqns = new HashSet<>();
+    for (JsonNode incident : MAPPER.readTree(response).path("data")) {
+      JsonNode reference = incident.path("testCaseReference");
+      if (reference.hasNonNull("fullyQualifiedName")) {
+        fqns.add(reference.get("fullyQualifiedName").asText());
+      }
+    }
+    return fqns;
+  }
+
   private Domain createDomain(OpenMetadataClient admin, String name, Deque<Runnable> cleanup) {
     CreateDomain create =
         new CreateDomain()
@@ -227,6 +337,36 @@ public class DomainIsolationIT {
     Domain domain = admin.domains().create(create);
     cleanup.push(() -> admin.domains().delete(domain.getId().toString()));
     return domain;
+  }
+
+  /**
+   * Creating a test case implicitly creates a test suite whose name is the table's FQN plus a
+   * suffix. {@link #createSchema} derives its service, database and schema names from the
+   * namespace, which embeds the test method name at every level, and the resulting test suite name
+   * overflows its column. Short names keep the FQN well inside the limit.
+   */
+  private DatabaseSchema createShortNamedSchema(
+      OpenMetadataClient admin, String prefix, Deque<Runnable> cleanup) {
+    Database database =
+        admin
+            .databases()
+            .create(
+                new CreateDatabase()
+                    .withName(prefix + "_db")
+                    .withService(SharedEntities.get().MYSQL_SERVICE.getFullyQualifiedName()));
+    cleanup.push(
+        () ->
+            admin
+                .databases()
+                .delete(
+                    database.getId().toString(),
+                    Map.of("recursive", "true", "hardDelete", "true")));
+    return admin
+        .databaseSchemas()
+        .create(
+            new CreateDatabaseSchema()
+                .withName(prefix + "_sch")
+                .withDatabase(database.getFullyQualifiedName()));
   }
 
   private DatabaseSchema createSchema(TestNamespace ns, Deque<Runnable> cleanup) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesRepository.java
@@ -37,6 +37,7 @@ import org.openmetadata.service.search.SearchListFilter;
 import org.openmetadata.service.search.SearchRepository;
 import org.openmetadata.service.search.SearchResultListMapper;
 import org.openmetadata.service.search.SearchSortFilter;
+import org.openmetadata.service.security.policyevaluator.SubjectContext;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.RestUtil;
 
@@ -456,6 +457,28 @@ public abstract class EntityTimeSeriesRepository<T extends EntityTimeSeriesInter
       String q,
       String queryString)
       throws IOException {
+    return listFromSearchWithOffset(
+        fields, searchListFilter, limit, offset, searchSortFilter, q, queryString, null);
+  }
+
+  /**
+   * Same as {@link #listFromSearchWithOffset(EntityUtil.Fields, SearchListFilter, int, int,
+   * SearchSortFilter, String, String)} but evaluates the caller's policies against the search query,
+   * so a listing cannot return time series documents the caller may not read. Domain conditions such
+   * as {@code hasDomain()} can only be enforced here: {@code RuleEvaluator#hasDomain} short-circuits
+   * to {@code true} for list operations because no single resource is in scope, and relies on this
+   * search-side filtering instead. Passing a {@code null} subject keeps the unfiltered behaviour.
+   */
+  public ResultList<T> listFromSearchWithOffset(
+      EntityUtil.Fields fields,
+      SearchListFilter searchListFilter,
+      int limit,
+      int offset,
+      SearchSortFilter searchSortFilter,
+      String q,
+      String queryString,
+      SubjectContext subjectContext)
+      throws IOException {
     List<T> entityList = new ArrayList<>();
     long total;
 
@@ -464,7 +487,14 @@ public abstract class EntityTimeSeriesRepository<T extends EntityTimeSeriesInter
     if (limit > 0) {
       SearchResultListMapper results =
           searchRepository.listWithOffset(
-              searchListFilter, limit, offset, entityType, searchSortFilter, q, queryString);
+              searchListFilter,
+              limit,
+              offset,
+              entityType,
+              searchSortFilter,
+              q,
+              queryString,
+              subjectContext);
       total = results.getTotal();
       for (Map<String, Object> json : results.getResults()) {
         T entity = setFieldsInternal(readTimeSeriesSource(json), fields);
@@ -488,7 +518,14 @@ public abstract class EntityTimeSeriesRepository<T extends EntityTimeSeriesInter
     } else {
       SearchResultListMapper results =
           searchRepository.listWithOffset(
-              searchListFilter, limit, offset, entityType, searchSortFilter, q, queryString);
+              searchListFilter,
+              limit,
+              offset,
+              entityType,
+              searchSortFilter,
+              q,
+              queryString,
+              subjectContext);
       total = results.getTotal();
       return new ResultList<>(entityList, null, limit, (int) total);
     }
@@ -505,6 +542,27 @@ public abstract class EntityTimeSeriesRepository<T extends EntityTimeSeriesInter
       String sortField,
       String sortType)
       throws IOException {
+    return listLatestFromSearch(
+        fields, contentFilter, groupBy, q, limit, offset, sortField, sortType, null);
+  }
+
+  /**
+   * Subject-aware variant of {@link #listLatestFromSearch(EntityUtil.Fields, SearchListFilter,
+   * String, String, Integer, Integer, String, String)}. The aggregation that picks the latest
+   * document per group must be filtered by the caller's policies too, otherwise {@code latest=true}
+   * bypasses the filtering applied to the plain listing.
+   */
+  public ResultList<T> listLatestFromSearch(
+      EntityUtil.Fields fields,
+      SearchListFilter contentFilter,
+      String groupBy,
+      String q,
+      Integer limit,
+      Integer offset,
+      String sortField,
+      String sortType,
+      SubjectContext subjectContext)
+      throws IOException {
     List<T> entityList = new ArrayList<>();
     SearchListFilter searchListFilter = new SearchListFilter();
     setIncludeSearchFields(searchListFilter);
@@ -513,7 +571,8 @@ public abstract class EntityTimeSeriesRepository<T extends EntityTimeSeriesInter
     SearchAggregation searchAggregation =
         buildComplexAggregation(groupBy, contentFilter, limit, offset, sortField, sortType);
     JsonObject jsonObjResults =
-        searchRepository.aggregate(q, entityType, searchAggregation, searchListFilter);
+        searchRepository.aggregate(
+            q, entityType, searchAggregation, searchListFilter, subjectContext);
 
     Optional<List> jsonObjects =
         JsonUtils.readJsonAtPath(jsonObjResults.toString(), aggregationPath, List.class);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResolutionStatusResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResolutionStatusResource.java
@@ -1,5 +1,9 @@
 package org.openmetadata.service.resources.dqtests;
 
+import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+import static org.openmetadata.service.security.DefaultAuthorizer.getSubjectContext;
+
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -52,6 +56,7 @@ import org.openmetadata.service.security.AuthorizationLogic;
 import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.security.policyevaluator.OperationContext;
 import org.openmetadata.service.security.policyevaluator.ResourceContextInterface;
+import org.openmetadata.service.security.policyevaluator.SubjectContext;
 import org.openmetadata.service.security.policyevaluator.TestCaseResourceContext;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.EntityUtil.Fields;
@@ -473,6 +478,9 @@ public class TestCaseResolutionStatusResource
 
     authorizer.authorizeRequests(securityContext, requests, AuthorizationLogic.ANY);
 
+    // The incident listing carries no single resource, so hasDomain() cannot be evaluated during
+    // authorization above; the caller's policies are enforced on the search query instead.
+    SubjectContext subjectContext = getSubjectContext(securityContext);
     if (latest) {
       // For latest results, use aggregation grouped by test case to get the latest status per test
       // case
@@ -485,10 +493,18 @@ public class TestCaseResolutionStatusResource
           limit,
           offset,
           defaultSortField,
-          sortType);
+          sortType,
+          subjectContext);
     } else {
       return repository.listFromSearchWithOffset(
-          new Fields(null), searchListFilter, limit, offset, searchSortFilter, null, null);
+          new Fields(null),
+          searchListFilter,
+          limit,
+          offset,
+          searchSortFilter,
+          null,
+          null,
+          subjectContext);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/AggregationManagementClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/AggregationManagementClient.java
@@ -68,6 +68,23 @@ public interface AggregationManagementClient {
       throws IOException;
 
   /**
+   * Same as {@link #aggregate(String, String, SearchAggregation, String)} but evaluates the caller's
+   * policies against the aggregation query, so an aggregation cannot surface documents the caller may
+   * not read. Defaults to the subject-less overload, which applies no policy filtering.
+   *
+   * @param subjectContext the caller, used to build the RBAC query
+   */
+  default JsonObject aggregate(
+      String query,
+      String index,
+      SearchAggregation searchAggregation,
+      String filter,
+      SubjectContext subjectContext)
+      throws IOException {
+    return aggregate(query, index, searchAggregation, filter);
+  }
+
+  /**
    * Get entity type counts with aggregation.
    * Returns count of entities grouped by entity type.
    *

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -4173,6 +4173,17 @@ public class SearchRepository {
         query, entityType, searchAggregation, filter.getCondition(entityType));
   }
 
+  public JsonObject aggregate(
+      String query,
+      String entityType,
+      SearchAggregation searchAggregation,
+      SearchListFilter filter,
+      SubjectContext subjectContext)
+      throws IOException {
+    return searchClient.aggregate(
+        query, entityType, searchAggregation, filter.getCondition(entityType), subjectContext);
+  }
+
   public DataQualityReport genericAggregation(
       String query, String index, SearchAggregation aggregationMetadata) throws IOException {
     return searchClient.genericAggregation(query, index, aggregationMetadata);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchAggregationManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchAggregationManager.java
@@ -87,6 +87,30 @@ public class ElasticSearchAggregationManager implements AggregationManagementCli
   }
 
   /**
+   * ANDs the caller's policy conditions into an aggregation query. Aggregations run over whole
+   * indexes, so without this a caller can read documents they are denied on the corresponding
+   * listing. A {@code null} or exempt subject (admin, bot, access control disabled) is left
+   * unfiltered.
+   */
+  private Query applyRbacQuery(Query query, SubjectContext subjectContext) {
+    if (!SearchUtils.shouldApplyRbacConditions(subjectContext, rbacConditionEvaluator)) {
+      return query;
+    }
+    OMQueryBuilder rbacQueryBuilder = rbacConditionEvaluator.evaluateConditions(subjectContext);
+    if (rbacQueryBuilder == null) {
+      // Fail closed: policies had to be applied for this caller (access control on, not admin/bot)
+      // but produced no query. Returning the unfiltered query would leak; match nothing instead.
+      return Query.of(qb -> qb.matchNone(m -> m));
+    }
+    Query rbacQuery = ((ElasticQueryBuilder) rbacQueryBuilder).buildV2();
+    if (query == null) {
+      return rbacQuery;
+    }
+    final Query existingQuery = query;
+    return Query.of(qb -> qb.bool(b -> b.must(existingQuery).filter(rbacQuery)));
+  }
+
+  /**
    * ANDs the org-wide-only ContextMemory filter into an aggregation query run without an
    * identifiable subject. Such a query cannot tell whose restricted memory a document is and must
    * fail closed: only memories everyone may read are aggregated. Non-memory documents are
@@ -377,27 +401,7 @@ public class ElasticSearchAggregationManager implements AggregationManagementCli
         }
       }
 
-      // Apply RBAC conditions
-      if (SearchUtils.shouldApplyRbacConditions(subjectContext, rbacConditionEvaluator)) {
-        OMQueryBuilder rbacQueryBuilder = rbacConditionEvaluator.evaluateConditions(subjectContext);
-        if (rbacQueryBuilder != null) {
-          Query rbacQuery = ((ElasticQueryBuilder) rbacQueryBuilder).buildV2();
-          if (parsedQuery != null) {
-            final Query existingQuery = parsedQuery;
-            parsedQuery =
-                Query.of(
-                    qb ->
-                        qb.bool(
-                            b -> {
-                              b.must(existingQuery);
-                              b.filter(rbacQuery);
-                              return b;
-                            }));
-          } else {
-            parsedQuery = rbacQuery;
-          }
-        }
-      }
+      parsedQuery = applyRbacQuery(parsedQuery, subjectContext);
 
       searchRequestBuilder.query(restrictToOrgWideMemories(parsedQuery));
 
@@ -452,6 +456,17 @@ public class ElasticSearchAggregationManager implements AggregationManagementCli
   public JsonObject aggregate(
       String query, String index, SearchAggregation searchAggregation, String filter)
       throws IOException {
+    return aggregate(query, index, searchAggregation, filter, null);
+  }
+
+  @Override
+  public JsonObject aggregate(
+      String query,
+      String index,
+      SearchAggregation searchAggregation,
+      String filter,
+      SubjectContext subjectContext)
+      throws IOException {
     if (!isClientAvailable) {
       LOG.error("ElasticSearch client is not available. Cannot perform aggregation.");
       throw new IOException("ElasticSearch client is not available");
@@ -503,7 +518,8 @@ public class ElasticSearchAggregationManager implements AggregationManagementCli
                 ? Query.of(q -> q.bool(b -> b.must(finalParsedQuery).filter(finalFilterQuery)))
                 : Query.of(q -> q.bool(b -> b.filter(finalFilterQuery)));
       }
-      searchRequestBuilder.query(restrictToOrgWideMemories(combinedQuery));
+      searchRequestBuilder.query(
+          restrictToOrgWideMemories(applyRbacQuery(combinedQuery, subjectContext)));
 
       searchRequestBuilder.aggregations(aggregations);
       searchRequestBuilder.size(0);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java
@@ -590,6 +590,17 @@ public class ElasticSearchClient implements SearchClient {
   }
 
   @Override
+  public JsonObject aggregate(
+      String query,
+      String index,
+      SearchAggregation searchAggregation,
+      String filter,
+      SubjectContext subjectContext)
+      throws IOException {
+    return aggregationManager.aggregate(query, index, searchAggregation, filter, subjectContext);
+  }
+
+  @Override
   public ElasticSearchConfiguration.SearchType getSearchType() {
     return ElasticSearchConfiguration.SearchType.ELASTICSEARCH;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchAggregationManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchAggregationManager.java
@@ -86,6 +86,30 @@ public class OpenSearchAggregationManager implements AggregationManagementClient
   }
 
   /**
+   * ANDs the caller's policy conditions into an aggregation query. Aggregations run over whole
+   * indexes, so without this a caller can read documents they are denied on the corresponding
+   * listing. A {@code null} or exempt subject (admin, bot, access control disabled) is left
+   * unfiltered.
+   */
+  private Query applyRbacQuery(Query query, SubjectContext subjectContext) {
+    if (!SearchUtils.shouldApplyRbacConditions(subjectContext, rbacConditionEvaluator)) {
+      return query;
+    }
+    OMQueryBuilder rbacQueryBuilder = rbacConditionEvaluator.evaluateConditions(subjectContext);
+    if (rbacQueryBuilder == null) {
+      // Fail closed: policies had to be applied for this caller (access control on, not admin/bot)
+      // but produced no query. Returning the unfiltered query would leak; match nothing instead.
+      return Query.of(qb -> qb.matchNone(m -> m));
+    }
+    Query rbacQuery = ((OpenSearchQueryBuilder) rbacQueryBuilder).buildV2();
+    if (query == null) {
+      return rbacQuery;
+    }
+    final Query existingQuery = query;
+    return Query.of(qb -> qb.bool(b -> b.must(existingQuery).filter(rbacQuery)));
+  }
+
+  /**
    * ANDs the org-wide-only ContextMemory filter into an aggregation query run without an
    * identifiable subject. Such a query cannot tell whose restricted memory a document is and must
    * fail closed: only memories everyone may read are aggregated. Non-memory documents are
@@ -357,27 +381,7 @@ public class OpenSearchAggregationManager implements AggregationManagementClient
         }
       }
 
-      // Apply RBAC conditions
-      if (SearchUtils.shouldApplyRbacConditions(subjectContext, rbacConditionEvaluator)) {
-        OMQueryBuilder rbacQueryBuilder = rbacConditionEvaluator.evaluateConditions(subjectContext);
-        if (rbacQueryBuilder != null) {
-          Query rbacQuery = ((OpenSearchQueryBuilder) rbacQueryBuilder).buildV2();
-          if (parsedQuery != null) {
-            final Query existingQuery = parsedQuery;
-            parsedQuery =
-                Query.of(
-                    qb ->
-                        qb.bool(
-                            b -> {
-                              b.must(existingQuery);
-                              b.filter(rbacQuery);
-                              return b;
-                            }));
-          } else {
-            parsedQuery = rbacQuery;
-          }
-        }
-      }
+      parsedQuery = applyRbacQuery(parsedQuery, subjectContext);
 
       searchRequestBuilder.query(restrictToOrgWideMemories(parsedQuery));
 
@@ -411,6 +415,17 @@ public class OpenSearchAggregationManager implements AggregationManagementClient
   @Override
   public JsonObject aggregate(
       String query, String index, SearchAggregation searchAggregation, String filter)
+      throws IOException {
+    return aggregate(query, index, searchAggregation, filter, null);
+  }
+
+  @Override
+  public JsonObject aggregate(
+      String query,
+      String index,
+      SearchAggregation searchAggregation,
+      String filter,
+      SubjectContext subjectContext)
       throws IOException {
     if (!isClientAvailable) {
       LOG.error("OpenSearch client is not available. Cannot perform aggregation.");
@@ -463,7 +478,8 @@ public class OpenSearchAggregationManager implements AggregationManagementClient
                 ? Query.of(q -> q.bool(b -> b.must(finalParsedQuery).filter(finalFilterQuery)))
                 : Query.of(q -> q.bool(b -> b.filter(finalFilterQuery)));
       }
-      searchRequestBuilder.query(restrictToOrgWideMemories(combinedQuery));
+      searchRequestBuilder.query(
+          restrictToOrgWideMemories(applyRbacQuery(combinedQuery, subjectContext)));
 
       searchRequestBuilder.aggregations(aggregations);
       searchRequestBuilder.size(0);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java
@@ -556,6 +556,17 @@ public class OpenSearchClient implements SearchClient {
   }
 
   @Override
+  public JsonObject aggregate(
+      String query,
+      String index,
+      SearchAggregation searchAggregation,
+      String filter,
+      SubjectContext subjectContext)
+      throws IOException {
+    return aggregationManager.aggregate(query, index, searchAggregation, filter, subjectContext);
+  }
+
+  @Override
   public ElasticSearchConfiguration.SearchType getSearchType() {
     return ElasticSearchConfiguration.SearchType.OPENSEARCH;
   }

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainIncidentIsolation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainIncidentIsolation.spec.ts
@@ -1,0 +1,228 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { expect, Page, test as base } from '@playwright/test';
+import { SidebarItem } from '../../../constant/sidebar';
+import { Domain } from '../../../support/domain/Domain';
+import { TableClass } from '../../../support/entity/TableClass';
+import { UserClass } from '../../../support/user/UserClass';
+import { performAdminLogin } from '../../../utils/admin';
+import { redirectToHomePage } from '../../../utils/common';
+import {
+  assignDomainOnlyAccess,
+  assignDomainToTable,
+  safeDelete,
+} from '../../../utils/domainIsolationUtils';
+import { waitForAllLoadersToDisappear } from '../../../utils/entity';
+import { seedFailedIncidents } from '../../../utils/incidentManager';
+import { enableDisableSearchRBAC } from '../../../utils/searchRBAC';
+import { sidebarClick } from '../../../utils/sidebar';
+
+// Issue #31740 — the Incident Manager listing is served by the `testCaseIncidentStatus/search/list`
+// endpoint, which never passed the caller's SubjectContext to the search layer. hasDomain() returns
+// true for list operations (no single resource is in scope) and defers to search-side filtering, so
+// without that SubjectContext no domain policy restricted the listing at all.
+//
+// The user under test deliberately has NO domain assigned. A user WITH a domain is not a valid
+// regression guard here: the page sends `domain=<their own domain>` (useIncidentList passes
+// activeDomain unless it is the default), and that caller-supplied filter alone hides foreign
+// incidents even on a server with the bug. With no domain the page sends no `domain` param, so the
+// policy evaluated server-side is the only thing that can filter the list — which is exactly the
+// behaviour this spec protects.
+const adminUser = new UserClass();
+const noDomainUser = new UserClass();
+const tenant = new Domain();
+const restrictedTable = new TableClass();
+const domainlessTable = new TableClass();
+
+let restrictedTestCaseName = '';
+let restrictedTestCaseFqn = '';
+let domainlessTestCaseName = '';
+let domainlessTestCaseFqn = '';
+
+const test = base.extend<{ adminPage: Page; noDomainPage: Page }>({
+  adminPage: async ({ browser }, use) => {
+    const page = await browser.newPage();
+    try {
+      await adminUser.login(page);
+      await use(page);
+    } finally {
+      await page.close();
+    }
+  },
+  noDomainPage: async ({ browser }, use) => {
+    const page = await browser.newPage();
+    try {
+      await noDomainUser.login(page);
+      await use(page);
+    } finally {
+      await page.close();
+    }
+  },
+});
+
+// Returns the test case FQNs the server actually sent to this page. The rendered table is paginated,
+// so a row can be missing from page 1 while still being exposed to the user — asserting only on the
+// DOM would let a real leak pass. Asserting on the payload the page requested closes that gap, and
+// the visible-row assertions below keep the user-facing behaviour covered too.
+const openIncidentManager = async (page: Page): Promise<string[]> => {
+  await redirectToHomePage(page);
+
+  // Matched on URL only. Narrowing the predicate by status would never resolve on an error
+  // response, turning a failing API into an opaque timeout instead of a status assertion.
+  const incidentResponse = page.waitForResponse((response) =>
+    response
+      .url()
+      .includes('/dataQuality/testCases/testCaseIncidentStatus/search/list')
+  );
+  await sidebarClick(page, SidebarItem.INCIDENT_MANAGER);
+  const response = await incidentResponse;
+
+  expect(response.status()).toBe(200);
+
+  await waitForAllLoadersToDisappear(page);
+
+  await expect(page.getByTestId('incident-filter-bar')).toBeVisible();
+
+  const body = await response.json();
+
+  return (body.data ?? []).map(
+    (incident: { testCaseReference?: { fullyQualifiedName?: string } }) =>
+      incident.testCaseReference?.fullyQualifiedName ?? ''
+  );
+};
+
+test.describe(
+  'Domain isolation - incident manager listing',
+  { tag: ['@domain-isolation'] },
+  () => {
+    test.beforeAll(
+      'Setup domain, tables, incidents and users',
+      async ({ browser }) => {
+        // test.slow() does not extend a hook's timeout, so set an explicit budget for creating the
+        // entities and waiting for both incidents to be indexed.
+        test.setTimeout(3 * 60 * 1000);
+
+        const { apiContext, afterAction } = await performAdminLogin(browser);
+
+        try {
+          await Promise.all([
+            adminUser.create(apiContext),
+            noDomainUser.create(apiContext),
+            tenant.create(apiContext),
+            restrictedTable.create(apiContext),
+            domainlessTable.create(apiContext),
+          ]);
+
+          await Promise.all([
+            adminUser.setAdminRole(apiContext),
+            // The role carries the domain policy; the empty domain list is the point of this spec —
+            // the user is subject to hasDomain() but owns no domain, so only domainless assets are
+            // theirs.
+            assignDomainOnlyAccess(apiContext, noDomainUser, []),
+            assignDomainToTable(
+              apiContext,
+              restrictedTable.entityResponseData?.id ?? '',
+              tenant
+            ),
+          ]);
+
+          // The table must carry its domain before the incident is indexed — the incident document
+          // inherits its domains from the test case, which inherits them from the table.
+          // seedFailedIncidents polls until each incident is searchable, so the assertions below
+          // never race Elasticsearch.
+          const [[restrictedTestCase], [domainlessTestCase]] =
+            await Promise.all([
+              seedFailedIncidents({
+                apiContext,
+                table: restrictedTable,
+                count: 1,
+              }),
+              seedFailedIncidents({
+                apiContext,
+                table: domainlessTable,
+                count: 1,
+              }),
+            ]);
+
+          restrictedTestCaseName = restrictedTestCase['name'] as string;
+          restrictedTestCaseFqn = restrictedTestCase[
+            'fullyQualifiedName'
+          ] as string;
+          domainlessTestCaseName = domainlessTestCase['name'] as string;
+          domainlessTestCaseFqn = domainlessTestCase[
+            'fullyQualifiedName'
+          ] as string;
+
+          await enableDisableSearchRBAC(apiContext, true);
+        } finally {
+          await afterAction();
+        }
+      }
+    );
+
+    test.afterAll('Cleanup', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+
+      try {
+        await enableDisableSearchRBAC(apiContext, false);
+
+        // Tables first: the domain is deleted once nothing references it any more.
+        await Promise.all([
+          safeDelete(() => restrictedTable.delete(apiContext)),
+          safeDelete(() => domainlessTable.delete(apiContext)),
+        ]);
+
+        await Promise.all([
+          safeDelete(() => tenant.delete(apiContext)),
+          safeDelete(() => noDomainUser.delete(apiContext)),
+          safeDelete(() => adminUser.delete(apiContext)),
+        ]);
+      } finally {
+        await afterAction();
+      }
+    });
+
+    test('user without a domain cannot see incidents belonging to a domain', async ({
+      noDomainPage,
+    }) => {
+      const listedFqns = await openIncidentManager(noDomainPage);
+
+      await test.step('the domained incident is withheld', async () => {
+        expect(listedFqns).not.toContain(restrictedTestCaseFqn);
+
+        await expect(
+          noDomainPage
+            .getByTestId('test-case-incident-manager-table')
+            .getByRole('link', { name: restrictedTestCaseName })
+        ).toHaveCount(0);
+      });
+
+      await test.step('the domainless incident is still listed', async () => {
+        expect(listedFqns).toContain(domainlessTestCaseFqn);
+
+        await expect(
+          noDomainPage
+            .getByTestId('test-case-incident-manager-table')
+            .getByRole('link', { name: domainlessTestCaseName })
+        ).toBeVisible();
+      });
+    });
+
+    test('admin sees incidents from every domain', async ({ adminPage }) => {
+      const listedFqns = await openIncidentManager(adminPage);
+
+      expect(listedFqns).toContain(restrictedTestCaseFqn);
+      expect(listedFqns).toContain(domainlessTestCaseFqn);
+    });
+  }
+);


### PR DESCRIPTION
### Describe your changes:

Fixes #31740

2.0 backport of #31741.

A domain-restricted user saw failed test case incidents from **every** domain on the Incident Manager page. Opening one was correctly blocked, but the listed row already leaked the test case name, the table name and the full FQN.

`RuleEvaluator#hasDomain` short-circuits to `true` for list operations (a listing has no single resource to evaluate the condition against) and defers enforcement to search-side RBAC filtering. The two search-backed listing paths in `EntityTimeSeriesRepository` never received a `SubjectContext`, so that filtering never ran and no policy could restrict the listing.

This threads the caller's `SubjectContext` through both paths so the existing RBAC search machinery filters the query.

#### Clean cherry-pick

Unlike the [1.13 backport](https://github.com/open-metadata/OpenMetadata/pull/31936), `2.0` is close enough to `main` that `8df0bb573d` cherry-picks almost cleanly — `2.0` already has the "ContextMemory" feature `main`'s `ElasticSearchAggregationManager`/`OpenSearchAggregationManager` build on, the full `DomainIsolationIT.java` test infrastructure, the `DomainIsolation` Playwright folder (already wired as its own dedicated CI project — `--project=DomainIsolation` is already invoked in `playwright-postgresql-e2e.yml`), and the `incident-filter-bar` testid the Playwright spec asserts on. Only one trivial import-ordering conflict in `TestCaseResolutionStatusResource.java`, resolved by hand.

All 10 files match the original PR's file list exactly — no hand-adaptation, no reconstructed test files, no dead code.

#
### Type of change:
- [x] Bug fix

#
### Tests:

#### Backend integration tests
- [x] `DomainIsolationIT#test_incidents_restrictedUserSeesOnlyOwnDomain` (existing test class on `2.0`, extended by the cherry-picked commit) — asserts both `latest=false` and `latest=true`.

#### Playwright (UI) tests
- [x] `DomainIncidentIsolation.spec.ts` — cherry-picked as-is, runs under the existing `DomainIsolation` project (already scheduled in CI).

#### Manual testing performed
Verified `mvn compile` for `openmetadata-service`, `mvn test-compile` for `openmetadata-integration-tests`, `mvn spotless:apply` (only removed two genuinely-unused imports left over from the conflict resolution), `yarn tsc:playwright` shows no new type errors, and `eslint`/`prettier` pass clean on the touched files. Not run against a live server in this session — first execution will be in CI.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable, no schema changes.
- [x] For UI changes: cherry-picked Playwright spec, see above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

Bug fix:
- [x] I have added a test that covers the exact scenario we are fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport threads the caller’s subject context through both Incident Manager search paths and applies RBAC predicates before plain-result retrieval or latest-status aggregation. It also adds backend and Playwright coverage for domain-isolated incident listings.

- Adds subject-aware time-series search and aggregation overloads.
- Applies equivalent RBAC query composition in Elasticsearch and OpenSearch.
- Extends domain-isolation coverage for both `latest=false` and `latest=true`.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is safe to merge, with only non-blocking repository-style cleanup needed in the RBAC helpers, Java test declarations, and Playwright constants.

The caller context reaches both incident search paths, and both search backends apply the resulting RBAC query before returning or aggregating documents; the accepted concerns are maintainability issues rather than functional defects.

**Files Needing Attention:** openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchAggregationManager.java, openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchAggregationManager.java, openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DomainIsolationIT.java, openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainIncidentIsolation.spec.ts
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResolutionStatusResource.java | Resolves the authenticated caller context and forwards it through both Incident Manager listing branches. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesRepository.java | Adds subject-aware overloads for offset listings and latest-record aggregations while retaining unfiltered compatibility overloads. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchAggregationManager.java | Applies caller RBAC predicates to aggregation queries, with a non-blocking repository-style violation in the new helper. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchAggregationManager.java | Mirrors the Elasticsearch RBAC aggregation behavior and its helper-structure concern. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DomainIsolationIT.java | Verifies both incident listing modes but omits required final declarations from added Java locals and parameters. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainIncidentIsolation.spec.ts | Adds end-to-end domain-isolation coverage, but introduces raw endpoint and selector magic strings. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Incident Manager
  participant Resource as Resolution Status Resource
  participant Repo as Time-Series Repository
  participant Search as Search Repository
  participant Engine as Elasticsearch/OpenSearch
  UI->>Resource: List incidents (latest true/false)
  Resource->>Resource: Authorize request and resolve SubjectContext
  alt "latest=true"
    Resource->>Repo: listLatestFromSearch(..., subject)
    Repo->>Search: aggregate(..., subject)
  else "latest=false"
    Resource->>Repo: listFromSearchWithOffset(..., subject)
    Repo->>Search: listWithOffset(..., subject)
  end
  Search->>Engine: Query with caller RBAC predicate
  Engine-->>UI: Policy-filtered incident rows
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fixes 31740: Enforce caller policies on ..."](https://github.com/open-metadata/openmetadata/commit/3a6cbe04f4a82d7eb8d99b82ce00e55b20ac9910) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56606363)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))

<!-- /greptile_comment -->