### PR TITLE
Fixes 31607: Restore Explore filter typography (2.0 backport)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/SortingDropDown.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/SortingDropDown.test.tsx
@@ -86,7 +86,7 @@ describe('Test Sorting DropDown Component', () => {
     const dropdownButton = dropdown.querySelector('button');
 
     expect(dropdownButton).toBeInTheDocument();
-    expect(dropdownButton).toHaveAttribute('data-size', 'xs');
+    expect(dropdownButton).toHaveAttribute('data-size', 'sm');
     expect(dropdownButton).toHaveAttribute('data-hide-focus-outline', 'true');
     expect(dropdownButton).not.toHaveClass('quick-filter-dropdown-trigger-btn');
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/SortingDropDown.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/SortingDropDown.tsx
@@ -42,12 +42,13 @@ const SortingDropDown: React.FC<SortingDropdownProps> = ({
 
   return (
     <Dropdown.Root data-testid="dropdown">
+      {/* Keep sorting labels aligned with the 14px filter treatment across consumers. */}
       <Button
         hideFocusOutline
         color="tertiary"
         data-testid="sorting-dropdown-label"
         iconTrailing={<ChevronDown size={14} />}
-        size="xs">
+        size="sm">
         {label}
       </Button>
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreV1.component.tsx
@@ -767,11 +767,12 @@ const ExploreV1: React.FC<ExploreProps> = ({
             <Divider className="tw:my-2" orientation="vertical" />
 
             <Dropdown.Root>
+              {/* The Tools label should match the adjacent 14px Explore filters. */}
               <Button
                 hideFocusOutline
                 color="tertiary"
                 iconTrailing={<ChevronDown size={14} />}
-                size="xs">
+                size="sm">
                 {t('label.tool-plural')}
               </Button>
               <Dropdown.Popover>

--- a/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreV1.test.tsx
@@ -586,7 +586,7 @@ describe('ExploreV1', () => {
     ).toHaveAttribute('data-title-strong', 'false');
     expect(screen.getByTestId('sorting-dropdown-label')).toHaveAttribute(
       'data-size',
-      'xs'
+      'sm'
     );
     expect(screen.getByTestId('sorting-dropdown-label')).toHaveAttribute(
       'data-hide-focus-outline',
@@ -597,7 +597,7 @@ describe('ExploreV1', () => {
     );
     expect(
       screen.getByText('label.tool-plural').closest('button')
-    ).toHaveAttribute('data-size', 'xs');
+    ).toHaveAttribute('data-size', 'sm');
     expect(
       screen.getByText('label.tool-plural').closest('button')
     ).toHaveAttribute('data-hide-focus-outline', 'true');


### PR DESCRIPTION
### Describe your changes:

Fixes #31607

Backports #32098 to the `2.0` branch.

Restores the Explore sorting and Tools actions to the shared `sm` button size so their 14px medium typography matches the adjacent filter labels. This preserves the focus-outline behavior introduced in #31608.

<img width="1498" height="554" alt="Explore filter typography" src="https://github.com/user-attachments/assets/4dffbb97-f394-47ec-b869-93fd9f27e5d5" />

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A — direct backport of the focused UI regression fix from #32098.

#
### Tests:

#### Use cases covered

- Popularity sorting uses the same typography treatment as adjacent Explore filters.
- Tools uses the same typography treatment as adjacent Explore filters.
- Both controls preserve the existing focus-outline behavior.

#### Unit tests

- [x] Component regression assertions are included for the restored `sm` button size.
- Files updated: `SortingDropDown.test.tsx`, `ExploreV1.test.tsx`
- Local result: 2 suites and 18 tests passed.

#### Backend integration tests

- [x] Not applicable (no backend API changes).

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Not applicable (covered by focused component regression tests).

#
### UI screen recording / screenshots:

The expected treatment is shown above and documented in #31607.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR is linked to a GitHub issue via `Fixes #31607` above.
- [x] Existing explanatory comments and regression tests are preserved from #32098.
- [x] For JSON Schema changes: not applicable; no schema changes.
- [x] For UI changes: the source PR screenshot is included above.
- [x] Tests are included and local verification passed.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR restores the shared small button sizing for the Explore sorting and Tools controls while preserving focus-outline behavior.
- Changes both controls from `xs` to `sm`.
- Updates focused component assertions for sizing and focus behavior.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Explore/SortingDropDown.tsx | Changes the sorting dropdown trigger from `xs` to `sm` while retaining its existing focus behavior. |
| openmetadata-ui/src/main/resources/ui/src/components/Explore/SortingDropDown.test.tsx | Updates the sorting dropdown regression assertion to expect the restored `sm` size. |
| openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreV1.component.tsx | Changes the Explore Tools trigger from `xs` to `sm` while retaining its existing focus behavior. |
| openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreV1.test.tsx | Updates regression assertions for the sorting and Tools trigger sizes. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;2.0&#39; into 31607-restore-ex..."](https://github.com/open-metadata/openmetadata/commit/bb20b96212c8abf84827f5d7ccf02014b86ab88b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57394335)</sub>

<!-- /greptile_comment -->