### PR TITLE
Fix 31889: Extract MLflow 3.x model signatures and paginate the regis…

### DIFF
--- a/ingestion/src/metadata/ingestion/source/mlmodel/mlflow/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/mlmodel/mlflow/metadata.py
@@ -12,37 +12,28 @@
 
 import ast  # noqa: I001
 import json
+import os
+import tempfile
 import traceback
 from collections.abc import Iterable
+from contextlib import contextmanager
+from pathlib import Path
 
+import yaml
+from mlflow.artifacts import download_artifacts
 from mlflow.entities import RunData
 from mlflow.entities.model_registry import ModelVersion, RegisteredModel
 from pydantic import ValidationError
 
 from metadata.generated.schema.api.data.createMlModel import CreateMlModelRequest
-from metadata.generated.schema.entity.data.mlmodel import (
-    FeatureType,
-    MlFeature,
-    MlHyperParameter,
-    MlStore,
-)
-from metadata.generated.schema.entity.services.connections.mlmodel.mlflowConnection import (
-    MlflowConnection,
-)
-from metadata.generated.schema.entity.services.ingestionPipelines.status import (
-    StackTraceError,
-)
-from metadata.generated.schema.metadataIngestion.workflow import (
-    Source as WorkflowSource,
-)
-from metadata.generated.schema.type.basic import (
-    EntityName,
-    FullyQualifiedEntityName,
-    Markdown,
-    SourceUrl,
-)
+from metadata.generated.schema.entity.data.mlmodel import FeatureType, MlFeature, MlHyperParameter, MlStore
+from metadata.generated.schema.entity.services.connections.mlmodel.mlflowConnection import MlflowConnection
+from metadata.generated.schema.entity.services.ingestionPipelines.status import StackTraceError
+from metadata.generated.schema.metadataIngestion.workflow import Source as WorkflowSource
+from metadata.generated.schema.type.basic import EntityName, FullyQualifiedEntityName, Markdown, SourceUrl
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import InvalidSourceException
+from metadata.ingestion.models.delete_entity import DeleteEntity
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.mlmodel.mlmodel_service import MlModelServiceSource
 from metadata.utils.filters import filter_by_mlmodel
@@ -54,6 +45,37 @@ logger = ingestion_logger()
 # Guards the version search pagination loop against a backend that keeps
 # handing back a page token, which would otherwise spin forever.
 MAX_VERSION_PAGES = 100
+# Same guard for the registry listing: a backend that keeps handing back a page token
+# would otherwise spin forever.
+MAX_MODEL_PAGES = 100
+
+# MLflow 2.x published a model's signature in this run tag. MLflow 3.x dropped it in
+# favour of LoggedModel entities, so the signature now has to be read from the MLmodel
+# metadata file that ships alongside the model artifacts.
+LOG_MODEL_HISTORY_TAG = "mlflow.log-model.history"
+MLMODEL_METADATA_FILE = "MLmodel"
+LOGGED_MODEL_URI_PREFIX = "models:/"
+SIGNATURE_STRING_TYPE = "string"
+# Status key for conditions that concern the registry as a whole rather than one model.
+REGISTRY_STATUS_KEY = "MLflow registry"
+# MLflow renders a tqdm progress bar on every artifact fetch, which lands in the
+# middle of the ingestion logs. The signature file is a few hundred bytes, so the
+# bar carries no information worth the noise.
+ARTIFACT_PROGRESS_BAR_ENV = "MLFLOW_ENABLE_ARTIFACTS_PROGRESS_BAR"
+
+
+@contextmanager
+def suppress_artifact_progress_bar():
+    """Keep MLflow's artifact progress bar out of the ingestion logs."""
+    previous = os.environ.get(ARTIFACT_PROGRESS_BAR_ENV)
+    os.environ[ARTIFACT_PROGRESS_BAR_ENV] = "false"
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(ARTIFACT_PROGRESS_BAR_ENV, None)
+        else:
+            os.environ[ARTIFACT_PROGRESS_BAR_ENV] = previous
 
 
 class MlflowSource(MlModelServiceSource):
@@ -78,7 +100,7 @@ class MlflowSource(MlModelServiceSource):
         """
         List and filters models from the registry
         """
