### PR TITLE
Fixes #31296: Backport OpenLineage Kafka SSL and password handling to 1.13

### DIFF
--- a/ingestion/src/metadata/ingestion/source/pipeline/openlineage/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/openlineage/connection.py
@@ -12,7 +12,7 @@
 """
 Source connection handler
 """
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from botocore.client import BaseClient
 from confluent_kafka import Consumer as KafkaConsumer
@@ -22,13 +22,17 @@ from metadata.clients.aws_client import AWSClient
 from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
 )
-from metadata.generated.schema.entity.services.connections.pipeline.openLineageConnection import (
-    KafkaBrokerConfig,
-    KinesisBrokerConfig,
-    OpenLineageConnection,
+from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kafkaBrokerConfig import (
+    Kafka as KafkaBrokerConfig,
+)
+from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kafkaBrokerConfig import (
+    SecurityProtocol as KafkaSecProtocol,
+)
+from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kinesisBrokerConfig import (
+    Kinesis as KinesisBrokerConfig,
 )
 from metadata.generated.schema.entity.services.connections.pipeline.openLineageConnection import (
-    SecurityProtocol as KafkaSecProtocol,
+    OpenLineageConnection,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
@@ -39,11 +43,32 @@ from metadata.ingestion.connections.test_connections import (
 )
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.constants import THREE_MIN
+from metadata.utils.ssl_manager import SSLManager
+
+
+class ManagedKafkaConsumer:
+    """Kafka consumer that owns its materialized SSL files."""
+
+    def __init__(
+        self, consumer: KafkaConsumer, ssl_manager: Optional[SSLManager] = None
+    ) -> None:
+        self._consumer = consumer
+        self._ssl_manager = ssl_manager
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._consumer, name)
+
+    def close(self) -> None:
+        try:
+            self._consumer.close()
+        finally:
+            if self._ssl_manager is not None:
+                self._ssl_manager.cleanup_temp_files()
 
 
 def get_connection(
     connection: OpenLineageConnection,
-) -> Union[KafkaConsumer, BaseClient]:
+) -> Union[ManagedKafkaConsumer, BaseClient]:
     """
     Create connection based on broker config type.
     """
