### PR TITLE
fix(security): bump fast-uri to 3.1.6

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/package.json
+++ b/openmetadata-ui-core-components/src/main/resources/ui/package.json
@@ -171,7 +171,7 @@
   },
   "resolutions": {
     "brace-expansion": "5.0.9",
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.6",
     "lodash": "4.18.1",
     "minimatch": "10.2.3",
     "nanoid": "3.3.17",

--- a/openmetadata-ui-core-components/src/main/resources/ui/yarn.lock
+++ b/openmetadata-ui-core-components/src/main/resources/ui/yarn.lock
@@ -4294,10 +4294,10 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-uri@3.1.5, fast-uri@^3.0.1:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
-  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
+fast-uri@3.1.6, fast-uri@^3.0.1:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.6.tgz#bfdd308ef763f835fed059f3c6c925f708e33e3a"
+  integrity sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==
 
 fastq@^1.13.0:
   version "1.20.1"
@@ -6581,6 +6581,7 @@ string-argv@~0.3.1:
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6672,6 +6673,7 @@ string_decoder@~1.1.1:
     safe-buffer "~5.1.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  name strip-ansi-cjs
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==

--- a/openmetadata-ui/src/main/resources/ui/package.json
+++ b/openmetadata-ui/src/main/resources/ui/package.json
@@ -309,7 +309,7 @@
     "form-data": "4.0.6",
     "tar-fs": "2.1.4",
     "brace-expansion": "1.1.18",
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.6",
     "linkify-it": "5.0.2",
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",

--- a/openmetadata-ui/src/main/resources/ui/yarn.lock
+++ b/openmetadata-ui/src/main/resources/ui/yarn.lock
@@ -7114,10 +7114,10 @@ fast-text-encoding@^1.0.6:
   resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz#0aa25f7f638222e3396d72bf936afcf1d42d6867"
   integrity sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==
 
-fast-uri@3.1.5, fast-uri@^3.0.1:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
-  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
+fast-uri@3.1.6, fast-uri@^3.0.1:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.6.tgz#bfdd308ef763f835fed059f3c6c925f708e33e3a"
+  integrity sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==
 
 fastq@^1.6.0:
   version "1.20.1"


### PR DESCRIPTION
## Advisory

`fast-uri` 3.1.5 is affected by four high-severity advisories, all fixed in **3.1.6**:

| CVE | Snyk ID | CVSS | Title |
|---|---|---|---|
| CVE-2026-75931 | SNYK-JS-FASTURI-19256867 | 8.7 | Interpretation Conflict |
| CVE-2026-76172 | SNYK-JS-FASTURI-19256869 | 8.7 | Improper Handling of URL Encoding (Hex Encoding) |
| CVE-2026-75975 | SNYK-JS-FASTURI-19256871 | 8.7 | Improper Validation of Syntactic Correctness of Input |
| CVE-2026-75899 | SNYK-JS-FASTURI-19256873 | 8.7 | Double Decoding of the Same Data |

## Raw scanner finding

From `ui-dep-scan.json` / `server-dep-scan.json`, security-scan run [33031058562](https://github.com/open-metadata/OpenMetadata/actions/runs/33031058562) (head `36f5148884`):

```
severity=high  package=fast-uri  version=3.1.5  title="Double Decoding of the Same Data"
  id=SNYK-JS-FASTURI-19256873  fixedIn=['2.4.5', '3.1.6', '4.1.3']  isUpgradable=True
  from=['open-metadata@0.1.0', '@rjsf/validator-ajv8@5.24.13', 'ajv@8.18.0', 'fast-uri@3.1.5']
```

(Three sibling entries with the same coordinates for the other three CVEs.)

## Why the version was stuck

`fast-uri` is not a direct dependency of either workspace. It arrived at 3.1.5 because
[#30915](https://github.com/open-metadata/OpenMetadata/pull/30915) added an explicit
`resolutions` pin on 2026-08-04 to clear the *previous* round of `fast-uri` CVEs. That pin
is now what holds the tree on the vulnerable version, so bumping the pin — rather than any
`dependencies` entry — is the fix.

## What I verified

- **The advisory is coherent.** `npm view fast-uri versions` lists `… 3.1.4, 3.1.5, 3.1.6, 4.0.0, … 4.1.3`. 3.1.6 is a real published release and 3.1.5 is genuinely below it.
- **The pin is in range for every declared dependent.** The only requester in either lockfile is `ajv`; `npm view ajv@8.18.0 dependencies.fast-uri` → `^3.0.1`. 3.1.6 satisfies it. This is an in-range patch bump inside 3.1.x, not a forced major.
- **No first-party code imports `fast-uri`.** `grep -rn fast-uri` over `openmetadata-ui/.../ui/src` and `openmetadata-ui-core-components/.../ui/src` returns nothing; it is reached only through `ajv` → `@rjsf/validator-ajv8`. There is no API surface of ours to break.
- **Lockfiles regenerated** with `yarn install --ignore-scripts` (yarn 1.22.19, Node 22.22.2) in each workspace. The `fast-uri` hunk is 4 lines changed in each lockfile.
- **Installed version confirmed** as `3.1.6` in both workspaces' `node_modules` after install.
- **`openmetadata-ui-core-components` builds green** — `yarn build` succeeds (Vite library build + `vite-plugin-dts` declarations, exit 0).

## Manifests touched

- `openmetadata-ui/src/main/resources/ui/package.json` — `resolutions."fast-uri"`: `3.1.5` → `3.1.6`
- `openmetadata-ui/src/main/resources/ui/yarn.lock`
- `openmetadata-ui-core-components/src/main/resources/ui/package.json` — same pin
- `openmetadata-ui-core-components/src/main/resources/ui/yarn.lock`

Only the `openmetadata-ui` workspace was flagged by the scanner. `openmetadata-ui-core-components`
carries the identical `resolutions` pin at the identical vulnerable version, so it is bumped in the
same change rather than left behind to be re-flagged later.

## What I did NOT test

- **No `openmetadata-ui` build, `tsc --noEmit`, Jest, Playwright, or lint run.** Only the
  `ui-core-components` build was executed.
- **Neither CVE was reproduced**, and no behavioural difference between 3.1.5 and 3.1.6 was
  exercised. The change rests on the upstream advisory and on `fast-uri` having no first-party
  caller here.
- **Incidental lockfile churn, disclosed:** the `openmetadata-ui-core-components` lockfile also
  gained two unrelated `name string-width-cjs` / `name strip-ansi-cjs` alias-metadata lines.
  These are written by the local yarn 1.22.19 for aliased dependencies and are not caused by this
  bump; they are left in so the committed lockfile matches what `yarn install` actually produces.

## Real-world exposure

Low. `fast-uri` is used here only by `ajv` for `$ref`/`format: uri` resolution inside
`@rjsf/validator-ajv8`, i.e. JSON-Schema-driven connector forms in the UI. Still worth fixing —
these are parser-correctness bugs in a URI parser reached from user-supplied schema content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)