### PR TITLE
Fixes #29940: render the tab that is on screen when the URL has no tab segment (#31448) (1.13 backport)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.interface.ts
@@ -13,6 +13,7 @@
 import { CustomizeEntityType } from '../../../constants/Customize.constants';
 import { OperationPermission } from '../../../context/PermissionProvider/PermissionProvider.interface';
 import { DataAssetRuleValidation } from '../../../context/RuleEnforcementProvider/RuleEnforcementProvider.interface';
+import { EntityTabs } from '../../../enums/entity.enum';
 import { ThreadType } from '../../../generated/entity/feed/thread';
 import { EntityReference } from '../../../generated/entity/type';
 import { Page } from '../../../generated/system/ui/page';
@@ -33,6 +34,10 @@ export interface GenericProviderProps<T extends Omit<EntityReference, 'type'>> {
   customizedPage?: Page | null;
   muiTags?: boolean;
   columnFqn?: string;
+  // The tab the page is actually rendering. Pages whose landing URL carries no `:tab`
+  // segment, and the domain tree view (which never writes the tab to the URL at all),
+  // must pass this so the widget layout matches the tab on screen.
+  activeTab?: EntityTabs;
 }
 
 export interface GenericContextType<T extends Omit<EntityReference, 'type'>> {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.tsx
@@ -71,6 +71,7 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
   customizedPage,
   muiTags = false,
   columnFqn,
+  activeTab,
 }: GenericProviderProps<T>) => {
   const GenericContext = createGenericContext<T>();
   const [threadLink, setThreadLink] = useState<string>('');
@@ -82,10 +83,19 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
   const location = useLocation();
   const navigate = useNavigate();
   const pageType = useMemo(() => ENTITY_PAGE_TYPE_MAP[type], [type]);
-  const { tab } = useRequiredParams<{ tab: EntityTabs }>();
+  const { tab: routeTab } = useRequiredParams<{ tab: EntityTabs }>();
+  // `routeTab` is undefined on an entity's landing URL (no `:tab` segment) and always
+  // undefined in the domain tree view, so it cannot be the sole source of truth for the
+  // layout -- falling back to the first customized tab renders another tab's widgets.
+  const currentTab = activeTab ?? routeTab;
   const expandedLayout = useRef<WidgetConfig[]>([]);
   const [layout, setLayout] = useState<WidgetConfig[]>(
-    getLayoutFromCustomizedPage(pageType, tab, customizedPage, isVersionView)
+    getLayoutFromCustomizedPage(
+      pageType,
+      currentTab,
+      customizedPage,
+      isVersionView
+    )
   );
   const [filteredKeys, setFilteredKeys] = useState<string[]>([]);
   const [activeTagDropdownKey, setActiveTagDropdownKey] = useState<
@@ -177,9 +187,14 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
 
   useEffect(() => {
     setLayout(
-      getLayoutFromCustomizedPage(pageType, tab, customizedPage, isVersionView)
+      getLayoutFromCustomizedPage(
+        pageType,
+        currentTab,
+        customizedPage,
+        isVersionView
+      )
     );
-  }, [customizedPage, tab, pageType, isVersionView]);
+  }, [customizedPage, currentTab, pageType, isVersionView]);
 
   const onThreadPanelClose = useCallback(() => {
     setThreadLink('');
@@ -239,7 +254,7 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
 
       // Update URL to include column FQN if the column has a fullyQualifiedName
       if (columnFqn && data.fullyQualifiedName) {
-        const newPath = getEntityDetailsPath(type, columnFqn, tab);
+        const newPath = getEntityDetailsPath(type, columnFqn, routeTab);
 
         // Only navigate if the path is different from current path to avoid loops
         if (location.pathname !== newPath) {
@@ -250,7 +265,7 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
     [
       data?.fullyQualifiedName,
       type,
-      tab,
+      routeTab,
       navigate,
       location.pathname,
       selectedColumn?.fullyQualifiedName,
@@ -262,7 +277,11 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
 
     // Update URL to remove column FQN
     if (data?.fullyQualifiedName) {
-      const newPath = getEntityDetailsPath(type, data.fullyQualifiedName, tab);
+      const newPath = getEntityDetailsPath(
+        type,
+        data.fullyQualifiedName,
+        routeTab
+      );
       navigate(newPath, { replace: true });
     } else if (location.hash) {
       // Fallback: just remove hash if no FQN available
@@ -271,7 +290,7 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
         { replace: true }
       );
     }
-  }, [data?.fullyQualifiedName, type, tab, location, navigate]);
+  }, [data?.fullyQualifiedName, type, routeTab, location, navigate]);
 
   // Wrapper for onColumnFieldUpdate that updates
   const handleColumnFieldUpdate = useCallback(
@@ -397,7 +416,7 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
   useEffect(() => {
     // on unmount remove filterKeys
     return () => setFilteredKeys([]);
-  }, [tab]);
+  }, [currentTab]);
 
   const values = useMemo(
     () => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProviderLayout.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProviderLayout.test.tsx
@@ -1,0 +1,133 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { CustomizeEntityType } from '../../../constants/Customize.constants';
+import { EntityTabs, EntityType } from '../../../enums/entity.enum';
+import { Page, PageType } from '../../../generated/system/ui/page';
+import { DEFAULT_ENTITY_PERMISSION } from '../../../utils/PermissionsUtils';
+import { useGenericContext } from './GenericContext';
+import { GenericProvider } from './GenericProvider';
+
+jest.mock('../../../rest/feedsAPI');
+
+jest.mock('../../../hooks/useEntityRules', () => ({
+  useEntityRules: jest.fn().mockImplementation(() => ({ entityRules: {} })),
+}));
+
+jest.mock('../../../hooks/useChangeSummary', () => ({
+  useChangeSummary: jest.fn().mockImplementation(() => ({ changeSummary: {} })),
+}));
+
+jest.mock(
+  '../../ActivityFeed/ActivityFeedProvider/ActivityFeedProvider',
+  () => ({
+    useActivityFeedProvider: () => ({
+      postFeed: jest.fn(),
+      deleteFeed: jest.fn(),
+      updateFeed: jest.fn(),
+    }),
+  })
+);
+
+jest.mock('../../ActivityFeed/ActivityThreadPanel/ActivityThreadPanel', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => <div>ActivityThreadPanel</div>),
+}));
+
+const DOCUMENTATION_WIDGETS = [
+  { i: 'KnowledgePanel.LeftPanel', h: 8, w: 6, x: 0, y: 0 },
+  { i: 'KnowledgePanel.Owners', h: 1, w: 2, x: 6, y: 0 },
+];
+
+// A persona customization that reorders the Domain page so Documentation is no longer
+// the first tab -- the configuration reported in issue #29940.
+const REORDERED_DOMAIN_PAGE = {
+  pageType: PageType.Domain,
+  tabs: [
+    { id: EntityTabs.SUBDOMAINS, layout: [] },
+    { id: EntityTabs.ASSETS, layout: [] },
+    { id: EntityTabs.DOCUMENTATION, layout: DOCUMENTATION_WIDGETS },
+  ],
+} as unknown as Page;
+
+const LayoutProbe = () => {
+  const { layout } = useGenericContext();
+
+  return (
+    <div data-testid="layout-keys">
+      {(layout ?? []).map((widget) => widget.i).join(',')}
+    </div>
+  );
+};
+
+const renderAt = (
+  path: string,
+  routePath: string,
+  props: Record<string, unknown> = {}
+) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          element={
+            <GenericProvider
+              customizedPage={REORDERED_DOMAIN_PAGE}
+              data={{ id: '123', name: 'domain' }}
+              permissions={DEFAULT_ENTITY_PERMISSION}
+              type={EntityType.DOMAIN as CustomizeEntityType}
+              onUpdate={jest.fn()}
+              {...props}>
+              <LayoutProbe />
+            </GenericProvider>
+          }
+          path={routePath}
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+
+describe('GenericProvider layout resolution', () => {
+  it('resolves the layout from the URL tab when one is present', () => {
+    renderAt('/domain/finance/documentation', '/domain/:fqn/:tab');
+
+    expect(screen.getByTestId('layout-keys')).toHaveTextContent(
+      DOCUMENTATION_WIDGETS.map((widget) => widget.i).join(',')
+    );
+  });
+
+  it('resolves the layout from the activeTab prop when the URL has no tab', () => {
+    renderAt('/domain/finance', '/domain/:fqn', {
+      activeTab: EntityTabs.DOCUMENTATION,
+    });
+
+    expect(screen.getByTestId('layout-keys')).toHaveTextContent(
+      DOCUMENTATION_WIDGETS.map((widget) => widget.i).join(',')
+    );
+  });
+
+  it('prefers the activeTab prop over the URL tab so an inline tab switch wins', () => {
+    // The domain tree view keeps the tab in local state and never writes it to the URL.
+    renderAt('/domain/finance/documentation', '/domain/:fqn/:tab', {
+      activeTab: EntityTabs.SUBDOMAINS,
+    });
+
+    expect(screen.getByTestId('layout-keys')).toHaveTextContent('');
+  });
+
+  it('falls back to the first customized tab when neither is supplied', () => {
+    renderAt('/domain/finance', '/domain/:fqn');
+
+    expect(screen.getByTestId('layout-keys')).toHaveTextContent('');
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
@@ -73,6 +73,7 @@ import { getFeedCounts } from '../../../utils/CommonUtils';
 import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
+  getRenderedActiveTab,
   getTabLabelMapFromTabs,
 } from '../../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import { getDataContractStatusIcon } from '../../../utils/DataContract/DataContractUtils';
@@ -109,7 +110,6 @@ import Loader from '../../common/Loader/Loader';
 import { ManageButtonItemLabel } from '../../common/ManageButtonContentItem/ManageButtonContentItem.component';
 import { GenericProvider } from '../../Customization/GenericProvider/GenericProvider';
 import { AssetSelectionDrawer } from '../../DataAssets/AssetsSelectionModal/AssetSelectionDrawer';
-import { DomainTabs } from '../../Domain/DomainPage.interface';
 import { EntityHeader } from '../../Entity/EntityHeader/EntityHeader.component';
 import { EntityStatusBadge } from '../../Entity/EntityStatusBadge/EntityStatusBadge.component';
 import Voting from '../../Entity/Voting/Voting.component';
@@ -701,6 +701,14 @@ const DataProductsDetailsPage = ({
     outputPortsCount,
   ]);
 
+  // `/dataProduct/:fqn` has no tab segment; resolve to the first rendered tab when the
+  // URL tab is absent/not rendered so we never land on a non-existent pane.
+  const currentTab = getRenderedActiveTab(
+    tabs,
+    activeTab as EntityTabs | undefined,
+    EntityTabs.DOCUMENTATION
+  );
+
   const iconData = useMemo(() => {
     return (
       <Avatar
@@ -919,6 +927,7 @@ const DataProductsDetailsPage = ({
 
         <GenericProvider<DataProduct>
           muiTags
+          activeTab={currentTab}
           currentVersionData={dataProduct}
           customizedPage={customizedPage}
           data={dataProduct}
@@ -931,7 +940,7 @@ const DataProductsDetailsPage = ({
             <div className="tw:p-5">
               <Tabs
                 destroyInactiveTabPane
-                activeKey={activeTab ?? DomainTabs.DOCUMENTATION}
+                activeKey={currentTab}
                 className="tabs-new"
                 data-testid="tabs"
                 items={tabs}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx
@@ -72,6 +72,7 @@ import { createEntityWithCoverImage } from '../../../utils/CoverImageUploadUtils
 import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
+  getRenderedActiveTab,
   getTabLabelMapFromTabs,
 } from '../../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import domainClassBase from '../../../utils/Domain/DomainClassBase';
@@ -172,10 +173,6 @@ const DomainDetails = ({
       (routeParams.fqn ? getDecodedFqn(routeParams.fqn) : ''),
     [domainFqnOverride, domain.fullyQualifiedName, routeParams.fqn]
   );
-  const activeTab = useMemo(
-    () => activeTabOverride ?? routeParams.tab ?? EntityTabs.DOCUMENTATION,
-    [activeTabOverride, routeParams.tab]
-  ) as EntityTabs;
   const { version } = routeParams;
   const { currentUser } = useApplicationStore();
 
@@ -212,6 +209,10 @@ const DomainDetails = ({
   );
   const urlEncodedFqn = getEncodedFqn(domain.fullyQualifiedName ?? '');
   const { customizedPage, isLoading } = useCustomPages(PageType.Domain);
+  // Explicit selection (tree-view override or URL); undefined on the landing URL.
+  const selectedTab = (activeTabOverride ?? routeParams.tab) as
+    | EntityTabs
+    | undefined;
   const [isTabExpanded, setIsTabExpanded] = useState(false);
   const isSubDomain = useMemo(() => !isEmpty(domain.parent), [domain]);
 
@@ -809,7 +810,7 @@ const DomainDetails = ({
       subDomainsCount,
       dataProductsCount,
       assetCount,
-      activeTab,
+      activeTab: selectedTab,
       onAddDataProduct,
       queryFilter,
       assetTabRef,
@@ -844,7 +845,7 @@ const DomainDetails = ({
     handleAssetClick,
     assetCount,
     dataProductsCount,
-    activeTab,
+    selectedTab,
     subDomainsCount,
     queryFilter,
     customizedPage?.tabs,
@@ -853,6 +854,13 @@ const DomainDetails = ({
     fetchDomainAssets,
     handleTabChange,
   ]);
+
+  // Resolve to the first rendered tab when the selection is absent/not rendered.
+  const activeTab = getRenderedActiveTab(
+    tabs,
+    selectedTab,
+    EntityTabs.DOCUMENTATION
+  );
 
   useEffect(() => {
     fetchDomainPermission();
@@ -1035,6 +1043,7 @@ const DomainDetails = ({
 
         <GenericProvider<Domain>
           muiTags
+          activeTab={activeTab}
           customizedPage={customizedPage}
           data={domain}
           isTabExpanded={isTabExpanded}

--- a/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.tsx
@@ -84,9 +84,8 @@ const DomainTreeView = ({
   const [hierarchy, setHierarchy] = useState<Domain[]>([]);
   const [expandedItems, setExpandedItems] = useState<string[]>([]);
   const [selectedFqn, setSelectedFqn] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<EntityTabs>(
-    EntityTabs.DOCUMENTATION
-  );
+  // Undefined = no explicit tab; DomainDetails resolves it to the persona's first tab.
+  const [activeTab, setActiveTab] = useState<EntityTabs | undefined>(undefined);
   const [selectedDomain, setSelectedDomain] = useState<Domain | null>(null);
   const [isHierarchyLoading, setIsHierarchyLoading] = useState<boolean>(false);
   const [isDomainLoading, setIsDomainLoading] = useState<boolean>(false);
@@ -485,7 +484,8 @@ const DomainTreeView = ({
 
   useEffect(() => {
     if (selectedFqn) {
-      setActiveTab(EntityTabs.DOCUMENTATION);
+      // Reset so the newly selected domain lands on its first rendered tab.
+      setActiveTab(undefined);
     }
   }, [selectedFqn]);
 
@@ -734,7 +734,8 @@ const DomainTreeView = ({
         if (requestedTab && Object.values(EntityTabs).includes(requestedTab)) {
           setActiveTab(requestedTab);
         } else {
-          setActiveTab(EntityTabs.DOCUMENTATION);
+          // No tab in the URL -- let DomainDetails resolve the first rendered tab.
+          setActiveTab(undefined);
         }
 
         updateExpansionForFqn(decodedFqn);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/CustomizePageEntityTabUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/CustomizePageEntityTabUtils.test.ts
@@ -1,0 +1,85 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { EntityTabs } from '../../enums/entity.enum';
+import { getRenderedActiveTab } from './CustomizePageEntityTabUtils';
+
+// Reproduces the persona from issue #29940 that reorders Documentation off the first
+// position (and can drop it entirely), so the resolved tab must come from the rendered
+// list and never a hardcoded default that is not on screen.
+const renderedTabs = [
+  { key: EntityTabs.SUBDOMAINS, label: 'Sub Domains' },
+  { key: EntityTabs.DATA_PRODUCTS, label: 'Data Products' },
+  { key: EntityTabs.DOCUMENTATION, label: 'Documentation' },
+  { key: EntityTabs.CUSTOM_PROPERTIES, label: 'Custom Properties' },
+];
+
+describe('getRenderedActiveTab', () => {
+  it('should return the selected tab when it is in the rendered list', () => {
+    expect(
+      getRenderedActiveTab(
+        renderedTabs,
+        EntityTabs.DATA_PRODUCTS,
+        EntityTabs.DOCUMENTATION
+      )
+    ).toBe(EntityTabs.DATA_PRODUCTS);
+  });
+
+  it('should fall back to the first rendered tab when no tab is selected', () => {
+    expect(
+      getRenderedActiveTab(renderedTabs, undefined, EntityTabs.DOCUMENTATION)
+    ).toBe(EntityTabs.SUBDOMAINS);
+  });
+
+  it('should fall back to the first rendered tab when the selection is not rendered', () => {
+    // e.g. the tree view seeds a hardcoded Documentation, or a URL deep-links a tab the
+    // persona removed -- neither is on screen, so the first rendered tab wins.
+    const withoutDocumentation = renderedTabs.filter(
+      (tab) => tab.key !== EntityTabs.DOCUMENTATION
+    );
+
+    expect(
+      getRenderedActiveTab(
+        withoutDocumentation,
+        EntityTabs.DOCUMENTATION,
+        EntityTabs.DOCUMENTATION
+      )
+    ).toBe(EntityTabs.SUBDOMAINS);
+  });
+
+  it('should honour the persona order for the first tab when no tab is selected', () => {
+    const reordered = [
+      { key: EntityTabs.CUSTOM_PROPERTIES, label: 'Custom Properties' },
+      { key: EntityTabs.DOCUMENTATION, label: 'Documentation' },
+    ];
+
+    expect(
+      getRenderedActiveTab(reordered, undefined, EntityTabs.DOCUMENTATION)
+    ).toBe(EntityTabs.CUSTOM_PROPERTIES);
+  });
+
+  it('should return the provided default when the rendered list is empty', () => {
+    expect(getRenderedActiveTab([], undefined, EntityTabs.DOCUMENTATION)).toBe(
+      EntityTabs.DOCUMENTATION
+    );
+  });
+
+  it('should return the provided default when the rendered list is undefined', () => {
+    expect(
+      getRenderedActiveTab(undefined, undefined, EntityTabs.DOCUMENTATION)
+    ).toBe(EntityTabs.DOCUMENTATION);
+  });
+
+  it('should default to the Overview tab when no default is supplied', () => {
+    expect(getRenderedActiveTab([])).toBe(EntityTabs.OVERVIEW);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/CustomizePageEntityTabUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/CustomizePageEntityTabUtils.ts
@@ -69,6 +69,17 @@ export const getDetailsTabWithNewLabel = (
   return newTabs.filter((data) => !data.isHidden);
 };
 
+// Resolve the tab actually on screen: the selected tab only when it is in the rendered
+// list, else the first rendered tab (persona order, hidden dropped), else the default.
+export const getRenderedActiveTab = (
+  tabs: TabsProps['items'],
+  selectedTab?: EntityTabs,
+  defaultTab: EntityTabs = EntityTabs.OVERVIEW
+): EntityTabs =>
+  ((selectedTab && tabs?.some((tab) => tab.key === selectedTab)
+    ? selectedTab
+    : tabs?.[0]?.key) ?? defaultTab) as EntityTabs;
+
 export const getTabLabelMapFromTabs = (
   tabs?: Tab[]
 ): Record<EntityTabs, string> => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Domain/DomainClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Domain/DomainClassBase.ts
@@ -42,7 +42,8 @@ export interface DomainDetailPageTabProps {
   subDomainsCount: number;
   dataProductsCount: number;
   assetCount: number;
-  activeTab: EntityTabs;
+  // Undefined when no tab is explicitly selected (landing URL / tree view).
+  activeTab?: EntityTabs;
   onAddDataProduct: () => void;
   onAddSubDomain: (subDomain: CreateDomain) => Promise<void>;
   onDeleteSubDomain: () => void;


### PR DESCRIPTION
Backport of #31448 to the 1.13 release branch.

Cherry-picked `60978fc3e3b9ba62d1414ab49aeae229a156410c`.

## Conflicts resolved
Two conflicts in `GenericProvider<...>` usage — 1.13 still uses the `muiTags` prop where main was renamed to `newTagsUI`. Kept 1.13's `muiTags` and added the new `activeTab` prop from the fix:
- `DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx` → `activeTab={currentTab}`
- `Domain/DomainDetails/DomainDetails.component.tsx` → `activeTab={activeTab}`

## Original description
`GenericProvider` read the active tab only from the `:tab` route param and, when absent, fell back to the first tab of the persona-customized page. Entity landing URLs carry no tab segment and the domain tree view keeps the tab in local state, so the provider resolved a different tab than the page rendered — causing a blank pane under persona tab reordering. Fix gives `GenericProvider` an explicit `activeTab` prop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR aligns customized widget layouts with the tab actually rendered when a domain or data-product URL lacks a tab segment.
- Adds an explicit active-tab input to GenericProvider while retaining route-derived tabs for URL construction.
- Resolves absent or unavailable selections to the first rendered persona tab.
- Updates domain tree selection state and adds focused layout and tab-resolution tests.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with tab selection and customized layout resolution consistently aligned on the changed landing and tree-view paths.

The resolved rendered tab now drives both the visible pane and GenericProvider layout, while tab builders construct their content independently of the previously hardcoded default.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.tsx | Uses the explicit rendered tab for layout synchronization while preserving the route tab for entity-detail URL generation. |
| openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx | Separates explicit tab selection from rendered-tab resolution and passes the resolved tab consistently to Tabs and GenericProvider. |
| openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx | Resolves landing and unavailable route tabs against the rendered persona tab list before rendering the pane and layout. |
| openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.tsx | Represents the absence of an explicit tree-view tab as undefined so DomainDetails can honor persona ordering. |
| openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/CustomizePageEntityTabUtils.ts | Adds a focused helper that selects a valid requested tab, the first rendered tab, or a supplied default. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Route[Route tab] --> Resolve{Selected tab exists in rendered tabs?}
  Local[Tree-view active tab] --> Resolve
  Tabs[Persona-ordered rendered tabs] --> Resolve
  Resolve -->|Yes| Selected[Use selected tab]
  Resolve -->|No| First[Use first rendered tab]
  Selected --> Page[Render tab pane]
  First --> Page
  Selected --> Provider[Resolve customized widget layout]
  First --> Provider
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fixes #29940: render the tab that is on ..."](https://github.com/open-metadata/openmetadata/commit/19a745d69e2dc0143144c3cc793eac551c4db58d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56628052)</sub>

<!-- /greptile_comment -->