-        for model in self.client.search_registered_models():
+        for model in self._iter_registered_models():
             if filter_by_mlmodel(self.source_config.mlModelFilterPattern, mlmodel_name=model.name):
                 self.status.filter(
                     model.name,
@@ -112,6 +134,69 @@ class MlflowSource(MlModelServiceSource):
                 continue
 
             yield model, latest_version
+
+    # What the last listing managed to see, for the deletion pass to consult. Both are
+    # recorded positively -- a listing that is truncated, abandoned mid-walk or never
+    # started leaves them at these defaults, so the unsafe cases fail closed.
+    listing_complete: bool = False
+    listed_model_count: int = 0
+
+    def _iter_registered_models(self) -> Iterable[RegisteredModel]:
+        """
+        Walk every page of the registry listing.
+
+        `search_registered_models` answers with one bounded page, so calling it once caps
+        ingestion at the page size and drops the rest without a word. Pages are streamed
+        rather than collected so ingestion starts on the first one.
+        """
+        self.listing_complete = False
+        self.listed_model_count = 0
+
+        page_token = None
+        total = 0
+        pages = 0
+
+        while pages < MAX_MODEL_PAGES:
+            page = self.client.search_registered_models(page_token=page_token)
+            total += len(page)
+            self.listed_model_count = total
+            pages += 1
+            yield from page
+
+            page_token = getattr(page, "token", None)
+            if not page_token:
+                self.listing_complete = True
+                break
+
+        if page_token:
+            reason = (
+                f"Stopped listing registered models after {MAX_MODEL_PAGES} pages with more still "
+                f"pending; only {total} model(s) were listed. Narrow the run with "
+                "`mlModelFilterPattern`."
+            )
+            logger.warning(reason)
+            self.status.warning(REGISTRY_STATUS_KEY, reason)
+
+        self._log_model_total(total, pages)
+
+    @staticmethod
+    def _log_model_total(total: int, pages: int) -> None:
+        """
+        State how many models the registry handed over, before any filtering.
+
+        Without this an empty registry is indistinguishable from a registry with nothing
+        new to ingest: both yield zero records and a 100% successful run, which reads as
+        "working" when in fact the credentials cannot see a single model.
+        """
+        logger.info(f"Listed {total} registered model(s) from the MLflow registry over {pages} page(s)")
+
+        if total == 0:
+            logger.warning(
+                "The MLflow registry returned no registered models, so there is nothing to ingest. "
+                "If models are expected, check that `registryUri` points at the registry holding them, "
+                "and that the credentials in use may list models -- a registry filters the listing by "
+                "the caller's permissions and returns an empty list rather than an error."
+            )
 
     def _get_latest_version(self, model: RegisteredModel) -> ModelVersion | None:
         """
@@ -179,6 +264,33 @@ class MlflowSource(MlModelServiceSource):
 
         return max(numbered, key=lambda pair: pair[0], default=(None, None))[1]
 
+    def mark_mlmodels_as_deleted(self) -> Iterable[Either[DeleteEntity]]:
+        """
+        Reconcile deletions only off a listing that saw the whole registry.
+
+        The base implementation deletes every model in OpenMetadata that this run did not
+        yield, which is only sound when the absence of a model means the registry no longer
+        has it. A listing that stopped early or came back empty cannot support that
+        reading, and acting on it soft-deletes healthy entities.
+        """
+        if not self.listing_complete:
+            logger.warning(
+                "Skipping deleted-model reconciliation: the registry listing did not complete, so "
+                "models it never reached would be wrongly marked as deleted."
+            )
+            return
+
+        if not self.listed_model_count:
+            logger.warning(
+                "Skipping deleted-model reconciliation: the registry listed no models at all. "
+                "Reading that as `every model was deleted` would soft-delete every model under "
+                "this service, when the likelier cause is a `registryUri` pointing at a registry "
+                "that holds none of them, or credentials that may not list models."
+            )
+            return
+
+        yield from super().mark_mlmodels_as_deleted()
+
     def _get_algorithm(self) -> str:  # pylint: disable=arguments-differ
         logger.info("Setting algorithm with default value `mlmodel` for Mlflow")
         return "mlmodel"
@@ -198,7 +310,7 @@ class MlflowSource(MlModelServiceSource):
             description=Markdown(model.description) if model.description else None,
             algorithm=self._get_algorithm(),  # Setting this to a constant
             mlHyperParameters=self._get_hyper_params(run.data),
-            mlFeatures=self._get_ml_features(run.data, latest_version.run_id, model.name),
+            mlFeatures=self._get_ml_features(run.data, latest_version.run_id, model.name, latest_version),
             mlStore=self._get_ml_store(latest_version, run),
             service=FullyQualifiedEntityName(self.context.get().mlmodel_service),
             sourceUrl=SourceUrl(source_url),
@@ -248,38 +360,153 @@ class MlflowSource(MlModelServiceSource):
         return None
 
     def _get_ml_features(  # pylint: disable=arguments-differ
-        self, data: RunData, run_id: str, model_name: str
+        self,
+        data: RunData,
+        run_id: str,
+        model_name: str,
+        version: ModelVersion | None = None,
     ) -> list[MlFeature] | None:
         """
-        The RunData object comes with stringified `tags`.
-        Let's transform those and try to extract the `signature`
-        information
+        Resolve the model's input signature into ML features.
+
+        The run tag is tried first since it needs no extra call, and the model artifacts
+        only afterwards: MLflow 3.x no longer writes the tag, so on those servers the
+        signature is only available from the MLmodel metadata file.
         """
-        if data.tags:
-            try:
-                props = json.loads(data.tags["mlflow.log-model.history"])
-                latest_props = next((prop for prop in props if prop["run_id"] == run_id), None)
-                if not latest_props:
-                    reason = f"Cannot find the run ID properties for {run_id}"
-                    logger.warning(reason)
-                    self.status.warning(model_name, reason)
-                    return None
+        columns = self._signature_columns_from_run_tags(data, run_id)
+        if columns is None and version is not None:
+            columns = self._signature_columns_from_artifacts(version, model_name)
 
-                if latest_props.get("signature") and latest_props["signature"].get("inputs"):
-                    features = ast.literal_eval(latest_props["signature"]["inputs"])
+        # A signature this cannot be built from must cost the features, not the model.
+        # Raising here would escape yield_mlmodel into the topology runner, which logs
+        # and drops the entity without recording a failure -- the model would vanish
+        # from the run with nothing to show why.
+        try:
+            return self._build_ml_features(columns)
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.debug(traceback.format_exc())
+            reason = f"Cannot build ML features for {model_name} from its signature - {exc}"
+            logger.warning(reason)
+            self.status.warning(model_name, reason)
+            return None
 
-                    return [
-                        MlFeature(
-                            name=feature["name"],
-                            dataType=FeatureType.categorical if feature["type"] == "string" else FeatureType.numerical,
-                        )
-                        for feature in features
-                    ]
+    def _signature_columns_from_run_tags(self, data: RunData, run_id: str) -> list[dict] | None:
+        """
+        Read the signature off the MLflow 2.x `mlflow.log-model.history` run tag.
 
-            except Exception as exc:  # pylint: disable=broad-except
-                logger.debug(traceback.format_exc())
-                reason = f"Cannot extract properties from RunData: {exc}"
-                logger.warning(reason)
-                self.status.warning(model_name, reason)
+        A missing tag or a tag with no entry for this run is not an error: it is the norm
+        on MLflow 3.x. Both cases return None so the caller can fall back to the artifacts.
+        """
+        history = (data.tags or {}).get(LOG_MODEL_HISTORY_TAG)
+        if not history:
+            logger.debug(f"Run {run_id} has no {LOG_MODEL_HISTORY_TAG} tag, as expected on MLflow 3.x")
+            return None
 
-        return None
+        columns = None
+        try:
+            entry = next(
+                (prop for prop in self._parse_signature_payload(history) if prop.get("run_id") == run_id), None
+            )
+            if entry is None:
+                logger.debug(f"No {LOG_MODEL_HISTORY_TAG} entry matches run {run_id}")
+            else:
+                inputs = (entry.get("signature") or {}).get("inputs")
+                columns = self._parse_signature_payload(inputs) if inputs else None
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.debug(traceback.format_exc())
+            logger.debug(f"Could not read the signature from the {LOG_MODEL_HISTORY_TAG} tag of run {run_id} - {exc}")
+
+        return columns
+
+    def _signature_columns_from_artifacts(self, version: ModelVersion, model_name: str) -> list[dict] | None:
+        """
+        Read the signature from the model's MLmodel metadata file.
+
+        `mlflow.models.get_model_info` is deliberately not used: it resolves `models:/`
+        URIs through MLflow's global tracking config, which this connector never sets, and
+        it imports pandas, which `mlflow-skinny` does not ship. Fetching the single
+        metadata file keeps the lookup on the configured client and free of both.
+        """
+        columns = None
+        try:
+            location = self._resolve_artifact_location(version)
+            if location:
+                columns = self._read_signature_columns(location)
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.debug(traceback.format_exc())
+            reason = f"Cannot read the model signature of {model_name} from its artifacts - {exc}"
+            logger.warning(reason)
+            self.status.warning(model_name, reason)
+
+        return columns
+
+    def _read_signature_columns(self, artifact_location: str) -> list[dict] | None:
+        """
+        Fetch only the MLmodel file from the artifact store and pull out the inputs.
+
+        No metadata API exposes the signature -- not the MLflow logged-model endpoint
+        nor the Unity Catalog model-version ones -- so it can only be read from the
+        model's own metadata file. Only that one file is fetched, never the weights.
+
+        `mlflow.artifacts.load_text` would be tidier but takes no `tracking_uri`, so it
+        would resolve against MLflow's global config instead of this connector's client.
+        """
+        artifact_uri = f"{artifact_location}/{MLMODEL_METADATA_FILE}"
+        logger.debug(f"Reading the model signature from {artifact_uri}")
+
+        with tempfile.TemporaryDirectory() as tmp_dir, suppress_artifact_progress_bar():
+            local_path = download_artifacts(
+                artifact_uri=artifact_uri,
+                dst_path=tmp_dir,
+                tracking_uri=self.service_connection.trackingUri,
+            )
+            metadata = yaml.safe_load(Path(local_path).read_text(encoding="utf-8")) or {}
+
+        inputs = (metadata.get("signature") or {}).get("inputs")
+
+        return self._parse_signature_payload(inputs) if inputs else None
+
+    def _resolve_artifact_location(self, version: ModelVersion) -> str | None:
+        """
+        Find where a version's artifacts live.
+
+        MLflow 3.x points `source` at a `models:/<model_id>` URI that only the registry can
+        resolve, so the LoggedModel has to be fetched to get a real location. Older
+        versions already carry a direct artifact URI.
+        """
+        source = version.source
+        if source and source.startswith(LOGGED_MODEL_URI_PREFIX):
+            model_id = source[len(LOGGED_MODEL_URI_PREFIX) :]
+            return self.client.get_logged_model(model_id).artifact_location
+
+        return source
+
+    @staticmethod
+    def _parse_signature_payload(raw: str) -> list[dict]:
+        """Signatures are JSON, but runs written by older clients hold a Python repr."""
+        try:
+            return json.loads(raw)
+        except (TypeError, ValueError):
+            return ast.literal_eval(raw)
+
+    @staticmethod
+    def _build_ml_features(columns: list[dict] | None) -> list[MlFeature] | None:
+        """
+        Map signature columns onto ML features.
+
+        Unnamed columns are skipped: tensor-based signatures have no column names and
+        cannot be represented as an MlFeature. So is anything that is not a column
+        mapping at all, so one malformed entry does not cost the whole signature.
+        """
+        features = [
+            MlFeature(
+                name=column["name"],
+                dataType=(
+                    FeatureType.categorical if column.get("type") == SIGNATURE_STRING_TYPE else FeatureType.numerical
+                ),
+            )
+            for column in columns or []
+            if isinstance(column, dict) and column.get("name")
+        ]
+
+        return features or None

--- a/ingestion/tests/unit/source/mlmodel/mlflow/test_metadata.py
+++ b/ingestion/tests/unit/source/mlmodel/mlflow/test_metadata.py
@@ -10,14 +10,23 @@
 #  limitations under the License.
 """Unit tests for the MLflow source version resolution."""
 
-from unittest.mock import MagicMock
+import json
+import logging
+from unittest.mock import MagicMock, patch
 
 import pytest
+from mlflow.entities import RunData, RunTag
 from mlflow.entities.model_registry import ModelVersion, RegisteredModel
 from mlflow.exceptions import MlflowException
 from mlflow.store.entities import PagedList
 
-from metadata.ingestion.source.mlmodel.mlflow.metadata import MAX_VERSION_PAGES, MlflowSource
+from metadata.generated.schema.entity.data.mlmodel import FeatureType
+from metadata.ingestion.source.mlmodel.mlflow.metadata import (
+    LOG_MODEL_HISTORY_TAG,
+    MAX_MODEL_PAGES,
+    MAX_VERSION_PAGES,
+    MlflowSource,
+)
 
 MODEL_NAME = "catalog.schema.wine_model"
 
@@ -189,3 +198,532 @@ def test_non_numeric_versions_are_skipped(bad_version):
     results = list(source.get_mlmodels())
 
     assert results[0][1].version == "4"
+
+
+# ---------------------------------------------------------------------------
+# Feature extraction
+#
+# MLflow 3.x stopped writing the mlflow.log-model.history run tag, so the signature
+# has to come from the model's MLmodel metadata file instead.
+# ---------------------------------------------------------------------------
+
+RUN_ID = "run-id"
+SIGNATURE_COLUMNS = [
+    {"type": "string", "name": "store_id", "required": True},
+    {"type": "long", "name": "week_of_year", "required": True},
+    {"type": "double", "name": "prior_sales", "required": True},
+]
+
+
+def make_run_data(tags: dict | None = None) -> RunData:
+    return RunData(metrics=None, params=None, tags=[RunTag(k, v) for k, v in (tags or {}).items()])
+
+
+def history_tag(run_id: str = RUN_ID, columns=SIGNATURE_COLUMNS) -> dict:
+    """The MLflow 2.x run tag: a JSON list whose `signature.inputs` is itself JSON."""
+    entry = {"run_id": run_id, "signature": {"inputs": json.dumps(columns)}}
+
+    return {LOG_MODEL_HISTORY_TAG: json.dumps([entry])}
+
+
+def make_feature_source(artifact_location: str | None = None) -> MlflowSource:
+    """An MlflowSource wired with only what the signature lookup touches."""
+    source = MlflowSource.__new__(MlflowSource)
+    source.client = MagicMock()
+    source.status = MagicMock()
+    source.service_connection = MagicMock(trackingUri="databricks")
+    source.client.get_logged_model.return_value = MagicMock(artifact_location=artifact_location)
+
+    return source
+
+
+def write_mlmodel(tmp_path, columns=SIGNATURE_COLUMNS, signature: bool = True) -> str:
+    """Write an MLmodel file the way MLflow does, and return its path."""
+    body = "flavors:\n  python_function: {}\n"
+    if signature:
+        body += f"signature:\n  inputs: '{json.dumps(columns)}'\n"
+    path = tmp_path / "MLmodel"
+    path.write_text(body, encoding="utf-8")
+
+    return str(path)
+
+
+def test_features_come_from_the_run_tag_when_present(tmp_path):
+    """MLflow 2.x path: the tag is authoritative and no artifact call is made."""
+    source = make_feature_source()
+
+    with patch("metadata.ingestion.source.mlmodel.mlflow.metadata.download_artifacts") as download:
+        features = source._get_ml_features(make_run_data(history_tag()), RUN_ID, MODEL_NAME, make_version("1"))
+
+    assert [f.name.root for f in features] == ["store_id", "week_of_year", "prior_sales"]
+    download.assert_not_called()
+
+
+def test_features_read_from_mlmodel_when_the_tag_is_absent(tmp_path):
+    """MLflow 3.x drops the tag; without the fallback this returned None."""
+    source = make_feature_source(artifact_location="dbfs:/logged_models/m-1/artifacts")
+    version = make_version("1")
+    version._source = "models:/m-1"
+
+    with patch(
+        "metadata.ingestion.source.mlmodel.mlflow.metadata.download_artifacts",
+        return_value=write_mlmodel(tmp_path),
+    ):
+        features = source._get_ml_features(make_run_data({"mlflow.user": "me"}), RUN_ID, MODEL_NAME, version)
+
+    assert [f.name.root for f in features] == ["store_id", "week_of_year", "prior_sales"]
+    assert [f.dataType for f in features] == [
+        FeatureType.categorical,
+        FeatureType.numerical,
+        FeatureType.numerical,
+    ]
+
+
+def test_a_missing_tag_alone_is_not_reported_as_a_problem(tmp_path):
+    """The tag is absent on every MLflow 3.x run -- that must not raise a warning."""
+    source = make_feature_source(artifact_location="dbfs:/logged_models/m-1/artifacts")
+    version = make_version("1")
+    version._source = "models:/m-1"
+
+    with patch(
+        "metadata.ingestion.source.mlmodel.mlflow.metadata.download_artifacts",
+        return_value=write_mlmodel(tmp_path),
+    ):
+        source._get_ml_features(make_run_data(), RUN_ID, MODEL_NAME, version)
+
+    source.status.warning.assert_not_called()
+
+
+def test_logged_model_uri_is_resolved_through_the_registry(tmp_path):
+    """`models:/<id>` is not an artifact path; the LoggedModel supplies the real one."""
+    source = make_feature_source(artifact_location="dbfs:/logged_models/m-abc/artifacts")
+    version = make_version("1")
+    version._source = "models:/m-abc"
+
+    with patch(
+        "metadata.ingestion.source.mlmodel.mlflow.metadata.download_artifacts",
+        return_value=write_mlmodel(tmp_path),
+    ) as download:
+        source._get_ml_features(make_run_data(), RUN_ID, MODEL_NAME, version)
+
+    source.client.get_logged_model.assert_called_once_with("m-abc")
+    assert download.call_args.kwargs["artifact_uri"] == "dbfs:/logged_models/m-abc/artifacts/MLmodel"
+    assert download.call_args.kwargs["tracking_uri"] == "databricks"
+
+
+def test_direct_artifact_source_needs_no_registry_lookup(tmp_path):
+    """MLflow 2.x sources already point at the artifact store."""
+    source = make_feature_source()
+    version = make_version("1")
+    version._source = "s3://bucket/models/1"
+
+    with patch(
+        "metadata.ingestion.source.mlmodel.mlflow.metadata.download_artifacts",
+        return_value=write_mlmodel(tmp_path),
+    ) as download:
+        source._get_ml_features(make_run_data(), RUN_ID, MODEL_NAME, version)
+
+    source.client.get_logged_model.assert_not_called()
+    assert download.call_args.kwargs["artifact_uri"] == "s3://bucket/models/1/MLmodel"
+
+
+def test_tag_without_an_entry_for_this_run_falls_back_to_the_artifacts(tmp_path):
+    """A tag that does not mention this run must not block the fallback."""
+    source = make_feature_source(artifact_location="dbfs:/logged_models/m-1/artifacts")
+    version = make_version("1")
+    version._source = "models:/m-1"
+
+    with patch(
+        "metadata.ingestion.source.mlmodel.mlflow.metadata.download_artifacts",
+        return_value=write_mlmodel(tmp_path),
+    ):
+        features = source._get_ml_features(
+            make_run_data(history_tag(run_id="a-different-run")), RUN_ID, MODEL_NAME, version
+        )
+
+    assert [f.name.root for f in features] == ["store_id", "week_of_year", "prior_sales"]
+
+
+def test_unnamed_columns_are_skipped(tmp_path):
+    """Tensor signatures carry no column names and cannot become MlFeatures."""
+    source = make_feature_source()
+    version = make_version("1")
+    version._source = "s3://bucket/models/1"
+    columns = [{"type": "tensor"}, {"type": "string", "name": "store_id"}]
+
+    with patch(
+        "metadata.ingestion.source.mlmodel.mlflow.metadata.download_artifacts",
+        return_value=write_mlmodel(tmp_path, columns=columns),
+    ):
+        features = source._get_ml_features(make_run_data(), RUN_ID, MODEL_NAME, version)
+
+    assert [f.name.root for f in features] == ["store_id"]
+
+
+def test_a_model_without_a_signature_yields_no_features(tmp_path):
+    source = make_feature_source()
+    version = make_version("1")
+    version._source = "s3://bucket/models/1"
+
+    with patch(
+        "metadata.ingestion.source.mlmodel.mlflow.metadata.download_artifacts",
+        return_value=write_mlmodel(tmp_path, signature=False),
+    ):
+        assert source._get_ml_features(make_run_data(), RUN_ID, MODEL_NAME, version) is None
+
+
+def test_artifact_read_failure_is_recorded_and_does_not_raise():
+    """A registry that will not hand over the MLmodel must not abort the model."""
+    source = make_feature_source()
+    version = make_version("1")
+    version._source = "s3://bucket/models/1"
+
+    with patch(
+        "metadata.ingestion.source.mlmodel.mlflow.metadata.download_artifacts",
+        side_effect=MlflowException("no access"),
+    ):
+        assert source._get_ml_features(make_run_data(), RUN_ID, MODEL_NAME, version) is None
+
+    source.status.warning.assert_called_once()
+
+
+def test_no_version_means_no_artifact_lookup():
+    """yield_mlmodel always passes a version, but the parameter stays optional."""
+    source = make_feature_source()
+
+    with patch("metadata.ingestion.source.mlmodel.mlflow.metadata.download_artifacts") as download:
+        assert source._get_ml_features(make_run_data(), RUN_ID, MODEL_NAME) is None
+
+    download.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Registry visibility
+#
+# A registry that returns nothing produces the same 0-record, 100%-success run as a
+# registry with nothing new, so the count has to be stated in the logs.
+# ---------------------------------------------------------------------------
+
+
+def named_model(name: str) -> RegisteredModel:
+    return RegisteredModel(name=name, latest_versions=[make_version("1")])
+
+
+def test_the_number_of_models_listed_is_logged(caplog):
+    source = make_source(latest_versions=[make_version("1")])
+
+    with caplog.at_level(logging.INFO):
+        list(source.get_mlmodels())
+
+    assert "Listed 1 registered model(s) from the MLflow registry over 1 page(s)" in caplog.text
+
+
+def test_an_empty_registry_is_logged_as_a_warning(caplog):
+    """The reporter's case: nothing listed, yet the run reported success."""
+    source = make_source()
+    source.client.search_registered_models.return_value = PagedList([], None)
+
+    with caplog.at_level(logging.WARNING):
+        assert list(source.get_mlmodels()) == []
+
+    assert "returned no registered models" in caplog.text
+    assert "registryUri" in caplog.text
+
+
+def test_every_page_of_the_registry_is_ingested(caplog):
+    """A single call returns one page; the models after it used to be dropped silently."""
+    source = make_source(latest_versions=[make_version("1")])
+    source.client.search_registered_models.side_effect = [
+        PagedList([named_model("a"), named_model("b")], "token-1"),
+        PagedList([named_model("c")], None),
+    ]
+
+    with caplog.at_level(logging.INFO):
+        results = list(source.get_mlmodels())
+
+    assert [model.name for model, _ in results] == ["a", "b", "c"]
+    assert "Listed 3 registered model(s) from the MLflow registry over 2 page(s)" in caplog.text
+
+
+def test_the_page_token_is_passed_back_to_the_registry():
+    source = make_source(latest_versions=[make_version("1")])
+    source.client.search_registered_models.side_effect = [
+        PagedList([named_model("a")], "token-1"),
+        PagedList([named_model("b")], None),
+    ]
+
+    list(source.get_mlmodels())
+
+    tokens = [call.kwargs.get("page_token") for call in source.client.search_registered_models.call_args_list]
+    assert tokens == [None, "token-1"]
+
+
+def test_an_empty_page_carrying_a_token_is_followed(caplog):
+    """
+    The reporter's registry: page 1 came back as ``{"next_page_token": "..."}`` with no
+    ``registered_models`` at all, which the SDK hands over as an empty page that still has
+    a token. Stopping there reported a 100% successful run over zero models.
+    """
+    source = make_source(latest_versions=[make_version("1")])
+    source.client.search_registered_models.side_effect = [
+        PagedList([], "token-1"),
+        PagedList([], "token-2"),
+        PagedList([named_model("a"), named_model("b")], None),
+    ]
+
+    with caplog.at_level(logging.INFO):
+        results = list(source.get_mlmodels())
+
+    assert [model.name for model, _ in results] == ["a", "b"]
+    assert "Listed 2 registered model(s) from the MLflow registry over 3 page(s)" in caplog.text
+    assert "returned no registered models" not in caplog.text
+
+
+def test_pagination_stops_at_the_page_budget(caplog):
+    """A backend that always returns a token must not spin forever."""
+    source = make_source(latest_versions=[make_version("1")])
+    source.client.search_registered_models.return_value = PagedList([named_model("a")], "always-more")
+
+    with caplog.at_level(logging.WARNING):
+        results = list(source.get_mlmodels())
+
+    assert len(results) == MAX_MODEL_PAGES
+    assert source.client.search_registered_models.call_count == MAX_MODEL_PAGES
+    assert f"after {MAX_MODEL_PAGES} pages" in caplog.text
+
+
+def test_a_complete_listing_is_not_flagged(caplog):
+    source = make_source(latest_versions=[make_version("1")])
+    source.client.search_registered_models.return_value = PagedList([named_model("a")], None)
+
+    with caplog.at_level(logging.WARNING):
+        list(source.get_mlmodels())
+
+    assert "pages with more still pending" not in caplog.text
+    assert "returned no registered models" not in caplog.text
+
+
+def test_a_malformed_history_tag_falls_back_to_the_artifacts(tmp_path):
+    """A tag that is not valid JSON must not sink the model."""
+    source = make_feature_source(artifact_location="dbfs:/logged_models/m-1/artifacts")
+    version = make_version("1")
+    version._source = "models:/m-1"
+
+    with patch(
+        "metadata.ingestion.source.mlmodel.mlflow.metadata.download_artifacts",
+        return_value=write_mlmodel(tmp_path),
+    ):
+        features = source._get_ml_features(
+            make_run_data({LOG_MODEL_HISTORY_TAG: "not-json-at-all"}), RUN_ID, MODEL_NAME, version
+        )
+
+    assert [f.name.root for f in features] == ["store_id", "week_of_year", "prior_sales"]
+
+
+def test_a_python_repr_signature_is_still_parsed():
+    """Older clients stored the signature as a Python repr rather than JSON."""
+    source = make_feature_source()
+    entry = {"run_id": RUN_ID, "signature": {"inputs": str(SIGNATURE_COLUMNS)}}
+
+    features = source._get_ml_features(make_run_data({LOG_MODEL_HISTORY_TAG: json.dumps([entry])}), RUN_ID, MODEL_NAME)
+
+    assert [f.name.root for f in features] == ["store_id", "week_of_year", "prior_sales"]
+
+
+# ---------------------------------------------------------------------------
+# Wiring
+# ---------------------------------------------------------------------------
+
+
+def test_models_outside_the_filter_pattern_are_reported_as_filtered():
+    source = make_source(latest_versions=[make_version("1")])
+    source.source_config = MagicMock(mlModelFilterPattern=MagicMock(includes=["^nothing-matches$"], excludes=None))
+
+    assert list(source.get_mlmodels()) == []
+    source.status.filter.assert_called_once_with(MODEL_NAME, "MlModel name pattern not allowed")
+
+
+def test_yield_mlmodel_carries_the_signature_onto_the_request(tmp_path):
+    """The end the whole fix serves: features reaching the CreateMlModelRequest."""
+    source = make_feature_source(artifact_location="dbfs:/logged_models/m-1/artifacts")
+    source.metadata = MagicMock()
+    source.mlmodel_source_state = set()
+    source.context = MagicMock()
+    source.context.get.return_value = MagicMock(mlmodel_service="mlflow_svc")
+    source.client.get_run.return_value = MagicMock(
+        data=make_run_data({"mlflow.user": "me"}),
+        info=MagicMock(artifact_uri="dbfs:/runs/1/artifacts"),
+    )
+
+    model = RegisteredModel(name=MODEL_NAME, latest_versions=None)
+    version = make_version("2")
+    version._source = "models:/m-1"
+
+    with patch(
+        "metadata.ingestion.source.mlmodel.mlflow.metadata.download_artifacts",
+        return_value=write_mlmodel(tmp_path),
+    ):
+        results = list(source.yield_mlmodel((model, version)))
+
+    request = results[0].right
+    assert [f.name.root for f in request.mlFeatures] == ["store_id", "week_of_year", "prior_sales"]
+    assert request.name.root == MODEL_NAME
+
+
+# ---------------------------------------------------------------------------
+# Review follow-ups
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(["store_id", "week_of_year"], id="list-of-strings"),
+        pytest.param([{"type": "string"}, "loose-string"], id="mixed-entries"),
+        pytest.param(42, id="not-iterable"),
+        pytest.param({"name": "store_id"}, id="mapping-not-a-list"),
+    ],
+)
+def test_a_malformed_signature_costs_the_features_not_the_model(payload):
+    """
+    Raising here would escape yield_mlmodel; the topology runner logs it and drops the
+    entity without recording a failure, so the model would vanish from the run.
+    """
+    source = make_feature_source()
+    entry = {"run_id": RUN_ID, "signature": {"inputs": json.dumps(payload)}}
+
+    features = source._get_ml_features(make_run_data({LOG_MODEL_HISTORY_TAG: json.dumps([entry])}), RUN_ID, MODEL_NAME)
+
+    assert features is None
+
+
+def test_one_bad_column_does_not_discard_the_good_ones():
+    source = make_feature_source()
+    columns = ["not-a-column", {"type": "string", "name": "store_id"}]
+    entry = {"run_id": RUN_ID, "signature": {"inputs": json.dumps(columns)}}
+
+    features = source._get_ml_features(make_run_data({LOG_MODEL_HISTORY_TAG: json.dumps([entry])}), RUN_ID, MODEL_NAME)
+
+    assert [f.name.root for f in features] == ["store_id"]
+
+
+def test_an_invalid_feature_name_is_reported_as_a_warning():
+    """A name pydantic rejects must degrade to no features, not lose the model."""
+    source = make_feature_source()
+    columns = [{"type": "string", "name": "x" * 1024}]
+    entry = {"run_id": RUN_ID, "signature": {"inputs": json.dumps(columns)}}
+
+    features = source._get_ml_features(make_run_data({LOG_MODEL_HISTORY_TAG: json.dumps([entry])}), RUN_ID, MODEL_NAME)
+
+    assert features is None
+    source.status.warning.assert_called_once()
+
+
+def wire_deletion(source: MlflowSource) -> MlflowSource:
+    """Attach what `mark_mlmodels_as_deleted` reads on top of a listing source."""
+    source.metadata = MagicMock()
+    source.context = MagicMock()
+    source.context.get.return_value = MagicMock(mlmodel_service="mlflow_svc")
+    source.mlmodel_source_state = set()
+    source.source_config.markDeletedMlModels = True
+
+    return source
+
+
+def make_deletion_source(listing_complete: bool = True, listed_model_count: int = 1) -> MlflowSource:
+    source = wire_deletion(make_source())
+    source.listing_complete = listing_complete
+    source.listed_model_count = listed_model_count
+
+    return source
+
+
+def test_a_truncated_listing_never_drives_deletions():
+    """
+    Every model past the page budget is absent from the source state, so reconciling
+    deletions off a partial listing would soft-delete perfectly good entities.
+    """
+    source = make_deletion_source(listing_complete=False)
+
+    with patch("metadata.ingestion.source.mlmodel.mlmodel_service.delete_entity_from_source") as delete:
+        assert list(source.mark_mlmodels_as_deleted()) == []
+
+    delete.assert_not_called()
+
+
+def test_a_listing_that_saw_no_models_never_drives_deletions():
+    """
+    Credentials that cannot list models, or a `registryUri` pointing elsewhere, both look
+    exactly like an empty registry. Reconciling against that empties the service.
+    """
+    source = make_deletion_source(listed_model_count=0)
+
+    with patch("metadata.ingestion.source.mlmodel.mlmodel_service.delete_entity_from_source") as delete:
+        assert list(source.mark_mlmodels_as_deleted()) == []
+
+    delete.assert_not_called()
+
+
+def test_a_complete_listing_still_reconciles_deletions():
+    source = make_deletion_source()
+
+    with patch(
+        "metadata.ingestion.source.mlmodel.mlmodel_service.delete_entity_from_source",
+        return_value=iter([]),
+    ) as delete:
+        list(source.mark_mlmodels_as_deleted())
+
+    delete.assert_called_once()
+
+
+def test_exhausting_the_page_budget_leaves_the_listing_incomplete():
+    source = make_source(latest_versions=[make_version("1")])
+    source.client.search_registered_models.return_value = PagedList([named_model("a")], "always-more")
+
+    list(source.get_mlmodels())
+
+    assert source.listing_complete is False
+    source.status.warning.assert_called_once()
+
+
+def test_a_listing_that_reaches_the_end_is_marked_complete():
+    source = make_source(latest_versions=[make_version("1")])
+    source.client.search_registered_models.return_value = PagedList([named_model("a")], None)
+
+    list(source.get_mlmodels())
+
+    assert source.listing_complete is True
+    assert source.listed_model_count == 1
+
+
+def test_abandoning_the_listing_part_way_never_drives_deletions():
+    """
+    Why completion is tracked positively rather than truncation negatively: a caller that
+    walks away mid-listing has seen just as partial a registry as a truncated run, and the
+    page budget was never reached to say so.
+    """
+    source = wire_deletion(make_source(latest_versions=[make_version("1")]))
+    source.client.search_registered_models.side_effect = [
+        PagedList([named_model("a")], "more"),
+        PagedList([named_model("b")], None),
+    ]
+
+    next(source.get_mlmodels())
+    assert source.listing_complete is False
+
+    with patch("metadata.ingestion.source.mlmodel.mlmodel_service.delete_entity_from_source") as delete:
+        assert list(source.mark_mlmodels_as_deleted()) == []
+
+    delete.assert_not_called()
+
+
+def test_a_fresh_listing_clears_a_stale_completion_flag():
+    """A reused source must not inherit the previous run's verdict."""
+    source = make_source(latest_versions=[make_version("1")])
+    source.listing_complete = True
+    source.listed_model_count = 7
+    source.client.search_registered_models.return_value = PagedList([named_model("a")], "always-more")
+
+    list(source.get_mlmodels())
+
+    assert source.listing_complete is False


