### PR TITLE
fix(ingestion): upgrade linux-libc-dev to clear kernel CVE scan findings

### DIFF
--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -47,10 +47,14 @@ RUN apt-get -qq update \
   # openssh -> 1:9.2p1-2+deb12u10, rsync -> 3.2.7-1+deb12u5,
   # curl/libcurl* -> 7.88.1-10+deb12u15, libmariadb3 -> 1:10.11.18-0+deb12u1,
   # wget, perl*, libnss3 -> tracked; upstream fix pending, no-op until Debian ships it).
-  # linux-libc-dev (source pkg "linux") -> kernel headers pulled by libc6-dev; only
-  # used at build time and the container runs the host kernel, so the kernel CVEs it
-  # reports (e.g. CVE-2026-68082, fixed 6.12.105-1) are not reachable at runtime.
-  # Upgraded here for scanner clearance; no-op until Debian security ships the fix.
+  # linux-libc-dev (source pkg "linux") -> kernel headers that libc6-dev pulls in for
+  # build-essential. A container runs the host kernel, so the headers are a build
+  # artifact and the kernel CVEs scanners report against them are not reachable at
+  # runtime. Tracked here so the image takes bookworm-security's kernel headers
+  # rather than whatever the base image froze. This does NOT clear CVE-2026-68082:
+  # that fix exists only in trixie-security (6.12.105-1, DSA-6466-1), and bookworm
+  # and bookworm-security are both still "vulnerable" on the 6.1 line. The image
+  # that reports it is trixie-based -- see ingestion/operators/docker/Dockerfile.
   # --only-upgrade is a no-op for packages not present in the base image.
   && apt-get -qq install -y --only-upgrade \
        libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \

--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -47,12 +47,16 @@ RUN apt-get -qq update \
   # openssh -> 1:9.2p1-2+deb12u10, rsync -> 3.2.7-1+deb12u5,
   # curl/libcurl* -> 7.88.1-10+deb12u15, libmariadb3 -> 1:10.11.18-0+deb12u1,
   # wget, perl*, libnss3 -> tracked; upstream fix pending, no-op until Debian ships it).
+  # linux-libc-dev (source pkg "linux") -> kernel headers pulled by libc6-dev; only
+  # used at build time and the container runs the host kernel, so the kernel CVEs it
+  # reports (e.g. CVE-2026-68082, fixed 6.12.105-1) are not reachable at runtime.
+  # Upgraded here for scanner clearance; no-op until Debian security ships the fix.
   # --only-upgrade is a no-op for packages not present in the base image.
   && apt-get -qq install -y --only-upgrade \
        libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
        libpam0g libpam-modules libpam-modules-bin libpam-runtime \
        curl libcurl4 libcurl3-gnutls libmariadb3 wget \
-       perl perl-base perl-modules-5.36 libperl5.36 libnss3 \
+       perl perl-base perl-modules-5.36 libperl5.36 libnss3 linux-libc-dev \
   # docker-ce-cli comes from the airflow base and nothing in this image runs it:
   # Airflow's DockerOperator and the ingestion test helpers both drive the daemon
   # through the docker-py SDK over the socket, never the binary. It is a 42 MB Go

--- a/ingestion/Dockerfile.ci
+++ b/ingestion/Dockerfile.ci
@@ -46,12 +46,20 @@ RUN dpkg --configure -a \
   # openssh -> 1:9.2p1-2+deb12u10, rsync -> 3.2.7-1+deb12u5,
   # curl/libcurl* -> 7.88.1-10+deb12u15, libmariadb3 -> 1:10.11.18-0+deb12u1,
   # wget, perl*, libnss3 -> tracked; upstream fix pending, no-op until Debian ships it).
+  # linux-libc-dev (source pkg "linux") -> kernel headers that libc6-dev pulls in for
+  # build-essential. A container runs the host kernel, so the headers are a build
+  # artifact and the kernel CVEs scanners report against them are not reachable at
+  # runtime. Tracked here so the image takes bookworm-security's kernel headers
+  # rather than whatever the base image froze. This does NOT clear CVE-2026-68082:
+  # that fix exists only in trixie-security (6.12.105-1, DSA-6466-1), and bookworm
+  # and bookworm-security are both still "vulnerable" on the 6.1 line. The image
+  # that reports it is trixie-based -- see ingestion/operators/docker/Dockerfile.
   # --only-upgrade is a no-op for packages not present in the base image.
   && apt-get -qq install -y --only-upgrade \
        libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
        libpam0g libpam-modules libpam-modules-bin libpam-runtime \
        curl libcurl4 libcurl3-gnutls libmariadb3 wget \
