### PR TITLE
fix(ui): Fix lineage canvas scrolling when the filters panel is expanded [1.13]

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -254,7 +254,9 @@ plugins: Dict[str, Set[str]] = {
     },
     "db2": {"ibm-db-sa~=0.4.1", "ibm-db>=3.2.6"},
     "db2-ibmi": {
-        # sqlalchemy-ibmi is pre-installed with --no-deps (SA<2 metadata conflict)
+        # sqlalchemy-ibmi is pre-installed with --no-deps (SA<2 metadata conflict).
+        # Its SA-1.x call sites are adapted at runtime by
+        # metadata.ingestion.source.database.db2.utils.patch_ibmi_dialect
     },
     "databricks": {
         VERSIONS["databricks-sqlalchemy"],

--- a/ingestion/src/metadata/ingestion/source/api/rest/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/api/rest/metadata.py
@@ -284,13 +284,18 @@ class RestSource(ApiServiceSource):
         """fetch request schema - supports both OpenAPI 3.0 and Swagger 2.0"""
         try:
             # Try OpenAPI 3.0 format first (requestBody)
-            schema_ref = (
+            schema = (
                 info.get("requestBody", {})
                 .get("content", {})
                 .get("application/json", {})
                 .get("schema", {})
-                .get("$ref")
             )
+            schema_ref = schema.get("$ref")
+            if (
+                not schema_ref
+                and self._parse_openapi_type(schema.get("type")) == DataTypeTopic.ARRAY
+            ):
+                schema_ref = schema.get("items", {}).get("$ref")
 
             if schema_ref:
                 return APISchema(schemaFields=self.process_schema_fields(schema_ref))
@@ -299,7 +304,14 @@ class RestSource(ApiServiceSource):
             parameters = info.get("parameters", [])
             for param in parameters:
                 if param.get("in") == "body" and "schema" in param:
-                    schema_ref = param["schema"].get("$ref")
+                    schema = param["schema"]
+                    schema_ref = schema.get("$ref")
+                    if (
+                        not schema_ref
+                        and self._parse_openapi_type(schema.get("type"))
+                        == DataTypeTopic.ARRAY
+                    ):
+                        schema_ref = schema.get("items", {}).get("$ref")
                     if schema_ref:
                         return APISchema(
                             schemaFields=self.process_schema_fields(schema_ref)
@@ -356,11 +368,22 @@ class RestSource(ApiServiceSource):
             logger.warning(f"Error resolving parameter reference: {err}")
             return None
 
-    def _parse_openapi_type(self, openapi_type: Optional[str]) -> DataTypeTopic:
+    def _parse_openapi_type(self, openapi_type: Optional[object]) -> DataTypeTopic:
         """
         Parse OpenAPI type string to DataTypeTopic enum.
         Shared type conversion logic used across the codebase.
         """
+        if isinstance(openapi_type, list):
+            non_null_types = [
+                item
+                for item in openapi_type
+                if isinstance(item, str) and item.lower() != "null"
+            ]
+            openapi_type = non_null_types[0] if len(non_null_types) == 1 else None
+
+        if not isinstance(openapi_type, str):
+            return DataTypeTopic.UNKNOWN
+
         if not openapi_type:
             return DataTypeTopic.UNKNOWN
 
@@ -504,6 +527,18 @@ class RestSource(ApiServiceSource):
             logger.warning(f"Error while parsing response schema: {err}")
         return None
 
+    def _resolve_schema_ref(self, schema_ref: str) -> Optional[dict]:
+        schema_name = schema_ref.rsplit("/", maxsplit=1)[-1]
+        if self.json_response.get("components"):
+            return (
+                self.json_response.get("components", {})
+                .get("schemas", {})
+                .get(schema_name)
+            )
+        if self.json_response.get("definitions"):
+            return self.json_response.get("definitions", {}).get(schema_name)
+        return None
+
     def process_schema_fields(
         self, schema_ref: str, parent_refs: Optional[List[str]] = None
     ) -> Optional[List[FieldModel]]:
@@ -512,20 +547,7 @@ class RestSource(ApiServiceSource):
                 parent_refs = []
             schema_name = schema_ref.split("/")[-1]
 
-            # Support both OpenAPI 3.0 (components.schemas) and Swagger 2.0 (definitions)
-            schema_fields = None
-            if self.json_response.get("components"):
-                # OpenAPI 3.0: components.schemas.{SchemaName}
-                schema_fields = (
-                    self.json_response.get("components", {})
-                    .get("schemas", {})
-                    .get(schema_name)
-                )
-            elif self.json_response.get("definitions"):
-                # Swagger 2.0: definitions.{SchemaName}
-                schema_fields = self.json_response.get("definitions", {}).get(
-                    schema_name
-                )
+            schema_fields = self._resolve_schema_ref(schema_ref)
 
             if not schema_fields:
                 logger.warning(
@@ -534,6 +556,16 @@ class RestSource(ApiServiceSource):
                 return None
 
             parent_refs.append(schema_ref)
+            if (
+                self._parse_openapi_type(schema_fields.get("type"))
+                == DataTypeTopic.ARRAY
+            ):
+                items_ref = schema_fields.get("items", {}).get("$ref")
+                if items_ref and items_ref not in parent_refs:
+                    fetched_fields = self.process_schema_fields(items_ref, parent_refs)
+                    parent_refs.pop()
+                    return fetched_fields
+
             fetched_fields = []
             for key, val in schema_fields.get("properties", {}).items():
                 dtype = val.get("type")
@@ -606,7 +638,8 @@ class RestSource(ApiServiceSource):
                 parent_refs.pop()
             return fetched_fields
         except Exception as err:
-            logger.warning(f"Error while processing schema fields: {err}")
+            warning = f"Error while processing schema fields: {err}"
+            logger.warning(warning)
             if parent_refs and (schema_ref in parent_refs):
                 parent_refs.pop()
                 logger.debug(

--- a/ingestion/src/metadata/ingestion/source/database/athena/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/athena/connection.py
@@ -13,7 +13,7 @@
 Source connection handler
 """
 from functools import partial
-from typing import Optional
+from typing import List, Optional
 from urllib.parse import quote_plus
 
 from sqlalchemy.engine import Engine
@@ -41,6 +41,11 @@ from metadata.ingestion.connections.test_connections import (
 )
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.constants import THREE_MIN
+from metadata.utils.filters import filter_by_schema
+
+# Cap how many schemas the test connection probes so a catalog with many
+# databases cannot exhaust the test-connection timeout.
+MAX_SCHEMAS_TO_PROBE = 100
 
 
 def get_connection_url(connection: AthenaConnection) -> str:
@@ -95,6 +100,27 @@ def get_lake_formation_client(connection: AthenaConnection):
     return AWSClient(connection.awsConfig).get_lake_formation_client()
 
 
+def get_targeted_schemas(
+    service_connection: AthenaConnection, inspector: Inspector
+) -> List[str]:
+    """
+    Return the schemas the configured schemaFilterPattern would target,
+    mirroring what the ingestion run will actually read. With no pattern
+    configured, every schema in the catalog is returned. Collection stops at
+    MAX_SCHEMAS_TO_PROBE so a catalog with very many databases cannot exhaust
+    the test-connection timeout.
+    """
+    schema_filter_pattern = service_connection.schemaFilterPattern
+    targeted: List[str] = []
+    for schema in inspector.get_schema_names() or []:
+        if filter_by_schema(schema_filter_pattern, schema):
+            continue
+        targeted.append(schema)
+        if len(targeted) >= MAX_SCHEMAS_TO_PROBE:
+            break
+    return targeted
+
+
 def test_connection(
     metadata: OpenMetadata,
     engine: Engine,
@@ -104,22 +130,60 @@ def test_connection(
 ) -> TestConnectionResult:
     """
     Test connection. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow
-    """
+    of a metadata workflow or during an Automation Workflow.
 
-    def get_test_schema(inspector: Inspector):
-        all_schemas = inspector.get_schema_names()
-        return all_schemas[0] if all_schemas else None
+    GetTables raises when the targeted schemas return zero readable tables
+    anywhere. AWS Lake Formation silently filters results - pyathena even
+    converts the underlying ClientError into an empty list - so an empty
+    result is indistinguishable from missing grants. Raising surfaces the
+    missing DESCRIBE/SELECT grants instead of passing and then ingesting 0
+    tables. By design this also fails a genuinely empty or view-only catalog
+    (no tables anywhere); the error message calls out that possibility.
+    """
+    catalog_id = service_connection.catalogId
+    catalog_label = (
+        f"catalog '{catalog_id}'"
+        if catalog_id
+        else "the default catalog (AwsDataCatalog)"
+    )
+    targeted_schemas_cache: dict = {}
+
+    def get_cached_targeted_schemas() -> List[str]:
+        if "value" not in targeted_schemas_cache:
+            targeted_schemas_cache["value"] = get_targeted_schemas(
+                service_connection, inspect(engine)
+            )
+        return targeted_schemas_cache["value"]
 
     def custom_executor_for_table():
+        targeted_schemas = get_cached_targeted_schemas()
         inspector = inspect(engine)
-        test_schema = get_test_schema(inspector)
-        return inspector.get_table_names(test_schema) if test_schema else []
+        if not targeted_schemas:
+            raise RuntimeError(
+                f"No schemas were available to read in {catalog_label}. This usually means the "
+                "configured schemaFilterPattern matches no databases, or the IAM role is missing "
+                "AWS Lake Formation DESCRIBE grants. Grant Lake Formation DESCRIBE/SELECT and verify "
+                "the schema filter pattern."
+            )
+        readable = any(inspector.get_table_names(schema) for schema in targeted_schemas)
+        if not readable:
+            raise RuntimeError(
+                f"Connected and listed schemas, but no tables were readable in any of the "
+                f"{len(targeted_schemas)} targeted schema(s) of {catalog_label}. AWS Lake Formation "
+                "returns an empty list (instead of an error) when grants are missing, so ingestion "
+                "would succeed and ingest 0 tables. Grant Lake Formation DESCRIBE/SELECT to the IAM "
+                "role on the catalog and its databases/tables, then retry. If the catalog is "
+                "genuinely empty (no tables yet), this failure is expected and can be ignored."
+            )
 
     def custom_executor_for_view():
+        targeted_schemas = get_cached_targeted_schemas()
         inspector = inspect(engine)
-        test_schema = get_test_schema(inspector)
-        return inspector.get_view_names(test_schema) if test_schema else []
+        # Views are frequently absent and GetViews is non-mandatory, so we
+        # probe for visibility but never raise on an empty result.
+        for schema in targeted_schemas:
+            if inspector.get_view_names(schema):
+                break
 
     test_fn = {
         "CheckAccess": partial(test_connection_engine_step, engine),

--- a/ingestion/src/metadata/ingestion/source/database/bigquery/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/bigquery/metadata.py
@@ -92,6 +92,7 @@ from metadata.ingestion.source.database.bigquery.queries import (
     BIGQUERY_GET_TABLE_DDLS,
     BIGQUERY_GET_TABLE_DDLS_BY_REGION,
     BIGQUERY_LIFE_CYCLE_QUERY,
+    BIGQUERY_LIFE_CYCLE_QUERY_BY_REGION,
 )
 from metadata.ingestion.source.database.column_type_parser import create_sqlalchemy_type
 from metadata.ingestion.source.database.common_db_source import (
@@ -517,6 +518,47 @@ class BigquerySource(LifeCycleQueryMixin, CommonDbSourceService, MultiDBSource):
                     exc,
                 )
         yield from super().yield_life_cycle_data(_)
+
+    def _get_schema_region(self, schema_name: str) -> Optional[str]:
+        """Resolve the dataset's region for region-scoped INFORMATION_SCHEMA queries."""
+        region = None
+        try:
+            dataset_obj = self.get_dataset_obj(schema_name)
+            region = getattr(dataset_obj, "location", None)
+        except Exception as exc:
+            logger.debug(traceback.format_exc())
+            logger.debug(
+                "Could not resolve dataset region for schema '%s', falling back to dataset-scoped query: %s",
+                schema_name,
+                exc,
+            )
+        return region
+
+    def get_life_cycle_query(self):
+        """
+        Build the life cycle query.
+
+        When the dataset region is resolvable we use the region-scoped variant that
+        also captures the last-modified timestamp from INFORMATION_SCHEMA.TABLE_STORAGE
+        (which is only exposed at region/org level). Otherwise we fall back to the
+        dataset-scoped created-only query.
+        """
+        database = (
+            self.context.get().database  # pyright: ignore[reportAttributeAccessIssue]
+        )
+        schema_name = (
+            self.context.get().database_schema  # pyright: ignore[reportAttributeAccessIssue]
+        )
+        region = self._get_schema_region(schema_name)
+        if region:
+            query = BIGQUERY_LIFE_CYCLE_QUERY_BY_REGION.format(
+                database_name=database, schema_name=schema_name, region=region
+            )
+        else:
+            query = BIGQUERY_LIFE_CYCLE_QUERY.format(
+                database_name=database, schema_name=schema_name
+            )
+        return query
 
     def _prefetch_policy_tags(self):
         """Pre-fetch all policy tags at schema level to avoid per-column API calls"""

--- a/ingestion/src/metadata/ingestion/source/database/bigquery/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/bigquery/queries.py
@@ -187,6 +187,25 @@ and table_catalog = '{database_name}'
 """
 )
 
+# TABLE_STORAGE is only exposed at the region/organization level (it cannot be
+# dataset-qualified like TABLES), so this variant is region-scoped and joins on
+# table_schema to restrict TABLE_STORAGE to the current dataset. Used when the
+# dataset's region can be resolved; otherwise we fall back to the dataset-scoped
+# created-only query above.
+BIGQUERY_LIFE_CYCLE_QUERY_BY_REGION = textwrap.dedent(
+    """
+select
+t.table_name as table_name,
+t.creation_time as created_at,
+s.storage_last_modified_time as updated_at
+from `{database_name}`.`region-{region}`.INFORMATION_SCHEMA.TABLES t
+left join `{database_name}`.`region-{region}`.INFORMATION_SCHEMA.TABLE_STORAGE s
+on t.table_name = s.table_name and t.table_schema = s.table_schema
+where t.table_schema = '{schema_name}'
+and t.table_catalog = '{database_name}'
+"""
+)
+
 BIGQUERY_GET_CHANGED_TABLES_FROM_CLOUD_LOGGING = """
 protoPayload.metadata.@type="type.googleapis.com/google.cloud.audit.BigQueryAuditMetadata"
 AND (

--- a/ingestion/src/metadata/ingestion/source/database/db2/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/db2/connection.py
@@ -41,6 +41,7 @@ from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.db2.utils import (
     check_clidriver_version,
     install_clidriver,
+    patch_ibmi_dialect,
 )
 from metadata.utils.constants import THREE_MIN, UTF_8
 from metadata.utils.logger import ingestion_logger
@@ -136,6 +137,7 @@ def get_connection(connection: Db2Connection) -> Engine:
             connection = ssl_manager.setup_ssl(connection)
 
     if is_ibmi:
+        patch_ibmi_dialect()
         return create_generic_db_connection(
             connection=connection,
             get_connection_url_fn=_get_ibmi_connection_url,

--- a/ingestion/src/metadata/ingestion/source/database/db2/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/db2/utils.py
@@ -14,7 +14,7 @@ Module to define overriden dialect methods
 """
 from enum import Enum
 
-from sqlalchemy import and_, join, sql
+from sqlalchemy import and_, join, select, sql, text
 from sqlalchemy.engine import reflection
 from sqlalchemy.sql import sqltypes as sa_types
 
@@ -252,3 +252,71 @@ def install_clidriver(clidriver_version: str) -> None:
         ]
     )
     return None
+
+
+_IBMI_PATCHED = False
+
+
+def _ibmi_compat_select(*args, **kwargs):
+    """Translate the SA-1.x ``select([cols], whereclause, order_by=...)`` form to
+    the modern signature. sqlalchemy-ibmi 0.9.3 uses the legacy form, removed in
+    SA 2.0. ``order_by`` must be carried over: get_foreign_keys and get_indexes
+    rely on it to group multi-column constraints in column order."""
+    if args and isinstance(args[0], (list, tuple)):
+        statement = select(*args[0])
+        for whereclause in args[1:]:
+            if whereclause is not None:
+                statement = statement.where(whereclause)
+        order_by = kwargs.pop("order_by", None)
+        if order_by is not None:
+            statement = statement.order_by(*order_by)
+        if kwargs:
+            raise TypeError(f"Unsupported legacy select() keywords: {sorted(kwargs)}")
+        return statement
+    return select(*args, **kwargs)
+
+
+def get_default_schema_name_ibmi(self, connection):
+    """SA 2.0 rejects raw strings passed to ``Connection.execute``."""
+    return self.normalize_name(
+        connection.execute(text("VALUES CURRENT_SCHEMA")).scalar()
+    )
+
+
+def check_text_server_ibmi(self, connection):  # pylint: disable=unused-argument
+    """SA 2.0 rejects raw strings passed to ``Connection.execute``."""
+    return connection.execute(
+        text("SELECT COUNT(*) FROM QSYS2.SYSTEXTSERVERS")
+    ).scalar()
+
+
+def patch_ibmi_dialect() -> bool:
+    """Adapt the sqlalchemy-ibmi dialect to SQLAlchemy 2.0 at runtime.
+
+    sqlalchemy-ibmi 0.9.3 pins sqlalchemy<2 but is installed with --no-deps, so
+    its SA-1.x call sites survive into a SA 2.0 runtime and fail on first use.
+    Reassigning the module-level ``select`` covers every legacy reflection query
+    at once, since the dialect resolves it as a global on each call.
+    """
+    global _IBMI_PATCHED  # noqa: PLW0603  # pylint: disable=global-statement
+    if _IBMI_PATCHED:
+        return True
+    try:
+        import sqlalchemy_ibmi.base as ibmi_base  # pylint: disable=import-outside-toplevel
+    except ImportError:
+        logger.debug("sqlalchemy-ibmi not installed - ibmi scheme unavailable")
+        return False
+
+    # A partially-initialised module (interrupted import) satisfies the import
+    # above but lacks the dialect, so assigning onto it would raise instead.
+    dialect = getattr(ibmi_base, "IBMiDb2Dialect", None)
+    if dialect is None:
+        logger.debug("sqlalchemy-ibmi is not usable - ibmi scheme unavailable")
+        return False
+
+    # pylint: disable=protected-access
+    ibmi_base.select = _ibmi_compat_select
+    dialect._get_default_schema_name = get_default_schema_name_ibmi
+    dialect._check_text_server = check_text_server_ibmi
+    _IBMI_PATCHED = True
+    return True

--- a/ingestion/src/metadata/ingestion/source/database/life_cycle_query_mixin.py
+++ b/ingestion/src/metadata/ingestion/source/database/life_cycle_query_mixin.py
@@ -51,6 +51,7 @@ class LifeCycleQueryByTable(BaseModel):
 
     table_name: str = Field(..., alias="TABLE_NAME")
     created_at: Optional[datetime] = Field(None, alias="CREATED_AT")
+    updated_at: Optional[datetime] = Field(None, alias="UPDATED_AT")
 
 
 class LifeCycleQueryMixin:
@@ -96,6 +97,15 @@ class LifeCycleQueryMixin:
 
         return queries_dict
 
+    @staticmethod
+    def _build_access_details(value: Optional[datetime]) -> AccessDetails:
+        """Convert a source timestamp into an AccessDetails, defaulting to the minimum date."""
+        source_datetime = value if value else datetime.min
+        timestamp_value = datetime_to_timestamp(source_datetime, milliseconds=True)
+        return AccessDetails(
+            timestamp=Timestamp(timestamp_value)
+        )  # pyright: ignore[reportCallIssue]
+
     def get_life_cycle_data(
         self, entity: Type[Entity], entity_name: str, entity_fqn: str, query: str
     ):
@@ -105,18 +115,17 @@ class LifeCycleQueryMixin:
         try:
             life_cycle_data = self.life_cycle_query_dict(query=query).get(entity_name)
             if life_cycle_data:
-                if life_cycle_data.created_at:
-                    timestamp_value = datetime_to_timestamp(
-                        life_cycle_data.created_at, milliseconds=True
+                life_cycle = LifeCycle(  # pyright: ignore[reportCallIssue]
+                    created=self._build_access_details(
+                        life_cycle_data.created_at  # pyright: ignore[reportAttributeAccessIssue]
                     )
-                else:
-                    timestamp_value = datetime_to_timestamp(
-                        datetime.min, milliseconds=True
-                    )  # Using minimum date
-
-                life_cycle = LifeCycle(
-                    created=AccessDetails(timestamp=Timestamp(timestamp_value))
                 )
+                if (
+                    life_cycle_data.updated_at  # pyright: ignore[reportAttributeAccessIssue]
+                ):
+                    life_cycle.updated = self._build_access_details(
+                        life_cycle_data.updated_at  # pyright: ignore[reportAttributeAccessIssue]
+                    )
 
                 yield Either(
                     right=OMetaLifeCycleData(
@@ -161,10 +170,7 @@ class LifeCycleQueryMixin:
                 entity=Table,
                 entity_name=self.context.get().table,
                 entity_fqn=table_fqn,
-                query=self.life_cycle_query.format(
-                    database_name=self.context.get().database,
-                    schema_name=self.context.get().database_schema,
-                ),
+                query=self.get_life_cycle_query(),
             )
         except Exception as exc:
             yield Either(

--- a/ingestion/src/metadata/ingestion/source/database/trino/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/trino/metadata.py
@@ -53,6 +53,75 @@ from metadata.utils.sqlalchemy_utils import get_all_table_comments
 logger = ingestion_logger()
 ROW_DATA_TYPE = "row"
 ARRAY_DATA_TYPE = "array"
+UNNAMED_FIELD_PREFIX = "field"
+
+# Trino renders a named ROW field as `"name" type`, always quoting the name and
+# escaping an embedded quote as `""`. A leading quote is therefore what tells a
+# named field apart from an unnamed one whose type happens to contain spaces.
+_QUOTED_FIELD_NAME = re.compile(r'^"((?:[^"]|"")*)"\s+(?P<type>.+)$', re.DOTALL)
+
+# The only Trino types rendered with spaces. Without this, an unnamed field such
+# as `timestamp(3) with time zone` would split into two tokens and be misread as
+# a field named `timestamp(3)`.
+_TYPE_CONTINUATION = re.compile(
+    r"^(?:with(?:out)?\s+time\s+zone|day\s+to\s+second|year\s+to\s+month|precision)$",
+    re.IGNORECASE,
+)
+
+
+def _starts_with_type(type_str: str, type_name: str) -> bool:
+    return type_str.lower().startswith(type_name)
+
+
+def split_row_field(field_str: str) -> Tuple[Optional[str], str]:
+    """
+    Split a single Trino ROW field into its (name, type) pair.
+
+    Trino allows the field name to be omitted entirely -- `row(bigint, varchar(1))`,
+    which is what any CTAS over a `ROW(...)` constructor produces -- so the name is
+    None for an unnamed field, mirroring how the driver's own ROW type models it.
+    Naming is left to `resolve_field_names`, which needs the whole ROW to guarantee
+    uniqueness.
+
+    Named fields arrive quoted (`row("a" bigint)`); the quotes are stripped so the
+    OpenMetadata child column is `a` rather than `"a"`, preserving the original case.
+    """
+    field_str = field_str.strip()
+
+    quoted = _QUOTED_FIELD_NAME.match(field_str)
+    if quoted:
+        return quoted.group(1).replace('""', '"'), quoted.group("type").strip()
+
+    parts = list(datatype.aware_split(field_str, delimiter=" ", maxsplit=1))
+    if len(parts) == 1 or _TYPE_CONTINUATION.match(parts[1].strip()):
+        return None, field_str
+    return parts[0], parts[1].strip()
+
+
+def resolve_field_names(
+    fields: List[Tuple[Optional[str], str]]
+) -> List[Tuple[str, str]]:
+    """
+    Give every field of one ROW a unique name.
+
+    Unnamed fields are named positionally to match Trino's 1-based field access, so
+    `s[1]` reads as `field1`. Because a ROW may mix unnamed fields with one named
+    literally `fieldN` -- `row(bigint, "field1" varchar)` is valid Trino -- a
+    positional name is suffixed until it is unique. Two children sharing a name
+    would make the nested column FQN ambiguous.
+    """
+    taken = {name for name, _ in fields if name is not None}
+    resolved = []
+    for position, (name, type_str) in enumerate(fields, start=1):
+        if name is None:
+            name = f"{UNNAMED_FIELD_PREFIX}{position}"
+            suffix = 1
+            while name in taken:
+                name = f"{UNNAMED_FIELD_PREFIX}{position}_{suffix}"
+                suffix += 1
+            taken.add(name)
+        resolved.append((name, type_str))
+    return resolved
 
 
 def get_type_name_and_opts(type_str: str) -> Tuple[str, Optional[str]]:
@@ -73,11 +142,11 @@ def parse_array_data_type(type_str: str) -> str:
     this method will return type as -> array<struct<col1:bigint,col2:string>>
     """
     type_name, type_opts = get_type_name_and_opts(type_str)
-    final = type_name + "<"
+    final = type_name.lower() + "<"
     if type_opts:
-        if type_opts.startswith(ROW_DATA_TYPE):
+        if _starts_with_type(type_opts, ROW_DATA_TYPE):
             final += parse_row_data_type(type_opts)
-        elif type_opts.startswith(ARRAY_DATA_TYPE):
+        elif _starts_with_type(type_opts, ARRAY_DATA_TYPE):
             final += parse_array_data_type(type_opts)
         else:
             final += type_opts
@@ -92,19 +161,40 @@ def parse_row_data_type(type_str: str) -> str:
     this method will return type as -> struct<col1:bigint,col2:bigint,col3:struct<col4:string,col5:bigint>>
     """
     type_name, type_opts = get_type_name_and_opts(type_str)
-    final = type_name.replace(ROW_DATA_TYPE, "struct") + "<"
+    final = type_name.lower().replace(ROW_DATA_TYPE, "struct") + "<"
     if type_opts:
-        for data_type in datatype.aware_split(type_opts) or []:
-            attr_name, attr_type_str = datatype.aware_split(
-                data_type.strip(), delimiter=" ", maxsplit=1
-            )
-            if attr_type_str.startswith(ROW_DATA_TYPE):
+        fields = [
+            split_row_field(field) for field in datatype.aware_split(type_opts) or []
+        ]
+        for attr_name, attr_type_str in resolve_field_names(fields):
+            if _starts_with_type(attr_type_str, ROW_DATA_TYPE):
                 final += attr_name + ":" + parse_row_data_type(attr_type_str) + ","
-            elif attr_type_str.startswith(ARRAY_DATA_TYPE):
+            elif _starts_with_type(attr_type_str, ARRAY_DATA_TYPE):
                 final += attr_name + ":" + parse_array_data_type(attr_type_str) + ","
             else:
                 final += attr_name + ":" + attr_type_str + ","
     return final[:-1] + ">"
+
+
+def _parse_sqltype(type_str: str, table_name: str, column_name: str):
+    """
+    Resolve the SQLAlchemy type for a Trino column, tolerating types the driver
+    cannot parse.
+
+    ``trino.sqlalchemy.datatype.parse_sqltype`` raises on ROW types with unnamed
+    fields (it unpacks every field as `name type`), which would otherwise abort
+    reflection for the whole table and publish it with no columns at all. The
+    OpenMetadata data type is derived from ``system_data_type`` for complex
+    columns, so falling back to NULLTYPE here keeps the column and its children.
+    """
+    try:
+        return datatype.parse_sqltype(type_str)
+    except Exception as err:  # pylint: disable=broad-except
+        logger.debug(traceback.format_exc())
+        logger.warning(
+            f"Could not resolve a SQLAlchemy type for column [{table_name}.{column_name}] of type [{type_str}]: {err}"
+        )
+        return sqltypes.NULLTYPE
 
 
 def _get_columns(
@@ -118,7 +208,9 @@ def _get_columns(
     res = connection.execute(sql.text(query))
     columns = []
     for record in res:
-        col_type = datatype.parse_sqltype(record.Type)
+        col_type = _parse_sqltype(
+            record.Type, table_name=table_name, column_name=record.Column
+        )
         column = {
             "name": record.Column,
             "type": col_type,
@@ -129,12 +221,15 @@ def _get_columns(
             "comment": record.Comment or None,
             "system_data_type": record.Type,
         }
-        type_str = record.Type.strip().lower()
+        # Keep the original case: Trino renders type names in lower case already,
+        # but preserves the case of quoted ROW field names, which become the
+        # OpenMetadata child column names.
+        type_str = record.Type.strip()
         type_name, type_opts = get_type_name_and_opts(type_str)
-        if type_opts and type_name == ROW_DATA_TYPE:
+        if type_opts and type_name.lower() == ROW_DATA_TYPE:
             column["system_data_type"] = parse_row_data_type(type_str)
             column["is_complex"] = True
-        elif type_opts and type_name == ARRAY_DATA_TYPE:
+        elif type_opts and type_name.lower() == ARRAY_DATA_TYPE:
             column["system_data_type"] = parse_array_data_type(type_str)
             column["is_complex"] = True
         columns.append(column)

--- a/ingestion/src/metadata/ingestion/source/mlmodel/mlflow/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/mlmodel/mlflow/metadata.py
@@ -147,11 +147,12 @@ class MlflowSource(MlModelServiceSource):
         versions: list[ModelVersion] = []
         page_token = None
 
-        # MLflow only bars `/` and `:` from model names, so a name may well contain
-        # a quote. Double quotes are the only delimiter the filter parser round-trips
-        # a single quote through: the SQL-style `''` escape parses, but yields the
-        # doubled quote verbatim and would silently match nothing.
-        filter_string = f'name="{model_name}"'
+        # Single quotes are mandatory. Unity Catalog does not parse this filter
+        # locally -- it forwards the string to the Databricks REST endpoint, whose
+        # parser accepts only `name = 'model_name'` and rejects a double-quoted
+        # name with INVALID_PARAMETER_VALUE. MLflow's own client-side parser is
+        # more permissive, so it cannot be used to validate this.
+        filter_string = f"name='{model_name}'"
 
         try:
             for _ in range(MAX_VERSION_PAGES):

--- a/ingestion/src/metadata/ingestion/source/pipeline/airflow/api/client.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/airflow/api/client.py
@@ -37,6 +37,9 @@ from metadata.ingestion.source.pipeline.airflow.api.auth import (
     build_basic_auth_callback,
     build_gcp_token_callback,
 )
+from metadata.ingestion.source.pipeline.airflow.api.exceptions import (
+    AirflowApiResponseError,
+)
 from metadata.ingestion.source.pipeline.airflow.api.models import (
     AirflowApiDagDetails,
     AirflowApiDagRun,
@@ -218,20 +221,29 @@ class AirflowApiClient:
             )
 
             response = self._parse_response(response)
-            if not response:
-                break
+            if not isinstance(response, dict) or not isinstance(
+                response.get(key), list
+            ):
+                raise AirflowApiResponseError(
+                    f"Invalid paginated response for {path} at offset={offset}"
+                )
 
-            page = response.get(key, [])
+            page = response[key]
+            total_entries = response.get("total_entries")
+            if total_entries is not None and type(total_entries) is not int:
+                raise AirflowApiResponseError(
+                    f"Invalid paginated response for {path} at offset={offset}"
+                )
             if not page:
+                if total_entries is not None and offset < total_entries:
+                    raise AirflowApiResponseError(
+                        f"Invalid paginated response for {path} at offset={offset}"
+                    )
                 break
             result.extend(page)
-            offset += limit
+            offset += len(page)
 
-            total_entries = response.get("total_entries")
-            if total_entries is not None:
-                if offset >= total_entries:
-                    break
-            elif len(page) < limit:
+            if total_entries is not None and offset >= total_entries:
                 break
         return result
 
@@ -268,12 +280,12 @@ class AirflowApiClient:
             if isinstance(schedule, dict):
                 schedule = schedule.get("value")
 
-        try:
-            task_response = self.get_dag_tasks(dag_id)
-            tasks_data = task_response.get("tasks", [])
-        except Exception as exc:
-            logger.warning(f"Could not fetch tasks for DAG {dag_id}: {exc}")
-            tasks_data = []
+        task_response = self.get_dag_tasks(dag_id)
+        if not isinstance(task_response, dict) or not isinstance(
+            task_response.get("tasks"), list
+        ):
+            raise AirflowApiResponseError(f"Invalid tasks response for DAG {dag_id}")
+        tasks_data = task_response["tasks"]
 
         tasks = [
             AirflowApiTask(

--- a/ingestion/src/metadata/ingestion/source/pipeline/airflow/api/exceptions.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/airflow/api/exceptions.py
@@ -1,0 +1,15 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Exceptions for the Airflow REST API clients."""
+
+
+class AirflowApiResponseError(RuntimeError):
+    """Airflow returned a response the client cannot trust as complete."""

--- a/ingestion/src/metadata/ingestion/source/pipeline/airflow/api/mwaa.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/airflow/api/mwaa.py
@@ -20,6 +20,9 @@ from urllib.parse import quote
 
 from metadata.clients.aws_client import AWSClient
 from metadata.generated.schema.security.credentials.awsCredentials import AWSCredentials
+from metadata.ingestion.source.pipeline.airflow.api.exceptions import (
+    AirflowApiResponseError,
+)
 from metadata.ingestion.source.pipeline.airflow.api.models import (
     AirflowApiDagDetails,
     AirflowApiDagRun,
@@ -129,21 +132,30 @@ class MWAAClient:
             query = {"limit": str(limit), "offset": str(offset)}
             response = self._invoke_rest_api(path, query=query)
 
-            if not response:
-                break
+            if not isinstance(response, dict) or not isinstance(
+                response.get(key), list
+            ):
+                raise AirflowApiResponseError(
+                    f"Invalid paginated response for {path} at offset={offset}"
+                )
 
-            page = response.get(key, [])
+            page = response[key]
+            total_entries = response.get("total_entries")
+            if total_entries is not None and type(total_entries) is not int:
+                raise AirflowApiResponseError(
+                    f"Invalid paginated response for {path} at offset={offset}"
+                )
             if not page:
+                if total_entries is not None and offset < total_entries:
+                    raise AirflowApiResponseError(
+                        f"Invalid paginated response for {path} at offset={offset}"
+                    )
                 break
 
             result.extend(page)
-            offset += limit
+            offset += len(page)
 
-            total_entries = response.get("total_entries")
-            if total_entries is not None:
-                if offset >= total_entries:
-                    break
-            elif len(page) < limit:
+            if total_entries is not None and offset >= total_entries:
                 break
 
         return result
@@ -176,13 +188,12 @@ class MWAAClient:
         if isinstance(schedule, dict):
             schedule = schedule.get("value")
 
-        # Get tasks for the DAG
-        try:
-            task_response = self.get_dag_tasks(dag_id)
-            tasks_data = task_response.get("tasks", [])
-        except Exception as exc:
-            logger.warning(f"Could not fetch tasks for DAG {dag_id}: {exc}")
-            tasks_data = []
+        task_response = self.get_dag_tasks(dag_id)
+        if not isinstance(task_response, dict) or not isinstance(
+            task_response.get("tasks"), list
+        ):
+            raise AirflowApiResponseError(f"Invalid tasks response for DAG {dag_id}")
+        tasks_data = task_response["tasks"]
 
         tasks = [
             AirflowApiTask(

--- a/ingestion/src/metadata/ingestion/source/pipeline/airflow/api/source.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/airflow/api/source.py
@@ -45,6 +45,7 @@ from metadata.generated.schema.type.basic import (
 from metadata.generated.schema.type.entityReferenceList import EntityReferenceList
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import InvalidSourceException
+from metadata.ingestion.models.delete_entity import DeleteEntity
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.models.pipeline_status import OMetaPipelineStatus
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
@@ -75,6 +76,8 @@ class AirflowApiSource(PipelineServiceSource):
     Pipeline metadata from Airflow's REST API
     """
 
+    _dag_listing_complete = True
+
     @classmethod
     def create(
         cls, config_dict, metadata: OpenMetadata, pipeline_name: Optional[str] = None
@@ -88,15 +91,56 @@ class AirflowApiSource(PipelineServiceSource):
         return cls(config, metadata)
 
     def get_pipelines_list(self) -> Iterable[AirflowApiDagDetails]:
-        all_dags = self.connection.get_all_dags()
-        for dag_data in all_dags:
+        self._dag_listing_complete = True
+        try:
+            dags = self.connection.get_all_dags()
+        except Exception:
+            self._dag_listing_complete = False
+            raise
+
+        for dag_data in dags:
             try:
                 yield self.connection.build_dag_details(dag_data)
             except Exception as exc:
-                logger.debug(traceback.format_exc())
-                logger.warning(
-                    f"Error building DAG details for {dag_data.get('dag_id')}: {exc}"
+                stack_trace = traceback.format_exc()
+                dag_id = dag_data.get("dag_id")
+                self.status.failed(
+                    StackTraceError(
+                        name=dag_id or "Unknown Airflow DAG",
+                        error=f"Error building DAG details for {dag_id}: {exc}",
+                        stackTrace=stack_trace,
+                    )
                 )
+                if dag_id:
+                    self._preserve_failed_dag(dag_id)
+
+    def _preserve_failed_dag(self, dag_id: str) -> None:
+        try:
+            pipeline_fqn = fqn.build(
+                metadata=self.metadata,
+                entity_type=Pipeline,
+                service_name=self.context.get().pipeline_service,
+                pipeline_name=dag_id,
+            )
+            if pipeline_fqn:
+                self.pipeline_source_state.add(pipeline_fqn)
+                return
+        except Exception as exc:
+            logger.debug(traceback.format_exc())
+            logger.warning(
+                f"Could not preserve source state for Airflow DAG {dag_id}: {exc}"
+            )
+
+        self._dag_listing_complete = False
+
+    def mark_pipelines_as_deleted(self) -> Iterable[Either[DeleteEntity]]:
+        if not self._dag_listing_complete:
+            logger.warning(
+                "Skipping stale-pipeline deletion because Airflow DAG discovery was incomplete "
+                "or a known DAG could not be preserved in source state."
+            )
+            return
+        yield from super().mark_pipelines_as_deleted()
 
     def get_pipeline_name(self, pipeline_details: AirflowApiDagDetails) -> str:
         return pipeline_details.dag_id

--- a/ingestion/tests/integration/airflow/test_airflow_api_connection.py
+++ b/ingestion/tests/integration/airflow/test_airflow_api_connection.py
@@ -427,7 +427,8 @@ class TestAirflowApiMockedIntegration:
                                 "triggerer_job": None,
                                 "note": "Data loaded to Snowflake successfully",
                             },
-                        ]
+                        ],
+                        "total_entries": 3,
                     }
                 }
             },

--- a/ingestion/tests/unit/source/database/athena/test_connection.py
+++ b/ingestion/tests/unit/source/database/athena/test_connection.py
@@ -1,0 +1,163 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for Athena connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.generated.schema.entity.services.connections.database.athenaConnection import (
+    AthenaConnection as AthenaConnectionConfig,
+)
+from metadata.generated.schema.entity.services.connections.database.athenaConnection import (
+    AthenaScheme,
+)
+from metadata.generated.schema.security.credentials.awsCredentials import AWSCredentials
+from metadata.generated.schema.type.filterPattern import FilterPattern
+from metadata.ingestion.source.database.athena import connection as athena_connection
+
+CONNECTION_MODULE = "metadata.ingestion.source.database.athena.connection"
+
+
+def _config(**kwargs) -> AthenaConnectionConfig:
+    base = {
+        "awsConfig": AWSCredentials(
+            awsAccessKeyId="key",
+            awsRegion="us-east-2",
+            awsSecretAccessKey="secret_key",
+        ),
+        "s3StagingDir": "s3://postgres/input/",
+        "workgroup": "primary",
+        "scheme": AthenaScheme.awsathena_rest,
+    }
+    base.update(kwargs)
+    return AthenaConnectionConfig(**base)
+
+
+def _run_steps_capturing(service_connection: AthenaConnectionConfig) -> dict:
+    """
+    Patch the framework so each test_fn callable is invoked directly and any
+    raised exception is captured. Returns {step_name: raised_exc_or_None}.
+    The executors are nested closures, so they are driven via the public
+    test_connection with inspect() mocked.
+    """
+    captured = {}
+
+    def fake_steps(*, test_fn, **_kwargs):
+        for name, fn in test_fn.items():
+            try:
+                fn()
+                captured[name] = None
+            except Exception as err:  # pylint: disable=broad-except
+                captured[name] = err
+        return MagicMock()
+
+    with patch(f"{CONNECTION_MODULE}.test_connection_steps", side_effect=fake_steps):
+        athena_connection.test_connection(
+            metadata=MagicMock(),
+            engine=MagicMock(),
+            service_connection=service_connection,
+        )
+    return captured
+
+
+def test_get_tables_raises_when_all_targeted_schemas_empty():
+    inspector = MagicMock()
+    inspector.get_schema_names.return_value = ["db1", "db2"]
+    inspector.get_table_names.return_value = []
+    with patch(f"{CONNECTION_MODULE}.inspect", return_value=inspector):
+        captured = _run_steps_capturing(_config(catalogId="my_catalog"))
+    assert isinstance(captured["GetTables"], Exception)
+
+
+def test_get_tables_passes_when_a_schema_has_tables():
+    inspector = MagicMock()
+    inspector.get_schema_names.return_value = ["db1", "db2"]
+    inspector.get_table_names.side_effect = lambda schema: (
+        ["t1"] if schema == "db2" else []
+    )
+    with patch(f"{CONNECTION_MODULE}.inspect", return_value=inspector):
+        captured = _run_steps_capturing(_config())
+    assert captured["GetTables"] is None
+
+
+def test_get_tables_honors_schema_filter_pattern():
+    inspector = MagicMock()
+    inspector.get_schema_names.return_value = ["db1", "db2"]
+    inspector.get_table_names.side_effect = lambda schema: (
+        ["t1"] if schema == "db2" else []
+    )
+    with patch(f"{CONNECTION_MODULE}.inspect", return_value=inspector):
+        captured = _run_steps_capturing(
+            _config(schemaFilterPattern=FilterPattern(includes=["db2"]))
+        )
+    assert captured["GetTables"] is None
+    probed = {call.args[0] for call in inspector.get_table_names.call_args_list}
+    assert probed == {"db2"}
+
+
+def test_get_tables_raises_when_filter_matches_nothing():
+    inspector = MagicMock()
+    inspector.get_schema_names.return_value = ["db1", "db2"]
+    with patch(f"{CONNECTION_MODULE}.inspect", return_value=inspector):
+        captured = _run_steps_capturing(
+            _config(
+                catalogId="my_catalog",
+                schemaFilterPattern=FilterPattern(includes=["nope"]),
+            )
+        )
+    assert isinstance(captured["GetTables"], Exception)
+    inspector.get_table_names.assert_not_called()
+
+
+def test_get_views_does_not_raise_when_empty():
+    inspector = MagicMock()
+    inspector.get_schema_names.return_value = ["db1"]
+    inspector.get_table_names.return_value = ["t1"]
+    inspector.get_view_names.return_value = []
+    with patch(f"{CONNECTION_MODULE}.inspect", return_value=inspector):
+        captured = _run_steps_capturing(_config())
+    assert captured["GetViews"] is None
+
+
+def test_get_tables_error_message_is_actionable():
+    inspector = MagicMock()
+    inspector.get_schema_names.return_value = ["db1"]
+    inspector.get_table_names.return_value = []
+    with patch(f"{CONNECTION_MODULE}.inspect", return_value=inspector):
+        captured = _run_steps_capturing(_config(catalogId="my_catalog"))
+    raised = str(captured["GetTables"])
+    assert "Lake Formation" in raised
+    assert "my_catalog" in raised
+    assert any(keyword in raised.lower() for keyword in ("describe", "select", "grant"))
+
+
+def test_get_tables_caps_probing_at_max_schemas():
+    inspector = MagicMock()
+    inspector.get_schema_names.return_value = [f"db{i}" for i in range(500)]
+    inspector.get_table_names.return_value = []
+    with patch(f"{CONNECTION_MODULE}.inspect", return_value=inspector):
+        captured = _run_steps_capturing(_config(catalogId="my_catalog"))
+    assert isinstance(captured["GetTables"], Exception)
+    assert (
+        inspector.get_table_names.call_count <= athena_connection.MAX_SCHEMAS_TO_PROBE
+    )
+
+
+def test_targeted_schemas_listed_once_across_table_and_view_steps():
+    inspector = MagicMock()
+    inspector.get_schema_names.return_value = ["db1"]
+    inspector.get_table_names.return_value = ["t1"]
+    inspector.get_view_names.return_value = []
+    with patch(f"{CONNECTION_MODULE}.inspect", return_value=inspector):
+        _run_steps_capturing(_config())
+    # The memoized table + view executors share a single schema listing on this
+    # inspector (1 call), instead of one each (2). GetSchemas uses its own
+    # inspector via execute_inspector_func and does not touch this mock.
+    assert inspector.get_schema_names.call_count == 1

--- a/ingestion/tests/unit/source/database/db2/test_connection.py
+++ b/ingestion/tests/unit/source/database/db2/test_connection.py
@@ -1,0 +1,202 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for the sqlalchemy-ibmi SQLAlchemy 2.0 compatibility layer."""
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import column, table
+from sqlalchemy.sql.elements import TextClause
+
+from metadata.generated.schema.entity.services.connections.database.db2Connection import (
+    Db2Connection as Db2ConnectionConfig,
+)
+from metadata.generated.schema.entity.services.connections.database.db2Connection import (
+    Db2Scheme,
+)
+from metadata.ingestion.source.database.db2.connection import get_connection
+from metadata.ingestion.source.database.db2.utils import (
+    _ibmi_compat_select,
+    patch_ibmi_dialect,
+)
+
+CONNECTION_MODULE = "metadata.ingestion.source.database.db2.connection"
+UTILS_MODULE = "metadata.ingestion.source.database.db2.utils"
+
+
+def _ibmi_config() -> Db2ConnectionConfig:
+    return Db2ConnectionConfig(
+        scheme=Db2Scheme.ibmi,
+        username="openmetadata_user",
+        password="openmetadata_password",
+        hostPort="myhost:8471",
+        database="MYDB",
+    )
+
+
+def _db2_config() -> Db2ConnectionConfig:
+    return Db2ConnectionConfig(
+        scheme=Db2Scheme.db2_ibm_db,
+        username="openmetadata_user",
+        password="openmetadata_password",
+        hostPort="localhost:50000",
+        database="testdb",
+    )
+
+
+def test_ibmi_scheme_patches_the_dialect_before_building_the_engine():
+    with patch(f"{CONNECTION_MODULE}.create_generic_db_connection"), patch(
+        f"{CONNECTION_MODULE}.patch_ibmi_dialect"
+    ) as mock_patch:
+        get_connection(_ibmi_config())
+
+    mock_patch.assert_called_once()
+
+
+def test_db2_scheme_does_not_patch_the_ibmi_dialect():
+    with patch(f"{CONNECTION_MODULE}.create_generic_db_connection"), patch(
+        f"{CONNECTION_MODULE}.check_ssl_and_init", return_value=None
+    ), patch(f"{CONNECTION_MODULE}.patch_ibmi_dialect") as mock_patch:
+        get_connection(_db2_config())
+
+    mock_patch.assert_not_called()
+
+
+_TABLE = table("t", column("a"), column("b"))
+
+
+def test_compat_select_accepts_the_legacy_column_list():
+    assert "SELECT t.a, t.b" in str(_ibmi_compat_select([_TABLE.c.a, _TABLE.c.b]))
+
+
+def test_compat_select_accepts_a_positional_whereclause():
+    statement = str(_ibmi_compat_select([_TABLE.c.a], _TABLE.c.b == "x"))
+
+    assert "WHERE t.b =" in statement
+
+
+def test_compat_select_expands_a_whole_table():
+    statement = str(_ibmi_compat_select([_TABLE], _TABLE.c.a == "z"))
+
+    assert "SELECT t.a, t.b" in statement
+    assert "WHERE t.a =" in statement
+
+
+def test_compat_select_ignores_a_none_whereclause():
+    assert "WHERE" not in str(_ibmi_compat_select([_TABLE.c.a], None))
+
+
+def test_compat_select_supports_where_chaining():
+    statement = _ibmi_compat_select([_TABLE.c.a]).where(_TABLE.c.b == "y")
+
+    assert "WHERE t.b =" in str(statement)
+
+
+def test_compat_select_passes_the_modern_form_through():
+    assert "SELECT t.a, t.b" in str(_ibmi_compat_select(_TABLE.c.a, _TABLE.c.b))
+
+
+def test_compat_select_carries_over_the_legacy_order_by_keyword():
+    """get_foreign_keys/get_indexes group composite constraints in column order."""
+    statement = str(
+        _ibmi_compat_select([_TABLE.c.a], _TABLE.c.b == "x", order_by=[_TABLE.c.b])
+    )
+
+    assert "ORDER BY t.b" in statement
+
+
+def test_compat_select_rejects_unsupported_legacy_keywords():
+    with pytest.raises(TypeError, match="Unsupported legacy select"):
+        _ibmi_compat_select([_TABLE.c.a], distinct=True)
+
+
+@pytest.fixture
+def ibmi_dialect():
+    """The patched dialect plus a bare instance to invoke unbound methods on."""
+    base = pytest.importorskip("sqlalchemy_ibmi.base")
+    patch_ibmi_dialect()
+    dialect = base.IBMiDb2Dialect.__new__(base.IBMiDb2Dialect)
+    dialect.normalize_name = lambda name: name.strip().lower() if name else name
+
+    return base, dialect
+
+
+def test_default_schema_name_is_sent_as_an_executable_clause(ibmi_dialect):
+    """SA 2.0 raises ObjectNotExecutableError on the raw string used upstream."""
+    base, dialect = ibmi_dialect
+    connection = MagicMock()
+    connection.execute.return_value.scalar.return_value = "MYLIB  "
+
+    assert base.IBMiDb2Dialect._get_default_schema_name(dialect, connection) == "mylib"
+    assert isinstance(connection.execute.call_args[0][0], TextClause)
+
+
+def test_check_text_server_is_sent_as_an_executable_clause(ibmi_dialect):
+    base, dialect = ibmi_dialect
+    connection = MagicMock()
+    connection.execute.return_value.scalar.return_value = 1
+
+    assert base.IBMiDb2Dialect._check_text_server(dialect, connection) == 1
+    assert isinstance(connection.execute.call_args[0][0], TextClause)
+
+
+def test_reflection_queries_compile_under_sqlalchemy_2(ibmi_dialect):
+    """get_schema_names uses the legacy select([...]) form the shim rewrites."""
+    base, dialect = ibmi_dialect
+    connection = MagicMock()
+    connection.execute.return_value = [("myschema",)]
+
+    names = base.IBMiDb2Dialect.get_schema_names.__wrapped__(dialect, connection)
+
+    assert names == ["myschema"]
+
+
+def test_index_reflection_preserves_composite_column_order(ibmi_dialect):
+    """get_indexes passes order_by= as a legacy keyword; dropping it would return
+    composite index columns in nondeterministic order."""
+    base, dialect = ibmi_dialect
+    dialect.denormalize_name = lambda name: name
+    connection = MagicMock()
+    connection.execute.return_value = [("IDX", "D", "COL_A"), ("IDX", "D", "COL_B")]
+
+    indexes = base.IBMiDb2Dialect.get_indexes.__wrapped__(
+        dialect, connection, "mytable", schema="myschema"
+    )
+
+    assert indexes[0]["column_names"] == ["col_a", "col_b"]
+    assert "ORDER BY" in str(connection.execute.call_args[0][0])
+
+
+def test_patching_the_dialect_twice_is_idempotent(ibmi_dialect):
+    assert patch_ibmi_dialect() is True
+    assert patch_ibmi_dialect() is True
+
+
+def test_patching_is_skipped_when_the_dialect_module_is_partially_initialised():
+    """An interrupted import leaves a module that imports but has no dialect."""
+    half_loaded = types.ModuleType("sqlalchemy_ibmi.base")
+    with patch.dict(
+        sys.modules,
+        {
+            "sqlalchemy_ibmi": types.ModuleType("sqlalchemy_ibmi"),
+            "sqlalchemy_ibmi.base": half_loaded,
+        },
+    ), patch(f"{UTILS_MODULE}._IBMI_PATCHED", False):
+        assert patch_ibmi_dialect() is False
+
+
+def test_patching_is_skipped_when_sqlalchemy_ibmi_is_absent():
+    with patch.dict(sys.modules, {"sqlalchemy_ibmi.base": None}), patch(
+        f"{UTILS_MODULE}._IBMI_PATCHED", False
+    ):
+        assert patch_ibmi_dialect() is False

--- a/ingestion/tests/unit/source/database/trino/test_complex_types.py
+++ b/ingestion/tests/unit/source/database/trino/test_complex_types.py
@@ -1,0 +1,197 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Regression tests for Trino ROW/ARRAY reflection.
+
+Every type string here is verbatim `SHOW COLUMNS` output captured from a live
+Trino 483 instance. Trino quotes named ROW fields and allows the name to be
+omitted entirely, neither of which the parser used to handle.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.sql import sqltypes
+
+from metadata.ingestion.source.database.trino.metadata import (
+    _get_columns,
+    parse_row_data_type,
+    resolve_field_names,
+    split_row_field,
+)
+
+
+class TestSplitRowField:
+    """Splitting a single ROW field into (name, type); None name means unnamed."""
+
+    @pytest.mark.parametrize(
+        ("field", "expected"),
+        [
+            # Trino always quotes a named field; the quotes must not leak into
+            # the OpenMetadata child column name.
+            ('"a" bigint', ("a", "bigint")),
+            ('"MyField" bigint', ("MyField", "bigint")),
+            ('"my col" bigint', ("my col", "bigint")),
+            # An embedded quote is escaped by doubling it.
+            ('"we""ird" bigint', ('we"ird', "bigint")),
+            # Unnamed fields.
+            ("bigint", (None, "bigint")),
+            ("varchar(1)", (None, "varchar(1)")),
+            # Unnamed fields whose type itself contains spaces.
+            ("timestamp(3) with time zone", (None, "timestamp(3) with time zone")),
+            ("interval day to second", (None, "interval day to second")),
+            ("double precision", (None, "double precision")),
+            # Named fields whose type contains spaces.
+            ('"ts" timestamp(3) with time zone', ("ts", "timestamp(3) with time zone")),
+            ('"iv" interval day to second', ("iv", "interval day to second")),
+            # Legacy unquoted form, still parsed as a named field.
+            ("a int", ("a", "int")),
+        ],
+    )
+    def test_split(self, field, expected):
+        assert split_row_field(field) == expected
+
+
+class TestResolveFieldNames:
+    """Unnamed fields are named positionally, and never collide with a real name."""
+
+    def test_unnamed_fields_get_positional_names(self):
+        fields = [(None, "bigint"), ("b", "varchar"), (None, "int")]
+
+        assert resolve_field_names(fields) == [
+            ("field1", "bigint"),
+            ("b", "varchar"),
+            ("field3", "int"),
+        ]
+
+    @pytest.mark.parametrize(
+        ("fields", "expected_names"),
+        [
+            # A field explicitly named `field1` alongside an unnamed field at
+            # position 1 -- `row(bigint, "field1" varchar)` is valid Trino.
+            ([(None, "bigint"), ("field1", "varchar")], ["field1_1", "field1"]),
+            ([("field2", "varchar"), (None, "bigint")], ["field2", "field2_1"]),
+            # Disambiguation must also dodge an explicit `fieldN_1`.
+            (
+                [(None, "bigint"), ("field1", "varchar"), ("field1_1", "varchar")],
+                ["field1_2", "field1", "field1_1"],
+            ),
+        ],
+    )
+    def test_positional_names_never_collide(self, fields, expected_names):
+        resolved = [name for name, _ in resolve_field_names(fields)]
+
+        assert resolved == expected_names
+        assert len(resolved) == len(set(resolved))
+
+
+class TestParseRowDataType:
+    """Full ROW type strings."""
+
+    @pytest.mark.parametrize(
+        ("type_str", "expected"),
+        [
+            ('row("a" bigint, "b" varchar)', "struct<a:bigint,b:varchar>"),
+            ("row(integer, varchar(1))", "struct<field1:integer,field2:varchar(1)>"),
+            # Trino allows a mix of named and unnamed fields in one ROW.
+            ('row(bigint, "b" bigint)', "struct<field1:bigint,b:bigint>"),
+            ('row("outer" row("inner" bigint))', "struct<outer:struct<inner:bigint>>"),
+            (
+                "row(row(integer, varchar(1)))",
+                "struct<field1:struct<field1:integer,field2:varchar(1)>>",
+            ),
+            (
+                'row("arr" array(row("a" bigint)))',
+                "struct<arr:array<struct<a:bigint>>>",
+            ),
+            (
+                "row(array(row(integer)))",
+                "struct<field1:array<struct<field1:integer>>>",
+            ),
+            # Case of a quoted field name is preserved in dataTypeDisplay.
+            ('row("MyField" bigint)', "struct<MyField:bigint>"),
+        ],
+    )
+    def test_parse(self, type_str, expected):
+        assert parse_row_data_type(type_str) == expected
+
+    def test_anonymous_fields_do_not_raise(self):
+        """Regression: this used to raise ValueError and drop every column."""
+        assert (
+            parse_row_data_type("row(bigint, varchar(10))")
+            == "struct<field1:bigint,field2:varchar(10)>"
+        )
+
+    @pytest.mark.parametrize(
+        ("type_str", "expected"),
+        [
+            ('row(bigint, "field1" varchar)', "struct<field1_1:bigint,field1:varchar>"),
+            ('row("field2" varchar, bigint)', "struct<field2:varchar,field2_1:bigint>"),
+        ],
+    )
+    def test_positional_name_does_not_shadow_an_explicit_field(
+        self, type_str, expected
+    ):
+        """A struct must never end up with two children of the same name."""
+        assert parse_row_data_type(type_str) == expected
+
+
+def _record(column, type_):
+    record = MagicMock()
+    record.Column, record.Type, record.Extra, record.Comment = column, type_, "", ""
+    return record
+
+
+def _columns_for(*type_strings):
+    connection = MagicMock()
+    connection.dialect.identifier_preparer.quote.side_effect = (
+        lambda value: f'"{value}"'
+    )
+    connection.execute.return_value = [
+        _record(f"c{i}", t) for i, t in enumerate(type_strings)
+    ]
+    return _get_columns(MagicMock(), connection, "t", "s")
+
+
+class TestGetColumns:
+    """The reflection entry point must never drop columns for an unparseable type."""
+
+    def test_anonymous_row_still_yields_all_columns(self):
+        """Regression: an unnamed ROW field used to abort reflection for the whole table."""
+        columns = _columns_for("bigint", "row(integer, varchar(1))", "varchar")
+
+        assert [c["name"] for c in columns] == ["c0", "c1", "c2"]
+        assert (
+            columns[1]["system_data_type"] == "struct<field1:integer,field2:varchar(1)>"
+        )
+        assert columns[1]["is_complex"] is True
+
+    def test_unparseable_type_falls_back_to_nulltype(self):
+        """The driver cannot build a ROW type with unnamed fields; reflection continues anyway."""
+        columns = _columns_for("row(integer, varchar(1))")
+
+        assert columns[0]["type"] is sqltypes.NULLTYPE
+
+    def test_named_row_children_are_not_quoted(self):
+        """Regression: children used to be named '"a"' rather than 'a'."""
+        columns = _columns_for('row("a" bigint, "b" varchar)')
+
+        assert columns[0]["system_data_type"] == "struct<a:bigint,b:varchar>"
+
+    def test_quoted_field_name_case_is_preserved(self):
+        columns = _columns_for('row("MyField" bigint)')
+
+        assert columns[0]["system_data_type"] == "struct<MyField:bigint>"
+
+    def test_simple_types_are_not_marked_complex(self):
+        columns = _columns_for("bigint", "varchar(10)")
+
+        assert all("is_complex" not in c for c in columns)

--- a/ingestion/tests/unit/source/mlmodel/mlflow/test_metadata.py
+++ b/ingestion/tests/unit/source/mlmodel/mlflow/test_metadata.py
@@ -16,7 +16,6 @@ import pytest
 from mlflow.entities.model_registry import ModelVersion, RegisteredModel
 from mlflow.exceptions import MlflowException
 from mlflow.store.entities import PagedList
-from mlflow.utils.search_utils import SearchModelUtils
 
 from metadata.ingestion.source.mlmodel.mlflow.metadata import MAX_VERSION_PAGES, MlflowSource
 
@@ -134,25 +133,25 @@ def test_search_never_passes_order_by():
 
     _, kwargs = source.client.search_model_versions.call_args
     assert "order_by" not in kwargs
-    assert kwargs["filter_string"] == f'name="{MODEL_NAME}"'
 
 
 @pytest.mark.parametrize(
     "model_name",
-    ["catalog.schema.o'brien_model", "catalog.schema.it's_a_model"],
+    ["catalog.schema.model", "engagement_dev.curated-ai-shared.instruments-similarity"],
 )
-def test_search_filter_survives_quotes_in_model_name(model_name):
-    """A quote in the name must not corrupt the filter, or the model silently vanishes."""
+def test_search_filter_uses_single_quotes(model_name):
+    """
+    Unity Catalog forwards this filter to the Databricks REST endpoint, which
+    accepts only `name = 'model_name'` and rejects a double-quoted name with
+    INVALID_PARAMETER_VALUE. MLflow's client-side parser is more permissive and
+    would happily accept the double-quoted form, so it cannot vouch for this.
+    """
     source = make_source(search_result=PagedList([make_version("2")], None), model_name=model_name)
 
     results = list(source.get_mlmodels())
 
     assert results[0][1].version == "2"
-    filter_string = source.client.search_model_versions.call_args[1]["filter_string"]
-    # The parser must recover the name byte-for-byte; the SQL-style '' escape
-    # parses cleanly but hands back a doubled quote, matching nothing.
-    parsed = SearchModelUtils.parse_search_filter(filter_string)
-    assert parsed[0]["value"] == model_name
+    assert source.client.search_model_versions.call_args[1]["filter_string"] == f"name='{model_name}'"
 
 
 def test_search_failure_is_recorded_and_does_not_raise():

--- a/ingestion/tests/unit/test_trino_complex_types.py
+++ b/ingestion/tests/unit/test_trino_complex_types.py
@@ -9,11 +9,16 @@ from metadata.ingestion.source.database.trino.metadata import (
 RAW_ARRAY_DATA_TYPES = [
     "array(string)",
     "array(row(check_datatype array(string)))",
+    # Real `SHOW COLUMNS` output, captured from Trino 483
+    "array(row(integer, decimal(2,1)))",
+    'array(row("a" bigint))',
 ]
 
 EXPECTED_ARRAY_DATA_TYPES = [
     "array<string>",
     "array<struct<check_datatype:array<string>>>",
+    "array<struct<field1:integer,field2:decimal(2,1)>>",
+    "array<struct<a:bigint>>",
 ]
 
 RAW_ROW_DATA_TYPES = [
@@ -23,6 +28,19 @@ RAW_ROW_DATA_TYPES = [
     "row(bigquerytestdatatype51 array(row(bigquery_test_datatype_511 array(string))))",
     "row(record_1 row(record_2 row(record_3 row(record_4 string))))",
     "row(splash row(color varchar, icon varchar, custom_story_board varchar, custom_android_splash varchar), android row(firebase_app_id varchar, google_services_json varchar, whitelisted_audience varchar, android_client_id varchar, build_preview row(download_url varchar, app_version varchar)), name varchar, app_icon varchar, url_scheme varchar, universal_link varchar, universal_links array(varchar), ios row(ios_client_id varchar))",
+    # Real `SHOW COLUMNS` output, captured from Trino 483: field names arrive
+    # quoted, and may be absent entirely.
+    'row("a" bigint, "b" varchar)',
+    "row(integer, varchar(1))",
+    'row(bigint, "b" bigint)',
+    "row(timestamp(3) with time zone)",
+    "row(interval day to second)",
+    'row("MyField" bigint)',
+    'row("we""ird" bigint)',
+    'row("my col" bigint)',
+    'row("outer" row("inner" bigint))',
+    'row("m" map(bigint, bigint))',
+    "row(row(integer, varchar(1)))",
 ]
 
 EXPECTED_ROW_DATA_TYPES = [
@@ -32,6 +50,17 @@ EXPECTED_ROW_DATA_TYPES = [
     "struct<bigquerytestdatatype51:array<struct<bigquery_test_datatype_511:array<string>>>>",
     "struct<record_1:struct<record_2:struct<record_3:struct<record_4:string>>>>",
     "struct<splash:struct<color:varchar,icon:varchar,custom_story_board:varchar,custom_android_splash:varchar>,android:struct<firebase_app_id:varchar,google_services_json:varchar,whitelisted_audience:varchar,android_client_id:varchar,build_preview:struct<download_url:varchar,app_version:varchar>>,name:varchar,app_icon:varchar,url_scheme:varchar,universal_link:varchar,universal_links:array<varchar>,ios:struct<ios_client_id:varchar>>",
+    "struct<a:bigint,b:varchar>",
+    "struct<field1:integer,field2:varchar(1)>",
+    "struct<field1:bigint,b:bigint>",
+    "struct<field1:timestamp(3) with time zone>",
+    "struct<field1:interval day to second>",
+    "struct<MyField:bigint>",
+    'struct<we"ird:bigint>',
+    "struct<my col:bigint>",
+    "struct<outer:struct<inner:bigint>>",
+    "struct<m:map(bigint, bigint)>",
+    "struct<field1:struct<field1:integer,field2:varchar(1)>>",
 ]
 
 # Test cases for dataLength conversion - only for types that should have dataLength

--- a/ingestion/tests/unit/topology/api/test_rest.py
+++ b/ingestion/tests/unit/topology/api/test_rest.py
@@ -771,6 +771,40 @@ class RESTTest(TestCase):
         field_names = {field.name.root for field in result.schemaFields}
         assert field_names == {"id", "username"}
 
+    def test_get_request_schema_swagger_2_array_body(self):
+        self.rest_source.json_response = {
+            "definitions": {
+                "User": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "integer"},
+                        "username": {"type": "string"},
+                    },
+                }
+            }
+        }
+        info = {
+            "parameters": [
+                {
+                    "in": "body",
+                    "name": "users",
+                    "schema": {
+                        "type": "array",
+                        "items": {"$ref": "#/definitions/User"},
+                    },
+                }
+            ]
+        }
+
+        result = self.rest_source._get_request_schema(info)
+
+        assert result is not None
+        assert result.schemaFields is not None
+        assert {field.name.root for field in result.schemaFields} == {
+            "id",
+            "username",
+        }
+
     def test_get_request_schema_query_parameters(self):
         """Test extracting request schema from query and path parameters"""
         result = self.rest_source._get_request_schema(MOCK_QUERY_PARAMETERS)
@@ -838,6 +872,31 @@ class RESTTest(TestCase):
         assert result.schemaFields is not None
         assert len(result.schemaFields) == 3
 
+    def test_get_request_schema_array_root(self):
+        self.rest_source.json_response = MOCK_SCHEMA_RESPONSE_SIMPLE
+        info = {
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/User"},
+                        }
+                    }
+                }
+            }
+        }
+
+        result = self.rest_source._get_request_schema(info)
+
+        assert result is not None
+        assert result.schemaFields is not None
+        assert {field.name.root for field in result.schemaFields} == {
+            "id",
+            "name",
+            "email",
+        }
+
     def test_get_response_schema_direct_ref(self):
         """Test extracting response schema with direct $ref"""
         self.rest_source.json_response = MOCK_SCHEMA_RESPONSE_SIMPLE
@@ -879,6 +938,34 @@ class RESTTest(TestCase):
         assert len(result.schemaFields) == 3
         field_names = {field.name.root for field in result.schemaFields}
         assert field_names == {"id", "name", "email"}
+
+    def test_get_response_schema_referenced_array_root(self):
+        self.rest_source.json_response = deepcopy(MOCK_SCHEMA_RESPONSE_SIMPLE)
+        self.rest_source.json_response["components"]["schemas"]["Users"] = {
+            "type": "array",
+            "items": {"$ref": "#/components/schemas/User"},
+        }
+        info = {
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {
+                            "schema": {"$ref": "#/components/schemas/Users"}
+                        }
+                    }
+                }
+            }
+        }
+
+        result = self.rest_source._get_response_schema(info)
+
+        assert result is not None
+        assert result.schemaFields is not None
+        assert {field.name.root for field in result.schemaFields} == {
+            "id",
+            "name",
+            "email",
+        }
 
     def test_get_response_schema_nested_data_ref(self):
         """Test extracting response schema from nested properties.data structure"""
@@ -926,6 +1013,51 @@ class RESTTest(TestCase):
         """Test _parse_openapi_type is case insensitive"""
         result = self.rest_source._parse_openapi_type("BOOLEAN")
         assert result == DataTypeTopic.BOOLEAN
+
+    def test_process_schema_fields_with_nullable_type(self):
+        self.rest_source.json_response = {
+            "components": {
+                "schemas": {
+                    "User": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": ["string", "null"]},
+                        },
+                    }
+                }
+            }
+        }
+
+        result = self.rest_source.process_schema_fields("#/components/schemas/User")
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].dataType == DataTypeTopic.STRING
+        assert self.rest_source.status.warnings == []
+
+    def test_process_schema_fields_reports_single_parsing_warning(self):
+        info = {
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {"$ref": ["invalid"]},
+                    }
+                }
+            }
+        }
+
+        self.rest_source._activate_handler()
+        try:
+            result = self.rest_source._get_request_schema(info)
+        finally:
+            self.rest_source._deactivate_handler()
+
+        assert result is not None
+        assert result.schemaFields is None
+        assert len(self.rest_source.status.warnings) == 1
+        assert "Error while processing schema fields" in next(
+            iter(self.rest_source.status.warnings[0].values())
+        )
 
     def test_extract_schema_from_response_openapi3(self):
         """Test _extract_schema_from_response extracts OpenAPI 3.0 schema"""

