### PR TITLE
test(playwright): fix ExploreAggregationCountsMatching timeout caused by suggestion-request response match

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ExploreAggregationCountsMatching.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ExploreAggregationCountsMatching.spec.ts
@@ -11,18 +11,20 @@
  *  limitations under the License.
  */
 
-import { expect, Page, Response, test } from '@playwright/test';
+import { expect, Locator, Page, Response, test } from '@playwright/test';
 import { redirectToHomePage } from '../../utils/common';
 
 // Maps entityType keys from the API aggregation to the explore left-panel tab testid labels.
 // The testid format is `${lowerCase(tabDetail.label)}-tab` (see ExploreUtils.tsx generateTabItems).
 const ENTITY_TYPE_TO_TAB_TESTID: Record<string, string> = {
   table: 'tables-tab',
+  tableColumn: 'columns-tab',
   database: 'databases-tab',
   databaseSchema: 'database schemas-tab',
   glossaryTerm: 'glossary terms-tab',
   dataProduct: 'data products-tab',
   dashboard: 'dashboards-tab',
+  dashboardDataModel: 'dashboard data models-tab',
   pipeline: 'pipelines-tab',
   topic: 'topics-tab',
   mlmodel: 'ml models-tab',
@@ -32,44 +34,70 @@ const ENTITY_TYPE_TO_TAB_TESTID: Record<string, string> = {
   storedProcedure: 'stored procedures-tab',
   tag: 'tags-tab',
   metric: 'metrics-tab',
+  apiCollection: 'api collections-tab',
+  apiEndpoint: 'api endpoints-tab',
+  directory: 'directories-tab',
+  file: 'files-tab',
+  spreadsheet: 'spreadsheets-tab',
+  worksheet: 'worksheets-tab',
 };
 
 const SEARCH_URL_FRAGMENT = '/api/v1/search/query';
 const SEARCH_QUERY = 'customers';
-const SEARCH_RESULT_SIZE = '15';
+const AGGREGATION_INDEX = 'dataAsset';
+// The left-panel count query asks for a single hit (`pageSize: 1`) and only the
+// entityType source field — see `runCountSearch` in ExploreUtils.tsx.
+const AGGREGATION_RESULT_SIZE = '1';
+// The tab results query is the only one that asks for trackTotalHits; the search-box
+// suggestion dropdown fires an index=dataAsset query with the same size/from, so the
+// predicate must not rely on size/from alone.
+const TAB_RESULT_SIZE = '15';
 
 const getSearchParams = (response: Response) =>
   new URL(response.url()).searchParams;
 
-const isSearchQueryResponse = (response: Response, index: string) => {
+const isSearchQuery = (response: Response) =>
+  response.url().includes(SEARCH_URL_FRAGMENT) &&
+  response.request().method() === 'GET' &&
+  getSearchParams(response).get('q') === SEARCH_QUERY;
+
+const isAggregationCountResponse = (response: Response) => {
   const searchParams = getSearchParams(response);
 
   return (
-    response.url().includes(SEARCH_URL_FRAGMENT) &&
-    response.request().method() === 'GET' &&
-    searchParams.get('q') === SEARCH_QUERY &&
-    searchParams.get('index') === index
+    isSearchQuery(response) &&
+    searchParams.get('index') === AGGREGATION_INDEX &&
+    searchParams.get('size') === AGGREGATION_RESULT_SIZE &&
+    searchParams.get('fetch_source') === 'true'
   );
 };
 
-const isTabSearchQueryResponse = (response: Response) => {
+const isTabResultsResponse = (response: Response, index?: string) => {
   const searchParams = getSearchParams(response);
-  const index = searchParams.get('index') ?? '';
 
   return (
-    isSearchQueryResponse(response, index) &&
-    searchParams.get('size') === SEARCH_RESULT_SIZE &&
+    isSearchQuery(response) &&
+    (index === undefined || searchParams.get('index') === index) &&
+    searchParams.get('track_total_hits') === 'true' &&
+    searchParams.get('size') === TAB_RESULT_SIZE &&
     searchParams.get('from') === '0'
   );
 };
 
-async function runSearchValidation(page: Page): Promise<void> {
-  const apiCountResPromise = page.waitForResponse((response) =>
-    isSearchQueryResponse(response, 'dataAsset')
-  );
+const getSelectedTab = (page: Page, tabTestId: string): Locator =>
+  page.locator('.ant-menu-item-selected').getByTestId(tabTestId);
 
-  const initialTabSearchResPromise = page.waitForResponse(
-    isTabSearchQueryResponse
+type TabSearchBody = {
+  hits: {
+    total: { value: number };
+    hits: Array<{ _source: { entityType: string } }>;
+  };
+};
+
+async function runSearchValidation(page: Page): Promise<void> {
+  const apiCountResPromise = page.waitForResponse(isAggregationCountResponse);
+  const initialTabSearchResPromise = page.waitForResponse((response) =>
+    isTabResultsResponse(response)
   );
 
   await page.getByTestId('searchBox').fill(SEARCH_QUERY);
@@ -84,10 +112,9 @@ async function runSearchValidation(page: Page): Promise<void> {
   expect(initialTabSearchRes.status()).toBe(200);
 
   const countResponseBody = await apiCountRes.json();
-  const initialTabSearchBody = await initialTabSearchRes.json();
-  const initialTabSearchIndex = new URL(
-    initialTabSearchRes.url()
-  ).searchParams.get('index');
+  const initialTabSearchBody: TabSearchBody = await initialTabSearchRes.json();
+  const initialTabSearchIndex =
+    getSearchParams(initialTabSearchRes).get('index');
 
   await expect(page.getByTestId('explore-left-panel')).toBeVisible();
 
@@ -95,6 +122,8 @@ async function runSearchValidation(page: Page): Promise<void> {
   const entityTypeBuckets: Array<{ key: string; doc_count: number }> =
     (aggregations['entityType'] ?? aggregations['sterms#entityType'])
       ?.buckets ?? [];
+
+  expect(entityTypeBuckets.length).toBeGreaterThan(0);
 
   await test.step('Verify left panel counts match API aggregation', async () => {
     for (const bucket of entityTypeBuckets) {
@@ -105,16 +134,13 @@ async function runSearchValidation(page: Page): Promise<void> {
       }
 
       const tabLocator = page.getByTestId(tabTestId);
-      const isTabVisible = await tabLocator.isVisible();
 
-      if (!isTabVisible) {
+      if (!(await tabLocator.isVisible())) {
         continue;
       }
 
-      const countLocator = tabLocator.getByTestId('filter-count');
-
       await expect(
-        countLocator,
+        tabLocator.getByTestId('filter-count'),
         `Left panel count for "${bucket.key}" should match API count`
       ).toHaveText(`${bucket.doc_count}`);
     }
@@ -129,30 +155,29 @@ async function runSearchValidation(page: Page): Promise<void> {
       }
 
       const tabLocator = page.getByTestId(tabTestId);
-      const isTabVisible = await tabLocator.isVisible();
 
-      if (!isTabVisible) {
+      if (!(await tabLocator.isVisible())) {
         continue;
       }
 
-      let tabSearchBody: {
-        hits: {
-          total: { value: number };
-          hits: Array<{ _source: { entityType: string } }>;
-        };
-      };
+      let tabSearchBody: TabSearchBody;
 
       if (bucket.key === initialTabSearchIndex) {
+        // The auto-selected tab is already loaded; clicking it is a no-op in the
+        // Menu onClick handler, so no request would ever arrive to wait for.
+        await expect(getSelectedTab(page, tabTestId)).toBeVisible();
+
         tabSearchBody = initialTabSearchBody;
       } else {
-        const tabSearchResPromise = page.waitForResponse(
-          (response) =>
-            isSearchQueryResponse(response, bucket.key) &&
-            getSearchParams(response).get('size') === SEARCH_RESULT_SIZE &&
-            getSearchParams(response).get('from') === '0'
+        const tabSearchResPromise = page.waitForResponse((response) =>
+          isTabResultsResponse(response, bucket.key)
         );
 
         await tabLocator.click();
+
+        // Fail fast if the click did not activate the tab, instead of hanging on a
+        // waitForResponse predicate that can never match.
+        await expect(getSelectedTab(page, tabTestId)).toBeVisible();
 
         const tabSearchRes = await tabSearchResPromise;
         expect(tabSearchRes.status()).toBe(200);
@@ -160,10 +185,8 @@ async function runSearchValidation(page: Page): Promise<void> {
         tabSearchBody = await tabSearchRes.json();
       }
 
-      const totalHits: number = tabSearchBody?.hits?.total?.value ?? 0;
-
       expect(
-        totalHits,
+        tabSearchBody?.hits?.total?.value ?? 0,
         `Tab "${bucket.key}" search total hits should match the aggregation count`
       ).toBe(bucket.doc_count);
     }

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ExploreAggregationCountsMatching.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ExploreAggregationCountsMatching.spec.ts
@@ -146,6 +146,19 @@ async function runSearchValidation(page: Page): Promise<void> {
     }
   });
 
+  // Asserted before any tab is clicked: the antd Menu is single-select, so the first
+  // click on another tab deselects this one. Buckets are ordered by doc_count, which is
+  // not the auto-selection order (findActiveSearchIndex picks the top-hit index), so this
+  // cannot be checked from inside the click loop.
+  await test.step('Verify the auto-selected tab is active', async () => {
+    const initialTabTestId =
+      ENTITY_TYPE_TO_TAB_TESTID[initialTabSearchIndex ?? ''];
+
+    if (initialTabTestId) {
+      await expect(getSelectedTab(page, initialTabTestId)).toBeVisible();
+    }
+  });
+
   await test.step('Click each tab and verify search results match entity type', async () => {
     for (const bucket of entityTypeBuckets) {
       const tabTestId = ENTITY_TYPE_TO_TAB_TESTID[bucket.key];
@@ -163,10 +176,8 @@ async function runSearchValidation(page: Page): Promise<void> {
       let tabSearchBody: TabSearchBody;
 
       if (bucket.key === initialTabSearchIndex) {
-        // The auto-selected tab is already loaded; clicking it is a no-op in the
-        // Menu onClick handler, so no request would ever arrive to wait for.
-        await expect(getSelectedTab(page, tabTestId)).toBeVisible();
-
+        // The auto-selected tab was already loaded by the initial search; clicking it
+        // is a no-op in the Menu onClick handler, so no request would ever arrive.
         tabSearchBody = initialTabSearchBody;
       } else {
         const tabSearchResPromise = page.waitForResponse((response) =>


### PR DESCRIPTION
### Describe your changes:

<!-- No GitHub issue opened for this; it is a CI test-only flake fix. Happy to file one if required. -->

I fixed the `ExploreAggregationCountsMatching` Playwright spec, which times out at 180s in CI
([failing run](https://github.com/open-metadata/OpenMetadata/actions/runs/32841938814/job/97790783440)).

**Root cause**

Both `page.waitForResponse` predicates in the spec matched the **search-box suggestion request**
instead of the Explore queries they were meant to capture.

While the user types, `components/AppBar/Suggestions.tsx` fires:

```
/api/v1/search/query?q=customers&index=dataAsset&from=0&size=15&deleted=false&query_filter=%7B%7D&exclude_source_fields=...
```

That URL satisfied both predicates:

- the count predicate only required `index=dataAsset`;
- the tab predicate compared `index` against `index` read off the *same* response — a tautology —
  and then only required `size=15&from=0`, which `PAGE_SIZE_BASE` in `Suggestions.tsx` happens to
  match exactly.

The suggestion response resolves before Explore's own queries, so `initialTabSearchIndex` became
`dataAsset` instead of the auto-selected `table`. The loop therefore treated the **already-active**
Tables tab as inactive and clicked it. The antd `Menu` `onClick` handler ignores a click on the
currently selected key (`if (info.key !== activeTabKey)`), so no request was issued and
`waitForResponse` hung until the test timeout.

Confirmed from the trace: the suggestion response body carries a full `sterms#entityType`
aggregation (same query, so identical bucket counts), which is why the earlier left-panel-count
step still passed and the failure surfaced only as a hang on the first tab click.

**Changes**

- Match the count query on params the suggestion request does not send (`size=1`,
  `fetch_source=true` — see `runCountSearch` in `ExploreUtils.tsx`).
- Match tab results on `track_total_hits=true`, sent only by Explore's results query, and pass the
  expected `index` explicitly instead of reading it off the response.
- Assert the tab is selected after clicking, so a click that fails to activate a tab fails fast
  instead of hanging on a predicate that can never match (per the handbook's
  "always assert the post-click state" rule).
- Assert the aggregation returned at least one bucket, so a wrong response body can no longer make
  the test pass vacuously with an empty loop.
- Add the missing `entityType` → tab mappings (`tableColumn`, `dashboardDataModel`, `apiCollection`,
  `apiEndpoint`, `directory`, `file`, `spreadsheet`, `worksheet`). Previously these buckets hit the
  `continue` branch and were silently skipped — 8 of 14 buckets were asserted; now all 14 are.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — test-only change, single file.

#
### Tests:

#### Use cases covered
- Searching `customers` from the landing page lands on Explore with the auto-selected tab, and each
  left-panel tab count matches the `entityType` aggregation from the count query.
- Clicking each left-panel tab issues a results query for that index whose `hits.total.value`
  matches the aggregation count for the same entity type.

#### Unit tests
Not applicable — Playwright spec only, no product code changed.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- Files updated: `openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ExploreAggregationCountsMatching.spec.ts`

#### Manual testing performed
1. Downloaded the failing run's trace and read `0-trace.network`, which showed the four
   `search/query` requests and confirmed the suggestion request (`index=dataAsset`, `size=15`)
   resolves before Explore's results query (`index=table`, `track_total_hits=true`).
2. Read the suggestion response body from the trace `resources/` dir and confirmed it carries
   `sterms#entityType` buckets — matching the counts in the trace screenshot (`tableColumn` 135,
   `table` 30, …) — which is what let the old predicate look correct.
3. `yarn lint:playwright` — 0 errors, no warnings on this file.
4. `npx prettier --check` and `npx tsc --noEmit` — clean for this file (repo-wide tsc has
   pre-existing unrelated errors).

**Not yet done:** I have not executed the spec against a live server. Please let CI's Playwright
job be the verification gate before merge.

#
### UI screen recording / screenshots:

Not applicable — no UI changes.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This test-only change makes the Explore aggregation-count Playwright test distinguish suggestion requests from the intended count and tab-result requests.
- Tightens response matching using request-specific search parameters.
- Adds explicit selected-tab and non-empty-aggregation assertions.
- Extends aggregation coverage to additional Explore entity types.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ExploreAggregationCountsMatching.spec.ts | Refines network-response predicates and expands tab-count validation without introducing an eligible follow-up defect. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(playwright): hoist the auto-selecte..."](https://github.com/open-metadata/openmetadata/commit/71c3a5bdc4750e6c8187c04c1b5ec56f3bb1e596) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56646724)</sub>

<!-- /greptile_comment -->