### PR TITLE
Cherry-pick to 2.0: NLQ RBAC, knowledge entityStatus, MCP tool surface

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpToolsValidationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpToolsValidationIT.java
@@ -719,13 +719,19 @@ public class McpToolsValidationIT extends McpTestBase {
     assertThat(firstResult.has("text")).isTrue();
     String responseText = firstResult.get("text").asText();
 
-    JsonNode entityData = OBJECT_MAPPER.readTree(responseText).get("entity");
+    // The patched entity is returned flat, the same shape the create_* tools return. It used to be
+    // wrapped in an "entity" key because the raw PatchResponse was serialized as-is.
+    JsonNode entityData = OBJECT_MAPPER.readTree(responseText);
     assertThat(entityData.has("id")).isTrue();
     assertThat(entityData.has("description")).isTrue();
     assertThat(entityData.get("description").asText())
         .contains("Updated description via MCP patch tool");
     assertThat(entityData.has("fullyQualifiedName")).isTrue();
     assertThat(entityData.get("fullyQualifiedName").asText()).isEqualTo(patchedEntity);
+    assertThat(entityData.path("_operation").asText())
+        .withFailMessage("Patch response payload: %s", responseText)
+        .isEqualTo("updated");
+    assertThat(entityData.has("version")).isTrue();
   }
 
   private void validateLineageResponse(JsonNode result, String expectedEntityFqn) throws Exception {

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CommonUtils.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CommonUtils.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.CreateEntity;
 import org.openmetadata.schema.EntityInterface;
@@ -62,6 +64,63 @@ public class CommonUtils {
       }
     }
     return teamsOrUsers;
+  }
+
+  /**
+   * Resolves owner names and fails on any that do not resolve, instead of dropping them.
+   *
+   * <p>{@link #getTeamsOrUsers} returns only what it could resolve and says nothing about the rest:
+   * {@code findByNameOrNull} returning null is not an exception, so nothing is thrown or logged.
+   * On an update that is data loss - one misspelled name resolves to an empty list, a {@code set}
+   * writes it, and every existing owner is deleted with a success response.
+   *
+   * @param owners the raw {@code owners} parameter, a string or list of strings
+   * @param paramName the parameter name to quote in the error
+   */
+  public static List<EntityReference> requireTeamsOrUsers(Object owners, String paramName) {
+    List<String> requested =
+        JsonUtils.readOrConvertValues(owners, String.class).stream().distinct().toList();
+    List<EntityReference> resolved = getTeamsOrUsers(owners);
+    Set<String> found =
+        resolved.stream().map(ref -> comparableName(ref.getName())).collect(Collectors.toSet());
+    List<String> missing =
+        requested.stream().filter(name -> !found.contains(comparableName(name))).toList();
+    if (!missing.isEmpty()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Parameter '%s': no user or team found for %s. Nothing was changed. Look the name up"
+                  + " with search_metadata (entityType='user' or 'team') and use the 'name' it"
+                  + " returns.",
+              paramName, missing));
+    }
+    return resolved;
+  }
+
+  /**
+   * The current owners whose names the caller named, for removals.
+   *
+   * <p>Removal must not go through {@link #requireTeamsOrUsers}: an owner who has been deleted no
+   * longer resolves, so requiring resolution would make the stale reference a caller most wants to
+   * clear the one they cannot. Matching what the entity already holds needs no directory lookup.
+   */
+  public static List<EntityReference> matchOwnersByName(
+      Object owners, List<EntityReference> existing) {
+    Set<String> wanted =
+        JsonUtils.readOrConvertValues(owners, String.class).stream()
+            .map(CommonUtils::comparableName)
+            .collect(Collectors.toSet());
+    return existing == null
+        ? List.of()
+        : existing.stream().filter(ref -> wanted.contains(comparableName(ref.getName()))).toList();
+  }
+
+  /** Owner names are compared case-insensitively and unquoted, so {@code "a.b"} matches {@code a.b}. */
+  private static String comparableName(String name) {
+    String result = name == null ? "" : name.trim();
+    if (result.length() > 1 && result.charAt(0) == '"' && result.endsWith("\"")) {
+      result = result.substring(1, result.length() - 1);
+    }
+    return result.toLowerCase(Locale.ROOT);
   }
 
   /**

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/DefaultToolContext.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/DefaultToolContext.java
@@ -10,6 +10,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.mcp.util.McpResponseTrim;
 import org.openmetadata.schema.entity.app.mcp.McpToolCallUsage;
@@ -176,7 +178,9 @@ public class DefaultToolContext {
       logToolFailure(toolName, ex, statusCode);
       Map<String, Object> error =
           errorPayload(
-              String.format("Error executing tool: %s", McpResponseTrim.safeMessage(ex)),
+              String.format(
+                  "Error executing tool: %s",
+                  McpResponseTrim.summarizeFailure(ex, isServerFault(statusCode))),
               statusCode);
       return new CallToolOutcome(errorResult(error), elapsedMs(startNanos), classifyException(ex));
     }
@@ -297,6 +301,35 @@ public class DefaultToolContext {
   }
 
   /**
+   * The status the backend already reported, when the exception carries one.
+   *
+   * <p>A search-client {@code ResponseException} embeds {@code status line [HTTP/1.1 400 Bad
+   * Request]} in its message but matches none of the name or message rules below, so it fell through
+   * to the default 500. {@link McpResponseTrim#summarizeFailure} turns a 5xx into "this is a backend
+   * fault, retrying will not help" - so a caller with a malformed {@code queryFilter} was told its
+   * arguments were fine. The reverse fired too: a real 5xx mentioning {@code
+   * index_not_found_exception} matched the "not found" rule and became a 404.
+   *
+   * <p>Believing the reported status settles both. Only 4xx and 5xx are taken; anything else falls
+   * through to the keyword table.
+   */
+  private static CategoryMatcher reportedStatus(String message) {
+    CategoryMatcher matched = null;
+    Matcher status = REPORTED_HTTP_STATUS.matcher(message);
+    if (status.find()) {
+      int code = Integer.parseInt(status.group(1));
+      if (code >= STATUS_BAD_REQUEST) {
+        matched = new CategoryMatcher(meta -> true, categoryForStatus(code), code);
+      }
+    }
+    return matched;
+  }
+
+  /** Matches the {@code status line [HTTP/1.1 400 Bad Request]} a search client embeds in its message. */
+  private static final Pattern REPORTED_HTTP_STATUS =
+      Pattern.compile("status line \\[http/\\d(?:\\.\\d)? (\\d{3})");
+
+  /**
    * Pairing of an exception (name, message) predicate with the telemetry bucket and HTTP status it
    * should produce. Kept as a static table so adding a new category (or extending an existing one
    * with a new keyword) is a one-line change rather than another {@code else if} branch.
@@ -339,7 +372,12 @@ public class DefaultToolContext {
                   meta.name().contains("Validation")
                       || meta.name().contains("IllegalArgument")
                       || meta.name().contains("BadRequest")
-                      || meta.message().contains("invalid argument"),
+                      || meta.message().contains("invalid argument")
+                      // A caller's queryFilter is parsed before the request is sent, so this
+                      // failure carries no reported status and used to default to 500 - reporting
+                      // the caller's own malformed DSL as a backend outage.
+                      || meta.message().contains("json parsing failed")
+                      || meta.message().contains("failed to parse"),
               McpToolCallUsage.ErrorCategory.VALIDATION,
               STATUS_BAD_REQUEST),
           new CategoryMatcher(
@@ -364,10 +402,13 @@ public class DefaultToolContext {
         new ExceptionMeta(
             cursor.getClass().getSimpleName(),
             cursor.getMessage() == null ? "" : cursor.getMessage().toLowerCase(Locale.ROOT));
-    return CATEGORY_MATCHERS.stream()
-        .filter(matcher -> matcher.matches().test(meta))
-        .findFirst()
-        .orElse(null);
+    CategoryMatcher reported = reportedStatus(meta.message());
+    return reported != null
+        ? reported
+        : CATEGORY_MATCHERS.stream()
+            .filter(matcher -> matcher.matches().test(meta))
+            .findFirst()
+            .orElse(null);
   }
 
   private static long elapsedMs(long startNanos) {

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetEntityTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetEntityTool.java
@@ -1,16 +1,25 @@
 package org.openmetadata.mcp.tools;
 
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.schema.type.MetadataOperation.VIEW_ALL;
+import static org.openmetadata.service.security.DefaultAuthorizer.getSubjectContext;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.mcp.util.McpParams;
 import org.openmetadata.mcp.util.McpResponseTrim;
+import org.openmetadata.schema.type.Edge;
+import org.openmetadata.schema.type.EntityLineage;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.limits.Limits;
@@ -57,6 +66,21 @@ public class GetEntityTool implements McpTool {
   private static final String SCHEMA_DEFINITION_TRUNCATED_KEY = "schemaDefinitionTruncated";
   private static final String SQL_TRUNCATED_KEY = "sqlTruncated";
 
+  private static final String ENTITIES_PARAM = "entities";
+  private static final char REFERENCE_SEPARATOR = ':';
+  private static final int MAX_BATCH = 10;
+  private static final String BAD_REFERENCE_MESSAGE =
+      "Expected 'entityType:fqn', e.g. 'table:svc.db.schema.orders'";
+
+  private static final String INCLUDE_PARAM = "include";
+  private static final String INCLUDE_LINEAGE = "lineage";
+  private static final String INCLUDE_QUALITY = "quality";
+  private static final String TEST_SUITE_KEY = "testSuite";
+  private static final String CERTIFICATION_KEY = "certification";
+
+  /** Two hops. The second one is what tells a caller whether a lone neighbour starts a chain. */
+  private static final int REACH_DEPTH = 2;
+
   private static final String COLUMN_OFFSET_PARAM = "columnOffset";
   private static final String COLUMN_LIMIT_PARAM = "columnLimit";
   private static final String TOTAL_COLUMNS_KEY = "totalColumns";