--- a/ingestion/tests/unit/topology/database/test_bigquery.py
+++ b/ingestion/tests/unit/topology/database/test_bigquery.py
@@ -57,6 +57,10 @@ from metadata.ingestion.api.parser import parse_workflow_config_gracefully
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.bigquery.lineage import BigqueryLineageSource
 from metadata.ingestion.source.database.bigquery.metadata import BigquerySource
+from metadata.ingestion.source.database.bigquery.queries import (
+    BIGQUERY_LIFE_CYCLE_QUERY,
+    BIGQUERY_LIFE_CYCLE_QUERY_BY_REGION,
+)
 from metadata.utils.lru_cache import LRUCache
 
 mock_bq_config = {
@@ -455,6 +459,23 @@ class BigqueryUnitTest(TestCase):
             ),
             EXPECTED_URL,
         )
+
+    def test_region_life_cycle_query_selects_last_modified(self):
+        query = BIGQUERY_LIFE_CYCLE_QUERY_BY_REGION.format(
+            database_name=MOCK_DB_NAME, schema_name=MOCK_SCHEMA_NAME, region="EU"
+        )
+
+        self.assertIn("creation_time as created_at", query)
+        self.assertIn("storage_last_modified_time as updated_at", query)
+        self.assertIn("`region-EU`.INFORMATION_SCHEMA.TABLE_STORAGE", query)
+
+    def test_dataset_life_cycle_query_is_created_only(self):
+        query = BIGQUERY_LIFE_CYCLE_QUERY.format(
+            database_name=MOCK_DB_NAME, schema_name=MOCK_SCHEMA_NAME
+        )
+
+        self.assertIn("creation_time as created_at", query)
+        self.assertNotIn("TABLE_STORAGE", query)
 
     @patch(
         "metadata.ingestion.source.database.database_service.DatabaseServiceSource.get_database_tag_labels"
@@ -979,6 +1000,37 @@ class TestBigqueryRegionAwareQueries:
         self.bq_source._prefetch_table_ddls(MOCK_DATABASE_SCHEMA.name.root)
 
         assert self.bq_source._table_ddl_cache == {}
+
+    # --- get_life_cycle_query ---
+
+    def test_life_cycle_query_uses_region_aware_query(self):
+        """Region-scoped query (with TABLE_STORAGE) is used when the dataset has a location."""
+        self._set_dataset_location("EU")
+
+        query = self.bq_source.get_life_cycle_query()
+
+        assert "`region-EU`.INFORMATION_SCHEMA.TABLE_STORAGE" in query
+        assert "storage_last_modified_time as updated_at" in query
+
+    def test_life_cycle_query_falls_back_without_location(self):
+        """Dataset-scoped created-only query is used when dataset location is None."""
+        self._set_dataset_location(None)
+
+        query = self.bq_source.get_life_cycle_query()
+
+        assert "region-" not in query
+        assert "TABLE_STORAGE" not in query
+        assert "creation_time as created_at" in query
+
+    def test_life_cycle_query_falls_back_when_location_unavailable(self):
+        """When client.get_dataset raises, falls back to the dataset-scoped created-only query."""
+        self.bq_source.client.get_dataset.side_effect = Exception("permission denied")
+        self.bq_source._dataset_obj_cache.clear()
+
+        query = self.bq_source.get_life_cycle_query()
+
+        assert "TABLE_STORAGE" not in query
+        assert "creation_time as created_at" in query
 
 
 class _EvictedOnReadCache(LRUCache):

--- a/ingestion/tests/unit/topology/database/test_life_cycle_query_mixin.py
+++ b/ingestion/tests/unit/topology/database/test_life_cycle_query_mixin.py
@@ -1,0 +1,100 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Unit tests for the shared LifeCycleQueryMixin.
+
+Covers alias parsing of the query model and population of the created/updated
+life cycle aspects, including backward-compatibility for sources whose query only
+returns a created timestamp.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from metadata.generated.schema.entity.data.table import Table
+from metadata.ingestion.source.database.life_cycle_query_mixin import (
+    LifeCycleQueryByTable,
+    LifeCycleQueryMixin,
+)
+from metadata.utils.time_utils import datetime_to_timestamp
+
+TABLE_NAME = "my_table"
+TABLE_FQN = "service.db.schema.my_table"
+CREATED_AT = datetime(2023, 1, 1, 10, 0, 0)
+UPDATED_AT = datetime(2024, 6, 15, 12, 30, 0)
+
+
+def _run_get_life_cycle_data(life_cycle_data):
+    mixin = LifeCycleQueryMixin()
+    mixin.life_cycle_query_dict = MagicMock(return_value={TABLE_NAME: life_cycle_data})
+    return list(
+        mixin.get_life_cycle_data(
+            entity=Table,
+            entity_name=TABLE_NAME,
+            entity_fqn=TABLE_FQN,
+            query="SELECT 1",
+        )
+    )
+
+
+class TestLifeCycleQueryByTable:
+    def test_parses_created_and_updated_aliases(self):
+        model = LifeCycleQueryByTable.model_validate(
+            {
+                "TABLE_NAME": TABLE_NAME,
+                "CREATED_AT": CREATED_AT,
+                "UPDATED_AT": UPDATED_AT,
+            }
+        )
+
+        assert model.table_name == TABLE_NAME
+        assert model.created_at == CREATED_AT
+        assert model.updated_at == UPDATED_AT
+
+    def test_updated_at_is_optional(self):
+        model = LifeCycleQueryByTable.model_validate(
+            {"TABLE_NAME": TABLE_NAME, "CREATED_AT": CREATED_AT}
+        )
+
+        assert model.updated_at is None
+
+
+class TestGetLifeCycleData:
+    def test_populates_updated_when_present(self):
+        life_cycle_data = LifeCycleQueryByTable(
+            table_name=TABLE_NAME, created_at=CREATED_AT, updated_at=UPDATED_AT
+        )
+
+        results = _run_get_life_cycle_data(life_cycle_data)
+
+        assert len(results) == 1
+        life_cycle = results[0].right.life_cycle
+        assert life_cycle.created.timestamp.root == datetime_to_timestamp(
+            CREATED_AT, milliseconds=True
+        )
+        assert life_cycle.updated is not None
+        assert life_cycle.updated.timestamp.root == datetime_to_timestamp(
+            UPDATED_AT, milliseconds=True
+        )
+
+    def test_updated_absent_keeps_created_only(self):
+        life_cycle_data = LifeCycleQueryByTable(
+            table_name=TABLE_NAME, created_at=CREATED_AT
+        )
+
+        results = _run_get_life_cycle_data(life_cycle_data)
+
+        assert len(results) == 1
+        life_cycle = results[0].right.life_cycle
+        assert life_cycle.created.timestamp.root == datetime_to_timestamp(
+            CREATED_AT, milliseconds=True
+        )
+        assert life_cycle.updated is None

--- a/ingestion/tests/unit/topology/pipeline/test_airflow_mwaa_client.py
+++ b/ingestion/tests/unit/topology/pipeline/test_airflow_mwaa_client.py
@@ -18,6 +18,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from metadata.generated.schema.security.credentials.awsCredentials import AWSCredentials
+from metadata.ingestion.source.pipeline.airflow.api.exceptions import (
+    AirflowApiResponseError,
+)
 from metadata.ingestion.source.pipeline.airflow.api.models import (
     AirflowApiDagDetails,
     AirflowApiDagRun,
@@ -479,6 +482,80 @@ class TestMWAAClientPagination:
         assert mock_mwaa_client.invoke_rest_api.call_count == 2
 
     @patch("metadata.ingestion.source.pipeline.airflow.api.mwaa.AWSClient")
+    def test_server_capped_pages_advance_by_returned_page_size(
+        self, mock_aws_client_cls
+    ):
+        mock_aws_client = MagicMock()
+        mock_mwaa_client = MagicMock()
+        mock_aws_client.get_mwaa_client.return_value = mock_mwaa_client
+        mock_aws_client_cls.return_value = mock_aws_client
+        mock_mwaa_client.invoke_rest_api.side_effect = [
+            {
+                "RestApiResponse": {
+                    "dags": [{"dag_id": f"dag{i}"} for i in range(50)],
+                    "total_entries": 150,
+                }
+            },
+            {
+                "RestApiResponse": {
+                    "dags": [{"dag_id": f"dag{i}"} for i in range(50, 100)],
+                    "total_entries": 150,
+                }
+            },
+            {
+                "RestApiResponse": {
+                    "dags": [{"dag_id": f"dag{i}"} for i in range(100, 150)],
+                    "total_entries": 150,
+                }
+            },
+        ]
+
+        client = MWAAClient(
+            AWSCredentials(
+                awsAccessKeyId="key", awsSecretAccessKey="secret", awsRegion="us-east-1"
+            ),
+            "test-env",
+        )
+
+        result = client._paginate("/dags", "dags", limit=100)
+
+        assert [dag["dag_id"] for dag in result] == [f"dag{i}" for i in range(150)]
+        assert [
+            call.kwargs["QueryParameters"]["offset"]
+            for call in mock_mwaa_client.invoke_rest_api.call_args_list
+        ] == ["0", "50", "100"]
+
+    @patch("metadata.ingestion.source.pipeline.airflow.api.mwaa.AWSClient")
+    def test_server_cap_without_total_entries_still_paginates(
+        self, mock_aws_client_cls
+    ):
+        mock_aws_client = MagicMock()
+        mock_mwaa_client = MagicMock()
+        mock_aws_client.get_mwaa_client.return_value = mock_mwaa_client
+        mock_aws_client_cls.return_value = mock_aws_client
+        mock_mwaa_client.invoke_rest_api.side_effect = [
+            {"RestApiResponse": {"dags": [{"dag_id": f"dag{i}"} for i in range(50)]}},
+            {
+                "RestApiResponse": {
+                    "dags": [{"dag_id": f"dag{i}"} for i in range(50, 100)]
+                }
+            },
+            {"RestApiResponse": {"dags": []}},
+        ]
+
+        client = MWAAClient(
+            AWSCredentials(
+                awsAccessKeyId="key", awsSecretAccessKey="secret", awsRegion="us-east-1"
+            ),
+            "test-env",
+        )
+
+        result = client._paginate("/dags", "dags", limit=100)
+
+        assert [dag["dag_id"] for dag in result] == [f"dag{i}" for i in range(100)]
+        assert mock_mwaa_client.invoke_rest_api.call_count == 3
+
+    @patch("metadata.ingestion.source.pipeline.airflow.api.mwaa.AWSClient")
     def test_paginate_without_total_entries_fetches_until_short_page(
         self, mock_aws_client_cls
     ):
@@ -493,6 +570,7 @@ class TestMWAAClientPagination:
         mock_mwaa_client.invoke_rest_api.side_effect = [
             {"RestApiResponse": page1},
             {"RestApiResponse": page2},
+            {"RestApiResponse": {"dags": []}},
         ]
 
         client = MWAAClient(
@@ -506,7 +584,7 @@ class TestMWAAClientPagination:
 
         assert len(result) == 120
         assert result[-1]["dag_id"] == "dag119"
-        assert mock_mwaa_client.invoke_rest_api.call_count == 2
+        assert mock_mwaa_client.invoke_rest_api.call_count == 3
 
     @patch("metadata.ingestion.source.pipeline.airflow.api.mwaa.AWSClient")
     def test_paginate_empty_response(self, mock_aws_client_cls):
@@ -524,9 +602,34 @@ class TestMWAAClientPagination:
             "test-env",
         )
 
-        result = client._paginate("/dags", "dags", limit=100)
+        with pytest.raises(AirflowApiResponseError, match="offset=0"):
+            client._paginate("/dags", "dags", limit=100)
 
-        assert result == []
+    @patch("metadata.ingestion.source.pipeline.airflow.api.mwaa.AWSClient")
+    def test_unreadable_page_does_not_truncate_the_dag_list(self, mock_aws_client_cls):
+        mock_aws_client = MagicMock()
+        mock_mwaa_client = MagicMock()
+        mock_aws_client.get_mwaa_client.return_value = mock_mwaa_client
+        mock_aws_client_cls.return_value = mock_aws_client
+        mock_mwaa_client.invoke_rest_api.side_effect = [
+            {
+                "RestApiResponse": {
+                    "dags": [{"dag_id": f"dag{i}"} for i in range(50)],
+                    "total_entries": 150,
+                }
+            },
+            {"RestApiResponse": "<html>upstream error</html>"},
+        ]
+
+        client = MWAAClient(
+            AWSCredentials(
+                awsAccessKeyId="key", awsSecretAccessKey="secret", awsRegion="us-east-1"
+            ),
+            "test-env",
+        )
+
+        with pytest.raises(AirflowApiResponseError, match="offset=50"):
+            client._paginate("/dags", "dags", limit=100)
 
     @patch("metadata.ingestion.source.pipeline.airflow.api.mwaa.AWSClient")
     def test_paginate_empty_page_key(self, mock_aws_client_cls):
@@ -727,14 +830,13 @@ class TestMWAAClientBuildDagDetails:
         assert result.fileloc == "/dags/test.py"
 
     @patch("metadata.ingestion.source.pipeline.airflow.api.mwaa.AWSClient")
-    @patch("metadata.ingestion.source.pipeline.airflow.api.mwaa.logger")
-    def test_build_dag_details_task_fetch_error(self, mock_logger, mock_aws_client_cls):
+    def test_build_dag_details_task_fetch_error(self, mock_aws_client_cls):
         mock_aws_client = MagicMock()
         mock_mwaa_client = MagicMock()
         mock_aws_client.get_mwaa_client.return_value = mock_mwaa_client
         mock_aws_client_cls.return_value = mock_aws_client
 
-        mock_mwaa_client.invoke_rest_api.side_effect = Exception("Task fetch failed")
+        mock_mwaa_client.invoke_rest_api.side_effect = RuntimeError("Task fetch failed")
 
         client = MWAAClient(
             AWSCredentials(
@@ -745,10 +847,26 @@ class TestMWAAClientBuildDagDetails:
 
         dag_data = {"dag_id": "test_dag"}
 
-        result = client.build_dag_details(dag_data)
+        with pytest.raises(RuntimeError, match="Task fetch failed"):
+            client.build_dag_details(dag_data)
 
-        assert result.tasks == []
-        mock_logger.warning.assert_called_once()
+    @patch("metadata.ingestion.source.pipeline.airflow.api.mwaa.AWSClient")
+    def test_build_dag_details_invalid_task_response(self, mock_aws_client_cls):
+        mock_aws_client = MagicMock()
+        mock_mwaa_client = MagicMock()
+        mock_aws_client.get_mwaa_client.return_value = mock_mwaa_client
+        mock_aws_client_cls.return_value = mock_aws_client
+        mock_mwaa_client.invoke_rest_api.return_value = {"RestApiResponse": {}}
+
+        client = MWAAClient(
+            AWSCredentials(
+                awsAccessKeyId="key", awsSecretAccessKey="secret", awsRegion="us-east-1"
+            ),
+            "test-env",
+        )
+
+        with pytest.raises(AirflowApiResponseError, match="Invalid tasks response"):
+            client.build_dag_details({"dag_id": "test_dag"})
 
 
 class TestMWAAClientGetDagRuns:
@@ -878,7 +996,8 @@ class TestMWAAClientGetTaskInstancesForRun:
                     "start_date": "2025-01-01T00:02:00+00:00",
                     "end_date": "2025-01-01T00:03:00+00:00",
                 },
-            ]
+            ],
+            "total_entries": 2,
         }
         mock_mwaa_client.invoke_rest_api.side_effect = [
             {"RestApiResponse": instances_response}
@@ -1086,7 +1205,8 @@ class TestMWAAClientEdgeCases:
         instances_response = {
             "task_instances": [
                 {"state": "success", "start_date": "2025-01-01T00:01:00+00:00"}
-            ]
+            ],
+            "total_entries": 1,
         }
         mock_mwaa_client.invoke_rest_api.side_effect = [
             {"RestApiResponse": instances_response}

--- a/ingestion/tests/unit/topology/pipeline/test_airflowapi.py
+++ b/ingestion/tests/unit/topology/pipeline/test_airflowapi.py
@@ -24,6 +24,9 @@ from metadata.generated.schema.entity.utils.common.accessTokenConfig import Acce
 from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.generated.schema.type.entityReferenceList import EntityReferenceList
 from metadata.ingestion.source.pipeline.airflow.api.client import AirflowApiClient
+from metadata.ingestion.source.pipeline.airflow.api.exceptions import (
+    AirflowApiResponseError,
+)
 from metadata.ingestion.source.pipeline.airflow.api.models import (
     AirflowApiDagDetails,
     AirflowApiDagRun,
@@ -259,6 +262,22 @@ class TestClientBuildDagDetails:
         assert result.tasks[0].downstream_task_ids == ["transform"]
         assert result.tasks[0].class_ref["class_name"] == "PythonOperator"
 
+    @patch("metadata.ingestion.source.pipeline.airflow.api.client.TrackedREST")
+    def test_task_fetch_error_is_not_converted_to_empty_tasks(self, mock_rest_cls):
+        client, mock_rest = _make_client(mock_rest_cls)
+        mock_rest.get.side_effect = TimeoutError("timed out")
+
+        with pytest.raises(TimeoutError, match="timed out"):
+            client.build_dag_details({"dag_id": "etl_pipeline"})
+
+    @patch("metadata.ingestion.source.pipeline.airflow.api.client.TrackedREST")
+    def test_invalid_task_response_is_not_converted_to_empty_tasks(self, mock_rest_cls):
+        client, mock_rest = _make_client(mock_rest_cls)
+        mock_rest.get.return_value = {}
+
+        with pytest.raises(AirflowApiResponseError, match="Invalid tasks response"):
+            client.build_dag_details({"dag_id": "etl_pipeline"})
+
 
 # ── Client: Date Field ───────────────────────────────────────────────────
 
@@ -352,18 +371,81 @@ class TestPaginateGetAllDags:
         assert mock_rest.get.call_count == 3
 
     @patch("metadata.ingestion.source.pipeline.airflow.api.client.TrackedREST")
+    def test_server_capped_pages_advance_by_returned_page_size(self, mock_rest_cls):
+        client, mock_rest = _make_client(mock_rest_cls)
+        mock_rest.get.side_effect = [
+            {
+                "dags": [{"dag_id": f"dag_{i}"} for i in range(50)],
+                "total_entries": 150,
+            },
+            {
+                "dags": [{"dag_id": f"dag_{i}"} for i in range(50, 100)],
+                "total_entries": 150,
+            },
+            {
+                "dags": [{"dag_id": f"dag_{i}"} for i in range(100, 150)],
+                "total_entries": 150,
+            },
+        ]
+
+        result = client.get_all_dags()
+
+        assert [dag["dag_id"] for dag in result] == [f"dag_{i}" for i in range(150)]
+        assert [call.args[0] for call in mock_rest.get.call_args_list] == [
+            "/v1/dags?limit=100&offset=0",
+            "/v1/dags?limit=100&offset=50",
+            "/v1/dags?limit=100&offset=100",
+        ]
+
+    @patch("metadata.ingestion.source.pipeline.airflow.api.client.TrackedREST")
+    def test_server_cap_without_total_entries_still_paginates(self, mock_rest_cls):
+        client, mock_rest = _make_client(mock_rest_cls)
+        mock_rest.get.side_effect = [
+            {"dags": [{"dag_id": f"dag_{i}"} for i in range(50)]},
+            {"dags": [{"dag_id": f"dag_{i}"} for i in range(50, 100)]},
+            {"dags": []},
+        ]
+
+        result = client.get_all_dags()
+
+        assert [dag["dag_id"] for dag in result] == [f"dag_{i}" for i in range(100)]
+        assert mock_rest.get.call_count == 3
+
+    @patch("metadata.ingestion.source.pipeline.airflow.api.client.TrackedREST")
+    def test_unreadable_page_does_not_truncate_the_dag_list(self, mock_rest_cls):
+        client, mock_rest = _make_client(mock_rest_cls)
+        mock_rest.get.side_effect = [
+            {
+                "dags": [{"dag_id": f"dag_{i}"} for i in range(50)],
+                "total_entries": 150,
+            },
+            {},
+        ]
+
+        with pytest.raises(AirflowApiResponseError, match="offset=50"):
+            client.get_all_dags()
+
+    @patch("metadata.ingestion.source.pipeline.airflow.api.client.TrackedREST")
+    def test_empty_page_before_total_entries_is_rejected(self, mock_rest_cls):
+        client, mock_rest = _make_client(mock_rest_cls)
+        mock_rest.get.return_value = {"dags": [], "total_entries": 1}
+
+        with pytest.raises(AirflowApiResponseError, match="offset=0"):
+            client.get_all_dags()
+
+    @patch("metadata.ingestion.source.pipeline.airflow.api.client.TrackedREST")
     def test_multiple_pages_without_total_entries(self, mock_rest_cls):
         client, mock_rest = _make_client(mock_rest_cls)
 
         page1 = {"dags": [{"dag_id": f"dag_{i}"} for i in range(100)]}
         page2 = {"dags": [{"dag_id": f"dag_{i}"} for i in range(100, 120)]}
-        mock_rest.get.side_effect = [page1, page2]
+        mock_rest.get.side_effect = [page1, page2, {"dags": []}]
 
         result = client.get_all_dags()
 
         assert len(result) == 120
         assert result[-1]["dag_id"] == "dag_119"
-        assert mock_rest.get.call_count == 2
+        assert mock_rest.get.call_count == 3
 
     @patch("metadata.ingestion.source.pipeline.airflow.api.client.TrackedREST")
     def test_empty_response(self, mock_rest_cls):
@@ -879,3 +961,61 @@ class TestClientGetDagRuns:
 
         runs = client.get_dag_runs("my_dag")
         assert runs == []
+
+
+class TestDagDetailFailureSafety:
+    def test_failed_dag_is_preserved_without_emitting_an_update(self):
+        source = MagicMock()
+        source.context.get.return_value.pipeline_service = "airflow_service"
+        source.connection.get_all_dags.return_value = [{"dag_id": "existing_dag"}]
+        source.connection.build_dag_details.side_effect = TimeoutError(
+            "tasks unavailable"
+        )
+        source._preserve_failed_dag = (
+            lambda dag_id: AirflowApiSource._preserve_failed_dag(source, dag_id)
+        )
+
+        result = list(AirflowApiSource.get_pipelines_list(source))
+
+        assert result == []
+        source.pipeline_source_state.add.assert_called_once_with(
+            "airflow_service.existing_dag"
+        )
+        source.status.failed.assert_called_once()
+        assert source._dag_listing_complete is True
+
+    @patch(
+        "metadata.ingestion.source.pipeline.airflow.api.source.fqn.build",
+        side_effect=ValueError("invalid FQN"),
+    )
+    def test_failed_state_registration_disables_stale_deletion(self, _mock_fqn):
+        source = MagicMock()
+        source.connection.get_all_dags.return_value = [{"dag_id": "existing_dag"}]
+        source.connection.build_dag_details.side_effect = TimeoutError(
+            "tasks unavailable"
+        )
+        source._preserve_failed_dag = (
+            lambda dag_id: AirflowApiSource._preserve_failed_dag(source, dag_id)
+        )
+
+        assert list(AirflowApiSource.get_pipelines_list(source)) == []
+        assert source._dag_listing_complete is False
+
+
+class TestDagListingFailureSafety:
+    def test_listing_failure_marks_the_listing_incomplete(self):
+        source = MagicMock()
+        source.connection.get_all_dags.side_effect = AirflowApiResponseError(
+            "invalid page"
+        )
+
+        with pytest.raises(AirflowApiResponseError, match="invalid page"):
+            list(AirflowApiSource.get_pipelines_list(source))
+
+        assert source._dag_listing_complete is False
+
+    def test_incomplete_listing_skips_stale_deletion(self):
+        source = MagicMock()
+        source._dag_listing_complete = False
+
+        assert list(AirflowApiSource.mark_pipelines_as_deleted(source)) == []

--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.interface.ts
@@ -13,6 +13,7 @@
 import { CustomizeEntityType } from '../../../constants/Customize.constants';
 import { OperationPermission } from '../../../context/PermissionProvider/PermissionProvider.interface';
 import { DataAssetRuleValidation } from '../../../context/RuleEnforcementProvider/RuleEnforcementProvider.interface';
+import { EntityTabs } from '../../../enums/entity.enum';
 import { ThreadType } from '../../../generated/entity/feed/thread';
 import { EntityReference } from '../../../generated/entity/type';
 import { Page } from '../../../generated/system/ui/page';
@@ -33,6 +34,10 @@ export interface GenericProviderProps<T extends Omit<EntityReference, 'type'>> {
   customizedPage?: Page | null;
   muiTags?: boolean;
   columnFqn?: string;
+  // The tab the page is actually rendering. Pages whose landing URL carries no `:tab`
+  // segment, and the domain tree view (which never writes the tab to the URL at all),
+  // must pass this so the widget layout matches the tab on screen.
+  activeTab?: EntityTabs;
 }
 
 export interface GenericContextType<T extends Omit<EntityReference, 'type'>> {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.tsx
@@ -71,6 +71,7 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
   customizedPage,
   muiTags = false,
   columnFqn,
+  activeTab,
 }: GenericProviderProps<T>) => {
   const GenericContext = createGenericContext<T>();
   const [threadLink, setThreadLink] = useState<string>('');
@@ -82,10 +83,19 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
   const location = useLocation();
   const navigate = useNavigate();
   const pageType = useMemo(() => ENTITY_PAGE_TYPE_MAP[type], [type]);
-  const { tab } = useRequiredParams<{ tab: EntityTabs }>();
+  const { tab: routeTab } = useRequiredParams<{ tab: EntityTabs }>();
+  // `routeTab` is undefined on an entity's landing URL (no `:tab` segment) and always
+  // undefined in the domain tree view, so it cannot be the sole source of truth for the
+  // layout -- falling back to the first customized tab renders another tab's widgets.
+  const currentTab = activeTab ?? routeTab;
   const expandedLayout = useRef<WidgetConfig[]>([]);
   const [layout, setLayout] = useState<WidgetConfig[]>(
-    getLayoutFromCustomizedPage(pageType, tab, customizedPage, isVersionView)
+    getLayoutFromCustomizedPage(
+      pageType,
+      currentTab,
+      customizedPage,
+      isVersionView
+    )
   );
   const [filteredKeys, setFilteredKeys] = useState<string[]>([]);
   const [activeTagDropdownKey, setActiveTagDropdownKey] = useState<
@@ -177,9 +187,14 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
 
   useEffect(() => {
     setLayout(
-      getLayoutFromCustomizedPage(pageType, tab, customizedPage, isVersionView)
+      getLayoutFromCustomizedPage(
+        pageType,
+        currentTab,
+        customizedPage,
+        isVersionView
+      )
     );
-  }, [customizedPage, tab, pageType, isVersionView]);
+  }, [customizedPage, currentTab, pageType, isVersionView]);
 
   const onThreadPanelClose = useCallback(() => {
     setThreadLink('');
@@ -239,7 +254,7 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
 
       // Update URL to include column FQN if the column has a fullyQualifiedName
       if (columnFqn && data.fullyQualifiedName) {
-        const newPath = getEntityDetailsPath(type, columnFqn, tab);
+        const newPath = getEntityDetailsPath(type, columnFqn, routeTab);
 
         // Only navigate if the path is different from current path to avoid loops
         if (location.pathname !== newPath) {
@@ -250,7 +265,7 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
     [
       data?.fullyQualifiedName,
       type,
-      tab,
+      routeTab,
       navigate,
       location.pathname,
       selectedColumn?.fullyQualifiedName,
@@ -262,7 +277,11 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
 
     // Update URL to remove column FQN
     if (data?.fullyQualifiedName) {
-      const newPath = getEntityDetailsPath(type, data.fullyQualifiedName, tab);
+      const newPath = getEntityDetailsPath(
+        type,
+        data.fullyQualifiedName,
+        routeTab
+      );
       navigate(newPath, { replace: true });
     } else if (location.hash) {
       // Fallback: just remove hash if no FQN available
@@ -271,7 +290,7 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
         { replace: true }
       );
     }
-  }, [data?.fullyQualifiedName, type, tab, location, navigate]);
+  }, [data?.fullyQualifiedName, type, routeTab, location, navigate]);
 
   // Wrapper for onColumnFieldUpdate that updates
   const handleColumnFieldUpdate = useCallback(
@@ -397,7 +416,7 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
   useEffect(() => {
     // on unmount remove filterKeys
     return () => setFilteredKeys([]);
-  }, [tab]);
+  }, [currentTab]);
 
   const values = useMemo(
     () => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProviderLayout.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProviderLayout.test.tsx
@@ -1,0 +1,133 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { CustomizeEntityType } from '../../../constants/Customize.constants';
+import { EntityTabs, EntityType } from '../../../enums/entity.enum';
+import { Page, PageType } from '../../../generated/system/ui/page';
+import { DEFAULT_ENTITY_PERMISSION } from '../../../utils/PermissionsUtils';
+import { useGenericContext } from './GenericContext';
+import { GenericProvider } from './GenericProvider';
+
+jest.mock('../../../rest/feedsAPI');
+
+jest.mock('../../../hooks/useEntityRules', () => ({
+  useEntityRules: jest.fn().mockImplementation(() => ({ entityRules: {} })),
+}));
+
+jest.mock('../../../hooks/useChangeSummary', () => ({
+  useChangeSummary: jest.fn().mockImplementation(() => ({ changeSummary: {} })),
+}));
+
+jest.mock(
+  '../../ActivityFeed/ActivityFeedProvider/ActivityFeedProvider',
+  () => ({
+    useActivityFeedProvider: () => ({
+      postFeed: jest.fn(),
+      deleteFeed: jest.fn(),
+      updateFeed: jest.fn(),
+    }),
+  })
+);
+
+jest.mock('../../ActivityFeed/ActivityThreadPanel/ActivityThreadPanel', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => <div>ActivityThreadPanel</div>),
+}));
+
+const DOCUMENTATION_WIDGETS = [
+  { i: 'KnowledgePanel.LeftPanel', h: 8, w: 6, x: 0, y: 0 },
+  { i: 'KnowledgePanel.Owners', h: 1, w: 2, x: 6, y: 0 },
+];
+
+// A persona customization that reorders the Domain page so Documentation is no longer
+// the first tab -- the configuration reported in issue #29940.
+const REORDERED_DOMAIN_PAGE = {
+  pageType: PageType.Domain,
+  tabs: [
+    { id: EntityTabs.SUBDOMAINS, layout: [] },
+    { id: EntityTabs.ASSETS, layout: [] },
+    { id: EntityTabs.DOCUMENTATION, layout: DOCUMENTATION_WIDGETS },
+  ],
+} as unknown as Page;
+
+const LayoutProbe = () => {
+  const { layout } = useGenericContext();
+
+  return (
+    <div data-testid="layout-keys">
+      {(layout ?? []).map((widget) => widget.i).join(',')}
+    </div>
+  );
+};
+
+const renderAt = (
+  path: string,
+  routePath: string,
+  props: Record<string, unknown> = {}
+) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          element={
+            <GenericProvider
+              customizedPage={REORDERED_DOMAIN_PAGE}
+              data={{ id: '123', name: 'domain' }}
+              permissions={DEFAULT_ENTITY_PERMISSION}
+              type={EntityType.DOMAIN as CustomizeEntityType}
+              onUpdate={jest.fn()}
+              {...props}>
+              <LayoutProbe />
+            </GenericProvider>
+          }
+          path={routePath}
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+
+describe('GenericProvider layout resolution', () => {
+  it('resolves the layout from the URL tab when one is present', () => {
+    renderAt('/domain/finance/documentation', '/domain/:fqn/:tab');
+
+    expect(screen.getByTestId('layout-keys')).toHaveTextContent(
+      DOCUMENTATION_WIDGETS.map((widget) => widget.i).join(',')
+    );
+  });
+
+  it('resolves the layout from the activeTab prop when the URL has no tab', () => {
+    renderAt('/domain/finance', '/domain/:fqn', {
+      activeTab: EntityTabs.DOCUMENTATION,
+    });
+
+    expect(screen.getByTestId('layout-keys')).toHaveTextContent(
+      DOCUMENTATION_WIDGETS.map((widget) => widget.i).join(',')
+    );
+  });
+
+  it('prefers the activeTab prop over the URL tab so an inline tab switch wins', () => {
+    // The domain tree view keeps the tab in local state and never writes it to the URL.
+    renderAt('/domain/finance/documentation', '/domain/:fqn/:tab', {
+      activeTab: EntityTabs.SUBDOMAINS,
+    });
+
+    expect(screen.getByTestId('layout-keys')).toHaveTextContent('');
+  });
+
+  it('falls back to the first customized tab when neither is supplied', () => {
+    renderAt('/domain/finance', '/domain/:fqn');
+
+    expect(screen.getByTestId('layout-keys')).toHaveTextContent('');
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
@@ -73,6 +73,7 @@ import { getFeedCounts } from '../../../utils/CommonUtils';
 import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
+  getRenderedActiveTab,
   getTabLabelMapFromTabs,
 } from '../../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import { getDataContractStatusIcon } from '../../../utils/DataContract/DataContractUtils';
@@ -109,7 +110,6 @@ import Loader from '../../common/Loader/Loader';
 import { ManageButtonItemLabel } from '../../common/ManageButtonContentItem/ManageButtonContentItem.component';
 import { GenericProvider } from '../../Customization/GenericProvider/GenericProvider';
 import { AssetSelectionDrawer } from '../../DataAssets/AssetsSelectionModal/AssetSelectionDrawer';
-import { DomainTabs } from '../../Domain/DomainPage.interface';
 import { EntityHeader } from '../../Entity/EntityHeader/EntityHeader.component';
 import { EntityStatusBadge } from '../../Entity/EntityStatusBadge/EntityStatusBadge.component';
 import Voting from '../../Entity/Voting/Voting.component';
@@ -701,6 +701,14 @@ const DataProductsDetailsPage = ({
     outputPortsCount,
   ]);
 
+  // `/dataProduct/:fqn` has no tab segment; resolve to the first rendered tab when the
+  // URL tab is absent/not rendered so we never land on a non-existent pane.
+  const currentTab = getRenderedActiveTab(
+    tabs,
+    activeTab as EntityTabs | undefined,
+    EntityTabs.DOCUMENTATION
+  );
+
   const iconData = useMemo(() => {
     return (
       <Avatar
@@ -919,6 +927,7 @@ const DataProductsDetailsPage = ({
 
         <GenericProvider<DataProduct>
           muiTags
+          activeTab={currentTab}
           currentVersionData={dataProduct}
           customizedPage={customizedPage}
           data={dataProduct}
@@ -931,7 +940,7 @@ const DataProductsDetailsPage = ({
             <div className="tw:p-5">
               <Tabs
                 destroyInactiveTabPane
-                activeKey={activeTab ?? DomainTabs.DOCUMENTATION}
+                activeKey={currentTab}
                 className="tabs-new"
                 data-testid="tabs"
                 items={tabs}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx
@@ -72,6 +72,7 @@ import { createEntityWithCoverImage } from '../../../utils/CoverImageUploadUtils
 import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
+  getRenderedActiveTab,
   getTabLabelMapFromTabs,
 } from '../../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import domainClassBase from '../../../utils/Domain/DomainClassBase';
@@ -172,10 +173,6 @@ const DomainDetails = ({
       (routeParams.fqn ? getDecodedFqn(routeParams.fqn) : ''),
     [domainFqnOverride, domain.fullyQualifiedName, routeParams.fqn]
   );
-  const activeTab = useMemo(
-    () => activeTabOverride ?? routeParams.tab ?? EntityTabs.DOCUMENTATION,
-    [activeTabOverride, routeParams.tab]
-  ) as EntityTabs;
   const { version } = routeParams;
   const { currentUser } = useApplicationStore();
 
@@ -212,6 +209,10 @@ const DomainDetails = ({
   );
   const urlEncodedFqn = getEncodedFqn(domain.fullyQualifiedName ?? '');
   const { customizedPage, isLoading } = useCustomPages(PageType.Domain);
+  // Explicit selection (tree-view override or URL); undefined on the landing URL.
+  const selectedTab = (activeTabOverride ?? routeParams.tab) as
+    | EntityTabs
+    | undefined;
   const [isTabExpanded, setIsTabExpanded] = useState(false);
   const isSubDomain = useMemo(() => !isEmpty(domain.parent), [domain]);
 
@@ -809,7 +810,7 @@ const DomainDetails = ({
       subDomainsCount,
       dataProductsCount,
       assetCount,
-      activeTab,
+      activeTab: selectedTab,
       onAddDataProduct,
       queryFilter,
       assetTabRef,
@@ -844,7 +845,7 @@ const DomainDetails = ({
     handleAssetClick,
     assetCount,
     dataProductsCount,
-    activeTab,
+    selectedTab,
     subDomainsCount,
     queryFilter,
     customizedPage?.tabs,
@@ -853,6 +854,13 @@ const DomainDetails = ({
     fetchDomainAssets,
     handleTabChange,
   ]);
+
+  // Resolve to the first rendered tab when the selection is absent/not rendered.
+  const activeTab = getRenderedActiveTab(
+    tabs,
+    selectedTab,
+    EntityTabs.DOCUMENTATION
+  );
 
   useEffect(() => {
     fetchDomainPermission();
@@ -1035,6 +1043,7 @@ const DomainDetails = ({
 
         <GenericProvider<Domain>
           muiTags
+          activeTab={activeTab}
           customizedPage={customizedPage}
           data={domain}
           isTabExpanded={isTabExpanded}

--- a/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.tsx
@@ -84,9 +84,8 @@ const DomainTreeView = ({
   const [hierarchy, setHierarchy] = useState<Domain[]>([]);
   const [expandedItems, setExpandedItems] = useState<string[]>([]);
   const [selectedFqn, setSelectedFqn] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<EntityTabs>(
-    EntityTabs.DOCUMENTATION
-  );
+  // Undefined = no explicit tab; DomainDetails resolves it to the persona's first tab.
+  const [activeTab, setActiveTab] = useState<EntityTabs | undefined>(undefined);
   const [selectedDomain, setSelectedDomain] = useState<Domain | null>(null);
   const [isHierarchyLoading, setIsHierarchyLoading] = useState<boolean>(false);
   const [isDomainLoading, setIsDomainLoading] = useState<boolean>(false);
@@ -485,7 +484,8 @@ const DomainTreeView = ({
 
   useEffect(() => {
     if (selectedFqn) {
-      setActiveTab(EntityTabs.DOCUMENTATION);
+      // Reset so the newly selected domain lands on its first rendered tab.
+      setActiveTab(undefined);
     }
   }, [selectedFqn]);
 
@@ -734,7 +734,8 @@ const DomainTreeView = ({
         if (requestedTab && Object.values(EntityTabs).includes(requestedTab)) {
           setActiveTab(requestedTab);
         } else {
-          setActiveTab(EntityTabs.DOCUMENTATION);
+          // No tab in the URL -- let DomainDetails resolve the first rendered tab.
+          setActiveTab(undefined);
         }
 
         updateExpansionForFqn(decodedFqn);

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/entity-lineage.style.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/entity-lineage.style.less
@@ -313,7 +313,7 @@
   }
 
   .lineage-card {
-    height: calc(100vh - @om-navbar-height - 140px);
+    height: calc(100vh - @om-navbar-height - 50px);
   }
 
   .entity-panel-container {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/entity-lineage.style.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/entity-lineage.style.less
@@ -273,10 +273,14 @@
 
 // lineage
 .lineage-card {
+  display: flex;
+  flex-direction: column;
+  height: @asset-details-tab-pane-height;
+
   .ant-card-body {
-    height: calc(
-      @asset-details-tab-pane-height - @lineage-card-header-height
-    ); // 280 for  DataAsset header
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
   }
 
   // lineage and it's children's always should be ltr
@@ -309,12 +313,7 @@
   }
 
   .lineage-card {
-    .ant-card-body {
-      // Navbar - breadcrumb
-      height: calc(100vh - @om-navbar-height - 140px);
-      // 120px for card header and breadcrumb + bottom padding 20px
-      overflow-y: auto;
-    }
+    height: calc(100vh - @om-navbar-height - 140px);
   }
 
   .entity-panel-container {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Lineage/Lineage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Lineage/Lineage.component.tsx
@@ -162,7 +162,7 @@ const Lineage = ({
       }>
       {
         <div
-          className="h-full relative lineage-container"
+          className="h-full relative overflow-hidden lineage-container"
           data-testid="lineage-container"
           id="lineage-container" // ID is required for export PNG functionality
           ref={reactFlowWrapper}>

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useCustomPages.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useCustomPages.ts
@@ -16,6 +16,7 @@ import { EntityType } from '../enums/entity.enum';
 import { Page, PageType } from '../generated/system/ui/page';
 import { NavigationItem } from '../generated/system/ui/uiCustomization';
 import { getDocumentByFQN } from '../rest/DocStoreAPI';
+import { getPersonaPage } from '../utils/CustomizePage/PersonaPage.utils';
 import { useApplicationStore } from './useApplicationStore';
 
 export const useCustomPages = (pageType: PageType | 'Navigation') => {
@@ -28,9 +29,7 @@ export const useCustomPages = (pageType: PageType | 'Navigation') => {
     const pageFQN = `${EntityType.PERSONA}${FQN_SEPARATOR_CHAR}${selectedPersona?.fullyQualifiedName}`;
     try {
       const doc = await getDocumentByFQN(pageFQN);
-      setCustomizedPage(
-        doc.data?.pages?.find((p: Page | null) => p?.pageType === pageType)
-      );
+      setCustomizedPage(getPersonaPage(doc, pageType) ?? null);
       setNavigation(doc.data?.navigation);
     } catch (error) {
       // Need to reset Navigation to avoid showing old navigation items

--- a/openmetadata-ui/src/main/resources/ui/src/pages/CustomizablePage/CustomizablePage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/CustomizablePage/CustomizablePage.tsx
@@ -43,6 +43,7 @@ import {
   updateDocument,
 } from '../../rest/DocStoreAPI';
 import { getPersonaByName } from '../../rest/PersonaAPI';
+import { updatePersonaDocumentPage } from '../../utils/CustomizePage/PersonaPage.utils';
 import { Transi18next } from '../../utils/i18next/LocalUtil';
 import { getSettingPath } from '../../utils/RouterUtils';
 import { showErrorToast, showSuccessToast } from '../../utils/ToastUtils';
@@ -61,7 +62,7 @@ export const CustomizablePage = () => {
   const { theme } = useApplicationStore();
   const [isLoading, setIsLoading] = useState(true);
   const [personaDetails, setPersonaDetails] = useState<Persona>();
-  const { document, setDocument, currentPage, getPage, setCurrentPageType } =
+  const { document, setDocument, currentPage, setCurrentPageType } =
     useCustomizeStore();
 
   const backgroundColor = useMemo(
@@ -77,23 +78,13 @@ export const CustomizablePage = () => {
     if (!document) {
       return;
     }
+    const newDoc = updatePersonaDocumentPage(document, pageFqn, newPage);
+
+    if (newDoc === document) {
+      return;
+    }
     try {
       let response: Document;
-      const newDoc = cloneDeep(document);
-      const pageData = getPage(pageFqn);
-
-      if (pageData) {
-        newDoc.data.pages = newPage
-          ? newDoc.data?.pages?.map((p: Page) =>
-              p.pageType === pageFqn ? newPage : p
-            )
-          : newDoc.data?.pages.filter((p: Page) => p.pageType !== pageFqn);
-      } else {
-        newDoc.data = {
-          ...newDoc.data,
-          pages: [...(newDoc.data.pages ?? []), newPage],
-        };
-      }
 
       if (document.id) {
         const jsonPatch = compare(document, newDoc);

--- a/openmetadata-ui/src/main/resources/ui/src/pages/CustomizablePage/CustomizeStore.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/CustomizablePage/CustomizeStore.ts
@@ -16,6 +16,11 @@ import { create } from 'zustand';
 import { Document } from '../../generated/entity/docStore/document';
 import { Page, PageType } from '../../generated/system/ui/page';
 import { NavigationItem } from '../../generated/system/ui/uiCustomization';
+import {
+  getPersonaPage,
+  normalizePersonaDocument,
+  updatePersonaDocumentPage,
+} from '../../utils/CustomizePage/PersonaPage.utils';
 
 interface CustomizePageStore {
   document: Document | null;
@@ -43,34 +48,28 @@ export const useCustomizeStore = create<CustomizePageStore>()((set, get) => ({
   setDocument: (document: Document) => {
     const { updateCurrentPage, currentPageType } = get();
 
-    // Remove undefined or null pages
-    const pages = document?.data?.pages?.filter(Boolean);
+    const normalizedDocument = normalizePersonaDocument(document);
+    const newPage = getPersonaPage(normalizedDocument, currentPageType);
 
-    const newPage = pages?.find((p: Page) => p?.pageType === currentPageType);
+    updateCurrentPage(newPage ?? ({ pageType: currentPageType } as Page));
 
-    updateCurrentPage(newPage ?? { pageType: currentPageType });
-
-    set({ document: { ...document, data: { ...document?.data, pages } } });
+    set({ document: normalizedDocument });
   },
 
   setPage: (page: Page) => {
     const { document } = get();
-    const newDocument = {
-      ...document,
-      data: {
-        ...document?.data,
-        pages: document?.data?.pages?.map((p: Page) =>
-          p.pageType === page.pageType ? page : p
-        ),
-      },
-    } as Document;
-    set({ document: newDocument });
+
+    if (document) {
+      set({
+        document: updatePersonaDocumentPage(document, page.pageType, page),
+      });
+    }
   },
 
   getPage: (pageType: string) => {
     const { document } = get();
 
-    return document?.data?.pages?.find((p: Page) => p.pageType === pageType);
+    return getPersonaPage(document, pageType) ?? null;
   },
 
   getNavigation: () => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataMarketplacePage/DataMarketplacePage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataMarketplacePage/DataMarketplacePage.component.tsx
@@ -30,12 +30,13 @@ import MarketplaceGreetingBanner from '../../components/DataMarketplace/Marketpl
 import MarketplaceSearchBar from '../../components/DataMarketplace/MarketplaceSearchBar/MarketplaceSearchBar.component';
 import { TAB_GRID_MAX_COLUMNS } from '../../constants/CustomizeWidgets.constants';
 import { EntityTabs, EntityType } from '../../enums/entity.enum';
-import { Page, PageType } from '../../generated/system/ui/page';
+import { PageType } from '../../generated/system/ui/page';
 import { useApplicationStore } from '../../hooks/useApplicationStore';
 import { useGridLayoutDirection } from '../../hooks/useGridLayoutDirection';
 import { getDocumentByFQN } from '../../rest/DocStoreAPI';
 import { getWidgetsFromKey } from '../../utils/CustomizePage/CustomizePageDispatchUtils';
 import { getLayoutFromCustomizedPage } from '../../utils/CustomizePage/CustomizePageWidgetUtils';
+import { getPersonaPage } from '../../utils/CustomizePage/PersonaPage.utils';
 import dataMarketplaceClassBase from '../../utils/DataMarketplace/DataMarketplaceClassBase';
 import { showErrorToast } from '../../utils/ToastUtils';
 import { WidgetConfig } from '../CustomizablePage/CustomizablePage.interface';
@@ -81,9 +82,7 @@ const DataMarketplacePage = () => {
       const pageFQN = `${EntityType.PERSONA}.${selectedPersona.fullyQualifiedName}`;
       const docData = await getDocumentByFQN(pageFQN);
 
-      const pageData = docData.data?.pages?.find(
-        (p: Page) => p.pageType === PageType.DataMarketplace
-      );
+      const pageData = getPersonaPage(docData, PageType.DataMarketplace);
 
       const tabLayout = getLayoutFromCustomizedPage(
         PageType.DataMarketplace,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.component.tsx
@@ -26,7 +26,7 @@ import { LOGGED_IN_USER_STORAGE_KEY } from '../../constants/constants';
 import { LandingPageWidgetKeys } from '../../enums/CustomizablePage.enum';
 import { EntityType } from '../../enums/entity.enum';
 import { Thread } from '../../generated/entity/feed/thread';
-import { Page, PageType } from '../../generated/system/ui/page';
+import { PageType } from '../../generated/system/ui/page';
 import { PersonaPreferences } from '../../generated/type/personaPreferences';
 import LimitWrapper from '../../hoc/LimitWrapper';
 import { useApplicationStore } from '../../hooks/useApplicationStore';
@@ -38,6 +38,7 @@ import { updateUserDetail } from '../../rest/userAPI';
 import { getConstrainedWidgetWidth } from '../../utils/CustomizableLandingPagePureUtils';
 import { getWidgetFromKey } from '../../utils/CustomizableLandingPageUtils';
 import customizePageClassBase from '../../utils/CustomizeMyDataPageClassBase';
+import { getPersonaPage } from '../../utils/CustomizePage/PersonaPage.utils';
 import { showErrorToast, showSuccessToast } from '../../utils/ToastUtils';
 import { WidgetConfig } from '../CustomizablePage/CustomizablePage.interface';
 import './my-data.less';
@@ -99,11 +100,12 @@ const MyDataPage = () => {
 
         setPersonaPreferences(docData.data?.personPreferences ?? []);
 
-        const pageData = docData.data?.pages?.find(
-          (p: Page) => p.pageType === PageType.LandingPage
-        ) ?? { layout: [], pageType: PageType.LandingPage };
+        const pageData = getPersonaPage(docData, PageType.LandingPage);
+        const customizedLayout = Array.isArray(pageData?.layout)
+          ? (pageData.layout as WidgetConfig[])
+          : [];
 
-        const filteredLayout = pageData.layout
+        const filteredLayout = customizedLayout
           .filter(
             (widget: WidgetConfig) =>
               !widget.i.startsWith(LandingPageWidgetKeys.CURATED_ASSETS) ||

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.test.tsx
@@ -305,6 +305,56 @@ describe('MyDataPage component', () => {
     ).toBeInTheDocument();
   });
 
+  it('MyDataPage should render a customized layout after a null legacy page', async () => {
+    (getDocumentByFQN as jest.Mock).mockResolvedValueOnce({
+      ...mockDocumentData,
+      data: {
+        pages: [null, ...mockDocumentData.data.pages],
+      },
+    });
+
+    render(<MyDataPage />);
+
+    expect(
+      await screen.findByText('KnowledgePanel.ActivityFeed')
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText('KnowledgePanel.Following')
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText('KnowledgePanel.RecentlyViewed')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('KnowledgePanel.KPI')).toBeNull();
+  });
+
+  it.each([
+    ['missing', undefined],
+    ['not an array', { invalid: true }],
+  ])(
+    'MyDataPage should use the default layout when the customized layout is %s',
+    async (_description, invalidLayout) => {
+      const landingPage =
+        invalidLayout === undefined
+          ? { pageType: PageType.LandingPage }
+          : { pageType: PageType.LandingPage, layout: invalidLayout };
+
+      (getDocumentByFQN as jest.Mock).mockResolvedValueOnce({
+        ...mockDocumentData,
+        data: { pages: [landingPage] },
+      });
+
+      render(<MyDataPage />);
+
+      expect(await screen.findByText('KnowledgePanel.KPI')).toBeInTheDocument();
+      expect(
+        await screen.findByText('KnowledgePanel.TotalAssets')
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByText('KnowledgePanel.MyData')
+      ).toBeInTheDocument();
+    }
+  );
+
   it('MyDataPage should render default widgets when there is no selected persona', async () => {
     mockSelectedPersona = null;
     render(<MyDataPage />);

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PlatformLineage/platform-lineage.less
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PlatformLineage/platform-lineage.less
@@ -18,9 +18,7 @@
   height: calc(100vh - @om-navbar-height - @platform-page-header-height);
   .lineage-card {
     height: 100%;
-    .ant-card-body {
-      height: calc(100% - 74px); // 74px is the height of card header
-    }
+    min-height: 0;
   }
 
   .full-screen-lineage {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/CustomizePageEntityTabUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/CustomizePageEntityTabUtils.test.ts
@@ -1,0 +1,85 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { EntityTabs } from '../../enums/entity.enum';
+import { getRenderedActiveTab } from './CustomizePageEntityTabUtils';
+
+// Reproduces the persona from issue #29940 that reorders Documentation off the first
+// position (and can drop it entirely), so the resolved tab must come from the rendered
+// list and never a hardcoded default that is not on screen.
+const renderedTabs = [
+  { key: EntityTabs.SUBDOMAINS, label: 'Sub Domains' },
+  { key: EntityTabs.DATA_PRODUCTS, label: 'Data Products' },
+  { key: EntityTabs.DOCUMENTATION, label: 'Documentation' },
+  { key: EntityTabs.CUSTOM_PROPERTIES, label: 'Custom Properties' },
+];
+
+describe('getRenderedActiveTab', () => {
+  it('should return the selected tab when it is in the rendered list', () => {
+    expect(
+      getRenderedActiveTab(
+        renderedTabs,
+        EntityTabs.DATA_PRODUCTS,
+        EntityTabs.DOCUMENTATION
+      )
+    ).toBe(EntityTabs.DATA_PRODUCTS);
+  });
+
+  it('should fall back to the first rendered tab when no tab is selected', () => {
+    expect(
+      getRenderedActiveTab(renderedTabs, undefined, EntityTabs.DOCUMENTATION)
+    ).toBe(EntityTabs.SUBDOMAINS);
+  });
+
+  it('should fall back to the first rendered tab when the selection is not rendered', () => {
+    // e.g. the tree view seeds a hardcoded Documentation, or a URL deep-links a tab the
+    // persona removed -- neither is on screen, so the first rendered tab wins.
+    const withoutDocumentation = renderedTabs.filter(
+      (tab) => tab.key !== EntityTabs.DOCUMENTATION
+    );
+
+    expect(
+      getRenderedActiveTab(
+        withoutDocumentation,
+        EntityTabs.DOCUMENTATION,
+        EntityTabs.DOCUMENTATION
+      )
+    ).toBe(EntityTabs.SUBDOMAINS);
+  });
+
+  it('should honour the persona order for the first tab when no tab is selected', () => {
+    const reordered = [
+      { key: EntityTabs.CUSTOM_PROPERTIES, label: 'Custom Properties' },
+      { key: EntityTabs.DOCUMENTATION, label: 'Documentation' },
+    ];
+
+    expect(
+      getRenderedActiveTab(reordered, undefined, EntityTabs.DOCUMENTATION)
+    ).toBe(EntityTabs.CUSTOM_PROPERTIES);
+  });
+
+  it('should return the provided default when the rendered list is empty', () => {
+    expect(getRenderedActiveTab([], undefined, EntityTabs.DOCUMENTATION)).toBe(
+      EntityTabs.DOCUMENTATION
+    );
+  });
+
+  it('should return the provided default when the rendered list is undefined', () => {
+    expect(
+      getRenderedActiveTab(undefined, undefined, EntityTabs.DOCUMENTATION)
+    ).toBe(EntityTabs.DOCUMENTATION);
+  });
+
+  it('should default to the Overview tab when no default is supplied', () => {
+    expect(getRenderedActiveTab([])).toBe(EntityTabs.OVERVIEW);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/CustomizePageEntityTabUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/CustomizePageEntityTabUtils.ts
@@ -69,6 +69,17 @@ export const getDetailsTabWithNewLabel = (
   return newTabs.filter((data) => !data.isHidden);
 };
 
+// Resolve the tab actually on screen: the selected tab only when it is in the rendered
+// list, else the first rendered tab (persona order, hidden dropped), else the default.
+export const getRenderedActiveTab = (
+  tabs: TabsProps['items'],
+  selectedTab?: EntityTabs,
+  defaultTab: EntityTabs = EntityTabs.OVERVIEW
+): EntityTabs =>
+  ((selectedTab && tabs?.some((tab) => tab.key === selectedTab)
+    ? selectedTab
+    : tabs?.[0]?.key) ?? defaultTab) as EntityTabs;
+
 export const getTabLabelMapFromTabs = (
   tabs?: Tab[]
 ): Record<EntityTabs, string> => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/PersonaPage.utils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/PersonaPage.utils.test.ts
@@ -1,0 +1,101 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Document } from '../../generated/entity/docStore/document';
+import { Page, PageType } from '../../generated/system/ui/page';
+import {
+  getPersonaPage,
+  normalizePersonaDocument,
+  updatePersonaDocumentPage,
+} from './PersonaPage.utils';
+
+const tablePage = {
+  pageType: PageType.Table,
+  tabs: [{ id: 'overview', layout: [], name: 'overview' }],
+} as unknown as Page;
+
+const dashboardPage = {
+  pageType: PageType.Dashboard,
+  layout: [],
+} as unknown as Page;
+
+const createDocument = (pages: unknown[]): Document => ({
+  data: { pages, navigation: [{ name: 'Explore' }] },
+  entityType: 'Page',
+  fullyQualifiedName: 'persona.test',
+  name: 'test',
+});
+
+describe('PersonaPage utilities', () => {
+  it('finds a valid page after invalid legacy entries', () => {
+    const document = createDocument([null, undefined, {}, tablePage]);
+
+    expect(getPersonaPage(document, PageType.Table)).toBe(tablePage);
+  });
+
+  it('normalizes invalid page entries without mutating the response', () => {
+    const document = createDocument([null, tablePage, undefined]);
+
+    const normalizedDocument = normalizePersonaDocument(document);
+
+    expect(normalizedDocument).not.toBe(document);
+    expect(normalizedDocument.data).not.toBe(document.data);
+    expect(normalizedDocument.data.pages).toEqual([tablePage]);
+    expect(normalizedDocument.data.navigation).toBe(document.data.navigation);
+    expect(document.data.pages).toEqual([null, tablePage, undefined]);
+  });
+
+  it('preserves tab-based pages without a top-level layout', () => {
+    const document = createDocument([tablePage]);
+
+    expect(normalizePersonaDocument(document)).toBe(document);
+  });
+
+  it('does not add an undefined page when resetting an unsaved layout', () => {
+    const document = {
+      ...createDocument([]),
+      data: { navigation: [{ name: 'Explore' }] },
+    };
+
+    expect(updatePersonaDocumentPage(document, PageType.DataMarketplace)).toBe(
+      document
+    );
+  });
+
+  it('adds, replaces, and removes pages while cleaning legacy entries', () => {
+    const document = createDocument([null, tablePage]);
+
+    const withDashboard = updatePersonaDocumentPage(
+      document,
+      PageType.Dashboard,
+      dashboardPage
+    );
+    const replacement = {
+      ...dashboardPage,
+      layout: [{ i: 'updated' }],
+    } as Page;
+    const withReplacement = updatePersonaDocumentPage(
+      withDashboard,
+      PageType.Dashboard,
+      replacement
+    );
+    const withoutTable = updatePersonaDocumentPage(
+      withReplacement,
+      PageType.Table
+    );
+
+    expect(withDashboard.data.pages).toEqual([tablePage, dashboardPage]);
+    expect(withReplacement.data.pages).toEqual([tablePage, replacement]);
+    expect(withoutTable.data.pages).toEqual([replacement]);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/PersonaPage.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/PersonaPage.utils.ts
@@ -1,0 +1,97 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Document } from '../../generated/entity/docStore/document';
+import { Page } from '../../generated/system/ui/page';
+
+const getPageEntries = (document?: Document | null): unknown[] | undefined => {
+  const pages = document?.data?.pages as unknown;
+
+  return Array.isArray(pages) ? pages : undefined;
+};
+
+const isPersonaPage = (value: unknown): value is Page =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as { pageType?: unknown }).pageType === 'string';
+
+export const getPersonaPage = (
+  document: Document | null | undefined,
+  pageType: string | null | undefined
+): Page | undefined => {
+  if (!pageType) {
+    return undefined;
+  }
+
+  return getPageEntries(document)?.find(
+    (page): page is Page => isPersonaPage(page) && page.pageType === pageType
+  );
+};
+
+export const normalizePersonaDocument = (document: Document): Document => {
+  const pageEntries = getPageEntries(document);
+
+  if (!pageEntries) {
+    return document;
+  }
+
+  const pages = pageEntries.filter(isPersonaPage);
+
+  if (pages.length === pageEntries.length) {
+    return document;
+  }
+
+  return {
+    ...document,
+    data: {
+      ...document.data,
+      pages,
+    },
+  };
+};
+
+export const updatePersonaDocumentPage = (
+  document: Document,
+  pageType: string,
+  newPage?: Page
+): Document => {
+  const pageEntries = getPageEntries(document);
+  const pages = pageEntries?.filter(isPersonaPage) ?? [];
+  const hasPage = pages.some((page) => page.pageType === pageType);
+  const hasInvalidPage =
+    pageEntries !== undefined && pageEntries.length !== pages.length;
+
+  if (!newPage && !hasPage && !hasInvalidPage) {
+    return document;
+  }
+
+  let updatedPages: Page[];
+
+  if (!newPage) {
+    updatedPages = pages.filter((page) => page.pageType !== pageType);
+  } else if (hasPage) {
+    updatedPages = pages.map((page) =>
+      page.pageType === pageType ? newPage : page
+    );
+  } else {
+    updatedPages = [...pages, newPage];
+  }
+
+  return {
+    ...document,
+    data: {
+      ...document.data,
+      pages: updatedPages,
+    },
+  };
+};

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Domain/DomainClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Domain/DomainClassBase.ts
@@ -42,7 +42,8 @@ export interface DomainDetailPageTabProps {
   subDomainsCount: number;
   dataProductsCount: number;
   assetCount: number;
-  activeTab: EntityTabs;
+  // Undefined when no tab is explicitly selected (landing URL / tree view).
+  activeTab?: EntityTabs;
   onAddDataProduct: () => void;
   onAddSubDomain: (subDomain: CreateDomain) => Promise<void>;
   onDeleteSubDomain: () => void;


### PR DESCRIPTION
### Describe your changes

Backport of #32036 for the 1.13 branch (direct re-implementation — cherry-pick had merge conflicts due to structural differences between main and 1.13).

**Problem**: When opening the filters section in the lineage tab, the bottom control buttons (zoom, minimap, etc.) become hidden because container elements with `overflow-y: auto` scroll when the filter panel expands.

**Fix**: Replace explicit `height: calc(...)` + `overflow-y: auto` on `.ant-card-body` elements with a flex-column layout on `.lineage-card`, so the canvas occupies available space correctly and content is bounded (`overflow: hidden`) rather than allowed to scroll.

### Changes

- **`entity-lineage.style.less`**: Make `.lineage-card` flex-column; change `.ant-card-body` to `flex: 1 / min-height: 0 / overflow: hidden`; move fullscreen height to the card itself (removing `overflow-y: auto` from body).
- **`platform-lineage.less`**: Remove `.ant-card-body` fixed height calc; add `min-height: 0` to `.lineage-card`.
- **`Lineage.component.tsx`**: Add `overflow-hidden` to the `lineage-container` div so ReactFlow panels are clipped within canvas bounds.

### Type of change

- [x] Bug fix

### High-level design

N/A — small change.

### Checklist

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces scrollable fixed-height lineage bodies with bounded flex layouts so expanding filters does not hide canvas controls.
- Makes entity lineage cards flex columns with a shrinkable, overflow-bounded body.
- Adjusts entity fullscreen sizing and platform lineage flex constraints.
- Clips the ReactFlow container to the available canvas bounds.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/entity-lineage.style.less | Converts the lineage card to a bounded flex-column layout and moves fullscreen sizing to the card. |
| openmetadata-ui/src/main/resources/ui/src/components/Lineage/Lineage.component.tsx | Adds overflow clipping to the lineage canvas container. |
| openmetadata-ui/src/main/resources/ui/src/pages/PlatformLineage/platform-lineage.less | Removes fixed body sizing and allows the platform lineage card to shrink correctly in its flex context. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): adjust fullscreen lineage heigh..."](https://github.com/open-metadata/openmetadata/commit/52d55a4bd31d175c957300717b26396391dcacee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56967688)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))

<!-- /greptile_comment -->