-       perl perl-base perl-modules-5.36 libperl5.36 libnss3 \
+       perl perl-base perl-modules-5.36 libperl5.36 libnss3 linux-libc-dev \
   && apt-get -qq purge -y \
        'imagemagick*' 'libmagick*' 'graphicsmagick*' \
   && apt-get -qq autoremove -y --purge \

--- a/ingestion/operators/docker/Dockerfile
+++ b/ingestion/operators/docker/Dockerfile
@@ -197,6 +197,14 @@ RUN pip install psycopg2 mysqlclient==2.1.1
 # -- it arrives transitively from the top-of-file apt layer -- and that layer's
 # frozen index is exactly why the image keeps shipping 2.8.2 and being reported
 # for CVE-2026-72522 while trixie-security has 2.8.3-1~deb13u1.
+# linux-libc-dev is the third, and the reason CVE-2026-68082 is reported against
+# this image: libc6-dev pulls the kernel headers in for build-essential, a
+# container runs the host kernel so they are a build artifact whose kernel CVEs
+# are not reachable at runtime, but scanners flag the installed version anyway.
+# trixie-security carries the fixed 6.12.105-1 (DSA-6466-1), so this clears the
+# finding on the next build rather than being a speculative no-op. Purging it
+# instead would cascade through libc6-dev to build-essential and break runtime
+# pip builds of C extensions.
 # The package sets are computed from dpkg rather than hand-listed. One source
 # package produces many binaries -- here util-linux, bsdutils, login, mount,
 # liblastlog2-2, libblkid1, libmount1, libsmartcols1 and libuuid1 -- and scanners
@@ -204,10 +212,11 @@ RUN pip install psycopg2 mysqlclient==2.1.1
 # binary it forgot, and liblastlog2-2 is exactly the one that is easy to forget.
 # Asking dpkg which installed packages came from the source cannot miss one, and
 # stays correct if Debian splits the source differently later.
-# util-linux is asserted non-empty and expat deliberately is not: util-linux is
-# Essential, so an empty query there means dpkg-query misbehaved and the build
-# must not continue, whereas expat is transitive and an empty query is a
-# legitimate image with nothing to patch. Asserting one of the two is what the
+# util-linux is asserted non-empty; expat and linux-libc-dev deliberately are
+# not. util-linux is Essential, so an empty query there means dpkg-query
+# misbehaved and the build must not continue, whereas the other two are
+# transitive and an empty query is a legitimate image with nothing to patch.
+# Asserting the one package that must always be present is what the
 # check is for -- `apt-get install --only-upgrade` with no package arguments
 # exits 0, so an all-empty query would give a green build that shipped the
 # vulnerable packages anyway. Fail closed.
@@ -220,8 +229,9 @@ RUN set -eu; \
     ul="$(dpkg-query -W -f='${source:Package} ${Package}\n' | awk '$1=="util-linux"{print $2}')"; \
     [ -n "$ul" ] || { echo "no src:util-linux packages found; refusing to skip the CVE patch" >&2; exit 1; }; \
     ex="$(dpkg-query -W -f='${source:Package} ${Package}\n' | awk '$1=="expat"{print $2}')"; \
+    kh="$(dpkg-query -W -f='${source:Package} ${Package}\n' | awk '$1=="linux"{print $2}')"; \
     apt-get -qq update; \
-    apt-get -qq install -y --only-upgrade $ul $ex; \
+    apt-get -qq install -y --only-upgrade $ul $ex $kh; \
     apt-get -qq purge -y libmariadb-dev libmariadb-dev-compat libunbound8; \
     apt-mark manual libmariadb3 mariadb-common; \
     apt-get -qq autoremove -y --purge; \

--- a/ingestion/operators/docker/Dockerfile.ci
+++ b/ingestion/operators/docker/Dockerfile.ci
@@ -205,6 +205,14 @@ RUN pip install psycopg2 mysqlclient==2.1.1
 # -- it arrives transitively from the top-of-file apt layer -- and that layer's
 # frozen index is exactly why the image keeps shipping 2.8.2 and being reported
 # for CVE-2026-72522 while trixie-security has 2.8.3-1~deb13u1.
+# linux-libc-dev is the third, and the reason CVE-2026-68082 is reported against
+# this image: libc6-dev pulls the kernel headers in for build-essential, a
+# container runs the host kernel so they are a build artifact whose kernel CVEs
+# are not reachable at runtime, but scanners flag the installed version anyway.
+# trixie-security carries the fixed 6.12.105-1 (DSA-6466-1), so this clears the
+# finding on the next build rather than being a speculative no-op. Purging it
+# instead would cascade through libc6-dev to build-essential and break runtime
+# pip builds of C extensions.
 # The package sets are computed from dpkg rather than hand-listed. One source
 # package produces many binaries -- here util-linux, bsdutils, login, mount,
 # liblastlog2-2, libblkid1, libmount1, libsmartcols1 and libuuid1 -- and scanners
