### PR TITLE
Fixes #31980: handle null persona customization pages (#31981) [2.0 backport]

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useCustomPages.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useCustomPages.test.ts
@@ -162,6 +162,35 @@ describe('useCustomPages', () => {
     expect(result.current.customizedPage?.pageType).toBe(PageType.Dashboard);
   });
 
+  it('should remove null pages before caching a legacy persona document', async () => {
+    const legacyDocument = {
+      ...mockDocument,
+      data: {
+        ...mockDocument.data,
+        pages: [null, mockPage],
+      },
+    } as Document;
+    mockGetDocumentByFQN.mockResolvedValue(legacyDocument);
+
+    const { result } = renderHook(() => useCustomPages(PageType.Table), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.customizedPage).toEqual(mockPage);
+    });
+
+    expect(
+      queryClient.getQueryData(['docStore', 'persona.test-persona'])
+    ).toEqual({
+      ...legacyDocument,
+      data: {
+        ...legacyDocument.data,
+        pages: [mockPage],
+      },
+    });
+  });
+
   it('should return updated results when selected persona changes', async () => {
     mockGetDocumentByFQN.mockResolvedValueOnce(mockDocument);
 

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useCustomPages.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useCustomPages.ts
@@ -12,7 +12,7 @@
  */
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
-import { Page, PageType } from '../generated/system/ui/page';
+import { PageType } from '../generated/system/ui/page';
 import { NavigationItem } from '../generated/system/ui/uiCustomization';
 import {
   docStoreQueryFn,
@@ -20,6 +20,7 @@ import {
   personaDocFqn,
   PERSONA_DOC_STALE_TIME,
 } from '../rest/queries/docStoreQuery';
+import { getPersonaPage } from '../utils/CustomizePage/PersonaPage.utils';
 import { useApplicationStore } from './useApplicationStore';
 
 export const useCustomPages = (pageType: PageType | 'Navigation') => {
@@ -45,10 +46,7 @@ export const useCustomPages = (pageType: PageType | 'Navigation') => {
   }, []);
 
   return {
-    customizedPage:
-      (doc?.data?.pages?.find((p: Page | null) => p?.pageType === pageType) as
-        | Page
-        | undefined) ?? null,
+    customizedPage: getPersonaPage(doc, pageType) ?? null,
     // Reset to [] on error to clear stale navigation items, null when no persona selected.
     navigation: isError
       ? ([] as NavigationItem[])

--- a/openmetadata-ui/src/main/resources/ui/src/pages/CustomizablePage/CustomizablePage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/CustomizablePage/CustomizablePage.test.tsx
@@ -12,7 +12,7 @@
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { act } from 'react';
 import { useParams } from 'react-router-dom';
 import { Page, PageType } from '../../generated/system/ui/page';
@@ -23,7 +23,7 @@ import {
   mockShowErrorToast,
   mockShowSuccessToast,
 } from '../../mocks/CustomizablePage.mock';
-import { getDocumentByFQN } from '../../rest/DocStoreAPI';
+import { getDocumentByFQN, updateDocument } from '../../rest/DocStoreAPI';
 import { getPersonaByName } from '../../rest/PersonaAPI';
 import { CustomizablePage } from './CustomizablePage';
 
@@ -40,21 +40,14 @@ jest.mock(
 
 jest.mock(
   '../../components/MyData/CustomizableComponents/CustomizeMyData/CustomizeMyData',
-  () =>
-    jest
-      .fn()
-      .mockImplementation(
-        ({ initialPageData, handleSaveCurrentPageLayout }) => (
-          <div data-testid="customize-my-data">
-            {initialPageData.data.page.layout.map((widget: WidgetConfig) => (
-              <div key={widget.i}>{widget.i}</div>
-            ))}
-            <div onClick={handleSaveCurrentPageLayout}>
-              handleSaveCurrentPageLayout
-            </div>
-          </div>
-        )
-      )
+  () => {
+    return jest.fn().mockImplementation(({ onSaveLayout }) => (
+      <div data-testid="customize-my-data">
+        CustomizeMyData
+        <button onClick={() => onSaveLayout()}>Reset layout</button>
+      </div>
+    ));
+  }
 );
 
 jest.mock('../../components/common/Loader/Loader', () => {
@@ -105,13 +98,6 @@ jest.mock('./CustomizeStore', () => ({
 }));
 
 jest.mock(
-  '../../components/MyData/CustomizableComponents/CustomizeMyData/CustomizeMyData',
-  () => {
-    return jest.fn().mockImplementation(() => <div>CustomizeMyData</div>);
-  }
-);
-
-jest.mock(
   '../../components/MyData/CustomizableComponents/CustomiseGlossaryTermDetailPage/CustomiseGlossaryTermDetailPage',
   () => {
     return jest
@@ -148,6 +134,11 @@ describe('CustomizablePage component', () => {
         },
       },
     });
+    (useParams as jest.Mock).mockReturnValue({
+      fqn: mockPersonaName,
+      pageFqn: PageType.LandingPage,
+    });
+    jest.clearAllMocks();
   });
 
   afterEach(() => {
@@ -198,6 +189,18 @@ describe('CustomizablePage component', () => {
 
     expect(screen.queryByText('CustomizeMyData')).toBeInTheDocument();
     expect(screen.queryByText('ErrorPlaceHolder')).toBeNull();
+  });
+
+  it('does not persist an undefined page when resetting an unsaved layout', async () => {
+    await act(async () => {
+      renderCustomizablePage();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Reset layout' }));
+    });
+
+    expect(updateDocument).not.toHaveBeenCalled();
   });
 
   it('CustomizablePage should return ErrorPlaceHolder for invalid page FQN', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/CustomizablePage/CustomizablePage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/CustomizablePage/CustomizablePage.tsx
@@ -47,6 +47,10 @@ import {
 } from '../../rest/DocStoreAPI';
 import { getPersonaByName } from '../../rest/PersonaAPI';
 import { docStoreQueryKey } from '../../rest/queries/docStoreQuery';
+import {
+  normalizePersonaDocument,
+  updatePersonaDocumentPage,
+} from '../../utils/CustomizePage/PersonaPage.utils';
 import { Transi18next } from '../../utils/i18next/LocalUtil';
 import { getSettingPath } from '../../utils/RouterUtils';
 import { showErrorToast, showSuccessToast } from '../../utils/ToastUtils';
@@ -83,7 +87,7 @@ const CustomizablePageContent = () => {
   const queryClient = useQueryClient();
   const [isLoading, setIsLoading] = useState(true);
   const [personaDetails, setPersonaDetails] = useState<Persona>();
-  const { document, setDocument, currentPage, getPage, setCurrentPageType } =
+  const { document, setDocument, currentPage, setCurrentPageType } =
     useCustomizeStore();
 
   const backgroundColor = useMemo(
@@ -95,27 +99,28 @@ const CustomizablePageContent = () => {
     [document, personaDetails]
   );
 
+  const syncSavedDocument = (response: Document) => {
+    const normalizedResponse = normalizePersonaDocument(response);
+
+    setDocument(normalizedResponse);
+    queryClient.setQueryData(
+      docStoreQueryKey(document?.fullyQualifiedName ?? ''),
+      normalizedResponse
+    );
+  };
+
   const handlePageCustomizeSave = async (newPage?: Page) => {
     if (!document) {
       return;
     }
+    const newDoc = updatePersonaDocumentPage(document, pageFqn, newPage);
+
+    if (newDoc === document) {
+      return;
+    }
+
     try {
       let response: Document;
-      const newDoc = cloneDeep(document);
-      const pageData = getPage(pageFqn);
-
-      if (pageData) {
-        newDoc.data.pages = newPage
-          ? newDoc.data?.pages?.map((p: Page) =>
-              p.pageType === pageFqn ? newPage : p
-            )
-          : newDoc.data?.pages.filter((p: Page) => p.pageType !== pageFqn);
-      } else {
-        newDoc.data = {
-          ...newDoc.data,
-          pages: [...(newDoc.data.pages ?? []), newPage],
-        };
-      }
 
       if (document.id) {
         const jsonPatch = compare(document, newDoc);
@@ -129,11 +134,7 @@ const CustomizablePageContent = () => {
             .filter(Boolean) as string[],
         });
       }
-      setDocument(response);
-      queryClient.setQueryData(
-        docStoreQueryKey(document.fullyQualifiedName ?? ''),
-        response
-      );
+      syncSavedDocument(response);
 
       showSuccessToast(
         t('server.page-layout-operation-success', {
@@ -177,11 +178,7 @@ const CustomizablePageContent = () => {
             .filter(Boolean) as string[],
         });
       }
-      setDocument(response);
-      queryClient.setQueryData(
-        docStoreQueryKey(document.fullyQualifiedName ?? ''),
-        response
-      );
+      syncSavedDocument(response);
 
       showSuccessToast(
         t('server.page-layout-operation-success', {
@@ -249,11 +246,7 @@ const CustomizablePageContent = () => {
             .filter(Boolean) as string[],
         });
       }
-      setDocument(response);
-      queryClient.setQueryData(
-        docStoreQueryKey(document.fullyQualifiedName ?? ''),
-        response
-      );
+      syncSavedDocument(response);
 
       showSuccessToast(
         t('server.page-layout-operation-success', {
@@ -313,11 +306,7 @@ const CustomizablePageContent = () => {
             .filter(Boolean) as string[],
         });
       }
-      setDocument(response);
-      queryClient.setQueryData(
-        docStoreQueryKey(document.fullyQualifiedName ?? ''),
-        response
-      );
+      syncSavedDocument(response);
 
       showSuccessToast(
         t('server.page-layout-operation-success', {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/CustomizablePage/CustomizeStore.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/CustomizablePage/CustomizeStore.ts
@@ -16,6 +16,11 @@ import { create } from 'zustand';
 import { Document } from '../../generated/entity/docStore/document';
 import { Page, PageType } from '../../generated/system/ui/page';
 import { NavigationItem } from '../../generated/system/ui/uiCustomization';
+import {
+  getPersonaPage,
+  normalizePersonaDocument,
+  updatePersonaDocumentPage,
+} from '../../utils/CustomizePage/PersonaPage.utils';
 
 interface CustomizePageStore {
   document: Document | null;
@@ -42,35 +47,28 @@ export const useCustomizeStore = create<CustomizePageStore>()((set, get) => ({
   currentPersonaDocStore: null,
   setDocument: (document: Document) => {
     const { updateCurrentPage, currentPageType } = get();
+    const normalizedDocument = normalizePersonaDocument(document);
+    const newPage = getPersonaPage(normalizedDocument, currentPageType);
 
-    // Remove undefined or null pages
-    const pages = document?.data?.pages?.filter(Boolean);
+    updateCurrentPage(newPage ?? ({ pageType: currentPageType } as Page));
 
-    const newPage = pages?.find((p: Page) => p?.pageType === currentPageType);
-
-    updateCurrentPage(newPage ?? { pageType: currentPageType });
-
-    set({ document: { ...document, data: { ...document?.data, pages } } });
+    set({ document: normalizedDocument });
   },
 
   setPage: (page: Page) => {
     const { document } = get();
-    const newDocument = {
-      ...document,
-      data: {
-        ...document?.data,
-        pages: document?.data?.pages?.map((p: Page) =>
-          p.pageType === page.pageType ? page : p
-        ),
-      },
-    } as Document;
-    set({ document: newDocument });
+
+    if (document) {
+      set({
+        document: updatePersonaDocumentPage(document, page.pageType, page),
+      });
+    }
   },
 
   getPage: (pageType: string) => {
     const { document } = get();
 
-    return document?.data?.pages?.find((p: Page) => p.pageType === pageType);
+    return getPersonaPage(document, pageType) ?? null;
   },
 
   getNavigation: () => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataMarketplacePage/DataMarketplacePage.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataMarketplacePage/DataMarketplacePage.component.test.tsx
@@ -149,6 +149,26 @@ describe('DataMarketplacePage component', () => {
     expect(showErrorToast).not.toHaveBeenCalled();
   });
 
+  it('renders the default layout when a legacy persona document contains a null page', async () => {
+    (getDocumentByFQN as jest.Mock).mockResolvedValue({
+      data: {
+        pages: [
+          {
+            pageType: PageType.LandingPage,
+          },
+          null,
+        ],
+      },
+    });
+
+    renderDataMarketplacePage();
+
+    expect(
+      await screen.findByTestId(defaultLayoutWidgetId)
+    ).toBeInTheDocument();
+    expect(showErrorToast).not.toHaveBeenCalled();
+  });
+
   it('renders the default layout when no persona is selected', async () => {
     mockSelectedPersona = null;
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataMarketplacePage/DataMarketplacePage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataMarketplacePage/DataMarketplacePage.component.tsx
@@ -25,7 +25,7 @@ import MarketplaceSearchBar from '../../components/DataMarketplace/MarketplaceSe
 import { TAB_GRID_MAX_COLUMNS } from '../../constants/CustomizeWidgets.constants';
 import { ClientErrors } from '../../enums/Axios.enum';
 import { EntityTabs } from '../../enums/entity.enum';
-import { Page, PageType } from '../../generated/system/ui/page';
+import { PageType } from '../../generated/system/ui/page';
 import { useApplicationStore } from '../../hooks/useApplicationStore';
 import {
   docStoreQueryFn,
@@ -35,6 +35,7 @@ import {
 } from '../../rest/queries/docStoreQuery';
 import { getWidgetsFromKey } from '../../utils/CustomizePage/CustomizePageDispatchUtils';
 import { getLayoutFromCustomizedPage } from '../../utils/CustomizePage/CustomizePageWidgetUtils';
+import { getPersonaPage } from '../../utils/CustomizePage/PersonaPage.utils';
 import dataMarketplaceClassBase from '../../utils/DataMarketplace/DataMarketplaceClassBase';
 import { showErrorToast } from '../../utils/ToastUtils';
 import { WidgetConfig } from '../CustomizablePage/CustomizablePage.interface';
@@ -121,9 +122,7 @@ const DataMarketplacePage = ({
       return defaultLayout;
     }
 
-    const pageData = docData.data?.pages?.find(
-      (p: Page) => p.pageType === PageType.DataMarketplace
-    );
+    const pageData = getPersonaPage(docData, PageType.DataMarketplace);
 
     const tabLayout = getLayoutFromCustomizedPage(
       PageType.DataMarketplace,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.component.tsx
@@ -26,7 +26,6 @@ import CustomiseLandingPageHeader from '../../components/MyData/CustomizableComp
 import PageLayoutV1 from '../../components/PageLayoutV1/PageLayoutV1';
 import { LOGGED_IN_USER_STORAGE_KEY } from '../../constants/constants';
 import { LandingPageWidgetKeys } from '../../enums/CustomizablePage.enum';
-import type { Page } from '../../generated/system/ui/page';
 import { PageType } from '../../generated/system/ui/page';
 import type { PersonaPreferences } from '../../generated/type/personaPreferences';
 import LimitWrapper from '../../hoc/LimitWrapper';
@@ -46,6 +45,7 @@ import {
 import { updateUserDetail } from '../../rest/userAPI';
 import { getConstrainedWidgetWidth } from '../../utils/CustomizableLandingPagePureUtils';
 import customizeMyDataPageClassBase from '../../utils/CustomizeMyDataPageClassBase';
+import { getPersonaPage } from '../../utils/CustomizePage/PersonaPage.utils';
 import { showErrorToast, showSuccessToast } from '../../utils/ToastUtils';
 import type { WidgetConfig } from '../CustomizablePage/CustomizablePage.interface';
 import './my-data.less';
@@ -114,10 +114,11 @@ const MyDataPage = () => {
     if (!docData || !selectedPersona) {
       return getDefaultLandingPageLayout();
     }
-    const pageData = docData.data?.pages?.find(
-      (p: Page) => p.pageType === PageType.LandingPage
-    ) ?? { layout: [], pageType: PageType.LandingPage };
-    const filteredLayout = (pageData.layout as WidgetConfig[])
+    const pageData = getPersonaPage(docData, PageType.LandingPage);
+    const customizedLayout = Array.isArray(pageData?.layout)
+      ? (pageData.layout as WidgetConfig[])
+      : [];
+    const filteredLayout = customizedLayout
       .filter(
         (widget: WidgetConfig) =>
           !widget.i.startsWith(LandingPageWidgetKeys.CURATED_ASSETS) ||

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.test.tsx
@@ -301,6 +301,54 @@ describe('MyDataPage component', () => {
     });
   });
 
+  it('MyDataPage should render a customized layout after a null legacy page', async () => {
+    (getDocumentByFQN as jest.Mock).mockResolvedValueOnce({
+      ...mockDocumentData,
+      data: {
+        pages: [null, ...mockDocumentData.data.pages],
+      },
+    });
+
+    renderMyDataPage();
+
+    expect(
+      await screen.findByText('KnowledgePanel.ActivityFeed')
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText('KnowledgePanel.Following')
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText('KnowledgePanel.RecentlyViewed')
+    ).toBeInTheDocument();
+  });
+
+  it.each([
+    ['missing', undefined],
+    ['not an array', { invalid: true }],
+  ])(
+    'MyDataPage should use the default layout when the customized layout is %s',
+    async (_description, invalidLayout) => {
+      const landingPage =
+        invalidLayout === undefined
+          ? { pageType: PageType.LandingPage }
+          : { pageType: PageType.LandingPage, layout: invalidLayout };
+
+      (getDocumentByFQN as jest.Mock).mockResolvedValueOnce({
+        ...mockDocumentData,
+        data: { pages: [landingPage] },
+      });
+
+      renderMyDataPage();
+
+      expect(
+        await screen.findByText('KnowledgePanel.DataAssets')
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByText('KnowledgePanel.KnowledgeCenter')
+      ).toBeInTheDocument();
+    }
+  );
+
   it('MyDataPage should not render announcement widget if there are no announcements', async () => {
     (getActiveAnnouncements as jest.Mock).mockImplementationOnce(() =>
       Promise.resolve({

--- a/openmetadata-ui/src/main/resources/ui/src/rest/queries/docStoreQuery.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/queries/docStoreQuery.ts
@@ -14,6 +14,7 @@
 import { FQN_SEPARATOR_CHAR } from '../../constants/char.constants';
 import { EntityType } from '../../enums/entity.enum';
 import { Document } from '../../generated/entity/docStore/document';
+import { normalizePersonaDocument } from '../../utils/CustomizePage/PersonaPage.utils';
 import { getDocumentByFQN } from '../DocStoreAPI';
 
 /**
@@ -36,8 +37,8 @@ export const PERSONA_DOC_STALE_TIME = 5 * 60 * 1000;
 
 export const docStoreQueryKey = (fqn: string) => ['docStore', fqn] as const;
 
-export const docStoreQueryFn = (fqn: string) => (): Promise<Document> =>
-  getDocumentByFQN(fqn);
+export const docStoreQueryFn = (fqn: string) => async (): Promise<Document> =>
+  normalizePersonaDocument(await getDocumentByFQN(fqn));
 
 /**
  * Derive the docStore FQN for a persona's UICustomization document.

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/PersonaPage.utils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/PersonaPage.utils.test.ts
@@ -1,0 +1,101 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Document } from '../../generated/entity/docStore/document';
+import { Page, PageType } from '../../generated/system/ui/page';
+import {
+  getPersonaPage,
+  normalizePersonaDocument,
+  updatePersonaDocumentPage,
+} from './PersonaPage.utils';
+
+const tablePage = {
+  pageType: PageType.Table,
+  tabs: [{ id: 'overview', layout: [], name: 'overview' }],
+} as unknown as Page;
+
+const dashboardPage = {
+  pageType: PageType.Dashboard,
+  layout: [],
+} as unknown as Page;
+
+const createDocument = (pages: unknown[]): Document => ({
+  data: { pages, navigation: [{ name: 'Explore' }] },
+  entityType: 'Page',
+  fullyQualifiedName: 'persona.test',
+  name: 'test',
+});
+
+describe('PersonaPage utilities', () => {
+  it('finds a valid page after invalid legacy entries', () => {
+    const document = createDocument([null, undefined, {}, tablePage]);
+
+    expect(getPersonaPage(document, PageType.Table)).toBe(tablePage);
+  });
+
+  it('normalizes invalid page entries without mutating the response', () => {
+    const document = createDocument([null, tablePage, undefined]);
+
+    const normalizedDocument = normalizePersonaDocument(document);
+
+    expect(normalizedDocument).not.toBe(document);
+    expect(normalizedDocument.data).not.toBe(document.data);
+    expect(normalizedDocument.data.pages).toEqual([tablePage]);
+    expect(normalizedDocument.data.navigation).toBe(document.data.navigation);
+    expect(document.data.pages).toEqual([null, tablePage, undefined]);
+  });
+
+  it('preserves tab-based pages without a top-level layout', () => {
+    const document = createDocument([tablePage]);
+
+    expect(normalizePersonaDocument(document)).toBe(document);
+  });
+
+  it('does not add an undefined page when resetting an unsaved layout', () => {
+    const document = {
+      ...createDocument([]),
+      data: { navigation: [{ name: 'Explore' }] },
+    };
+
+    expect(updatePersonaDocumentPage(document, PageType.DataMarketplace)).toBe(
+      document
+    );
+  });
+
+  it('adds, replaces, and removes pages while cleaning legacy entries', () => {
+    const document = createDocument([null, tablePage]);
+
+    const withDashboard = updatePersonaDocumentPage(
+      document,
+      PageType.Dashboard,
+      dashboardPage
+    );
+    const replacement = {
+      ...dashboardPage,
+      layout: [{ i: 'updated' }],
+    } as Page;
+    const withReplacement = updatePersonaDocumentPage(
+      withDashboard,
+      PageType.Dashboard,
+      replacement
+    );
+    const withoutTable = updatePersonaDocumentPage(
+      withReplacement,
+      PageType.Table
+    );
+
+    expect(withDashboard.data.pages).toEqual([tablePage, dashboardPage]);
+    expect(withReplacement.data.pages).toEqual([tablePage, replacement]);
+    expect(withoutTable.data.pages).toEqual([replacement]);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/PersonaPage.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/PersonaPage.utils.ts
@@ -1,0 +1,97 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Document } from '../../generated/entity/docStore/document';
+import { Page } from '../../generated/system/ui/page';
+
+const getPageEntries = (document?: Document | null): unknown[] | undefined => {
+  const pages = document?.data?.pages as unknown;
+
+  return Array.isArray(pages) ? pages : undefined;
+};
+
+const isPersonaPage = (value: unknown): value is Page =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as { pageType?: unknown }).pageType === 'string';
+
+export const getPersonaPage = (
+  document: Document | null | undefined,
+  pageType: string | null | undefined
+): Page | undefined => {
+  if (!pageType) {
+    return undefined;
+  }
+
+  return getPageEntries(document)?.find(
+    (page): page is Page => isPersonaPage(page) && page.pageType === pageType
+  );
+};
+
+export const normalizePersonaDocument = (document: Document): Document => {
+  const pageEntries = getPageEntries(document);
+
+  if (!pageEntries) {
+    return document;
+  }
+
+  const pages = pageEntries.filter(isPersonaPage);
+
+  if (pages.length === pageEntries.length) {
+    return document;
+  }
+
+  return {
+    ...document,
+    data: {
+      ...document.data,
+      pages,
+    },
+  };
+};
+
+export const updatePersonaDocumentPage = (
+  document: Document,
+  pageType: string,
+  newPage?: Page
+): Document => {
+  const pageEntries = getPageEntries(document);
+  const pages = pageEntries?.filter(isPersonaPage) ?? [];
+  const hasPage = pages.some((page) => page.pageType === pageType);
+  const hasInvalidPage =
+    pageEntries !== undefined && pageEntries.length !== pages.length;
+
+  if (!newPage && !hasPage && !hasInvalidPage) {
+    return document;
+  }
+
+  let updatedPages: Page[];
+
+  if (!newPage) {
+    updatedPages = pages.filter((page) => page.pageType !== pageType);
+  } else if (hasPage) {
+    updatedPages = pages.map((page) =>
+      page.pageType === pageType ? newPage : page
+    );
+  } else {
+    updatedPages = [...pages, newPage];
+  }
+
+  return {
+    ...document,
+    data: {
+      ...document.data,
+      pages: updatedPages,
+    },
+  };
+};


### PR DESCRIPTION
Backport of #31981 to the 2.0 branch.

Handles null persona customization pages and validates the My Data customized layout.

Cherry-picked from commit 0cf8599f45. One conflict in `CustomizablePage.test.tsx` (CustomizeMyData mock) was resolved by taking the PR's version to match the rewritten component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport makes persona customization documents resilient to null or malformed page entries and validates My Data layouts before rendering.

- Adds shared helpers to find, normalize, add, replace, and remove persona pages.
- Normalizes persona documents at the query, store, and post-save cache boundaries.
- Uses safe page lookup across My Data, Data Marketplace, and custom-page consumers.
- Adds regression coverage for legacy null pages, malformed layouts, and resetting an unsaved layout.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the changed lookup, normalization, mutation, and fallback paths aligned with the generated persona-page contract.

The normalization retains every schema-valid page, removes only invalid legacy entries, preserves unrelated document data, and the affected consumers have explicit regression coverage for null pages and malformed layouts.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/PersonaPage.utils.ts | Introduces schema-compatible page guards and immutable normalization/update helpers that safely remove invalid legacy entries. |
| openmetadata-ui/src/main/resources/ui/src/pages/CustomizablePage/CustomizablePage.tsx | Centralizes persona page mutation and normalizes successful API responses before updating the store and query cache. |
| openmetadata-ui/src/main/resources/ui/src/pages/CustomizablePage/CustomizeStore.ts | Reuses the shared helpers so store initialization, lookup, and page replacement tolerate invalid legacy entries consistently. |
| openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.component.tsx | Safely resolves the landing page and falls back to the default layout when the stored layout is absent, malformed, or empty. |
| openmetadata-ui/src/main/resources/ui/src/rest/queries/docStoreQuery.ts | Normalizes fetched persona documents before they enter the shared React Query cache. |
| openmetadata-ui/src/main/resources/ui/src/hooks/useCustomPages.ts | Replaces nullable inline page traversal with the guarded shared lookup helper. |
| openmetadata-ui/src/main/resources/ui/src/pages/DataMarketplacePage/DataMarketplacePage.component.tsx | Uses guarded persona-page lookup so null legacy entries no longer break marketplace layout resolution. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  API[Persona document API] --> Normalize[Normalize page entries]
  Normalize --> Cache[React Query cache]
  Cache --> Lookup[Find page by page type]
  Lookup --> MyData[My Data layout]
  Lookup --> Marketplace[Data Marketplace layout]
  Lookup --> CustomPages[Custom page hooks]
  Editor[Customization editor] --> Update[Add, replace, or remove page]
  Update --> API
  API --> Normalize
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fixes #31980: handle null persona custom..."](https://github.com/open-metadata/openmetadata/commit/6aab1b41fb8fe1a5181e02b5cdd34c9089d64078) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56645283)</sub>

**Context used:**

- Knowledge Base — [Metadata web application](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/metadata-web-application.md)
- Knowledge Base — [UI foundations](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/ui-foundations.md)

<!-- /greptile_comment -->