### PR TITLE
chore(codeowners): unown the generated UI tree

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,9 @@
 # Review from UI owners for changes around UI code
 /openmetadata-ui/src/main/resources/ui/ @chirag-madlani @karanh37 @ShaileshParmar11
 
+# Auto generated code has no ownership
+/openmetadata-ui/src/main/resources/ui/src/generated/
+
 # Review from @chireg / @karan for changes around component library
 /openmetadata-ui-core-components/src/main/resources/ui/ @chirag-madlani @karanh37
 


### PR DESCRIPTION
### Describe your changes:

Not applicable — repo config chore, no linked issue. This follows the precedent of every other CODEOWNERS change in this repo (#31290, #31097, #30385, #23616), none of which linked an issue.

Everything under `openmetadata-ui/src/main/resources/ui/src/generated/` is emitted by `make generate` — json2ts over the `openmetadata-spec` JSON Schemas, plus the antlr4 JavaScript target — so a backend-only schema change regenerates those 898 files and, under the existing UI rule, blocks on a UI review that has nothing to review. CODEOWNERS is last-match-wins and GitHub treats a pattern with no owners as not owned by anyone, which takes the path out of "require review from Code Owners"; hand-editing generated output is already forbidden by the schema-first rule, so review belongs on the schema rather than on its output. Mixed PRs are unaffected — touching real UI code alongside a regen still matches the UI rule and still needs a UI stamp.

#
### Type of change:
- [x] Improvement

#
### High-level design:

N/A — small change (one file, three added lines).

#
### Tests:

#### Use cases covered
- A backend-only schema change that regenerates `ui/src/generated/**` no longer requires a UI code-owner approval.
- A PR that touches hand-written UI code (with or without a regen alongside it) still requires a UI code-owner approval.

#### Unit tests
Not applicable — no application code changed.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI application code changed; only the CODEOWNERS mapping for the generated tree).

#### Manual testing performed
1. Ran GitHub's own CODEOWNERS validator against this branch — `gh api "repos/open-metadata/OpenMetadata/codeowners/errors?ref=pmbrull/drop-generated-ui-codeowners"` → `{"errors":[]}`. Same call against `main` also returns `{"errors":[]}`, so there is no pre-existing error masking a new one.
2. Simulated CODEOWNERS last-match-wins resolution over all 898 files returned by `git ls-files openmetadata-ui/src/main/resources/ui/src/generated` — every one resolves to no owner.
3. Control probe: `openmetadata-ui/src/main/resources/ui/src/App.tsx` still resolves to the UI rule with all three owners, confirming the new line does not over-match.

#
### UI screen recording / screenshots:

Not applicable — no user-facing UI change.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` — N/A, no linked issue; title follows the `chore(codeowners):` convention used by prior CODEOWNERS PRs.
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above — N/A, see above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed — N/A, no schema changes.
- [x] For UI changes: I attached a screen recording and/or screenshots above — N/A, no UI changes.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above — N/A, config-only change; verification evidence listed under manual testing.

<!-- Improvement -->
- [x] I have added tests around the new logic — N/A, no logic added.
- [x] For connector/ingestion changes: I updated the documentation — N/A, no connector/ingestion changes.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR exempts the generated UI source tree from the broader UI CODEOWNERS rule so schema-driven regeneration does not require UI-owner approval.

- Adds an ownerless override for `openmetadata-ui/src/main/resources/ui/src/generated/`.
- Leaves ownership of hand-written UI paths unchanged.
- The accompanying comment should explain the rationale rather than restating the override.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only a non-blocking request to make the new CODEOWNERS comment explain the rationale for the exception.

The generated-tree override is narrowly placed after the broader UI rule and no concrete ownership regression remains; only the adjacent explanatory comment fails to preserve the non-obvious schema-first rationale.

**Files Needing Attention:** .github/CODEOWNERS
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/CODEOWNERS | Adds a narrowly scoped ownerless override for generated UI files; matching behavior appears intentional, with one non-blocking comment-quality issue. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(codeowners): unown the generated U..."](https://github.com/open-metadata/openmetadata/commit/19e78f64d4d8a7cde2595c551d98bfef9f7f07fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57032034)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))

<!-- /greptile_comment -->