### PR TITLE
fix(ui): resolve cached-image race in Icon and move IconProps to interface file

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Certification/Certification.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Certification/Certification.component.tsx
@@ -161,7 +161,7 @@ const Certification = ({
 
             const isIcon = Boolean(iconURL) && !isImageUrl(iconURL as string);
             const renderedIcon = iconURL ? (
-              <Icon alt={title} iconValue={iconURL} size={28} />
+              <Icon alt={title} fallback={<CertificationIcon height={28} width={28} />} iconValue={iconURL}  size={28} />
             ) : null;
 
             return (

--- a/openmetadata-ui/src/main/resources/ui/src/components/Certification/Certification.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Certification/Certification.component.tsx
@@ -161,7 +161,12 @@ const Certification = ({
 
             const isIcon = Boolean(iconURL) && !isImageUrl(iconURL as string);
             const renderedIcon = iconURL ? (
-              <Icon alt={title} fallback={<CertificationIcon height={28} width={28} />} iconValue={iconURL}  size={28} />
+              <Icon
+                alt={title}
+                fallback={<CertificationIcon height={28} width={28} />}
+                iconValue={iconURL}
+                size={28}
+              />
             ) : null;
 
             return (

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Icon/Icon.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Icon/Icon.interface.ts
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { ReactNode } from 'react';
+
+export interface IconProps {
+  iconValue: string | undefined;
+  size?: number;
+  className?: string;
+  /** Layout/positioning styles (e.g. margin, flexShrink). Applied to the element
+   * occupying space in the caller's layout, regardless of loading state. */
+  wrapperStyle?: React.CSSProperties;
+  /** Cosmetic styles for the rendered icon/image itself (e.g. borderRadius). Never
+   * applied to the loading skeleton. */
+  imageStyle?: React.CSSProperties;
+  strokeWidth?: number;
+  alt?: string;
+  fallback?: ReactNode;
+}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Icon/Icon.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Icon/Icon.test.tsx
@@ -233,5 +233,28 @@ describe('Icon', () => {
 
       expect(container).toBeEmptyDOMElement();
     });
+
+    it('should show the image immediately when it is already cached (complete before onLoad fires)', () => {
+      Object.defineProperty(HTMLImageElement.prototype, 'complete', {
+        configurable: true,
+        get: () => true,
+      });
+      Object.defineProperty(HTMLImageElement.prototype, 'naturalWidth', {
+        configurable: true,
+        get: () => 1,
+      });
+
+      const { container, getByTestId } = render(
+        <Icon iconValue="http://example.com/cached.png" />
+      );
+
+      expect(getByTestId('icon-image')).not.toHaveStyle({ display: 'none' });
+      expect(
+        container.querySelector('[aria-hidden="true"]')
+      ).not.toBeInTheDocument();
+
+      Reflect.deleteProperty(HTMLImageElement.prototype, 'complete');
+      Reflect.deleteProperty(HTMLImageElement.prototype, 'naturalWidth');
+    });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Icon/Icon.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Icon/Icon.tsx
@@ -11,23 +11,9 @@
  *  limitations under the License.
  */
 import { Skeleton } from '@openmetadata/ui-core-components';
-import { FC, ReactNode, useEffect, useState } from 'react';
+import { FC, useEffect, useRef, useState } from 'react';
 import { getTagImageSrc, ICON_MAP, isImageUrl } from '../../../utils/IconUtils';
-
-export interface IconProps {
-  iconValue: string | undefined;
-  size?: number;
-  className?: string;
-  /** Layout/positioning styles (e.g. margin, flexShrink). Applied to the element
-   * occupying space in the caller's layout, regardless of loading state. */
-  wrapperStyle?: React.CSSProperties;
-  /** Cosmetic styles for the rendered icon/image itself (e.g. borderRadius). Never
-   * applied to the loading skeleton. */
-  imageStyle?: React.CSSProperties;
-  strokeWidth?: number;
-  alt?: string;
-  fallback?: ReactNode;
-}
+import { IconProps } from './Icon.interface';
 
 type IconLoadState = 'loading' | 'loaded' | 'error';
 
@@ -48,10 +34,25 @@ export const Icon: FC<IconProps> = ({
   alt = 'icon',
 }) => {
   const [loadState, setLoadState] = useState<IconLoadState>('loading');
+  const imgRef = useRef<HTMLImageElement>(null);
 
   useEffect(() => {
     setLoadState('loading');
   }, [iconValue]);
+
+  // For already-cached images the browser fires the load event synchronously
+  // while creating the <img> element — before React has attached its onLoad
+  // listener. Check img.complete after every transition into 'loading' so
+  // cached icons are revealed immediately on re-mount.
+  useEffect(() => {
+    if (loadState !== 'loading') {
+      return;
+    }
+    const img = imgRef.current;
+    if (img?.complete) {
+      setLoadState(img.naturalWidth > 0 ? 'loaded' : 'error');
+    }
+  }, [loadState]);
 
   if (!iconValue) {
     return <>{fallback}</>;
@@ -81,6 +82,7 @@ export const Icon: FC<IconProps> = ({
       <img
         alt={alt}
         data-testid="icon-image"
+        ref={imgRef}
         src={getTagImageSrc(iconValue)}
         style={{
           width: size,


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Refactoring:**
    - Extracted `IconProps` interface into a dedicated `Icon.interface.ts` file
- **Bug fix:**
    - Resolved cached image race condition in `Icon` component by checking `img.complete` on mount
- **Testing & Components:**
    - Added unit test for cached images in `Icon.test.tsx` and updated `Certification` component fallback

<sub>This will update automatically on new commits.</sub>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates the shared Icon component to resolve already-complete images after mounting and moves its props into a dedicated interface file.
- Adds cached-image completion handling and a focused unit test.
- Adds a certification fallback icon when custom image loading fails.
- Extracts `IconProps` into `Icon.interface.ts`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/common/Icon/Icon.tsx | Adds a post-mount completion check for cached images and imports the extracted props interface. |
| openmetadata-ui/src/main/resources/ui/src/components/common/Icon/Icon.test.tsx | Adds coverage verifying that an already-complete cached image is displayed without its loading skeleton. |
| openmetadata-ui/src/main/resources/ui/src/components/common/Icon/Icon.interface.ts | Defines the extracted IconProps interface without changing its prop shape. |
| openmetadata-ui/src/main/resources/ui/src/components/Certification/Certification.component.tsx | Supplies the standard certification icon as a fallback when a configured icon fails to load. |

</details>

<sub>Reviews (2): Last reviewed commit: ["lint fix"](https://github.com/open-metadata/openmetadata/commit/5b2668f0bf86d653c8e93db21c2c42977266e2ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56755479)</sub>

<!-- /greptile_comment -->