### PR DESCRIPTION
cherry-picking https://github.com/open-metadata/OpenMetadata/commit/9487c7898c5a8f83f4645f4bc430714cbbbaef7e from main

----
## Summary by Gitar

- **MLflow model signatures:**
    - Extracted MLflow 3.x model signatures from `MLmodel` metadata files when run tags are absent
    - Added robust error handling and fallback parsing for signature payload formats
- **Registry pagination and reconciliation:**
    - Implemented pagination for MLflow registered models listing up to `MAX_MODEL_PAGES`
    - Prevented deletion reconciliation on incomplete or empty registry listings

<sub>This will update automatically on new commits.</sub>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds MLflow 3.x signature extraction from `MLmodel` artifacts and paginates registry/model-version discovery while attempting to make deletion reconciliation safer.
- Falls back from legacy run-tag signatures to artifact metadata.
- Traverses paginated registered-model and model-version results.
- Suppresses deletion reconciliation for truncated or empty registry listings.
- Adds unit coverage for signature formats, pagination, and deletion guards.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until deletion reconciliation is suppressed when any listed model fails to enter the live source state.

A complete registry pagination walk can contain models that are skipped because version or run-ID resolution fails; the new guard still runs reconciliation and can soft-delete those models from OpenMetadata even though they remain in MLflow.

**Files Needing Attention:** ingestion/src/metadata/ingestion/source/mlmodel/mlflow/metadata.py
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/mlmodel/mlflow/metadata.py | Adds signature fallback and pagination, but its deletion guard does not suppress reconciliation after per-model discovery failures. |
| ingestion/tests/unit/source/mlmodel/mlflow/test_metadata.py | Adds broad unit coverage, though it does not cover deletion behavior when a listed model fails version or run-ID resolution. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Paginate MLflow registry] --> B{Listing complete and nonempty?}
  B -- No --> C[Skip deletion reconciliation]
  B -- Yes --> D[Resolve each model version]
  D --> E{Version and run ID available?}
  E -- Yes --> F[Yield model and register live state]
  E -- No --> G[Record model failure]
  F --> H[Reconcile stale models]
  G --> H
  H --> I[Failed listed model may be soft-deleted]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;2.0&#39; into fix/mlflow\_featu..."](https://github.com/open-metadata/openmetadata/commit/b3153bb41532668d7efe0c241f4d537a0744fd74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57028710)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Metadata ingestion](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/metadata-ingestion.md)
- Knowledge Base — [Ingestion connectors](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/ingestion-connectors.md)

<!-- /greptile_comment -->