### PR TITLE
fix(mcp): attach detached javadocs to their methods and import HashMap

### DIFF
--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/LineageTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/LineageTool.java
@@ -1,6 +1,7 @@
 package org.openmetadata.mcp.tools;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.api.lineage.AddLineage;
@@ -91,7 +92,7 @@ public class LineageTool implements McpTool {
           String.format(
               "Parameter '%s' must be an object with 'type' and 'fqn' (or 'id')", paramName));
     }
-    return new java.util.HashMap<>((Map<String, Object>) raw);
+    return new HashMap<>((Map<String, Object>) raw);
   }
 
   @Override

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
@@ -596,28 +596,6 @@ public class SearchMetadataTool implements McpTool {
     return result;
   }
 
-  @SuppressWarnings("unused")
-  /**
-   * Entity references and tag labels are collapsed to the identifier a caller can act on.
-   *
-   * <p>{@code tier}, {@code service}, {@code database} and {@code databaseSchema} each repeat a full
-   * descriptor on every hit, which on a 10-hit response was most of the payload. Every MCP tool is
-   * addressed by {@code (entityType, fqn)}, so the FQN is the actionable part.
-   */
-  /**
-   * Caps a hydrated bulk field on a search hit.
-   *
-   * <p>{@code fields=columns} hydrates every column with its full description, so one wide table can
-   * dominate a page. A search hit exists to be chosen between; {@code get_entity_details} is where
-   * the full detail lives.
-   */
-  /** True when hit scores vary, i.e. something actually ranked them. */
-  /**
-   * Wraps a query so excluded entity types never match, letting the engine backfill the page.
-   *
-   * <p>{@code tableColumn} documents sit inside the default {@code dataAsset} scope, so a broad
-   * sweep can return mostly columns inheriting their parent's tags or certification.
-   */
   /**
    * A queryFilter whose only job is to exclude entity types, for the path where the caller supplied
    * no filter of their own. Null when there is nothing to exclude, so the request is unchanged.
@@ -633,6 +611,12 @@ public class SearchMetadataTool implements McpTool {
     return filter;
   }
 
+  /**
+   * Wraps a query so excluded entity types never match, letting the engine backfill the page.
+   *
+   * <p>{@code tableColumn} documents sit inside the default {@code dataAsset} scope, so a broad
+   * sweep can return mostly columns inheriting their parent's tags or certification.
+   */
   private static JsonNode excludeTypesFrom(JsonNode query, Set<String> excluded) {
     JsonNode result = query;
     if (!excluded.isEmpty()) {
@@ -652,6 +636,7 @@ public class SearchMetadataTool implements McpTool {
     return result;
   }
 
+  /** True when hit scores vary, i.e. something actually ranked them. */
   private static boolean scoresDiscriminate(List<?> hits) {
     Object first = null;
     boolean varies = false;
@@ -671,6 +656,13 @@ public class SearchMetadataTool implements McpTool {
     return varies;
   }
 
+  /**
+   * Caps a hydrated bulk field on a search hit.
+   *
+   * <p>{@code fields=columns} hydrates every column with its full description, so one wide table can
+   * dominate a page. A search hit exists to be chosen between; {@code get_entity_details} is where
+   * the full detail lives.
+   */
   private static Object capBulkField(String field, Object value, Map<String, Object> result) {
     Object capped = value;
     if (BULK_FIELDS.contains(field)
@@ -683,6 +675,13 @@ public class SearchMetadataTool implements McpTool {
     return capped;
   }
 
+  /**
+   * Entity references and tag labels are collapsed to the identifier a caller can act on.
+   *
+   * <p>{@code tier}, {@code service}, {@code database} and {@code databaseSchema} each repeat a full
+   * descriptor on every hit, which on a 10-hit response was most of the payload. Every MCP tool is
+   * addressed by {@code (entityType, fqn)}, so the FQN is the actionable part.
+   */
   private static Object slimField(String field, Object value) {
     Object result = value;
     if (REFERENCE_FIELDS.contains(field)) {


### PR DESCRIPTION
Review nits from the bots on #32142 (cherry-pick of #32019 into `2.0`), fixed here on `main` so the two branches do not drift.

| File | Fix |
|---|---|
| `SearchMetadataTool.java` | Five javadoc blocks were stacked above `excludeOnlyFilter`, so only the last applied. Each block moved above the method it documents (`slimField`, `capBulkField`, `scoresDiscriminate`, `excludeTypesFrom`); the stale `@SuppressWarnings("unused")` dropped, since `excludeOnlyFilter` is used and tested. |
| `LineageTool.java` | `new java.util.HashMap<>(...)` replaced with an imported `HashMap`. |

Comments only plus one import: no behaviour change. `mvn spotless:apply -pl openmetadata-mcp` clean, `mvn compile -pl openmetadata-mcp` BUILD SUCCESS.






<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects documentation attachment and import style in the MCP module without changing runtime behavior.
- Attaches each detached Javadoc block to its intended helper method in `SearchMetadataTool`.
- Removes the stale unused-warning suppression from the used `excludeOnlyFilter` helper.
- Imports `HashMap` in `LineageTool` instead of using its fully qualified name.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/LineageTool.java | Replaces a fully qualified `HashMap` construction with the equivalent imported class. |
| openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java | Moves existing Javadocs onto their intended methods and removes a stale suppression without affecting executable code. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/mcp-review-..."](https://github.com/open-metadata/openmetadata/commit/161b3d6d18d5553a9ae377a7df6b0160240a4745) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57397084)</sub>

<!-- /greptile_comment -->