### PR TITLE
Fixes #31980: handle null persona customization pages (#31981) [1.13 backport]

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useCustomPages.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useCustomPages.ts
@@ -16,6 +16,7 @@ import { EntityType } from '../enums/entity.enum';
 import { Page, PageType } from '../generated/system/ui/page';
 import { NavigationItem } from '../generated/system/ui/uiCustomization';
 import { getDocumentByFQN } from '../rest/DocStoreAPI';
+import { getPersonaPage } from '../utils/CustomizePage/PersonaPage.utils';
 import { useApplicationStore } from './useApplicationStore';
 
 export const useCustomPages = (pageType: PageType | 'Navigation') => {
@@ -28,9 +29,7 @@ export const useCustomPages = (pageType: PageType | 'Navigation') => {
     const pageFQN = `${EntityType.PERSONA}${FQN_SEPARATOR_CHAR}${selectedPersona?.fullyQualifiedName}`;
     try {
       const doc = await getDocumentByFQN(pageFQN);
-      setCustomizedPage(
-        doc.data?.pages?.find((p: Page | null) => p?.pageType === pageType)
-      );
+      setCustomizedPage(getPersonaPage(doc, pageType) ?? null);
       setNavigation(doc.data?.navigation);
     } catch (error) {
       // Need to reset Navigation to avoid showing old navigation items

--- a/openmetadata-ui/src/main/resources/ui/src/pages/CustomizablePage/CustomizablePage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/CustomizablePage/CustomizablePage.tsx
@@ -43,6 +43,7 @@ import {
   updateDocument,
 } from '../../rest/DocStoreAPI';
 import { getPersonaByName } from '../../rest/PersonaAPI';
+import { updatePersonaDocumentPage } from '../../utils/CustomizePage/PersonaPage.utils';
 import { Transi18next } from '../../utils/i18next/LocalUtil';
 import { getSettingPath } from '../../utils/RouterUtils';
 import { showErrorToast, showSuccessToast } from '../../utils/ToastUtils';
@@ -61,7 +62,7 @@ export const CustomizablePage = () => {
   const { theme } = useApplicationStore();
   const [isLoading, setIsLoading] = useState(true);
   const [personaDetails, setPersonaDetails] = useState<Persona>();
-  const { document, setDocument, currentPage, getPage, setCurrentPageType } =
+  const { document, setDocument, currentPage, setCurrentPageType } =
     useCustomizeStore();
 
   const backgroundColor = useMemo(
@@ -77,23 +78,13 @@ export const CustomizablePage = () => {
     if (!document) {
       return;
     }
+    const newDoc = updatePersonaDocumentPage(document, pageFqn, newPage);
+
+    if (newDoc === document) {
+      return;
+    }
     try {
       let response: Document;
-      const newDoc = cloneDeep(document);
-      const pageData = getPage(pageFqn);
-
-      if (pageData) {
-        newDoc.data.pages = newPage
-          ? newDoc.data?.pages?.map((p: Page) =>
-              p.pageType === pageFqn ? newPage : p
-            )
-          : newDoc.data?.pages.filter((p: Page) => p.pageType !== pageFqn);
-      } else {
-        newDoc.data = {
-          ...newDoc.data,
-          pages: [...(newDoc.data.pages ?? []), newPage],
-        };
-      }
 
       if (document.id) {
         const jsonPatch = compare(document, newDoc);

--- a/openmetadata-ui/src/main/resources/ui/src/pages/CustomizablePage/CustomizeStore.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/CustomizablePage/CustomizeStore.ts
@@ -16,6 +16,11 @@ import { create } from 'zustand';
 import { Document } from '../../generated/entity/docStore/document';
 import { Page, PageType } from '../../generated/system/ui/page';
 import { NavigationItem } from '../../generated/system/ui/uiCustomization';
+import {
+  getPersonaPage,
+  normalizePersonaDocument,
+  updatePersonaDocumentPage,
+} from '../../utils/CustomizePage/PersonaPage.utils';
 
 interface CustomizePageStore {
   document: Document | null;
@@ -43,34 +48,28 @@ export const useCustomizeStore = create<CustomizePageStore>()((set, get) => ({
   setDocument: (document: Document) => {
     const { updateCurrentPage, currentPageType } = get();
 
-    // Remove undefined or null pages
-    const pages = document?.data?.pages?.filter(Boolean);
+    const normalizedDocument = normalizePersonaDocument(document);
+    const newPage = getPersonaPage(normalizedDocument, currentPageType);
 
-    const newPage = pages?.find((p: Page) => p?.pageType === currentPageType);
+    updateCurrentPage(newPage ?? ({ pageType: currentPageType } as Page));
 
-    updateCurrentPage(newPage ?? { pageType: currentPageType });
-
-    set({ document: { ...document, data: { ...document?.data, pages } } });
+    set({ document: normalizedDocument });
   },
 
   setPage: (page: Page) => {
     const { document } = get();
-    const newDocument = {
-      ...document,
-      data: {
-        ...document?.data,
-        pages: document?.data?.pages?.map((p: Page) =>
-          p.pageType === page.pageType ? page : p
-        ),
-      },
-    } as Document;
-    set({ document: newDocument });
+
+    if (document) {
+      set({
+        document: updatePersonaDocumentPage(document, page.pageType, page),
+      });
+    }
   },
 
   getPage: (pageType: string) => {
     const { document } = get();
 
-    return document?.data?.pages?.find((p: Page) => p.pageType === pageType);
+    return getPersonaPage(document, pageType) ?? null;
   },
 
   getNavigation: () => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataMarketplacePage/DataMarketplacePage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataMarketplacePage/DataMarketplacePage.component.tsx
@@ -30,12 +30,13 @@ import MarketplaceGreetingBanner from '../../components/DataMarketplace/Marketpl
 import MarketplaceSearchBar from '../../components/DataMarketplace/MarketplaceSearchBar/MarketplaceSearchBar.component';
 import { TAB_GRID_MAX_COLUMNS } from '../../constants/CustomizeWidgets.constants';
 import { EntityTabs, EntityType } from '../../enums/entity.enum';
-import { Page, PageType } from '../../generated/system/ui/page';
+import { PageType } from '../../generated/system/ui/page';
 import { useApplicationStore } from '../../hooks/useApplicationStore';
 import { useGridLayoutDirection } from '../../hooks/useGridLayoutDirection';
 import { getDocumentByFQN } from '../../rest/DocStoreAPI';
 import { getWidgetsFromKey } from '../../utils/CustomizePage/CustomizePageDispatchUtils';
 import { getLayoutFromCustomizedPage } from '../../utils/CustomizePage/CustomizePageWidgetUtils';
+import { getPersonaPage } from '../../utils/CustomizePage/PersonaPage.utils';
 import dataMarketplaceClassBase from '../../utils/DataMarketplace/DataMarketplaceClassBase';
 import { showErrorToast } from '../../utils/ToastUtils';
 import { WidgetConfig } from '../CustomizablePage/CustomizablePage.interface';
@@ -81,9 +82,7 @@ const DataMarketplacePage = () => {
       const pageFQN = `${EntityType.PERSONA}.${selectedPersona.fullyQualifiedName}`;
       const docData = await getDocumentByFQN(pageFQN);
 
-      const pageData = docData.data?.pages?.find(
-        (p: Page) => p.pageType === PageType.DataMarketplace
-      );
+      const pageData = getPersonaPage(docData, PageType.DataMarketplace);
 
       const tabLayout = getLayoutFromCustomizedPage(
         PageType.DataMarketplace,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.component.tsx
@@ -26,7 +26,7 @@ import { LOGGED_IN_USER_STORAGE_KEY } from '../../constants/constants';
 import { LandingPageWidgetKeys } from '../../enums/CustomizablePage.enum';
 import { EntityType } from '../../enums/entity.enum';
 import { Thread } from '../../generated/entity/feed/thread';
-import { Page, PageType } from '../../generated/system/ui/page';
+import { PageType } from '../../generated/system/ui/page';
 import { PersonaPreferences } from '../../generated/type/personaPreferences';
 import LimitWrapper from '../../hoc/LimitWrapper';
 import { useApplicationStore } from '../../hooks/useApplicationStore';
@@ -38,6 +38,7 @@ import { updateUserDetail } from '../../rest/userAPI';
 import { getConstrainedWidgetWidth } from '../../utils/CustomizableLandingPagePureUtils';
 import { getWidgetFromKey } from '../../utils/CustomizableLandingPageUtils';
 import customizePageClassBase from '../../utils/CustomizeMyDataPageClassBase';
+import { getPersonaPage } from '../../utils/CustomizePage/PersonaPage.utils';
 import { showErrorToast, showSuccessToast } from '../../utils/ToastUtils';
 import { WidgetConfig } from '../CustomizablePage/CustomizablePage.interface';
 import './my-data.less';
@@ -99,11 +100,12 @@ const MyDataPage = () => {
 
         setPersonaPreferences(docData.data?.personPreferences ?? []);
 
-        const pageData = docData.data?.pages?.find(
-          (p: Page) => p.pageType === PageType.LandingPage
-        ) ?? { layout: [], pageType: PageType.LandingPage };
+        const pageData = getPersonaPage(docData, PageType.LandingPage);
+        const customizedLayout = Array.isArray(pageData?.layout)
+          ? (pageData.layout as WidgetConfig[])
+          : [];
 
-        const filteredLayout = pageData.layout
+        const filteredLayout = customizedLayout
           .filter(
             (widget: WidgetConfig) =>
               !widget.i.startsWith(LandingPageWidgetKeys.CURATED_ASSETS) ||

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.test.tsx
@@ -305,6 +305,56 @@ describe('MyDataPage component', () => {
     ).toBeInTheDocument();
   });
 
+  it('MyDataPage should render a customized layout after a null legacy page', async () => {
+    (getDocumentByFQN as jest.Mock).mockResolvedValueOnce({
+      ...mockDocumentData,
+      data: {
+        pages: [null, ...mockDocumentData.data.pages],
+      },
+    });
+
+    render(<MyDataPage />);
+
+    expect(
+      await screen.findByText('KnowledgePanel.ActivityFeed')
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText('KnowledgePanel.Following')
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText('KnowledgePanel.RecentlyViewed')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('KnowledgePanel.KPI')).toBeNull();
+  });
+
+  it.each([
+    ['missing', undefined],
+    ['not an array', { invalid: true }],
+  ])(
+    'MyDataPage should use the default layout when the customized layout is %s',
+    async (_description, invalidLayout) => {
+      const landingPage =
+        invalidLayout === undefined
+          ? { pageType: PageType.LandingPage }
+          : { pageType: PageType.LandingPage, layout: invalidLayout };
+
+      (getDocumentByFQN as jest.Mock).mockResolvedValueOnce({
+        ...mockDocumentData,
+        data: { pages: [landingPage] },
+      });
+
+      render(<MyDataPage />);
+
+      expect(await screen.findByText('KnowledgePanel.KPI')).toBeInTheDocument();
+      expect(
+        await screen.findByText('KnowledgePanel.TotalAssets')
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByText('KnowledgePanel.MyData')
+      ).toBeInTheDocument();
+    }
+  );
+
   it('MyDataPage should render default widgets when there is no selected persona', async () => {
     mockSelectedPersona = null;
     render(<MyDataPage />);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/PersonaPage.utils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/PersonaPage.utils.test.ts
@@ -1,0 +1,101 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Document } from '../../generated/entity/docStore/document';
+import { Page, PageType } from '../../generated/system/ui/page';
+import {
+  getPersonaPage,
+  normalizePersonaDocument,
+  updatePersonaDocumentPage,
+} from './PersonaPage.utils';
+
+const tablePage = {
+  pageType: PageType.Table,
+  tabs: [{ id: 'overview', layout: [], name: 'overview' }],
+} as unknown as Page;
+
+const dashboardPage = {
+  pageType: PageType.Dashboard,
+  layout: [],
+} as unknown as Page;
+
+const createDocument = (pages: unknown[]): Document => ({
+  data: { pages, navigation: [{ name: 'Explore' }] },
+  entityType: 'Page',
+  fullyQualifiedName: 'persona.test',
+  name: 'test',
+});
+
+describe('PersonaPage utilities', () => {
+  it('finds a valid page after invalid legacy entries', () => {
+    const document = createDocument([null, undefined, {}, tablePage]);
+
+    expect(getPersonaPage(document, PageType.Table)).toBe(tablePage);
+  });
+
+  it('normalizes invalid page entries without mutating the response', () => {
+    const document = createDocument([null, tablePage, undefined]);
+
+    const normalizedDocument = normalizePersonaDocument(document);
+
+    expect(normalizedDocument).not.toBe(document);
+    expect(normalizedDocument.data).not.toBe(document.data);
+    expect(normalizedDocument.data.pages).toEqual([tablePage]);
+    expect(normalizedDocument.data.navigation).toBe(document.data.navigation);
+    expect(document.data.pages).toEqual([null, tablePage, undefined]);
+  });
+
+  it('preserves tab-based pages without a top-level layout', () => {
+    const document = createDocument([tablePage]);
+
+    expect(normalizePersonaDocument(document)).toBe(document);
+  });
+
+  it('does not add an undefined page when resetting an unsaved layout', () => {
+    const document = {
+      ...createDocument([]),
+      data: { navigation: [{ name: 'Explore' }] },
+    };
+
+    expect(updatePersonaDocumentPage(document, PageType.DataMarketplace)).toBe(
+      document
+    );
+  });
+
+  it('adds, replaces, and removes pages while cleaning legacy entries', () => {
+    const document = createDocument([null, tablePage]);
+
+    const withDashboard = updatePersonaDocumentPage(
+      document,
+      PageType.Dashboard,
+      dashboardPage
+    );
+    const replacement = {
+      ...dashboardPage,
+      layout: [{ i: 'updated' }],
+    } as Page;
+    const withReplacement = updatePersonaDocumentPage(
+      withDashboard,
+      PageType.Dashboard,
+      replacement
+    );
+    const withoutTable = updatePersonaDocumentPage(
+      withReplacement,
+      PageType.Table
+    );
+
+    expect(withDashboard.data.pages).toEqual([tablePage, dashboardPage]);
+    expect(withReplacement.data.pages).toEqual([tablePage, replacement]);
+    expect(withoutTable.data.pages).toEqual([replacement]);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/PersonaPage.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/PersonaPage.utils.ts
@@ -1,0 +1,97 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Document } from '../../generated/entity/docStore/document';
+import { Page } from '../../generated/system/ui/page';
+
+const getPageEntries = (document?: Document | null): unknown[] | undefined => {
+  const pages = document?.data?.pages as unknown;
+
+  return Array.isArray(pages) ? pages : undefined;
+};
+
+const isPersonaPage = (value: unknown): value is Page =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as { pageType?: unknown }).pageType === 'string';
+
+export const getPersonaPage = (
+  document: Document | null | undefined,
+  pageType: string | null | undefined
+): Page | undefined => {
+  if (!pageType) {
+    return undefined;
+  }
+
+  return getPageEntries(document)?.find(
+    (page): page is Page => isPersonaPage(page) && page.pageType === pageType
+  );
+};
+
+export const normalizePersonaDocument = (document: Document): Document => {
+  const pageEntries = getPageEntries(document);
+
+  if (!pageEntries) {
+    return document;
+  }
+
+  const pages = pageEntries.filter(isPersonaPage);
+
+  if (pages.length === pageEntries.length) {
+    return document;
+  }
+
+  return {
+    ...document,
+    data: {
+      ...document.data,
+      pages,
+    },
+  };
+};
+
+export const updatePersonaDocumentPage = (
+  document: Document,
+  pageType: string,
+  newPage?: Page
+): Document => {
+  const pageEntries = getPageEntries(document);
+  const pages = pageEntries?.filter(isPersonaPage) ?? [];
+  const hasPage = pages.some((page) => page.pageType === pageType);
+  const hasInvalidPage =
+    pageEntries !== undefined && pageEntries.length !== pages.length;
+
+  if (!newPage && !hasPage && !hasInvalidPage) {
+    return document;
+  }
+
+  let updatedPages: Page[];
+
+  if (!newPage) {
+    updatedPages = pages.filter((page) => page.pageType !== pageType);
+  } else if (hasPage) {
+    updatedPages = pages.map((page) =>
+      page.pageType === pageType ? newPage : page
+    );
+  } else {
+    updatedPages = [...pages, newPage];
+  }
+
+  return {
+    ...document,
+    data: {
+      ...document.data,
+      pages: updatedPages,
+    },
+  };
+};


### PR DESCRIPTION
Backport of #31981 to the 1.13 branch.

### Why this is an adaptation, not a plain cherry-pick
The 1.13 branch predates the react-query `docStore` refactor used by #31981, so several files in the original PR either do not exist on 1.13 (`rest/queries/docStoreQuery.ts`, `DataMarketplacePage.component.test.tsx`) or fetch data through a different path (`getDocumentByFQN` directly, no `queryClient`). The fix was therefore ported to 1.13's data-fetching path while keeping the same behavior.

### What changed
- **New:** `utils/CustomizePage/PersonaPage.utils.ts` — `getPersonaPage` / `normalizePersonaDocument` / `updatePersonaDocumentPage`, which filter null/invalid page entries before they reach the UI. Ported unchanged from the source PR (only depends on generated types), with its unit test.
- `useCustomPages`, `CustomizeStore`, `CustomizablePage`, `MyDataPage`, `DataMarketplacePage` now use these helpers instead of raw `data.pages.find(...)` / manual page mutation.
- `MyDataPage` guards against a non-array customized layout and falls back to the default layout.

### Omitted from the source PR
- `rest/queries/docStoreQuery.ts` and the `queryClient.setQueryData` wiring — the react-query layer is not present on 1.13.
- `DataMarketplacePage.component.test.tsx` — the page has no test on 1.13.
- The react-query-specific additions to `useCustomPages.test.ts`. The equivalent MyDataPage tests (null legacy page + invalid layout) were ported and adapted to 1.13's `getDocumentByFQN`-based harness.

### Testing
- `PersonaPage.utils.ts` type-checks clean in isolation.
- ⚠️ Full `jest`/build could not be run in this worktree: `node_modules` is symlinked to a checkout where MUI has been removed, while 1.13 still depends on `@mui/material` (referenced in `setupTests.js`). CI on the 1.13 branch will run the suite with the correct dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport adds shared persona-page normalization helpers and applies them across customization, landing-page, and marketplace data-fetching paths. It filters null or structurally invalid legacy page entries, avoids persisting undefined pages, and falls back to the default My Data layout when customized layout data is not an array.
- Adds tested helpers for finding, normalizing, replacing, adding, and removing persona pages.
- Updates customization state and persistence paths to use the shared helpers.
- Makes My Data and Data Marketplace tolerate null legacy page entries.
- Adds My Data fallback coverage for missing and non-array layouts.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code defects identified.

The new helpers preserve all currently valid page representations, current save callers maintain page-type identity, and the updated consumers safely handle null entries and invalid landing-page layouts without introducing a reachable regression.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/PersonaPage.utils.ts | Introduces non-mutating helpers that safely filter invalid page entries and update a requested persona page. |
| openmetadata-ui/src/main/resources/ui/src/pages/CustomizablePage/CustomizablePage.tsx | Replaces manual page mutation with the shared update helper and skips no-op saves. |
| openmetadata-ui/src/main/resources/ui/src/pages/CustomizablePage/CustomizeStore.ts | Normalizes loaded persona documents and consistently delegates page lookup and mutation to shared utilities. |
| openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.component.tsx | Safely resolves the landing page and falls back to the default layout for missing or non-array customization data. |
| openmetadata-ui/src/main/resources/ui/src/pages/DataMarketplacePage/DataMarketplacePage.component.tsx | Uses null-safe persona-page lookup while preserving existing customized and default layout behavior. |
| openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/PersonaPage.utils.test.ts | Covers legacy invalid entries, immutability, tab-based pages, no-op resets, and add/replace/remove behavior. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  API[Persona document API] --> Normalize[Validate persona page entries]
  Normalize --> Find[Find requested page type]
  Find -->|Valid customization| UI[Render customized layout]
  Find -->|Missing or invalid| Default[Render default layout]
  UI --> Save[Add, replace, or remove page]
  Save --> API
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fixes #31980: handle null persona custom..."](https://github.com/open-metadata/openmetadata/commit/6ddf314e1e1ea005064b51f7c47aa0244c58c312) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56652204)</sub>

<!-- /greptile_comment -->