### PR TITLE
fix(ui): Fix lineage canvas scrolling when the filters panel is expanded

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/entity-lineage.style.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/entity-lineage.style.less
@@ -154,11 +154,6 @@
   // 20px bottom spacing
   height: calc(@asset-details-tab-pane-height - 20px);
 
-  .lineage-container {
-    height: calc(100% - 77px);
-    overflow-y: auto;
-  }
-
   // lineage and it's children's always should be ltr
   direction: ltr;
 
@@ -304,7 +299,6 @@
   .lineage-card {
     // Navbar - breadcrumb - bottom spacing
     height: calc(100vh - @om-navbar-height - 36px - 20px);
-    overflow-y: auto;
   }
 
   .entity-panel-container {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Lineage/Lineage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Lineage/Lineage.component.tsx
@@ -170,13 +170,15 @@ const Lineage = ({
   // Loading the react flow component after the nodes and edges are initialised improves performance
   // considerably. So added an init state for showing loader.
   return (
-    <Card className="lineage-card card-padding-0" data-testid="lineage-details">
-      <div className="tw:py-4 tw:px-6 tw:border-b tw:border-tertiary ">
+    <Card
+      className="lineage-card card-padding-0 tw:flex tw:flex-col"
+      data-testid="lineage-details">
+      <div className="tw:py-4 tw:px-6 tw:border-b tw:border-tertiary tw:shrink-0">
         {header}
       </div>
 
       <div
-        className="lineage-container"
+        className="lineage-container tw:flex-1 tw:min-h-0 tw:overflow-hidden"
         data-testid="lineage-container"
         id="lineage-container" // ID is required for export PNG functionality
         ref={reactFlowWrapper}>

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PlatformLineage/platform-lineage.less
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PlatformLineage/platform-lineage.less
@@ -18,9 +18,7 @@
   height: calc(100vh - @om-navbar-height - @platform-page-header-height);
   .lineage-card {
     height: 100%;
-    .ant-card-body {
-      height: calc(100% - 74px); // 74px is the height of card header
-    }
+    min-height: 0;
   }
 
   .full-screen-lineage {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:


https://github.com/user-attachments/assets/7e3012a5-a068-4112-8ad4-d9c645c58f83

https://github.com/user-attachments/assets/8afec563-cd03-4ae3-af6e-9edb7045dce3



Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces explicit lineage height and scroll calculations with a flex-column layout so the canvas occupies the available space when surrounding panels change size.
- Makes the lineage header non-shrinking and the canvas container flex to the remaining height.
- Removes obsolete container scrolling and Ant Card body sizing rules.
- Applies bounded flex sizing to entity and platform lineage views.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Lineage/Lineage.component.tsx | Converts the custom Card into a flex column whose direct lineage-container child fills the remaining bounded height. |
| openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/entity-lineage.style.less | Removes explicit canvas height and card scrolling now handled by the shared flex layout. |
| openmetadata-ui/src/main/resources/ui/src/pages/PlatformLineage/platform-lineage.less | Removes an obsolete Ant Card body override and permits the fixed-height lineage card to shrink correctly. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into lineage-scrolli..."](https://github.com/open-metadata/openmetadata/commit/42bac305c193bd5f043eee6e0259df28a62eae87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56651319)</sub>

<!-- /greptile_comment -->