### PR TITLE
fix(ci): clear java checkstyle, python checkstyle and static-check fa…

### DIFF
--- a/ingestion/.dockerignore
+++ b/ingestion/.dockerignore
@@ -1,0 +1,12 @@
+# Applies only to builds whose context is ingestion/ (currently the Airflow test image).
+# Dockerfile.ci builds from the repository root and uses the top-level .dockerignore.
+build/
+dist/
+tests/
+examples/
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+**/__pycache__/
+**/*.py[cod]

--- a/ingestion/src/metadata/ingestion/source/database/db2/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/db2/utils.py
@@ -283,7 +283,7 @@ def patch_ibmi_dialect() -> bool:
     if _IBMI_PATCHED:
         return True
     try:
-        import sqlalchemy_ibmi.base as ibmi_base
+        import sqlalchemy_ibmi.base as ibmi_base  # noqa: PLC0415
     except ImportError:
         logger.debug("sqlalchemy-ibmi not installed - ibmi scheme unavailable")
         return False

--- a/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
@@ -63,6 +63,7 @@ from metadata.generated.schema.tests.testDefinition import (
 )
 from metadata.generated.schema.type.basic import (
     FullyQualifiedEntityName,
+    Markdown,
     SqlQuery,
     Timestamp,
     Uuid,
@@ -1895,10 +1896,11 @@ class DbtSource(DbtServiceSource):
                 # entityLink shapes), so its description is only set on creation and
                 # never patched from an individual node.
                 if not check_test_definition_exists:
+                    test_description = get_dbt_test_description(manifest_node)
                     yield Either(
                         right=CreateTestDefinitionRequest(
                             name=test_definition_name,
-                            description=get_dbt_test_description(manifest_node),
+                            description=Markdown(test_description) if test_description else None,
                             entityType=entity_type,
                             testPlatforms=[TestPlatform.dbt],
                             parameterDefinition=create_test_case_parameter_definitions(manifest_node),
@@ -1948,7 +1950,7 @@ class DbtSource(DbtServiceSource):
                         yield Either(
                             right=CreateTestCaseRequest(
                                 name=manifest_node.name,
-                                description=description,
+                                description=Markdown(description) if description else None,
                                 testDefinition=FullyQualifiedEntityName(test_definition_name),
                                 entityLink=entity_link_str,
                                 parameterValues=create_test_case_parameter_values(dbt_test),

--- a/ingestion/src/metadata/ingestion/source/database/hive/custom_hive_connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/custom_hive_connection.py
@@ -111,7 +111,7 @@ class CustomHiveConnection(BaseConnection):
                 self._transport = thrift_transport
             else:
                 # Create puretransport with SSL
-                import puretransport
+                import puretransport  # noqa: PLC0415
 
                 socket_kwargs = _get_ssl_socket_kwargs(
                     ssl_certfile=ssl_certfile,

--- a/ingestion/src/metadata/ingestion/source/database/vertica/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/vertica/metadata.py
@@ -251,9 +251,9 @@ def get_table_comment(
 
 VerticaDialect.get_columns = get_columns
 VerticaDialect._get_column_info = _get_column_info  # pylint: disable=protected-access
-VerticaDialect.get_view_definition = get_view_definition
+VerticaDialect.get_view_definition = get_view_definition  # pyright: ignore[reportAttributeAccessIssue]
 VerticaDialect.get_all_table_comments = get_all_table_comments
-VerticaDialect.get_table_comment = get_table_comment
+VerticaDialect.get_table_comment = get_table_comment  # pyright: ignore[reportAttributeAccessIssue]
 
 
 class VerticaSource(CommonDbSourceService, MultiDBSource):

--- a/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/metadata.py
@@ -18,6 +18,7 @@ from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional, Tuple  # noqa: UP035
 
 from cachetools import LRUCache
+from pydantic import AnyUrl
 
 from metadata.generated.schema.api.data.createPipeline import CreatePipelineRequest
 from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
@@ -49,7 +50,10 @@ from metadata.generated.schema.type.basic import (
 from metadata.generated.schema.type.entityLineage import EntitiesEdge, LineageDetails
 from metadata.generated.schema.type.entityLineage import Source as LineageSource
 from metadata.generated.schema.type.entityReference import EntityReference
-from metadata.generated.schema.type.pipelineObservability import PipelineObservability
+from metadata.generated.schema.type.pipelineObservability import (
+    LastRunStatus,
+    PipelineObservability,
+)
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.lineage.models import ConnectionTypeDialectMapper, Dialect
@@ -484,7 +488,7 @@ class DbtcloudSource(PipelineServiceSource):
                 fromEntity=EntityReference(id=from_entity.id, type="table"),
                 toEntity=EntityReference(id=to_entity.id, type="table"),
                 lineageDetails=LineageDetails(
-                    pipeline=EntityReference(id=pipeline_entity.id.root, type="pipeline"),
+                    pipeline=EntityReference(id=pipeline_entity.id, type="pipeline"),
                     source=LineageSource.PipelineLineage,
                 ),
             )
@@ -596,10 +600,10 @@ class DbtcloudSource(PipelineServiceSource):
         return [
             TaskStatus(
                 name=DEFAULT_TASK_NAME,
-                executionStatus=self._map_run_status(run.state or run.status),
+                executionStatus=StatusType(self._map_run_status(run.state or run.status)),
                 startTime=self._parse_timestamp(run.started_at) if run.started_at else None,
                 endTime=self._parse_timestamp(run.finished_at) if run.finished_at else None,
-                logLink=run.href,
+                logLink=AnyUrl(run.href) if run.href else None,
             )
         ]
 
@@ -612,7 +616,7 @@ class DbtcloudSource(PipelineServiceSource):
         """Build PipelineObservability object from run data."""
         return PipelineObservability(
             pipeline=EntityReference(
-                id=pipeline_entity.id.root if hasattr(pipeline_entity.id, "root") else pipeline_entity.id,
+                id=pipeline_entity.id,
                 type="pipeline",
                 fullyQualifiedName=pipeline_entity.fullyQualifiedName.root
                 if hasattr(pipeline_entity.fullyQualifiedName, "root")
@@ -622,7 +626,7 @@ class DbtcloudSource(PipelineServiceSource):
             startTime=self._parse_timestamp(run.started_at) if run.started_at else None,
             endTime=self._parse_timestamp(run.finished_at) if run.finished_at else None,
             lastRunTime=self._parse_timestamp(run.finished_at) if run.finished_at else None,
-            lastRunStatus=self._map_run_status(run.state or run.status),
+            lastRunStatus=LastRunStatus(self._map_run_status(run.state or run.status)),
         )
 
     def get_table_pipeline_observability(
@@ -734,7 +738,7 @@ class DbtcloudSource(PipelineServiceSource):
                     continue
 
                 pipeline_status = PipelineStatus(
-                    executionStatus=self._map_run_status(run.state or run.status),
+                    executionStatus=StatusType(self._map_run_status(run.state or run.status)),
                     taskStatus=self._build_task_statuses(run),
                     timestamp=status_timestamp,
                 )

--- a/ingestion/tests/integration/airflow/Dockerfile
+++ b/ingestion/tests/integration/airflow/Dockerfile
@@ -1,0 +1,40 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Airflow carrying the working tree's OpenMetadata lineage provider. Build context is
+# ingestion/, so src/metadata/generated must already exist (make generate).
+
+FROM apache/airflow:3.3.0-python3.10
+
+USER airflow
+COPY --chown=airflow:0 . /tmp/ingestion
+
+# airflow-constraints-3.3.0.txt is deliberately NOT applied: it pins chardet==7.5.1
+# against openmetadata-ingestion's chardet==4.0.0. Dockerfile.ci installs the package
+# unconstrained for the same reason. apache-airflow is pinned so the resolver cannot move it.
+RUN pip install --no-cache-dir uv \
+ && uv pip install --no-cache "apache-airflow==3.3.0" /tmp/ingestion \
+ && rm -rf /tmp/ingestion
+
+# Migrating at build time keeps container start to a few seconds.
+RUN airflow db migrate \
+ && echo '{"admin": "admin"}' > /opt/airflow/simple_auth_manager_passwords.json
+
+# A file, not a `bash -c` string: passing a multi-line command through the container
+# runtime mangles the newlines and bash silently starts nothing.
+RUN printf '%s\n' \
+      '#!/usr/bin/env bash' \
+      'set -e' \
+      'airflow dag-processor &' \
+      'airflow scheduler &' \
+      'exec airflow api-server --port 8080' \
+      > /opt/airflow/start-test-airflow.sh \
+ && chmod +x /opt/airflow/start-test-airflow.sh

--- a/ingestion/tests/integration/airflow/conftest.py
+++ b/ingestion/tests/integration/airflow/conftest.py
@@ -1,0 +1,170 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Airflow container fixtures.
+
+Runs Airflow with the OpenMetadata lineage provider in a testcontainer, so the suite owns
+its own DAGs and connections instead of depending on the compose ingestion service.
+"""
+
+import json
+import shutil
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+import requests
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.docker_client import DockerClient
+
+AIRFLOW_BASE_IMAGE = "apache/airflow:3.3.0-python3.10"
+AIRFLOW_TEST_IMAGE = "om-airflow-lineage-test:local"
+
+# Fixed network name declared by docker/development/docker-compose.yml, so the container
+# resolves `openmetadata-server` exactly as the OM connection below expects.
+OM_NETWORK = "ometa_network"
+OM_SERVER_HOST = "openmetadata-server"
+OM_SERVER_PORT = 8585
+
+AIRFLOW_ADMIN = "admin"
+OM_CONNECTION_ID = "openmetadata_conn_id"
+OM_JWT = (
+    "eyJraWQiOiJHYjM4OWEtOWY3Ni1nZGpzLWE5MmotMDI0MmJrOTQzNTYiLCJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9"
+    ".eyJzdWIiOiJhZG1pbiIsImlzQm90IjpmYWxzZSwiaXNzIjoib3Blbi1tZXRhZGF0YS5vcmciLCJpYXQiOjE2NjM5Mzg0"
+    "NjIsImVtYWlsIjoiYWRtaW5Ab3Blbm1ldGFkYXRhLm9yZyJ9.tS8um_5DKu7HgzGBzS1VTA5uUjKWOCU0B_j08WXBiEC0"
+    "mr0zNREkqVfwFDD-d24HlNEbrqioLsBuFRiwIWKc1m_ZlVQbG7P36RUxhuv2vbSp80FKyNM-Tj93FDzq91jsyNmsQhyNv"
+    "_fNr3TXfzzSPjHt8Go0FMMP66weoKMgW2PbXlhVKwEuXUHyakLLzewm9UMeQaEiRzhiTMU3UkLXcKbYEJJvfNFcLwSl9W"
+    "8JCO_l0Yj3ud-qt_nQYEZwqW6u5nfdQllN133iikV4fM5QZsMCnm8Rq1mvLR0y9bmJiD7fwM1tmJ791TUWqmKaTnP49U4"
+    "93VanKpUAfzIiOiIbhg"
+)
+
+_DOCKERFILE = "tests/integration/airflow/Dockerfile"
+
+# A list, and via bash: the base image's entrypoint prefixes anything it does not
+# recognise with `airflow`, and a single string would be re-split by the runtime.
+_START_AIRFLOW = ["bash", "/opt/airflow/start-test-airflow.sh"]
+
+
+def _ingestion_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _auth_token(host: str, port: str) -> str | None:
+    """Airflow JWT for the admin user, or None while the API is still starting."""
+    try:
+        response = requests.post(
+            f"http://{host}:{port}/auth/token",
+            json={"username": AIRFLOW_ADMIN, "password": AIRFLOW_ADMIN},
+            timeout=10,
+        )
+    except requests.RequestException:
+        return None
+    return response.json().get("access_token") if response.status_code in (200, 201) else None
+
+
+def _wait_for_airflow_api(container, timeout: int = 420) -> None:
+    """Block until the Airflow API issues tokens. Raises TimeoutError otherwise."""
+    host = container.get_container_host_ip()
+    port = container.get_exposed_port(8080)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if _auth_token(host, port):
+            return
+        time.sleep(5)
+
+    stdout, stderr = container.get_logs()
+    raise TimeoutError(
+        f"Airflow API did not become ready within {timeout}s.\n"
+        f"--- container stdout ---\n{stdout.decode(errors='replace')[-4000:]}\n"
+        f"--- container stderr ---\n{stderr.decode(errors='replace')[-4000:]}"
+    )
+
+
+@pytest.fixture(scope="session")
+def airflow_image():
+    """Build the Airflow image carrying the working tree's lineage provider."""
+    DockerClient().client.images.build(
+        path=str(_ingestion_root()),
+        dockerfile=_DOCKERFILE,
+        tag=AIRFLOW_TEST_IMAGE,
+        rm=True,
+    )
+    return AIRFLOW_TEST_IMAGE
+
+
+@pytest.fixture(scope="module")
+def airflow_dag_dir():
+    """Host directory mounted as the Airflow DAG folder; tests write their DAGs here."""
+    # Not tmp_path_factory: its 0700 dirs are unreadable to the container's airflow user
+    # on Linux, and Docker Desktop's uid translation hides that everywhere but CI.
+    dag_dir = Path(tempfile.mkdtemp(prefix="airflow_dags_"))
+    dag_dir.chmod(0o755)
+
+    yield dag_dir
+
+    shutil.rmtree(dag_dir, ignore_errors=True)
+
+
+@pytest.fixture(scope="module")
+def airflow_container(airflow_image, airflow_dag_dir):
+    """Airflow reachable on the host, joined to the OpenMetadata compose network."""
+    connection = json.dumps(
+        {
+            "conn_type": "openmetadata",
+            "host": OM_SERVER_HOST,
+            "schema": "http",
+            "port": OM_SERVER_PORT,
+            "password": OM_JWT,
+        }
+    )
+
+    container = (
+        DockerContainer(AIRFLOW_TEST_IMAGE)
+        .with_kwargs(network=OM_NETWORK)
+        .with_exposed_ports(8080)
+        .with_volume_mapping(str(airflow_dag_dir), "/opt/airflow/dags", "ro")
+        .with_env("AIRFLOW__CORE__EXECUTOR", "LocalExecutor")
+        .with_env("AIRFLOW__CORE__LOAD_EXAMPLES", "False")
+        .with_env("AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_USERS", f"{AIRFLOW_ADMIN}:admin")
+        .with_env(
+            "AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_PASSWORDS_FILE",
+            "/opt/airflow/simple_auth_manager_passwords.json",
+        )
+        # Default is 300s; a DAG written after start would otherwise take 5 minutes to appear.
+        .with_env("AIRFLOW__DAG_PROCESSOR__REFRESH_INTERVAL", "5")
+        .with_env(f"AIRFLOW_CONN_{OM_CONNECTION_ID.upper()}", connection)
+        .with_command(_START_AIRFLOW)
+    )
+
+    with container:
+        _wait_for_airflow_api(container)
+        yield container
+
+
+@pytest.fixture(scope="module")
+def airflow_api(airflow_container):
+    """Base URL of the Airflow REST API as seen from the host."""
+    host = airflow_container.get_container_host_ip()
+    port = airflow_container.get_exposed_port(8080)
+    return f"http://{host}:{port}/api/v2"
+
+
+@pytest.fixture(scope="module")
+def airflow_headers(airflow_container):
+    """Authorization headers carrying a freshly minted Airflow JWT."""
+    token = _auth_token(
+        airflow_container.get_container_host_ip(),
+        airflow_container.get_exposed_port(8080),
+    )
+    assert token, "Airflow refused to issue a token"
+
+    return {"Content-Type": "application/json", "Authorization": f"Bearer {token}"}

--- a/ingestion/tests/integration/airflow/test_airflow_lineage.py
+++ b/ingestion/tests/integration/airflow/test_airflow_lineage.py
@@ -8,20 +8,17 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
 """
-Test airflow lineage operator and hook.
+Validate that the OpenMetadata Lineage Operator ingests a DAG run and its inlets/outlets.
 
-This test is coupled with the example DAG `lineage_tutorial_operator`.
-
-With the `docker compose up` setup, you can debug the progress
-by setting breakpoints in this file.
+The DAG, the Airflow connection and the OpenMetadata entities are all created here, so the
+suite depends on nothing beyond a reachable OpenMetadata server.
 """
 
 import time
-from typing import Optional
-from unittest import TestCase
+from datetime import datetime, timezone
 
+import pytest
 import requests
 
 from metadata.generated.schema.api.data.createDatabase import CreateDatabaseRequest
@@ -29,282 +26,201 @@ from metadata.generated.schema.api.data.createDatabaseSchema import (
     CreateDatabaseSchemaRequest,
 )
 from metadata.generated.schema.api.data.createTable import CreateTableRequest
-from metadata.generated.schema.api.services.createDatabaseService import (
-    CreateDatabaseServiceRequest,
-)
 from metadata.generated.schema.entity.data.pipeline import Pipeline, StatusType
 from metadata.generated.schema.entity.data.table import Column, DataType, Table
-from metadata.generated.schema.entity.services.connections.database.common.basicAuth import (
-    BasicAuth,
-)
-from metadata.generated.schema.entity.services.connections.database.mysqlConnection import (
-    MysqlConnection,
-)
-from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
-    OpenMetadataConnection,
-)
-from metadata.generated.schema.entity.services.databaseService import (
-    DatabaseConnection,
-    DatabaseService,
-    DatabaseServiceType,
-)
+from metadata.generated.schema.entity.services.databaseService import DatabaseService
 from metadata.generated.schema.entity.services.pipelineService import PipelineService
-from metadata.generated.schema.security.client.openMetadataJWTClientConfig import (
-    OpenMetadataJWTClientConfig,
-)
-from metadata.ingestion.ometa.ometa_api import OpenMetadata
 
-# These variables are just here to validate elements in the local deployment
-OM_HOST_PORT = "http://localhost:8585/api"
-OM_JWT = "eyJraWQiOiJHYjM4OWEtOWY3Ni1nZGpzLWE5MmotMDI0MmJrOTQzNTYiLCJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhZG1pbiIsImlzQm90IjpmYWxzZSwiaXNzIjoib3Blbi1tZXRhZGF0YS5vcmciLCJpYXQiOjE2NjM5Mzg0NjIsImVtYWlsIjoiYWRtaW5Ab3Blbm1ldGFkYXRhLm9yZyJ9.tS8um_5DKu7HgzGBzS1VTA5uUjKWOCU0B_j08WXBiEC0mr0zNREkqVfwFDD-d24HlNEbrqioLsBuFRiwIWKc1m_ZlVQbG7P36RUxhuv2vbSp80FKyNM-Tj93FDzq91jsyNmsQhyNv_fNr3TXfzzSPjHt8Go0FMMP66weoKMgW2PbXlhVKwEuXUHyakLLzewm9UMeQaEiRzhiTMU3UkLXcKbYEJJvfNFcLwSl9W8JCO_l0Yj3ud-qt_nQYEZwqW6u5nfdQllN133iikV4fM5QZsMCnm8Rq1mvLR0y9bmJiD7fwM1tmJ791TUWqmKaTnP49U493VanKpUAfzIiOiIbhg"
-AIRFLOW_HOST = "http://localhost:8080"
-AIRFLOW_API_ROOT = f"{AIRFLOW_HOST}/api/v2/"
-AIRFLOW_USERNAME = "admin"
-AIRFLOW_PASSWORD = "admin"
-DEFAULT_OM_AIRFLOW_CONNECTION = "openmetadata_conn_id"
-OM_LINEAGE_DAG_NAME = "lineage_tutorial_operator"
+from ..integration_base import get_create_service  # noqa: TID252
+from .conftest import OM_CONNECTION_ID  # noqa: TID252
+
+DAG_ID = "lineage_tutorial_operator"
+DAG_DESCRIPTION = "A simple tutorial DAG"
 PIPELINE_SERVICE_NAME = "airflow_lineage_op_service"
 
+DB_SERVICE_NAME = "test-service-table-lineage"
+DATABASE_NAME = "test-db"
+SCHEMA_NAME = "test-schema"
+INLET_NAMES = ("lineage-test-inlet", "lineage-test-inlet2")
+OUTLET_NAME = "lineage-test-outlet"
+SCHEMA_FQN = f"{DB_SERVICE_NAME}.{DATABASE_NAME}.{SCHEMA_NAME}"
 
-def get_airflow_jwt_token() -> str:
-    """Get JWT token from Airflow 3.x auth endpoint"""
-    token_url = f"{AIRFLOW_HOST}/auth/token"
-    payload = {"username": AIRFLOW_USERNAME, "password": AIRFLOW_PASSWORD}
-    response = requests.post(token_url, json=payload, timeout=10)
-    if response.status_code in (200, 201):
-        return response.json().get("access_token")
-    raise RuntimeError(f"Failed to get JWT token: {response.status_code} - {response.text}")
+DAG_SOURCE = f'''
+"""DAG owned by tests/integration/airflow/test_airflow_lineage.py."""
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.providers.standard.operators.bash import BashOperator
+
+from airflow_provider_openmetadata.hooks.openmetadata import OpenMetadataHook
+from airflow_provider_openmetadata.lineage.operator import OpenMetadataLineageOperator
+
+with DAG(
+    "{DAG_ID}",
+    default_args={{"owner": "openmetadata", "retries": 0, "retry_delay": timedelta(seconds=5)}},
+    description="{DAG_DESCRIPTION}",
+    schedule=None,
+    is_paused_upon_creation=True,
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
+) as dag:
+    print_date = BashOperator(
+        task_id="print_date",
+        bash_command="date",
+        outlets=[{{"tables": ["{SCHEMA_FQN}.{OUTLET_NAME}"]}}],
+    )
+
+    sleep = BashOperator(
+        task_id="sleep",
+        bash_command="sleep 1",
+        inlets=[{{"tables": ["{SCHEMA_FQN}.{INLET_NAMES[0]}", "{SCHEMA_FQN}.{INLET_NAMES[1]}"]}}],
+    )
+
+    templated = BashOperator(
+        task_id="templated",
+        bash_command='echo "{{{{ ds }}}}"',
+    )
+
+    lineage_op = OpenMetadataLineageOperator(
+        task_id="lineage_op",
+        server_config=OpenMetadataHook("{OM_CONNECTION_ID}").get_conn(),
+        service_name="{PIPELINE_SERVICE_NAME}",
+        only_keep_dag_lineage=True,
+    )
+
+    print_date >> [sleep, templated] >> lineage_op
+'''
 
 
-def get_airflow_headers() -> dict:
-    """Get authentication headers for Airflow 3.x API requests"""
-    jwt_token = get_airflow_jwt_token()
-    return {
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {jwt_token}",
-    }
-
-
-def get_task_status_type_by_name(pipeline: Pipeline, name: str) -> Optional[StatusType]:  # noqa: UP045
-    """
-    Given a pipeline, get its status by name
-    """
+def _task_status(pipeline: Pipeline, name: str):
     return next(
         (status.executionStatus for status in pipeline.pipelineStatus.taskStatus if status.name == name),
         None,
     )
 
 
-class AirflowLineageTest(TestCase):
-    """
-    This test will trigger an Airflow DAG and validate that the
-    OpenMetadata Lineage Operator can properly handle the
-    metadata ingestion and processes inlets and outlets.
-    """
-
-    server_config = OpenMetadataConnection(
-        hostPort=OM_HOST_PORT,
-        authProvider="openmetadata",
-        securityConfig=OpenMetadataJWTClientConfig(jwtToken=OM_JWT),
+@pytest.fixture(scope="module")
+def om_entities(metadata):
+    """The database service, schema and tables the DAG declares as inlets and outlets."""
+    service = metadata.create_or_update(data=get_create_service(entity=DatabaseService, name=DB_SERVICE_NAME))
+    database = metadata.create_or_update(
+        data=CreateDatabaseRequest(name=DATABASE_NAME, service=service.fullyQualifiedName)
     )
-    metadata = OpenMetadata(server_config)
-
-    assert metadata.health_check()
-
-    service = CreateDatabaseServiceRequest(
-        name="test-service-table-lineage",
-        serviceType=DatabaseServiceType.Mysql,
-        connection=DatabaseConnection(
-            config=MysqlConnection(
-                username="username",
-                authType=BasicAuth(password="password"),
-                hostPort="http://localhost:1234",
-            )
-        ),
+    db_schema = metadata.create_or_update(
+        data=CreateDatabaseSchemaRequest(name=SCHEMA_NAME, database=database.fullyQualifiedName)
     )
-    service_type = "databaseService"
 
-    @classmethod
-    def setUpClass(cls) -> None:
-        """
-        Prepare ingredients: Table Entity + DAG
-        """
-
-        service_entity = cls.metadata.create_or_update(data=cls.service)
-
-        create_db = CreateDatabaseRequest(
-            name="test-db",
-            service=service_entity.fullyQualifiedName,
-        )
-
-        create_db_entity = cls.metadata.create_or_update(data=create_db)
-
-        create_schema = CreateDatabaseSchemaRequest(
-            name="test-schema",
-            database=create_db_entity.fullyQualifiedName,
-        )
-
-        create_schema_entity = cls.metadata.create_or_update(data=create_schema)
-
-        create_inlet = CreateTableRequest(
-            name="lineage-test-inlet",
-            databaseSchema=create_schema_entity.fullyQualifiedName,
-            columns=[Column(name="id", dataType=DataType.BIGINT)],
-        )
-
-        create_inlet_2 = CreateTableRequest(
-            name="lineage-test-inlet2",
-            databaseSchema=create_schema_entity.fullyQualifiedName,
-            columns=[Column(name="id", dataType=DataType.BIGINT)],
-        )
-
-        create_outlet = CreateTableRequest(
-            name="lineage-test-outlet",
-            databaseSchema=create_schema_entity.fullyQualifiedName,
-            columns=[Column(name="id", dataType=DataType.BIGINT)],
-        )
-
-        cls.metadata.create_or_update(data=create_inlet)
-        cls.metadata.create_or_update(data=create_inlet_2)
-        cls.table_outlet = cls.metadata.create_or_update(data=create_outlet)
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        """
-        Clean up
-        """
-
-        db_service = cls.metadata.get_by_name(entity=DatabaseService, fqn="test-service-table-lineage")
-        if db_service:
-            service_id = str(db_service.id.root)
-            cls.metadata.delete(
-                entity=DatabaseService,
-                entity_id=service_id,
-                recursive=True,
-                hard_delete=True,
+    tables = {}
+    for table_name in (*INLET_NAMES, OUTLET_NAME):
+        tables[table_name] = metadata.create_or_update(
+            data=CreateTableRequest(
+                name=table_name,
+                databaseSchema=db_schema.fullyQualifiedName,
+                columns=[Column(name="id", dataType=DataType.BIGINT)],
             )
-
-        # Service ID created from the Airflow Lineage Operator in the
-        # example DAG
-        pipeline_service = cls.metadata.get_by_name(entity=PipelineService, fqn=PIPELINE_SERVICE_NAME)
-        if pipeline_service:
-            pipeline_service_id = str(pipeline_service.id.root)
-            cls.metadata.delete(
-                entity=PipelineService,
-                entity_id=pipeline_service_id,
-                recursive=True,
-                hard_delete=True,
-            )
-
-    def test_dag_runs(self) -> None:
-        """
-        Trigger the Airflow DAG and wait until it runs.
-
-        Note that the DAG definition is in examples/airflow_lineage_operator.py
-        and it is expected to fail. This will allow us to validate
-        the task status afterward.
-        """
-
-        headers = get_airflow_headers()
-
-        # 1. Validate that the OpenMetadata connection exists
-        res = requests.get(
-            AIRFLOW_API_ROOT + f"connections/{DEFAULT_OM_AIRFLOW_CONNECTION}",
-            headers=headers,
         )
-        if res.status_code != 200:
-            raise RuntimeError(
-                f"Could not fetch {DEFAULT_OM_AIRFLOW_CONNECTION} connection: {res.status_code} - {res.text}"
-            )
 
-        # 2. Enable the DAG
-        res = requests.patch(
-            AIRFLOW_API_ROOT + f"dags/{OM_LINEAGE_DAG_NAME}",
-            json={"is_paused": False},
-            headers=headers,
+    yield tables
+
+    metadata.delete(entity=DatabaseService, entity_id=service.id, recursive=True, hard_delete=True)
+    pipeline_service = metadata.get_by_name(entity=PipelineService, fqn=PIPELINE_SERVICE_NAME)
+    if pipeline_service:
+        metadata.delete(
+            entity=PipelineService,
+            entity_id=pipeline_service.id,
+            recursive=True,
+            hard_delete=True,
         )
-        if res.status_code != 200:
-            raise RuntimeError(f"Could not enable {OM_LINEAGE_DAG_NAME} DAG: {res.status_code} - {res.text}")
 
-        # 3. Trigger the DAG (Airflow 3.x requires logical_date)
-        from datetime import datetime, timezone
 
-        res = requests.post(
-            AIRFLOW_API_ROOT + f"dags/{OM_LINEAGE_DAG_NAME}/dagRuns",
-            json={"logical_date": datetime.now(timezone.utc).isoformat()},
-            headers=headers,
+@pytest.fixture(scope="module")
+def registered_dag(airflow_container, airflow_dag_dir, airflow_api, airflow_headers, om_entities):
+    """DAG_ID, once the dag-processor has picked the file up."""
+    dag_file = airflow_dag_dir / f"{DAG_ID}.py"
+    dag_file.write_text(DAG_SOURCE)
+    dag_file.chmod(0o644)
+
+    deadline = time.monotonic() + 180
+    while time.monotonic() < deadline:
+        response = requests.get(f"{airflow_api}/dags/{DAG_ID}", headers=airflow_headers, timeout=30)
+        if response.status_code == 200:
+            return DAG_ID
+        time.sleep(5)
+
+    errors = requests.get(f"{airflow_api}/importErrors", headers=airflow_headers, timeout=30)
+    # An empty importErrors list means the processor never read the file at all, so show
+    # it what it can actually see in the mount.
+    listing = airflow_container.exec("ls -la /opt/airflow/dags")
+    raise TimeoutError(
+        f"{DAG_ID} never registered.\nImport errors: {errors.text}\n"
+        f"Container view of /opt/airflow/dags:\n{listing.output.decode(errors='replace')}"
+    )
+
+
+@pytest.fixture(scope="module")
+def dag_run(airflow_api, airflow_headers, registered_dag):
+    """A finished run of the lineage DAG."""
+    unpause = requests.patch(
+        f"{airflow_api}/dags/{registered_dag}",
+        json={"is_paused": False},
+        headers=airflow_headers,
+        timeout=30,
+    )
+    assert unpause.status_code == 200, f"Could not unpause {registered_dag}: {unpause.text}"
+
+    triggered = requests.post(
+        f"{airflow_api}/dags/{registered_dag}/dagRuns",
+        json={"logical_date": datetime.now(timezone.utc).isoformat()},
+        headers=airflow_headers,
+        timeout=30,
+    )
+    assert triggered.status_code in (200, 201), f"Could not trigger {registered_dag}: {triggered.text}"
+    run_id = triggered.json()["dag_run_id"]
+
+    deadline = time.monotonic() + 300
+    state = "queued"
+    while state not in ("success", "failed") and time.monotonic() < deadline:
+        time.sleep(5)
+        response = requests.get(
+            f"{airflow_api}/dags/{registered_dag}/dagRuns/{run_id}",
+            headers=airflow_headers,
+            timeout=30,
         )
-        if res.status_code != 200:
-            raise RuntimeError(f"Could not trigger {OM_LINEAGE_DAG_NAME} DAG: {res.status_code} - {res.text}")
-        dag_run_id = res.json()["dag_run_id"]
+        state = response.json().get("state")
 
-        # 4. Wait until the DAG is flagged as `successful` or `failed`
-        state = "queued"
-        tries = 0
-        max_tries = 12  # 60 seconds total (12 * 5 seconds)
-        while state not in ("success", "failed") and tries < max_tries:
-            tries += 1
-            time.sleep(5)
+    assert state in ("success", "failed"), f"{registered_dag} did not finish in time. Last state: {state}"
 
-            res = requests.get(
-                AIRFLOW_API_ROOT + f"dags/{OM_LINEAGE_DAG_NAME}/dagRuns/{dag_run_id}",
-                headers=headers,
-            )
-            dag_run_data = res.json()
-            state = dag_run_data.get("state")
-            print(f"Try {tries}/{max_tries}: DAG state = {state}")  # noqa: T201
+    return run_id
 
-        if state not in ("success", "failed"):
-            raise RuntimeError(f"DAG {OM_LINEAGE_DAG_NAME} has not finished on time. Last state: {state}")
 
-    def test_pipeline_created(self) -> None:
-        """
-        Validate that the pipeline has been created
-        """
-        pipeline_service: PipelineService = self.metadata.get_by_name(entity=PipelineService, fqn=PIPELINE_SERVICE_NAME)
-        self.assertIsNotNone(pipeline_service)
+def test_pipeline_created(metadata, dag_run):
+    assert metadata.get_by_name(entity=PipelineService, fqn=PIPELINE_SERVICE_NAME) is not None
 
-        pipeline: Pipeline = self.metadata.get_by_name(
-            entity=Pipeline,
-            fqn=f"{PIPELINE_SERVICE_NAME}.{OM_LINEAGE_DAG_NAME}",
-            fields=["tasks", "pipelineStatus"],
+    pipeline = metadata.get_by_name(
+        entity=Pipeline,
+        fqn=f"{PIPELINE_SERVICE_NAME}.{DAG_ID}",
+        fields=["tasks", "pipelineStatus"],
+    )
+
+    assert pipeline is not None
+    assert {task.name for task in pipeline.tasks} == {"print_date", "sleep", "templated", "lineage_op"}
+    assert pipeline.description.root == DAG_DESCRIPTION
+    assert pipeline.pipelineStatus is not None, "Pipeline status should be collected via REST API"
+    assert _task_status(pipeline, "print_date") == StatusType.Successful
+    assert _task_status(pipeline, "sleep") == StatusType.Successful
+    assert _task_status(pipeline, "templated") == StatusType.Successful
+
+
+def test_pipeline_lineage(metadata, om_entities, dag_run):
+    outlet_id = str(om_entities[OUTLET_NAME].id.root)
+
+    for inlet_name in INLET_NAMES:
+        lineage = metadata.get_lineage_by_name(entity=Table, fqn=f"{SCHEMA_FQN}.{inlet_name}")
+
+        assert {node["name"] for node in lineage.get("nodes") or []} == {OUTLET_NAME}
+        assert len(lineage.get("downstreamEdges")) == 1
+        assert lineage["downstreamEdges"][0]["toEntity"] == outlet_id
+        assert (
+            lineage["downstreamEdges"][0]["lineageDetails"]["pipeline"]["fullyQualifiedName"]
+            == f"{PIPELINE_SERVICE_NAME}.{DAG_ID}"
         )
-        self.assertIsNotNone(pipeline)
-
-        expected_task_names = set((task.name for task in pipeline.tasks))  # noqa: C401, UP034
-        self.assertEqual(expected_task_names, {"print_date", "sleep", "templated", "lineage_op"})
-
-        self.assertEqual(pipeline.description.root, "A simple tutorial DAG")
-
-        # Validate status
-        self.assertIsNotNone(pipeline.pipelineStatus, "Pipeline status should be collected via REST API")
-        self.assertEqual(get_task_status_type_by_name(pipeline, "print_date"), StatusType.Successful)
-        self.assertEqual(get_task_status_type_by_name(pipeline, "sleep"), StatusType.Successful)
-        self.assertEqual(get_task_status_type_by_name(pipeline, "templated"), StatusType.Successful)
-
-    def test_pipeline_lineage(self) -> None:
-        """
-        Validate that the pipeline has proper lineage
-        """
-        root_name = "test-service-table-lineage.test-db.test-schema"
-
-        # Check that both inlets have the same outlet
-        for inlet_table in [
-            f"{root_name}.lineage-test-inlet",
-            f"{root_name}.lineage-test-inlet2",
-        ]:
-            lineage = self.metadata.get_lineage_by_name(
-                entity=Table,
-                fqn=inlet_table,
-            )
-            node_names = set((node["name"] for node in lineage.get("nodes") or []))  # noqa: C401, UP034
-            self.assertEqual(node_names, {"lineage-test-outlet"})
-            self.assertEqual(len(lineage.get("downstreamEdges")), 1)
-            self.assertEqual(
-                lineage["downstreamEdges"][0]["toEntity"],
-                str(self.table_outlet.id.root),
-            )
-            self.assertEqual(
-                lineage["downstreamEdges"][0]["lineageDetails"]["pipeline"]["fullyQualifiedName"],
-                f"{PIPELINE_SERVICE_NAME}.{OM_LINEAGE_DAG_NAME}",
-            )

--- a/ingestion/tests/integration/alationsink/test_alationsink.py
+++ b/ingestion/tests/integration/alationsink/test_alationsink.py
@@ -12,19 +12,27 @@
 Test Alation Sink using the integration testing
 """
 
-from unittest import TestCase
 from unittest.mock import patch
 
+import pytest
+
+from metadata.generated.schema.api.data.createDatabase import CreateDatabaseRequest
+from metadata.generated.schema.api.data.createDatabaseSchema import (
+    CreateDatabaseSchemaRequest,
+)
+from metadata.generated.schema.api.data.createTable import (
+    CreateTableRequest as CreateOMTableRequest,
+)
 from metadata.generated.schema.entity.data.database import Database
 from metadata.generated.schema.entity.data.databaseSchema import DatabaseSchema
-from metadata.generated.schema.entity.data.table import Table
-from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
-    OpenMetadataConnection,
+from metadata.generated.schema.entity.data.table import (
+    Column,
+    Constraint,
+    DataType,
+    Table,
+    TableType,
 )
-from metadata.generated.schema.metadataIngestion.workflow import (
-    OpenMetadataWorkflowConfig,
-)
-from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.generated.schema.entity.services.databaseService import DatabaseService
 from metadata.ingestion.ometa.utils import model_str
 from metadata.ingestion.source.metadata.alationsink.metadata import AlationsinkSource
 from metadata.ingestion.source.metadata.alationsink.models import (
@@ -34,6 +42,8 @@ from metadata.ingestion.source.metadata.alationsink.models import (
     CreateSchemaRequest,
     CreateTableRequest,
 )
+
+from ..integration_base import generate_name, get_create_service  # noqa: TID252
 
 mock_alation_sink_config = {
     "source": {
@@ -46,7 +56,7 @@ mock_alation_sink_config = {
                 "projectName": "Test",
                 "paginationLimit": 50,
                 "datasourceLinks": {
-                    "112": "sample_data.ecommerce_db",
+                    "112": "my_service.my_database",
                 },
             }
         },
@@ -71,13 +81,17 @@ mock_alation_sink_config = {
 
 MOCK_ALATION_DATASOURCE_ID = 34
 
+DATABASE_NAME = "my_database"
+DATABASE_DESCRIPTION = "Mock database for the Alation sink request builders."
+SCHEMA_NAME = "my_schema"
+SCHEMA_DESCRIPTION = "Mock schema for the Alation sink request builders."
 
-def mock_write_entities(self, ds_id, create_request):  # pylint: disable=unused-argument
-    return {"job_id": "10378"}
-
-
-def mock_write_entity(self, create_request):  # pylint: disable=unused-argument
-    return {"ds_id": "13"}
+# `::>` is not an FQN separator; it guards against a builder that over-quotes names.
+QUOTED_TABLE_NAME = "dim_::>address"
+REGULAR_TABLE_NAME = "dim_address"
+VIEW_TABLE_NAME = "dim_address_clean"
+TABLE_DESCRIPTION = "Mock dimension table holding customer addresses."
+VIEW_DESCRIPTION = "Created from dim_address after a small cleanup."
 
 
 def mock_list_connectors():
@@ -90,241 +104,98 @@ def mock_list_connectors():
     }
 
 
+# get_create_service builds a Mysql service, which SERVICE_TYPE_MAPPER resolves to the
+# "MySQL OCF Connector" entry above.
+EXPECTED_CONNECTOR_ID = 116
+
+TABLE_COLUMNS = [
+    Column(
+        name="address_id",
+        dataType=DataType.NUMERIC,
+        dataTypeDisplay="numeric",
+        description="Unique identifier for the address.",
+        constraint=Constraint.PRIMARY_KEY,
+        ordinalPosition=1,
+    ),
+    Column(
+        name="shop_id",
+        dataType=DataType.NUMERIC,
+        dataTypeDisplay="numeric",
+        description="The ID of the store.",
+        constraint=Constraint.NOT_NULL,
+        ordinalPosition=2,
+    ),
+    Column(
+        name="city",
+        dataType=DataType.VARCHAR,
+        dataLength=100,
+        dataTypeDisplay="varchar(100)",
+        description="The city of the address.",
+        constraint=Constraint.NULL,
+        ordinalPosition=3,
+    ),
+]
+
 EXPECTED_DATASOURCE_REQUEST = CreateDatasourceRequest(
     uri="None",
-    connector_id=115,
+    connector_id=EXPECTED_CONNECTOR_ID,
     db_username="Test",
     db_password=None,
-    title="ecommerce_db",
-    description="This **mock** database contains schemas related to shopify sales and orders with related dimension tables.",
+    title=DATABASE_NAME,
+    description=DATABASE_DESCRIPTION,
 )
 
 EXPECTED_SCHEMA_REQUEST = CreateSchemaRequest(
-    key="34.shopify",
-    title="shopify",
-    description="This **mock** database contains schema related to shopify sales and orders with related dimension tables.",
+    key=f"{MOCK_ALATION_DATASOURCE_ID}.{SCHEMA_NAME}",
+    title=SCHEMA_NAME,
+    description=SCHEMA_DESCRIPTION,
 )
-
-
-BASE_DESC = "This dimension table contains the billing and shipping addresses of customers. You can join this table with the sales table to generate lists of the billing and shipping addresses. Customers can enter their addresses more than once, so the same address can appear in more than one row in this table. This table contains one row per customer address."
 
 EXPECTED_TABLES = [
     CreateTableRequest(
-        key="34.shopify.dim_::>address",
-        title="dim_::>address",
-        description=BASE_DESC,
+        key=f"{MOCK_ALATION_DATASOURCE_ID}.{SCHEMA_NAME}.{QUOTED_TABLE_NAME}",
+        title=QUOTED_TABLE_NAME,
+        description=TABLE_DESCRIPTION,
         table_type="TABLE",
         sql=None,
     ),
     CreateTableRequest(
-        key="34.shopify.dim_address",
-        title="dim_address",
-        description=BASE_DESC,
+        key=f"{MOCK_ALATION_DATASOURCE_ID}.{SCHEMA_NAME}.{REGULAR_TABLE_NAME}",
+        title=REGULAR_TABLE_NAME,
+        description=TABLE_DESCRIPTION,
         table_type="TABLE",
         sql=None,
     ),
     CreateTableRequest(
-        key="34.shopify.dim_address_clean",
-        title="dim_address_clean",
-        description="Created from dim_address after a small cleanup.",
+        key=f"{MOCK_ALATION_DATASOURCE_ID}.{SCHEMA_NAME}.{VIEW_TABLE_NAME}",
+        title=VIEW_TABLE_NAME,
+        description=VIEW_DESCRIPTION,
         table_type="VIEW",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.dim_customer",
-        title="dim_customer",
-        description="The dimension table contains data about your customers. The customers table contains one row per customer. It includes historical metrics (such as the total amount that each customer has spent in your store) as well as forward-looking metrics (such as the predicted number of days between future orders and the expected order value in the next 30 days). This table also includes columns that segment customers into various categories (such as new, returning, promising, at risk, dormant, and loyal), which you can use to target marketing activities.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.dim_location",
-        title="dim_location",
-        description="The dimension table contains metrics about your Shopify POS. This table contains one row per Shopify POS location. You can use this table to generate a list of the Shopify POS locations or you can join the table with the sales table to measure sales performance.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.dim_staff",
-        title="dim_staff",
-        description="This dimension table contains information about the staff accounts in the store. It contains one row per staff account. Use this table to generate a list of your staff accounts, or join it with the sales, API clients and locations tables to analyze staff performance at Shopify POS locations.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key='34.shopify."dim.api/client"',
-        title="dim.api/client",
-        description="This dimension table contains a row for each channel or app that your customers use to create orders. Some examples of these include Facebook and Online Store. You can join this table with the sales table to measure channel performance.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key='34.shopify."dim.product"',
-        title="dim.product",
-        description="This dimension table contains information about each of the products in your store. This table contains one row per product. This table reflects the current state of products in your Shopify admin.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key='34.shopify."dim.product.variant"',
-        title="dim.product.variant",
-        description="This dimension table contains current information about each of the product variants in your store. This table contains one row per product variant.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key='34.shopify."dim.shop"',
-        title="dim.shop",
-        description="This dimension table contains online shop information. This table contains one shop per row.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.dim(shop)",
-        title="dim(shop)",
-        description="This dimension table contains online shop information with weird characters.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.fact_line_item_Lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_sed_do_eiusmod_tempor_incididunt_ut_labore_et_dolore_magna_aliqua_Ut_enim_ad_minim_veniam_quis_nostrud_exercitation_ullamco_laboris_nisi_ut_aliquip_ex_ea_commodo_consequat_Duis_aute_iru",
-        title="fact_line_item_Lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_sed_do_eiusmod_tempor_incididunt_ut_labore_et_dolore_magna_aliqua_Ut_enim_ad_minim_veniam_quis_nostrud_exercitation_ullamco_laboris_nisi_ut_aliquip_ex_ea_commodo_consequat_Duis_aute_iru",
-        description="The fact table contains information about the line items in orders. Each row in the table is a line item in an order. It contains product and product variant details as they were at the time of the order. This table does not include information about returns. Join this table with the TODO fact_sales table to get the details of the product on the day it was sold. This data will match what appears on the order in your Shopify admin as well as the in the Sales reports.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.fact_order",
-        title="fact_order",
-        description="The orders table contains information about each order in your store. Although this table is good for generating order lists and joining with the dim_customer, use the sales table instead for computing financial or other metrics.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.fact_sale",
-        title="fact_sale",
-        description="The fact table captures the value of products sold or returned, as well as the values of other charges such as taxes and shipping costs. The sales table contains one row per order line item, one row per returned line item, and one row per shipping charge. Use this table when you need financial metrics.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.fact_session",
-        title="fact_session",
-        description="This fact table contains information about the visitors to your online store. This table has one row per session, where one session can contain many page views. If you use Urchin Traffic Module (UTM) parameters in marketing campaigns, then you can use this table to track how many customers they direct to your store.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.raw_customer",
-        title="raw_customer",
-        description="This is a raw customers table as represented in our online DB. This contains personal, shipping and billing addresses and details of the customer store and customer profile. This table is used to build our dimensional and fact tables",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.raw_order",
-        title="raw_order",
-        description="This is a raw orders table as represented in our online DB. This table contains all the orders by the customers and can be used to buid our dim and fact tables",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.raw_product_catalog",
-        title="raw_product_catalog",
-        description="This is a raw product catalog table contains the product listing, price, seller etc.. represented in our online DB. ",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.магазин",
-        title="магазин",
-        description="This dimension table contains online shop information with weird characters.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.icemarketdata_global",
-        title="icemarketdata_global",
-        description=BASE_DESC,
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.global_market",
-        title="global_market",
-        description=BASE_DESC,
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.global",
-        title="global",
-        description=BASE_DESC,
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.ice_global",
-        title="ice_global",
-        description=BASE_DESC,
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.mortgage",
-        title="mortgage",
-        description=BASE_DESC,
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.funds_closingprocessdocumentsrelationship",
-        title="funds_closingprocessdocumentsrelationship",
-        description=BASE_DESC,
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.big_data_table_with_nested_columns",
-        title="big_data_table_with_nested_columns",
-        description="A large table with thousands of columns including nested "
-        "structures for testing pagination and search performance",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.performance_test_table",
-        title="performance_test_table",
-        description="A table with thousands of columns designed for testing the "
-        "performance of paginated column APIs. This table contains 2000 columns "
-        "with various data types to simulate real-world scenarios where tables "
-        "have large numbers of columns.",
-        table_type="TABLE",
         sql=None,
     ),
 ]
 
 EXPECTED_COLUMNS = [
     CreateColumnRequest(
-        key="34.shopify.dim_address.address_id",
+        key=f"{MOCK_ALATION_DATASOURCE_ID}.{SCHEMA_NAME}.{REGULAR_TABLE_NAME}.address_id",
         column_type="numeric",
         title="address_id",
         description="Unique identifier for the address.",
         nullable=None,
         position="1",
         index=ColumnIndex(
-            isPrimaryKey=None,
+            isPrimaryKey=True,
             isForeignKey=None,
             referencedColumnId=None,
             isOtherIndex=None,
         ),
     ),
     CreateColumnRequest(
-        key="34.shopify.dim_address.shop_id",
+        key=f"{MOCK_ALATION_DATASOURCE_ID}.{SCHEMA_NAME}.{REGULAR_TABLE_NAME}.shop_id",
         column_type="numeric",
         title="shop_id",
-        description="The ID of the store. This column is a foreign key reference to the shop_id column in the dim_shop table.",
-        nullable=None,
+        description="The ID of the store.",
+        nullable=False,
         position="2",
         index=ColumnIndex(
             isPrimaryKey=None,
@@ -334,138 +205,12 @@ EXPECTED_COLUMNS = [
         ),
     ),
     CreateColumnRequest(
-        key="34.shopify.dim_address.first_name",
-        column_type="varchar",
-        title="first_name",
-        description="First name of the customer.",
-        nullable=None,
-        position="3",
-        index=ColumnIndex(
-            isPrimaryKey=None,
-            isForeignKey=None,
-            referencedColumnId=None,
-            isOtherIndex=None,
-        ),
-    ),
-    CreateColumnRequest(
-        key="34.shopify.dim_address.last_name",
-        column_type="varchar",
-        title="last_name",
-        description="Last name of the customer.",
-        nullable=None,
-        position="4",
-        index=ColumnIndex(
-            isPrimaryKey=None,
-            isForeignKey=None,
-            referencedColumnId=None,
-            isOtherIndex=None,
-        ),
-    ),
-    CreateColumnRequest(
-        key="34.shopify.dim_address.address1",
-        column_type="varchar",
-        title="address1",
-        description="The first address line. For example, 150 Elgin St.",
-        nullable=None,
-        position="5",
-        index=ColumnIndex(
-            isPrimaryKey=None,
-            isForeignKey=None,
-            referencedColumnId=None,
-            isOtherIndex=None,
-        ),
-    ),
-    CreateColumnRequest(
-        key="34.shopify.dim_address.address2",
-        column_type="varchar",
-        title="address2",
-        description="The second address line. For example, Suite 800.",
-        nullable=None,
-        position="6",
-        index=ColumnIndex(
-            isPrimaryKey=None,
-            isForeignKey=None,
-            referencedColumnId=None,
-            isOtherIndex=None,
-        ),
-    ),
-    CreateColumnRequest(
-        key="34.shopify.dim_address.company",
-        column_type="varchar",
-        title="company",
-        description="The name of the customer's business, if one exists.",
-        nullable=None,
-        position="7",
-        index=ColumnIndex(
-            isPrimaryKey=None,
-            isForeignKey=None,
-            referencedColumnId=None,
-            isOtherIndex=None,
-        ),
-    ),
-    CreateColumnRequest(
-        key="34.shopify.dim_address.city",
-        column_type="varchar",
+        key=f"{MOCK_ALATION_DATASOURCE_ID}.{SCHEMA_NAME}.{REGULAR_TABLE_NAME}.city",
+        column_type="varchar(100)",
         title="city",
-        description="The name of the city. For example, Palo Alto.",
-        nullable=None,
-        position="8",
-        index=ColumnIndex(
-            isPrimaryKey=None,
-            isForeignKey=None,
-            referencedColumnId=None,
-            isOtherIndex=None,
-        ),
-    ),
-    CreateColumnRequest(
-        key="34.shopify.dim_address.region",
-        column_type="varchar",
-        title="region",
-        description="The name of the region, such as a province or state, where the customer is located. For example, Ontario or New York. This column is the same as CustomerAddress.province in the Admin API.",
-        nullable=None,
-        position="9",
-        index=ColumnIndex(
-            isPrimaryKey=None,
-            isForeignKey=None,
-            referencedColumnId=None,
-            isOtherIndex=None,
-        ),
-    ),
-    CreateColumnRequest(
-        key="34.shopify.dim_address.zip",
-        column_type="varchar",
-        title="zip",
-        description="The ZIP or postal code. For example, 90210.",
-        nullable=None,
-        position="10",
-        index=ColumnIndex(
-            isPrimaryKey=None,
-            isForeignKey=None,
-            referencedColumnId=None,
-            isOtherIndex=None,
-        ),
-    ),
-    CreateColumnRequest(
-        key="34.shopify.dim_address.country",
-        column_type="varchar",
-        title="country",
-        description="The full name of the country. For example, Canada.",
-        nullable=None,
-        position="11",
-        index=ColumnIndex(
-            isPrimaryKey=None,
-            isForeignKey=None,
-            referencedColumnId=None,
-            isOtherIndex=None,
-        ),
-    ),
-    CreateColumnRequest(
-        key="34.shopify.dim_address.phone",
-        column_type="varchar",
-        title="phone",
-        description="The phone number of the customer.",
-        nullable=None,
-        position="12",
+        description="The city of the address.",
+        nullable=True,
+        position="3",
         index=ColumnIndex(
             isPrimaryKey=None,
             isForeignKey=None,
@@ -476,83 +221,108 @@ EXPECTED_COLUMNS = [
 ]
 
 
-class AlationSinkTest(TestCase):
-    """
-    Implements the necessary methods to extract
-    Alation Sink Metadata Unit Test
-    """
+@pytest.fixture(scope="module")
+def alation_sink_source(metadata):
+    """AlationsinkSource whose connector listing is stubbed to mock_list_connectors."""
+    with patch.object(AlationsinkSource, "test_connection", return_value=False):
+        source = AlationsinkSource.create(mock_alation_sink_config["source"], metadata)
+    source.connectors = mock_list_connectors()
+    return source
 
-    @patch("metadata.ingestion.source.metadata.alationsink.metadata.AlationsinkSource.test_connection")
-    def __init__(self, methodName, test_connection) -> None:  # noqa: N803
-        super().__init__(methodName)
-        test_connection.return_value = False
-        self.config = OpenMetadataWorkflowConfig.model_validate(mock_alation_sink_config)
-        self.alation_sink_source = AlationsinkSource.create(
-            mock_alation_sink_config["source"],
-            OpenMetadata(self.config.workflowConfig.openMetadataServerConfig),
+
+@pytest.fixture(scope="module")
+def om_database(metadata):
+    """A Mysql service holding one database, one schema and three tables."""
+    service = metadata.create_or_update(data=get_create_service(entity=DatabaseService, name=generate_name()))
+    database = metadata.create_or_update(
+        data=CreateDatabaseRequest(
+            name=DATABASE_NAME,
+            description=DATABASE_DESCRIPTION,
+            service=service.fullyQualifiedName,
         )
-        self.alation_sink_source.connectors = mock_list_connectors()
-        self.metadata = OpenMetadata(
-            OpenMetadataConnection.model_validate(
-                mock_alation_sink_config["workflowConfig"]["openMetadataServerConfig"]
+    )
+    db_schema = metadata.create_or_update(
+        data=CreateDatabaseSchemaRequest(
+            name=SCHEMA_NAME,
+            description=SCHEMA_DESCRIPTION,
+            database=database.fullyQualifiedName,
+        )
+    )
+    for name, description, table_type in (
+        (QUOTED_TABLE_NAME, TABLE_DESCRIPTION, TableType.Regular),
+        (REGULAR_TABLE_NAME, TABLE_DESCRIPTION, TableType.Regular),
+        (VIEW_TABLE_NAME, VIEW_DESCRIPTION, TableType.View),
+    ):
+        metadata.create_or_update(
+            data=CreateOMTableRequest(
+                name=name,
+                description=description,
+                tableType=table_type,
+                databaseSchema=db_schema.fullyQualifiedName,
+                columns=TABLE_COLUMNS,
             )
         )
 
-    def test_datasources(self):
-        """
-        Testing datasource API request creation model
-        """
-        om_database = self.metadata.get_by_name(entity=Database, fqn="sample_data.ecommerce_db")
-        returned_datasource_request = self.alation_sink_source.create_datasource_request(om_database)
-        self.assertEqual(returned_datasource_request, EXPECTED_DATASOURCE_REQUEST)
+    yield database
 
-    def test_schemas(self):
-        """
-        Testing schema API request creation
-        """
-        om_schema = self.metadata.get_by_name(entity=DatabaseSchema, fqn="sample_data.ecommerce_db.shopify")
-        returned_schema_request = self.alation_sink_source.create_schema_request(
-            alation_datasource_id=MOCK_ALATION_DATASOURCE_ID, om_schema=om_schema
+    metadata.delete(
+        entity=DatabaseService,
+        entity_id=service.id,
+        recursive=True,
+        hard_delete=True,
+    )
+
+
+def test_datasources(metadata, alation_sink_source, om_database):
+    database = metadata.get_by_name(entity=Database, fqn=om_database.fullyQualifiedName)
+
+    assert alation_sink_source.create_datasource_request(database) == EXPECTED_DATASOURCE_REQUEST
+
+
+def test_schemas(metadata, alation_sink_source, om_database):
+    om_schema = metadata.get_by_name(
+        entity=DatabaseSchema,
+        fqn=f"{model_str(om_database.fullyQualifiedName)}.{SCHEMA_NAME}",
+    )
+    returned_schema_request = alation_sink_source.create_schema_request(
+        alation_datasource_id=MOCK_ALATION_DATASOURCE_ID, om_schema=om_schema
+    )
+
+    assert returned_schema_request == EXPECTED_SCHEMA_REQUEST
+
+
+def test_tables(metadata, alation_sink_source, om_database):
+    om_tables = metadata.list_all_entities(
+        entity=Table,
+        skip_on_failure=True,
+        params={"database": f"{model_str(om_database.fullyQualifiedName)}.{SCHEMA_NAME}"},
+    )
+    returned_tables = [
+        alation_sink_source.create_table_request(
+            alation_datasource_id=MOCK_ALATION_DATASOURCE_ID,
+            schema_name=SCHEMA_NAME,
+            om_table=om_table,
         )
-        self.assertEqual(returned_schema_request, EXPECTED_SCHEMA_REQUEST)
+        for om_table in om_tables
+    ]
 
-    def test_tables(self):
-        """
-        Testing table API request creation
-        """
-        om_tables = self.metadata.list_all_entities(
-            entity=Table,
-            skip_on_failure=True,
-            params={"database": "sample_data.ecommerce_db.shopify"},
+    assert sorted(returned_tables, key=lambda table: table.key) == sorted(EXPECTED_TABLES, key=lambda table: table.key)
+
+
+def test_columns(metadata, alation_sink_source, om_database):
+    om_table = metadata.get_by_name(
+        entity=Table,
+        fqn=f"{model_str(om_database.fullyQualifiedName)}.{SCHEMA_NAME}.{REGULAR_TABLE_NAME}",
+    )
+    returned_columns = [
+        alation_sink_source.create_column_request(
+            alation_datasource_id=MOCK_ALATION_DATASOURCE_ID,
+            schema_name=SCHEMA_NAME,
+            table_name=model_str(om_table.name),
+            om_column=om_column,
+            table_constraints=om_table.tableConstraints,
         )
-        returned_tables = []
-        for om_table in om_tables:
-            returned_tables.append(  # noqa: PERF401
-                self.alation_sink_source.create_table_request(
-                    alation_datasource_id=MOCK_ALATION_DATASOURCE_ID,
-                    schema_name="shopify",
-                    om_table=om_table,
-                )
-            )
-        self.assertGreaterEqual(len(returned_tables), len(EXPECTED_TABLES))
-        for expected_table in EXPECTED_TABLES:
-            self.assertIn(expected_table, returned_tables)
+        for om_column in om_table.columns
+    ]
 
-    def test_columns(self):
-        """
-        Testing column API request creation
-        """
-        om_table = self.metadata.get_by_name(entity=Table, fqn="sample_data.ecommerce_db.shopify.dim_address")
-        returned_columns = []
-        for om_column in om_table.columns:
-            returned_columns.append(  # noqa: PERF401
-                self.alation_sink_source.create_column_request(
-                    alation_datasource_id=MOCK_ALATION_DATASOURCE_ID,
-                    schema_name="shopify",
-                    table_name=model_str(om_table.name),
-                    om_column=om_column,
-                    table_constraints=om_table.tableConstraints,
-                )
-            )
-        for _, (expected, original) in enumerate(zip(EXPECTED_COLUMNS, returned_columns)):  # noqa: B905
-            self.assertEqual(expected, original)
+    assert returned_columns == EXPECTED_COLUMNS

--- a/ingestion/tests/integration/ometa/test_ometa_user_api.py
+++ b/ingestion/tests/integration/ometa/test_ometa_user_api.py
@@ -65,6 +65,29 @@ def test_team(metadata):
 
 
 @pytest.fixture(scope="module")
+def test_team_data(metadata):
+    """A Group team named "Data", whose name also matches DataInsightsApplicationBot."""
+    # Sample-data lanes already own this team; deleting theirs would break their tests.
+    existing = metadata.get_by_name(entity=Team, fqn="Data")
+    if existing:
+        yield existing
+        return
+
+    team = metadata.create_or_update(
+        data=CreateTeamRequest(teamType=TeamType.Group, name="Data", email="data@getcollate.io")
+    )
+
+    yield team
+
+    _safe_delete(
+        metadata,
+        entity=Team,
+        entity_id=team.id,
+        hard_delete=True,
+    )
+
+
+@pytest.fixture(scope="module")
 def test_user_1(metadata):
     """Create first test user."""
     user = metadata.create_or_update(
@@ -174,7 +197,7 @@ class TestOMetaUserAPI:
         # I can get the team by its mail
         assert test_team.id == metadata.get_reference_by_email(email="ops.team@getcollate.io").root[0].id
 
-    def test_es_search_from_name(self, metadata, test_user_1, test_user_2, test_team):
+    def test_es_search_from_name(self, metadata, test_user_1, test_user_2, test_team, test_team_data):
         """
         We can fetch users by its name
         """

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResolutionStatusResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResolutionStatusResource.java
@@ -1,7 +1,5 @@
 package org.openmetadata.service.resources.dqtests;
 
-import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
-import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.service.security.DefaultAuthorizer.getSubjectContext;
 
 import io.swagger.v3.oas.annotations.ExternalDocumentation;


### PR DESCRIPTION
### Describe your changes:

Fixes #<issue-number>

Two independent things, both aimed at getting a PR opened against `2.0` to a green
python/java CI:

1. **Clear the checkstyle and static-check failures** that fire on any PR based on
   `2.0` (commit 1).
2. **Backport main's self-sufficient integration tests** so the three suites that
   depended on the compose ingestion container stop failing (commit 2).

#### Why the integration tests were failing

`py-tests.yml` triggers on `pull_request_target`, which GitHub resolves from the
**default branch**. So PRs based on `2.0` are validated by **main's**
`py-tests-shared.yml`, not `2.0`'s own workflow. Main's workflow brings the stack up
with `-i false`:

```
command: ./docker/run_local_docker.sh -m no-ui -s true -i false
Running local docker using mode [no-ui] ... including ingestion [false]
Skipping Airflow DAG setup (ingestion disabled)
```

No `openmetadata_ingestion` container means no Airflow on `:8080` and no sample-data
DAGs. Main can afford that because **PR #30714** (`2e7662cdb11`) made the affected
tests self-sufficient in the same commit that introduced the shared workflow. That
commit never reached `2.0` (`git compare 2.0...2e7662cdb11` → `diverged`), so `2.0`
inherited the constraint without the accommodation — deterministic failures on
shard-2 and shard-3 across all Python versions.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

#### Backported — already on main (8 files)

All from PR #30714 unless noted.

| File | Backport fidelity |
|---|---|
| `ingestion/tests/integration/alationsink/test_alationsink.py` | verbatim |
| `ingestion/tests/integration/alationsink/__init__.py` | verbatim (empty) |
| `ingestion/tests/integration/ometa/test_ometa_user_api.py` | verbatim |
| `ingestion/tests/integration/airflow/test_airflow_lineage.py` | verbatim |
| `ingestion/.dockerignore` | verbatim |
| `ingestion/tests/integration/airflow/Dockerfile` | **adapted** — `FROM`, pip pin, comment: `3.3.1` → `3.3.0` |
| `ingestion/tests/integration/airflow/conftest.py` | **adapted** — `AIRFLOW_BASE_IMAGE`: `3.3.1` → `3.3.0` |
| `ingestion/src/metadata/ingestion/source/database/vertica/metadata.py` | verbatim (`# pyright: ignore[reportAttributeAccessIssue]` ×2, already on main at the same lines) |

What the backported tests now do instead of depending on the ingestion container:

- **airflow** — `conftest.py` + `Dockerfile` build and run Airflow in a
  testcontainer joined to `ometa_network`, so the suite owns its DAGs and OM
  connection. `test_dag_runs` is dropped (main dropped it), so 3 failing tests
  become 2 passing ones.
- **alationsink** — builds its own MySQL service → database → schema → 3 tables and
  tears them down, instead of reading `sample_data.ecommerce_db`.
- **ometa** — a `test_team_data` fixture creates the "Data" team that
  `test_es_search_from_name` asserts on (yielding the existing one untouched on
  sample-data lanes).
- **`.dockerignore`** — trims the airflow image's build context to `src/`. Applies
  only to builds whose context is `ingestion/`, which is exclusively this new image;
  every other image builds from the repository root.

#### 2.0-only — not on main (5 files)

Each exists because main fixed the same problem by *relaxing the check* in a config
file `2.0` never received, while the enforcement still applies to `2.0`.

| File | Change | Why main doesn't need it |
|---|---|---|
| `.../database/db2/utils.py` | `# noqa: PLC0415` | main globally disables `PLC0415` in `ingestion/pyproject.toml:209`; 2.0's config lacks that line |
| `.../database/hive/custom_hive_connection.py` | `# noqa: PLC0415` | same |
| `.../database/dbt/metadata.py` | wrap the test description in `Markdown` | main leaves the call unwrapped and baselines the error (29 `reportArgumentType` entries vs 2.0's 27) |
| `.../pipeline/dbtcloud/metadata.py` | pass `Uuid` through, build `StatusType`/`LastRunStatus`, wrap `logLink` in `AnyUrl` | same — main baselines 13 entries vs 2.0's 7 |
| `.../dqtests/TestCaseResolutionStatusResource.java` | drop 2 unused static imports | **must not go to main** — main genuinely calls `listOrEmpty` in bulk-create code 2.0 doesn't have |

For the four python ones, `2.0` could instead adopt main's config (add `PLC0415` to
the ignore list, refresh the two baseline entry sets). The code fixes were chosen
because `ingestion/src` already carries 262 `# noqa: PLC0415` comments — the
branch's own convention — and because fixing the types beats baselining them. All
four are runtime no-ops: pydantic was coercing these values already.

#
### How was this patch tested / verified:

- **`mvn spotless:apply` → `git diff-files --quiet`** (the exact java-checkstyle
  gate): exits 0.
- **`make py_format_check`**: ruff lint + format clean across 2654 files.
- **basedpyright**: 233 → 225 errors locally, exactly the 8 CI errors that reproduce
  on macOS; the 2 vertica ones need `sqlalchemy_vertica` installed.
- **Airflow test image builds against 2.0's pins**: `docker build` exit 0. The
  critical step, `uv pip install "apache-airflow==3.3.0" /tmp/ingestion`, resolved
  212 packages with no conflict and left airflow at 3.3.0; `airflow db migrate`
  succeeded. This is what the 3.3.0 adaptation is for.
- **Container boots on Airflow 3.3.0**: a throwaway test exercising only the new
  conftest fixtures confirmed the API issues a JWT via the simple auth manager and
  the dag-processor picks up a DAG from the mounted host dir. Both passed.
- **Unit tests**: `test_dbtcloud.py` 69 passed; dbt tests 47 passed.
- **Collection**: 10 tests across the three backported files; the whole airflow dir
  collects 24 with no regression from the new conftest.
- Every alationsink expectation was checked against 2.0's builder code —
  `SERVICE_TYPE_MAPPER[Mysql]` → connector_id 116, `model_str(None)` → `"None"`,
  `TABLE_TYPE_MAPPER` → `TABLE`/`VIEW`, `_check_nullable_column` →
  `None`/`False`/`True`, and `fqn._build` leaving `dim_::>address` unquoted.

The backported tests need a live OpenMetadata server, so their assertions are
unproven until CI runs; the mechanism they depend on is proven.

#
### Known remaining CI failures (pre-existing, out of scope):

- **4 `tests/unit/pii` tests** — main's workflow installs a pinned
  `en_core_web_md==3.8.0` wheel while 2.0's `setup.py` pins `spacy<3.8` → 3.7.5. CI
  logs the mismatch (`W095 ... trained with spaCy v3.8.0 ... current version
  (3.7.5)`), degrading NER. Aligning needs main's whole pin cluster
  (`numpy>=2,<3`, `pandas>=2.2.2,<3`, `spacy>=3.8.2,<3.9`, `scikit-learn`,
  `asammdf`) — a numpy-2 migration that belongs in its own PR.
- **`maven-sonarcloud-ci`** — main's workflow references
  `.github/actions/cache-ui-dist`, which doesn't exist on 2.0.
- **`BaseEntityIT$ListEntityHistoryByTimestampPaginationTest`** (1 of 15,313 java
  ITs) — `assertNoRepeats(paged.versionKeys())` at `BaseEntityIT.java:7288` is the
  only assertion in that test not scoped with `ownVersions(...)`. It saw 17 rows
  where the test creates 15, so ≥2 belonged to other tests writing versions inside
  the same wall-clock window under parallel execution. The filtered correctness
  assertion at 7284–7287 passed. Same unfiltered code is on main; flake, not a
  regression.
