### PR TITLE
fix(ui): modal and right panel reopen immediately after close

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterDocument.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterDocument.spec.ts
@@ -974,6 +974,7 @@ test.describe('Context Center - Documents Page', () => {
     expect(panelClipboardText).toContain(`document=${doc.id}`);
 
     await panel.getByTestId('close-preview-btn').click();
+    await panel.waitFor({ state: 'hidden' });
     await expect(panel).not.toBeVisible();
   });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterMemories.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterMemories.spec.ts
@@ -566,6 +566,8 @@ test.describe(
         await expect(page).toHaveURL(new RegExp(`memory=${sharedMemoryName}`));
 
         await page.getByRole('button', { name: /cancel/i }).click();
+        await expect(dialog).not.toBeVisible();
+        await expect(page).not.toHaveURL(/memory=/);
       });
     });
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterDocumentsPage/ContextCenterDocumentsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterDocumentsPage/ContextCenterDocumentsPage.tsx
@@ -356,7 +356,6 @@ const ContextCenterDocumentsPage: FC = () => {
     return () => {
       isCancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allDocuments, isDocumentsLoading, searchParams, t, setSearchParams]);
 
   useEffect(() => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterDocumentsPage/ContextCenterDocumentsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterDocumentsPage/ContextCenterDocumentsPage.tsx
@@ -356,14 +356,8 @@ const ContextCenterDocumentsPage: FC = () => {
     return () => {
       isCancelled = true;
     };
-  }, [
-    allDocuments,
-    isDocumentsLoading,
-    previewFile,
-    searchParams,
-    t,
-    setSearchParams,
-  ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [allDocuments, isDocumentsLoading, searchParams, t, setSearchParams]);
 
   useEffect(() => {
     const folderId = searchParams.get('folder');

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterMemoriesPage/ContextCenterMemoriesPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterMemoriesPage/ContextCenterMemoriesPage.tsx
@@ -470,7 +470,8 @@ const ContextCenterMemoriesPage: FC = () => {
           return prev;
         });
       });
-  }, [isViewModalOpen, searchParams, handleViewMemory, setSearchParams]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams, handleViewMemory, setSearchParams]);
 
   const handleModalSuccess = useCallback(() => {
     handleModalClose();

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterMemoriesPage/ContextCenterMemoriesPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterMemoriesPage/ContextCenterMemoriesPage.tsx
@@ -470,7 +470,6 @@ const ContextCenterMemoriesPage: FC = () => {
           return prev;
         });
       });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams, handleViewMemory, setSearchParams]);
 
   const handleModalSuccess = useCallback(() => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataMarketplacePage/DataMarketplacePage.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataMarketplacePage/DataMarketplacePage.component.test.tsx
@@ -12,6 +12,7 @@
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
+import { HelmetProvider } from 'react-helmet-async';
 import { PageType } from '../../generated/system/ui/page';
 import { getDocumentByFQN } from '../../rest/DocStoreAPI';
 import { showErrorToast } from '../../utils/ToastUtils';
@@ -83,9 +84,11 @@ let queryClient: QueryClient;
 
 const renderDataMarketplacePage = () =>
   render(
-    <QueryClientProvider client={queryClient}>
-      <DataMarketplacePage />
-    </QueryClientProvider>
+    <HelmetProvider>
+      <QueryClientProvider client={queryClient}>
+        <DataMarketplacePage />
+      </QueryClientProvider>
+    </HelmetProvider>
   );
 
 describe('DataMarketplacePage component', () => {


### PR DESCRIPTION
## Port of #32097 to `2.0`

### Describe your changes

Closing the view modal (Context Center Memories) or the document preview panel (Context Center Documents) caused it to immediately reopen. A `useEffect` that handles URL-driven panel opening had the open-state variable (`isViewModalOpen` / `previewFile`) in its dependency array. When the user closed the panel, that variable changed, re-triggering the effect. At that moment `searchParams` still held the URL param (router navigation hadn't rendered yet), so the guard condition passed and the modal/panel reopened.

**Fix:** remove the open-state variable from each effect's dependency array so the effect only fires on `searchParams` changes (URL navigation), not on modal/panel state changes.

### Type of change
- [x] Bug fix

### High-level design

N/A — small change, identical to #32097.

### Tests

#### Playwright (UI) tests
- [x] Added Playwright regression assertions (same as #32097).
  - `ContextCenterMemories.spec.ts` — `expect(dialog).not.toBeVisible()` + `expect(page).not.toHaveURL(/memory=/)` after cancel click
  - `ContextCenterDocument.spec.ts` — `panel.waitFor({ state: 'hidden' })` before the existing `not.toBeVisible()` assertion







<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents Context Center document previews and memory modals from reopening immediately after close by removing local open state from URL-driven effect dependencies.
- Adds Playwright assertions covering modal closure and URL cleanup.
- Adds `HelmetProvider` to the Data Marketplace test renderer.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterDocumentsPage/ContextCenterDocumentsPage.tsx | Removes preview state from the URL-driven effect dependencies so closing the panel does not immediately trigger reopening. |
| openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterMemoriesPage/ContextCenterMemoriesPage.tsx | Removes modal-open state from the URL-driven effect dependencies so closing the memory dialog does not immediately trigger reopening. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterDocument.spec.ts | Waits explicitly for the document preview panel to become hidden after closing it. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterMemories.spec.ts | Verifies that cancellation closes the memory dialog and removes the memory query parameter. |
| openmetadata-ui/src/main/resources/ui/src/pages/DataMarketplacePage/DataMarketplacePage.component.test.tsx | Wraps the tested page with the required asynchronous Helmet context provider. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;2.0&#39; into port-pr-32097-to..."](https://github.com/open-metadata/openmetadata/commit/31448c39090a3dbaa46b3fcbe1f0dd58c3622938) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57165522)</sub>

<!-- /greptile_comment -->