### PR TITLE
fix(ui): apply icon-image classes to the <img> instead of its wrapper span

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsV1/TagsV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsV1/TagsV1.component.tsx
@@ -147,10 +147,10 @@ const TagsV1 = ({
 
     return (
       <Icon
+        className='tw:mr-4 tw:shrink-0'
         fallback={startIcon}
         iconValue={tag.style?.iconURL}
         size={12}
-        wrapperStyle={{ marginRight: 4, flexShrink: 0 }}
       />
     );
   }, [hideIcon, tag.style?.iconURL, startIcon]);

--- a/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsV1/TagsV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsV1/TagsV1.component.tsx
@@ -147,7 +147,7 @@ const TagsV1 = ({
 
     return (
       <Icon
-        className='tw:mr-4 tw:shrink-0'
+        className='tw:mr-1 tw:shrink-0'
         fallback={startIcon}
         iconValue={tag.style?.iconURL}
         size={12}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsV1/TagsV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsV1/TagsV1.component.tsx
@@ -147,7 +147,7 @@ const TagsV1 = ({
 
     return (
       <Icon
-        className='tw:mr-1 tw:shrink-0'
+        className="tw:mr-1 tw:shrink-0"
         fallback={startIcon}
         iconValue={tag.style?.iconURL}
         size={12}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CertificationTag/CertificationTag.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CertificationTag/CertificationTag.test.tsx
@@ -112,7 +112,6 @@ describe('CertificationTag', () => {
       expect.objectContaining({
         iconValue: 'https://example.com/gold.png',
         size: 14,
-        className: 'certification-img',
         alt: 'certification: Gold Medal',
       }),
       expect.anything()

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CertificationTag/CertificationTag.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CertificationTag/CertificationTag.tsx
@@ -37,11 +37,11 @@ const CertificationTag = ({
     return (
       <Icon
         alt={`certification: ${name}`}
-        className="certification-img"
         fallback={
           <CertificationIcon height={defaultIconSize} width={defaultIconSize} />
         }
         iconValue={iconURL}
+        imageClassName='tw:h-3.5 tw:w-3.5'
         size={defaultIconSize}
       />
     );

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CertificationTag/CertificationTag.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CertificationTag/CertificationTag.tsx
@@ -41,7 +41,7 @@ const CertificationTag = ({
           <CertificationIcon height={defaultIconSize} width={defaultIconSize} />
         }
         iconValue={iconURL}
-        imageClassName='tw:h-3.5 tw:w-3.5'
+        imageClassName="tw:h-3.5 tw:w-3.5"
         size={defaultIconSize}
       />
     );

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Icon/Icon.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Icon/Icon.interface.ts
@@ -16,12 +16,10 @@ export interface IconProps {
   iconValue: string | undefined;
   size?: number;
   className?: string;
-  /** Layout/positioning styles (e.g. margin, flexShrink). Applied to the element
-   * occupying space in the caller's layout, regardless of loading state. */
-  wrapperStyle?: React.CSSProperties;
   /** Cosmetic styles for the rendered icon/image itself (e.g. borderRadius). Never
    * applied to the loading skeleton. */
   imageStyle?: React.CSSProperties;
+  imageClassName?: string;
   strokeWidth?: number;
   alt?: string;
   fallback?: ReactNode;

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Icon/Icon.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Icon/Icon.test.tsx
@@ -124,36 +124,6 @@ describe('Icon', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('should apply wrapperStyle to the wrapper regardless of loading state', () => {
-      const { container, getByTestId } = render(
-        <Icon
-          iconValue="http://example.com/image.png"
-          wrapperStyle={{ marginRight: 4, flexShrink: 0 }}
-        />
-      );
-
-      const wrapper = container.firstChild;
-
-      expect(wrapper).toHaveStyle({ marginRight: '4px', flexShrink: 0 });
-
-      fireEvent.load(getByTestId('icon-image'));
-
-      expect(wrapper).toHaveStyle({ marginRight: '4px', flexShrink: 0 });
-    });
-
-    it('should not apply wrapperStyle to the loading skeleton itself', () => {
-      const { container } = render(
-        <Icon
-          iconValue="http://example.com/image.png"
-          wrapperStyle={{ marginRight: 4 }}
-        />
-      );
-
-      expect(container.querySelector('[aria-hidden="true"]')).not.toHaveStyle({
-        marginRight: '4px',
-      });
-    });
-
     it('should render the img element with the resolved src', () => {
       const { getByTestId } = render(
         <Icon iconValue="http://example.com/image.png" />

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Icon/Icon.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Icon/Icon.tsx
@@ -28,7 +28,7 @@ export const Icon: FC<IconProps> = ({
   fallback = null,
   size = 24,
   className = '',
-  wrapperStyle,
+  imageClassName = '',
   imageStyle = {},
   strokeWidth = 1.5,
   alt = 'icon',
@@ -62,9 +62,9 @@ export const Icon: FC<IconProps> = ({
   if (IconComponent) {
     return (
       <IconComponent
-        className={className}
+        className={imageClassName}
         size={size}
-        style={{ strokeWidth, ...wrapperStyle, ...imageStyle }}
+        style={{ strokeWidth, ...imageStyle }}
       />
     );
   }
@@ -74,13 +74,16 @@ export const Icon: FC<IconProps> = ({
   }
 
   return (
-    <span className={className} style={wrapperStyle}>
+    <span
+      className={className}
+      >
       {loadState === 'loading' && (
         <Skeleton height={size} variant="circular" width={size} />
       )}
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- img load lifecycle */}
       <img
         alt={alt}
+        className={imageClassName}
         data-testid="icon-image"
         ref={imgRef}
         src={getTagImageSrc(iconValue)}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Icon/Icon.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Icon/Icon.tsx
@@ -75,9 +75,7 @@ export const Icon: FC<IconProps> = ({
   }
 
   return (
-    <span
-      className={className}
-      >
+    <span className={className}>
       {loadState === 'loading' && (
         <Skeleton height={size} variant="circular" width={size} />
       )}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Icon/Icon.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Icon/Icon.tsx
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 import { Skeleton } from '@openmetadata/ui-core-components';
+import classNames from 'classnames';
 import { FC, useEffect, useRef, useState } from 'react';
 import { getTagImageSrc, ICON_MAP, isImageUrl } from '../../../utils/IconUtils';
 import { IconProps } from './Icon.interface';
@@ -62,7 +63,7 @@ export const Icon: FC<IconProps> = ({
   if (IconComponent) {
     return (
       <IconComponent
-        className={imageClassName}
+        className={classNames(className, imageClassName)}
         size={size}
         style={{ strokeWidth, ...imageStyle }}
       />

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/TagChip/TagChip.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/TagChip/TagChip.tsx
@@ -91,7 +91,7 @@ const TagChip: FC<TagChipProps> = ({
   const chipIcon = useMemo(
     () => (
       <Icon
-        className='tw:mr-1 tw:shrink-0'
+        className="tw:mr-1 tw:shrink-0"
         fallback={<Tag01 size={sizeStyles[size].icon} />}
         iconValue={icon}
         size={12}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/TagChip/TagChip.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/TagChip/TagChip.tsx
@@ -91,7 +91,7 @@ const TagChip: FC<TagChipProps> = ({
   const chipIcon = useMemo(
     () => (
       <Icon
-        className='tw:mr-4 tw:shrink-0'
+        className='tw:mr-1 tw:shrink-0'
         fallback={<Tag01 size={sizeStyles[size].icon} />}
         iconValue={icon}
         size={12}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/TagChip/TagChip.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/TagChip/TagChip.tsx
@@ -91,10 +91,10 @@ const TagChip: FC<TagChipProps> = ({
   const chipIcon = useMemo(
     () => (
       <Icon
+        className='tw:mr-4 tw:shrink-0'
         fallback={<Tag01 size={sizeStyles[size].icon} />}
         iconValue={icon}
         size={12}
-        wrapperStyle={{ marginRight: 4, flexShrink: 0 }}
       />
     ),
     [icon, size]

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TagPage/TagPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TagPage/TagPage.tsx
@@ -746,11 +746,7 @@ const TagPage = () => {
     if (tagItem?.style?.iconURL) {
       return (
         <div className="align-middle" data-testid="icon">
-          <Icon
-            className="object-contain"
-            iconValue={tagItem.style.iconURL}
-            size={36}
-          />
+          <Icon iconValue={tagItem.style.iconURL} size={36} />
         </div>
       );
     }

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ClassificationUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ClassificationUtils.tsx
@@ -13,8 +13,8 @@
 
 import {
   Toggle,
-  Tooltip as UTTooltip,
   TooltipTrigger,
+  Tooltip as UTTooltip,
 } from '@openmetadata/ui-core-components';
 import { Button, Space, Tooltip, Typography } from 'antd';
 import { Link } from 'react-router-dom';
@@ -88,7 +88,7 @@ export const getCommonColumns = (options?: {
       render: (_, record) => (
         <div className="d-flex items-center gap-2">
           <Icon
-            className="flex-shrink-0"
+            className="tw:shrink-0"
             iconValue={record.style?.iconURL}
             size={18}
           />

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ClassificationUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ClassificationUtils.tsx
@@ -13,8 +13,8 @@
 
 import {
   Toggle,
-  TooltipTrigger,
   Tooltip as UTTooltip,
+  TooltipTrigger,
 } from '@openmetadata/ui-core-components';
 import { Button, Space, Tooltip, Typography } from 'antd';
 import { Link } from 'react-router-dom';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataProductUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataProductUtils.tsx
@@ -143,11 +143,11 @@ export interface DataProductDetailPageTabProps {
  */
 export const getDataProductIconByUrl = (iconURL?: string) => (
   <ImageIcon
-    className="tw:h-6 tw:w-6 tw:text-quaternary"
     fallback={
       <DefaultDataProductIcon className="tw:text-quaternary data-product-default-icon" />
     }
     iconValue={iconURL}
+    imageClassName="tw:h-6 tw:w-6 tw:text-quaternary"
     size={24}
   />
 );

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DomainUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DomainUtils.tsx
@@ -449,9 +449,9 @@ export const getDomainWidgetsFromKey = (widgetConfig: WidgetConfig) => {
 
 export const getDomainIcon = (iconURL?: string) => (
   <Icon
-    className="tw:h-6 tw:w-6 tw:text-quaternary"
     fallback={<DomainIcon className="tw:text-quaternary" />}
     iconValue={iconURL}
+    imageClassName="tw:h-6 tw:w-6 tw:text-quaternary"
     size={24}
   />
 );


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...
<img width="469" height="153" alt="Screenshot 2026-08-26 at 5 53 46 PM" src="https://github.com/user-attachments/assets/120add5c-b8fe-4033-99e9-2d808f85aed3" />
<img width="268" height="545" alt="Screenshot 2026-08-26 at 5 55 57 PM" src="https://github.com/user-attachments/assets/39d2d3ca-6e74-4d5b-b4ea-c41ae2eb4ba4" />
<img width="296" height="100" alt="Screenshot 2026-08-26 at 5 56 05 PM" src="https://github.com/user-attachments/assets/e72b257e-0140-48cf-b39f-b0873157c306" />
<img width="862" height="357" alt="Screenshot 2026-08-26 at 5 57 10 PM" src="https://github.com/user-attachments/assets/af2c6da4-8a84-4e79-a56e-ce557004122c" />
<img width="617" height="207" alt="Screenshot 2026-08-26 at 5 58 23 PM" src="https://github.com/user-attachments/assets/eab25cc5-39b0-40a3-a79c-e00f9ba46586" />
<img width="1503" height="361" alt="Screenshot 2026-08-26 at 5 58 48 PM" src="https://github.com/user-attachments/assets/472b1cf1-8d01-4a24-a75b-3dc07d078081" />


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->






----
## Summary by Gitar

- **Refactored `Icon` component properties:**
    - Replaced `wrapperStyle` with `imageClassName` in `IconProps` to apply image-specific styling directly to underlying images and built-in icons
    - Updated callers including `TagsV1`, `CertificationTag`, `TagChip`, `DataProductUtils`, and `DomainUtils` to use `imageClassName` or Tailwind layout classes appropriately

<sub>This will update automatically on new commits.</sub>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR moves icon-specific classes from the `Icon` wrapper to the rendered image or built-in icon while retaining wrapper classes for layout.
- Adds an `imageClassName` prop and removes `wrapperStyle`.
- Updates tag, certification, domain, and data-product icon callers to use the revised styling contract.
- Aligns the affected unit-test expectations with the new contract.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported Icon and CertificationTag contract issues are resolved by the current implementation and updated assertions.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/common/Icon/Icon.tsx | Separates wrapper layout classes from image classes and merges both class inputs for built-in SVG icons. |
| openmetadata-ui/src/main/resources/ui/src/components/common/Icon/Icon.interface.ts | Replaces the wrapper-style API with an image-specific class-name property. |
| openmetadata-ui/src/main/resources/ui/src/components/common/CertificationTag/CertificationTag.tsx | Applies 14px sizing directly to custom certification images while retaining explicit fallback-icon dimensions. |
| openmetadata-ui/src/main/resources/ui/src/components/common/Icon/Icon.test.tsx | Updates the Icon test suite after removal of the wrapper-style contract. |
| openmetadata-ui/src/main/resources/ui/src/components/common/CertificationTag/CertificationTag.test.tsx | Aligns the mocked Icon expectation with CertificationTag’s revised image-class contract. |

</details>

<sub>Reviews (4): Last reviewed commit: ["unit test fix"](https://github.com/open-metadata/openmetadata/commit/b7791c12c42026b9050ed827b633c30fdcc6eff1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57060796)</sub>

<!-- /greptile_comment -->