### PR TITLE
Fixes #32107: install official pydoris driver

### DIFF
--- a/.github/actions/setup-openmetadata-test-environment/action.yml
+++ b/.github/actions/setup-openmetadata-test-environment/action.yml
@@ -48,8 +48,8 @@ inputs:
     required: false
     default: "false"
   install-test-dependencies:
-    # ingestion[all], ingestion[test], sqlalchemy-redshift/ibmi,
-    # pydoris-custom, and nox are only used by py-tests / py-cli-e2e / py-operator
+    # ingestion[all], ingestion[test], sqlalchemy-redshift/ibmi, and nox are only
+    # used by py-tests / py-cli-e2e / py-operator
     # workflows that invoke Python on the runner. Playwright E2E workflows drive
     # the browser and let the ingestion Docker container run its own installs, so
     # they can pass "false" here to shave ~3-4 minutes per shard off setup.
@@ -141,7 +141,7 @@ runs:
       if: ${{ inputs.fast-mode != 'true' && inputs.lightweight-ingestion != 'true' && inputs.install-test-dependencies == 'true' }}
       run: |
         source env/bin/activate
-        uv pip install --no-deps "sqlalchemy-ibmi==0.9.3" "pydoris-custom==1.1.0"
+        uv pip install --no-deps "sqlalchemy-ibmi==0.9.3"
         uv pip install "${{ github.workspace }}/ingestion[all]"
         uv pip install "${{ github.workspace }}/ingestion[test]"
         uv pip install nox

--- a/ingestion/Dockerfile.ci
+++ b/ingestion/Dockerfile.ci
@@ -126,9 +126,9 @@ RUN pip install "." --constraint "/home/airflow/airflow-constraints-3.3.1.txt"
 
 WORKDIR /home/airflow/ingestion
 
-# Pre-install dialect packages that declare SQLAlchemy<2 in their metadata
-# but work fine at runtime with SQLAlchemy 2.0 (unmaintained packages).
-RUN pip install --no-deps "sqlalchemy-ibmi==0.9.3" "pydoris-custom==1.1.0"
+# Pre-install the unmaintained dialect package that declares SQLAlchemy<2 in its
+# metadata but works at runtime with SQLAlchemy 2.0.
+RUN pip install --no-deps "sqlalchemy-ibmi==0.9.3"
 RUN pip install "datamodel-code-generator==0.64.0"
 RUN mkdir -p /home/airflow/ingestion/src/metadata/generated
 RUN python /home/airflow/scripts/datamodel_generation.py

--- a/ingestion/operators/docker/Dockerfile.ci
+++ b/ingestion/operators/docker/Dockerfile.ci
@@ -161,9 +161,9 @@ ENV PIP_QUIET=1
 ENV CFLAGS="-Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration -Wno-error=int-conversion"
 
 ARG INGESTION_DEPENDENCY="all"
-# Pre-install dialect packages that declare SQLAlchemy<2 in their metadata
-# but work fine at runtime with SQLAlchemy 2.0 (unmaintained packages).
-RUN pip install --no-deps "sqlalchemy-ibmi==0.9.3" "pydoris-custom==1.1.0"
+# Pre-install the unmaintained dialect package that declares SQLAlchemy<2 in its
+# metadata but works at runtime with SQLAlchemy 2.0.
+RUN pip install --no-deps "sqlalchemy-ibmi==0.9.3"
 RUN pip install "datamodel-code-generator==0.64.0"
 RUN mkdir -p /ingestion/src/metadata/generated
 RUN python /scripts/datamodel_generation.py