@@ -101,8 +125,108 @@ public class GetEntityTool implements McpTool {
   public Map<String, Object> execute(
       Authorizer authorizer, CatalogSecurityContext securityContext, Map<String, Object> params)
       throws IOException {
-    String entityType = (String) params.get("entityType");
-    String fqn = (String) params.get("fqn");
+    List<String> batch = McpParams.getStringList(params, ENTITIES_PARAM);
+    Map<String, Object> result;
+    if (batch.isEmpty()) {
+      result =
+          readOne(
+              authorizer,
+              securityContext,
+              params,
+              (String) params.get("entityType"),
+              (String) params.get("fqn"));
+    } else {
+      result = readMany(authorizer, securityContext, params, batch);
+    }
+    return result;
+  }
+
+  /**
+   * Reads up to {@link #MAX_BATCH} entities in one call instead of one call each.
+   *
+   * <p>Each entity resolves on its own, so an unknown type, a missing asset or a denied permission
+   * returns an {@code error} entry for that entity rather than failing the whole call.
+   */
+  private Map<String, Object> readMany(
+      Authorizer authorizer,
+      CatalogSecurityContext securityContext,
+      Map<String, Object> params,
+      List<String> batch) {
+    List<Map<String, Object>> entities = new ArrayList<>();
+    for (String reference : batch.subList(0, Math.min(batch.size(), MAX_BATCH))) {
+      entities.add(readBatchEntry(authorizer, securityContext, params, reference));
+    }
+    Map<String, Object> result = new LinkedHashMap<>();
+    result.put("entities", entities);
+    result.put("requested", batch.size());
+    result.put("returned", entities.size());
+    if (batch.size() > MAX_BATCH) {
+      result.put(
+          McpResponseTrim.MESSAGE_KEY,
+          String.format(
+              "%d entities requested, %d returned. Ask for at most %d per call.",
+              batch.size(), entities.size(), MAX_BATCH));
+    }
+    return result;
+  }
+
+  /** One batch entry, with its own failure contained to itself. */
+  private Map<String, Object> readBatchEntry(
+      Authorizer authorizer,
+      CatalogSecurityContext securityContext,
+      Map<String, Object> params,
+      String reference) {
+    Map<String, Object> entry;
+    EntityRef parsed = parseReference(reference);
+    if (parsed == null) {
+      entry = batchError(reference, BAD_REFERENCE_MESSAGE);
+    } else {
+      try {
+        entry = readOne(authorizer, securityContext, params, parsed.entityType(), parsed.fqn());
+      } catch (Exception e) {
+        LOG.warn("Batch read failed for {}: {}", reference, e.getMessage());
+        entry = batchError(reference, McpResponseTrim.safeMessage(e));
+      }
+    }
+    return entry;
+  }
+
+  record EntityRef(String entityType, String fqn) {}
+
+  /**
+   * Splits {@code entityType:fqn} on the first colon only, because an FQN can contain colons.
+   * Returns null when unparseable, so the caller can report it per entity.
+   */
+  @VisibleForTesting
+  static EntityRef parseReference(String reference) {
+    EntityRef parsed = null;
+    if (reference != null) {
+      int separator = reference.indexOf(REFERENCE_SEPARATOR);
+      boolean parseable = separator > 0 && separator < reference.length() - 1;
+      if (parseable) {
+        String type = reference.substring(0, separator).trim();
+        String fqn = reference.substring(separator + 1).trim();
+        if (!type.isEmpty() && !fqn.isEmpty()) {
+          parsed = new EntityRef(type, fqn);
+        }
+      }
+    }
+    return parsed;
+  }
+
+  private static Map<String, Object> batchError(String reference, String message) {
+    Map<String, Object> entry = new LinkedHashMap<>();
+    entry.put("requested", reference);
+    entry.put(McpResponseTrim.ERROR_KEY, message);
+    return entry;
+  }
+
+  private Map<String, Object> readOne(
+      Authorizer authorizer,
+      CatalogSecurityContext securityContext,
+      Map<String, Object> params,
+      String entityType,
+      String fqn) {
     // Authorize by FQN so entity-scoped tag/owner/domain policies are evaluated, not just the
     // resource-type permission.
     authorizer.authorize(
@@ -113,14 +237,243 @@ public class GetEntityTool implements McpTool {
     int columnOffset =
         Math.max(0, McpParams.getInt(params, COLUMN_OFFSET_PARAM, DEFAULT_COLUMN_OFFSET));
     int columnLimit = McpParams.getInt(params, COLUMN_LIMIT_PARAM, NO_COLUMN_LIMIT);
-    String fields = "*";
     Map<String, Object> entityData =
-        JsonUtils.getMap(Entity.getEntityByName(entityType, fqn, fields, null));
+        JsonUtils.getMap(Entity.getEntityByName(entityType, fqn, "*", null));
 
     // Clean response to optimize LLM context usage, then bound the columns array so a wide entity
     // stays under the dispatch-level size cap instead of being replaced by an empty stub.
     Map<String, Object> cleaned = cleanEntityResponse(entityData);
-    return applyColumnWindow(cleaned, columnOffset, columnLimit);
+    resolveCertification(cleaned);
+    Map<String, Object> windowed = applyColumnWindow(cleaned, columnOffset, columnLimit);
+    addIncludes(
+        windowed,
+        new IncludeContext(authorizer, securityContext, entityType, fqn),
+        McpParams.getStringList(params, INCLUDE_PARAM));
+    return windowed;
+  }
+
+  /**
+   * Folds lineage and test health into this response, so the caller does not spend a call on each.
+   * Both are cheap in-process reads.
+   *
+   * <p>Each section degrades on its own: if one fails, its slot carries a note and the entity read
+   * still succeeds.
+   */
+  /**
+   * What an include section needs to fetch and authorize its own data. Each section reaches a
+   * different entity than {@link #readOne} authorized - lineage the neighbours, quality the test
+   * suite - so each carries the caller's identity.
+   */
+  private record IncludeContext(
+      Authorizer authorizer,
+      CatalogSecurityContext securityContext,
+      String entityType,
+      String fqn) {}
+
+  private static void addIncludes(
+      Map<String, Object> result, IncludeContext ctx, List<String> include) {
+    if (nullOrEmpty(include)) {
+      return;
+    }
+    if (include.contains(INCLUDE_LINEAGE)) {
+      result.put(INCLUDE_LINEAGE, section(() -> neighbours(ctx), INCLUDE_LINEAGE, ctx.fqn()));
+    }
+    if (include.contains(INCLUDE_QUALITY)) {
+      result.put(INCLUDE_QUALITY, section(() -> quality(result, ctx), INCLUDE_QUALITY, ctx.fqn()));
+    }
+  }
+
+  /** Runs one include section, converting a failure into a note instead of losing the whole read. */
+  private static Object section(Supplier<Object> supplier, String name, String fqn) {
+    Object value;
+    try {
+      value = supplier.get();
+    } catch (Exception e) {
+      LOG.warn("include={} failed for {}: {}", name, fqn, e.getMessage());
+      value = Map.of("unavailable", McpResponseTrim.safeMessage(e));
+    }
+    return value;
+  }
+
+  /**
+   * Immediate neighbours, plus whether the graph continues past them. {@code get_entity_lineage} is
+   * still the tool for depth and edge detail.
+   *
+   * <p>Reads two hops once and decides "is there more" from which edges touch the root. Probing
+   * each neighbour instead means looking it up under the root's entity type, which fails whenever a
+   * neighbour is a different type - a table feeding a dashboard, say.
+   */
+  private static Map<String, Object> neighbours(IncludeContext ctx) {
+    // The subject context applies the caller's domain restrictions
+    // (LineageRepository.pruneLineageByDomain). Without it they see neighbours they cannot access.
+    EntityLineage lineage =
+        Entity.getLineageRepository()
+            .getByName(
+                ctx.entityType(),
+                ctx.fqn(),
+                REACH_DEPTH,
+                REACH_DEPTH,
+                getSubjectContext(ctx.securityContext()));
+    UUID root = rootId(lineage, ctx.fqn());
+    Map<UUID, EntityReference> index = indexNodes(lineage);
+    Map<String, Object> summary = new LinkedHashMap<>();
+    addDirection(summary, root, index, lineage.getUpstreamEdges(), true);
+    addDirection(summary, root, index, lineage.getDownstreamEdges(), false);
+    summary.put("note", reachNote(continuesAnywhere(summary)));
+    return summary;
+  }
+
+  /** Neighbours whose edge touches the root, and whether any edge in that direction does not. */
+  @VisibleForTesting
+  static void addDirection(
+      Map<String, Object> summary,
+      UUID root,
+      Map<UUID, EntityReference> index,
+      List<Edge> edges,
+      boolean upstream) {
+    List<String> immediate = new ArrayList<>();
+    boolean continues = false;
+    for (Edge edge : nullOrEmpty(edges) ? List.<Edge>of() : edges) {
+      UUID near = upstream ? edge.getToEntity() : edge.getFromEntity();
+      UUID far = upstream ? edge.getFromEntity() : edge.getToEntity();
+      if (root.equals(near)) {
+        addEndpoint(immediate, index, far);
+      } else {
+        continues = true;
+      }
+    }
+    summary.put(upstream ? "upstream" : "downstream", immediate);
+    summary.put(upstream ? "hasMoreUpstream" : "hasMoreDownstream", continues);
+  }
+
+  private static boolean continuesAnywhere(Map<String, Object> summary) {
+    return Boolean.TRUE.equals(summary.get("hasMoreUpstream"))
+        || Boolean.TRUE.equals(summary.get("hasMoreDownstream"));
+  }
+
+  /**
+   * The entity's own id, which every reach decision is measured against. Throwing when it is absent
+   * lets {@link #section} report it, rather than guessing the flags.
+   */
+  private static UUID rootId(EntityLineage lineage, String fqn) {
+    EntityReference entity = lineage.getEntity();
+    if (entity == null || entity.getId() == null) {
+      throw new IllegalStateException("Lineage for '" + fqn + "' carries no root entity");
+    }
+    return entity.getId();
+  }
+
+  private static Map<UUID, EntityReference> indexNodes(EntityLineage lineage) {
+    Map<UUID, EntityReference> index = new HashMap<>();
+    if (!nullOrEmpty(lineage.getNodes())) {
+      lineage.getNodes().forEach(node -> index.put(node.getId(), node));
+    }
+    return index;
+  }
+
+  /**
+   * Says whether the graph continues past the immediate neighbours. Without it a single upstream is
+   * ambiguous between "that is everything" and "that is the first of several hops".
+   */
+  private static String reachNote(boolean continues) {
+    return continues
+        ? "Immediate neighbours only, and the graph continues beyond them. Use get_entity_lineage"
+            + " for the full depth."
+        : "Immediate neighbours only - and this is the complete graph; nothing lies beyond these."
+            + " A further get_entity_lineage call would add only edge detail.";
+  }
+
+  private static void addEndpoint(List<String> names, Map<UUID, EntityReference> index, UUID id) {
+    EntityReference ref = index.get(id);
+    if (ref != null
+        && ref.getFullyQualifiedName() != null
+        && !names.contains(ref.getFullyQualifiedName())) {
+      names.add(ref.getFullyQualifiedName());
+    }
+  }
+
+  /**
+   * Test health for the entity's suite. The entity carries the suite reference but not its
+   * pass/fail counts, so answering "are the tests passing?" otherwise costs another call.
+   */
+  private static Object quality(Map<String, Object> entity, IncludeContext ctx) {
+    Object suiteRef = entity.get(TEST_SUITE_KEY);
+    Object result = Map.of("note", "No test suite is attached to this entity.");
+    if (suiteRef instanceof Map<?, ?> ref && ref.get("fullyQualifiedName") != null) {
+      String suiteFqn = ref.get("fullyQualifiedName").toString();
+      // A test suite is its own entity with its own policies, so being able to see the table it is
+      // attached to does not imply the right to read it.
+      ctx.authorizer()
+          .authorize(
+              ctx.securityContext(),
+              new OperationContext(Entity.TEST_SUITE, VIEW_ALL),
+              new ResourceContext<>(Entity.TEST_SUITE, null, suiteFqn));
+      Map<String, Object> suite =
+          JsonUtils.getMap(
+              Entity.getEntityByName(Entity.TEST_SUITE, suiteFqn, "*", Include.NON_DELETED));
+      Map<String, Object> health = new LinkedHashMap<>();
+      health.put("testSuite", suiteFqn);
+      health.put("summary", withNeverRun(suite.get("summary")));
+      // columnTestSummary counts tests per column but does not name them. The suite already has
+      // per-test names and statuses, so pass those through instead of forcing another call.
+      Object perTest = suite.get("testCaseResultSummary");
+      if (perTest instanceof List<?> list && !list.isEmpty()) {
+        health.put("tests", list);
+      }
+      result = health;
+    }
+    return result;
+  }
+
+  /**
+   * Resolves certification expiry here too, not only in search hits. This tool used to return
+   * {@code expiryDate} as epoch millis next to {@code state: "Confirmed"}, so a lapsed badge read as
+   * a live one unless the caller converted the timestamp by hand.
+   */
+  private static void resolveCertification(Map<String, Object> entity) {
+    Object certification = entity.get(CERTIFICATION_KEY);
+    if (certification != null) {
+      entity.put(
+          CERTIFICATION_KEY,
+          McpResponseTrim.slimCertification(certification, System.currentTimeMillis()));
+    }
+  }
+
+  /**
+   * Adds the bucket the raw summary cannot express: tests that exist but have never run.
+   *
+   * <p>The summary counts success/failed/aborted/queued against a total. When nothing has run, every
+   * bucket is zero while total is 13 - which reads as "13 tests, no failures, healthy" and is the
+   * opposite of the truth.
+   */
+  @VisibleForTesting
+  static Object withNeverRun(Object rawSummary) {
+    Object result = rawSummary;
+    if (rawSummary instanceof Map<?, ?> summary) {
+      Map<String, Object> annotated = new LinkedHashMap<>();
+      summary.forEach((key, value) -> annotated.put(String.valueOf(key), value));
+      // Queued does not count as executed: a queued test has produced no verdict, so counting it
+      // would let a suite that is only waiting to run report neverRun: 0. This also matches
+      // AIContextMarkdown.appendCoverageVerdict, so both tools give the same verdict.
+      int executed =
+          intOf(annotated.get("success"))
+              + intOf(annotated.get("failed"))
+              + intOf(annotated.get("aborted"));
+      int neverRun = Math.max(0, intOf(annotated.get("total")) - executed);
+      annotated.put("neverRun", neverRun);
+      if (neverRun > 0 && executed == 0) {
+        annotated.put(
+            McpResponseTrim.MESSAGE_KEY,
+            "No test has ever executed on this suite. Zero failures here means unverified, not"
+                + " healthy.");
+      }
+      result = annotated;
+    }
+    return result;
+  }
+
+  private static int intOf(Object value) {
+    return value instanceof Number number ? number.intValue() : 0;
   }
 
   /**

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetLineageTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetLineageTool.java
@@ -1,6 +1,7 @@
 package org.openmetadata.mcp.tools;
 
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+import static org.openmetadata.service.security.DefaultAuthorizer.getSubjectContext;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.annotations.VisibleForTesting;
@@ -47,6 +48,8 @@ public class GetLineageTool implements McpTool {
   // Maximum depth to prevent exponential response growth (lineage graphs can explode)
   private static final int MAX_DEPTH = 10;
   private static final String RELATIONSHIP_SQL = "sql";
+  private static final String PARAM_INCLUDE_COLUMN_LINEAGE = "includeColumnLineage";
+  private static final String PARAM_INCLUDE_SQL = "includeSql";
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   record SlimEdge(
@@ -64,6 +67,7 @@ public class GetLineageTool implements McpTool {
       Integer assetEdges,
       String sqlQuery,
       Boolean sqlTruncated,
+      Boolean hasSql,
       List<TempLineageTable> tempLineageTables,
       Long updatedAt,
       String updatedBy,
@@ -77,7 +81,10 @@ public class GetLineageTool implements McpTool {
       List<SlimEdge> upstream,
       List<SlimEdge> downstream) {}
 
-  private record SqlText(String value, Boolean truncated) {}
+  private record SqlText(String value, Boolean truncated, Boolean present) {}
+
+  /** What an edge should carry. Grouped so the slimming chain keeps a small, stable signature. */
+  record EdgeOptions(boolean includeColumnLineage, boolean includeSql) {}
 
   @Override
   public Map<String, Object> execute(
@@ -92,7 +99,10 @@ public class GetLineageTool implements McpTool {
         new ResourceContext<>(entityType));
     int upstreamDepth = clampDepth(McpParams.getInt(params, "upstreamDepth", DEFAULT_DEPTH));
     int downstreamDepth = clampDepth(McpParams.getInt(params, "downstreamDepth", DEFAULT_DEPTH));
-    boolean includeColumnLineage = McpParams.getBoolean(params, "includeColumnLineage", false);
+    EdgeOptions options =
+        new EdgeOptions(
+            McpParams.getBoolean(params, PARAM_INCLUDE_COLUMN_LINEAGE, false),
+            McpParams.getBoolean(params, PARAM_INCLUDE_SQL, false));
     LOG.info(
         "Getting lineage for entity type: {}, FQN: {}, upstreamDepth: {}, downstreamDepth: {}, "
             + "includeColumnLineage: {}",
@@ -100,10 +110,18 @@ public class GetLineageTool implements McpTool {
         fqn,
         upstreamDepth,
         downstreamDepth,
-        includeColumnLineage);
+        options.includeColumnLineage());
+    // The subject context applies the caller's domain restrictions
+    // (LineageRepository.pruneLineageByDomain); the overload without it prunes nothing.
     EntityLineage lineage =
-        Entity.getLineageRepository().getByName(entityType, fqn, upstreamDepth, downstreamDepth);
-    return enforceSizeBudget(toSlim(lineage, includeColumnLineage));
+        Entity.getLineageRepository()
+            .getByName(
+                entityType,
+                fqn,
+                upstreamDepth,
+                downstreamDepth,
+                getSubjectContext(securityContext));
+    return enforceSizeBudget(toSlim(lineage, options));
   }
 
   private static void validateParams(Map<String, Object> params) {
@@ -119,11 +137,13 @@ public class GetLineageTool implements McpTool {
 
   @VisibleForTesting
   static SlimLineage toSlim(EntityLineage lineage, boolean includeColumnLineage) {
+    return toSlim(lineage, new EdgeOptions(includeColumnLineage, true));
+  }
+
+  static SlimLineage toSlim(EntityLineage lineage, EdgeOptions options) {
     Map<UUID, EntityReference> nodeIndex = buildNodeIndex(lineage);
-    List<SlimEdge> upstream =
-        slimEdges(lineage.getUpstreamEdges(), nodeIndex, includeColumnLineage);
-    List<SlimEdge> downstream =
-        slimEdges(lineage.getDownstreamEdges(), nodeIndex, includeColumnLineage);
+    List<SlimEdge> upstream = slimEdges(lineage.getUpstreamEdges(), nodeIndex, options);
+    List<SlimEdge> downstream = slimEdges(lineage.getDownstreamEdges(), nodeIndex, options);
     EntityReference root = lineage.getEntity();
     return new SlimLineage(
         refFqn(root),
@@ -145,19 +165,19 @@ public class GetLineageTool implements McpTool {
   }
 
   private static List<SlimEdge> slimEdges(
-      List<Edge> edges, Map<UUID, EntityReference> nodeIndex, boolean includeColumnLineage) {
+      List<Edge> edges, Map<UUID, EntityReference> nodeIndex, EdgeOptions options) {
     // The repository dedups nodes but not edges: a node reachable via multiple paths has its
     // upstream/downstream edges re-added on each recursion. Identical slim edges carry no extra
     // information, so collapse them with a LinkedHashSet (record equality), preserving order.
     Set<SlimEdge> deduped = new LinkedHashSet<>();
     if (!nullOrEmpty(edges)) {
-      edges.forEach(edge -> deduped.add(buildSlimEdge(edge, nodeIndex, includeColumnLineage)));
+      edges.forEach(edge -> deduped.add(buildSlimEdge(edge, nodeIndex, options)));
     }
     return new ArrayList<>(deduped);
   }
 
   private static SlimEdge buildSlimEdge(
-      Edge edge, Map<UUID, EntityReference> nodeIndex, boolean includeColumns) {
+      Edge edge, Map<UUID, EntityReference> nodeIndex, EdgeOptions options) {
     // computeLineage adds every edge endpoint to nodes (or it is the root), so nodeIndex
     // resolves both ends. If that invariant ever breaks (a partial/cached graph), the endpoint
     // fields come back null and identical anonymous edges dedup-collapse — warn instead of
@@ -172,7 +192,7 @@ public class GetLineageTool implements McpTool {
     }
     LineageDetails details = edge.getLineageDetails();
     EntityReference pipeline = details != null ? details.getPipeline() : null;
-    SqlText sql = fullSqlQuery(details);
+    SqlText sql = sqlText(details, options.includeSql());
     return new SlimEdge(
         refFqn(from),
         refFqn(to),
@@ -188,10 +208,11 @@ public class GetLineageTool implements McpTool {
         details != null ? details.getAssetEdges() : null,
         sql.value(),
         sql.truncated(),
+        sql.present(),
         details != null ? details.getTempLineageTables() : null,
         details != null ? details.getUpdatedAt() : null,
         details != null ? details.getUpdatedBy() : null,
-        columnsLineageOf(details, includeColumns));
+        columnsLineageOf(details, options.includeColumnLineage()));
   }
 
   private static List<ColumnLineage> columnsLineageOf(
@@ -212,14 +233,20 @@ public class GetLineageTool implements McpTool {
   }
 
   /**
-   * Edge SQL is returned in full. Size is controlled by returning fewer edges (see {@link
-   * #enforceSizeBudget}), never by cutting the transformation SQL, which is exactly the metadata a
-   * lineage caller needs. The {@code sqlTruncated} marker stays in the record for wire compatibility
-   * and is always null now.
+   * Edge SQL is opt-in. On an 18-edge graph {@code sqlQuery} was ~94% of the response, so a caller
+   * asking "what feeds this table?" paid for transformation SQL to learn 18 table names.
+   *
+   * <p>When SQL is not requested the text is omitted and {@code hasSql} is set instead, so the
+   * caller still knows a transformation exists and can re-request with {@code includeSql=true}.
+   * Dropping it silently would hide that it was ever there.
+   *
+   * <p>When SQL <em>is</em> requested it is returned in full and never cut. Size is then controlled
+   * by returning fewer edges (see {@link #enforceSizeBudget}).
    */
-  private static SqlText fullSqlQuery(LineageDetails details) {
-    String sql = details != null ? details.getSqlQuery() : null;
-    return new SqlText(sql, null);
+  private static SqlText sqlText(LineageDetails details, boolean includeSql) {
+    final String sql = details != null ? details.getSqlQuery() : null;
+    final Boolean present = nullOrEmpty(sql) ? null : Boolean.TRUE;
+    return new SqlText(includeSql ? sql : null, null, present);
   }
 
   private static String refFqn(EntityReference ref) {
@@ -246,13 +273,45 @@ public class GetLineageTool implements McpTool {
    * represented, and per-direction markers tell the caller how many edges were withheld.
    */
   @VisibleForTesting
+  /**
+   * Always states whether the graph is complete.
+   *
+   * <p>"30 downstream" and "at least 30 downstream" are different answers to "what breaks if I
+   * deprecate this", and the response used to carry no signal either way. {@code get_entity_details}
+   * has flagged the analogous column case with {@code columnsTruncated} all along.
+   */
   static Map<String, Object> enforceSizeBudget(SlimLineage slim) {
+    int totalUpstream = slim.upstream() == null ? 0 : slim.upstream().size();
+    int totalDownstream = slim.downstream() == null ? 0 : slim.downstream().size();
     Map<String, Object> full = JsonUtils.getMap(slim);
     Map<String, Object> result = full;
     if (McpResponseTrim.serializedLength(full) > McpResponseTrim.MAX_RESPONSE_CHARS) {
       result = fitGraphToBudget(slim);
     }
+    annotateCompleteness(result, totalUpstream, totalDownstream);
     return result;
+  }
+
+  private static void annotateCompleteness(
+      Map<String, Object> result, int totalUpstream, int totalDownstream) {
+    int returnedUpstream = sizeOf(result.get("upstream"));
+    int returnedDownstream = sizeOf(result.get("downstream"));
+    boolean clipped = returnedUpstream < totalUpstream || returnedDownstream < totalDownstream;
+    result.put("totalEdges", totalUpstream + totalDownstream);
+    result.put("returnedEdges", returnedUpstream + returnedDownstream);
+    result.put("edgesTruncated", clipped);
+    if (clipped) {
+      result.put(
+          McpResponseTrim.MESSAGE_KEY,
+          String.format(
+              "Graph clipped to fit the response budget: %d of %d edges returned. Reduce"
+                  + " upstreamDepth/downstreamDepth for a complete graph at a shallower depth.",
+              returnedUpstream + returnedDownstream, totalUpstream + totalDownstream));
+    }
+  }
+
+  private static int sizeOf(Object edges) {
+    return edges instanceof List<?> list ? list.size() : 0;
   }
 
   private static Map<String, Object> fitGraphToBudget(SlimLineage slim) {
@@ -309,8 +368,18 @@ public class GetLineageTool implements McpTool {
    * could overwhelm LLM context. Parsing is delegated to {@link McpParams}; the valid range is
    * specific to this tool, so the clamp stays here.
    */
+  /**
+   * Zero is a meaningful request, not a mistake: it is how a caller asks for one direction only.
+   * {@code LineageRepository} honours 0, so clamping the floor to 1 here silently overrode the
+   * caller and returned the edges they asked to omit.
+   */
   private static int clampDepth(int depth) {
-    return Math.min(Math.max(depth, 1), MAX_DEPTH);
+    return Math.min(Math.max(depth, 0), MAX_DEPTH);
+  }
+
+  @VisibleForTesting
+  static int clampDepthForTest(int depth) {
+    return clampDepth(depth);
   }
 
   @Override

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/LineageTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/LineageTool.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.api.lineage.AddLineage;
 import org.openmetadata.schema.type.EntitiesEdge;
 import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
@@ -22,19 +23,8 @@ public class LineageTool implements McpTool {
       Authorizer authorizer,
       CatalogSecurityContext catalogSecurityContext,
       Map<String, Object> params) {
-    EntityReference fromEntity =
-        JsonUtils.convertValue(params.get("fromEntity"), EntityReference.class);
-    EntityReference toEntity =
-        JsonUtils.convertValue(params.get("toEntity"), EntityReference.class);
-
-    if (fromEntity == null || fromEntity.getType() == null || fromEntity.getId() == null) {
-      throw new IllegalArgumentException(
-          "Parameter 'fromEntity' is required and must include 'type' and 'id'");
-    }
-    if (toEntity == null || toEntity.getType() == null || toEntity.getId() == null) {
-      throw new IllegalArgumentException(
-          "Parameter 'toEntity' is required and must include 'type' and 'id'");
-    }
+    EntityReference fromEntity = resolveEndpoint(params.get(FROM_ENTITY), FROM_ENTITY);
+    EntityReference toEntity = resolveEndpoint(params.get(TO_ENTITY), TO_ENTITY);
 
     authorizer.authorize(
         catalogSecurityContext,
@@ -58,6 +48,50 @@ public class LineageTool implements McpTool {
     String updatedBy = catalogSecurityContext.getUserPrincipal().getName();
     Entity.getLineageRepository().addLineage(lineage, updatedBy);
     return Map.of("result", "Lineage Edge created successfully");
+  }
+
+  private static final String FROM_ENTITY = "fromEntity";
+  private static final String TO_ENTITY = "toEntity";
+  private static final String FQN = "fqn";
+  private static final String FULLY_QUALIFIED_NAME = "fullyQualifiedName";
+
+  /**
+   * Accepts an endpoint by {@code fqn} as well as by {@code id}.
+   *
+   * <p>This was the only tool addressed by UUID; every other one takes {@code (entityType, fqn)}. A
+   * caller holding a search result, which names assets by FQN, had to spend a lookup resolving an
+   * id - and that is why UUIDs could not simply be dropped from search hits. {@code fqn} is an alias
+   * for {@code fullyQualifiedName}, the name every other tool uses.
+   */
+  private static EntityReference resolveEndpoint(Object raw, String paramName) {
+    Map<String, Object> endpoint = asEndpointMap(raw, paramName);
+    String type = (String) endpoint.get("type");
+    Object fqn = endpoint.containsKey(FQN) ? endpoint.get(FQN) : endpoint.get(FULLY_QUALIFIED_NAME);
+    if (type == null || (endpoint.get("id") == null && fqn == null)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Parameter '%s' is required and must include 'type' plus either 'fqn' or 'id'."
+                  + " Prefer 'fqn' - it is what search results return.",
+              paramName));
+    }
+    EntityReference result;
+    if (endpoint.get("id") != null) {
+      endpoint.remove(FQN);
+      result = JsonUtils.convertValue(endpoint, EntityReference.class);
+    } else {
+      result = Entity.getEntityReferenceByName(type, fqn.toString(), Include.NON_DELETED);
+    }
+    return result;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> asEndpointMap(Object raw, String paramName) {
+    if (!(raw instanceof Map)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Parameter '%s' must be an object with 'type' and 'fqn' (or 'id')", paramName));
+    }
+    return new java.util.HashMap<>((Map<String, Object>) raw);
   }
 
   @Override

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/LineageTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/LineageTool.java
@@ -1,6 +1,7 @@
 package org.openmetadata.mcp.tools;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.api.lineage.AddLineage;
@@ -91,7 +92,7 @@ public class LineageTool implements McpTool {
           String.format(
               "Parameter '%s' must be an object with 'type' and 'fqn' (or 'id')", paramName));
     }
-    return new java.util.HashMap<>((Map<String, Object>) raw);
+    return new HashMap<>((Map<String, Object>) raw);
   }
 
   @Override

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/McpResponseUtils.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/McpResponseUtils.java
@@ -1,9 +1,15 @@
 package org.openmetadata.mcp.tools;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.type.ChangeDescription;
 import org.openmetadata.schema.type.EventType;
+import org.openmetadata.schema.type.FieldChange;
 import org.openmetadata.schema.utils.JsonUtils;
 
 public final class McpResponseUtils {
@@ -19,6 +25,8 @@ public final class McpResponseUtils {
           "sourceHash");
 
   private static final String CREATED = "created";
+  private static final String VERSION_KEY = "version";
+  private static final String CHANGED_KEY = "changed";
   private static final String UPDATED = "updated";
   private static final String OPERATION_KEY = "_operation";
   private static final String DELETED_KEY = "deleted";
@@ -33,5 +41,40 @@ public final class McpResponseUtils {
     }
     doc.put(OPERATION_KEY, EventType.ENTITY_CREATED.equals(changeType) ? CREATED : UPDATED);
     return doc;
+  }
+
+  /**
+   * {@link #compact} plus the two things only an update can answer: the new version, and which
+   * fields actually changed.
+   *
+   * <p>{@link #compact} strips {@code changeDescription} because it is noise on a create - nothing
+   * changed, the entity is new. On a patch it is the confirmation the caller wrote for. Only the
+   * field names are kept: the full object carries old and new values for every field, far more than
+   * "did my change land" needs.
+   */
+  public static Map<String, Object> compactPatch(EntityInterface entity, EventType changeType) {
+    Map<String, Object> doc = compact(entity, changeType);
+    doc.put(VERSION_KEY, entity.getVersion());
+    List<String> changed = changedFields(entity.getChangeDescription());
+    if (!changed.isEmpty()) {
+      doc.put(CHANGED_KEY, changed);
+    }
+    return doc;
+  }
+
+  private static List<String> changedFields(ChangeDescription change) {
+    Set<String> names = new LinkedHashSet<>();
+    if (change != null) {
+      collectNames(change.getFieldsAdded(), names);
+      collectNames(change.getFieldsUpdated(), names);
+      collectNames(change.getFieldsDeleted(), names);
+    }
+    return new ArrayList<>(names);
+  }
+
+  private static void collectNames(List<FieldChange> changes, Set<String> names) {
+    if (changes != null) {
+      changes.stream().map(FieldChange::getName).filter(Objects::nonNull).forEach(names::add);
+    }
   }
 }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/PatchEntityTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/PatchEntityTool.java
@@ -4,13 +4,17 @@ import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
+import jakarta.json.JsonException;
+import jakarta.json.JsonObject;
 import jakarta.json.JsonPatch;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
 import java.io.StringReader;
+import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.type.change.ChangeSource;
-import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.EntityRepository;
 import org.openmetadata.service.limits.Limits;
@@ -21,34 +25,153 @@ import org.openmetadata.service.security.policyevaluator.OperationContext;
 import org.openmetadata.service.security.policyevaluator.ResourceContext;
 import org.openmetadata.service.util.RestUtil;
 
+/**
+ * Applies a JSON Patch (RFC 6902) to an entity - the same document the REST PATCH API takes, passed
+ * through as written.
+ *
+ * <p>Nothing here inspects or rewrites the operations. A patch touches exactly the paths it names,
+ * which is the point of the format; this tool's job is to authorize it and hand it to the
+ * repository. The parts that are easy to get wrong - {@code /owners} replaces the whole list where
+ * {@code /owners/-} appends to it - are taught in the tool description, where the model reads them,
+ * rather than enforced by second-guessing a well-formed patch.
+ */
 @Slf4j
 public class PatchEntityTool implements McpTool {
+
+  private static final String PATCH_PARAM = "patch";
+  private static final String OP_KEY = "op";
+  private static final String PATH_KEY = "path";
+  private static final String VALUE_KEY = "value";
+  private static final String FROM_KEY = "from";
+
+  /** The members RFC 6902 requires for each operation, beyond {@code op} itself. */
+  private static final Map<String, List<String>> REQUIRED_MEMBERS =
+      Map.of(
+          "add", List.of(PATH_KEY, VALUE_KEY),
+          "replace", List.of(PATH_KEY, VALUE_KEY),
+          "test", List.of(PATH_KEY, VALUE_KEY),
+          "remove", List.of(PATH_KEY),
+          "move", List.of(PATH_KEY, FROM_KEY),
+          "copy", List.of(PATH_KEY, FROM_KEY));
+
   @Override
   public Map<String, Object> execute(
       Authorizer authorizer, CatalogSecurityContext securityContext, Map<String, Object> params) {
     String entityType = (String) params.get("entityType");
     String fqn = (String) params.get("fqn");
-    String jsonPatchString = (String) params.get("patch");
-    if (nullOrEmpty(jsonPatchString)) {
-      throw new IllegalArgumentException("Patch cannot be null or empty");
-    }
+    requireTarget(entityType, fqn);
 
-    JsonArray patchArray = Json.createReader(new StringReader(jsonPatchString)).readArray();
-    JsonPatch jsonPatch = Json.createPatch(patchArray);
+    JsonPatch jsonPatch = parsePatch((String) params.get(PATCH_PARAM));
 
-    // Validate If the User Can Perform the Patch Operation
-    OperationContext operationContext = new OperationContext(entityType, jsonPatch);
+    // The permission comes from the patch itself: the operations it carries decide which
+    // MetadataOperations are checked, exactly as the REST resource does it.
     authorizer.authorize(
-        securityContext, operationContext, new ResourceContext<>(entityType, null, fqn));
+        securityContext,
+        new OperationContext(entityType, jsonPatch),
+        new ResourceContext<>(entityType, null, fqn));
 
     EntityRepository<? extends EntityInterface> repository = Entity.getEntityRepository(entityType);
-
     String userName = securityContext.getUserPrincipal().getName();
-    String impersonatedBy = ImpersonationContext.getImpersonatedBy();
     RestUtil.PatchResponse<? extends EntityInterface> response =
-        repository.patch(null, fqn, userName, jsonPatch, ChangeSource.MANUAL, null, impersonatedBy);
+        repository.patch(
+            null,
+            fqn,
+            userName,
+            jsonPatch,
+            // AUTOMATED, not MANUAL: the write is made by an agent through MCP, not by a person
+            // editing in the UI. RecognizerFeedbackRepository draws the same line - a human review
+            // is MANUAL, anything machine-made is AUTOMATED - and the change summary is what tells
+            // a stewardship report which is which.
+            ChangeSource.AUTOMATED,
+            null,
+            ImpersonationContext.getImpersonatedBy());
     McpChangeEventUtil.publishChangeEvent(response.entity(), response.changeType(), userName);
-    return JsonUtils.convertValue(response, Map.class);
+    return McpResponseUtils.compactPatch(response.entity(), response.changeType());
+  }
+
+  private static void requireTarget(String entityType, String fqn) {
+    if (nullOrEmpty(entityType) || nullOrEmpty(fqn)) {
+      throw new IllegalArgumentException("Parameters 'entityType' and 'fqn' are required");
+    }
+  }
+
+  private static JsonPatch parsePatch(String rawPatch) {
+    if (nullOrEmpty(rawPatch)) {
+      throw new IllegalArgumentException(
+          "Parameter 'patch' is required: a JSONPatch document (RFC 6902) as a JSON array string,"
+              + " e.g. [{\"op\": \"replace\", \"path\": \"/description\", \"value\": \"...\"}].");
+    }
+    JsonArray operations = readOperations(rawPatch);
+    operations.forEach(PatchEntityTool::requireOperationShape);
+    return Json.createPatch(operations);
+  }
+
+  /**
+   * Checks that one operation has the members RFC 6902 requires for its {@code op}.
+   *
+   * <p>Structural only, deliberately. {@code Json.createPatch} validates nothing - it builds
+   * happily and fails at apply time, inside {@code repository.patch}, where an unknown {@code op}
+   * surfaces as a {@code JsonException} and a bare {@code [{"foo":"bar"}]} as a raw {@code
+   * NullPointerException}; the dispatcher reads neither as the caller's fault and answers 500 with
+   * "retrying will not help", for a document the model wrote and could correct.
+   *
+   * <p>Whether a path exists is <em>not</em> checked here. That is a question about the entity, not
+   * about the document, and the two are indistinguishable once the patch is applied: replacing
+   * {@code /description} or appending to {@code /owners/-} both fail against an object that lacks
+   * those members, and both are perfectly valid patches. The repository answers that question
+   * against the real entity.
+   */
+  private static void requireOperationShape(JsonValue operation) {
+    if (operation.getValueType() != JsonValue.ValueType.OBJECT) {
+      throw invalidPatch("every operation must be a JSON object, and this one is not");
+    }
+    JsonObject fields = operation.asJsonObject();
+    String op = memberOrNull(fields, OP_KEY);
+    if (op == null || !REQUIRED_MEMBERS.containsKey(op)) {
+      throw invalidPatch(
+          "'op' must be one of " + REQUIRED_MEMBERS.keySet() + ", and this one is " + op);
+    }
+    REQUIRED_MEMBERS.get(op).stream()
+        .filter(member -> !fields.containsKey(member))
+        .findFirst()
+        .ifPresent(
+            missing -> {
+              throw invalidPatch("a '" + op + "' operation needs a '" + missing + "' member");
+            });
+  }
+
+  private static String memberOrNull(JsonObject fields, String key) {
+    JsonValue value = fields.get(key);
+    return value != null && value.getValueType() == JsonValue.ValueType.STRING
+        ? ((JsonString) value).getString()
+        : null;
+  }
+
+  private static IllegalArgumentException invalidPatch(String reason) {
+    return new IllegalArgumentException(
+        "Parameter 'patch' is not a valid JSONPatch document: "
+            + reason
+            + ". Nothing was changed. See https://jsonpatch.com for the shape of each operation.");
+  }
+
+  /**
+   * Parses the document, reporting a syntax error as the caller's to fix.
+   *
+   * <p>The patch is an argument, so malformed JSON is a bad argument. Left to propagate, the
+   * dispatcher classifies an unrecognised exception as a server fault and tells the model its
+   * arguments were fine and not to retry - for a document the model wrote and could correct.
+   */
+  private static JsonArray readOperations(String rawPatch) {
+    try {
+      return Json.createReader(new StringReader(rawPatch)).readArray();
+    } catch (JsonException | IllegalStateException e) {
+      throw new IllegalArgumentException(
+          "Parameter 'patch' is not valid JSON: "
+              + e.getMessage()
+              + ". It must be a JSON array of operations, e.g. [{\"op\": \"add\", \"path\":"
+              + " \"/owners/-\", \"value\": {\"id\": \"<uuid>\", \"type\": \"user\"}}].",
+          e);
+    }
   }
 
   @Override

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/RootCauseAnalysisTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/RootCauseAnalysisTool.java
@@ -1,7 +1,9 @@
 package org.openmetadata.mcp.tools;
 
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.mcp.tools.SearchMetadataTool.cleanSearchResponseObject;
 import static org.openmetadata.service.search.SearchUtils.isConnectedVia;
+import static org.openmetadata.service.security.DefaultAuthorizer.getSubjectContext;
 
 import com.google.common.annotations.VisibleForTesting;
 import jakarta.ws.rs.core.Response;
@@ -22,6 +24,8 @@ import org.openmetadata.schema.api.lineage.LineageDirection;
 import org.openmetadata.schema.api.lineage.SearchLineageRequest;
 import org.openmetadata.schema.api.lineage.SearchLineageResult;
 import org.openmetadata.schema.tests.type.TestCaseResult;
+import org.openmetadata.schema.type.EntityLineage;
+import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.schema.utils.ResultList;
@@ -33,11 +37,20 @@ import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.security.auth.CatalogSecurityContext;
 import org.openmetadata.service.security.policyevaluator.OperationContext;
 import org.openmetadata.service.security.policyevaluator.ResourceContext;
+import org.openmetadata.service.security.policyevaluator.SubjectContext;
 
 @Slf4j
 public class RootCauseAnalysisTool implements McpTool {
 
   private static final int DEFAULT_DEPTH = 3;
+
+  /**
+   * The bucket ceiling {@code EntityTimeSeriesRepository.buildAggregationNodes} applies when the
+   * caller passes no limit. Mirrored here so a full page can be reported as possibly-truncated
+   * rather than asserted complete.
+   */
+  private static final int RESULT_BUCKET_CAP = 100;
+
   private static final int MAX_DEPTH = 10;
   // Slimming budgets come from McpResponseTrim so RCA's lineage-derived payload stays within
   // LLM/MCP context limits. The backend (searchDataQualityLineage / searchLineageWithDirection)
@@ -76,7 +89,8 @@ public class RootCauseAnalysisTool implements McpTool {
             downstreamDepth,
             queryFilter,
             includeDeleted,
-            includeColumns);
+            includeColumns,
+            getSubjectContext(securityContext));
     try {
       return analyze(request);
     } catch (IOException e) {
@@ -91,6 +105,11 @@ public class RootCauseAnalysisTool implements McpTool {
   }
 
   /** Bundles the parsed and validated tool arguments for a single root cause analysis run. */
+  /**
+   * {@code subject} is the caller's identity, carried so every lineage read below applies their
+   * domain restrictions ({@code LineageDomainFilter}). The overloads that omit it prune nothing, so
+   * a domain-restricted caller would see producers and impacted assets they cannot access.
+   */
   private record RcaRequest(
       String fqn,
       String entityType,
@@ -98,7 +117,8 @@ public class RootCauseAnalysisTool implements McpTool {
       int downstreamDepth,
       String queryFilter,
       boolean includeDeleted,
-      boolean includeColumns) {}
+      boolean includeColumns,
+      SubjectContext subject) {}
 
   private Map<String, Object> analyze(RcaRequest request) throws IOException {
     Map<String, Object> result = new HashMap<>();
@@ -112,45 +132,131 @@ public class RootCauseAnalysisTool implements McpTool {
                 request.fqn(),
                 request.upstreamDepth(),
                 request.queryFilter(),
-                request.includeDeleted());
+                request.includeDeleted(),
+                request.subject());
     Map<String, Object> upstreamAnalysis =
-        buildUpstreamAnalysis(upstreamResponse.getEntity(), request.includeColumns());
+        buildUpstreamAnalysis(upstreamResponse.getEntity(), request);
     result.put("upstreamAnalysis", upstreamAnalysis);
 
     int failureCount =
         ((Number) upstreamAnalysis.getOrDefault("failingUpstreamNodesCount", 0)).intValue();
-    boolean hasFailures = failureCount > 0;
+    boolean rootFails = Boolean.TRUE.equals(upstreamAnalysis.get(ROOT_HAS_FAILING_TESTS));
+    boolean hasFailures = failureCount > 0 || rootFails;
     result.put(
         "downstreamAnalysis",
         hasFailures ? buildDownstreamAnalysis(request) : noFailuresDownstream());
     result.put("status", hasFailures ? "failed" : "success");
-    result.put(
-        "summary",
-        String.format(
-            "Analyzed upstream causes and downstream impacts for '%s'. Found %d upstream failure(s).",
-            request.fqn(), failureCount));
+    result.put("summary", summarize(request.fqn(), failureCount, rootFails));
     return enforceSizeBudget(result);
   }
 
-  private Map<String, Object> buildUpstreamAnalysis(Object upstreamEntity, boolean includeColumns) {
+  /**
+   * Distinguishes "the failures start here" from "the failures are inherited from upstream".
+   *
+   * <p>The DQ lineage walk includes the analysed entity among its own nodes when that entity has
+   * failing tests, so counting nodes reported an upstream failure that did not exist.
+   */
+  @VisibleForTesting
+  static String summarize(String fqn, int upstreamFailures, boolean rootFails) {
+    final String origin;
+    if (upstreamFailures > 0) {
+      origin =
+          String.format(
+              "Found %d failing upstream entity(ies) — the likely root cause is upstream.",
+              upstreamFailures);
+    } else if (rootFails) {
+      origin =
+          "No upstream entity has failing tests, so the failures originate on this asset itself.";
+    } else {
+      origin = "No failing tests found on this asset or upstream of it.";
+    }
+    return String.format(
+        "Analyzed upstream causes and downstream impacts for '%s'. %s", fqn, origin);
+  }
+
+  private Map<String, Object> buildUpstreamAnalysis(Object upstreamEntity, RcaRequest request) {
     Map<String, Object> upstreamAnalysis = new HashMap<>();
     if (!(upstreamEntity instanceof Map)) {
       return upstreamAnalysis;
     }
     Map<String, Object> upstreamLineageData = castMap(upstreamEntity);
     Set<?> rawEdges = asSet(upstreamLineageData.get("edges"));
-    List<Map<String, Object>> nodes = slimUpstreamNodes(asSet(upstreamLineageData.get("nodes")));
+    List<Map<String, Object>> allNodes = slimUpstreamNodes(asSet(upstreamLineageData.get("nodes")));
+    List<Map<String, Object>> nodes = new ArrayList<>();
+    Map<String, Object> rootNode = null;
+    for (Map<String, Object> node : allNodes) {
+      if (request.fqn().equals(node.get("fullyQualifiedName"))) {
+        rootNode = node;
+      } else {
+        nodes.add(node);
+      }
+    }
+    boolean rootFails = rootNode != null;
 
+    upstreamAnalysis.put(ROOT_HAS_FAILING_TESTS, rootFails);
+    // Knowing that the root is failing without knowing which tests failed costs another search.
+    // The same helper already resolves this for upstream nodes; the root was just excluded.
+    if (rootFails) {
+      Map<String, Object> rootTests = addTestCaseResultForTestSuite(rootNode);
+      // A list with no total reads as possibly-trimmed, especially next to this tool's own notice
+      // that node and edge details are cut for context. Say whether it is the full set.
+      Object results = rootTests.get("testCaseResults");
+      if (results instanceof List<?> list) {
+        annotateCompleteness(rootTests, list.size());
+      }
+      upstreamAnalysis.put("rootFailingTests", rootTests);
+    }
     upstreamAnalysis.put("failingUpstreamNodesCount", nodes.size());
     if (!nodes.isEmpty()) {
       nodes.forEach(node -> node.put("failingTestCases", addTestCaseResultForTestSuite(node)));
       upstreamAnalysis.put("failingUpstreamNodes", nodes);
     }
     upstreamAnalysis.put("failingUpstreamEdgesCount", rawEdges.size());
-    upstreamAnalysis.put("failingUpstreamEdges", slimEdges(rawEdges, includeColumns));
+    upstreamAnalysis.put("failingUpstreamEdges", slimEdges(rawEdges, request.includeColumns()));
     upstreamAnalysis.put(
         "description", "Upstream entities that may be causing data quality failures");
+    if (nodes.isEmpty()) {
+      addUpstreamProducers(upstreamAnalysis, request);
+    }
     return upstreamAnalysis;
+  }
+
+  /**
+   * When nothing upstream is failing, the DQ walk returns no upstream edges at all - so a caller
+   * asking "what could be causing this?" learns nothing about what feeds the asset. The producers
+   * are cheap to resolve in-process, so attach them here instead of costing another call.
+   */
+  private static void addUpstreamProducers(
+      Map<String, Object> upstreamAnalysis, RcaRequest request) {
+    try {
+      EntityLineage lineage =
+          Entity.getLineageRepository()
+              .getByName(
+                  request.entityType(),
+                  request.fqn(),
+                  request.upstreamDepth(),
+                  0,
+                  request.subject());
+      List<Map<String, Object>> producers = new ArrayList<>();
+      if (lineage != null && !nullOrEmpty(lineage.getNodes())) {
+        lineage.getNodes().forEach(node -> producers.add(producerOf(node)));
+      }
+      upstreamAnalysis.put("upstreamProducers", producers);
+      upstreamAnalysis.put(
+          "upstreamProducersNote",
+          "No upstream entity has failing tests. These are the assets that feed this one, so the"
+              + " cause is more likely to be local (a load, a transformation) than inherited.");
+    } catch (Exception e) {
+      // Producers are context, not the answer: a lineage lookup failure must not fail the analysis.
+      LOG.warn("Could not resolve upstream producers for {}: {}", request.fqn(), e.getMessage());
+    }
+  }
+
+  private static Map<String, Object> producerOf(EntityReference node) {
+    Map<String, Object> producer = new LinkedHashMap<>();
+    producer.put("fullyQualifiedName", node.getFullyQualifiedName());
+    producer.put("type", node.getType());
+    return producer;
   }
 
   private Map<String, Object> buildDownstreamAnalysis(RcaRequest request) {
@@ -168,7 +274,8 @@ public class RootCauseAnalysisTool implements McpTool {
               .withIsConnectedVia(isConnectedVia(request.entityType()))
               .withIncludeDeleted(request.includeDeleted());
       SearchLineageResult downstreamResult =
-          Entity.getSearchRepository().searchLineageWithDirection(downstreamRequest);
+          Entity.getSearchRepository()
+              .searchLineageWithDirection(downstreamRequest, request.subject());
       addDownstreamNodes(downstreamAnalysis, downstreamResult);
       addDownstreamEdges(downstreamAnalysis, downstreamResult, request.includeColumns());
     } catch (Exception e) {
@@ -182,7 +289,10 @@ public class RootCauseAnalysisTool implements McpTool {
   private static void addDownstreamNodes(
       Map<String, Object> downstreamAnalysis, SearchLineageResult result) {
     if (result.getNodes() != null) {
-      downstreamAnalysis.put("downstreamImpactedNodesCount", result.getNodes().size());
+      // The traversal includes the analysed asset itself at nodeDepth 0, so counting it would
+      // overstate the blast radius by one on every call.
+      downstreamAnalysis.put(
+          "downstreamImpactedNodesCount", Math.max(0, result.getNodes().size() - 1));
       downstreamAnalysis.put("downstreamNodes", slimDownstreamNodes(result.getNodes()));
     }
   }
@@ -226,11 +336,23 @@ public class RootCauseAnalysisTool implements McpTool {
     if (info != null) {
       Object entity = info.get("entity");
       if (entity instanceof Map) {
-        slim.put("entity", slimNodeEntity(castMap(entity)));
+        slim.put("entity", withoutBulkFields(slimNodeEntity(castMap(entity))));
       }
       putIfPresent(slim, "nodeDepth", info.get("nodeDepth"));
     }
     return slim;
+  }
+
+  /**
+   * Strips the per-node bulk that impact analysis never reads.
+   *
+   * <p>A single downstream node can carry its column names twice over - once as {@code columnNames},
+   * again inside {@code aiContext} - which dominated the response. A downstream node answers "what
+   * else breaks", so it needs identity only: FQN, name, type, owners, tier.
+   */
+  private static Map<String, Object> withoutBulkFields(Map<String, Object> entity) {
+    NODE_BULK_FIELDS.forEach(entity::remove);
+    return entity;
   }
 
   /**
@@ -325,7 +447,11 @@ public class RootCauseAnalysisTool implements McpTool {
     }
   }
 
+  private static final Set<String> NODE_BULK_FIELDS =
+      Set.of("aiContext", "columnNames", "columns", "schemaDefinition", "sampleData", "profile");
+
   private static final String UPSTREAM_ANALYSIS = "upstreamAnalysis";
+  private static final String ROOT_HAS_FAILING_TESTS = "rootHasFailingTests";
   private static final String DOWNSTREAM_ANALYSIS = "downstreamAnalysis";
   private static final String UPSTREAM_EDGES = "failingUpstreamEdges";
   private static final String DOWNSTREAM_EDGES = "downstreamEdges";
@@ -469,13 +595,26 @@ public class RootCauseAnalysisTool implements McpTool {
     return hint;
   }
 
+  /**
+   * Failing tests for one node's suite, and - when it could not answer - why.
+   *
+   * <p>An empty map used to mean three different things: no suite attached, the backend threw, or no
+   * failing tests. Next to a {@code status: "failed"} verdict those are opposite meanings.
+   */
   private Map<String, Object> addTestCaseResultForTestSuite(Map<String, Object> node) {
     Map<String, Object> testCaseResult = new HashMap<>();
     Map<String, Object> testSuiteMap = JsonUtils.getMap(node.get("testSuite"));
-    if (testSuiteMap == null || testSuiteMap.get("id") == null) {
-      return testCaseResult;
+    String testSuiteId = testSuiteMap == null ? null : (String) testSuiteMap.get("id");
+    if (testSuiteId == null) {
+      testCaseResult.put(
+          "note", "No test suite is attached to this asset, so no test results could be read.");
+    } else {
+      readFailingTests(testSuiteId, testCaseResult);
     }
-    String testSuiteId = (String) testSuiteMap.get("id");
+    return testCaseResult;
+  }
+
+  private void readFailingTests(String testSuiteId, Map<String, Object> testCaseResult) {
     SearchListFilter searchListFilter = new SearchListFilter();
     searchListFilter.addQueryParam("testCaseStatus", "Failed");
     searchListFilter.addQueryParam("testSuiteId", testSuiteId);
@@ -500,8 +639,35 @@ public class RootCauseAnalysisTool implements McpTool {
       }
     } catch (IOException e) {
       LOG.error("Failed to fetch test case results for test suite: {}", testSuiteId, e);
+      testCaseResult.put(
+          "unavailable",
+          "The test-result backend could not be reached, so which tests are failing here is"
+              + " unknown. This is not the same as none failing.");
     }
-    return testCaseResult;
+  }
+
+  /**
+   * States how many tests are failing and whether that is all of them.
+   *
+   * <p>{@code complete} was hardcoded true, which the lookup cannot back: it passes no limit, so
+   * {@code EntityTimeSeriesRepository} caps the aggregation at {@link #RESULT_BUCKET_CAP} buckets
+   * and a bigger suite is silently truncated. Landing exactly on the cap is the one case where
+   * completeness is unknowable, so say so.
+   */
+  @VisibleForTesting
+  static void annotateCompleteness(Map<String, Object> tests, int failingCount) {
+    boolean atCap = failingCount >= RESULT_BUCKET_CAP;
+    tests.put("failingTestCount", failingCount);
+    tests.put("complete", !atCap);
+    if (atCap) {
+      tests.put(
+          "completeNote",
+          String.format(
+              "The test-result lookup returns at most %d tests, and that many came back, so more may"
+                  + " be failing. Use search_metadata with entityType='testCase' and a filter on"
+                  + " originEntityFQN for the full set.",
+              RESULT_BUCKET_CAP));
+    }
   }
 
   private static int clampDepth(int depth) {

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
@@ -4,6 +4,7 @@ import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.service.security.DefaultAuthorizer.getSubjectContext;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import jakarta.ws.rs.core.Response;
@@ -14,9 +15,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.mcp.util.McpParams;
 import org.openmetadata.mcp.util.McpResponseTrim;
 import org.openmetadata.mcp.util.PageCursor;
 import org.openmetadata.mcp.util.ResponseBudget;
@@ -33,6 +36,18 @@ public class SearchMetadataTool implements McpTool {
 
   private static final int DEFAULT_MAX_AGGREGATION_BUCKETS = 10;
   private static final int MAX_ALLOWED_AGGREGATION_BUCKETS = 50;
+
+  private static final Set<String> REFERENCE_FIELDS =
+      Set.of("service", "database", "databaseSchema");
+  private static final Set<String> REFERENCE_LIST_FIELDS = Set.of("owners", "domains");
+  private static final Set<String> TAG_FIELDS = Set.of("tier", "tags");
+  private static final String CERTIFICATION_FIELD = "certification";
+  private static final Set<String> BULK_FIELDS =
+      Set.of("columns", "columnNames", "charts", "tasks");
+  private static final int MAX_BULK_ITEMS = 60;
+  private static final String DESCRIPTION_TRUNCATED_KEY = "descriptionTruncated";
+  private static final String TEST_CASE_ENTITY = "testCase";
+  private static final String NEVER_RUN_KEY = "neverRun";
 
   private static final List<String> ESSENTIAL_FIELDS_ONLY =
       List.of(
@@ -186,6 +201,8 @@ public class SearchMetadataTool implements McpTool {
       }
     }
 
+    Set<String> excludedTypes =
+        new java.util.HashSet<>(McpParams.getStringList(params, "excludeEntityTypes"));
     List<String> requestedFields = new ArrayList<>();
     String fieldsParam = stringParam(params, "fields", null);
     if (fieldsParam != null && !fieldsParam.trim().isEmpty()) {
@@ -209,13 +226,20 @@ public class SearchMetadataTool implements McpTool {
 
       if (!queryNode.has("query")) {
         ObjectNode queryWrapper = JsonUtils.getObjectMapper().createObjectNode();
-        queryWrapper.set("query", queryNode);
+        queryWrapper.set("query", excludeTypesFrom(queryNode, excludedTypes));
         queryFilter = JsonUtils.pojoToJson(queryWrapper);
       } else {
-        queryFilter = JsonUtils.pojoToJson(queryNode);
+        ObjectNode wrapped = (ObjectNode) queryNode;
+        wrapped.set("query", excludeTypesFrom(wrapped.get("query"), excludedTypes));
+        queryFilter = JsonUtils.pojoToJson(wrapped);
       }
       LOG.debug("Applied query filter to query: {}", queryFilter);
     }
+
+    // With no caller-supplied queryFilter there is nothing to fold the exclusion into, so build a
+    // filter carrying only the exclusion. The standard search path ANDs it with the text query
+    // (OpenSearchSearchManager.applyQueryFilter), so the engine applies it and the page backfills.
+    String exclusionFilter = queryFilter == null ? excludeOnlyFilter(excludedTypes) : null;
 
     LOG.info(
         "Search query: {}, index: {}, limit: {}, includeDeleted: {}",
@@ -242,6 +266,7 @@ public class SearchMetadataTool implements McpTool {
           new SearchRequest()
               .withQuery(query)
               .withIndex(Entity.getSearchRepository().getIndexOrAliasName(index))
+              .withQueryFilter(exclusionFilter)
               .withSize(size)
               .withFrom(from)
               .withFetchSource(true)
@@ -268,14 +293,46 @@ public class SearchMetadataTool implements McpTool {
       searchResponse = JsonUtils.convertValue(response.getEntity(), Map.class);
     }
 
-    return buildEnhancedSearchResponse(
-        searchResponse,
-        query,
-        size,
-        from,
-        requestedFields,
-        includeAggregations,
-        maxAggregationBuckets);
+    Map<String, Object> enhanced =
+        buildEnhancedSearchResponse(
+            searchResponse,
+            query,
+            size,
+            from,
+            requestedFields,
+            includeAggregations,
+            maxAggregationBuckets);
+    return dropExcludedTypes(enhanced, excludedTypes);
+  }
+
+  /**
+   * Backstop removal of excluded hits. The real exclusion happens in {@link #excludeTypesFrom}.
+   *
+   * <p>Post-filtering alone is not enough: it strips hits from a page already fetched, so a page
+   * that happened to be all columns came back empty - which reads as "no such assets exist" when
+   * hundreds do.
+   */
+  private static Map<String, Object> dropExcludedTypes(
+      Map<String, Object> response, Set<String> excluded) {
+    if (!excluded.isEmpty() && response.get("results") instanceof List<?> results) {
+      List<Object> kept =
+          results.stream()
+              .filter(hit -> !isExcluded(hit, excluded))
+              .collect(Collectors.toCollection(ArrayList::new));
+      int removed = results.size() - kept.size();
+      response.put("results", kept);
+      response.put("returnedCount", kept.size());
+      if (removed > 0) {
+        response.put("excludedByType", removed);
+      }
+    }
+    return response;
+  }
+
+  private static boolean isExcluded(Object hit, Set<String> excluded) {
+    Map<String, Object> map = safeGetMap(hit);
+    Object type = map == null ? null : map.get("entityType");
+    return type != null && excluded.contains(type.toString());
   }
 
   @Override
@@ -337,6 +394,7 @@ public class SearchMetadataTool implements McpTool {
         totalResults = ((Number) topHits.get("total")).intValue();
       }
 
+      boolean scoresVary = scoresDiscriminate(hits);
       for (Object hitObj : hits) {
         Map<String, Object> hit = safeGetMap(hitObj);
         if (hit == null) continue;
@@ -345,7 +403,10 @@ public class SearchMetadataTool implements McpTool {
         if (source == null) continue;
 
         Map<String, Object> cleanedSource = cleanSearchResult(source, requestedFields);
-        if (hit.containsKey("_score")) {
+        // A pure queryFilter lookup runs no scoring query, so every hit carries the same constant
+        // _score. Publishing that as "similarityScore" presents a filter match as a ranking, so
+        // emit it only when the scores actually differ.
+        if (hit.containsKey("_score") && scoresVary) {
           cleanedSource.put("similarityScore", hit.get("_score"));
         }
         cleanedResults.add(cleanedSource);
@@ -463,24 +524,50 @@ public class SearchMetadataTool implements McpTool {
     // Always include essential fields
     for (String field : ESSENTIAL_FIELDS_ONLY) {
       if (source.containsKey(field)) {
-        result.put(field, source.get(field));
+        result.put(field, slimField(field, source.get(field)));
       }
     }
 
-    // Add any specifically requested additional fields
+    // Slim requested fields too: `fields=certification` used to bypass slimField and return the
+    // whole nested label, with expiry as epoch millis, on every hit.
     for (String field : requestedFields) {
       if (source.containsKey(field)) {
-        result.put(field, source.get(field));
+        result.put(field, capBulkField(field, slimField(field, source.get(field)), result));
       }
     }
 
     addSlimTestCaseResult(source, result);
 
-    // Truncate long descriptions to optimize LLM context usage
+    // Truncate long descriptions, and say so. A silent cut is worse than a short field: the caller
+    // reads it as the complete text. Columns were already flagged this way; descriptions were not.
     if (result.get("description") instanceof String description) {
-      result.put("description", McpResponseTrim.truncateDescription(description));
+      String trimmed = McpResponseTrim.truncateDescription(description);
+      result.put("description", trimmed);
+      if (trimmed.length() < description.length()) {
+        result.put(DESCRIPTION_TRUNCATED_KEY, Boolean.TRUE);
+      }
     }
+    markNeverRunTestCase(result);
     return result;
+  }
+
+  /**
+   * Distinguishes a test that has never executed from a field that was simply not returned.
+   *
+   * <p>{@code testCaseStatus} is accurate once a test has run, so its absence is genuine - but
+   * absence alone is ambiguous, and callers spent extra calls just to learn that "no status" meant
+   * "never ran".
+   *
+   * <p>Reported as a separate {@code neverRun} flag, not as a {@code testCaseStatus} value:
+   * {@code testCaseStatus} is a closed schema enum (Success, Failed, Aborted, Queued) with a
+   * generated parser behind it, so writing {@code "NeverRun"} into it invents a value that exists
+   * nowhere in OpenMetadata and throws in any client that parses the field.
+   */
+  private static void markNeverRunTestCase(Map<String, Object> result) {
+    boolean isTestCase = TEST_CASE_ENTITY.equals(result.get("entityType"));
+    if (isTestCase && result.get("testCaseStatus") == null) {
+      result.put(NEVER_RUN_KEY, Boolean.TRUE);
+    }
   }
 
   private static void addSlimTestCaseResult(
@@ -510,6 +597,106 @@ public class SearchMetadataTool implements McpTool {
   }
 
   @SuppressWarnings("unused")
+  /**
+   * Entity references and tag labels are collapsed to the identifier a caller can act on.
+   *
+   * <p>{@code tier}, {@code service}, {@code database} and {@code databaseSchema} each repeat a full
+   * descriptor on every hit, which on a 10-hit response was most of the payload. Every MCP tool is
+   * addressed by {@code (entityType, fqn)}, so the FQN is the actionable part.
+   */
+  /**
+   * Caps a hydrated bulk field on a search hit.
+   *
+   * <p>{@code fields=columns} hydrates every column with its full description, so one wide table can
+   * dominate a page. A search hit exists to be chosen between; {@code get_entity_details} is where
+   * the full detail lives.
+   */
+  /** True when hit scores vary, i.e. something actually ranked them. */
+  /**
+   * Wraps a query so excluded entity types never match, letting the engine backfill the page.
+   *
+   * <p>{@code tableColumn} documents sit inside the default {@code dataAsset} scope, so a broad
+   * sweep can return mostly columns inheriting their parent's tags or certification.
+   */
+  /**
+   * A queryFilter whose only job is to exclude entity types, for the path where the caller supplied
+   * no filter of their own. Null when there is nothing to exclude, so the request is unchanged.
+   */
+  @VisibleForTesting
+  static String excludeOnlyFilter(Set<String> excluded) {
+    String filter = null;
+    if (!excluded.isEmpty()) {
+      ObjectNode wrapper = JsonUtils.getObjectMapper().createObjectNode();
+      wrapper.set("query", excludeTypesFrom(null, excluded));
+      filter = JsonUtils.pojoToJson(wrapper);
+    }
+    return filter;
+  }
+
+  private static JsonNode excludeTypesFrom(JsonNode query, Set<String> excluded) {
+    JsonNode result = query;
+    if (!excluded.isEmpty()) {
+      ObjectNode bool = JsonUtils.getObjectMapper().createObjectNode();
+      ObjectNode inner = bool.putObject("bool");
+      // A null query means there is nothing to exclude *from* - the caller supplied no filter - so
+      // the bool carries must_not alone and matches everything else.
+      if (query != null) {
+        inner.set("must", query);
+      }
+      ArrayNode mustNot = inner.putArray("must_not");
+      for (String type : excluded) {
+        mustNot.addObject().putObject("term").put("entityType", type);
+      }
+      result = bool;
+    }
+    return result;
+  }
+
+  private static boolean scoresDiscriminate(List<?> hits) {
+    Object first = null;
+    boolean varies = false;
+    for (Object hitObj : hits) {
+      Map<String, Object> hit = safeGetMap(hitObj);
+      Object score = hit == null ? null : hit.get("_score");
+      if (score == null) {
+        continue;
+      }
+      if (first == null) {
+        first = score;
+      } else if (!first.equals(score)) {
+        varies = true;
+        break;
+      }
+    }
+    return varies;
+  }
+
+  private static Object capBulkField(String field, Object value, Map<String, Object> result) {
+    Object capped = value;
+    if (BULK_FIELDS.contains(field)
+        && value instanceof List<?> items
+        && items.size() > MAX_BULK_ITEMS) {
+      capped = new ArrayList<>(items.subList(0, MAX_BULK_ITEMS));
+      result.put(field + "Total", items.size());
+      result.put(field + "Truncated", Boolean.TRUE);
+    }
+    return capped;
+  }
+
+  private static Object slimField(String field, Object value) {
+    Object result = value;
+    if (REFERENCE_FIELDS.contains(field)) {
+      result = McpResponseTrim.slimRef(value);
+    } else if (REFERENCE_LIST_FIELDS.contains(field)) {
+      result = McpResponseTrim.slimRefs(value);
+    } else if (TAG_FIELDS.contains(field)) {
+      result = McpResponseTrim.slimTag(value);
+    } else if (CERTIFICATION_FIELD.equals(field)) {
+      result = McpResponseTrim.slimCertification(value, System.currentTimeMillis());
+    }
+    return result;
+  }
+
   public static Map<String, Object> cleanSearchResponseObject(Map<String, Object> object) {
     DETAILED_EXCLUDE_KEYS.forEach(object::remove);
     return object;

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
@@ -596,28 +596,6 @@ public class SearchMetadataTool implements McpTool {
     return result;
   }
 
-  @SuppressWarnings("unused")
-  /**
-   * Entity references and tag labels are collapsed to the identifier a caller can act on.
-   *
-   * <p>{@code tier}, {@code service}, {@code database} and {@code databaseSchema} each repeat a full
-   * descriptor on every hit, which on a 10-hit response was most of the payload. Every MCP tool is
-   * addressed by {@code (entityType, fqn)}, so the FQN is the actionable part.
-   */
-  /**
-   * Caps a hydrated bulk field on a search hit.
-   *
-   * <p>{@code fields=columns} hydrates every column with its full description, so one wide table can
-   * dominate a page. A search hit exists to be chosen between; {@code get_entity_details} is where
-   * the full detail lives.
-   */
-  /** True when hit scores vary, i.e. something actually ranked them. */
-  /**
-   * Wraps a query so excluded entity types never match, letting the engine backfill the page.
-   *
-   * <p>{@code tableColumn} documents sit inside the default {@code dataAsset} scope, so a broad
-   * sweep can return mostly columns inheriting their parent's tags or certification.
-   */
   /**
    * A queryFilter whose only job is to exclude entity types, for the path where the caller supplied
    * no filter of their own. Null when there is nothing to exclude, so the request is unchanged.
@@ -633,6 +611,12 @@ public class SearchMetadataTool implements McpTool {
     return filter;
   }
 
+  /**
+   * Wraps a query so excluded entity types never match, letting the engine backfill the page.
+   *
+   * <p>{@code tableColumn} documents sit inside the default {@code dataAsset} scope, so a broad
+   * sweep can return mostly columns inheriting their parent's tags or certification.
+   */
   private static JsonNode excludeTypesFrom(JsonNode query, Set<String> excluded) {
     JsonNode result = query;
     if (!excluded.isEmpty()) {
@@ -652,6 +636,7 @@ public class SearchMetadataTool implements McpTool {
     return result;
   }
 
+  /** True when hit scores vary, i.e. something actually ranked them. */
   private static boolean scoresDiscriminate(List<?> hits) {
     Object first = null;
     boolean varies = false;
@@ -671,6 +656,13 @@ public class SearchMetadataTool implements McpTool {
     return varies;
   }
 
+  /**
+   * Caps a hydrated bulk field on a search hit.
+   *
+   * <p>{@code fields=columns} hydrates every column with its full description, so one wide table can
+   * dominate a page. A search hit exists to be chosen between; {@code get_entity_details} is where
+   * the full detail lives.
+   */
   private static Object capBulkField(String field, Object value, Map<String, Object> result) {
     Object capped = value;
     if (BULK_FIELDS.contains(field)
@@ -683,6 +675,13 @@ public class SearchMetadataTool implements McpTool {
     return capped;
   }
 
+  /**
+   * Entity references and tag labels are collapsed to the identifier a caller can act on.
+   *
+   * <p>{@code tier}, {@code service}, {@code database} and {@code databaseSchema} each repeat a full
+   * descriptor on every hit, which on a 10-hit response was most of the payload. Every MCP tool is
+   * addressed by {@code (entityType, fqn)}, so the FQN is the actionable part.
+   */
   private static Object slimField(String field, Object value) {
     Object result = value;
     if (REFERENCE_FIELDS.contains(field)) {

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SemanticSearchTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SemanticSearchTool.java
@@ -1,5 +1,6 @@
 package org.openmetadata.mcp.tools;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -7,6 +8,8 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.UnaryOperator;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.mcp.util.McpParams;
 import org.openmetadata.mcp.util.McpResponseTrim;
@@ -62,6 +65,8 @@ public class SemanticSearchTool implements McpTool {
   /** Read-side ceiling on the metric expression a summary carries. */
   private static final int MAX_METRIC_CODE_CHARS = 1000;
 
+  private static final int MAX_COLUMN_NAMES = 60;
+
   @Override
   public Map<String, Object> execute(
       Authorizer authorizer, CatalogSecurityContext securityContext, Map<String, Object> params)
@@ -105,7 +110,7 @@ public class SemanticSearchTool implements McpTool {
       return buildResponse(query, response, size, from);
     } catch (Exception e) {
       LOG.error("Semantic search failed: {}", e.getMessage(), e);
-      return errorResponse("Semantic search failed: " + McpResponseTrim.safeMessage(e));
+      return errorResponse(failureMessage(e));
     }
   }
 
@@ -186,7 +191,6 @@ public class SemanticSearchTool implements McpTool {
 
     result.put("results", cleanedResults);
     result.put("returnedCount", cleanedResults.size());
-    result.put("totalFound", cleanedResults.size());
     result.put(
         "usage",
         "To get full details for any result, call get_entity_details with the result's exact 'entityType' and 'fullyQualifiedName' values.");
@@ -201,7 +205,32 @@ public class SemanticSearchTool implements McpTool {
         response,
         "Showing %d results. Pass 'nextCursor' to fetch the next page, or refine your query. "
             + "Adjust 'threshold' to filter by similarity score.");
+    addParentTotal(result, from);
     return result;
+  }
+
+  /**
+   * Publishes {@code totalFound} in the same unit as everything else here: entities.
+   *
+   * <p>{@code VectorSearchResponse.totalHits} counts chunks, not entities - the vector service
+   * indexes several chunks per entity - while {@code results}, {@code returnedCount}, {@code size},
+   * {@code from} and {@code nextCursor} all count parents. Reporting it made eight matching tables
+   * read as {@code totalFound: 96}.
+   *
+   * <p>So report what is known: once paging stops, {@code from + returnedCount} is exact. While it
+   * continues, the same figure is a lower bound and is labelled as one.
+   */
+  @VisibleForTesting
+  static void addParentTotal(Map<String, Object> result, int from) {
+    int returned = result.get("returnedCount") instanceof Number number ? number.intValue() : 0;
+    result.put("totalFound", from + returned);
+    if (Boolean.TRUE.equals(result.get(McpResponseTrim.HAS_MORE_KEY))) {
+      result.put("totalFoundIsLowerBound", Boolean.TRUE);
+      result.put(
+          "totalFoundNote",
+          "'totalFound' counts the entities seen so far, not the whole corpus - more exist. Page"
+              + " with 'nextCursor' until 'hasMore' is absent to get the exact count.");
+    }
   }
 
   /**
@@ -277,15 +306,19 @@ public class SemanticSearchTool implements McpTool {
     copyIfPresent(hit, cleaned, "name");
     copyIfPresent(hit, cleaned, "displayName");
     copyIfPresent(hit, cleaned, "serviceType");
-    copyIfPresent(hit, cleaned, "service");
-    copyIfPresent(hit, cleaned, "database");
-    copyIfPresent(hit, cleaned, "databaseSchema");
-    copyIfPresent(hit, cleaned, "owners");
-    copyIfPresent(hit, cleaned, "tier");
-    copyIfPresent(hit, cleaned, "tags");
-    copyIfPresent(hit, cleaned, "domains");
-    copyIfPresent(hit, cleaned, "columns");
-    copyIfPresent(hit, cleaned, "certification");
+    copySlim(hit, cleaned, "service", McpResponseTrim::slimRef);
+    copySlim(hit, cleaned, "database", McpResponseTrim::slimRef);
+    copySlim(hit, cleaned, "databaseSchema", McpResponseTrim::slimRef);
+    copySlim(hit, cleaned, "owners", McpResponseTrim::slimRefs);
+    copySlim(hit, cleaned, "domains", McpResponseTrim::slimRefs);
+    copySlim(hit, cleaned, "tier", McpResponseTrim::slimTag);
+    copySlim(hit, cleaned, "tags", McpResponseTrim::slimTag);
+    copyColumnNames(hit, cleaned);
+    copySlim(
+        hit,
+        cleaned,
+        "certification",
+        value -> McpResponseTrim.slimCertification(value, System.currentTimeMillis()));
     // Metric facts: a metric summary without its expression, granularity, type and unit cannot be
     // told apart from a similarly named metric, which forced a per-result get_entity_details call.
     copyMetricExpression(hit, cleaned);
@@ -342,6 +375,54 @@ public class SemanticSearchTool implements McpTool {
     }
   }
 
+  /** Copies a field through a slimming function, skipping absent fields. */
+  private void copySlim(
+      Map<String, Object> hit,
+      Map<String, Object> cleaned,
+      String field,
+      UnaryOperator<Object> slim) {
+    Object value = hit.get(field);
+    if (value != null) {
+      cleaned.put(field, slim.apply(value));
+    }
+  }
+
+  /**
+   * Emits column <em>names</em> rather than full column objects, matching {@code search_metadata}.
+   * Full {@code columns} was most of a 10-hit response - per-column descriptions that do not help
+   * choose between assets. Names still answer "does this table have a customer_id column?", and
+   * {@code get_entity_details} stays the way to get the detail.
+   */
+  private void copyColumnNames(Map<String, Object> hit, Map<String, Object> cleaned) {
+    if (hit.get("columns") instanceof List<?> columns && !columns.isEmpty()) {
+      List<Object> names =
+          columns.stream()
+              .map(column -> column instanceof Map<?, ?> map ? map.get("name") : column)
+              .filter(Objects::nonNull)
+              .toList();
+      if (!names.isEmpty()) {
+        putCappedColumnNames(cleaned, names);
+      }
+    }
+  }
+
+  /**
+   * Caps the column-name list on a search hit.
+   *
+   * <p>One hit carrying ~1000 generated names pushed a response past the client's display budget and
+   * cost the caller most of its results. Nobody picks an asset by its 900th column, so cap the list
+   * and say when it was cut.
+   */
+  private static void putCappedColumnNames(Map<String, Object> cleaned, List<Object> names) {
+    if (names.size() <= MAX_COLUMN_NAMES) {
+      cleaned.put("columnNames", names);
+    } else {
+      cleaned.put("columnNames", names.subList(0, MAX_COLUMN_NAMES));
+      cleaned.put("totalColumns", names.size());
+      cleaned.put("columnNamesTruncated", Boolean.TRUE);
+    }
+  }
+
   private void copyIfPresent(Map<String, Object> source, Map<String, Object> target, String key) {
     if (source.containsKey(key)) {
       target.put(key, source.get(key));
@@ -386,6 +467,24 @@ public class SemanticSearchTool implements McpTool {
     }
 
     return Collections.emptyMap();
+  }
+
+  /**
+   * Describes a failure as what it actually was.
+   *
+   * <p>This used to hardcode {@code serverFault = true} and tell every caller to stop using the
+   * tool, so a bad {@code filters} value or an unparseable cursor was reported as a backend outage -
+   * telling the caller its arguments were fine when they were the problem.
+   */
+  private static String failureMessage(Exception e) {
+    boolean backendFault =
+        DefaultToolContext.isServerFault(DefaultToolContext.resolveStatusCode(e));
+    String advice =
+        backendFault
+            ? " Semantic search depends on an embedding backend; when it is unavailable, use"
+                + " search_metadata with a queryFilter instead of retrying this tool."
+            : " This is a problem with the arguments, not the backend - correct them and retry.";
+    return "Semantic search failed: " + McpResponseTrim.summarizeFailure(e, backendFault) + advice;
   }
 
   private Map<String, Object> errorResponse(String message) {

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/util/McpParams.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/util/McpParams.java
@@ -1,6 +1,10 @@
 package org.openmetadata.mcp.util;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Lenient coercion of MCP tool arguments. MCP clients send arguments as an untyped {@code
@@ -67,5 +71,36 @@ public final class McpParams {
       result = defaultValue;
     }
     return result;
+  }
+
+  /**
+   * Reads a list-of-strings parameter, tolerating the single-string form.
+   *
+   * <p>MCP clients serialize a one-element array inconsistently - some send {@code ["lineage"]},
+   * others {@code "lineage"}. Accepting either costs one branch and removes a retry the caller
+   * cannot diagnose from a type error.
+   */
+  /** A string parameter, or {@code fallback} when absent or blank. */
+  public static String getString(Map<String, Object> params, String key, String fallback) {
+    Object raw = params == null ? null : params.get(key);
+    String value = fallback;
+    if (raw != null && !raw.toString().isBlank()) {
+      value = raw.toString();
+    }
+    return value;
+  }
+
+  public static List<String> getStringList(Map<String, Object> params, String key) {
+    Object raw = params == null ? null : params.get(key);
+    List<String> values = new ArrayList<>();
+    if (raw instanceof List<?> list) {
+      list.stream().filter(Objects::nonNull).map(Object::toString).forEach(values::add);
+    } else if (raw instanceof String single && !single.isBlank()) {
+      Arrays.stream(single.split(","))
+          .map(String::trim)
+          .filter(v -> !v.isEmpty())
+          .forEach(values::add);
+    }
+    return values;
   }
 }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/util/McpResponseTrim.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/util/McpResponseTrim.java
@@ -3,6 +3,8 @@ package org.openmetadata.mcp.util;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.openmetadata.schema.utils.JsonUtils;
 
 /**
@@ -78,6 +80,135 @@ public final class McpResponseTrim {
 
   private McpResponseTrim() {}
 
+  /**
+   * Collapses an entity-reference-shaped map to the one field a caller can act on: its FQN.
+   *
+   * <p>Search hits embed full {@code EntityReference} objects for {@code service}, {@code database},
+   * {@code databaseSchema} and {@code owners}, and every hit from the same schema repeats the same
+   * descriptor. Since every MCP tool is addressed by {@code (entityType, fqn)}, the rest is unusable
+   * weight.
+   *
+   * <p>Anything not reference-shaped is returned untouched, rather than silently emptied.
+   */
+  public static Object slimRef(Object value) {
+    Object result = value;
+    if (value instanceof Map<?, ?> ref) {
+      Object fqn = ref.get("fullyQualifiedName");
+      Object name = fqn != null ? fqn : ref.get("name");
+      if (name != null) {
+        result = unquoteSegment(name.toString()) + inheritedSuffix(ref);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Keeps the one flag that has to survive collapsing a reference to its name.
+   *
+   * <p>Without it, an owner inherited from the parent database looks identical to a deliberately
+   * assigned steward - and that distinction is the whole answer to "who should I talk to".
+   */
+  private static String inheritedSuffix(Map<?, ?> ref) {
+    return Boolean.TRUE.equals(ref.get("inherited")) ? " (inherited)" : "";
+  }
+
+  /**
+   * Drops the quoting OpenMetadata adds around an FQN segment containing a dot.
+   *
+   * <p>A user named {@code vishnu.jain} has the FQN {@code "vishnu.jain"}, quotes included, so an
+   * owners list mixed quoted and unquoted entries. The quotes only separate segments inside a
+   * multi-part FQN; on a single segment they say nothing and make the value harder to reuse.
+   */
+  private static String unquoteSegment(String fqn) {
+    String result = fqn;
+    boolean singleQuotedSegment =
+        fqn.length() > 1
+            && fqn.charAt(0) == '"'
+            && fqn.charAt(fqn.length() - 1) == '"'
+            && fqn.indexOf('"', 1) == fqn.length() - 1;
+    if (singleQuotedSegment) {
+      result = fqn.substring(1, fqn.length() - 1);
+    }
+    return result;
+  }
+
+  /** {@link #slimRef} across a list, e.g. {@code owners} or {@code domains}. */
+  public static Object slimRefs(Object value) {
+    Object result = value;
+    if (value instanceof List<?> refs) {
+      result = refs.stream().map(McpResponseTrim::slimRef).toList();
+    }
+    return result;
+  }
+
+  /**
+   * Collapses a tag-label-shaped map to its {@code tagFQN}. Tier and classification labels carry a
+   * paragraph-length {@code description} that repeats on every hit carrying that tag.
+   */
+  public static Object slimTag(Object value) {
+    Object result = value;
+    if (value instanceof Map<?, ?> tag && tag.get("tagFQN") != null) {
+      result = tag.get("tagFQN");
+    } else if (value instanceof List<?> tags) {
+      result = tags.stream().map(McpResponseTrim::slimTag).toList();
+    }
+    return result;
+  }
+
+  /**
+   * Collapses a certification to its FQN plus a resolved validity, e.g. {@code
+   * "Certification.Gold (EXPIRED 2026-07-29)"}.
+   *
+   * <p>The nested label repeats a description, colour and icon URL on every certified hit. More
+   * importantly, expiry ships as raw epoch millis next to {@code state: "Confirmed"}, so a lapsed
+   * badge reads as a live trust signal unless the caller does the date arithmetic itself.
+   */
+  public static Object slimCertification(Object value, long nowMillis) {
+    Object result = value;
+    if (value instanceof Map<?, ?> certification) {
+      Object label = certification.get("tagLabel");
+      Map<?, ?> tag = label instanceof Map<?, ?> inner ? inner : certification;
+      Object fqn = tag.get("tagFQN");
+      if (fqn != null) {
+        result = fqn + expirySuffix(certification, tag, nowMillis);
+      }
+    }
+    return result;
+  }
+
+  private static String expirySuffix(Map<?, ?> certification, Map<?, ?> tag, long nowMillis) {
+    Object expiry = expiryOf(certification, tag);
+    String suffix = "";
+    if (expiry instanceof Number millis) {
+      String date =
+          java.time.Instant.ofEpochMilli(millis.longValue())
+              .atZone(java.time.ZoneOffset.UTC)
+              .toLocalDate()
+              .toString();
+      suffix =
+          millis.longValue() < nowMillis
+              ? " (EXPIRED " + date + ")"
+              : " (valid until " + date + ")";
+    } else {
+      // The index is inconsistent: some documents carry the full certification, others only
+      // {tagLabel:{tagFQN}}. A bare label reads as a live badge and "(expiry unknown)" reads as "no
+      // expiry set", so say what is actually true - the date exists, just not in this projection.
+      suffix = " (expiry not in this index - check get_entity_details before trusting)";
+    }
+    return suffix;
+  }
+
+  private static Object expiryOf(Map<?, ?> certification, Map<?, ?> tag) {
+    Object expiry = certification.get("expiryDate");
+    if (expiry == null && tag.get("metadata") instanceof Map<?, ?> metadata) {
+      expiry = metadata.get("expiryDate");
+    }
+    if (expiry == null) {
+      expiry = tag.get("expiryDate");
+    }
+    return expiry;
+  }
+
   /** Cuts {@code value} to {@code maxLength} characters plus an ellipsis when it is longer. */
   public static String truncate(String value, int maxLength) {
     String result = value;
@@ -123,6 +254,53 @@ public final class McpResponseTrim {
     envelope.put(MAX_RESPONSE_CHARS_KEY, MAX_RESPONSE_CHARS);
     envelope.put(MESSAGE_KEY, advice);
     return envelope;
+  }
+
+  /** A backend message longer than this is summarised; the full text stays in the server log. */
+  public static final int FAILURE_MESSAGE_MAX_LENGTH = 400;
+
+  /** Matches the useful half of a search-backend error: the first concrete cause type it names. */
+  private static final Pattern ROOT_CAUSE_TYPE = Pattern.compile("\"type\"\\s*:\\s*\"([a-z_]+)\"");
+
+  /**
+   * Compresses a backend failure into something a model can act on.
+   *
+   * <p>An OpenSearch {@code ResponseException} stringifies to its whole response body - one failing
+   * search put ~4,000 characters in front of the model, mostly the same error repeated per shard,
+   * and none of it said whether retrying would help.
+   *
+   * <p>So: keep the first line, name the cause once, and say whether the arguments were at fault.
+   * The full text is already in the server log for the operator.
+   */
+  public static String summarizeFailure(Throwable t, boolean serverFault) {
+    String message = safeMessage(t);
+    String summary = message;
+    if (message.length() > FAILURE_MESSAGE_MAX_LENGTH) {
+      summary = firstLine(message) + causeSuffix(message);
+      summary = truncate(summary, FAILURE_MESSAGE_MAX_LENGTH);
+    }
+    if (serverFault) {
+      summary +=
+          " [This is a backend fault, not a problem with the arguments you sent. Retrying the same"
+              + " call will not help; try a different tool or a narrower request.]";
+    }
+    return summary;
+  }
+
+  private static String firstLine(String message) {
+    int newline = message.indexOf('\n');
+    String line = newline > 0 ? message.substring(0, newline) : message;
+    return truncate(line, FAILURE_MESSAGE_MAX_LENGTH / 2);
+  }
+
+  /** Names the underlying cause once, rather than letting it repeat per failed shard. */
+  private static String causeSuffix(String message) {
+    Matcher matcher = ROOT_CAUSE_TYPE.matcher(message);
+    String suffix = "";
+    if (matcher.find()) {
+      suffix = " (cause: " + matcher.group(1) + ")";
+    }
+    return suffix;
   }
 
   /**

--- a/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
+++ b/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
@@ -68,7 +68,7 @@
         "destructiveHint": false,
         "openWorldHint": false
       },
-      "description": "Keyword-based search for data assets and data quality entities in OpenMetadata. Best when you know specific names, owners, tags, tiers, services, or column names. Use this for exact lookups (e.g., 'find table X', 'tables owned by team Y'), filtering by metadata properties, counting assets, and aggregations. Also searches data quality test cases and test suites when entityType is 'testCase' or 'testSuite' — these are NOT part of the default search scope, so always set entityType explicitly for data quality questions. Supports pagination and advanced OpenSearch DSL queries. Choose this over semantic_search when the query targets known identifiers or structured attributes. Results include 'fullyQualifiedName' and 'entityType' — pass these directly to get_entity_details for full entity information.",
+      "description": "Keyword-based search for data assets and data quality entities in OpenMetadata. TWO RULES THAT ARE EASY TO GET SILENTLY WRONG: (1) To read several KNOWN entities at once, use a 'terms' clause on 'fullyQualifiedName' in 'queryFilter' together with 'fields' — that hydrates them all in ONE call instead of one get_entity_details per entity. (2) To find a table's data-quality tests, match on 'originEntityFQN', NOT 'entityFQN'. A column-level test stores the COLUMN's FQN in 'entityFQN', so matching the table FQN silently returns only table-level tests with a clean, wrong total. Best when you know specific names, owners, tags, tiers, services, or column names. Use this for exact lookups (e.g., 'find table X', 'tables owned by team Y'), filtering by metadata properties, counting assets, and aggregations. Also searches data quality test cases and test suites when entityType is 'testCase' or 'testSuite' — these are NOT part of the default search scope, so always set entityType explicitly for data quality questions. Supports pagination and advanced OpenSearch DSL queries. Choose this over semantic_search when the query targets known identifiers or structured attributes. Descriptions are shortened in results and flagged with 'descriptionTruncated': true when cut — call get_entity_details for the full text. A testCase that has never executed carries no 'testCaseStatus' and is flagged 'neverRun': true, which is distinct from Success/Failed/Aborted and is NOT the same as passing. Results include 'fullyQualifiedName' and 'entityType' — pass these directly to get_entity_details for full entity information.",
       "parameters": {
         "description": "Use 'query' for keyword search or 'queryFilter' for advanced OpenSearch DSL. Best for exact matches and filtering by metadata properties.",
         "type": "object",
@@ -79,11 +79,11 @@
           },
           "entityType": {
             "type": "string",
-            "description": "Filter by entity type (auto-detected if not specified). Use the singular form. Common data assets: table, dashboard, topic, pipeline, container, chart, metric, mlmodel, searchIndex, storedProcedure, apiEndpoint, apiCollection, dashboardDataModel, spreadsheet, worksheet, file, directory. Containers and services: database, databaseSchema, databaseService, dashboardService, messagingService, pipelineService, mlmodelService, storageService, searchService, apiService, metadataService, driveService, securityService. Governance: glossary, glossaryTerm, tag, classification, domain, dataProduct, user, team. Data quality: testCase (includes the tested asset's FQN in 'entityFQN' and latest status in 'testCaseStatus'), testSuite, testCaseResult, testCaseResolutionStatus. Also resolvable and under-used: tableColumn (a real per-column index — search column names/descriptions/tags directly instead of paging get_entity_details over a wide table) and page (Knowledge Center articles); both are inside the default 'dataAsset' scope, so entityType='table' and an unfiltered search can both return column documents — read 'entityType' on each hit rather than assuming. Outside the default scope, so they must be set explicitly: query (SQL that has actually run against an asset, with 'queryUsedIn'), contextMemory and contextFile (Context Center knowledge)."
+            "description": "Filter by entity type (auto-detected if not specified). Use the singular form. Common data assets: table, dashboard, topic, pipeline, container, chart, metric, mlmodel, searchIndex, storedProcedure, apiEndpoint, apiCollection, dashboardDataModel, spreadsheet, worksheet, file, directory. Containers and services: database, databaseSchema, databaseService, dashboardService, messagingService, pipelineService, mlmodelService, storageService, searchService, apiService, metadataService, driveService, securityService. Governance: glossary, glossaryTerm, tag, classification, domain, dataProduct, user, team. Data quality: testCase (includes the tested asset's FQN in 'entityFQN' and latest status in 'testCaseStatus': Success/Failed/Aborted once run; a test that has never executed carries no status and is flagged 'neverRun': true). IMPORTANT when finding a table's tests: a COLUMN-level test stores the column's FQN in 'entityFQN' (e.g. '...dim_address.zip'), so an exact term/terms match on the table FQN silently returns only table-level tests and a clean, wrong total. Match on 'originEntityFQN' instead - it rolls up to the tested asset for both table and column tests - or use a wildcard on 'entityFQN'., testSuite, testCaseResult, testCaseResolutionStatus. Also resolvable and under-used: tableColumn (a real per-column index — search column names/descriptions/tags directly instead of paging get_entity_details over a wide table) and page (Knowledge Center articles); both are inside the default 'dataAsset' scope, so entityType='table' and an unfiltered search can both return column documents — read 'entityType' on each hit rather than assuming. Outside the default scope, so they must be set explicitly: query (SQL that has actually run against an asset, with 'queryUsedIn'), contextMemory and contextFile (Context Center knowledge)."
           },
           "queryFilter": {
             "type": "string",
-            "description": "Advanced: Direct OpenSearch JSON query string for precise control. Only use if you can generate valid OpenSearch DSL. When provided, this overrides the 'query' parameter. Must include entityType filter. Example: '{\"bool\": {\"must\": [{\"term\": {\"entityType\": \"table\"}}, {\"nested\": {\"path\": \"owners\", \"query\": {\"term\": {\"owners.name\": \"marketing\"}}}}]}}'. Key rules: Use singular entityType, 'owners.name' (plural), tier format is 'Tier.Tier1', columns are NOT nested, owners IS nested (wrap owners queries in {\"nested\": {\"path\": \"owners\", \"query\": ...}}). 'fullyQualifiedName' is indexed with a lowercase normalizer, so values in 'term'/'terms' clauses must be lowercased — {\"terms\": {\"fullyQualifiedName\": [\"dailyactiveusers\"]}} matches, the original casing silently matches nothing. Combining a 'terms' clause on 'fullyQualifiedName' with 'fields' is the way to hydrate many known entities in one call."
+            "description": "Advanced: Direct OpenSearch JSON query string for precise control. Only use if you can generate valid OpenSearch DSL. When provided, this overrides the 'query' parameter. Must include entityType filter. Example: '{\"bool\": {\"must\": [{\"term\": {\"entityType\": \"table\"}}, {\"nested\": {\"path\": \"owners\", \"query\": {\"term\": {\"owners.name\": \"marketing\"}}}}]}}'. Key rules: Use singular entityType, 'owners.name' (plural), tier format is 'Tier.Tier1', columns are NOT nested, owners IS nested (wrap owners queries in {\"nested\": {\"path\": \"owners\", \"query\": ...}}). 'fullyQualifiedName' is indexed with a lowercase normalizer, so values in 'term'/'terms' clauses must be lowercased — {\"terms\": {\"fullyQualifiedName\": [\"dailyactiveusers\"]}} matches, the original casing silently matches nothing. The SAME lowercase rule applies to 'entityFQN' and 'originEntityFQN' on test-case documents — lowercase those values too, or a term/terms clause returns a clean, wrong zero. Combining a 'terms' clause on 'fullyQualifiedName' with 'fields' is the way to hydrate many known entities in one call."
           },
           "from": {
             "type": "integer",
@@ -106,7 +106,7 @@
           },
           "fields": {
             "type": "string",
-            "description": "Comma-separated additional fields to include. Default returns: name, displayName, fullyQualifiedName, description, entityType, service, database, databaseSchema, serviceType, href, tags, owners, tier, tableType, columnNames.\n\nAdditional fields by entity type:\n- Table entities: columns, schemaDefinition, upstreamLineage, entityRelationship, aiContext (materialized structural context: columns, primaryKey, foreignKeys, frequentJoins, partitionColumns)\n- Topic entities: messageSchema, partitions, replicationFactor  \n- Dashboard entities: charts, dataModels, project\n- Pipeline entities: tasks, pipelineUrl, scheduleInterval\n- TestCase entities: testCaseResult (full latest result; a slim status/timestamp/result version is returned by default), testDefinition, testSuite, testSuites, parameterValues, table\n- All entities: createdAt, updatedAt, changeDescription, extension, domain, dataProducts, lifeCycle, sourceHash\n\nExample: 'columns' for table column details, or 'aiContext' for the structural context (keys, joins, partitions) in the search hit itself. To read SQL that has actually run against an asset, search entityType='query' instead — 'queries' is not retrievable as a field."
+            "description": "Comma-separated additional fields to include. Default returns: name, displayName, fullyQualifiedName, description, entityType, service, database, databaseSchema, serviceType, href, tags, owners, tier, tableType, columnNames.\n\nAdditional fields by entity type:\n- Table entities: columns, schemaDefinition, upstreamLineage, entityRelationship, aiContext (materialized structural context: columns, primaryKey, foreignKeys, frequentJoins, partitionColumns)\n- Topic entities: messageSchema, partitions, replicationFactor  \n- Dashboard entities: charts, dataModels, project\n- Pipeline entities: tasks, pipelineUrl, scheduleInterval\n- TestCase entities: testCaseResult (full latest result; a slim status/timestamp/result version is returned by default), testDefinition, testSuite, testSuites, parameterValues, table\n- All entities: createdAt, updatedAt, changeDescription, extension, domain, dataProducts, lifeCycle, sourceHash, certification (the certification badge is NOT returned by default - request it explicitly when trustworthiness matters)\n\nBulk fields (columns, charts, tasks) are capped per hit and flagged with '<field>Truncated' plus '<field>Total' — search hits are for choosing between assets; use get_entity_details for the full list. Example: 'columns' for table column details, or 'aiContext' for the structural context (keys, joins, partitions) in the search hit itself. To read SQL that has actually run against an asset, search entityType='query' instead — 'queries' is not retrievable as a field.\n\nReferences (service, database, databaseSchema, owners, domains) and tags (tags, tier) are returned as fully-qualified-name STRINGS, not nested objects — pass them directly to another tool. An owner inherited from the parent database or schema is suffixed '(inherited)', so a real steward is distinguishable from a cascaded placeholder."
           },
           "includeAggregations": {
             "type": "boolean",
@@ -117,6 +117,13 @@
             "type": "integer",
             "description": "Maximum number of aggregation buckets to return per field when includeAggregations is true. Limits response size to prevent context overflow. Default is 10, maximum allowed is 50.",
             "default": 10
+          },
+          "excludeEntityTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Entity types to drop from the results, e.g. ['tableColumn']. Column documents sit inside the default 'dataAsset' scope, so a broad sweep can return mostly columns inheriting their parent's tags or certification. Excluded hits are removed and counted under 'excludedByType'."
           }
         },
         "required": [],
@@ -197,7 +204,7 @@
         "destructiveHint": false,
         "openWorldHint": false
       },
-      "description": "Meaning-based discovery of data assets using vector embeddings. Best for exploratory or vague queries where you don't know exact names — it finds conceptually related assets even when no keywords match. Use this when the user describes what data they need in plain language (e.g., 'tables about customer spending behavior', 'anything related to revenue forecasting'). Returns entity summaries with name, columns, description, and metadata. Metric results additionally carry 'metricExpression', 'metricType', 'granularity' and 'unitOfMeasurement' — enough to tell similarly named metrics apart (e.g. daily vs monthly active users) and shortlist the right one without fetching each candidate. Choose this over search_metadata when the query is about meaning or concepts rather than specific identifiers or attributes. Results include 'fullyQualifiedName' and 'entityType' — pass these directly to get_entity_details for full entity information, including custom properties ('extension'), which summaries never include. One result is returned per entity: the best-matching passage represents it.",
+      "description": "Meaning-based discovery of data assets using vector embeddings. Best for exploratory or vague queries where you don't know exact names — it finds conceptually related assets even when no keywords match. Use this when the user describes what data they need in plain language (e.g., 'tables about customer spending behavior', 'anything related to revenue forecasting'). Returns compact entity summaries: name, description, column NAMES (not full column definitions), and metadata. References (service, database, databaseSchema, owners, domains) and tags are returned as fully-qualified-name strings rather than nested objects, so they can be passed straight to another tool. Column name lists are capped per hit and flagged with 'columnNamesTruncated'/'totalColumns'. Use get_entity_details for full column definitions. Metric results additionally carry 'metricExpression', 'metricType', 'granularity' and 'unitOfMeasurement' — enough to tell similarly named metrics apart (e.g. daily vs monthly active users) and shortlist the right one without fetching each candidate. Choose this over search_metadata when the query is about meaning or concepts rather than specific identifiers or attributes. Results include 'fullyQualifiedName' and 'entityType' — pass these directly to get_entity_details for full entity information, including custom properties ('extension'), which summaries never include. One result is returned per entity: the best-matching passage represents it.",
       "parameters": {
         "description": "Use 'query' to describe what you're looking for in plain language. The system finds conceptually similar assets using vector similarity. Optionally filter by entity type, service, or tags.",
         "type": "object",
@@ -287,7 +294,7 @@
         "destructiveHint": false,
         "openWorldHint": false
       },
-      "description": "Get detailed information about a specific entity by its fully qualified name, including its custom properties (returned under the 'extension' field). IMPORTANT: Use the 'fullyQualifiedName' and 'entityType' values directly from search_metadata or semantic_search results — do not construct the FQN manually. Response is optimized for LLM context: verbose index/noise metadata fields are excluded. Descriptions (entity-level and per-column) are returned in FULL and are never truncated — total response size is bounded by column pagination instead. Only the raw schema DDL and dbt model SQL carry a large safety cap (~30000 characters, flagged with 'schemaDefinitionTruncated' or 'sqlTruncated' inside 'dataModel') to keep the response retrievable; realistic DDL/SQL is well under this. For wide entities (many columns), the 'columns' array is paginated: when it is capped the response sets 'columnsTruncated' with 'totalColumns', 'returnedColumns', 'columnOffset' and 'hasMoreColumns'. When 'hasMoreColumns' is true, fetch the next page by calling again with 'columnOffset' set to the previous 'columnOffset' + 'returnedColumns'; when it is false there are no further columns to retrieve.",
+      "description": "Get detailed information about one or more entities. Pass a single 'entityType' + 'fqn', or 'entities' to read up to 10 in one call - prefer that over repeated single calls when you already hold several FQNs. Includes custom properties (returned under the 'extension' field). Certification is returned with its validity already resolved, e.g. 'Certification.Gold (EXPIRED 2026-07-29)', so a lapsed badge cannot be mistaken for a live one. IMPORTANT: Use the 'fullyQualifiedName' and 'entityType' values directly from search_metadata or semantic_search results — do not construct the FQN manually. Response is optimized for LLM context: verbose index/noise metadata fields are excluded. Descriptions (entity-level and per-column) are returned in FULL and are never truncated — total response size is bounded by column pagination instead. Only the raw schema DDL and dbt model SQL carry a large safety cap (~30000 characters, flagged with 'schemaDefinitionTruncated' or 'sqlTruncated' inside 'dataModel') to keep the response retrievable; realistic DDL/SQL is well under this. For wide entities (many columns), the 'columns' array is paginated: when it is capped the response sets 'columnsTruncated' with 'totalColumns', 'returnedColumns', 'columnOffset' and 'hasMoreColumns'. When 'hasMoreColumns' is true, fetch the next page by calling again with 'columnOffset' set to the previous 'columnOffset' + 'returnedColumns'; when it is false there are no further columns to retrieve. Use 'include' to fold lineage and data-quality health into this call rather than following up with get_entity_lineage or a test-suite lookup.",
       "parameters": {
         "description": "Use 'fullyQualifiedName' and 'entityType' from search results directly.",
         "type": "object",
@@ -298,7 +305,7 @@
           },
           "fqn": {
             "type": "string",
-            "description": "Fully qualified name of the entity. IMPORTANT: Use the exact 'fullyQualifiedName' value from search_metadata or semantic_search results. Do not attempt to construct or modify the FQN."
+            "description": "Fully qualified name of the entity. Use the exact 'fullyQualifiedName' from a search result when you have one, or a known-good FQN the user supplied. Do not assemble an FQN from parts you are guessing at."
           },
           "columnOffset": {
             "type": "integer",
@@ -307,12 +314,27 @@
           "columnLimit": {
             "type": "integer",
             "description": "Maximum number of columns to return starting at 'columnOffset'. Omit to return as many columns as fit the response size budget (columns beyond the budget are dropped and flagged with 'columnsTruncated'/'hasMoreColumns')."
+          },
+          "include": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "lineage",
+                "quality"
+              ]
+            },
+            "description": "Extra sections to fold into this response instead of making another call. 'lineage' adds the immediate upstream and downstream FQNs (what feeds this asset, what breaks if it changes) plus 'hasMoreUpstream'/'hasMoreDownstream' so you can tell a complete graph from the first hop of a chain without a second call. 'quality' adds its test suite's pass/fail summary, including a 'neverRun' count so a suite whose tests have never executed is not mistaken for a clean one. When the asset has no test suite at all - the common case in a young catalog - it returns a note saying so, which is different again from a suite whose tests have not run. Each section degrades independently: if one cannot be read you get a note for that section, not a failed call. Use get_entity_lineage instead when you need lineage depth or transformation SQL."
+          },
+          "entities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Read several entities in ONE call. Each item is 'entityType:fqn', e.g. 'table:sample_data.ecommerce_db.shopify.dim_address'. Maximum 10 per call. Prefer this over repeated single calls when a search returned multiple assets worth inspecting. Each entity resolves independently: an unknown type, a missing asset or a permission denial returns an 'error' entry for that one entity instead of failing the whole call. When 'entities' is used the response is {entities:[...], requested, returned}; 'include' applies to every entity."
           }
         },
-        "required": [
-          "entityType",
-          "fqn"
-        ]
+        "required": []
       }
     },
     {
@@ -600,11 +622,11 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "Glossary Term name."
+            "description": "Name of the glossary. Must be unique."
           },
           "description": {
             "type": "string",
-            "description": "Glossary Term description."
+            "description": "Description of the glossary in Markdown format."
           },
           "owners": {
             "type": "array",
@@ -615,7 +637,7 @@
           },
           "reviewers": {
             "type": "array",
-            "description": "Glossary Term owner. This could be an OpenMetadata User or Team. If you don't know who the owner is, you can leave this empty, but let the user know that they can add owners later.",
+            "description": "Users or teams who review changes to terms in this glossary. Setting reviewers turns on the approval workflow: new terms enter as Draft and stay there until a reviewer approves them. Leave empty for terms to be created already Approved.",
             "items": {
               "type": "string"
             }
@@ -639,9 +661,10 @@
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,
+        "idempotentHint": false,
         "openWorldHint": false
       },
-      "description": "Patches an existing Entity based on a JSONPatch. NOT for creating entities — use the matching create_* tool for that; NOT for Context Center memories — use create_context_memory. Beforehand the Entity should be validated by finding it and creating a proper patch. IMPORTANT field naming rules: all array/list fields use PLURAL names in the JSON body — use 'domains' (not 'domain'), 'owners' (not 'owner'), 'tags' (not 'tag'), 'reviewers' (not 'reviewer'). Domain values must be entity reference objects: {\"id\": \"<uuid>\", \"type\": \"domain\"}. Owner values must be entity reference objects: {\"id\": \"<uuid>\", \"type\": \"user\" or \"team\"}. To add a domain: [{\"op\": \"add\", \"path\": \"/domains/0\", \"value\": {\"id\": \"<domain-id>\", \"type\": \"domain\", \"name\": \"<domain-name>\"}}]. To replace description: [{\"op\": \"add\", \"path\": \"/description\", \"value\": \"new description\"}]. Always look up entity UUIDs using search or get tools before patching. Do not guess field names from prior knowledge, schema fields have been renamed over time. Call get_entity_details on the target first and use ONLY field names present in that response. If a patch is rejected with \"Invalid field 'X'\", the error lists the valid names and suggests the closest match: use it and retry. Writes take effect immediately and can overwrite existing state — confirm the target with the user before calling.",
+      "description": "Update an existing entity by applying a JSONPatch document (RFC 6902), exactly as the REST PATCH API takes it. Any operation on any field is allowed and is passed through as written, so a patch touches only the paths it names - see https://jsonpatch.com. THE PATH DECIDES WHETHER YOU ADD OR REPLACE, which is the easy thing to get wrong on arrays: '/owners/-' APPENDS one owner, while '/owners' REPLACES the whole list with what you supply. Same for tags, reviewers, domains, experts and dataProducts. To append: {\"op\": \"add\", \"path\": \"/owners/-\", \"value\": {\"id\": \"<uuid>\", \"type\": \"user\"}}. To remove one: {\"op\": \"remove\", \"path\": \"/owners/0\"}. To replace the whole list deliberately, target the array itself. If you do not know what a list currently holds, read it with get_entity_details first. Use 'replace' for a field that already has a value and 'add' for one that is absent or to extend an array. NOT for creating entities - use the matching create_* tool; NOT for Context Center memories - use create_context_memory. FIELD NAMING: array fields are plural - 'domains' (not 'domain'), 'owners' (not 'owner'), 'tags' (not 'tag'), 'reviewers' (not 'reviewer'). Owners and domains are entity references: {\"id\": \"<uuid>\", \"type\": \"user\"|\"team\"|\"domain\"}. A tier is a tag, e.g. {\"tagFQN\": \"Tier.Tier1\"} - so replacing '/tags' wholesale drops the asset's tier and its glossary terms along with it. Look entity UUIDs up with search or get tools before patching, and do not guess field names from prior knowledge - schema fields have been renamed over time. Call get_entity_details on the target and use only names present in that response. If a patch is rejected with \"Invalid field 'X'\", the error lists the valid names and suggests the closest match: use it and retry. Writes take effect immediately and can overwrite existing state - confirm the target with the user before calling.",
       "parameters": {
         "type": "object",
         "properties": {
@@ -655,7 +678,7 @@
           },
           "patch": {
             "type": "string",
-            "description": "JSONPatch operations as a JSON array string. Each operation has 'op' (add/remove/replace), 'path' (JSON Pointer starting with /), and 'value'. Field paths MUST use plural names for array fields: /domains, /owners, /tags, /reviewers. Example to set a domain: [{\"op\": \"add\", \"path\": \"/domains/0\", \"value\": {\"id\": \"<domain-uuid>\", \"type\": \"domain\", \"name\": \"<domain-name>\"}}]."
+            "description": "The JSONPatch document, as a JSON array string. Each operation has 'op' (add, remove, replace, move, copy, test), 'path' (a JSON Pointer starting with /), and 'value' where the op needs one. Example: [{\"op\": \"replace\", \"path\": \"/description\", \"value\": \"new description\"}]. Appending to an array uses the '-' index: [{\"op\": \"add\", \"path\": \"/owners/-\", \"value\": {\"id\": \"<uuid>\", \"type\": \"user\"}}]."
           }
         },
         "required": [
@@ -673,7 +696,7 @@
         "destructiveHint": false,
         "openWorldHint": false
       },
-      "description": "Get a compact lineage graph (upstream/downstream dependencies) of a specific entity. Use this for root cause (upstream entities) or impact (downstream entities) analysis and explaining dependencies between entities. By default the response is table-level and optimized for size: each edge carries the connected assets' names, FQNs, types and relationship info (pipeline or sql), and the transformation SQL in full — response size is controlled by returning fewer edges, never by cutting SQL. Set includeColumnLineage=true only when the user explicitly asks about column-level lineage.",
+      "description": "Get a compact lineage graph (upstream/downstream dependencies) of a specific entity. Use this for root cause (upstream entities) or impact (downstream entities) analysis and explaining dependencies between entities. The default response is table-level and small: each edge carries the connected assets' names, FQNs, types and relationship info (pipeline or sql). Transformation SQL is NOT included by default because it dominates response size; an edge that has SQL is marked with 'hasSql': true, so re-call with includeSql=true only for the specific question that needs the transformation text. Set includeColumnLineage=true only when the user explicitly asks about column-level lineage.",
       "parameters": {
         "description": "Fqn is the fully qualified name of the entity. Entity type could be table, topic etc.",
         "type": "object",
@@ -700,6 +723,11 @@
             "type": "boolean",
             "description": "Include column-level lineage mappings on each edge. Defaults to false to keep the response table-level and small. Set to true only when the user explicitly needs column-to-column lineage, as it can significantly increase response size on wide tables.",
             "default": false
+          },
+          "includeSql": {
+            "type": "boolean",
+            "default": false,
+            "description": "Include each edge's full transformation SQL. Defaults to false: SQL is typically over 90% of a lineage response, so it is omitted unless asked for. Edges that have SQL are flagged with 'hasSql': true — request it only for those you care about."
           }
         },
         "required": [
@@ -716,13 +744,13 @@
         "destructiveHint": true,
         "openWorldHint": false
       },
-      "description": "This tool can be used to create lineage between two assets. It takes the source and target asset details and creates a lineage relationship between them. Writes take effect immediately and can overwrite existing state — confirm the target with the user before calling.",
+      "description": "Required to create lineage between two assets. Identify each endpoint by 'fqn' (preferred) or 'id', plus its 'type'.",
       "parameters": {
         "description": "Required to create lineage between two assets.",
         "type": "object",
         "properties": {
           "fromEntity": {
-            "description": "Source Entity.",
+            "description": "Source entity. Identify it by 'fqn' (preferred - this is what search results return) or by 'id'.",
             "type": "object",
             "properties": {
               "type": {
@@ -731,16 +759,19 @@
               },
               "id": {
                 "type": "string",
-                "description": "Id of the entity"
+                "description": "Id of the entity. Only needed when you do not have its fqn."
+              },
+              "fqn": {
+                "type": "string",
+                "description": "Fully qualified name of the entity, exactly as returned by search_metadata or semantic_search."
               }
             },
             "required": [
-              "type",
-              "id"
+              "type"
             ]
           },
           "toEntity": {
-            "description": "Destination Entity.",
+            "description": "Destination entity. Identify it by 'fqn' (preferred - this is what search results return) or by 'id'.",
             "type": "object",
             "properties": {
               "type": {
@@ -749,12 +780,15 @@
               },
               "id": {
                 "type": "string",
-                "description": "Id of the entity"
+                "description": "Id of the entity. Only needed when you do not have its fqn."
+              },
+              "fqn": {
+                "type": "string",
+                "description": "Fully qualified name of the entity, exactly as returned by search_metadata or semantic_search."
               }
             },
             "required": [
-              "type",
-              "id"
+              "type"
             ]
           }
         },
@@ -1279,7 +1313,7 @@
         "destructiveHint": false,
         "openWorldHint": false
       },
-      "description": "Performs comprehensive root cause analysis via data quality lineage. First identifies upstream failures that may be causing issues for the specified asset. If failures are found, automatically analyzes downstream impact to show which assets may be affected. Returns both upstream root causes and downstream impact analysis. In the response 'status' indicates whether upstream failures were found. If 'status' is 'failed', the 'upstreamAnalysis' can be used to identify the nodes and edges leading to failures and downstreamAnalysis can tell what all nodes in downstream are impacted. If 'status' is 'success', it means no upstream failures were found, and downstream impact analysis was not performed. Responses are compact and table-level by default: node and edge details are trimmed to keep the payload within LLM context limits, while the transformation SQL on each edge is returned in full. Set 'includeColumnLineage' to true only when column-level lineage is needed.",
+      "description": "Performs comprehensive root cause analysis via data quality lineage. First identifies upstream failures that may be causing issues for the specified asset. If failures are found, automatically analyzes downstream impact to show which assets may be affected. Returns both upstream root causes and downstream impact analysis. In the response 'status' is 'failed' when failing tests were found ANYWHERE - either upstream or on the analysed asset itself - and 'success' when nothing is failing. Read 'rootHasFailingTests' and 'failingUpstreamNodesCount' together to tell the two apart: a root failure with zero failing upstream nodes means the problem starts here, not inherited. Downstream impact analysis runs whenever either is true. Responses are compact and table-level by default: node payloads are trimmed to identity (FQN, name, type, depth) and transformation SQL is NOT included — an edge that has SQL is flagged with 'hasSql'. Use get_entity_lineage with includeSql=true when you need the transformation text. Set 'includeColumnLineage' to true only when column-level lineage is needed. When the analysed asset's own tests are failing, the response sets 'rootHasFailingTests' and returns those failing tests and their latest results under 'rootFailingTests' — you do not need a separate testCase search to learn what is failing.",
       "parameters": {
         "type": "object",
         "properties": {

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/McpSdkUpgradeTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/McpSdkUpgradeTest.java
@@ -201,6 +201,30 @@ public class McpSdkUpgradeTest {
     assertThat(patchTool.annotations()).isNotNull();
     assertThat(patchTool.annotations().readOnlyHint()).isFalse();
     assertThat(patchTool.annotations().destructiveHint()).isTrue();
+    // A JSONPatch is not idempotent in general - an 'add' to '/owners/-' appends again on a retry -
+    // so a client must not treat a retry as free. The MCP default is false, but state it.
+    assertThat(patchTool.annotations().idempotentHint()).isFalse();
+  }
+
+  /**
+   * Guards against copy-paste duplication when a tool description is edited. These are sent to the
+   * model on every request, so a repeated sentence is paid for on every call - and folding two tools
+   * together left exactly that in patch_entity once already.
+   */
+  @Test
+  void testToolDescriptionsDoNotRepeatThemselves() {
+    List<McpSchema.Tool> tools = McpUtils.getToolProperties("json/data/mcp/tools.json");
+
+    for (McpSchema.Tool tool : tools) {
+      List<String> sentences =
+          java.util.Arrays.stream(tool.description().split("(?<=[.!?])\\s+"))
+              .map(String::trim)
+              .filter(sentence -> sentence.length() > 40)
+              .toList();
+      assertThat(sentences)
+          .as("tool '%s' repeats a sentence in its description", tool.name())
+          .doesNotHaveDuplicates();
+    }
   }
 
   private static final List<String> UPSERT_CAPABLE_CREATE_TOOLS =

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/GetEntityToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/GetEntityToolTest.java
@@ -14,6 +14,8 @@
 package org.openmetadata.mcp.tools;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -376,5 +378,32 @@ class GetEntityToolTest {
   @SuppressWarnings("unchecked")
   private static Map<String, Object> castMap(Object value) {
     return (Map<String, Object>) value;
+  }
+
+  @Test
+  void parseReferenceSplitsOnTheFirstColonOnly() {
+    // A testCase FQN embeds colons; splitting on all of them would truncate a valid entity.
+    GetEntityTool.EntityRef parsed =
+        GetEntityTool.parseReference("testCase:svc.db.schema.tbl.col::column_values_between");
+
+    assertEquals("testCase", parsed.entityType());
+    assertEquals("svc.db.schema.tbl.col::column_values_between", parsed.fqn());
+  }
+
+  @Test
+  void parseReferenceTrimsAndAcceptsTheOrdinaryForm() {
+    GetEntityTool.EntityRef parsed =
+        GetEntityTool.parseReference("  table : sample_data.ecommerce_db.shopify.dim_address ");
+
+    assertEquals("table", parsed.entityType());
+    assertEquals("sample_data.ecommerce_db.shopify.dim_address", parsed.fqn());
+  }
+
+  @Test
+  void parseReferenceRejectsWhatCannotBeAnEntity() {
+    assertNull(GetEntityTool.parseReference(null));
+    assertNull(GetEntityTool.parseReference("no-colon-at-all"), "a bare FQN has no entity type");
+    assertNull(GetEntityTool.parseReference(":svc.db.tbl"), "an empty type is not resolvable");
+    assertNull(GetEntityTool.parseReference("table:"), "an empty FQN is not resolvable");
   }
 }

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/GetLineageToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/GetLineageToolTest.java
@@ -112,6 +112,85 @@ class GetLineageToolTest {
   }
 
   @Test
+  void omitsSqlByDefaultButFlagsThatItExists() {
+    String sql = "SELECT a, b FROM upstream_table";
+    Map<String, Object> response =
+        GetLineageTool.enforceSizeBudget(
+            GetLineageTool.toSlim(
+                singleUpstreamEdge(sql, List.of()), new GetLineageTool.EdgeOptions(false, false)));
+    Map<String, Object> edge = firstUpstreamEdge(response);
+
+    assertNull(edge.get("sqlQuery"), "SQL must be omitted unless includeSql is set");
+    assertEquals(
+        Boolean.TRUE,
+        edge.get("hasSql"),
+        "an edge whose SQL was withheld must say so, or the caller cannot know to ask for it");
+  }
+
+  @Test
+  void returnsSqlWhenExplicitlyRequested() {
+    String sql = "SELECT a, b FROM upstream_table";
+    Map<String, Object> response =
+        GetLineageTool.enforceSizeBudget(
+            GetLineageTool.toSlim(
+                singleUpstreamEdge(sql, List.of()), new GetLineageTool.EdgeOptions(false, true)));
+    Map<String, Object> edge = firstUpstreamEdge(response);
+
+    assertEquals(sql, edge.get("sqlQuery"), "opting in must return the SQL in full");
+    assertEquals(Boolean.TRUE, edge.get("hasSql"));
+  }
+
+  @Test
+  void edgeWithoutSqlCarriesNoHasSqlFlag() {
+    Map<String, Object> response =
+        GetLineageTool.enforceSizeBudget(
+            GetLineageTool.toSlim(
+                singleUpstreamEdge(null, List.of()), new GetLineageTool.EdgeOptions(false, false)));
+    Map<String, Object> edge = firstUpstreamEdge(response);
+
+    assertNull(edge.get("sqlQuery"));
+    assertNull(edge.get("hasSql"), "absent SQL must not be advertised as withheld");
+  }
+
+  @Test
+  void withholdingSqlIsWhereTheSavingComesFrom() {
+    // A live 18-edge graph measured 33,038 tokens, 93.8% of it sqlQuery. Guard the property that
+    // makes that saving real: the default response must be a small fraction of the opted-in one.
+    String sql = "SELECT col FROM t WHERE x = 1 -- padding padding padding\n".repeat(40);
+    int withSql =
+        McpResponseTrim.serializedLength(
+            GetLineageTool.enforceSizeBudget(
+                GetLineageTool.toSlim(
+                    singleUpstreamEdge(sql, List.of()),
+                    new GetLineageTool.EdgeOptions(false, true))));
+    int withoutSql =
+        McpResponseTrim.serializedLength(
+            GetLineageTool.enforceSizeBudget(
+                GetLineageTool.toSlim(
+                    singleUpstreamEdge(sql, List.of()),
+                    new GetLineageTool.EdgeOptions(false, false))));
+
+    assertTrue(
+        withoutSql * 5 < withSql,
+        "default response must be under a fifth of the SQL-bearing one, got "
+            + withoutSql
+            + " vs "
+            + withSql);
+  }
+
+  @Test
+  void depthZeroIsHonouredNotClampedToOne() {
+    assertEquals(
+        0,
+        GetLineageTool.clampDepthForTest(0),
+        "downstreamDepth=0 means 'omit this direction'; clamping it to 1 returns edges the caller "
+            + "explicitly asked to skip");
+    assertEquals(1, GetLineageTool.clampDepthForTest(1));
+    assertEquals(10, GetLineageTool.clampDepthForTest(99), "depth stays capped at MAX_DEPTH");
+    assertEquals(0, GetLineageTool.clampDepthForTest(-5), "a negative depth means none, not all");
+  }
+
+  @Test
   void includesColumnLineageWhenRequested() {
     ColumnLineage column =
         new ColumnLineage()
@@ -296,5 +375,19 @@ class GetLineageToolTest {
               .withToColumn("db.public.orders.derived_column_with_a_long_name_" + i));
     }
     return columns;
+  }
+
+  @Test
+  void lineageAlwaysStatesWhetherTheGraphIsComplete() {
+    Map<String, Object> response =
+        GetLineageTool.enforceSizeBudget(
+            GetLineageTool.toSlim(singleUpstreamEdge("SELECT 1", List.of()), false));
+
+    assertEquals(
+        Boolean.FALSE,
+        response.get("edgesTruncated"),
+        "a complete graph must say so - silence is what forced a caller to probe with extra calls");
+    assertEquals(1, response.get("totalEdges"));
+    assertEquals(1, response.get("returnedEdges"));
   }
 }

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/HonestResponseTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/HonestResponseTest.java
@@ -1,0 +1,268 @@
+package org.openmetadata.mcp.tools;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.mcp.util.McpResponseTrim;
+import org.openmetadata.schema.type.Edge;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.utils.JsonUtils;
+
+/**
+ * Cases where a response used to state something it could not know.
+ *
+ * <p>Each of these was a live defect: a count in the wrong unit, a completeness flag that nothing
+ * backed, a client error blamed on the backend, an exclusion that never reached the engine. They
+ * share a failure mode rather than a call site - the payload was confident and wrong, which is worse
+ * than an error for a caller that cannot check.
+ */
+class HonestResponseTest {
+
+  // --- excludeEntityTypes reaching the engine -------------------------------------------------
+
+  @Test
+  void anExclusionWithNoCallerFilterStillBecomesAQuery() throws IOException {
+    String filter = SearchMetadataTool.excludeOnlyFilter(Set.of("tableColumn"));
+
+    assertTrue(filter != null, "without this the exclusion never reached the engine at all");
+    JsonNode mustNot = JsonUtils.readTree(filter).path("query").path("bool").path("must_not");
+    assertEquals(1, mustNot.size(), "the exclusion is a real must_not clause, not a post-filter");
+    assertEquals(
+        "tableColumn",
+        mustNot.get(0).path("term").path("entityType").asText(),
+        "post-filtering an already-fetched page returned an empty page for a query with hundreds of "
+            + "matches, which reads as 'no such assets exist'");
+  }
+
+  @Test
+  void nothingToExcludeLeavesTheRequestUnchanged() {
+    assertNull(
+        SearchMetadataTool.excludeOnlyFilter(Set.of()),
+        "an empty exclusion must not attach a filter that narrows an ordinary search");
+  }
+
+  // --- semantic_search totalFound counted in entities -----------------------------------------
+
+  @Test
+  void totalFoundCountsEntitiesAndSaysWhenItIsOnlyALowerBound() {
+    Map<String, Object> page = new HashMap<>();
+    page.put("returnedCount", 8);
+    page.put(McpResponseTrim.HAS_MORE_KEY, Boolean.TRUE);
+
+    SemanticSearchTool.addParentTotal(page, 10);
+
+    assertEquals(
+        18,
+        page.get("totalFound"),
+        "results are collapsed to one row per parent, so totalFound must count parents too - "
+            + "reporting the backend's chunk count made 8 tables read as 96");
+    assertEquals(Boolean.TRUE, page.get("totalFoundIsLowerBound"), "more pages exist, so say so");
+  }
+
+  @Test
+  void aFinishedPageReportsAnExactTotalWithNoCaveat() {
+    Map<String, Object> page = new HashMap<>();
+    page.put("returnedCount", 3);
+
+    SemanticSearchTool.addParentTotal(page, 0);
+
+    assertEquals(3, page.get("totalFound"), "paging has stopped, so the count is exact");
+    assertNull(page.get("totalFoundIsLowerBound"), "an exact total must not be hedged");
+  }
+
+  // --- RCA completeness ------------------------------------------------------------------------
+
+  @Test
+  void aShortFailingTestListIsReportedComplete() {
+    Map<String, Object> tests = new HashMap<>();
+
+    RootCauseAnalysisTool.annotateCompleteness(tests, 3);
+
+    assertEquals(3, tests.get("failingTestCount"));
+    assertEquals(Boolean.TRUE, tests.get("complete"), "three of three is genuinely the whole set");
+    assertNull(tests.get("completeNote"));
+  }
+
+  @Test
+  void aFullBucketIsNotClaimedComplete() {
+    Map<String, Object> tests = new HashMap<>();
+
+    RootCauseAnalysisTool.annotateCompleteness(tests, 100);
+
+    assertEquals(
+        Boolean.FALSE,
+        tests.get("complete"),
+        "the lookup passes no limit, so the terms aggregation caps at 100 buckets and a full page "
+            + "cannot be distinguished from a truncated one - 'complete: true' was hardcoded");
+    assertTrue(
+        tests.get("completeNote").toString().contains("originEntityFQN"),
+        "the caveat carries the way to get the full set, not just the fact that it is capped");
+  }
+
+  // --- failure classification ------------------------------------------------------------------
+
+  @Test
+  void aStatusTheBackendReportedBeatsTheKeywordGuess() {
+    Exception parseFailure =
+        new IOException(
+            "method [POST], host [http://localhost:9200], URI [/table_search_index/_search],"
+                + " status line [HTTP/1.1 400 Bad Request] {\"error\":{\"root_cause\":"
+                + "[{\"type\":\"parsing_exception\",\"reason\":\"[bool] malformed query\"}]}}");
+
+    int status = DefaultToolContext.resolveStatusCode(parseFailure);
+
+    assertEquals(
+        400,
+        status,
+        "no name or keyword rule matches a search client's ResponseException, so this fell through "
+            + "to 500 - and a 500 makes summarizeFailure tell the model its arguments were fine "
+            + "and not to retry, for a query it wrote and could have fixed");
+    assertFalse(DefaultToolContext.isServerFault(status), "a 400 is the caller's to correct");
+  }
+
+  @Test
+  void aReportedServerErrorIsStillAServerFault() {
+    Exception shardFailure =
+        new IOException(
+            "status line [HTTP/1.1 503 Service Unavailable] {\"error\":{\"type\":"
+                + "\"index_not_found_exception\"}}");
+
+    int status = DefaultToolContext.resolveStatusCode(shardFailure);
+
+    assertEquals(
+        503,
+        status,
+        "the body says index_not_found, which the keyword table read as a 404 - the reported status "
+            + "is the one that is actually true");
+    assertTrue(DefaultToolContext.isServerFault(status));
+  }
+
+  @Test
+  void anExceptionWithNoReportedStatusStillUsesTheKeywordTable() {
+    assertEquals(
+        400,
+        DefaultToolContext.resolveStatusCode(new IllegalArgumentException("bad 'size' parameter")),
+        "the status extractor is an addition, not a replacement");
+  }
+
+  @Test
+  void aQueryFilterThatFailsToParseIsTheCallersProblem() {
+    Exception malformed =
+        new IOException("JSON parsing failed with message [Failed to process JSON ]");
+
+    int status = DefaultToolContext.resolveStatusCode(malformed);
+
+    assertEquals(
+        400,
+        status,
+        "a queryFilter is parsed before the request is sent, so this failure carries no reported "
+            + "status and defaulted to 500 - telling the model its malformed DSL was a backend "
+            + "outage not worth retrying, when it wrote the DSL and could fix it");
+    assertFalse(DefaultToolContext.isServerFault(status));
+  }
+
+  // --- never-run semantics --------------------------------------------------------------------
+
+  @Test
+  void aQueuedTestDoesNotCountAsExecuted() {
+    Map<String, Object> summary =
+        Map.of("total", 13, "success", 0, "failed", 0, "aborted", 0, "queued", 13);
+
+    Map<?, ?> annotated = (Map<?, ?>) GetEntityTool.withNeverRun(summary);
+
+    assertEquals(
+        13,
+        annotated.get("neverRun"),
+        "a queued test has produced no verdict, so counting it as executed would let a suite that "
+            + "is merely waiting to run report neverRun: 0 - the exact 'zero failures reads as "
+            + "healthy' trap this exists to close");
+    assertTrue(
+        annotated.get(McpResponseTrim.MESSAGE_KEY).toString().contains("unverified"),
+        "the caveat must still fire for an all-queued suite");
+  }
+
+  @Test
+  void executedTestsSuppressTheNeverRunCaveat() {
+    Map<String, Object> summary =
+        Map.of("total", 4, "success", 3, "failed", 1, "aborted", 0, "queued", 0);
+
+    Map<?, ?> annotated = (Map<?, ?>) GetEntityTool.withNeverRun(summary);
+
+    assertEquals(0, annotated.get("neverRun"));
+    assertNull(annotated.get(McpResponseTrim.MESSAGE_KEY), "nothing to caveat when all tests ran");
+  }
+
+  // --- lineage reach without a per-neighbour probe ----------------------------------------------
+
+  @Test
+  void reachIsDecidedByWhereEdgesAttachNotByProbingEachNeighbour() {
+    UUID root = UUID.randomUUID();
+    UUID parent = UUID.randomUUID();
+    UUID grandparent = UUID.randomUUID();
+    Map<UUID, EntityReference> index = new HashMap<>();
+    index.put(parent, ref(parent, "svc.db.schema.parent"));
+    index.put(grandparent, ref(grandparent, "svc.db.schema.grandparent"));
+    List<Edge> upstream = List.of(edge(parent, root), edge(grandparent, parent));
+
+    Map<String, Object> summary = new LinkedHashMap<>();
+    GetEntityTool.addDirection(summary, root, index, upstream, true);
+
+    assertEquals(
+        List.of("svc.db.schema.parent"),
+        summary.get("upstream"),
+        "only the edge touching the root is an immediate neighbour");
+    assertEquals(
+        Boolean.TRUE,
+        summary.get("hasMoreUpstream"),
+        "the second-hop edge is the whole signal - the probe it replaced looked each neighbour up "
+            + "under the ROOT's entity type, so a neighbour of any other type threw and the entire "
+            + "lineage block degraded to 'unavailable'");
+  }
+
+  @Test
+  void aTerminatingChainReportsNoMore() {
+    UUID root = UUID.randomUUID();
+    UUID parent = UUID.randomUUID();
+    Map<UUID, EntityReference> index = new HashMap<>();
+    index.put(parent, ref(parent, "svc.db.schema.parent"));
+
+    Map<String, Object> summary = new LinkedHashMap<>();
+    GetEntityTool.addDirection(summary, root, index, List.of(edge(parent, root)), true);
+
+    assertEquals(Boolean.FALSE, summary.get("hasMoreUpstream"), "one hop and the graph ends");
+  }
+
+  @Test
+  void anEmptyDirectionIsStillReported() {
+    Map<String, Object> summary = new LinkedHashMap<>();
+
+    GetEntityTool.addDirection(
+        summary, UUID.randomUUID(), new HashMap<>(), new ArrayList<>(), false);
+
+    assertEquals(List.of(), summary.get("downstream"));
+    assertEquals(
+        Boolean.FALSE,
+        summary.get("hasMoreDownstream"),
+        "an absent flag would leave the caller guessing whether the direction was checked");
+  }
+
+  private static EntityReference ref(UUID id, String fqn) {
+    return new EntityReference().withId(id).withFullyQualifiedName(fqn);
+  }
+
+  private static Edge edge(UUID from, UUID to) {
+    return new Edge().withFromEntity(from).withToEntity(to);
+  }
+}

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/LineageToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/LineageToolTest.java
@@ -1,0 +1,47 @@
+package org.openmetadata.mcp.tools;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class LineageToolTest {
+
+  private static IllegalArgumentException rejects(Map<String, Object> params) {
+    return assertThrows(
+        IllegalArgumentException.class, () -> new LineageTool().execute(null, null, params));
+  }
+
+  @Test
+  void rejectsAnEndpointWithNeitherFqnNorId() {
+    Map<String, Object> params = new HashMap<>();
+    params.put("fromEntity", Map.of("type", "table"));
+    params.put("toEntity", Map.of("type", "table", "fqn", "svc.db.schema.target"));
+
+    String message = rejects(params).getMessage();
+
+    assertTrue(message.contains("fromEntity"), "the failing parameter must be named: " + message);
+    assertTrue(
+        message.contains("'fqn'") && message.contains("'id'"),
+        "the message must name both accepted identifiers so the model can retry without guessing: "
+            + message);
+    assertTrue(
+        message.contains("search results return"),
+        "the message should point at the identifier the caller already has: " + message);
+  }
+
+  @Test
+  void rejectsAnEndpointThatIsNotAnObject() {
+    Map<String, Object> params = new HashMap<>();
+    params.put("fromEntity", "svc.db.schema.source");
+    params.put("toEntity", Map.of("type", "table", "fqn", "svc.db.schema.target"));
+
+    String message = rejects(params).getMessage();
+
+    assertTrue(
+        message.contains("must be an object"),
+        "a bare string endpoint must be explained, not cast-cast-crashed: " + message);
+  }
+}

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/McpResponseUtilsTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/McpResponseUtilsTest.java
@@ -4,10 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.entity.data.Glossary;
+import org.openmetadata.schema.type.ChangeDescription;
 import org.openmetadata.schema.type.EventType;
+import org.openmetadata.schema.type.FieldChange;
 
 class McpResponseUtilsTest {
 
@@ -18,6 +22,51 @@ class McpResponseUtilsTest {
     glossary.setUpdatedBy("x");
     glossary.setDeleted(false);
     return glossary;
+  }
+
+  private static Glossary patchedGlossary() {
+    Glossary glossary = buildGlossary();
+    glossary.setVersion(1.3);
+    glossary.setChangeDescription(
+        new ChangeDescription()
+            .withFieldsUpdated(List.of(new FieldChange().withName("description")))
+            .withFieldsAdded(List.of(new FieldChange().withName("tags"))));
+    return glossary;
+  }
+
+  @Test
+  void compactPatchKeepsWhatOnlyAnUpdateCanAnswer() {
+    Map<String, Object> doc =
+        McpResponseUtils.compactPatch(patchedGlossary(), EventType.ENTITY_UPDATED);
+
+    // compact() strips both of these because they are meaningless on a create. On a patch they are
+    // the confirmation the caller wrote for, so aligning the response must not drop them.
+    assertEquals(1.3, doc.get("version"), "the new version must survive the slimming");
+    // Order is added-then-updated-then-deleted, which is not a contract - the set is.
+    assertEquals(
+        Set.of("description", "tags"),
+        Set.copyOf((List<?>) doc.get("changed")),
+        "which fields actually changed is the answer to 'did my update land'");
+    assertEquals("updated", doc.get("_operation"));
+  }
+
+  @Test
+  void compactPatchStillDropsTheNoise() {
+    Map<String, Object> doc =
+        McpResponseUtils.compactPatch(patchedGlossary(), EventType.ENTITY_UPDATED);
+
+    assertFalse(doc.containsKey("updatedBy"));
+    assertFalse(
+        doc.containsKey("changeDescription"),
+        "the full object carries old and new values for every field - the names are enough");
+  }
+
+  @Test
+  void compactPatchOmitsChangedWhenNothingIsRecorded() {
+    Map<String, Object> doc =
+        McpResponseUtils.compactPatch(buildGlossary(), EventType.ENTITY_UPDATED);
+
+    assertFalse(doc.containsKey("changed"), "an empty list would read as 'nothing changed'");
   }
 
   @Test

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/PatchEntityToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/PatchEntityToolTest.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.openmetadata.schema.EntityInterface;
@@ -87,7 +89,7 @@ class PatchEntityToolTest {
               any(String.class),
               eq("alice"),
               any(),
-              eq(ChangeSource.MANUAL),
+              eq(ChangeSource.AUTOMATED),
               isNull(),
               impersonatedByCaptor.capture());
 
@@ -128,7 +130,7 @@ class PatchEntityToolTest {
               any(String.class),
               eq("alice"),
               any(),
-              eq(ChangeSource.MANUAL),
+              eq(ChangeSource.AUTOMATED),
               isNull(),
               impersonatedByCaptor.capture());
 
@@ -171,16 +173,105 @@ class PatchEntityToolTest {
     }
   }
 
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "[{\"op\":\"replace\",\"path\":\"/description\",\"value\":\"x\"}]",
+        "[{\"op\":\"add\",\"path\":\"/owners/-\",\"value\":{\"id\":\"u\",\"type\":\"user\"}}]",
+        "[{\"op\":\"remove\",\"path\":\"/owners/0\"}]",
+        "[{\"op\":\"move\",\"from\":\"/a\",\"path\":\"/b\"}]",
+        "[{\"op\":\"test\",\"path\":\"/description\",\"value\":\"x\"}]"
+      })
+  void execute_validPatchReachesTheRepository(String goodPatch) {
+    // Validation must judge the DOCUMENT, never the entity. An earlier attempt checked the patch by
+    // applying it to an empty object, which rejected every one of these - including the
+    // owner-append
+    // the tool description itself advertises - because the paths do not exist in '{}'. Whether a
+    // path exists is the repository's question to answer against the real entity.
+    @SuppressWarnings("unchecked")
+    EntityRepository<EntityInterface> mockRepo = mock(EntityRepository.class);
+    EntityInterface mockEntity = mock(EntityInterface.class);
+    when(mockRepo.patch(any(), any(String.class), any(), any(), any(), any(), any()))
+        .thenReturn(
+            new RestUtil.PatchResponse<>(Response.Status.OK, mockEntity, EventType.ENTITY_UPDATED));
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("entityType", "table");
+    params.put("fqn", "db.schema.test_table");
+    params.put("patch", goodPatch);
+
+    try (MockedStatic<Entity> entityMock = mockStatic(Entity.class);
+        MockedStatic<McpChangeEventUtil> changeEventMock = mockStatic(McpChangeEventUtil.class);
+        MockedStatic<JsonUtils> jsonMock = mockStatic(JsonUtils.class)) {
+      entityMock.when(() -> Entity.getEntityRepository("table")).thenReturn(mockRepo);
+      jsonMock.when(() -> JsonUtils.convertValue(any(), eq(Map.class))).thenReturn(Map.of());
+
+      new PatchEntityTool().execute(authorizer, securityContext, params);
+
+      verify(mockRepo).patch(any(), any(String.class), any(), any(), any(), any(), any());
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "[{\"foo\":\"bar\"}]",
+        "[{\"op\":\"bogus\",\"path\":\"/x\",\"value\":1}]",
+        "[{\"op\":\"replace\"}]",
+        "[\"not-an-object\"]"
+      })
+  void execute_validJsonButInvalidPatch_isAlsoTheCallersProblem(String badPatch) {
+    Map<String, Object> params = new HashMap<>();
+    params.put("entityType", "table");
+    params.put("fqn", "db.schema.test_table");
+    params.put("patch", badPatch);
+
+    // Json.createPatch does not validate operations - it builds happily and only fails on apply(),
+    // inside the repository. There an unknown op is a JsonException and a bare object is a raw
+    // NullPointerException; the dispatcher reads neither as the caller's fault and returns 500
+    // with "retrying will not help", for a document the model wrote and could fix.
+    assertThatThrownBy(() -> new PatchEntityTool().execute(authorizer, securityContext, params))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not a valid JSONPatch document");
+  }
+
   @Test
-  void execute_nullPatch_throwsIllegalArgumentException() {
+  void execute_malformedPatch_isTheCallersProblemNotABackendFault() {
+    Map<String, Object> params = new HashMap<>();
+    params.put("entityType", "table");
+    params.put("fqn", "db.schema.test_table");
+    params.put("patch", "[{\"op\": \"add\", \"path\": \"/owners/-\", \"value\": {\"id\": \"x\"}]");
+
+    // An IllegalArgumentException is what the dispatcher maps to 400. Letting the JSON library's
+    // own exception escape produced a 500 telling the model its arguments were fine and not to
+    // retry - for a document the model wrote and could fix.
+    assertThatThrownBy(() -> new PatchEntityTool().execute(authorizer, securityContext, params))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not valid JSON");
+  }
+
+  @Test
+  void execute_missingPatch_throwsIllegalArgumentException() {
     Map<String, Object> params = new HashMap<>();
     params.put("entityType", "table");
     params.put("fqn", "db.schema.test_table");
     params.put("patch", null);
 
+    // The patch document is the whole interface, so its absence names the RFC and shows the shape.
     assertThatThrownBy(() -> new PatchEntityTool().execute(authorizer, securityContext, params))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Patch cannot be null or empty");
+        .hasMessageContaining("'patch' is required")
+        .hasMessageContaining("RFC 6902");
+  }
+
+  @Test
+  void execute_missingTarget_namesBothRequiredParameters() {
+    Map<String, Object> params = new HashMap<>();
+    params.put("fqn", "db.schema.test_table");
+
+    assertThatThrownBy(() -> new PatchEntityTool().execute(authorizer, securityContext, params))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("'entityType' and 'fqn' are required");
   }
 
   @Test

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/RootCauseAnalysisToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/RootCauseAnalysisToolTest.java
@@ -14,6 +14,8 @@
 package org.openmetadata.mcp.tools;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -303,5 +305,29 @@ class RootCauseAnalysisToolTest {
     assertThat(outDownstream.get("downstreamImpactedEdgesCount")).isEqualTo(200);
     assertThat(JsonUtils.pojoToJson(output).length())
         .isLessThan(McpResponseTrim.MAX_RESPONSE_CHARS);
+  }
+
+  @Test
+  void summaryDistinguishesLocalFailuresFromInheritedOnes() {
+    String fqn = "sample_data.ecommerce_db.shopify.dim_address";
+
+    String inherited = RootCauseAnalysisTool.summarize(fqn, 2, false);
+    assertTrue(
+        inherited.contains("2 failing upstream"),
+        "an upstream cause must be stated as upstream: " + inherited);
+    assertTrue(inherited.contains("root cause is upstream"), inherited);
+
+    // The regression: the DQ walk returns the analysed entity among its own nodes, so counting
+    // nodes previously reported "Found 1 upstream failure(s)" for an asset with a clean upstream.
+    String local = RootCauseAnalysisTool.summarize(fqn, 0, true);
+    assertTrue(
+        local.contains("originate on this asset itself"),
+        "failures with a clean upstream must be attributed locally: " + local);
+    assertFalse(
+        local.contains("upstream failure"),
+        "must not claim an upstream failure when none exists: " + local);
+
+    String clean = RootCauseAnalysisTool.summarize(fqn, 0, false);
+    assertTrue(clean.contains("No failing tests found"), clean);
   }
 }

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SearchMetadataCleanTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SearchMetadataCleanTest.java
@@ -1,0 +1,73 @@
+package org.openmetadata.mcp.tools;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Contracts a caller relies on to know what it did and did not receive. */
+class SearchMetadataCleanTest {
+
+  private static Map<String, Object> hit(Map<String, Object> source) {
+    return SearchMetadataTool.cleanSearchResult(new HashMap<>(source), List.of());
+  }
+
+  @Test
+  void aCutDescriptionSaysThatItWasCut() {
+    String long1 = "x".repeat(900);
+    Map<String, Object> cleaned = hit(Map.of("entityType", "table", "description", long1));
+
+    assertTrue(
+        cleaned.get("description").toString().length() < long1.length(), "long text is shortened");
+    assertEquals(
+        Boolean.TRUE,
+        cleaned.get("descriptionTruncated"),
+        "a silent cut reads as the complete text - a caller reported a truncated description as "
+            + "the whole field and lost the sentence that mattered");
+  }
+
+  @Test
+  void aShortDescriptionCarriesNoTruncationMarker() {
+    Map<String, Object> cleaned =
+        hit(Map.of("entityType", "table", "description", "One row per customer address."));
+
+    assertEquals("One row per customer address.", cleaned.get("description"));
+    assertNull(
+        cleaned.get("descriptionTruncated"), "an untouched field must not claim to be truncated");
+  }
+
+  @Test
+  void aTestThatNeverRanIsFlaggedWithoutInventingAStatus() {
+    Map<String, Object> cleaned = hit(Map.of("entityType", "testCase", "name", "row_count_check"));
+
+    assertEquals(
+        Boolean.TRUE,
+        cleaned.get("neverRun"),
+        "absence is ambiguous: callers spent extra calls on a test suite summary purely to learn "
+            + "that a missing status meant the test had never executed");
+    assertNull(
+        cleaned.get("testCaseStatus"),
+        "testCaseStatus is a closed schema enum (Success/Failed/Aborted/Queued) with a generated "
+            + "parser behind it - writing 'NeverRun' into it invents a value that exists nowhere "
+            + "in OpenMetadata and throws in any client that parses the field");
+  }
+
+  @Test
+  void anExecutedTestKeepsItsRealStatusAndIsNotFlagged() {
+    Map<String, Object> cleaned = hit(Map.of("entityType", "testCase", "testCaseStatus", "Failed"));
+
+    assertEquals("Failed", cleaned.get("testCaseStatus"), "a real result is never overwritten");
+    assertNull(cleaned.get("neverRun"), "a test that ran must not be flagged as never run");
+  }
+
+  @Test
+  void nonTestEntitiesAreNotGivenATestStatus() {
+    Map<String, Object> cleaned = hit(Map.of("entityType", "table", "name", "dim_address"));
+
+    assertNull(cleaned.get("testCaseStatus"), "a table has no test status of its own");
+  }
+}

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SemanticSearchToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SemanticSearchToolTest.java
@@ -217,7 +217,10 @@ class SemanticSearchToolTest {
     assertEquals("Users", cleaned.get("displayName"));
     assertEquals("BigQuery", cleaned.get("serviceType"));
     assertEquals("A short description", cleaned.get("description"));
-    assertNotNull(cleaned.get("columns"));
+    // Column *names* replace full column objects: on a live 10-hit response full `columns` was
+    // 68.6% of the payload, and per-column descriptions do not help pick the right asset.
+    assertNull(cleaned.get("columns"), "full column objects must not ship in a search hit");
+    assertNotNull(cleaned.get("columnNames"), "column names are kept so the hit stays selectable");
     assertEquals(0.95, cleaned.get("similarityScore"));
     assertTrue(!cleaned.containsKey("_score"));
     assertTrue(!cleaned.containsKey("embedding"));

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/util/McpParamsTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/util/McpParamsTest.java
@@ -14,8 +14,10 @@
 package org.openmetadata.mcp.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -70,5 +72,33 @@ class McpParamsTest {
   void getBooleanFallsBackOnMissingAndNull() {
     assertThat(McpParams.getBoolean(new HashMap<>(), "flag", true)).isTrue();
     assertThat(McpParams.getBoolean(params("flag", null), "flag", true)).isTrue();
+  }
+
+  @Test
+  void getStringListAcceptsTheFormsAModelActuallySends() {
+    assertEquals(
+        List.of("lineage", "quality"),
+        McpParams.getStringList(Map.of("include", List.of("lineage", "quality")), "include"),
+        "the declared array form");
+    assertEquals(
+        List.of("lineage"),
+        McpParams.getStringList(Map.of("include", "lineage"), "include"),
+        "a bare string must not be read as an empty list - some clients drop the array wrapper for "
+            + "a single element, and a silently-empty include looks like the caller never asked");
+    assertEquals(
+        List.of("lineage", "quality"),
+        McpParams.getStringList(Map.of("include", "lineage, quality"), "include"),
+        "a comma-separated string is what a model writes when it is unsure of the shape");
+  }
+
+  @Test
+  void getStringListIsEmptyRatherThanNullForAbsentOrJunkInput() {
+    assertEquals(List.of(), McpParams.getStringList(Map.of(), "include"));
+    assertEquals(List.of(), McpParams.getStringList(null, "include"));
+    assertEquals(List.of(), McpParams.getStringList(Map.of("include", ""), "include"));
+    assertEquals(
+        List.of(),
+        McpParams.getStringList(Map.of("include", 42), "include"),
+        "an unusable value yields no sections rather than throwing on an optional parameter");
   }
 }

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/util/McpResponseTrimTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/util/McpResponseTrimTest.java
@@ -14,8 +14,12 @@
 package org.openmetadata.mcp.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -90,5 +94,183 @@ class McpResponseTrimTest {
     assertThat(McpResponseTrim.safeMessage(new RuntimeException("boom"))).isEqualTo("boom");
     assertThat(McpResponseTrim.safeMessage(new RuntimeException())).isEqualTo("<no message>");
     assertThat(McpResponseTrim.safeMessage(null)).isEqualTo("<no message>");
+  }
+
+  @Test
+  void slimRefKeepsOnlyTheActionableIdentifier() {
+    Map<String, Object> ref = new LinkedHashMap<>();
+    ref.put("id", "8c1e1f4e-0000-0000-0000-000000000000");
+    ref.put("type", "databaseSchema");
+    ref.put("name", "shopify");
+    ref.put("fullyQualifiedName", "sample_data.ecommerce_db.shopify");
+    ref.put("description", "A long schema description repeated on every hit from this schema.");
+    ref.put("deleted", false);
+
+    assertEquals(
+        "sample_data.ecommerce_db.shopify",
+        McpResponseTrim.slimRef(ref),
+        "every MCP tool is addressed by (entityType, fqn), so the FQN is the only actionable part");
+  }
+
+  @Test
+  void slimRefFallsBackToNameAndPassesThroughUnknownShapes() {
+    assertEquals("marketing", McpResponseTrim.slimRef(Map.of("name", "marketing")));
+    assertEquals("already-a-string", McpResponseTrim.slimRef("already-a-string"));
+    Map<String, Object> odd = Map.of("unexpected", "shape");
+    assertEquals(
+        odd, McpResponseTrim.slimRef(odd), "an unrecognised payload passes through, never emptied");
+  }
+
+  @Test
+  void slimTagDropsTheRepeatedTagDescription() {
+    Map<String, Object> tier = new LinkedHashMap<>();
+    tier.put("tagFQN", "Tier.Tier1");
+    tier.put("description", "Critical Source of Truth business data assets ...");
+    tier.put("labelType", "Manual");
+    tier.put("state", "Confirmed");
+
+    assertEquals("Tier.Tier1", McpResponseTrim.slimTag(tier));
+    assertEquals(
+        List.of("PII.Sensitive", "Tier.Tier1"),
+        McpResponseTrim.slimTag(
+            List.of(Map.of("tagFQN", "PII.Sensitive"), Map.of("tagFQN", "Tier.Tier1"))));
+  }
+
+  @Test
+  void slimmingASearchHitIsWhereTheSavingComesFrom() {
+    // On a live 10-hit search_metadata response, tier alone was 26.2% of the payload and the
+    // service/database/databaseSchema references a further 32.9%. Guard the ratio, not the shape.
+    Map<String, Object> schemaRef = new LinkedHashMap<>();
+    schemaRef.put("id", "8c1e1f4e-0000-0000-0000-000000000000");
+    schemaRef.put("type", "databaseSchema");
+    schemaRef.put("name", "shopify");
+    schemaRef.put("fullyQualifiedName", "sample_data.ecommerce_db.shopify");
+    schemaRef.put("description", "A long schema description repeated on every hit ".repeat(4));
+
+    int before = McpResponseTrim.serializedLength(schemaRef);
+    int after = McpResponseTrim.serializedLength(McpResponseTrim.slimRef(schemaRef));
+
+    assertTrue(
+        after * 4 < before,
+        "a slimmed reference must be a small fraction of the embedded object, got "
+            + after
+            + " vs "
+            + before);
+  }
+
+  @Test
+  void summarizesAFourKilobyteSearchBackendFailure() {
+    // Shape taken from a real failing search_metadata call: one status line, then a shard-failure
+    // body that repeats the same null_pointer_exception once per shard.
+    String shardFailure =
+        "{\"shard\":0,\"index\":\"table_search_index_rebuild_1787425808482\","
+            + "\"node\":\"BJKMp72iTySSK0CbcFTzFg\",\"reason\":{\"type\":\"null_pointer_exception\","
+            + "\"reason\":null,\"suppressed\":[{\"type\":\"null_pointer_exception\",\"reason\":null},"
+            + "{\"type\":\"null_pointer_exception\",\"reason\":null}]}},";
+    String repeated = shardFailure.repeat(24);
+    String raw =
+        "method [POST], host [http://localhost:9200], URI [/dataAsset/_search], status line "
+            + "[HTTP/1.1 500 Internal Server Error]\n"
+            + "{\"error\":{\"root_cause\":["
+            + repeated
+            + "],\"type\":\"search_phase_execution_exception\",\"reason\":\"all shards failed\"}}";
+    assertTrue(raw.length() > 1500, "fixture must be big enough to be worth summarising");
+
+    String summary = McpResponseTrim.summarizeFailure(new RuntimeException(raw), true);
+
+    assertTrue(
+        summary.length() < raw.length() / 3,
+        "a backend failure must not cost more context than a successful call: " + summary.length());
+    assertTrue(summary.contains("null_pointer_exception"), "the cause is named once: " + summary);
+    assertFalse(
+        summary.contains("\"reason\":null},{\"type\""),
+        "the per-shard repetition must not survive: " + summary);
+    assertTrue(
+        summary.contains("not a problem with the arguments"),
+        "a 5xx must tell the caller retrying the same call will not help: " + summary);
+  }
+
+  @Test
+  void leavesAShortActionableMessageAlone() {
+    String actionable =
+        "Parameter 'metricExpressionLanguage' is required and must be a non-blank string. "
+            + "Valid values are: SQL, Java, JavaScript, Python, External. Received: null";
+
+    String summary = McpResponseTrim.summarizeFailure(new RuntimeException(actionable), false);
+
+    assertEquals(
+        actionable,
+        summary,
+        "a 4xx that already names the field and its valid values is exactly what we want the model "
+            + "to read - summarising it would remove the fix");
+  }
+
+  @Test
+  void slimCertificationResolvesExpiryInsteadOfShippingEpochMillis() {
+    long now = 1_756_000_000_000L;
+    Map<String, Object> label = new LinkedHashMap<>();
+    label.put("tagFQN", "Certification.Gold");
+    label.put("state", "Confirmed");
+    label.put("description", "Gold certified Data Asset.");
+    label.put("iconURL", "GoldCertification.svg");
+    Map<String, Object> certification = new LinkedHashMap<>();
+    certification.put("tagLabel", label);
+    certification.put("expiryDate", 1_785_312_839_519L);
+
+    Object lapsed = McpResponseTrim.slimCertification(certification, 1_790_000_000_000L);
+    assertEquals(
+        "Certification.Gold (EXPIRED 2026-07-29)",
+        lapsed,
+        "a lapsed badge beside state=Confirmed reads as trustworthy unless expiry is resolved here");
+
+    Object live = McpResponseTrim.slimCertification(certification, now);
+    assertTrue(live.toString().startsWith("Certification.Gold (valid until "), live.toString());
+  }
+
+  @Test
+  void slimCertificationKeepsTheLabelWhenThereIsNoExpiry() {
+    Map<String, Object> certification =
+        Map.of("tagLabel", Map.of("tagFQN", "Certification.Bronze"));
+    String summary = McpResponseTrim.slimCertification(certification, 1L).toString();
+    assertTrue(summary.startsWith("Certification.Bronze"), summary);
+    assertTrue(
+        summary.contains("not in this index") && summary.contains("get_entity_details"),
+        "an un-indexed expiry must name the cause and where to resolve it - a bare label reads as "
+            + "a live badge, and 'unknown' reads as 'no expiry set'. Both mislead: "
+            + summary);
+    assertEquals(
+        "not-a-map",
+        McpResponseTrim.slimCertification("not-a-map", 1L),
+        "an unrecognised shape passes through rather than being emptied");
+  }
+
+  @Test
+  void slimRefMarksAnInheritedOwnerSoItIsNotMistakenForASteward() {
+    Map<String, Object> inherited = new LinkedHashMap<>();
+    inherited.put("name", "admin");
+    inherited.put("type", "user");
+    inherited.put("inherited", true);
+
+    assertEquals(
+        "admin (inherited)",
+        McpResponseTrim.slimRef(inherited),
+        "an owner cascaded from the parent database is not who you talk to - collapsing it to a "
+            + "bare name made it indistinguishable from a real steward");
+  }
+
+  @Test
+  void slimRefLeavesADirectOwnerUnmarked() {
+    Map<String, Object> direct = new LinkedHashMap<>();
+    direct.put("name", "vishnu.jain");
+    direct.put("type", "user");
+
+    assertEquals(
+        "vishnu.jain",
+        McpResponseTrim.slimRef(direct),
+        "a deliberately-assigned owner carries no qualifier");
+    assertEquals(
+        "sample_data.ecommerce_db",
+        McpResponseTrim.slimRef(Map.of("fullyQualifiedName", "sample_data.ecommerce_db")),
+        "a non-owner reference is unaffected");
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AIContextMarkdown.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AIContextMarkdown.java
@@ -159,11 +159,41 @@ public final class AIContextMarkdown {
     }
   }
 
+  /**
+   * Says which of three states an all-zero test line means. They are identical in the counts above
+   * and are opposite trust verdicts.
+   *
+   * <p>{@code total} is the discriminator and was ignored: gating only on passed+failed+aborted told
+   * an asset with a suite but no test cases - a normal state, since the suite is created first -
+   * that "no test has ever executed … treat quality here as unverified". This markdown is served
+   * over REST and read by an LLM, so a wrong verdict propagates into answers.
+   */
+  private static void appendCoverageVerdict(
+      StringBuilder markdown, DataQuality dataQuality, int executed) {
+    int total = orZero(dataQuality.getTotal());
+    if (total == 0) {
+      markdown.append(
+          "\n> No data-quality test is defined on this asset. Quality here is unmeasured - which is"
+              + " neither good nor bad, and is not the same as tests passing.\n");
+    } else if (executed == 0) {
+      markdown
+          .append("\n> None of the ")
+          .append(total)
+          .append(
+              " data-quality tests defined on this asset has ever executed. This is NOT the same as"
+                  + " passing: treat quality here as unverified.\n");
+    }
+  }
+
   private static void appendDataQuality(
       StringBuilder markdown, DataQuality dataQuality, String headingPrefix) {
     if (dataQuality != null) {
       appendHeading(markdown, headingPrefix, "Data Quality");
       markdown.append('\n');
+      int executed =
+          orZero(dataQuality.getPassed())
+              + orZero(dataQuality.getFailed())
+              + orZero(dataQuality.getAborted());
       markdown
           .append("Tests — passed: ")
           .append(orZero(dataQuality.getPassed()))
@@ -172,6 +202,7 @@ public final class AIContextMarkdown {
           .append(", aborted: ")
           .append(orZero(dataQuality.getAborted()))
           .append('\n');
+      appendCoverageVerdict(markdown, dataQuality, executed);
       if (dataQuality.getFailed() != null && dataQuality.getFailed() > 0) {
         markdown
             .append("\n> ")

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResolutionStatusResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResolutionStatusResource.java
@@ -1,7 +1,5 @@
 package org.openmetadata.service.resources.dqtests;
 
-import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
-import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.service.security.DefaultAuthorizer.getSubjectContext;
 
 import io.swagger.v3.oas.annotations.ExternalDocumentation;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/knowledge/KnowledgePageMapper.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/knowledge/KnowledgePageMapper.java
@@ -31,6 +31,9 @@ public class KnowledgePageMapper implements EntityMapper<Page, CreatePage> {
         .withPageType(create.getPageType())
         .withPage(create.getPage())
         .withParent(create.getParent())
-        .withRelatedEntities(relatedEntities);
+        .withRelatedEntities(relatedEntities)
+        // Handed through untouched: a null reaches EntityRepository.setDefaultStatus, which fills
+        // in Unprocessed.
+        .withEntityStatus(create.getEntityStatus());
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java
@@ -370,6 +370,129 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
     }
   }
 
+  /**
+   * Applies the caller's {@code queryFilter} on top of whatever query the builder already carries.
+   * Extracted so the NLQ path applies the same filter as the keyword path — it previously ran the
+   * LLM-transformed query with the caller's filter silently dropped.
+   */
+  private void applyQueryFilter(
+      ElasticSearchRequestBuilder requestBuilder,
+      org.openmetadata.schema.search.SearchRequest request) {
+    if (!nullOrEmpty(request.getQueryFilter()) && !request.getQueryFilter().equals("{}")) {
+      try {
+        String queryToProcess = EsUtils.parseJsonQuery(request.getQueryFilter());
+        Query filterQuery = Query.of(q -> q.withJson(new StringReader(queryToProcess)));
+        Query existingQuery = requestBuilder.query();
+        if (existingQuery != null) {
+          Query combinedQuery =
+              Query.of(
+                  q ->
+                      q.bool(
+                          b -> {
+                            b.must(existingQuery);
+                            b.filter(filterQuery);
+                            return b;
+                          }));
+          requestBuilder.query(combinedQuery);
+        } else {
+          requestBuilder.query(filterQuery);
+        }
+      } catch (Exception ex) {
+        LOG.error("Error parsing query_filter from query parameters, ignoring filter", ex);
+      }
+    }
+  }
+
+  /**
+   * Applies the {@code deleted} constraint, tolerating documents that carry no {@code deleted} field
+   * at all on the multi-entity aliases. Extracted for reuse by the NLQ path, which previously ignored
+   * the flag entirely and so could return soft-deleted assets.
+   */
+  private void applyDeletedFilter(
+      ElasticSearchRequestBuilder requestBuilder,
+      org.openmetadata.schema.search.SearchRequest request,
+      String indexName) {
+    if (!nullOrEmpty(request.getDeleted())) {
+      Query existingQuery = requestBuilder.query();
+      Query deletedQuery;
+
+      if (indexName.equals(GLOBAL_SEARCH_ALIAS) || indexName.equals(DATA_ASSET_SEARCH_ALIAS)) {
+        deletedQuery =
+            Query.of(
+                q ->
+                    q.bool(
+                        b ->
+                            b.should(
+                                    s ->
+                                        s.bool(
+                                            bb ->
+                                                bb.must(existingQuery)
+                                                    .must(m -> m.exists(e -> e.field("deleted")))
+                                                    .must(
+                                                        m ->
+                                                            m.term(
+                                                                t ->
+                                                                    t.field("deleted")
+                                                                        .value(
+                                                                            FieldValue.of(
+                                                                                request
+                                                                                    .getDeleted()))))))
+                                .should(
+                                    s ->
+                                        s.bool(
+                                            bb ->
+                                                bb.must(existingQuery)
+                                                    .mustNot(
+                                                        mn ->
+                                                            mn.exists(e -> e.field("deleted")))))));
+      } else {
+        deletedQuery =
+            Query.of(
+                q ->
+                    q.bool(
+                        b ->
+                            b.must(existingQuery)
+                                .must(
+                                    m ->
+                                        m.term(
+                                            t ->
+                                                t.field("deleted")
+                                                    .value(FieldValue.of(request.getDeleted()))))));
+      }
+      requestBuilder.query(deletedQuery);
+    }
+  }
+
+  /**
+   * Builds the request for an NLQ search whose query the provider already transformed.
+   *
+   * <p>The happy path used to apply only context-memory visibility, while {@code
+   * fallbackToBasicSearch} applied RBAC as well — so the same user got different results depending on
+   * whether the NLQ provider answered or failed. RBAC, the caller's {@code queryFilter} (which is
+   * where the Collate AI-dashboard visibility injection rides) and the {@code deleted} flag are all
+   * applied here, so both paths are constrained identically.
+   */
+  ElasticSearchRequestBuilder buildNlqRequestBuilder(
+      org.openmetadata.schema.search.SearchRequest request,
+      SubjectContext subjectContext,
+      String transformedQuery)
+      throws com.fasterxml.jackson.core.JsonProcessingException {
+    ElasticSearchRequestBuilder requestBuilder = new ElasticSearchRequestBuilder();
+    String queryToProcess = EsUtils.parseJsonQuery(transformedQuery);
+    requestBuilder.query(Query.of(q -> q.withJson(new StringReader(queryToProcess))));
+    requestBuilder.from(request.getFrom());
+    requestBuilder.size(request.getSize());
+
+    // applyRbacCondition already applies the ContextMemory visibility filter.
+    applyRbacCondition(subjectContext, requestBuilder);
+    applyQueryFilter(requestBuilder, request);
+    // Strip any clusterAlias prefix first, the same way doSearch does — the deleted filter compares
+    // this against the dataAsset/all aliases.
+    String indexName = Entity.getSearchRepository().getIndexNameWithoutAlias(request.getIndex());
+    applyDeletedFilter(requestBuilder, request, indexName);
+    return requestBuilder;
+  }
+
   private void applyRbacCondition(
       SubjectContext subjectContext, ElasticSearchRequestBuilder requestBuilder) {
     if (shouldApplyRbacConditions(subjectContext, rbacConditionEvaluator)) {
@@ -594,15 +717,8 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
         io.micrometer.core.instrument.Timer.Sample searchTimerSample =
             org.openmetadata.service.monitoring.RequestLatencyContext.startSearchOperation();
 
-        // Parse the transformed query and create Query object
-        ElasticSearchRequestBuilder requestBuilder = new ElasticSearchRequestBuilder();
-        String queryToProcess = EsUtils.parseJsonQuery(transformedQuery);
-        Query nlqQuery = Query.of(q -> q.withJson(new StringReader(queryToProcess)));
-        requestBuilder.query(nlqQuery);
-
-        requestBuilder.from(request.getFrom());
-        requestBuilder.size(request.getSize());
-        applyContextMemoryVisibility(subjectContext, requestBuilder);
+        ElasticSearchRequestBuilder requestBuilder =
+            buildNlqRequestBuilder(request, subjectContext, transformedQuery);
 
         // Add aggregations for NLQ query
         addAggregationsToNLQQuery(requestBuilder, request.getIndex());
@@ -1241,30 +1357,7 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
     // Apply RBAC query
     applyRbacCondition(subjectContext, requestBuilder);
 
-    // Apply query filter
-    if (!nullOrEmpty(request.getQueryFilter()) && !request.getQueryFilter().equals("{}")) {
-      try {
-        String queryToProcess = EsUtils.parseJsonQuery(request.getQueryFilter());
-        Query filterQuery = Query.of(q -> q.withJson(new StringReader(queryToProcess)));
-        Query existingQuery = requestBuilder.query();
-        if (existingQuery != null) {
-          Query combinedQuery =
-              Query.of(
-                  q ->
-                      q.bool(
-                          b -> {
-                            b.must(existingQuery);
-                            b.filter(filterQuery);
-                            return b;
-                          }));
-          requestBuilder.query(combinedQuery);
-        } else {
-          requestBuilder.query(filterQuery);
-        }
-      } catch (Exception ex) {
-        LOG.error("Error parsing query_filter from query parameters, ignoring filter", ex);
-      }
-    }
+    applyQueryFilter(requestBuilder, request);
 
     // Apply post filter
     if (!nullOrEmpty(request.getPostFilter())) {
@@ -1284,56 +1377,7 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
       requestBuilder.searchAfter(searchAfterValues);
     }
 
-    // Handle deleted field for backward compatibility
-    if (!nullOrEmpty(request.getDeleted())) {
-      Query existingQuery = requestBuilder.query();
-      Query deletedQuery;
-
-      if (indexName.equals(GLOBAL_SEARCH_ALIAS) || indexName.equals(DATA_ASSET_SEARCH_ALIAS)) {
-        deletedQuery =
-            Query.of(
-                q ->
-                    q.bool(
-                        b ->
-                            b.should(
-                                    s ->
-                                        s.bool(
-                                            bb ->
-                                                bb.must(existingQuery)
-                                                    .must(m -> m.exists(e -> e.field("deleted")))
-                                                    .must(
-                                                        m ->
-                                                            m.term(
-                                                                t ->
-                                                                    t.field("deleted")
-                                                                        .value(
-                                                                            FieldValue.of(
-                                                                                request
-                                                                                    .getDeleted()))))))
-                                .should(
-                                    s ->
-                                        s.bool(
-                                            bb ->
-                                                bb.must(existingQuery)
-                                                    .mustNot(
-                                                        mn ->
-                                                            mn.exists(e -> e.field("deleted")))))));
-      } else {
-        deletedQuery =
-            Query.of(
-                q ->
-                    q.bool(
-                        b ->
-                            b.must(existingQuery)
-                                .must(
-                                    m ->
-                                        m.term(
-                                            t ->
-                                                t.field("deleted")
-                                                    .value(FieldValue.of(request.getDeleted()))))));
-      }
-      requestBuilder.query(deletedQuery);
-    }
+    applyDeletedFilter(requestBuilder, request, indexName);
 
     // Handle sorting — always append a deterministic tiebreaker so equal-ranked docs order
     // identically across shards/replicas; without it the same query bounces between copies.

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
@@ -574,15 +574,8 @@ public class OpenSearchSearchManager implements SearchManagementClient {
         // Start search operation timing
         Timer.Sample searchTimerSample = RequestLatencyContext.startSearchOperation();
 
-        // Parse the transformed query and create Query object
-        OpenSearchRequestBuilder requestBuilder = new OpenSearchRequestBuilder();
-        String queryToProcess = OsUtils.parseJsonQuery(transformedQuery);
-        Query nlqQuery = Query.of(q -> q.wrapper(w -> w.query(queryToProcess)));
-        requestBuilder.query(nlqQuery);
-
-        requestBuilder.from(request.getFrom());
-        requestBuilder.size(request.getSize());
-        applyContextMemoryVisibility(subjectContext, requestBuilder);
+        OpenSearchRequestBuilder requestBuilder =
+            buildNlqRequestBuilder(request, subjectContext, transformedQuery);
 
         // Add aggregations for NLQ query
         addAggregationsToNLQQuery(requestBuilder, request.getIndex());
@@ -895,6 +888,129 @@ public class OpenSearchSearchManager implements SearchManagementClient {
     return query == null
         ? memoryFilter
         : Query.of(q -> q.bool(b -> b.must(query).filter(memoryFilter)));
+  }
+
+  /**
+   * Applies the caller's {@code queryFilter} on top of whatever query the builder already carries.
+   * Extracted so the NLQ path applies the same filter as the keyword path — it previously ran the
+   * LLM-transformed query with the caller's filter silently dropped.
+   */
+  private void applyQueryFilter(
+      OpenSearchRequestBuilder requestBuilder,
+      org.openmetadata.schema.search.SearchRequest request) {
+    if (!nullOrEmpty(request.getQueryFilter()) && !request.getQueryFilter().equals("{}")) {
+      try {
+        String queryToProcess = OsUtils.parseJsonQuery(request.getQueryFilter());
+        Query filterQuery = Query.of(q -> q.wrapper(w -> w.query(queryToProcess)));
+        Query existingQuery = requestBuilder.query();
+        if (existingQuery != null) {
+          Query combinedQuery =
+              Query.of(
+                  q ->
+                      q.bool(
+                          b -> {
+                            b.must(existingQuery);
+                            b.filter(filterQuery);
+                            return b;
+                          }));
+          requestBuilder.query(combinedQuery);
+        } else {
+          requestBuilder.query(filterQuery);
+        }
+      } catch (Exception ex) {
+        LOG.error("Error parsing query_filter from query parameters, ignoring filter", ex);
+      }
+    }
+  }
+
+  /**
+   * Applies the {@code deleted} constraint, tolerating documents that carry no {@code deleted} field
+   * at all on the multi-entity aliases. Extracted for reuse by the NLQ path, which previously ignored
+   * the flag entirely and so could return soft-deleted assets.
+   */
+  private void applyDeletedFilter(
+      OpenSearchRequestBuilder requestBuilder,
+      org.openmetadata.schema.search.SearchRequest request,
+      String indexName) {
+    if (!nullOrEmpty(request.getDeleted())) {
+      Query existingQuery = requestBuilder.query();
+      Query deletedQuery;
+
+      if (indexName.equals(GLOBAL_SEARCH_ALIAS) || indexName.equals(DATA_ASSET_SEARCH_ALIAS)) {
+        deletedQuery =
+            Query.of(
+                q ->
+                    q.bool(
+                        b ->
+                            b.should(
+                                    s ->
+                                        s.bool(
+                                            bb ->
+                                                bb.must(existingQuery)
+                                                    .must(m -> m.exists(e -> e.field("deleted")))
+                                                    .must(
+                                                        m ->
+                                                            m.term(
+                                                                t ->
+                                                                    t.field("deleted")
+                                                                        .value(
+                                                                            FieldValue.of(
+                                                                                request
+                                                                                    .getDeleted()))))))
+                                .should(
+                                    s ->
+                                        s.bool(
+                                            bb ->
+                                                bb.must(existingQuery)
+                                                    .mustNot(
+                                                        mn ->
+                                                            mn.exists(e -> e.field("deleted")))))));
+      } else {
+        deletedQuery =
+            Query.of(
+                q ->
+                    q.bool(
+                        b ->
+                            b.must(existingQuery)
+                                .must(
+                                    m ->
+                                        m.term(
+                                            t ->
+                                                t.field("deleted")
+                                                    .value(FieldValue.of(request.getDeleted()))))));
+      }
+      requestBuilder.query(deletedQuery);
+    }
+  }
+
+  /**
+   * Builds the request for an NLQ search whose query the provider already transformed.
+   *
+   * <p>The happy path used to apply only context-memory visibility, while {@code
+   * fallbackToBasicSearch} applied RBAC as well — so the same user got different results depending on
+   * whether the NLQ provider answered or failed. RBAC, the caller's {@code queryFilter} (which is
+   * where the Collate AI-dashboard visibility injection rides) and the {@code deleted} flag are all
+   * applied here, so both paths are constrained identically.
+   */
+  OpenSearchRequestBuilder buildNlqRequestBuilder(
+      org.openmetadata.schema.search.SearchRequest request,
+      SubjectContext subjectContext,
+      String transformedQuery)
+      throws com.fasterxml.jackson.core.JsonProcessingException {
+    OpenSearchRequestBuilder requestBuilder = new OpenSearchRequestBuilder();
+    String queryToProcess = OsUtils.parseJsonQuery(transformedQuery);
+    requestBuilder.query(Query.of(q -> q.wrapper(w -> w.query(queryToProcess))));
+    requestBuilder.from(request.getFrom());
+    requestBuilder.size(request.getSize());
+
+    applyRbacQueryWithCaching(subjectContext, requestBuilder);
+    applyContextMemoryVisibility(subjectContext, requestBuilder);
+    applyQueryFilter(requestBuilder, request);
+    // Strip any clusterAlias prefix first, the same way doSearch does — the deleted filter compares
+    // this against the dataAsset/all aliases.
+    String indexName = Entity.getSearchRepository().getIndexNameWithoutAlias(request.getIndex());
+    applyDeletedFilter(requestBuilder, request, indexName);
+    return requestBuilder;
   }
 
   private void applyContextMemoryVisibility(
@@ -1288,30 +1404,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
     applyRbacQueryWithCaching(subjectContext, requestBuilder);
     applyContextMemoryVisibility(subjectContext, requestBuilder);
 
-    // Apply query filter
-    if (!nullOrEmpty(request.getQueryFilter()) && !request.getQueryFilter().equals("{}")) {
-      try {
-        String queryToProcess = OsUtils.parseJsonQuery(request.getQueryFilter());
-        Query filterQuery = Query.of(q -> q.wrapper(w -> w.query(queryToProcess)));
-        Query existingQuery = requestBuilder.query();
-        if (existingQuery != null) {
-          Query combinedQuery =
-              Query.of(
-                  q ->
-                      q.bool(
-                          b -> {
-                            b.must(existingQuery);
-                            b.filter(filterQuery);
-                            return b;
-                          }));
-          requestBuilder.query(combinedQuery);
-        } else {
-          requestBuilder.query(filterQuery);
-        }
-      } catch (Exception ex) {
-        LOG.error("Error parsing query_filter from query parameters, ignoring filter", ex);
-      }
-    }
+    applyQueryFilter(requestBuilder, request);
 
     // Apply post filter
     if (!nullOrEmpty(request.getPostFilter())) {
@@ -1333,56 +1426,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
       requestBuilder.searchAfter(searchAfterValues);
     }
 
-    // Handle deleted field for backward compatibility
-    if (!nullOrEmpty(request.getDeleted())) {
-      Query existingQuery = requestBuilder.query();
-      Query deletedQuery;
-
-      if (indexName.equals(GLOBAL_SEARCH_ALIAS) || indexName.equals(DATA_ASSET_SEARCH_ALIAS)) {
-        deletedQuery =
-            Query.of(
-                q ->
-                    q.bool(
-                        b ->
-                            b.should(
-                                    s ->
-                                        s.bool(
-                                            bb ->
-                                                bb.must(existingQuery)
-                                                    .must(m -> m.exists(e -> e.field("deleted")))
-                                                    .must(
-                                                        m ->
-                                                            m.term(
-                                                                t ->
-                                                                    t.field("deleted")
-                                                                        .value(
-                                                                            FieldValue.of(
-                                                                                request
-                                                                                    .getDeleted()))))))
-                                .should(
-                                    s ->
-                                        s.bool(
-                                            bb ->
-                                                bb.must(existingQuery)
-                                                    .mustNot(
-                                                        mn ->
-                                                            mn.exists(e -> e.field("deleted")))))));
-      } else {
-        deletedQuery =
-            Query.of(
-                q ->
-                    q.bool(
-                        b ->
-                            b.must(existingQuery)
-                                .must(
-                                    m ->
-                                        m.term(
-                                            t ->
-                                                t.field("deleted")
-                                                    .value(FieldValue.of(request.getDeleted()))))));
-      }
-      requestBuilder.query(deletedQuery);
-    }
+    applyDeletedFilter(requestBuilder, request, indexName);
 
     // Handle sorting — always append a deterministic tiebreaker so equal-ranked docs order
     // identically across shards/replicas; without it the same query bounces between copies.

--- a/openmetadata-service/src/test/java/org/openmetadata/service/aicontext/AIContextMarkdownTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/aicontext/AIContextMarkdownTest.java
@@ -486,6 +486,46 @@ class AIContextMarkdownTest {
     assertTrue(markdown.contains("currently failing"), "missing failing-test warning");
   }
 
+  private static String qualityMarkdown(DataQuality dataQuality) {
+    return AIContextMarkdown.render(
+        new AIContext()
+            .withEntityType("table")
+            .withFullyQualifiedName("svc.db.sch.orders")
+            .withObservability(new Observability().withDataQuality(dataQuality)));
+  }
+
+  @Test
+  void render_saysQualityIsUnmeasuredWhenNoTestIsDefined() {
+    // An attached suite with no test cases in it is a normal state - the suite is created before
+    // its tests - and gating only on passed+failed+aborted told the reader every one of those
+    // assets had tests that never ran, which is a state that does not exist.
+    String markdown =
+        qualityMarkdown(new DataQuality().withTotal(0).withPassed(0).withFailed(0).withAborted(0));
+
+    assertTrue(markdown.contains("No data-quality test is defined"), "missing unmeasured verdict");
+    assertFalse(
+        markdown.contains("has ever executed"),
+        "an asset with no tests must not be described as having tests that never ran");
+  }
+
+  @Test
+  void render_saysTestsAreUnverifiedWhenDefinedButNeverRun() {
+    String markdown =
+        qualityMarkdown(new DataQuality().withTotal(13).withPassed(0).withFailed(0).withAborted(0));
+
+    assertTrue(markdown.contains("None of the 13"), "the count of defined tests is load-bearing");
+    assertTrue(markdown.contains("NOT the same as"), "zero failures must not read as healthy");
+  }
+
+  @Test
+  void render_addsNoCoverageVerdictWhenTestsHaveRun() {
+    String markdown =
+        qualityMarkdown(new DataQuality().withTotal(4).withPassed(4).withFailed(0).withAborted(0));
+
+    assertFalse(markdown.contains("No data-quality test is defined"), "tests exist");
+    assertFalse(markdown.contains("None of the"), "and they ran");
+  }
+
   @Test
   void appendEntitySections_honorsSelectionAndHeadingDepth() {
     StringBuilder markdown = new StringBuilder();

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/knowledge/KnowledgePageMapperTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/knowledge/KnowledgePageMapperTest.java
@@ -1,0 +1,74 @@
+package org.openmetadata.service.resources.knowledge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.api.data.CreatePage;
+import org.openmetadata.schema.entity.data.Article;
+import org.openmetadata.schema.entity.data.Page;
+import org.openmetadata.schema.entity.data.PageType;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.EntityStatus;
+
+class KnowledgePageMapperTest {
+
+  @Test
+  void theRequestedEntityStatusReachesTheEntity() {
+    // CreatePage carries entityStatus, but the mapper never copied it, so every article was
+    // persisted as Unprocessed no matter what the caller asked for.
+    Page page =
+        new KnowledgePageMapper().createToEntity(createPage(EntityStatus.ARCHIVED), "admin");
+
+    assertEquals(EntityStatus.ARCHIVED, page.getEntityStatus());
+  }
+
+  @Test
+  void anOmittedEntityStatusIsCarriedThroughUnchanged() {
+    // Omits entityStatus entirely instead of setting it to null. Asserts propagation rather than a
+    // literal value on purpose: createPage.json declares "default": "Approved" next to a $ref, and
+    // whether jsonschema2pojo materializes that default at all depends on schema processing order,
+    // so the generated field is null on some builds and Unprocessed on others. Either way the
+    // mapper must hand the value through untouched - null then reaches
+    // EntityRepository.setDefaultStatus, which fills in Unprocessed.
+    CreatePage request =
+        withRelatedEntity(
+            new CreatePage()
+                .withName("runbook")
+                .withPageType(PageType.ARTICLE)
+                .withPage(new Article()));
+
+    Page page = new KnowledgePageMapper().createToEntity(request, "admin");
+
+    assertEquals(request.getEntityStatus(), page.getEntityStatus());
+  }
+
+  @Test
+  void anExplicitNullEntityStatusIsLeftForTheRepositoryDefault() {
+    // The mapper must not invent a status of its own: a null reaches the repository, which then
+    // fills in Unprocessed via setDefaultStatus.
+    Page page = new KnowledgePageMapper().createToEntity(createPage(null), "admin");
+
+    assertNull(page.getEntityStatus());
+  }
+
+  private static CreatePage createPage(EntityStatus status) {
+    return withRelatedEntity(
+            new CreatePage()
+                .withName("runbook")
+                .withPageType(PageType.ARTICLE)
+                .withPage(new Article()))
+        .withEntityStatus(status);
+  }
+
+  /**
+   * Supplies relatedEntities so the mapper skips its Organization-team fallback, which needs a live
+   * entity registry and is not what these tests are about.
+   */
+  private static CreatePage withRelatedEntity(CreatePage request) {
+    return request.withRelatedEntities(
+        List.of(new EntityReference().withId(UUID.randomUUID()).withType("table")));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/ElasticSearchNlqRequestBuilderTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/ElasticSearchNlqRequestBuilderTest.java
@@ -1,0 +1,199 @@
+package org.openmetadata.service.search.elasticsearch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import es.co.elastic.clients.elasticsearch._types.FieldValue;
+import es.co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openmetadata.schema.api.search.GlobalSettings;
+import org.openmetadata.schema.api.search.SearchSettings;
+import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.settings.SettingsType;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.resources.settings.SettingsCache;
+import org.openmetadata.service.search.SearchRepository;
+import org.openmetadata.service.search.elasticsearch.queries.ElasticQueryBuilder;
+import org.openmetadata.service.search.security.RBACConditionEvaluator;
+import org.openmetadata.service.security.policyevaluator.SubjectContext;
+
+/**
+ * The NLQ happy path used to run the LLM-transformed query with only context-memory visibility
+ * applied — no RBAC clause, no queryFilter, no deleted filter — while the fallback path applied all
+ * three. Results therefore differed depending on whether the NLQ provider happened to answer.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ElasticSearchNlqRequestBuilderTest {
+
+  private static final String TRANSFORMED_QUERY = "{\"match_all\":{}}";
+  private static final String RBAC_MARKER = "rbac_marker";
+
+  private SearchRepository searchRepository;
+  private SearchRepository previousSearchRepository;
+
+  @BeforeEach
+  void setUp() {
+    // Entity.searchRepository is process-global and the JVM is reused across test classes, so the
+    // previous value is restored in tearDown to keep other tests order-independent.
+    previousSearchRepository = Entity.getSearchRepository();
+    searchRepository = mock(SearchRepository.class);
+    when(searchRepository.getIndexNameWithoutAlias(anyString()))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    Entity.setSearchRepository(searchRepository);
+  }
+
+  @AfterEach
+  void tearDown() {
+    Entity.setSearchRepository(previousSearchRepository);
+  }
+
+  @Test
+  void nlqRequestCarriesTheRbacClause() throws Exception {
+    Query rbacQuery = termQuery(RBAC_MARKER);
+    ElasticQueryBuilder rbacBuilder = mock(ElasticQueryBuilder.class);
+    when(rbacBuilder.buildV2()).thenReturn(rbacQuery);
+    RBACConditionEvaluator evaluator = mock(RBACConditionEvaluator.class);
+    when(evaluator.evaluateConditions(any())).thenReturn(rbacBuilder);
+
+    try (MockedStatic<SettingsCache> settings = accessControl(true)) {
+      ElasticSearchRequestBuilder builder =
+          manager(evaluator)
+              .buildNlqRequestBuilder(request(null, null), subject(), TRANSFORMED_QUERY);
+
+      assertTrue(containsFilter(builder.query(), rbacQuery), "RBAC clause missing from NLQ query");
+    }
+  }
+
+  @Test
+  void nlqRequestMergesTheCallerQueryFilter() throws Exception {
+    try (MockedStatic<SettingsCache> settings = accessControl(false)) {
+      ElasticSearchRequestBuilder builder =
+          manager(null)
+              .buildNlqRequestBuilder(
+                  request("{\"term\":{\"service.name.keyword\":\"snowflake\"}}", null),
+                  subject(),
+                  TRANSFORMED_QUERY);
+
+      assertNotNull(builder.query());
+      assertTrue(
+          containsTermOnField(builder.query(), "service.name.keyword"),
+          "queryFilter was dropped from the NLQ query");
+    }
+  }
+
+  @Test
+  void nlqRequestHonoursTheDeletedFlag() throws Exception {
+    try (MockedStatic<SettingsCache> settings = accessControl(false)) {
+      ElasticSearchRequestBuilder builder =
+          manager(null).buildNlqRequestBuilder(request(null, true), subject(), TRANSFORMED_QUERY);
+
+      assertTrue(
+          containsTermOnField(builder.query(), "deleted"), "deleted filter missing from NLQ query");
+    }
+  }
+
+  @Test
+  void deletedFilterTreatsAClusterAliasPrefixedIndexAsTheDataAssetAlias() throws Exception {
+    // doSearch strips the clusterAlias prefix before comparing against the dataAsset/all aliases,
+    // which selects the lenient branch that also keeps documents carrying no "deleted" field. The
+    // NLQ path has to strip it the same way, or a cluster-alias deployment silently drops those
+    // documents.
+    when(searchRepository.getIndexNameWithoutAlias("collate_prod_dataAsset"))
+        .thenReturn("dataAsset");
+
+    try (MockedStatic<SettingsCache> settings = accessControl(false)) {
+      org.openmetadata.schema.search.SearchRequest request =
+          request(null, true).withIndex("collate_prod_dataAsset");
+
+      ElasticSearchRequestBuilder builder =
+          manager(null).buildNlqRequestBuilder(request, subject(), TRANSFORMED_QUERY);
+
+      assertEquals(
+          2,
+          builder.query().bool().should().size(),
+          "prefixed dataAsset alias took the strict deleted branch");
+    }
+  }
+
+  /** Walks the bool tree looking for a term clause on {@code field}. */
+  private static boolean containsTermOnField(Query query, String field) {
+    boolean found = false;
+    if (query != null) {
+      if (query.isTerm()) {
+        found = field.equals(query.term().field());
+      } else if (query.isBool()) {
+        found =
+            java.util.stream.Stream.of(
+                    query.bool().must(),
+                    query.bool().should(),
+                    query.bool().filter(),
+                    query.bool().mustNot())
+                .flatMap(List::stream)
+                .anyMatch(child -> containsTermOnField(child, field));
+      }
+    }
+    return found;
+  }
+
+  private static boolean containsFilter(Query query, Query expected) {
+    return query != null
+        && query.isBool()
+        && (query.bool().filter().contains(expected)
+            || query.bool().must().stream().anyMatch(m -> containsFilter(m, expected)));
+  }
+
+  private static Query termQuery(String field) {
+    return Query.of(q -> q.term(t -> t.field(field).value(FieldValue.of(true))));
+  }
+
+  private ElasticSearchSearchManager manager(RBACConditionEvaluator evaluator) {
+    return new ElasticSearchSearchManager(null, evaluator, "", null);
+  }
+
+  private static org.openmetadata.schema.search.SearchRequest request(
+      String queryFilter, Boolean deleted) {
+    return new org.openmetadata.schema.search.SearchRequest()
+        .withQuery("which tables hold customer data")
+        .withIndex("dataAsset")
+        .withFrom(0)
+        .withSize(10)
+        .withQueryFilter(queryFilter)
+        .withDeleted(deleted);
+  }
+
+  private static SubjectContext subject() {
+    User user = new User().withId(UUID.randomUUID()).withName("analyst").withRoles(List.of());
+    SubjectContext subjectContext = mock(SubjectContext.class);
+    when(subjectContext.isAdmin()).thenReturn(false);
+    when(subjectContext.isBot()).thenReturn(false);
+    when(subjectContext.user()).thenReturn(user);
+    return subjectContext;
+  }
+
+  private static MockedStatic<SettingsCache> accessControl(boolean enabled) {
+    MockedStatic<SettingsCache> settings = mockStatic(SettingsCache.class);
+    SearchSettings searchSettings =
+        new SearchSettings()
+            .withGlobalSettings(new GlobalSettings().withEnableAccessControl(enabled));
+    settings
+        .when(() -> SettingsCache.getSetting(SettingsType.SEARCH_SETTINGS, SearchSettings.class))
+        .thenReturn(searchSettings);
+    return settings;
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchNlqRequestBuilderTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchNlqRequestBuilderTest.java
@@ -1,0 +1,220 @@
+package org.openmetadata.service.search.opensearch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openmetadata.schema.api.search.GlobalSettings;
+import org.openmetadata.schema.api.search.SearchSettings;
+import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.settings.SettingsType;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.resources.settings.SettingsCache;
+import org.openmetadata.service.search.SearchRepository;
+import org.openmetadata.service.search.opensearch.queries.OpenSearchQueryBuilder;
+import org.openmetadata.service.search.security.RBACConditionEvaluator;
+import org.openmetadata.service.security.policyevaluator.SubjectContext;
+import os.org.opensearch.client.opensearch._types.FieldValue;
+import os.org.opensearch.client.opensearch._types.query_dsl.Query;
+
+/**
+ * The NLQ happy path used to run the LLM-transformed query with only context-memory visibility
+ * applied — no RBAC clause, no queryFilter, no deleted filter — while the fallback path applied all
+ * three. Results therefore differed depending on whether the NLQ provider happened to answer.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class OpenSearchNlqRequestBuilderTest {
+
+  private static final String TRANSFORMED_QUERY = "{\"match_all\":{}}";
+  private static final String RBAC_MARKER = "rbac_marker";
+
+  private SearchRepository searchRepository;
+  private SearchRepository previousSearchRepository;
+
+  @BeforeEach
+  void setUp() {
+    // Entity.searchRepository is process-global and the JVM is reused across test classes, so the
+    // previous value is restored in tearDown to keep other tests order-independent.
+    previousSearchRepository = Entity.getSearchRepository();
+    searchRepository = mock(SearchRepository.class);
+    when(searchRepository.getIndexNameWithoutAlias(anyString()))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    Entity.setSearchRepository(searchRepository);
+  }
+
+  @AfterEach
+  void tearDown() {
+    Entity.setSearchRepository(previousSearchRepository);
+  }
+
+  @Test
+  void nlqRequestCarriesTheRbacClause() throws Exception {
+    Query rbacQuery = termQuery(RBAC_MARKER);
+    OpenSearchQueryBuilder rbacBuilder = mock(OpenSearchQueryBuilder.class);
+    when(rbacBuilder.buildV2()).thenReturn(rbacQuery);
+    RBACConditionEvaluator evaluator = mock(RBACConditionEvaluator.class);
+    when(evaluator.evaluateConditions(any())).thenReturn(rbacBuilder);
+
+    try (MockedStatic<SettingsCache> settings = accessControl(true)) {
+      OpenSearchRequestBuilder builder =
+          manager(evaluator)
+              .buildNlqRequestBuilder(request(null, null), subject(), TRANSFORMED_QUERY);
+
+      assertTrue(containsFilter(builder.query(), rbacQuery), "RBAC clause missing from NLQ query");
+    }
+  }
+
+  @Test
+  void nlqRequestMergesTheCallerQueryFilter() throws Exception {
+    try (MockedStatic<SettingsCache> settings = accessControl(false)) {
+      OpenSearchRequestBuilder builder =
+          manager(null)
+              .buildNlqRequestBuilder(
+                  request("{\"term\":{\"service.name.keyword\":\"snowflake\"}}", null),
+                  subject(),
+                  TRANSFORMED_QUERY);
+
+      assertNotNull(builder.query());
+      // The transformed NLQ query is one wrapper; the caller's queryFilter is a second one. Only
+      // one is present when the filter is dropped.
+      assertEquals(2, countWrappers(builder.query()), "queryFilter was dropped from the NLQ query");
+    }
+  }
+
+  @Test
+  void nlqRequestHonoursTheDeletedFlag() throws Exception {
+    try (MockedStatic<SettingsCache> settings = accessControl(false)) {
+      OpenSearchRequestBuilder builder =
+          manager(null).buildNlqRequestBuilder(request(null, true), subject(), TRANSFORMED_QUERY);
+
+      assertTrue(
+          containsTermOnField(builder.query(), "deleted"), "deleted filter missing from NLQ query");
+    }
+  }
+
+  @Test
+  void deletedFilterTreatsAClusterAliasPrefixedIndexAsTheDataAssetAlias() throws Exception {
+    // doSearch strips the clusterAlias prefix before comparing against the dataAsset/all aliases,
+    // which selects the lenient branch that also keeps documents carrying no "deleted" field. The
+    // NLQ path has to strip it the same way, or a cluster-alias deployment silently drops those
+    // documents.
+    when(searchRepository.getIndexNameWithoutAlias("collate_prod_dataAsset"))
+        .thenReturn("dataAsset");
+
+    try (MockedStatic<SettingsCache> settings = accessControl(false)) {
+      org.openmetadata.schema.search.SearchRequest request =
+          request(null, true).withIndex("collate_prod_dataAsset");
+
+      OpenSearchRequestBuilder builder =
+          manager(null).buildNlqRequestBuilder(request, subject(), TRANSFORMED_QUERY);
+
+      assertEquals(
+          2,
+          builder.query().bool().should().size(),
+          "prefixed dataAsset alias took the strict deleted branch");
+    }
+  }
+
+  /** Counts wrapper (raw-JSON) queries in the bool tree. */
+  private static int countWrappers(Query query) {
+    int count = 0;
+    if (query != null) {
+      if (query.isWrapper()) {
+        count = 1;
+      } else if (query.isBool()) {
+        count =
+            java.util.stream.Stream.of(
+                    query.bool().must(),
+                    query.bool().should(),
+                    query.bool().filter(),
+                    query.bool().mustNot())
+                .flatMap(List::stream)
+                .mapToInt(OpenSearchNlqRequestBuilderTest::countWrappers)
+                .sum();
+      }
+    }
+    return count;
+  }
+
+  /** Walks the bool tree looking for a term clause on {@code field}. */
+  private static boolean containsTermOnField(Query query, String field) {
+    boolean found = false;
+    if (query != null) {
+      if (query.isTerm()) {
+        found = field.equals(query.term().field());
+      } else if (query.isBool()) {
+        found =
+            java.util.stream.Stream.of(
+                    query.bool().must(),
+                    query.bool().should(),
+                    query.bool().filter(),
+                    query.bool().mustNot())
+                .flatMap(List::stream)
+                .anyMatch(child -> containsTermOnField(child, field));
+      }
+    }
+    return found;
+  }
+
+  private static boolean containsFilter(Query query, Query expected) {
+    return query != null
+        && query.isBool()
+        && (query.bool().filter().contains(expected)
+            || query.bool().must().stream().anyMatch(m -> containsFilter(m, expected)));
+  }
+
+  private static Query termQuery(String field) {
+    return Query.of(q -> q.term(t -> t.field(field).value(FieldValue.of(true))));
+  }
+
+  private OpenSearchSearchManager manager(RBACConditionEvaluator evaluator) {
+    return new OpenSearchSearchManager(null, evaluator, "", null);
+  }
+
+  private static org.openmetadata.schema.search.SearchRequest request(
+      String queryFilter, Boolean deleted) {
+    return new org.openmetadata.schema.search.SearchRequest()
+        .withQuery("which tables hold customer data")
+        .withIndex("dataAsset")
+        .withFrom(0)
+        .withSize(10)
+        .withQueryFilter(queryFilter)
+        .withDeleted(deleted);
+  }
+
+  private static SubjectContext subject() {
+    User user = new User().withId(UUID.randomUUID()).withName("analyst").withRoles(List.of());
+    SubjectContext subjectContext = mock(SubjectContext.class);
+    when(subjectContext.isAdmin()).thenReturn(false);
+    when(subjectContext.isBot()).thenReturn(false);
+    when(subjectContext.user()).thenReturn(user);
+    return subjectContext;
+  }
+
+  private static MockedStatic<SettingsCache> accessControl(boolean enabled) {
+    MockedStatic<SettingsCache> settings = mockStatic(SettingsCache.class);
+    SearchSettings searchSettings =
+        new SearchSettings()
+            .withGlobalSettings(new GlobalSettings().withEnableAccessControl(enabled));
+    settings
+        .when(() -> SettingsCache.getSetting(SettingsType.SEARCH_SETTINGS, SearchSettings.class))
+        .thenReturn(searchSettings);
+    return settings;
+  }
+}


### PR DESCRIPTION
Cherry-picks to `2.0` (clean, no conflicts):

| Commit | PR | Change |
|---|---|---|
| `3ecb59c3edb` | #31727 | fix(search): apply RBAC, queryFilter and deleted to the NLQ happy path |
| `0a763e26e6d` | #31728 | fix(knowledge): carry the requested entityStatus onto the created page |
| `135597b3392` | #32019 | Make the MCP tool surface cheaper to call and honest about what it returns |

All three applied with `git cherry-pick -x` on top of `origin/2.0` (`f0169918862`), zero conflicts. No code changes beyond the picks.




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This cherry-pick brings NLQ authorization and filtering corrections, knowledge-page entity-status propagation, and a more compact MCP tool contract to the 2.0 branch.
- Applies caller RBAC, query filters, and deleted-state behavior to NLQ search requests.
- Preserves the requested entity status while creating knowledge pages.
- Expands and trims MCP entity, lineage, search, patch, and diagnostic responses while keeping tool definitions and tests aligned.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetEntityTool.java | Adds batched entity reads, optional lineage and quality sections, certification normalization, and response-size controls. |
| openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetLineageTool.java | Adds caller-domain pruning, opt-in SQL and column details, graph completeness metadata, and zero-depth support. |
| openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/LineageTool.java | Allows lineage endpoints to resolve from FQNs as well as entity IDs and uses the repository import convention. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java | Carries authorization, query-filter, and deleted-state constraints into Elasticsearch NLQ request construction. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java | Carries authorization, query-filter, and deleted-state constraints into OpenSearch NLQ request construction. |
| openmetadata-service/src/main/java/org/openmetadata/service/resources/knowledge/KnowledgePageMapper.java | Propagates the requested entity status to newly created knowledge pages. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Client[MCP or NLQ caller] --> Security[Caller security context]
  Security --> Search[NLQ search with RBAC and filters]
  Security --> Tools[MCP tool execution]
  Tools --> Entity[Entity and quality details]
  Tools --> Lineage[Domain-pruned lineage]
  Tools --> Patch[Authorized entity patch]
  Request[Knowledge page request] --> Mapper[Knowledge page mapper]
  Mapper --> Status[Requested entity status]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: spotless:apply on TestCaseResolut..."](https://github.com/open-metadata/openmetadata/commit/1e859e34cfb2926aa140279cdd25d862c8ca3d80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57394716)</sub>

<!-- /greptile_comment -->