### PR TITLE
Fixes #31296: Backport OpenLineage Kafka SSL and password handling to 2.0

### DIFF
--- a/ingestion/src/metadata/ingestion/source/pipeline/openlineage/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/openlineage/connection.py
@@ -23,15 +23,20 @@ from metadata.clients.aws_client import AWSClient
 from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
 )
-from metadata.generated.schema.entity.services.connections.pipeline.openLineageConnection import (
-    KafkaBrokerConfig,
-    KinesisBrokerConfig,
+from metadata.generated.schema.entity.services.connections.messaging.saslMechanismType import (
+    SaslMechanismType as KafkaSaslMechanism,
+)
+from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kafkaBrokerConfig import (
+    Kafka as KafkaBrokerConfig,
+)
+from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kafkaBrokerConfig import (
+    SecurityProtocol as KafkaSecProtocol,
+)
+from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kinesisBrokerConfig import (
+    Kinesis as KinesisBrokerConfig,
 )
 from metadata.generated.schema.entity.services.connections.pipeline.openLineageConnection import (
     OpenLineageConnection as OpenLineageConnectionConfig,
-)
-from metadata.generated.schema.entity.services.connections.pipeline.openLineageConnection import (
-    SecurityProtocol as KafkaSecProtocol,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
@@ -48,30 +53,41 @@ from metadata.utils.ssl_manager import SSLManager
 
 def _get_kafka_connection(
     broker: KafkaBrokerConfig,
-) -> tuple[KafkaConsumer | None, SSLManager | None]:
-    requires_ssl = broker.securityProtocol.value in (
+) -> tuple[KafkaConsumer, SSLManager | None]:
+    security_protocol = broker.securityProtocol or KafkaSecProtocol.PLAINTEXT
+    requires_ssl = security_protocol.value in (
         KafkaSecProtocol.SSL.value,
         KafkaSecProtocol.SASL_SSL.value,
     )
-    if requires_ssl and broker.sslConfig is None:
+    requires_sasl = security_protocol.value in (
+        KafkaSecProtocol.SASL_PLAINTEXT.value,
+        KafkaSecProtocol.SASL_SSL.value,
+    )
+    ssl_config = broker.sslConfig
+    if requires_ssl and ssl_config is None:
         raise SourceConnectionException("SSL security protocol requires an SSL configuration with a CA certificate.")
+    sasl_config = broker.saslConfig
+    if requires_sasl and sasl_config is None:
+        raise SourceConnectionException(
+            "SASL security protocol requires a SASL configuration with a username and password."
+        )
     ssl_manager = None
     try:
         config = {
             "bootstrap.servers": broker.brokersUrl,
             "group.id": broker.consumerGroupName,
             "auto.offset.reset": broker.consumerOffsets.value,
-            "security.protocol": broker.securityProtocol.value,
+            "security.protocol": security_protocol.value,
         }
-        if requires_ssl:
+        if requires_ssl and ssl_config is not None:
             # confluent_kafka's ssl.*.location keys take file paths, but the
             # connection config holds the cert/key content (pasted or uploaded).
             # Materialize them to temp files so the broker is handed a real bundle;
             # the caller registers ssl_manager.cleanup_temp_files to tear them down.
             ssl_manager = SSLManager(
-                ca=broker.sslConfig.root.caCertificate,
-                cert=broker.sslConfig.root.sslCertificate,
-                key=broker.sslConfig.root.sslKey,
+                ca=ssl_config.root.caCertificate,
+                cert=ssl_config.root.sslCertificate,
+                key=ssl_config.root.sslKey,
             )
             ssl_locations = {
                 "ssl.ca.location": ssl_manager.ca_file_path,
@@ -80,18 +96,15 @@ def _get_kafka_connection(
             }
             config.update({key: value for key, value in ssl_locations.items() if value is not None})
 
-        if broker.securityProtocol.value in (
-            KafkaSecProtocol.SASL_PLAINTEXT.value,
-            KafkaSecProtocol.SASL_SSL.value,
-        ):
+        if requires_sasl and sasl_config is not None:
             config.update(
                 {
-                    "sasl.mechanism": broker.saslConfig.saslMechanism.value,
-                    "sasl.username": broker.saslConfig.saslUsername,
+                    "sasl.mechanism": (sasl_config.saslMechanism or KafkaSaslMechanism.PLAIN).value,
+                    "sasl.username": sasl_config.saslUsername,
                 }
             )
-            if broker.saslConfig.saslPassword is not None:
-                config["sasl.password"] = broker.saslConfig.saslPassword.get_secret_value()
+            if sasl_config.saslPassword is not None:
+                config["sasl.password"] = sasl_config.saslPassword.get_secret_value()
 
         kafka_consumer = KafkaConsumer(config)
         kafka_consumer.subscribe([broker.topicName])

--- a/ingestion/src/metadata/ingestion/source/pipeline/openlineage/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/openlineage/connection.py
@@ -55,6 +55,7 @@ def _get_kafka_connection(
     )
     if requires_ssl and broker.sslConfig is None:
         raise SourceConnectionException("SSL security protocol requires an SSL configuration with a CA certificate.")
+    ssl_manager = None
     try:
         config = {
             "bootstrap.servers": broker.brokersUrl,
@@ -62,7 +63,6 @@ def _get_kafka_connection(
             "auto.offset.reset": broker.consumerOffsets.value,
             "security.protocol": broker.securityProtocol.value,
         }
-        ssl_manager = None
         if requires_ssl:
             # confluent_kafka's ssl.*.location keys take file paths, but the
             # connection config holds the cert/key content (pasted or uploaded).
@@ -98,6 +98,10 @@ def _get_kafka_connection(
 
         return kafka_consumer, ssl_manager  # noqa: TRY300
     except Exception as exc:
+        # The cert material is materialized to temp files before the consumer is
+        # created; tear it down if we never hand the manager to the caller.
+        if ssl_manager is not None:
+            ssl_manager.cleanup_temp_files()
         msg = f"Unknown error connecting with Kafka broker: {exc}."
         raise SourceConnectionException(msg)  # noqa: B904
 

--- a/ingestion/src/metadata/ingestion/source/pipeline/openlineage/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/openlineage/connection.py
@@ -43,9 +43,18 @@ from metadata.ingestion.connections.test_connections import (
 )
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.constants import THREE_MIN
+from metadata.utils.ssl_manager import SSLManager
 
 
-def _get_kafka_connection(broker: KafkaBrokerConfig) -> KafkaConsumer:
+def _get_kafka_connection(
+    broker: KafkaBrokerConfig,
+) -> tuple[KafkaConsumer | None, SSLManager | None]:
+    requires_ssl = broker.securityProtocol.value in (
+        KafkaSecProtocol.SSL.value,
+        KafkaSecProtocol.SASL_SSL.value,
+    )
+    if requires_ssl and broker.sslConfig is None:
+        raise SourceConnectionException("SSL security protocol requires an SSL configuration with a CA certificate.")
     try:
         config = {
             "bootstrap.servers": broker.brokersUrl,
@@ -53,17 +62,23 @@ def _get_kafka_connection(broker: KafkaBrokerConfig) -> KafkaConsumer:
             "auto.offset.reset": broker.consumerOffsets.value,
             "security.protocol": broker.securityProtocol.value,
         }
-        if broker.securityProtocol.value in (
-            KafkaSecProtocol.SSL.value,
-            KafkaSecProtocol.SASL_SSL.value,
-        ):
-            config.update(
-                {
-                    "ssl.ca.location": broker.sslConfig.root.caCertificate,
-                    "ssl.certificate.location": broker.sslConfig.root.sslCertificate,
-                    "ssl.key.location": broker.sslConfig.root.sslKey,
-                }
+        ssl_manager = None
+        if requires_ssl:
+            # confluent_kafka's ssl.*.location keys take file paths, but the
+            # connection config holds the cert/key content (pasted or uploaded).
+            # Materialize them to temp files so the broker is handed a real bundle;
+            # the caller registers ssl_manager.cleanup_temp_files to tear them down.
+            ssl_manager = SSLManager(
+                ca=broker.sslConfig.root.caCertificate,
+                cert=broker.sslConfig.root.sslCertificate,
+                key=broker.sslConfig.root.sslKey,
             )
+            ssl_locations = {
+                "ssl.ca.location": ssl_manager.ca_file_path,
+                "ssl.certificate.location": ssl_manager.cert_file_path,
+                "ssl.key.location": ssl_manager.key_file_path,
+            }
+            config.update({key: value for key, value in ssl_locations.items() if value is not None})
 
         if broker.securityProtocol.value in (
             KafkaSecProtocol.SASL_PLAINTEXT.value,
@@ -73,14 +88,15 @@ def _get_kafka_connection(broker: KafkaBrokerConfig) -> KafkaConsumer:
                 {
                     "sasl.mechanism": broker.saslConfig.saslMechanism.value,
                     "sasl.username": broker.saslConfig.saslUsername,
-                    "sasl.password": broker.saslConfig.saslPassword,
                 }
             )
+            if broker.saslConfig.saslPassword is not None:
+                config["sasl.password"] = broker.saslConfig.saslPassword.get_secret_value()
 
         kafka_consumer = KafkaConsumer(config)
         kafka_consumer.subscribe([broker.topicName])
 
-        return kafka_consumer  # noqa: TRY300
+        return kafka_consumer, ssl_manager  # noqa: TRY300
     except Exception as exc:
         msg = f"Unknown error connecting with Kafka broker: {exc}."
         raise SourceConnectionException(msg)  # noqa: B904
@@ -102,8 +118,10 @@ class OpenLineageConnection(BaseConnection[OpenLineageConnectionConfig, KafkaCon
         broker = self.service_connection.brokerConfig
 
         if isinstance(broker, KafkaBrokerConfig):
-            consumer = _get_kafka_connection(broker)
+            consumer, ssl_manager = _get_kafka_connection(broker)
             self._on_close(consumer.close)
+            if ssl_manager is not None:
+                self._on_close(ssl_manager.cleanup_temp_files)
             return consumer
 
         if isinstance(broker, KinesisBrokerConfig):

--- a/ingestion/src/metadata/ingestion/source/pipeline/openlineage/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/openlineage/metadata.py
@@ -29,9 +29,13 @@ from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.entity.data.pipeline import Pipeline
 from metadata.generated.schema.entity.data.table import Table
 from metadata.generated.schema.entity.data.topic import Topic
+from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kafkaBrokerConfig import (
+    Kafka as KafkaBrokerConfig,
+)
+from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kinesisBrokerConfig import (
+    Kinesis as KinesisBrokerConfig,
+)
 from metadata.generated.schema.entity.services.connections.pipeline.openLineageConnection import (
-    KafkaBrokerConfig,
-    KinesisBrokerConfig,
     OpenLineageConnection,
 )
 from metadata.generated.schema.entity.services.databaseService import (

--- a/ingestion/tests/unit/source/pipeline/openlineage/test_connection.py
+++ b/ingestion/tests/unit/source/pipeline/openlineage/test_connection.py
@@ -13,6 +13,8 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from metadata.generated.schema.entity.services.connections.messaging.saslMechanismType import (
     SaslMechanismType,
 )
@@ -26,6 +28,7 @@ from metadata.generated.schema.security.ssl.validateSSLClientConfig import (
 )
 from metadata.generated.schema.security.ssl.verifySSLConfig import SslConfig
 from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.connections.test_connections import SourceConnectionException
 from metadata.ingestion.source.pipeline.openlineage.connection import (
     OpenLineageConnection,
     _get_kafka_connection,
@@ -79,6 +82,20 @@ def test_kafka_ssl_ca_content_is_materialized_as_temp_file():
     assert config["ssl.key.location"] is not None
     assert ssl_manager is not None
     ssl_manager.cleanup_temp_files()
+
+
+def test_kafka_ssl_temp_files_cleaned_up_when_consumer_fails():
+    """If the consumer cannot be built, the materialized cert temp files must still be
+    torn down so repeated failed connects do not orphan cert material in the temp dir."""
+    broker = _ssl_broker()
+    ssl_manager = MagicMock()
+    with (
+        patch(f"{CONNECTION_MODULE}.SSLManager", return_value=ssl_manager),
+        patch(f"{CONNECTION_MODULE}.KafkaConsumer", side_effect=Exception("boom")),
+        pytest.raises(SourceConnectionException),
+    ):
+        _get_kafka_connection(broker)
+    ssl_manager.cleanup_temp_files.assert_called_once()
 
 
 def test_kafka_sasl_password_is_read_from_secret():

--- a/ingestion/tests/unit/source/pipeline/openlineage/test_connection.py
+++ b/ingestion/tests/unit/source/pipeline/openlineage/test_connection.py
@@ -10,15 +10,41 @@
 #  limitations under the License.
 """Unit tests for OpenLineage connection handling."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from metadata.generated.schema.entity.services.connections.messaging.saslMechanismType import (
+    SaslMechanismType,
+)
+from metadata.generated.schema.entity.services.connections.pipeline.openLineageConnection import (
+    KafkaBrokerConfig,
+    SecurityProtocol,
+)
+from metadata.generated.schema.security.sasl.saslClientConfig import SaslClientConfig
+from metadata.generated.schema.security.ssl.validateSSLClientConfig import (
+    ValidateSslClientConfig,
+)
+from metadata.generated.schema.security.ssl.verifySSLConfig import SslConfig
 from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.source.pipeline.openlineage.connection import (
-    KafkaBrokerConfig,
     OpenLineageConnection,
+    _get_kafka_connection,
 )
 
 CONNECTION_MODULE = "metadata.ingestion.source.pipeline.openlineage.connection"
+
+CA_CERT = "-----BEGIN CERTIFICATE-----\nTEST CA CONTENT\n-----END CERTIFICATE-----\n"
+
+
+def _ssl_broker():
+    ssl_config = SslConfig(root=ValidateSslClientConfig(caCertificate=CA_CERT, sslCertificate="CERT", sslKey="KEY"))
+    return KafkaBrokerConfig(
+        brokersUrl="broker:9092",
+        topicName="openlineage",
+        consumerGroupName="om",
+        securityProtocol=SecurityProtocol.SSL,
+        sslConfig=ssl_config,
+    )
 
 
 def test_openlineage_connection_is_base_connection():
@@ -29,11 +55,67 @@ def test_get_client_builds_client():
     service_connection = MagicMock()
     service_connection.brokerConfig = MagicMock(spec=KafkaBrokerConfig)
     with patch(f"{CONNECTION_MODULE}._get_kafka_connection") as mock_kafka:
+        mock_kafka.return_value = (MagicMock(), None)
         conn = OpenLineageConnection(service_connection)
         client = conn.client
 
-    assert client is mock_kafka.return_value
+    assert client is mock_kafka.return_value[0]
     mock_kafka.assert_called_once_with(service_connection.brokerConfig)
+
+
+def test_kafka_ssl_ca_content_is_materialized_as_temp_file():
+    """SSL cert content must be written to a temp file whose path is passed to the consumer,
+    not the raw (masked) secret — confluent_kafka's ssl.*.location keys are file paths."""
+    broker = _ssl_broker()
+    with patch(f"{CONNECTION_MODULE}.KafkaConsumer") as mock_consumer:
+        _, ssl_manager = _get_kafka_connection(broker)
+
+    config = mock_consumer.call_args.args[0]
+    ca_path = config["ssl.ca.location"]
+    assert ca_path is not None
+    assert Path(ca_path).is_file()
+    assert "TEST CA CONTENT" in Path(ca_path).read_text(encoding="utf-8")
+    assert config["ssl.certificate.location"] is not None
+    assert config["ssl.key.location"] is not None
+    assert ssl_manager is not None
+    ssl_manager.cleanup_temp_files()
+
+
+def test_kafka_sasl_password_is_read_from_secret():
+    """The SASL password should be resolved through the secret, not passed as the masked object."""
+    sasl_config = SaslClientConfig(
+        saslMechanism=SaslMechanismType.PLAIN,
+        saslUsername="user",
+        saslPassword="super-secret",
+    )
+    broker = KafkaBrokerConfig(
+        brokersUrl="broker:9092",
+        topicName="openlineage",
+        securityProtocol=SecurityProtocol.SASL_PLAINTEXT,
+        saslConfig=sasl_config,
+    )
+    with patch(f"{CONNECTION_MODULE}.KafkaConsumer") as mock_consumer:
+        _, ssl_manager = _get_kafka_connection(broker)
+
+    config = mock_consumer.call_args.args[0]
+    assert config["sasl.password"] == "super-secret"
+    assert config["sasl.username"] == "user"
+    assert ssl_manager is None
+
+
+def test_kafka_plaintext_skips_ssl_and_sasl():
+    broker = KafkaBrokerConfig(
+        brokersUrl="broker:9092",
+        topicName="openlineage",
+        securityProtocol=SecurityProtocol.PLAINTEXT,
+    )
+    with patch(f"{CONNECTION_MODULE}.KafkaConsumer") as mock_consumer:
+        _, ssl_manager = _get_kafka_connection(broker)
+
+    config = mock_consumer.call_args.args[0]
+    assert not any(key.startswith("ssl.") for key in config)
+    assert not any(key.startswith("sasl.") for key in config)
+    assert ssl_manager is None
 
 
 def test_test_connection_runs_steps():

--- a/ingestion/tests/unit/source/pipeline/openlineage/test_connection.py
+++ b/ingestion/tests/unit/source/pipeline/openlineage/test_connection.py
@@ -18,8 +18,10 @@ import pytest
 from metadata.generated.schema.entity.services.connections.messaging.saslMechanismType import (
     SaslMechanismType,
 )
-from metadata.generated.schema.entity.services.connections.pipeline.openLineageConnection import (
-    KafkaBrokerConfig,
+from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kafkaBrokerConfig import (
+    Kafka as KafkaBrokerConfig,
+)
+from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kafkaBrokerConfig import (
     SecurityProtocol,
 )
 from metadata.generated.schema.security.sasl.saslClientConfig import SaslClientConfig

--- a/ingestion/tests/unit/topology/pipeline/test_openlineage.py
+++ b/ingestion/tests/unit/topology/pipeline/test_openlineage.py
@@ -15,11 +15,15 @@ from metadata.generated.schema.entity.data.pipeline import Pipeline, Task
 from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
     OpenMetadataConnection,
 )
-from metadata.generated.schema.entity.services.connections.pipeline.openLineageConnection import (
+from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kafkaBrokerConfig import (
     ConsumerOffsets,
-    ConsumerOffsets1,
-    KinesisBrokerConfig,
     SecurityProtocol,
+)
+from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kinesisBrokerConfig import (
+    ConsumerOffsets as ConsumerOffsets1,
+)
+from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kinesisBrokerConfig import (
+    Kinesis as KinesisBrokerConfig,
 )
 from metadata.generated.schema.entity.services.databaseService import (
     DatabaseServiceType,

--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/ClassConverterFactory.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/ClassConverterFactory.java
@@ -57,6 +57,7 @@ import org.openmetadata.schema.services.connections.pipeline.AirflowRestApiConne
 import org.openmetadata.schema.services.connections.pipeline.MatillionConnection;
 import org.openmetadata.schema.services.connections.pipeline.MulesoftConnection;
 import org.openmetadata.schema.services.connections.pipeline.NifiConnection;
+import org.openmetadata.schema.services.connections.pipeline.OpenLineageConnection;
 import org.openmetadata.schema.services.connections.pipeline.PrefectConnection;
 import org.openmetadata.schema.services.connections.pipeline.SSISConnection;
 import org.openmetadata.schema.services.connections.pipeline.WherescapeConnection;
@@ -118,6 +119,7 @@ public final class ClassConverterFactory {
             Map.entry(Workflow.class, new WorkflowClassConverter()),
             Map.entry(CockroachConnection.class, new CockroachConnectionClassConverter()),
             Map.entry(NifiConnection.class, new NifiConnectionClassConverter()),
+            Map.entry(OpenLineageConnection.class, new OpenLineageConnectionClassConverter()),
             Map.entry(MatillionConnection.class, new MatillionConnectionClassConverter()),
             Map.entry(PrefectConnection.class, new PrefectConnectionClassConverter()),
             Map.entry(VertexAIConnection.class, new VertexAIConnectionClassConverter()),

--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/OpenLineageConnectionClassConverter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/OpenLineageConnectionClassConverter.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.secrets.converter;
+
+import java.util.List;
+import org.openmetadata.schema.services.connections.pipeline.OpenLineageConnection;
+import org.openmetadata.schema.services.connections.pipeline.openlineage.KafkaBrokerConfig;
+import org.openmetadata.schema.services.connections.pipeline.openlineage.KinesisBrokerConfig;
+import org.openmetadata.schema.utils.JsonUtils;
+
+/** Converter class to get an `OpenLineageConnection` object. */
+public class OpenLineageConnectionClassConverter extends ClassConverter {
+
+  public OpenLineageConnectionClassConverter() {
+    super(OpenLineageConnection.class);
+  }
+
+  @Override
+  public Object convert(Object object) {
+    OpenLineageConnection openLineageConnection =
+        (OpenLineageConnection) JsonUtils.convertValue(object, this.clazz);
+
+    tryToConvertOrFail(
+            openLineageConnection.getBrokerConfig(),
+            List.of(KafkaBrokerConfig.class, KinesisBrokerConfig.class))
+        .ifPresent(openLineageConnection::setBrokerConfig);
+
+    return openLineageConnection;
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/secrets/converter/ClassConverterFactoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/secrets/converter/ClassConverterFactoryTest.java
@@ -24,6 +24,7 @@ import org.openmetadata.schema.services.connections.database.TrinoConnection;
 import org.openmetadata.schema.services.connections.database.datalake.GCSConfig;
 import org.openmetadata.schema.services.connections.pipeline.AirflowConnection;
 import org.openmetadata.schema.services.connections.pipeline.MatillionConnection;
+import org.openmetadata.schema.services.connections.pipeline.OpenLineageConnection;
 import org.openmetadata.schema.services.connections.search.ElasticSearchConnection;
 import org.openmetadata.schema.services.connections.storage.GCSConnection;
 
@@ -52,6 +53,7 @@ public class ClassConverterFactoryTest {
         Workflow.class,
         SalesforceConnection.class,
         MatillionConnection.class,
+        OpenLineageConnection.class,
       })
   void testClassConverterIsSet(Class<?> clazz) {
     assertFalse(

--- a/openmetadata-service/src/test/java/org/openmetadata/service/secrets/converter/OpenLineageConnectionClassConverterTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/secrets/converter/OpenLineageConnectionClassConverterTest.java
@@ -1,0 +1,59 @@
+package org.openmetadata.service.secrets.converter;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.security.credentials.AWSCredentials;
+import org.openmetadata.schema.services.connections.pipeline.OpenLineageConnection;
+import org.openmetadata.schema.services.connections.pipeline.openlineage.KafkaBrokerConfig;
+import org.openmetadata.schema.services.connections.pipeline.openlineage.KinesisBrokerConfig;
+import org.openmetadata.schema.utils.JsonUtils;
+
+class OpenLineageConnectionClassConverterTest {
+
+  private final ClassConverter converter =
+      ClassConverterFactory.getConverter(OpenLineageConnection.class);
+
+  @Test
+  void testConvertsKafkaBrokerConfig() {
+    KafkaBrokerConfig kafkaBrokerConfig =
+        new KafkaBrokerConfig().withBrokersUrl("broker:9092").withTopicName("openlineage");
+
+    OpenLineageConnection input = new OpenLineageConnection().withBrokerConfig(kafkaBrokerConfig);
+    Object rawInput = JsonUtils.readValue(JsonUtils.pojoToJson(input), Object.class);
+
+    OpenLineageConnection result = (OpenLineageConnection) converter.convert(rawInput);
+
+    assertNotNull(result);
+    assertInstanceOf(KafkaBrokerConfig.class, result.getBrokerConfig());
+  }
+
+  @Test
+  void testConvertsKinesisBrokerConfig() {
+    KinesisBrokerConfig kinesisBrokerConfig =
+        new KinesisBrokerConfig()
+            .withStreamName("openlineage-stream")
+            .withAwsConfig(new AWSCredentials().withAwsRegion("us-east-1"));
+
+    OpenLineageConnection input = new OpenLineageConnection().withBrokerConfig(kinesisBrokerConfig);
+    Object rawInput = JsonUtils.readValue(JsonUtils.pojoToJson(input), Object.class);
+
+    OpenLineageConnection result = (OpenLineageConnection) converter.convert(rawInput);
+
+    assertNotNull(result);
+    assertInstanceOf(KinesisBrokerConfig.class, result.getBrokerConfig());
+  }
+
+  @Test
+  void testNullBrokerConfigDoesNotThrow() {
+    OpenLineageConnection input = new OpenLineageConnection();
+    Object rawInput = JsonUtils.readValue(JsonUtils.pojoToJson(input), Object.class);
+
+    OpenLineageConnection result = (OpenLineageConnection) converter.convert(rawInput);
+
+    assertNotNull(result);
+    assertNull(result.getBrokerConfig());
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/secrets/masker/TestEntityMasker.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/secrets/masker/TestEntityMasker.java
@@ -21,14 +21,17 @@ import org.openmetadata.schema.security.SecurityConfiguration;
 import org.openmetadata.schema.security.client.OpenMetadataJWTClientConfig;
 import org.openmetadata.schema.security.credentials.GCPCredentials;
 import org.openmetadata.schema.security.credentials.GCPValues;
+import org.openmetadata.schema.security.sasl.SASLClientConfig;
 import org.openmetadata.schema.services.connections.dashboard.SupersetConnection;
 import org.openmetadata.schema.services.connections.database.BigQueryConnection;
 import org.openmetadata.schema.services.connections.database.DatalakeConnection;
 import org.openmetadata.schema.services.connections.database.MysqlConnection;
 import org.openmetadata.schema.services.connections.database.common.basicAuth;
 import org.openmetadata.schema.services.connections.database.datalake.GCSConfig;
+import org.openmetadata.schema.services.connections.messaging.SaslMechanismType;
 import org.openmetadata.schema.services.connections.metadata.OpenMetadataConnection;
 import org.openmetadata.schema.services.connections.pipeline.AirflowConnection;
+import org.openmetadata.schema.services.connections.pipeline.OpenLineageConnection;
 import org.openmetadata.schema.utils.JsonUtils;
 
 abstract class TestEntityMasker {
@@ -169,6 +172,46 @@ abstract class TestEntityMasker {
         JsonUtils.convertValue(
                 ((MysqlConnection) unmasked.getConnection()).getAuthType(), basicAuth.class)
             .getPassword());
+  }
+
+  @Test
+  void testOpenLineageConnectionMasker() {
+    SASLClientConfig saslConfig =
+        new SASLClientConfig()
+            .withSaslMechanism(SaslMechanismType.PLAIN)
+            .withSaslUsername("user")
+            .withSaslPassword(PASSWORD);
+    OpenLineageConnection.KafkaBrokerConfig brokerConfig =
+        new OpenLineageConnection.KafkaBrokerConfig()
+            .withBrokersUrl("broker:9092")
+            .withTopicName("openlineage")
+            .withConsumerGroupName("om")
+            .withSecurityProtocol(
+                OpenLineageConnection.KafkaBrokerConfig.SecurityProtocol.SASL_SSL)
+            .withSaslConfig(saslConfig);
+    OpenLineageConnection connection =
+        new OpenLineageConnection().withBrokerConfig(brokerConfig);
+
+    OpenLineageConnection masked =
+        (OpenLineageConnection)
+            EntityMaskerFactory.createEntityMasker()
+                .maskServiceConnectionConfig(connection, "OpenLineage", ServiceType.PIPELINE);
+    assertNotNull(masked);
+    assertEquals(
+        getMaskedPassword(),
+        ((OpenLineageConnection.KafkaBrokerConfig) masked.getBrokerConfig())
+            .getSaslConfig()
+            .getSaslPassword());
+    OpenLineageConnection unmasked =
+        (OpenLineageConnection)
+            EntityMaskerFactory.createEntityMasker()
+                .unmaskServiceConnectionConfig(
+                    masked, connection, "OpenLineage", ServiceType.PIPELINE);
+    assertEquals(
+        PASSWORD,
+        ((OpenLineageConnection.KafkaBrokerConfig) unmasked.getBrokerConfig())
+            .getSaslConfig()
+            .getSaslPassword());
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/secrets/masker/TestEntityMasker.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/secrets/masker/TestEntityMasker.java
@@ -32,6 +32,7 @@ import org.openmetadata.schema.services.connections.messaging.SaslMechanismType;
 import org.openmetadata.schema.services.connections.metadata.OpenMetadataConnection;
 import org.openmetadata.schema.services.connections.pipeline.AirflowConnection;
 import org.openmetadata.schema.services.connections.pipeline.OpenLineageConnection;
+import org.openmetadata.schema.services.connections.pipeline.openlineage.KafkaBrokerConfig;
 import org.openmetadata.schema.utils.JsonUtils;
 
 abstract class TestEntityMasker {
@@ -181,16 +182,14 @@ abstract class TestEntityMasker {
             .withSaslMechanism(SaslMechanismType.PLAIN)
             .withSaslUsername("user")
             .withSaslPassword(PASSWORD);
-    OpenLineageConnection.KafkaBrokerConfig brokerConfig =
-        new OpenLineageConnection.KafkaBrokerConfig()
+    KafkaBrokerConfig brokerConfig =
+        new KafkaBrokerConfig()
             .withBrokersUrl("broker:9092")
             .withTopicName("openlineage")
             .withConsumerGroupName("om")
-            .withSecurityProtocol(
-                OpenLineageConnection.KafkaBrokerConfig.SecurityProtocol.SASL_SSL)
+            .withSecurityProtocol(KafkaBrokerConfig.SecurityProtocol.SASL_SSL)
             .withSaslConfig(saslConfig);
-    OpenLineageConnection connection =
-        new OpenLineageConnection().withBrokerConfig(brokerConfig);
+    OpenLineageConnection connection = new OpenLineageConnection().withBrokerConfig(brokerConfig);
 
     OpenLineageConnection masked =
         (OpenLineageConnection)
@@ -199,9 +198,7 @@ abstract class TestEntityMasker {
     assertNotNull(masked);
     assertEquals(
         getMaskedPassword(),
-        ((OpenLineageConnection.KafkaBrokerConfig) masked.getBrokerConfig())
-            .getSaslConfig()
-            .getSaslPassword());
+        ((KafkaBrokerConfig) masked.getBrokerConfig()).getSaslConfig().getSaslPassword());
     OpenLineageConnection unmasked =
         (OpenLineageConnection)
             EntityMaskerFactory.createEntityMasker()
@@ -209,9 +206,7 @@ abstract class TestEntityMasker {
                     masked, connection, "OpenLineage", ServiceType.PIPELINE);
     assertEquals(
         PASSWORD,
-        ((OpenLineageConnection.KafkaBrokerConfig) unmasked.getBrokerConfig())
-            .getSaslConfig()
-            .getSaslPassword());
+        ((KafkaBrokerConfig) unmasked.getBrokerConfig()).getSaslConfig().getSaslPassword());
   }
 
   @Test

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/pipeline/openLineageConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/pipeline/openLineageConnection.json
@@ -13,151 +13,6 @@
         "OpenLineage"
       ],
       "default": "OpenLineage"
-    },
-    "kafkaBrokerConfig": {
-      "title": "Kafka",
-      "description": "Kafka broker configuration for OpenLineage events.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "brokersUrl": {
-          "title": "Kafka Brokers List",
-          "description": "Kafka bootstrap servers URL.",
-          "type": "string"
-        },
-        "topicName": {
-          "title": "Topic Name",
-          "description": "Topic from where OpenLineage events will be pulled.",
-          "type": "string"
-        },
-        "consumerGroupName": {
-          "title": "Consumer Group",
-          "description": "Kafka consumer group name.",
-          "type": "string"
-        },
-        "consumerOffsets": {
-          "title": "Initial Consumer Offsets",
-          "description": "Initial Kafka consumer offset.",
-          "default": "earliest",
-          "type": "string",
-          "enum": [
-            "earliest",
-            "latest"
-          ],
-          "javaEnums": [
-            {
-              "name": "earliest"
-            },
-            {
-              "name": "latest"
-            }
-          ]
-        },
-        "poolTimeout": {
-          "title": "Single Pool Call Timeout",
-          "description": "Max allowed wait time.",
-          "type": "number",
-          "default": 1.0
-        },
-        "sessionTimeout": {
-          "title": "Broker Inactive Session Timeout",
-          "description": "Max allowed inactivity time.",
-          "type": "integer",
-          "default": 30
-        },
-        "securityProtocol": {
-          "title": "Kafka Security Protocol",
-          "description": "Kafka security protocol config.",
-          "default": "PLAINTEXT",
-          "type": "string",
-          "enum": [
-            "PLAINTEXT",
-            "SASL_PLAINTEXT",
-            "SSL",
-            "SASL_SSL"
-          ],
-          "javaEnums": [
-            {
-              "name": "PLAINTEXT"
-            },
-            {
-              "name": "SASL_PLAINTEXT"
-            },
-            {
-              "name": "SSL"
-            },
-            {
-              "name": "SASL_SSL"
-            }
-          ]
-        },
-        "sslConfig": {
-          "title": "SSL",
-          "description": "SSL Configuration details.",
-          "$ref": "../../../../security/ssl/verifySSLConfig.json#/definitions/sslConfig"
-        },
-        "saslConfig": {
-          "title": "SASL",
-          "description": "SASL Configuration details.",
-          "$ref": "../../../../security/sasl/saslClientConfig.json"
-        }
-      },
-      "required": [
-        "brokersUrl",
-        "topicName"
-      ]
-    },
-    "kinesisBrokerConfig": {
-      "title": "Kinesis",
-      "description": "AWS Kinesis Data Streams configuration for OpenLineage events.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "streamName": {
-          "title": "Stream Name",
-          "description": "Kinesis Data Stream name.",
-          "type": "string"
-        },
-        "awsConfig": {
-          "title": "AWS Credentials Configuration",
-          "description": "AWS credentials configuration.",
-          "$ref": "../../../../security/credentials/awsCredentials.json"
-        },
-        "consumerOffsets": {
-          "title": "Initial Consumer Offsets",
-          "description": "Initial Kinesis shard iterator type.",
-          "default": "TRIM_HORIZON",
-          "type": "string",
-          "enum": [
-            "TRIM_HORIZON",
-            "LATEST"
-          ],
-          "javaEnums": [
-            {
-              "name": "TRIM_HORIZON"
-            },
-            {
-              "name": "LATEST"
-            }
-          ]
-        },
-        "poolTimeout": {
-          "title": "Poll Interval",
-          "description": "Poll interval in seconds.",
-          "type": "number",
-          "default": 1.0
-        },
-        "sessionTimeout": {
-          "title": "Session Timeout",
-          "description": "Max inactivity timeout in seconds.",
-          "type": "integer",
-          "default": 30
-        }
-      },
-      "required": [
-        "streamName",
-        "awsConfig"
-      ]
     }
   },
   "properties": {
@@ -171,10 +26,10 @@
       "description": "Event broker configuration. Choose between Kafka and Kinesis.",
       "oneOf": [
         {
-          "$ref": "#/definitions/kafkaBrokerConfig"
+          "$ref": "openlineage/kafkaBrokerConfig.json"
         },
         {
-          "$ref": "#/definitions/kinesisBrokerConfig"
+          "$ref": "openlineage/kinesisBrokerConfig.json"
         }
       ]
     },

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/pipeline/openlineage/kafkaBrokerConfig.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/pipeline/openlineage/kafkaBrokerConfig.json
@@ -1,0 +1,96 @@
+{
+  "$id": "https://open-metadata.org/schema/entity/services/connections/pipeline/openlineage/kafkaBrokerConfig.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Kafka",
+  "description": "Kafka broker configuration for OpenLineage events.",
+  "javaType": "org.openmetadata.schema.services.connections.pipeline.openlineage.KafkaBrokerConfig",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "brokersUrl": {
+      "title": "Kafka Brokers List",
+      "description": "Kafka bootstrap servers URL.",
+      "type": "string"
+    },
+    "topicName": {
+      "title": "Topic Name",
+      "description": "Topic from where OpenLineage events will be pulled.",
+      "type": "string"
+    },
+    "consumerGroupName": {
+      "title": "Consumer Group",
+      "description": "Kafka consumer group name.",
+      "type": "string"
+    },
+    "consumerOffsets": {
+      "title": "Initial Consumer Offsets",
+      "description": "Initial Kafka consumer offset.",
+      "default": "earliest",
+      "type": "string",
+      "enum": [
+        "earliest",
+        "latest"
+      ],
+      "javaEnums": [
+        {
+          "name": "earliest"
+        },
+        {
+          "name": "latest"
+        }
+      ]
+    },
+    "poolTimeout": {
+      "title": "Single Pool Call Timeout",
+      "description": "Max allowed wait time.",
+      "type": "number",
+      "default": 1.0
+    },
+    "sessionTimeout": {
+      "title": "Broker Inactive Session Timeout",
+      "description": "Max allowed inactivity time.",
+      "type": "integer",
+      "default": 30
+    },
+    "securityProtocol": {
+      "title": "Kafka Security Protocol",
+      "description": "Kafka security protocol config.",
+      "default": "PLAINTEXT",
+      "type": "string",
+      "enum": [
+        "PLAINTEXT",
+        "SASL_PLAINTEXT",
+        "SSL",
+        "SASL_SSL"
+      ],
+      "javaEnums": [
+        {
+          "name": "PLAINTEXT"
+        },
+        {
+          "name": "SASL_PLAINTEXT"
+        },
+        {
+          "name": "SSL"
+        },
+        {
+          "name": "SASL_SSL"
+        }
+      ]
+    },
+    "sslConfig": {
+      "title": "SSL",
+      "description": "SSL Configuration details.",
+      "$ref": "../../../../../security/ssl/verifySSLConfig.json#/definitions/sslConfig"
+    },
+    "saslConfig": {
+      "title": "SASL",
+      "description": "SASL Configuration details.",
+      "$ref": "../../../../../security/sasl/saslClientConfig.json"
+    }
+  },
+  "required": [
+    "brokersUrl",
+    "topicName"
+  ]
+}

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/pipeline/openlineage/kinesisBrokerConfig.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/pipeline/openlineage/kinesisBrokerConfig.json
@@ -1,0 +1,55 @@
+{
+  "$id": "https://open-metadata.org/schema/entity/services/connections/pipeline/openlineage/kinesisBrokerConfig.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Kinesis",
+  "description": "AWS Kinesis Data Streams configuration for OpenLineage events.",
+  "javaType": "org.openmetadata.schema.services.connections.pipeline.openlineage.KinesisBrokerConfig",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "streamName": {
+      "title": "Stream Name",
+      "description": "Kinesis Data Stream name.",
+      "type": "string"
+    },
+    "awsConfig": {
+      "title": "AWS Credentials Configuration",
+      "description": "AWS credentials configuration.",
+      "$ref": "../../../../../security/credentials/awsCredentials.json"
+    },
+    "consumerOffsets": {
+      "title": "Initial Consumer Offsets",
+      "description": "Initial Kinesis shard iterator type.",
+      "default": "TRIM_HORIZON",
+      "type": "string",
+      "enum": [
+        "TRIM_HORIZON",
+        "LATEST"
+      ],
+      "javaEnums": [
+        {
+          "name": "TRIM_HORIZON"
+        },
+        {
+          "name": "LATEST"
+        }
+      ]
+    },
+    "poolTimeout": {
+      "title": "Poll Interval",
+      "description": "Poll interval in seconds.",
+      "type": "number",
+      "default": 1.0
+    },
+    "sessionTimeout": {
+      "title": "Session Timeout",
+      "description": "Max inactivity timeout in seconds.",
+      "type": "integer",
+      "default": 30
+    }
+  },
+  "required": [
+    "streamName",
+    "awsConfig"
+  ]
+}

--- a/openmetadata-spec/src/main/resources/json/schema/security/sasl/saslClientConfig.json
+++ b/openmetadata-spec/src/main/resources/json/schema/security/sasl/saslClientConfig.json
@@ -21,7 +21,8 @@
     "saslPassword": {
       "title": "SASL Password",
       "description": "The SASL authentication password.",
-      "type": "string"
+      "type": "string",
+      "format": "password"
     }
   }
 }

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/openlineage/kafkaBrokerConfig.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/openlineage/kafkaBrokerConfig.ts
@@ -1,0 +1,126 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/**
+ * Kafka broker configuration for OpenLineage events.
+ */
+export interface KafkaBrokerConfig {
+    /**
+     * Kafka bootstrap servers URL.
+     */
+    brokersUrl: string;
+    /**
+     * Kafka consumer group name.
+     */
+    consumerGroupName?: string;
+    /**
+     * Initial Kafka consumer offset.
+     */
+    consumerOffsets?: InitialConsumerOffsets;
+    /**
+     * Max allowed wait time.
+     */
+    poolTimeout?: number;
+    /**
+     * SASL Configuration details.
+     */
+    saslConfig?: SASLClientConfig;
+    /**
+     * Kafka security protocol config.
+     */
+    securityProtocol?: KafkaSecurityProtocol;
+    /**
+     * Max allowed inactivity time.
+     */
+    sessionTimeout?: number;
+    /**
+     * SSL Configuration details.
+     */
+    sslConfig?: Config;
+    /**
+     * Topic from where OpenLineage events will be pulled.
+     */
+    topicName: string;
+}
+
+/**
+ * Initial Kafka consumer offset.
+ */
+export enum InitialConsumerOffsets {
+    Earliest = "earliest",
+    Latest = "latest",
+}
+
+/**
+ * SASL Configuration details.
+ *
+ * SASL client configuration.
+ */
+export interface SASLClientConfig {
+    /**
+     * SASL security mechanism
+     */
+    saslMechanism?: SaslMechanismType;
+    /**
+     * The SASL authentication password.
+     */
+    saslPassword?: string;
+    /**
+     * The SASL authentication username.
+     */
+    saslUsername?: string;
+}
+
+/**
+ * SASL security mechanism
+ *
+ * SASL Mechanism consumer config property
+ */
+export enum SaslMechanismType {
+    Gssapi = "GSSAPI",
+    Oauthbearer = "OAUTHBEARER",
+    Plain = "PLAIN",
+    ScramSHA256 = "SCRAM-SHA-256",
+    ScramSHA512 = "SCRAM-SHA-512",
+}
+
+/**
+ * Kafka security protocol config.
+ */
+export enum KafkaSecurityProtocol {
+    Plaintext = "PLAINTEXT",
+    SSL = "SSL",
+    SaslPlaintext = "SASL_PLAINTEXT",
+    SaslSSL = "SASL_SSL",
+}
+
+/**
+ * SSL Configuration details.
+ *
+ * Client SSL configuration
+ *
+ * OpenMetadata Client configured to validate SSL certificates.
+ */
+export interface Config {
+    /**
+     * The CA certificate used for SSL validation.
+     */
+    caCertificate?: string;
+    /**
+     * The SSL certificate used for client authentication.
+     */
+    sslCertificate?: string;
+    /**
+     * The private key associated with the SSL certificate.
+     */
+    sslKey?: string;
+}

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/openlineage/kinesisBrokerConfig.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/openlineage/kinesisBrokerConfig.ts
@@ -1,0 +1,99 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/**
+ * AWS Kinesis Data Streams configuration for OpenLineage events.
+ */
+export interface KinesisBrokerConfig {
+    /**
+     * AWS credentials configuration.
+     */
+    awsConfig: AWSCredentials;
+    /**
+     * Initial Kinesis shard iterator type.
+     */
+    consumerOffsets?: InitialConsumerOffsets;
+    /**
+     * Poll interval in seconds.
+     */
+    poolTimeout?: number;
+    /**
+     * Max inactivity timeout in seconds.
+     */
+    sessionTimeout?: number;
+    /**
+     * Kinesis Data Stream name.
+     */
+    streamName: string;
+}
+
+/**
+ * AWS credentials configuration.
+ *
+ * AWS credentials configs.
+ */
+export interface AWSCredentials {
+    /**
+     * The Amazon Resource Name (ARN) of the role to assume. Required Field in case of Assume
+     * Role
+     */
+    assumeRoleArn?: string;
+    /**
+     * An identifier for the assumed role session. Use the role session name to uniquely
+     * identify a session when the same role is assumed by different principals or for different
+     * reasons. Required Field in case of Assume Role
+     */
+    assumeRoleSessionName?: string;
+    /**
+     * The Amazon Resource Name (ARN) of the role to assume. Optional Field in case of Assume
+     * Role
+     */
+    assumeRoleSourceIdentity?: string;
+    /**
+     * AWS Access key ID.
+     */
+    awsAccessKeyId?: string;
+    /**
+     * AWS Region
+     */
+    awsRegion: string;
+    /**
+     * AWS Secret Access Key.
+     */
+    awsSecretAccessKey?: string;
+    /**
+     * AWS Session Token.
+     */
+    awsSessionToken?: string;
+    /**
+     * Enable AWS IAM authentication. When enabled, uses the default credential provider chain
+     * (environment variables, instance profile, etc.). Defaults to false for backward
+     * compatibility.
+     */
+    enabled?: boolean;
+    /**
+     * EndPoint URL for the AWS
+     */
+    endPointURL?: string;
+    /**
+     * The name of a profile to use with the boto session.
+     */
+    profileName?: string;
+}
+
+/**
+ * Initial Kinesis shard iterator type.
+ */
+export enum InitialConsumerOffsets {
+    Latest = "LATEST",
+    TrimHorizon = "TRIM_HORIZON",
+}


### PR DESCRIPTION
Fixes #31296

## Description

Backports the merged OpenLineage Kafka authentication fix to the `2.0` release branch.

The change materializes inline TLS certificate content to temporary files before configuring `confluent-kafka`, marks the SASL password as a secret-backed password field, converts the nested broker configuration for API masking, and cleans up temporary SSL files on both connection failure and shutdown.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport adds secret-aware OpenLineage Kafka authentication, materializes inline TLS data into temporary files, and introduces cleanup for those files. It also splits Kafka and Kinesis broker contracts into generated model types and adds Java conversion and masking support.

- Converts the shared SASL password into a secret-backed value and unwraps it for confluent-kafka.
- Materializes Kafka TLS certificate content through SSLManager and cleans it up after failures or connection shutdown.
- Adds dedicated Kafka and Kinesis schemas, generated TypeScript models, and Java broker subtype conversion.
- Extends ingestion, converter, and masking tests for the new behavior.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after addressing the non-blocking Java immutability and TypeScript formatting convention violations.

The Kafka secret, TLS lifecycle, schema split, and broker conversion paths have no established blocking defect; the accepted feedback concerns repository-required formatting and immutability conventions.

**Files Needing Attention:** openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/OpenLineageConnectionClassConverter.java and the generated OpenLineage Kafka/Kinesis TypeScript models
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/pipeline/openlineage/connection.py | Adds protocol validation, secret unwrapping, TLS materialization, and failure/shutdown cleanup for Kafka connections. |
| openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/OpenLineageConnectionClassConverter.java | Converts untyped OpenLineage broker configuration into Kafka or Kinesis models, with a minor repository-convention violation. |
| openmetadata-spec/src/main/resources/json/schema/security/sasl/saslClientConfig.json | Marks the shared SASL password as password-formatted so generated consumers treat it as secret-backed. |
| openmetadata-spec/src/main/resources/json/schema/entity/services/connections/pipeline/openLineageConnection.json | Replaces inline broker definitions with dedicated Kafka and Kinesis schema references. |
| openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/openlineage/kafkaBrokerConfig.ts | Adds the generated Kafka broker model, but its indentation does not follow required Prettier formatting. |
| openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/openlineage/kinesisBrokerConfig.ts | Adds the generated Kinesis broker model with the same formatting issue. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  S[OpenLineage connection schema] --> K[Kafka broker config]
  S --> N[Kinesis broker config]
  K --> M[Secret masking and subtype conversion]
  K --> P[Python Kafka connection]
  P --> T[SSLManager temporary certificate files]
  P --> C[confluent-kafka consumer]
  C --> X[Consumer close]
  T --> Y[Temporary-file cleanup]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): add missing generated TS types ..."](https://github.com/open-metadata/openmetadata/commit/8bea792cc018bb6a1ed0f937c234d94da1a07fcb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57019313)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))
- Knowledge Base — [Ingestion connectors](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/ingestion-connectors.md)
- Knowledge Base — [Metadata schema contracts](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/metadata-schema-contracts.md)
</details>


<!-- /greptile_comment -->