### PR TITLE
fix(ui): prevent null page slots in persona UI customization

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/CustomizablePage/CustomizablePage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/CustomizablePage/CustomizablePage.tsx
@@ -47,6 +47,7 @@ import {
 } from '../../rest/DocStoreAPI';
 import { getPersonaByName } from '../../rest/PersonaAPI';
 import { docStoreQueryKey } from '../../rest/queries/docStoreQuery';
+import { getUpdatedPagesForCustomization } from '../../utils/CustomizableLandingPagePureUtils';
 import { Transi18next } from '../../utils/i18next/LocalUtil';
 import { getSettingPath } from '../../utils/RouterUtils';
 import { showErrorToast, showSuccessToast } from '../../utils/ToastUtils';
@@ -83,7 +84,7 @@ const CustomizablePageContent = () => {
   const queryClient = useQueryClient();
   const [isLoading, setIsLoading] = useState(true);
   const [personaDetails, setPersonaDetails] = useState<Persona>();
-  const { document, setDocument, currentPage, getPage, setCurrentPageType } =
+  const { document, setDocument, currentPage, setCurrentPageType } =
     useCustomizeStore();
 
   const backgroundColor = useMemo(
@@ -102,20 +103,12 @@ const CustomizablePageContent = () => {
     try {
       let response: Document;
       const newDoc = cloneDeep(document);
-      const pageData = getPage(pageFqn);
 
-      if (pageData) {
-        newDoc.data.pages = newPage
-          ? newDoc.data?.pages?.map((p: Page) =>
-              p.pageType === pageFqn ? newPage : p
-            )
-          : newDoc.data?.pages.filter((p: Page) => p.pageType !== pageFqn);
-      } else {
-        newDoc.data = {
-          ...newDoc.data,
-          pages: [...(newDoc.data.pages ?? []), newPage],
-        };
-      }
+      newDoc.data.pages = getUpdatedPagesForCustomization(
+        newDoc.data?.pages,
+        pageFqn,
+        newPage
+      );
 
       if (document.id) {
         const jsonPatch = compare(document, newDoc);

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataMarketplacePage/DataMarketplacePage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataMarketplacePage/DataMarketplacePage.component.tsx
@@ -121,9 +121,9 @@ const DataMarketplacePage = ({
       return defaultLayout;
     }
 
-    const pageData = docData.data?.pages?.find(
-      (p: Page) => p.pageType === PageType.DataMarketplace
-    );
+    const pageData = docData.data?.pages
+      ?.filter(Boolean)
+      .find((p: Page) => p?.pageType === PageType.DataMarketplace);
 
     const tabLayout = getLayoutFromCustomizedPage(
       PageType.DataMarketplace,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.component.tsx
@@ -114,9 +114,12 @@ const MyDataPage = () => {
     if (!docData || !selectedPersona) {
       return getDefaultLandingPageLayout();
     }
-    const pageData = docData.data?.pages?.find(
-      (p: Page) => p.pageType === PageType.LandingPage
-    ) ?? { layout: [], pageType: PageType.LandingPage };
+    const pageData = docData.data?.pages
+      ?.filter(Boolean)
+      .find((p: Page) => p?.pageType === PageType.LandingPage) ?? {
+      layout: [],
+      pageType: PageType.LandingPage,
+    };
     const filteredLayout = (pageData.layout as WidgetConfig[])
       .filter(
         (widget: WidgetConfig) =>

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomizableLandingPagePureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomizableLandingPagePureUtils.ts
@@ -20,6 +20,7 @@ import {
 } from '../constants/CustomizeMyDataPage.constants';
 import { LandingPageWidgetKeys } from '../enums/CustomizablePage.enum';
 import type { Document } from '../generated/entity/docStore/document';
+import type { Page } from '../generated/system/ui/page';
 import type { WidgetConfig } from '../pages/CustomizablePage/CustomizablePage.interface';
 import i18n from './i18next/LocalUtil';
 
@@ -453,4 +454,29 @@ export const getUniqueFilteredLayout = (layout: WidgetConfig[]) => {
     ),
     'i'
   );
+};
+
+/**
+ * Computes the updated `pages` array for a persona customization document.
+ * A missing `newPage` means "reset" — the page is removed if present and,
+ * crucially, no empty slot is appended for a page that was never customized.
+ * Appending an absent value here is how a `null` element used to leak into the
+ * persisted array (an undefined slot serializes to `null` on create). Existing
+ * null/undefined slots from legacy data are also dropped.
+ */
+export const getUpdatedPagesForCustomization = (
+  existingPages: Page[] | undefined,
+  pageType: string,
+  newPage?: Page
+): Page[] => {
+  const pages = (existingPages ?? []).filter(Boolean);
+  const isPagePresent = pages.some((page) => page?.pageType === pageType);
+
+  if (!newPage) {
+    return pages.filter((page) => page?.pageType !== pageType);
+  }
+
+  return isPagePresent
+    ? pages.map((page) => (page?.pageType === pageType ? newPage : page))
+    : [...pages, newPage];
 };

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomizableLandingPageUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomizableLandingPageUtils.test.tsx
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 import { act, render, screen } from '@testing-library/react';
+import { Page, PageType } from '../generated/system/ui/page';
 import { mockWidget } from '../mocks/AddWidgetTabContent.mock';
 import { mockCurrentAddWidget } from '../mocks/CustomizablePage.mock';
 import {
@@ -21,6 +22,7 @@ import {
   getNewWidgetPlacement,
   getRemoveWidgetHandler,
   getUniqueFilteredLayout,
+  getUpdatedPagesForCustomization,
   getWidgetWidthLabelFromKey,
 } from './CustomizableLandingPagePureUtils';
 import { getWidgetFromKey } from './CustomizableLandingPageUtils';
@@ -348,5 +350,87 @@ describe('CustomizableLandingPageUtils', () => {
       expect(result).toHaveLength(2);
       expect(result[1].i).toBe('ExtraWidget.EmptyWidgetPlaceholder');
     });
+  });
+});
+
+describe('getUpdatedPagesForCustomization', () => {
+  const landingPage = { pageType: PageType.LandingPage } as Page;
+  const tablePage = { pageType: PageType.Table } as Page;
+  const glossaryPage = { pageType: PageType.Glossary } as Page;
+
+  it('should not append an empty slot when resetting a page that is not customized', () => {
+    const result = getUpdatedPagesForCustomization(
+      [landingPage, tablePage, glossaryPage],
+      PageType.DataMarketplace,
+      undefined
+    );
+
+    expect(result).toEqual([landingPage, tablePage, glossaryPage]);
+    expect(result).not.toContain(undefined);
+    expect(result).not.toContain(null);
+  });
+
+  it('should remove the page when resetting a customized page', () => {
+    const result = getUpdatedPagesForCustomization(
+      [landingPage, tablePage, glossaryPage],
+      PageType.Table,
+      undefined
+    );
+
+    expect(result).toEqual([landingPage, glossaryPage]);
+  });
+
+  it('should append the new page when customizing a page that is not present', () => {
+    const dataMarketplacePage = {
+      pageType: PageType.DataMarketplace,
+    } as Page;
+
+    const result = getUpdatedPagesForCustomization(
+      [landingPage, tablePage, glossaryPage],
+      PageType.DataMarketplace,
+      dataMarketplacePage
+    );
+
+    expect(result).toEqual([
+      landingPage,
+      tablePage,
+      glossaryPage,
+      dataMarketplacePage,
+    ]);
+  });
+
+  it('should replace the existing page when updating a customized page', () => {
+    const updatedTablePage = {
+      pageType: PageType.Table,
+      tabs: [],
+    } as unknown as Page;
+
+    const result = getUpdatedPagesForCustomization(
+      [landingPage, tablePage, glossaryPage],
+      PageType.Table,
+      updatedTablePage
+    );
+
+    expect(result).toEqual([landingPage, updatedTablePage, glossaryPage]);
+  });
+
+  it('should strip pre-existing null slots from legacy pages data', () => {
+    const result = getUpdatedPagesForCustomization(
+      [landingPage, null as unknown as Page, tablePage],
+      PageType.Glossary,
+      glossaryPage
+    );
+
+    expect(result).toEqual([landingPage, tablePage, glossaryPage]);
+  });
+
+  it('should handle an undefined pages array', () => {
+    const result = getUpdatedPagesForCustomization(
+      undefined,
+      PageType.Table,
+      undefined
+    );
+
+    expect(result).toEqual([]);
   });
 });


### PR DESCRIPTION
## Problem

A persona UI-customization document (docStore, `entityType: Page`, FQN `persona.<name>`) can end up with a **`null` element inside `data.pages`**. Any page consumer that iterates `data.pages` and reads `.pageType` without a null guard then throws `Cannot read properties of null (reading 'pageType')` and the page fails to render. This surfaced on a 2.0 instance via the new **Data Marketplace** page, whose customization doc held `[LandingPage, Table, Glossary, null]` (null at index 3).

## Root cause

Three interacting pieces — verified by reproducing the exact `[…, null]` state end-to-end:

1. **The seed.** `handlePageCustomizeSave` had an else-branch that appended `newPage` unconditionally. On **reset** (`newPage === undefined`) of a page that isn't customized yet, it appended an absent value. On the **create** path this serializes (`JSON.stringify`) to a persisted `null`. (On the update/PATCH path the same append is a silent no-op, which is why a "reset" theory looked wrong until the create path was considered.)

2. **A hidden divergence.** `CustomizeStore.setDocument` strips nulls from the in-memory copy (`pages.filter(Boolean)`), so the client's baseline no longer matches the server's real array.

3. **Index drift.** Saves send an index-based JSON Patch (`add /data/pages/N`) computed against that null-stripped baseline, but the server applies it to the true array that still contains the null. Because the client baseline is one element shorter, each `add` inserts before the null and pushes it one slot right — after LandingPage/Table/Glossary are added, the null lands at index 3.

This is **not** a migration bug — no backend/SQL migration touches `data.pages`; `data` is stored as an opaque blob. The 2.0 upgrade only shipped the first *reader* (Data Marketplace) that doesn't tolerate the pre-existing null.

## Fix (focused)

- Extract the pages-array update into a pure, tested helper `getUpdatedPagesForCustomization`, which **never appends an absent page** (reset becomes a no-op or a removal) and drops any legacy null/undefined slots. This closes the seed.
- Guard the raw-document readers in `DataMarketplacePage` and `MyDataPage` with `filter(Boolean)` so documents that *already* contain a null no longer crash.

## Tests

Adds regression tests in `CustomizableLandingPageUtils.test.tsx` covering reset-on-uncustomized-page (the seed), reset-on-customized-page (removal), add, replace, legacy-null stripping, and undefined input.

## Notes / follow-up

- This stops **new** nulls and stops **crashes** on existing ones. Instances that already hold a null in a persona doc still carry it harmlessly (readers now tolerate it) until cleaned; a one-off data sweep (or a store-level self-heal that stops `setDocument` stripping the baseline) can be done separately.
- Should be cherry-picked to the 2.0 release branch.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents reset operations from creating null persona-page entries and adds null-safe reads for the landing and Data Marketplace pages.

- Extracts page-array add, replace, removal, and legacy-null filtering into a tested pure helper.
- Adds null guards to two raw customization-document consumers.
- Adds regression coverage for page update and reset behavior.
- The patch baseline remains normalized differently from persisted legacy documents, so subsequent saves can still target incorrect array indices.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until saves of legacy persona documents use a patch baseline aligned with the persisted array or otherwise replace the pages array atomically.

Existing persona documents containing null slots are normalized only in client state, so index-based patches generated by the changed save path can still update or remove the wrong persisted page.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/src/pages/CustomizablePage/CustomizablePage.tsx; openmetadata-ui/src/main/resources/ui/src/utils/CustomizableLandingPagePureUtils.ts
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/pages/CustomizablePage/CustomizablePage.tsx | Delegates page updates to the new helper, but continues generating patches from a client baseline that can differ from persisted legacy data. |
| openmetadata-ui/src/main/resources/ui/src/utils/CustomizableLandingPagePureUtils.ts | Correctly prevents absent-page appends and normalizes the supplied array, although it cannot repair the separate patch-baseline divergence. |
| openmetadata-ui/src/main/resources/ui/src/pages/DataMarketplacePage/DataMarketplacePage.component.tsx | Safely ignores null page entries before selecting the Data Marketplace customization. |
| openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.component.tsx | Safely ignores null page entries before selecting the landing-page customization. |
| openmetadata-ui/src/main/resources/ui/src/utils/CustomizableLandingPageUtils.test.tsx | Covers the pure helper’s reset, removal, addition, replacement, null filtering, and undefined-input behavior, but not patching against a divergent persisted baseline. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant API as DocStore API
  participant Store as CustomizeStore
  participant Save as CustomizablePage
  API->>Store: Persisted pages [A, null, B]
  Store->>Store: filter(Boolean) → [A, B]
  Save->>Save: Update normalized pages
  Save->>Save: compare([A, B], updated)
  Save->>API: Index-based JSON Patch
  API->>API: Apply patch to [A, null, B]
  Note over API: Patch index can target a different slot
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): prevent null page slots in pers..."](https://github.com/open-metadata/openmetadata/commit/3bc3a7f185f774fc9be81f0bbcffc5c2b3b6f8ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56615435)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Metadata web application](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/metadata-web-application.md)

<!-- /greptile_comment -->