### PR TITLE
fix(data-quality): make TestCaseRepository.linkedTablesCache static to stop intermittent 500s (1.13)

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -158,13 +158,9 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
         fields.contains(INCIDENTS_FIELD) ? getIncidentId(test) : test.getIncidentId());
   }
 
-  // Must be static: the base EntityRepository constructor publishes `this` into the global
-  // repository map (Entity.registerEntity) before this subclass field initializer runs, so an
-  // instance field is unsafely published and can be observed null by other threads. That surfaced
-  // as an intermittent NPE in clearParentCache() (invoked per-request by
-  // ImpersonationCleanupFilter),
-  // failing unrelated requests with a 500. A static ThreadLocal is initialized at class load and
-  // safely published. Matches the 2.0/main declaration.
+  // Static so it is safely published: the base constructor registers `this` before subclass
+  // fields initialize, so an instance ThreadLocal could be observed null and NPE in
+  // clearParentCache().
   private static final ThreadLocal<Map<String, Table>> linkedTablesCache = new ThreadLocal<>();
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -158,7 +158,14 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
         fields.contains(INCIDENTS_FIELD) ? getIncidentId(test) : test.getIncidentId());
   }
 
-  private final ThreadLocal<Map<String, Table>> linkedTablesCache = new ThreadLocal<>();
+  // Must be static: the base EntityRepository constructor publishes `this` into the global
+  // repository map (Entity.registerEntity) before this subclass field initializer runs, so an
+  // instance field is unsafely published and can be observed null by other threads. That surfaced
+  // as an intermittent NPE in clearParentCache() (invoked per-request by
+  // ImpersonationCleanupFilter),
+  // failing unrelated requests with a 500. A static ThreadLocal is initialized at class load and
+  // safely published. Matches the 2.0/main declaration.
+  private static final ThreadLocal<Map<String, Table>> linkedTablesCache = new ThreadLocal<>();
 
   @Override
   public void setFieldsInBulk(Fields fields, List<TestCase> testCases) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TestCaseRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TestCaseRepositoryTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -20,6 +22,21 @@ import org.openmetadata.service.util.EntityUtil.Fields;
 import org.openmetadata.service.util.EntityUtil.RelationIncludes;
 
 class TestCaseRepositoryTest {
+
+  @Test
+  void linkedTablesCacheIsStaticSoItIsSafelyPublished() throws NoSuchFieldException {
+    // The base EntityRepository constructor publishes `this` into the global repository map
+    // (Entity.registerEntity) as its last step, before this subclass field initializer runs. An
+    // instance ThreadLocal is therefore unsafely published and can be observed null on other
+    // threads, making clearParentCache() throw an NPE — which, because it runs per-request via
+    // ImpersonationCleanupFilter, turned unrelated requests into 500s. A static field is
+    // initialized at class load and safely published, so it must stay static.
+    Field field = TestCaseRepository.class.getDeclaredField("linkedTablesCache");
+    assertTrue(
+        Modifier.isStatic(field.getModifiers()),
+        "linkedTablesCache must be static to avoid unsafe publication via the constructor's "
+            + "registerEntity(this) escape; a null value here NPEs in clearParentCache()");
+  }
 
   @Test
   void postUpdateHydratesTestSuitesBeforeLifecycleUpdate() {


### PR DESCRIPTION
## What was happening

On 1.13, several unrelated GET APIs intermittently returned **HTTP 500** with a bare `NullPointerException` (no message, no stack trace). Observed on:

- `GET /api/v1/containers/name/{fqn}/ancestors`
- `GET /api/v1/queries`

…but it can hit almost any endpoint. The same request would succeed one moment and 500 the next, so it looked flaky and had no usable stack trace in the logs.

## The actual cause

The failing endpoints are innocent. The NPE is thrown **after** the handler runs, in a response filter that executes on **every** request:

```
ImpersonationCleanupFilter        (JAX-RS response filter — runs on every response)
  → Entity.clearRepositoryThreadLocals()   (loops over ALL repositories)
      → TestCaseRepository.clearParentCache()  → linkedTablesCache.remove()   ← NPE (field observed as null)
```

So the request's real work (e.g. computing container ancestors) completes fine, then this per-request cleanup step throws, and the response is turned into a 500.

## Why the field was null (unsafe publication)

`linkedTablesCache` was an **instance** `final ThreadLocal`. The base `EntityRepository` constructor's **last statement** publishes the instance into the global repository map:

```java
Entity.registerEntity(entityClass, entityType, this);   // last line of the base constructor
```

In Java, a subclass's field initializers run **after** the superclass constructor returns. Because `this` escapes into a shared static map *before* `TestCaseRepository.linkedTablesCache` is assigned, the field is **unsafely published** — other threads can observe it as `null` indefinitely (the `final`-field safe-publication guarantee does not apply when `this` escapes during construction).

`clearParentCache()` then does `linkedTablesCache.remove()` on that null-observed field → NPE. Because it runs on the hottest request path, the JVM's fast-throw optimization strips the stack and message, which is why the logs only showed `NullPointerException / message [null]`.

(The base-class ThreadLocals don't hit this because they're initialized *before* the `registerEntity(this)` escape; only the subclass field, initialized after, is exposed — which is exactly why `super.clearParentCache()` succeeded and the very next line failed.)

## The fix

Make `linkedTablesCache` **static**. A static `ThreadLocal` is initialized at class load and safely published, so it is never null. There is a single repository instance per entity type, so this does not change runtime behavior.

This simply **backports the declaration already on `2.0` and `main`**, where the field is already `private static final` — the fix was never brought to `1.13`.

## Test

Adds `TestCaseRepositoryTest.linkedTablesCacheIsStaticSoItIsSafelyPublished`, which fails if the field is reverted to a non-static (unsafely published) field.

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
```





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport safely initializes the test-case linked-table ThreadLocal before repository publication, preventing request-cleanup failures caused by observing an uninitialized subclass field.

- Makes `linkedTablesCache` static so class initialization safely publishes it before repository registration.
- Adds a regression test requiring the field to remain static.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java | Changes the linked-table ThreadLocal to static initialization, eliminating the unsafe-publication window without altering its per-thread semantics. |
| openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TestCaseRepositoryTest.java | Adds a focused reflection-based regression test that prevents the safely published field from reverting to instance scope. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant JVM as Class initialization
    participant Repo as TestCaseRepository
    participant Registry as Entity registry
    participant Filter as Response cleanup
    JVM->>Repo: Initialize static linkedTablesCache
    Repo->>Registry: Base constructor registers repository
    Filter->>Repo: clearParentCache()
    Repo->>Repo: linkedTablesCache.remove()
    Note over Repo: ThreadLocal is initialized before publication
```
</details>

<sub>Reviews (3): Last reviewed commit: ["docs: shorten and genericize the linkedT..."](https://github.com/open-metadata/openmetadata/commit/7f43c2fc06287a740466ade1debd5a507855af8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57096510)</sub>

<!-- /greptile_comment -->