@@ -212,10 +220,11 @@ RUN pip install psycopg2 mysqlclient==2.1.1
 # binary it forgot, and liblastlog2-2 is exactly the one that is easy to forget.
 # Asking dpkg which installed packages came from the source cannot miss one, and
 # stays correct if Debian splits the source differently later.
-# util-linux is asserted non-empty and expat deliberately is not: util-linux is
-# Essential, so an empty query there means dpkg-query misbehaved and the build
-# must not continue, whereas expat is transitive and an empty query is a
-# legitimate image with nothing to patch. Asserting one of the two is what the
+# util-linux is asserted non-empty; expat and linux-libc-dev deliberately are
+# not. util-linux is Essential, so an empty query there means dpkg-query
+# misbehaved and the build must not continue, whereas the other two are
+# transitive and an empty query is a legitimate image with nothing to patch.
+# Asserting the one package that must always be present is what the
 # check is for -- `apt-get install --only-upgrade` with no package arguments
 # exits 0, so an all-empty query would give a green build that shipped the
 # vulnerable packages anyway. Fail closed.
@@ -228,8 +237,9 @@ RUN set -eu; \
     ul="$(dpkg-query -W -f='${source:Package} ${Package}\n' | awk '$1=="util-linux"{print $2}')"; \
     [ -n "$ul" ] || { echo "no src:util-linux packages found; refusing to skip the CVE patch" >&2; exit 1; }; \
     ex="$(dpkg-query -W -f='${source:Package} ${Package}\n' | awk '$1=="expat"{print $2}')"; \
+    kh="$(dpkg-query -W -f='${source:Package} ${Package}\n' | awk '$1=="linux"{print $2}')"; \
     apt-get -qq update; \
-    apt-get -qq install -y --only-upgrade $ul $ex; \
+    apt-get -qq install -y --only-upgrade $ul $ex $kh; \
     apt-get -qq purge -y libmariadb-dev libmariadb-dev-compat libunbound8; \
     apt-mark manual libmariadb3 mariadb-common; \
     apt-get -qq autoremove -y --purge; \


### PR DESCRIPTION
## What / Why

AWS Inspector reports **CVE-2026-68082** (Critical, CVSS 9.8) against the `openmetadata/ingestion-slim` image (Debian 13 base). The finding maps to the Debian **source** package `linux`; the binary package actually installed in the image is `linux-libc-dev` (kernel headers), pulled in transitively by `libc6-dev`/`build-essential` at build time.

Containers run the **host** kernel, never the kernel referenced by the image's `linux-libc-dev` headers, so the reported kernel vulnerability is not reachable at runtime. However, the scanner flags the installed package version regardless of reachability, so the finding needs to be cleared for scan hygiene.

## Change

Add `linux-libc-dev` to the existing `--only-upgrade` security block in `ingestion/Dockerfile`. This makes the package track Debian security updates on each build:

- It is a **no-op** until Debian security publishes the fixed version (`6.12.105-1`).
- Once available, the next image build auto-remediates.

This matches the pattern already used in the same block for other tracked packages (`wget`, `perl*`, `libnss3`, etc.).

## Notes / Alternatives considered

- **Purging `linux-libc-dev`** would cascade to `libc6-dev`/`build-essential` and risk breaking runtime pip C-extension builds — not done.
- **Suppressing the finding in Inspector** as not-runtime-reachable is also valid, but tracking the upgrade is the durable fix.

## Testing

- [ ] Image rebuild
- [ ] Re-scan to confirm the finding clears once Debian ships `6.12.105-1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates all four ingestion image definitions to track Debian security upgrades for `linux-libc-dev`.
- Adds an explicit `linux-libc-dev` upgrade to the bookworm Airflow images.
- Dynamically discovers and upgrades installed binaries from Debian’s `linux` source package in the trixie operator images.
- Documents why the headers remain installed and how the upgrade addresses scanner findings.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/Dockerfile | Adds `linux-libc-dev` to the existing bookworm security-upgrade package list and documents its scope. |
| ingestion/Dockerfile.ci | Mirrors the production Airflow image’s `linux-libc-dev` security upgrade in CI. |
| ingestion/operators/docker/Dockerfile | Extends the trixie security layer to discover and upgrade installed packages produced from Debian’s `linux` source package. |
| ingestion/operators/docker/Dockerfile.ci | Mirrors the trixie source-package upgrade logic in the operator CI image. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ingestion): clear CVE-2026-68082 in ..."](https://github.com/open-metadata/openmetadata/commit/28030b4bad84d1e5b44a3e0ce335e4bb4f85ecc0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57398151)</sub>

<!-- /greptile_comment -->