--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -70,6 +70,7 @@ VERSIONS = {
     "cockroach": "sqlalchemy-cockroachdb~=2.0",
     "cassandra": "cassandra-driver>=3.28.0",
     "opensearch": "opensearch-py~=2.4.0",
+    "pydoris": "pydoris==1.2.0",
     "starrocks": "pymysql~=1.0",
     "google-cloud-bigtable": "google-cloud-bigtable>=2.0.0",
     "google-cloud-pubsub": "google-cloud-pubsub>=2.0.0",
@@ -301,9 +302,7 @@ plugins: Dict[str, Set[str]] = {  # noqa: UP006
     "deltalake-storage": {"deltalake>=0.19.0,<0.20"},
     "deltalake-spark": {"delta-spark>=3.0.0,<4.0.0", "pyspark==3.5.6"},
     "domo": {VERSIONS["pydomo"]},
-    # pydoris-custom declares sqlalchemy<2 but works at runtime with SA 2.0.
-    # Pre-installed with --no-deps in Dockerfiles.
-    "doris": set(),
+    "doris": {VERSIONS["pydoris"]},
     "starrocks": {VERSIONS["pymysql"]},
     "druid": {"pydruid>=0.6.5"},
     "dynamodb": {VERSIONS["boto3"]},
@@ -524,7 +523,7 @@ test = {
     VERSIONS["grpc-tools"],
     VERSIONS["neo4j"],
     VERSIONS["cockroach"],
-    # pydoris-custom pre-installed with --no-deps in Dockerfiles (SA<2 metadata constraint).
+    VERSIONS["pydoris"],
     VERSIONS["starrocks"],
     *plugins["vertica"],
     "testcontainers~=4.8.0",

--- a/ingestion/tests/unit/source/database/doris/test_connection.py
+++ b/ingestion/tests/unit/source/database/doris/test_connection.py
@@ -16,7 +16,6 @@ from metadata.generated.schema.entity.services.connections.database.dorisConnect
 from metadata.generated.schema.entity.services.connections.database.dorisConnection import (
     DorisScheme,
 )
-from metadata.ingestion.connections.builders import get_connection_url_common
 from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.source.database.doris.connection import DorisConnection
 
@@ -25,7 +24,7 @@ def test_doris_connection_is_base_connection():
     assert issubclass(DorisConnection, BaseConnection)
 
 
-def test_basic_auth_builds_expected_url():
+def test_basic_auth_builds_doris_engine():
     connection = DorisConnectionConfig(
         username="openmetadata_user",
         password="openmetadata_password",
@@ -33,10 +32,9 @@ def test_basic_auth_builds_expected_url():
         databaseSchema="openmetadata_db",
         scheme=DorisScheme.doris,
     )
-    # Assert via the URL builder, not .client: the doris dialect (pydoris-custom,
-    # mysqlclient DBAPI) is installed --no-deps in runtime images only and is
-    # absent from the unit-test environment.
-    assert (
-        get_connection_url_common(connection)
-        == "doris://openmetadata_user:openmetadata_password@localhost:9030/openmetadata_db"
-    )
+    with DorisConnection(connection) as owned:
+        assert owned.client.dialect.name == "pydoris"
+        assert (
+            owned.client.url.render_as_string(hide_password=False)
+            == "doris://openmetadata_user:openmetadata_password@localhost:9030/openmetadata_db"
+        )


### PR DESCRIPTION
Fixes #32107

### Describe your changes:

Install the official pydoris 1.2.0 distribution through the Doris ingestion extra. This release supports SQLAlchemy 2 and publishes the Doris dialect entry point, so the connector no longer depends on the image-specific pydoris-custom workaround.

The Doris connection unit test now constructs the real SQLAlchemy engine and verifies the resolved dialect and connection URL.

### Type of change:

- [x] Bug fix

### High-level design:

N/A — small dependency correction.

### UI screen recording / screenshots:

Not applicable.

### Checklist:

- [x] I have read the CONTRIBUTING document.
- [x] My PR title is Fixes 32107: install official pydoris driver.
- [x] My PR is linked to GitHub issue #32107.
- [x] I have added a test that covers the exact scenario being fixed.



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces the image-specific `pydoris-custom` workaround with the official `pydoris==1.2.0` dependency and validates the real SQLAlchemy dialect.
- Adds the official driver to the Doris and test extras.
- Removes obsolete custom-driver installation from shared CI and ingestion images.
- Updates the Doris connection test to construct an engine and verify its dialect and URL.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/actions/setup-openmetadata-test-environment/action.yml | Removes the obsolete `pydoris-custom` pre-installation, resolving the previously reported duplicate-distribution issue. |
| ingestion/Dockerfile.ci | Removes the custom Doris driver workaround so the ingestion extra supplies the official package. |
| ingestion/operators/docker/Dockerfile.ci | Aligns the operator image with the official Doris dependency supplied by ingestion extras. |
| ingestion/setup.py | Pins `pydoris==1.2.0` and includes it in both the Doris and test dependency sets. |
| ingestion/tests/unit/source/database/doris/test_connection.py | Exercises real engine construction and checks the resolved Doris dialect and rendered connection URL. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix CI Doris dependency setup"](https://github.com/open-metadata/openmetadata/commit/6f36797f55880508464a675210d52a8a89ea76f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57064226)</sub>

<!-- /greptile_comment -->