@@ -58,45 +83,72 @@ def get_connection(
     raise SourceConnectionException(f"Unsupported broker config type: {type(broker)}")
 
 
-def _get_kafka_connection(broker: KafkaBrokerConfig) -> KafkaConsumer:
+def _get_kafka_connection(broker: KafkaBrokerConfig) -> ManagedKafkaConsumer:
+    security_protocol = broker.securityProtocol or KafkaSecProtocol.PLAINTEXT
+    requires_ssl = security_protocol.value in (
+        KafkaSecProtocol.SSL.value,
+        KafkaSecProtocol.SASL_SSL.value,
+    )
+    requires_sasl = security_protocol.value in (
+        KafkaSecProtocol.SASL_PLAINTEXT.value,
+        KafkaSecProtocol.SASL_SSL.value,
+    )
+    ssl_config = broker.sslConfig
+    if requires_ssl and ssl_config is None:
+        raise SourceConnectionException(
+            "SSL security protocol requires an SSL configuration with a CA certificate."
+        )
+    sasl_config = broker.saslConfig
+    if requires_sasl and sasl_config is None:
+        raise SourceConnectionException(
+            "SASL security protocol requires a SASL configuration with a username and password."
+        )
+    ssl_manager = None
     try:
         config = {
             "bootstrap.servers": broker.brokersUrl,
             "group.id": broker.consumerGroupName,
             "auto.offset.reset": broker.consumerOffsets.value,
-            "security.protocol": broker.securityProtocol.value,
+            "security.protocol": security_protocol.value,
         }
-        if broker.securityProtocol.value in (
-            KafkaSecProtocol.SSL.value,
-            KafkaSecProtocol.SASL_SSL.value,
-        ):
+        if requires_ssl and ssl_config is not None:
+            ssl_manager = SSLManager(
+                ca=ssl_config.root.caCertificate,
+                cert=ssl_config.root.sslCertificate,
+                key=ssl_config.root.sslKey,
+            )
+            ssl_locations = {
+                "ssl.ca.location": ssl_manager.ca_file_path,
+                "ssl.certificate.location": ssl_manager.cert_file_path,
+                "ssl.key.location": ssl_manager.key_file_path,
+            }
             config.update(
                 {
-                    "ssl.ca.location": broker.sslConfig.root.caCertificate,
-                    "ssl.certificate.location": broker.sslConfig.root.sslCertificate,
-                    "ssl.key.location": broker.sslConfig.root.sslKey,
+                    key: value
+                    for key, value in ssl_locations.items()
+                    if value is not None
                 }
             )
 
-        if broker.securityProtocol.value in (
-            KafkaSecProtocol.SASL_PLAINTEXT.value,
-            KafkaSecProtocol.SASL_SSL.value,
-        ):
+        if requires_sasl and sasl_config is not None:
             config.update(
                 {
-                    "sasl.mechanism": broker.saslConfig.saslMechanism.value,
-                    "sasl.username": broker.saslConfig.saslUsername,
-                    "sasl.password": broker.saslConfig.saslPassword,
+                    "sasl.mechanism": sasl_config.saslMechanism.value,
+                    "sasl.username": sasl_config.saslUsername,
                 }
             )
+            if sasl_config.saslPassword is not None:
+                config["sasl.password"] = sasl_config.saslPassword.get_secret_value()
 
         kafka_consumer = KafkaConsumer(config)
         kafka_consumer.subscribe([broker.topicName])
 
-        return kafka_consumer
+        return ManagedKafkaConsumer(kafka_consumer, ssl_manager)
     except Exception as exc:
+        if ssl_manager is not None:
+            ssl_manager.cleanup_temp_files()
         msg = f"Unknown error connecting with Kafka broker: {exc}."
-        raise SourceConnectionException(msg)
+        raise SourceConnectionException(msg) from exc
 
 
 def _get_kinesis_connection(broker: KinesisBrokerConfig):

--- a/ingestion/src/metadata/ingestion/source/pipeline/openlineage/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/openlineage/metadata.py
@@ -29,9 +29,13 @@ from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.entity.data.pipeline import Pipeline
 from metadata.generated.schema.entity.data.table import Table
 from metadata.generated.schema.entity.data.topic import Topic
+from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kafkaBrokerConfig import (
+    Kafka as KafkaBrokerConfig,
+)
+from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kinesisBrokerConfig import (
+    Kinesis as KinesisBrokerConfig,
+)
 from metadata.generated.schema.entity.services.connections.pipeline.openLineageConnection import (
-    KafkaBrokerConfig,
-    KinesisBrokerConfig,
     OpenLineageConnection,
 )
 from metadata.generated.schema.entity.services.databaseService import (

--- a/ingestion/src/metadata/ingestion/source/pipeline/openlineage/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/openlineage/metadata.py
@@ -1276,10 +1276,7 @@ class OpenlineageSource(PipelineServiceSource):
                 elif message.error():
                     logger.warning(f"Kafka consumer error: {message.error()}")
                     empty_msg_cnt += 1
-                    if (
-                        empty_msg_cnt * pool_timeout
-                        > self.service_connection.sessionTimeout
-                    ):
+                    if empty_msg_cnt * pool_timeout > broker.sessionTimeout:
                         session_active = False
                 else:
                     logger.debug(f"new message {message.value()}")

--- a/ingestion/src/metadata/ingestion/source/pipeline/openlineage/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/openlineage/metadata.py
@@ -196,6 +196,21 @@ class OpenlineageSource(PipelineServiceSource):
     _service_cache: Dict[str, str]  # noqa: UP006
     _current_pipeline_service: Optional[str] = None  # noqa: UP045
 
+    def __init__(self, config: WorkflowSource, metadata: OpenMetadata):
+        try:
+            super().__init__(config, metadata)
+        except Exception:
+            connection = getattr(self, "connection", None)
+            if connection is not None:
+                try:
+                    connection.close()
+                except Exception:
+                    logger.warning(
+                        "Failed to close the OpenLineage broker after source initialization failed",
+                        exc_info=True,
+                    )
+            raise
+
     @classmethod
     def create(
         cls, config_dict, metadata: OpenMetadata, pipeline_name: Optional[str] = None

--- a/ingestion/tests/unit/source/pipeline/openlineage/test_connection.py
+++ b/ingestion/tests/unit/source/pipeline/openlineage/test_connection.py
@@ -1,0 +1,125 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from metadata.generated.schema.entity.services.connections.messaging.saslMechanismType import (
+    SaslMechanismType,
+)
+from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kafkaBrokerConfig import (
+    Kafka as KafkaBrokerConfig,
+)
+from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kafkaBrokerConfig import (
+    SecurityProtocol,
+)
+from metadata.generated.schema.security.sasl.saslClientConfig import SaslClientConfig
+from metadata.generated.schema.security.ssl.validateSSLClientConfig import (
+    ValidateSslClientConfig,
+)
+from metadata.generated.schema.security.ssl.verifySSLConfig import SslConfig
+from metadata.ingestion.connections.test_connections import SourceConnectionException
+from metadata.ingestion.source.pipeline.openlineage.connection import (
+    ManagedKafkaConsumer,
+    _get_kafka_connection,
+)
+from metadata.utils.ssl_manager import SSLManager
+
+CONNECTION_MODULE = "metadata.ingestion.source.pipeline.openlineage.connection"
+CA_CERT = "-----BEGIN CERTIFICATE-----\nTEST CA CONTENT\n-----END CERTIFICATE-----\n"
+
+
+def _ssl_broker() -> KafkaBrokerConfig:
+    return KafkaBrokerConfig(
+        brokersUrl="broker:9092",
+        topicName="openlineage",
+        consumerGroupName="om",
+        securityProtocol=SecurityProtocol.SSL,
+        sslConfig=SslConfig(
+            root=ValidateSslClientConfig(
+                caCertificate=CA_CERT,
+                sslCertificate="CERT",
+                sslKey="KEY",
+            )
+        ),
+    )
+
+
+def test_kafka_ssl_content_is_materialized_and_removed_on_close():
+    broker = _ssl_broker()
+    with patch(f"{CONNECTION_MODULE}.KafkaConsumer") as kafka_consumer:
+        consumer = _get_kafka_connection(broker)
+
+    config = kafka_consumer.call_args.args[0]
+    ssl_paths = [Path(value) for key, value in config.items() if key.startswith("ssl.")]
+    assert all(path.is_file() for path in ssl_paths)
+    assert "TEST CA CONTENT" in Path(config["ssl.ca.location"]).read_text(
+        encoding="utf-8"
+    )
+
+    consumer.close()
+
+    kafka_consumer.return_value.close.assert_called_once_with()
+    assert all(not path.exists() for path in ssl_paths)
+
+
+def test_kafka_ssl_content_is_removed_if_consumer_creation_fails():
+    managers = []
+
+    def build_ssl_manager(*args, **kwargs):
+        manager = SSLManager(*args, **kwargs)
+        managers.append(manager)
+        return manager
+
+    with patch(f"{CONNECTION_MODULE}.SSLManager", side_effect=build_ssl_manager), patch(
+        f"{CONNECTION_MODULE}.KafkaConsumer",
+        side_effect=RuntimeError("connection failed"),
+    ), pytest.raises(SourceConnectionException):
+        _get_kafka_connection(_ssl_broker())
+
+    assert len(managers) == 1
+    assert managers[0].temp_files == []
+
+
+def test_kafka_sasl_password_is_resolved_from_secret():
+    broker = KafkaBrokerConfig(
+        brokersUrl="broker:9092",
+        topicName="openlineage",
+        securityProtocol=SecurityProtocol.SASL_PLAINTEXT,
+        saslConfig=SaslClientConfig(
+            saslMechanism=SaslMechanismType.PLAIN,
+            saslUsername="user",
+            saslPassword="super-secret",
+        ),
+    )
+    with patch(f"{CONNECTION_MODULE}.KafkaConsumer") as kafka_consumer:
+        consumer = _get_kafka_connection(broker)
+
+    config = kafka_consumer.call_args.args[0]
+    assert config["sasl.password"] == "super-secret"
+    assert config["sasl.username"] == "user"
+    assert isinstance(consumer, ManagedKafkaConsumer)
+
+
+def test_kafka_plaintext_does_not_create_security_configuration():
+    broker = KafkaBrokerConfig(
+        brokersUrl="broker:9092",
+        topicName="openlineage",
+        securityProtocol=SecurityProtocol.PLAINTEXT,
+    )
+    with patch(f"{CONNECTION_MODULE}.KafkaConsumer") as kafka_consumer:
+        _get_kafka_connection(broker)
+
+    config = kafka_consumer.call_args.args[0]
+    assert not any(key.startswith("ssl.") for key in config)
+    assert not any(key.startswith("sasl.") for key in config)

--- a/ingestion/tests/unit/topology/pipeline/test_openlineage.py
+++ b/ingestion/tests/unit/topology/pipeline/test_openlineage.py
@@ -9,6 +9,7 @@ from uuid import UUID
 
 import pytest
 from cachetools import LRUCache
+from pydantic import SecretStr
 
 from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.entity.data.pipeline import Pipeline, Task
@@ -47,6 +48,10 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 from metadata.generated.schema.type.basic import FullyQualifiedEntityName
 from metadata.generated.schema.type.entityLineage import ColumnLineage
 from metadata.generated.schema.type.entityReference import EntityReference
+from metadata.ingestion.connections.test_connections import SourceConnectionException
+from metadata.ingestion.source.pipeline.openlineage.connection import (
+    ManagedKafkaConsumer,
+)
 from metadata.ingestion.source.pipeline.openlineage.metadata import (
     KPL_AGGREGATED_MAGIC,
     RESOLUTION_CACHE_MAXSIZE,
@@ -62,6 +67,7 @@ from metadata.ingestion.source.pipeline.openlineage.models import (
 from metadata.ingestion.source.pipeline.openlineage.utils import (
     message_to_open_lineage_event,
 )
+from metadata.utils.ssl_manager import SSLManager
 
 MOCK_WORKFLOW_CONFIG = {
     "openMetadataServerConfig": {
@@ -195,6 +201,46 @@ EXPECTED_OL_EVENT = OpenLineageEvent(
     inputs=FULL_OL_KAFKA_EVENT["inputs"],
     outputs=FULL_OL_KAFKA_EVENT["outputs"],
 )
+
+
+def test_failed_source_connection_test_releases_kafka_ssl_resources():
+    class TrackingKafkaConsumer:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    kafka_consumer = TrackingKafkaConsumer()
+    ssl_manager = SSLManager(ca=SecretStr("test-ca-certificate"))
+    assert ssl_manager.ca_file_path is not None
+    ca_path = Path(ssl_manager.ca_file_path)
+    managed_consumer = ManagedKafkaConsumer(kafka_consumer, ssl_manager)
+    config = OpenMetadataWorkflowConfig.model_validate(MOCK_OL_CONFIG)
+
+    assert ca_path.exists()
+
+    try:
+        with (
+            patch(
+                "metadata.ingestion.source.pipeline.pipeline_service.get_connection",
+                return_value=managed_consumer,
+            ),
+            patch(
+                "metadata.ingestion.source.pipeline.pipeline_service.PipelineServiceSource.test_connection",
+                side_effect=SourceConnectionException("broker unavailable"),
+            ),
+            pytest.raises(SourceConnectionException),
+        ):
+            OpenlineageSource.create(
+                MOCK_OL_CONFIG["source"],
+                config.workflowConfig.openMetadataServerConfig,
+            )
+
+        assert kafka_consumer.closed
+        assert not ca_path.exists()
+    finally:
+        ssl_manager.cleanup_temp_files()
 
 
 class OpenLineageUnitTest(unittest.TestCase):

--- a/ingestion/tests/unit/topology/pipeline/test_openlineage.py
+++ b/ingestion/tests/unit/topology/pipeline/test_openlineage.py
@@ -17,6 +17,11 @@ from metadata.generated.schema.entity.services.connections.metadata.openMetadata
 )
 from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kafkaBrokerConfig import (
     ConsumerOffsets,
+)
+from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kafkaBrokerConfig import (
+    Kafka as KafkaBrokerConfig,
+)
+from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kafkaBrokerConfig import (
     SecurityProtocol,
 )
 from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kinesisBrokerConfig import (
@@ -2972,6 +2977,28 @@ class TestKinesisMultiShardPolling(unittest.TestCase):
         events = list(source._poll_kinesis(broker))
 
         assert len(events) == 2
+
+
+class TestKafkaPolling(unittest.TestCase):
+    def test_consumer_errors_use_broker_session_timeout(self):
+        message = MagicMock()
+        message.error.return_value = "broker error"
+        consumer = MagicMock()
+        consumer.poll.return_value = message
+        broker = KafkaBrokerConfig(
+            brokersUrl="broker:9092",
+            topicName="openlineage",
+            poolTimeout=1.0,
+            sessionTimeout=1,
+        )
+        source = object.__new__(OpenlineageSource)
+        source.client = consumer
+
+        events = list(source._poll_kafka(broker))
+
+        assert events == []
+        assert consumer.poll.call_count == 2
+        consumer.close.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/ingestion/tests/unit/topology/pipeline/test_openlineage.py
+++ b/ingestion/tests/unit/topology/pipeline/test_openlineage.py
@@ -15,11 +15,15 @@ from metadata.generated.schema.entity.data.pipeline import Pipeline, Task
 from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
     OpenMetadataConnection,
 )
-from metadata.generated.schema.entity.services.connections.pipeline.openLineageConnection import (
+from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kafkaBrokerConfig import (
     ConsumerOffsets,
-    ConsumerOffsets1,
-    KinesisBrokerConfig,
     SecurityProtocol,
+)
+from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kinesisBrokerConfig import (
+    ConsumerOffsets as ConsumerOffsets1,
+)
+from metadata.generated.schema.entity.services.connections.pipeline.openlineage.kinesisBrokerConfig import (
+    Kinesis as KinesisBrokerConfig,
 )
 from metadata.generated.schema.entity.services.databaseService import (
     DatabaseServiceType,

--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/ClassConverterFactory.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/ClassConverterFactory.java
@@ -57,6 +57,7 @@ import org.openmetadata.schema.services.connections.pipeline.AirflowRestApiConne
 import org.openmetadata.schema.services.connections.pipeline.MatillionConnection;
 import org.openmetadata.schema.services.connections.pipeline.MulesoftConnection;
 import org.openmetadata.schema.services.connections.pipeline.NifiConnection;
+import org.openmetadata.schema.services.connections.pipeline.OpenLineageConnection;
 import org.openmetadata.schema.services.connections.pipeline.SSISConnection;
 import org.openmetadata.schema.services.connections.pipeline.WherescapeConnection;
 import org.openmetadata.schema.services.connections.search.ElasticSearchConnection;
@@ -117,6 +118,7 @@ public final class ClassConverterFactory {
             Map.entry(Workflow.class, new WorkflowClassConverter()),
             Map.entry(CockroachConnection.class, new CockroachConnectionClassConverter()),
             Map.entry(NifiConnection.class, new NifiConnectionClassConverter()),
+            Map.entry(OpenLineageConnection.class, new OpenLineageConnectionClassConverter()),
             Map.entry(MatillionConnection.class, new MatillionConnectionClassConverter()),
             Map.entry(VertexAIConnection.class, new VertexAIConnectionClassConverter()),
             Map.entry(RangerConnection.class, new RangerConnectionClassConverter()),

--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/OpenLineageConnectionClassConverter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/OpenLineageConnectionClassConverter.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.secrets.converter;
+
+import java.util.List;
+import org.openmetadata.schema.services.connections.pipeline.OpenLineageConnection;
+import org.openmetadata.schema.services.connections.pipeline.openlineage.KafkaBrokerConfig;
+import org.openmetadata.schema.services.connections.pipeline.openlineage.KinesisBrokerConfig;
+import org.openmetadata.schema.utils.JsonUtils;
+
+/** Converter class to get an `OpenLineageConnection` object. */
+public class OpenLineageConnectionClassConverter extends ClassConverter {
+
+  public OpenLineageConnectionClassConverter() {
+    super(OpenLineageConnection.class);
+  }
+
+  @Override
+  public Object convert(Object object) {
+    OpenLineageConnection connection =
+        (OpenLineageConnection) JsonUtils.convertValue(object, this.clazz);
+
+    tryToConvertOrFail(
+            connection.getBrokerConfig(),
+            List.of(KafkaBrokerConfig.class, KinesisBrokerConfig.class))
+        .ifPresent(connection::setBrokerConfig);
+
+    return connection;
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/secrets/converter/ClassConverterFactoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/secrets/converter/ClassConverterFactoryTest.java
@@ -24,6 +24,7 @@ import org.openmetadata.schema.services.connections.database.TrinoConnection;
 import org.openmetadata.schema.services.connections.database.datalake.GCSConfig;
 import org.openmetadata.schema.services.connections.pipeline.AirflowConnection;
 import org.openmetadata.schema.services.connections.pipeline.MatillionConnection;
+import org.openmetadata.schema.services.connections.pipeline.OpenLineageConnection;
 import org.openmetadata.schema.services.connections.search.ElasticSearchConnection;
 import org.openmetadata.schema.services.connections.storage.GCSConnection;
 
@@ -52,6 +53,7 @@ public class ClassConverterFactoryTest {
         Workflow.class,
         SalesforceConnection.class,
         MatillionConnection.class,
+        OpenLineageConnection.class,
       })
   void testClassConverterIsSet(Class<?> clazz) {
     assertFalse(

--- a/openmetadata-service/src/test/java/org/openmetadata/service/secrets/converter/OpenLineageConnectionClassConverterTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/secrets/converter/OpenLineageConnectionClassConverterTest.java
@@ -1,0 +1,37 @@
+package org.openmetadata.service.secrets.converter;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.security.sasl.SASLClientConfig;
+import org.openmetadata.schema.services.connections.messaging.SaslMechanismType;
+import org.openmetadata.schema.services.connections.pipeline.OpenLineageConnection;
+import org.openmetadata.schema.services.connections.pipeline.openlineage.KafkaBrokerConfig;
+import org.openmetadata.schema.utils.JsonUtils;
+
+class OpenLineageConnectionClassConverterTest {
+
+  @Test
+  void testConvertsKafkaBrokerConfigWithSaslPassword() {
+    KafkaBrokerConfig brokerConfig =
+        new KafkaBrokerConfig()
+            .withBrokersUrl("broker:9092")
+            .withTopicName("openlineage")
+            .withSaslConfig(
+                new SASLClientConfig()
+                    .withSaslMechanism(SaslMechanismType.PLAIN)
+                    .withSaslUsername("user")
+                    .withSaslPassword("secret"));
+    OpenLineageConnection input = new OpenLineageConnection().withBrokerConfig(brokerConfig);
+    Object rawInput = JsonUtils.readValue(JsonUtils.pojoToJson(input), Object.class);
+
+    OpenLineageConnection result =
+        (OpenLineageConnection)
+            ClassConverterFactory.getConverter(OpenLineageConnection.class).convert(rawInput);
+
+    assertNotNull(result);
+    assertInstanceOf(KafkaBrokerConfig.class, result.getBrokerConfig());
+    assertNotNull(((KafkaBrokerConfig) result.getBrokerConfig()).getSaslConfig());
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/secrets/converter/OpenLineageConnectionClassConverterTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/secrets/converter/OpenLineageConnectionClassConverterTest.java
@@ -2,12 +2,15 @@ package org.openmetadata.service.secrets.converter;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.security.credentials.AWSCredentials;
 import org.openmetadata.schema.security.sasl.SASLClientConfig;
 import org.openmetadata.schema.services.connections.messaging.SaslMechanismType;
 import org.openmetadata.schema.services.connections.pipeline.OpenLineageConnection;
 import org.openmetadata.schema.services.connections.pipeline.openlineage.KafkaBrokerConfig;
+import org.openmetadata.schema.services.connections.pipeline.openlineage.KinesisBrokerConfig;
 import org.openmetadata.schema.utils.JsonUtils;
 
 class OpenLineageConnectionClassConverterTest {
@@ -33,5 +36,35 @@ class OpenLineageConnectionClassConverterTest {
     assertNotNull(result);
     assertInstanceOf(KafkaBrokerConfig.class, result.getBrokerConfig());
     assertNotNull(((KafkaBrokerConfig) result.getBrokerConfig()).getSaslConfig());
+  }
+
+  @Test
+  void testConvertsKinesisBrokerConfig() {
+    KinesisBrokerConfig brokerConfig =
+        new KinesisBrokerConfig()
+            .withStreamName("openlineage-stream")
+            .withAwsConfig(new AWSCredentials().withAwsRegion("us-east-1"));
+    OpenLineageConnection input = new OpenLineageConnection().withBrokerConfig(brokerConfig);
+    Object rawInput = JsonUtils.readValue(JsonUtils.pojoToJson(input), Object.class);
+
+    OpenLineageConnection result =
+        (OpenLineageConnection)
+            ClassConverterFactory.getConverter(OpenLineageConnection.class).convert(rawInput);
+
+    assertNotNull(result);
+    assertInstanceOf(KinesisBrokerConfig.class, result.getBrokerConfig());
+  }
+
+  @Test
+  void testNullBrokerConfigDoesNotThrow() {
+    OpenLineageConnection input = new OpenLineageConnection();
+    Object rawInput = JsonUtils.readValue(JsonUtils.pojoToJson(input), Object.class);
+
+    OpenLineageConnection result =
+        (OpenLineageConnection)
+            ClassConverterFactory.getConverter(OpenLineageConnection.class).convert(rawInput);
+
+    assertNotNull(result);
+    assertNull(result.getBrokerConfig());
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/secrets/masker/TestEntityMasker.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/secrets/masker/TestEntityMasker.java
@@ -21,14 +21,18 @@ import org.openmetadata.schema.security.SecurityConfiguration;
 import org.openmetadata.schema.security.client.OpenMetadataJWTClientConfig;
 import org.openmetadata.schema.security.credentials.GCPCredentials;
 import org.openmetadata.schema.security.credentials.GCPValues;
+import org.openmetadata.schema.security.sasl.SASLClientConfig;
 import org.openmetadata.schema.services.connections.dashboard.SupersetConnection;
 import org.openmetadata.schema.services.connections.database.BigQueryConnection;
 import org.openmetadata.schema.services.connections.database.DatalakeConnection;
 import org.openmetadata.schema.services.connections.database.MysqlConnection;
 import org.openmetadata.schema.services.connections.database.common.basicAuth;
 import org.openmetadata.schema.services.connections.database.datalake.GCSConfig;
+import org.openmetadata.schema.services.connections.messaging.SaslMechanismType;
 import org.openmetadata.schema.services.connections.metadata.OpenMetadataConnection;
 import org.openmetadata.schema.services.connections.pipeline.AirflowConnection;
+import org.openmetadata.schema.services.connections.pipeline.OpenLineageConnection;
+import org.openmetadata.schema.services.connections.pipeline.openlineage.KafkaBrokerConfig;
 import org.openmetadata.schema.utils.JsonUtils;
 
 abstract class TestEntityMasker {
@@ -169,6 +173,39 @@ abstract class TestEntityMasker {
         JsonUtils.convertValue(
                 ((MysqlConnection) unmasked.getConnection()).getAuthType(), basicAuth.class)
             .getPassword());
+  }
+
+  @Test
+  void testOpenLineageConnectionMasker() {
+    KafkaBrokerConfig brokerConfig =
+        new KafkaBrokerConfig()
+            .withBrokersUrl("broker:9092")
+            .withTopicName("openlineage")
+            .withSecurityProtocol(KafkaBrokerConfig.SecurityProtocol.SASL_SSL)
+            .withSaslConfig(
+                new SASLClientConfig()
+                    .withSaslMechanism(SaslMechanismType.PLAIN)
+                    .withSaslUsername("user")
+                    .withSaslPassword(PASSWORD));
+    OpenLineageConnection connection = new OpenLineageConnection().withBrokerConfig(brokerConfig);
+
+    OpenLineageConnection masked =
+        (OpenLineageConnection)
+            EntityMaskerFactory.createEntityMasker()
+                .maskServiceConnectionConfig(connection, "OpenLineage", ServiceType.PIPELINE);
+    assertNotNull(masked);
+    assertEquals(
+        getMaskedPassword(),
+        ((KafkaBrokerConfig) masked.getBrokerConfig()).getSaslConfig().getSaslPassword());
+
+    OpenLineageConnection unmasked =
+        (OpenLineageConnection)
+            EntityMaskerFactory.createEntityMasker()
+                .unmaskServiceConnectionConfig(
+                    masked, connection, "OpenLineage", ServiceType.PIPELINE);
+    assertEquals(
+        PASSWORD,
+        ((KafkaBrokerConfig) unmasked.getBrokerConfig()).getSaslConfig().getSaslPassword());
   }
 
   @Test

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/pipeline/openLineageConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/pipeline/openLineageConnection.json
@@ -13,151 +13,6 @@
         "OpenLineage"
       ],
       "default": "OpenLineage"
-    },
-    "kafkaBrokerConfig": {
-      "title": "Kafka",
-      "description": "Kafka broker configuration for OpenLineage events.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "brokersUrl": {
-          "title": "Kafka Brokers List",
-          "description": "Kafka bootstrap servers URL.",
-          "type": "string"
-        },
-        "topicName": {
-          "title": "Topic Name",
-          "description": "Topic from where OpenLineage events will be pulled.",
-          "type": "string"
-        },
-        "consumerGroupName": {
-          "title": "Consumer Group",
-          "description": "Kafka consumer group name.",
-          "type": "string"
-        },
-        "consumerOffsets": {
-          "title": "Initial Consumer Offsets",
-          "description": "Initial Kafka consumer offset.",
-          "default": "earliest",
-          "type": "string",
-          "enum": [
-            "earliest",
-            "latest"
-          ],
-          "javaEnums": [
-            {
-              "name": "earliest"
-            },
-            {
-              "name": "latest"
-            }
-          ]
-        },
-        "poolTimeout": {
-          "title": "Single Pool Call Timeout",
-          "description": "Max allowed wait time.",
-          "type": "number",
-          "default": 1.0
-        },
-        "sessionTimeout": {
-          "title": "Broker Inactive Session Timeout",
-          "description": "Max allowed inactivity time.",
-          "type": "integer",
-          "default": 30
-        },
-        "securityProtocol": {
-          "title": "Kafka Security Protocol",
-          "description": "Kafka security protocol config.",
-          "default": "PLAINTEXT",
-          "type": "string",
-          "enum": [
-            "PLAINTEXT",
-            "SASL_PLAINTEXT",
-            "SSL",
-            "SASL_SSL"
-          ],
-          "javaEnums": [
-            {
-              "name": "PLAINTEXT"
-            },
-            {
-              "name": "SASL_PLAINTEXT"
-            },
-            {
-              "name": "SSL"
-            },
-            {
-              "name": "SASL_SSL"
-            }
-          ]
-        },
-        "sslConfig": {
-          "title": "SSL",
-          "description": "SSL Configuration details.",
-          "$ref": "../../../../security/ssl/verifySSLConfig.json#/definitions/sslConfig"
-        },
-        "saslConfig": {
-          "title": "SASL",
-          "description": "SASL Configuration details.",
-          "$ref": "../../../../security/sasl/saslClientConfig.json"
-        }
-      },
-      "required": [
-        "brokersUrl",
-        "topicName"
-      ]
-    },
-    "kinesisBrokerConfig": {
-      "title": "Kinesis",
-      "description": "AWS Kinesis Data Streams configuration for OpenLineage events.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "streamName": {
-          "title": "Stream Name",
-          "description": "Kinesis Data Stream name.",
-          "type": "string"
-        },
-        "awsConfig": {
-          "title": "AWS Credentials Configuration",
-          "description": "AWS credentials configuration.",
-          "$ref": "../../../../security/credentials/awsCredentials.json"
-        },
-        "consumerOffsets": {
-          "title": "Initial Consumer Offsets",
-          "description": "Initial Kinesis shard iterator type.",
-          "default": "TRIM_HORIZON",
-          "type": "string",
-          "enum": [
-            "TRIM_HORIZON",
-            "LATEST"
-          ],
-          "javaEnums": [
-            {
-              "name": "TRIM_HORIZON"
-            },
-            {
-              "name": "LATEST"
-            }
-          ]
-        },
-        "poolTimeout": {
-          "title": "Poll Interval",
-          "description": "Poll interval in seconds.",
-          "type": "number",
-          "default": 1.0
-        },
-        "sessionTimeout": {
-          "title": "Session Timeout",
-          "description": "Max inactivity timeout in seconds.",
-          "type": "integer",
-          "default": 30
-        }
-      },
-      "required": [
-        "streamName",
-        "awsConfig"
-      ]
     }
   },
   "properties": {
@@ -171,10 +26,10 @@
       "description": "Event broker configuration. Choose between Kafka and Kinesis.",
       "oneOf": [
         {
-          "$ref": "#/definitions/kafkaBrokerConfig"
+          "$ref": "openlineage/kafkaBrokerConfig.json"
         },
         {
-          "$ref": "#/definitions/kinesisBrokerConfig"
+          "$ref": "openlineage/kinesisBrokerConfig.json"
         }
       ]
     },

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/pipeline/openlineage/kafkaBrokerConfig.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/pipeline/openlineage/kafkaBrokerConfig.json
@@ -1,0 +1,96 @@
+{
+  "$id": "https://open-metadata.org/schema/entity/services/connections/pipeline/openlineage/kafkaBrokerConfig.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Kafka",
+  "description": "Kafka broker configuration for OpenLineage events.",
+  "javaType": "org.openmetadata.schema.services.connections.pipeline.openlineage.KafkaBrokerConfig",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "brokersUrl": {
+      "title": "Kafka Brokers List",
+      "description": "Kafka bootstrap servers URL.",
+      "type": "string"
+    },
+    "topicName": {
+      "title": "Topic Name",
+      "description": "Topic from where OpenLineage events will be pulled.",
+      "type": "string"
+    },
+    "consumerGroupName": {
+      "title": "Consumer Group",
+      "description": "Kafka consumer group name.",
+      "type": "string"
+    },
+    "consumerOffsets": {
+      "title": "Initial Consumer Offsets",
+      "description": "Initial Kafka consumer offset.",
+      "default": "earliest",
+      "type": "string",
+      "enum": [
+        "earliest",
+        "latest"
+      ],
+      "javaEnums": [
+        {
+          "name": "earliest"
+        },
+        {
+          "name": "latest"
+        }
+      ]
+    },
+    "poolTimeout": {
+      "title": "Single Pool Call Timeout",
+      "description": "Max allowed wait time.",
+      "type": "number",
+      "default": 1.0
+    },
+    "sessionTimeout": {
+      "title": "Broker Inactive Session Timeout",
+      "description": "Max allowed inactivity time.",
+      "type": "integer",
+      "default": 30
+    },
+    "securityProtocol": {
+      "title": "Kafka Security Protocol",
+      "description": "Kafka security protocol config.",
+      "default": "PLAINTEXT",
+      "type": "string",
+      "enum": [
+        "PLAINTEXT",
+        "SASL_PLAINTEXT",
+        "SSL",
+        "SASL_SSL"
+      ],
+      "javaEnums": [
+        {
+          "name": "PLAINTEXT"
+        },
+        {
+          "name": "SASL_PLAINTEXT"
+        },
+        {
+          "name": "SSL"
+        },
+        {
+          "name": "SASL_SSL"
+        }
+      ]
+    },
+    "sslConfig": {
+      "title": "SSL",
+      "description": "SSL Configuration details.",
+      "$ref": "../../../../../security/ssl/verifySSLConfig.json#/definitions/sslConfig"
+    },
+    "saslConfig": {
+      "title": "SASL",
+      "description": "SASL Configuration details.",
+      "$ref": "../../../../../security/sasl/saslClientConfig.json"
+    }
+  },
+  "required": [
+    "brokersUrl",
+    "topicName"
+  ]
+}

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/pipeline/openlineage/kinesisBrokerConfig.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/pipeline/openlineage/kinesisBrokerConfig.json
@@ -1,0 +1,55 @@
+{
+  "$id": "https://open-metadata.org/schema/entity/services/connections/pipeline/openlineage/kinesisBrokerConfig.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Kinesis",
+  "description": "AWS Kinesis Data Streams configuration for OpenLineage events.",
+  "javaType": "org.openmetadata.schema.services.connections.pipeline.openlineage.KinesisBrokerConfig",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "streamName": {
+      "title": "Stream Name",
+      "description": "Kinesis Data Stream name.",
+      "type": "string"
+    },
+    "awsConfig": {
+      "title": "AWS Credentials Configuration",
+      "description": "AWS credentials configuration.",
+      "$ref": "../../../../../security/credentials/awsCredentials.json"
+    },
+    "consumerOffsets": {
+      "title": "Initial Consumer Offsets",
+      "description": "Initial Kinesis shard iterator type.",
+      "default": "TRIM_HORIZON",
+      "type": "string",
+      "enum": [
+        "TRIM_HORIZON",
+        "LATEST"
+      ],
+      "javaEnums": [
+        {
+          "name": "TRIM_HORIZON"
+        },
+        {
+          "name": "LATEST"
+        }
+      ]
+    },
+    "poolTimeout": {
+      "title": "Poll Interval",
+      "description": "Poll interval in seconds.",
+      "type": "number",
+      "default": 1.0
+    },
+    "sessionTimeout": {
+      "title": "Session Timeout",
+      "description": "Max inactivity timeout in seconds.",
+      "type": "integer",
+      "default": 30
+    }
+  },
+  "required": [
+    "streamName",
+    "awsConfig"
+  ]
+}

--- a/openmetadata-spec/src/main/resources/json/schema/security/sasl/saslClientConfig.json
+++ b/openmetadata-spec/src/main/resources/json/schema/security/sasl/saslClientConfig.json
@@ -21,7 +21,8 @@
     "saslPassword": {
       "title": "SASL Password",
       "description": "The SASL authentication password.",
-      "type": "string"
+      "type": "string",
+      "format": "password"
     }
   }
 }

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/openlineage/kafkaBrokerConfig.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/openlineage/kafkaBrokerConfig.ts
@@ -1,0 +1,126 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/**
+ * Kafka broker configuration for OpenLineage events.
+ */
+export interface KafkaBrokerConfig {
+    /**
+     * Kafka bootstrap servers URL.
+     */
+    brokersUrl: string;
+    /**
+     * Kafka consumer group name.
+     */
+    consumerGroupName?: string;
+    /**
+     * Initial Kafka consumer offset.
+     */
+    consumerOffsets?: InitialConsumerOffsets;
+    /**
+     * Max allowed wait time.
+     */
+    poolTimeout?: number;
+    /**
+     * SASL Configuration details.
+     */
+    saslConfig?: SASLClientConfig;
+    /**
+     * Kafka security protocol config.
+     */
+    securityProtocol?: KafkaSecurityProtocol;
+    /**
+     * Max allowed inactivity time.
+     */
+    sessionTimeout?: number;
+    /**
+     * SSL Configuration details.
+     */
+    sslConfig?: Config;
+    /**
+     * Topic from where OpenLineage events will be pulled.
+     */
+    topicName: string;
+}
+
+/**
+ * Initial Kafka consumer offset.
+ */
+export enum InitialConsumerOffsets {
+    Earliest = "earliest",
+    Latest = "latest",
+}
+
+/**
+ * SASL Configuration details.
+ *
+ * SASL client configuration.
+ */
+export interface SASLClientConfig {
+    /**
+     * SASL security mechanism
+     */
+    saslMechanism?: SaslMechanismType;
+    /**
+     * The SASL authentication password.
+     */
+    saslPassword?: string;
+    /**
+     * The SASL authentication username.
+     */
+    saslUsername?: string;
+}
+
+/**
+ * SASL security mechanism
+ *
+ * SASL Mechanism consumer config property
+ */
+export enum SaslMechanismType {
+    Gssapi = "GSSAPI",
+    Oauthbearer = "OAUTHBEARER",
+    Plain = "PLAIN",
+    ScramSHA256 = "SCRAM-SHA-256",
+    ScramSHA512 = "SCRAM-SHA-512",
+}
+
+/**
+ * Kafka security protocol config.
+ */
+export enum KafkaSecurityProtocol {
+    Plaintext = "PLAINTEXT",
+    SSL = "SSL",
+    SaslPlaintext = "SASL_PLAINTEXT",
+    SaslSSL = "SASL_SSL",
+}
+
+/**
+ * SSL Configuration details.
+ *
+ * Client SSL configuration
+ *
+ * OpenMetadata Client configured to validate SSL certificates.
+ */
+export interface Config {
+    /**
+     * The CA certificate used for SSL validation.
+     */
+    caCertificate?: string;
+    /**
+     * The SSL certificate used for client authentication.
+     */
+    sslCertificate?: string;
+    /**
+     * The private key associated with the SSL certificate.
+     */
+    sslKey?: string;
+}

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/openlineage/kinesisBrokerConfig.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/openlineage/kinesisBrokerConfig.ts
@@ -1,0 +1,99 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/**
+ * AWS Kinesis Data Streams configuration for OpenLineage events.
+ */
+export interface KinesisBrokerConfig {
+    /**
+     * AWS credentials configuration.
+     */
+    awsConfig: AWSCredentials;
+    /**
+     * Initial Kinesis shard iterator type.
+     */
+    consumerOffsets?: InitialConsumerOffsets;
+    /**
+     * Poll interval in seconds.
+     */
+    poolTimeout?: number;
+    /**
+     * Max inactivity timeout in seconds.
+     */
+    sessionTimeout?: number;
+    /**
+     * Kinesis Data Stream name.
+     */
+    streamName: string;
+}
+
+/**
+ * AWS credentials configuration.
+ *
+ * AWS credentials configs.
+ */
+export interface AWSCredentials {
+    /**
+     * The Amazon Resource Name (ARN) of the role to assume. Required Field in case of Assume
+     * Role
+     */
+    assumeRoleArn?: string;
+    /**
+     * An identifier for the assumed role session. Use the role session name to uniquely
+     * identify a session when the same role is assumed by different principals or for different
+     * reasons. Required Field in case of Assume Role
+     */
+    assumeRoleSessionName?: string;
+    /**
+     * The Amazon Resource Name (ARN) of the role to assume. Optional Field in case of Assume
+     * Role
+     */
+    assumeRoleSourceIdentity?: string;
+    /**
+     * AWS Access key ID.
+     */
+    awsAccessKeyId?: string;
+    /**
+     * AWS Region
+     */
+    awsRegion: string;
+    /**
+     * AWS Secret Access Key.
+     */
+    awsSecretAccessKey?: string;
+    /**
+     * AWS Session Token.
+     */
+    awsSessionToken?: string;
+    /**
+     * Enable AWS IAM authentication. When enabled, uses the default credential provider chain
+     * (environment variables, instance profile, etc.). Defaults to false for backward
+     * compatibility.
+     */
+    enabled?: boolean;
+    /**
+     * EndPoint URL for the AWS
+     */
+    endPointURL?: string;
+    /**
+     * The name of a profile to use with the boto session.
+     */
+    profileName?: string;
+}
+
+/**
+ * Initial Kinesis shard iterator type.
+ */
+export enum InitialConsumerOffsets {
+    Latest = "LATEST",
+    TrimHorizon = "TRIM_HORIZON",
+}


### PR DESCRIPTION
Fixes #31296

## Description

Backports the OpenLineage Kafka SSL and SASL password handling fix to the `1.13` release branch.

The schema changes name the existing Kafka and Kinesis broker models so the API can convert and mask the nested SASL password. The connector materializes inline TLS certificate content to temporary files before configuring `confluent-kafka`, resolves the password through the secret type, and removes temporary files on both construction failure and consumer shutdown.

The 1.13 ingestion lifecycle predates `BaseConnection`, so this version uses a connector-local managed consumer instead of backporting the newer connection framework.

No database migration is required.






<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR backports secure OpenLineage Kafka connection handling to the 1.13 branch.
- Moves Kafka and Kinesis broker definitions into named schemas so generated models and secret conversion can handle nested configuration.
- Resolves SASL passwords through the generated secret type and materializes inline TLS values into temporary files.
- Introduces a managed Kafka consumer that removes TLS files during shutdown and source-construction failure.
- Registers server-side OpenLineage conversion and adds masking, conversion, connection, and polling coverage.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/pipeline/openlineage/connection.py | Adds SASL secret resolution, inline TLS materialization, and managed cleanup around the Kafka consumer. |
| ingestion/src/metadata/ingestion/source/pipeline/openlineage/metadata.py | Closes an initialized broker connection when source construction fails and uses the broker-specific Kafka session timeout. |
| openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/OpenLineageConnectionClassConverter.java | Converts nested OpenLineage Kafka and Kinesis broker configurations into their generated concrete types. |
| openmetadata-spec/src/main/resources/json/schema/entity/services/connections/pipeline/openLineageConnection.json | Replaces inline broker definitions with named schema references used consistently across generated consumers. |
| openmetadata-spec/src/main/resources/json/schema/security/sasl/saslClientConfig.json | Marks the SASL password with the password format so secret masking and conversion recognize it. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Source as OpenLineage source
  participant Manager as SSL manager
  participant Kafka as Kafka consumer
  Source->>Manager: Materialize inline TLS values
  Manager-->>Source: Temporary file paths
  Source->>Kafka: Construct and subscribe
  alt Construction or connection test fails
    Source->>Kafka: Close consumer when created
    Source->>Manager: Remove temporary files
  else Source runs
    Source->>Kafka: Poll OpenLineage events
    Source->>Kafka: Close on shutdown
    Source->>Manager: Remove temporary files
  end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(openlineage): clean up failed Kafka ..."](https://github.com/open-metadata/openmetadata/commit/efdbcfc0c2ec388e9517b4fe750cf853361d4d39) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57049113)</sub>

**Context used:**

- Knowledge Base — [Ingestion connectors](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/ingestion-connectors.md)
- Knowledge Base — [Metadata schema contracts](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/metadata-schema-contracts.md)

<!-- /greptile_comment -->