### PR TITLE
fix(playwright): select Collate SaaS Runner before password fill in ServiceCreationPermissions

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceCreationPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceCreationPermissions.spec.ts
@@ -355,9 +355,9 @@ test.describe(
       await advanceToServiceConnectionStep(page);
 
       await page.locator('#root\\/username').fill('test_user');
+      await selectIngestionRunnerFromDropdown(page, COLLATE_SAAS_RUNNER);
       await page.locator('#root\\/authType\\/password').fill('test_password');
       await page.locator('#root\\/hostPort').fill('localhost:3306');
-      await selectIngestionRunnerFromDropdown(page, COLLATE_SAAS_RUNNER);
 
       await testConnectionIfRequired(page);
       await page.getByTestId('next-button').click();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceCreationPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceCreationPermissions.spec.ts
@@ -17,6 +17,7 @@ import {
   SERVICE_CREATOR_RULES,
   SERVICE_VIEWER_RULES,
 } from '../../constant/permission';
+import { COLLATE_SAAS_RUNNER } from '../../constant/serviceForm';
 import { GlobalSettingOptions } from '../../constant/settings';
 import { PolicyClass } from '../../support/access-control/PoliciesClass';
 import { RolesClass } from '../../support/access-control/RolesClass';
@@ -30,6 +31,7 @@ import {
 } from '../../utils/common';
 import { updateDescription } from '../../utils/entity';
 import { visitServiceDetailsPage } from '../../utils/service';
+import { selectIngestionRunnerFromDropdown } from '../../utils/serviceFormUtils';
 import {
   advanceToServiceConnectionStep,
   getAgentCard,
@@ -355,6 +357,7 @@ test.describe(
       await page.locator('#root\\/username').fill('test_user');
       await page.locator('#root\\/authType\\/password').fill('test_password');
       await page.locator('#root\\/hostPort').fill('localhost:3306');
+      await selectIngestionRunnerFromDropdown(page, COLLATE_SAAS_RUNNER);
 
       await testConnectionIfRequired(page);
       await page.getByTestId('next-button').click();


### PR DESCRIPTION
### Describe your changes:

I worked on selecting the Collate SaaS Runner before filling password fields in the `ServiceCreationPermissions` Playwright test because when the default runner is Remote Runner, the form validation enforces a `secret:` prefix on all password fields — causing the test to fail with a plain-text value like `test_password`.

- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- User with service creation permission can create a new database service (the exact failing test)

#### Unit tests
- [ ] Not applicable (Playwright test fix only)

#### Backend integration tests
- [ ] Not applicable (no backend API changes)

#### Ingestion integration tests
- [ ] Not applicable (no ingestion changes)

#### Playwright (UI) tests
- [x] Fixed existing test: `ServiceCreationPermissions.spec.ts` — "User with service creation permission can create a new database service"
- Files updated: `openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceCreationPermissions.spec.ts`

#### Manual testing performed
Not applicable — this is a Playwright test fix; the change adds `selectIngestionRunnerFromDropdown(page, COLLATE_SAAS_RUNNER)` which is a no-op when the runner dropdown is absent (guarded by `isVisible()`).

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix
- [x] I have added a test that covers the exact scenario we are fixing.
-->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the service-creation Playwright flow to select the Collate SaaS Runner before entering a plain-text password.
- Imports the Collate SaaS runner constant and runner-selection helper.
- Moves runner selection ahead of password entry to avoid Remote Runner secret-prefix validation.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceCreationPermissions.spec.ts | Selects the Collate SaaS Runner before filling the password in the database-service creation test. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(playwright): move runner selection b..."](https://github.com/open-metadata/openmetadata/commit/ea09756bd77aa78eba183d40418560011e34be28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57079037)</sub>

<!-- /greptile_comment -->