### PR TITLE
fix(security): bump pyathena to 3.35.4

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -73,7 +73,7 @@ VERSIONS = {
     "starrocks": "pymysql~=1.0",
     "google-cloud-bigtable": "google-cloud-bigtable>=2.0.0",
     "google-cloud-pubsub": "google-cloud-pubsub>=2.0.0",
-    "pyathena": "pyathena~=3.25.0",
+    "pyathena": "pyathena~=3.35.4",  # <3.35.4 routes DELETE/CTAS to the Hive escaper -> SQL injection (CVE-2026-65321)
     "s3fs": "s3fs~=2026.3",
     "sqlalchemy-bigquery": "sqlalchemy-bigquery>=1.15.0",
     # <1.0: 1.0.0 is a SQLAlchemy-2.0 rewrite (first release since 0.0.5 in 2020) that drops


### PR DESCRIPTION
## Advisory

**CVE-2026-65321** / GHSA-xwj5-g6cv-4r5c / SNYK-PYTHON-PYATHENA-19270043 — **critical, CVSS 9.3**
(`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P`), CWE-89 SQL Injection.
Vulnerable range `[,3.35.4)`; fixed in **3.35.4**.

> Affected versions of this package are vulnerable to SQL Injection through its escaper selection
> for `DELETE` and `CREATE TABLE ... AS SELECT` statements. An attacker can break out of a
> parameterized string literal and inject arbitrary SQL by supplying a value containing a single
> quote in a `DELETE` or CTAS query. The vulnerable code routes those statements to the Hive-style
> backslash escaper, but Athena/Trino parses backslashes as ordinary characters inside string
> literals […]

## Raw scanner finding

`ingestion-dep-scan.json`, security-scan run [33031058562](https://github.com/open-metadata/OpenMetadata/actions/runs/33031058562) (head `36f5148884`) — the only non-base-image critical in this run:

```
severity=critical  package=pyathena  version=3.25.0  title="SQL Injection"
  id=SNYK-PYTHON-PYATHENA-19270043  CVE-2026-65321  cvssScore=9.3
  fixedIn=['3.35.4']  semver.vulnerable=['[,3.35.4)']
  isUpgradable=False  isPatchable=False
  from=['ingestion@0.0.0', 'pyathena@3.25.0']
```

Snyk reports `isUpgradable: False` because the fix falls outside the declared pin
`pyathena~=3.25.0` (`>=3.25.0, <3.26.0`) — the pin itself is what blocks the fix, so the pin is
what this PR changes.

## What I verified

**1 — the advisory is coherent.** `pyathena` 3.35.4 is a real published release
(`https://pypi.org/pypi/pyathena/3.35.4/json`, `requires_python: >=3.10`), and 3.25.0 is genuinely
below it. It is a minor bump inside the 3.x line, not a major.

**2 — the full pyathena API surface this repo uses still exists at 3.35.4.** The Athena connector
does not just import pyathena, it monkey-patches private internals, so I installed 3.35.4 into a
clean **Python 3.10** venv (the version CI runs) with `sqlalchemy 2.0.52` — inside this repo's
declared `sqlalchemy>=2.0.0,<3` range — and checked every symbol:

| Symbol | Used at | Present in 3.35.4 |
|---|---|---|
| `pyathena.sqlalchemy.compiler.AthenaStatementCompiler` | `profiler/interface/sqlalchemy/athena/profiler_interface.py:25` | yes |
| `AthenaStatementCompiler.visit_column` (patched) | same file | yes |
| `pyathena.sqlalchemy.util._HashableDict` (private) | `.../database/athena/utils.py:17,274,275` | yes |
| `pyathena.sqlalchemy.base.AthenaDialect` | `.../database/athena/metadata.py:19` | yes |
| `AthenaDialect._pattern_column_type` (private) | `.../athena/utils.py:37` | yes (`base.py:185`) |
| `AthenaDialect._get_table` / `_get_column_type` / `get_columns` / `get_view_definition` / `get_table_options` / `_raw_connection` | patched in `athena/metadata.py:74-77`, defined in `athena/utils.py` | all yes |
| `AthenaTableMetadata.{columns, partition_keys, parameters, location, compression, row_format, file_format, serde_properties, table_properties}` | `athena/utils.py` `get_columns` / `get_table_options` | all yes |
| `awsathena+rest` dialect entry point | `athenaConnection.json:18` scheme enum | yes → resolves to `AthenaRestDialect` |

`sa.create_engine("awsathena+rest://…")` resolves to `AthenaRestDialect` on 3.35.4.

**3 — no dependency floor is violated.** 3.35.4 declares `boto3>=1.41.2` / `botocore>=1.41.2`;
this repo already pins `boto3~=1.41.5` (`setup.py:30`), which satisfies both. Its `sqlalchemy`
extra declares `>=1.0.0`, satisfied by the repo's `sqlalchemy>=2.0.0,<3`.

**4 — it is consistent with the rest of the repo.** `ingestion/airflow-constraints-3.3.1.txt:50`
already carries `PyAthena==3.35.4`. That constraint file is only applied to the
`openmetadata-airflow-apis` install in `Dockerfile.ci`, not to the ingestion install, so there is
no live resolver conflict today — but 3.35.4 is what the pinned Airflow 3.3.1 constraint set
expects, and after this change the two agree.

**5 — formatting/lint.** `ruff format --check` and `ruff check` (with `ingestion/pyproject.toml`)
both pass on the changed file; the new line is 119 chars against the configured `line-length = 120`.

## Manifests touched

- `ingestion/setup.py` — `VERSIONS["pyathena"]`: `pyathena~=3.25.0` → `pyathena~=3.35.4`.
  This one entry feeds both the `athena` extra (`setup.py:218`) and the test/dev set (`setup.py:550`).

No lockfile to regenerate on the Python side.

## What I did NOT test

- **No ingestion test suite run, and no `pip install -e '.[athena]'` against the real ingestion
  dependency set.** The verification above is a targeted API-surface check in an isolated venv
  containing only `pyathena` + `sqlalchemy`. It proves the symbols exist and the dialect resolves;
  it does **not** prove the whole ingestion resolver still solves with 3.35.4 alongside every other
  pinned connector. CI is the check for that — please let it run before this leaves draft.
- **No live Athena connection, no metadata ingestion run, and no profiler run.** Behavioural
  equivalence of `get_columns` / `get_table_options` / struct-column profiling against a real
  Athena catalog is unverified.
- **The CVE was not reproduced**, and I did not diff pyathena's own behaviour across the ten minor
  releases between 3.25 and 3.35 beyond the symbol check above. That gap is the main reason this
  is a draft.

## Real-world exposure

The injection vector is `DELETE` and `CTAS` statement compilation. OpenMetadata's Athena connector
is read-only (metadata reflection via the Athena/Glue API plus `SELECT` for profiling), so it is
not obviously on the vulnerable path — but `pyathena` is also exposed to users through the profiler
and is a shipped dependency of the ingestion image, so a CVSS 9.3 SQL injection in it should not be
carried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR upgrades PyAthena from the 3.25 release line to the security-fixed 3.35 release line.
- Raises the minimum PyAthena version to 3.35.4 for Athena and test/development extras.
- Documents the DELETE/CTAS SQL-injection vulnerability addressed by the new minimum.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified in the dependency update.

The upgraded dependency requirements remain jointly satisfiable, the supported runtime is compatible, and available evidence does not establish a regression in the Athena connector paths.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/setup.py | Updates the shared PyAthena dependency declaration to the security-fixed 3.35.4 release line without creating a demonstrated resolver or compatibility conflict. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): bump pyathena to 3.35.4"](https://github.com/open-metadata/openmetadata/commit/ebc67043192525e5b4bfcd81007e2629fbbba735) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57392220)</sub>

<!-- /greptile_comment -->