### PR TITLE
fix(ui): support jsonc parser named exports

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/eslint.config.mjs
+++ b/openmetadata-ui/src/main/resources/ui/eslint.config.mjs
@@ -22,7 +22,7 @@ import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 import sonarjs from 'eslint-plugin-sonarjs';
 import globals from 'globals';
-import jsoncParser from 'jsonc-eslint-parser';
+import * as jsoncParser from 'jsonc-eslint-parser';
 import tseslint from 'typescript-eslint';
 import openMetadataImports from './eslint-rules/openmetadata-imports.mjs';
 import openMetadataPerformance from './eslint-rules/openmetadata-performance.mjs';


### PR DESCRIPTION
### Describe your changes:

Updates the ESLint flat config to load `jsonc-eslint-parser` through its named ESM exports.

#### Root cause and failure chain

The `eslint-plugin-jsonc` dependency update in #31621 resolves `jsonc-eslint-parser` to 3.3.0. That parser release does not expose a default ESM export, while `eslint.config.mjs` imports one. ESLint therefore throws while loading its configuration, before it processes any files.

The UI Checkstyle sequence organizes imports before running ESLint. When ESLint exits during configuration loading, those formatting changes remain in the checkout. Later licence-header and core-components i18n clean-tree checks then report unrelated files as failures. Importing the parser namespace supplies the parser object expected by ESLint and allows the entire sequence to finish normally.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A — one-line compatibility fix for the parser's ESM export shape.

#
### Tests:

#### Use cases covered

- ESLint loads the flat configuration with `jsonc-eslint-parser` 3.3.0 and processes a TypeScript source file.
- The repository's changed-file UI checkstyle sequence completes without leaving generated changes.

#### Unit tests

Not applicable — this change only corrects build-tool module loading.

#### Backend integration tests

- [x] Not applicable (no backend API changes).

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Not applicable (no user-facing UI changes).

#### Manual testing performed

1. Imported `eslint.config.mjs` directly with Node.js.
2. Ran ESLint against `src/rest/testAPI.ts`; it completed with zero errors.
3. Ran `make ui-checkstyle-changed` from the repository root.
4. Ran Prettier, licence-header, and whitespace checks.

#
### UI screen recording / screenshots:

Not applicable — no user-facing UI changes.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have reviewed the changed logic for non-obvious behavior; no code comment is needed for the ESM import syntax.
- [x] Tests are listed above.
