### PR TITLE
Backport #32083 to 2.0: initialize DB2 CLI driver once per process

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/db2/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/db2/connection.py
@@ -13,8 +13,6 @@
 Source connection handler
 """
 
-import importlib
-import sys
 from abc import ABC
 from pathlib import Path
 from typing import Any, Optional
@@ -137,17 +135,11 @@ class Db2Connection(BaseConnection[Db2ConnectionConfig, Engine]):
             clidriver_version = check_clidriver_version(clidriver_version)
             if clidriver_version:
                 install_clidriver(clidriver_version.value)
-                # Invalidate cached clidriver module so the next import
-                # picks up the freshly installed path
-                sys.modules.pop("clidriver", None)
 
         if connection.license and connection.licenseFileName:
             # pylint: disable=import-outside-toplevel
             # clidriver is installed at runtime by install_clidriver above
             import clidriver  # noqa: PLC0415 # pyright: ignore[reportMissingImports]
-
-            if clidriver_version:
-                importlib.reload(clidriver)
 
             license_dir = Path(clidriver.__path__[0], "license")
             license_dir.mkdir(parents=True, exist_ok=True)

--- a/ingestion/src/metadata/ingestion/source/database/db2/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/db2/utils.py
@@ -13,7 +13,10 @@
 Module to define overriden dialect methods
 """
 
+import sys
 from enum import Enum
+from threading import Lock
+from types import SimpleNamespace
 
 from sqlalchemy import and_, join, select, sql, text
 from sqlalchemy.engine import reflection
@@ -24,6 +27,9 @@ from metadata.utils.logger import ingestion_logger
 logger = ingestion_logger()
 
 BASE_CLIDRIVER_URL = "https://public.dhe.ibm.com/ibmdl/export/pub/software/data/db2/drivers/odbc_cli"
+
+_CLIDRIVER_INSTALL_LOCK = Lock()
+_CLIDRIVER_INSTALL_STATE = SimpleNamespace(version=None)
 
 
 class DB2CLIDriverVersions(Enum):
@@ -151,16 +157,25 @@ def check_clidriver_version(clidriver_version: str):
     return DB2CLIDriverVersions(clidriver_version)
 
 
-# pylint: disable=too-many-statements,too-many-branches
 def install_clidriver(clidriver_version: str) -> None:
-    """
-    Install the CLI Driver for DB2
-    """
+    """Install a DB2 CLI driver version once per process."""
+    with _CLIDRIVER_INSTALL_LOCK:
+        if _CLIDRIVER_INSTALL_STATE.version == clidriver_version:
+            return
+
+        _CLIDRIVER_INSTALL_STATE.version = None
+        if _install_clidriver(clidriver_version):
+            sys.modules.pop("clidriver", None)
+            _CLIDRIVER_INSTALL_STATE.version = clidriver_version
+
+
+# pylint: disable=too-many-statements,too-many-branches
+def _install_clidriver(clidriver_version: str) -> bool:
+    """Install the requested DB2 CLI driver version."""
     # pylint: disable=import-outside-toplevel
     import os  # noqa: PLC0415
     import platform  # noqa: PLC0415
     import subprocess  # noqa: PLC0415
-    import sys  # noqa: PLC0415
     from importlib.metadata import (  # noqa: PLC0415
         PackageNotFoundError,
         distribution,
@@ -204,8 +219,8 @@ def install_clidriver(clidriver_version: str) -> None:
             default_clidriver_url = f"{BASE_CLIDRIVER_URL}/nt32_odbc_cli.zip"
             clidriver_url = f"{BASE_CLIDRIVER_URL}/{str(clidriver_version)}/nt32_odbc_cli.zip"  # noqa: RUF010
     else:
-        logger.error(f"Unsupported operating system for db2 driver installation: {system}")
-        return None  # noqa: RET501
+        logger.error("Unsupported operating system for db2 driver installation: %s", system)
+        return False
 
     # set env variables for CLIDRIVER_VERSION and IBM_DB_INSTALLER_URL
     os.environ["CLIDRIVER_VERSION"] = clidriver_version
@@ -213,8 +228,8 @@ def install_clidriver(clidriver_version: str) -> None:
         os.environ["IBM_DB_INSTALLER_URL"] = clidriver_url
     else:
         os.environ["IBM_DB_INSTALLER_URL"] = default_clidriver_url
-    logger.info(f"Set IBM_DB_INSTALLER_URL to {os.environ['IBM_DB_INSTALLER_URL']}")
-    logger.info(f"Set CLIDRIVER_VERSION to {os.environ['CLIDRIVER_VERSION']}")
+    logger.info("Set IBM_DB_INSTALLER_URL to %s", os.environ["IBM_DB_INSTALLER_URL"])
+    logger.info("Set CLIDRIVER_VERSION to %s", os.environ["CLIDRIVER_VERSION"])
     # Uninstall ibm_db if it is already installed
     try:
         distribution("ibm_db")
@@ -236,7 +251,7 @@ def install_clidriver(clidriver_version: str) -> None:
             "--no-cache-dir",
         ]
     )
-    return None  # noqa: RET501
+    return True
 
 
 _IBMI_PATCHED = False

--- a/ingestion/tests/unit/source/database/db2/test_clidriver.py
+++ b/ingestion/tests/unit/source/database/db2/test_clidriver.py
@@ -1,0 +1,91 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for DB2 CLI driver installation."""
+
+from concurrent.futures import ThreadPoolExecutor
+from importlib.metadata import PackageNotFoundError
+from subprocess import CalledProcessError
+from threading import Event
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from metadata.ingestion.source.database.db2.utils import install_clidriver
+
+UTILS_MODULE = "metadata.ingestion.source.database.db2.utils"
+
+
+@pytest.fixture
+def clidriver_install_command():
+    url_response = MagicMock()
+    url_response.__enter__.return_value = url_response
+    with (
+        patch(f"{UTILS_MODULE}._CLIDRIVER_INSTALL_STATE.version", None),
+        patch("platform.system", return_value="linux"),
+        patch("platform.architecture", return_value=("64bit", "")),
+        patch("urllib.request.urlopen", return_value=url_response),
+        patch(
+            "importlib.metadata.distribution",
+            side_effect=PackageNotFoundError("ibm_db"),
+        ),
+        patch("subprocess.check_call") as install_command,
+    ):
+        yield install_command
+
+
+def test_same_clidriver_version_is_installed_once(clidriver_install_command):
+    install_clidriver("12.1.0")
+    install_clidriver("12.1.0")
+
+    assert clidriver_install_command.call_count == 1
+
+
+def test_failed_clidriver_installation_is_retried(clidriver_install_command):
+    clidriver_install_command.side_effect = [
+        CalledProcessError(1, ["pip", "install"]),
+        None,
+    ]
+
+    with pytest.raises(CalledProcessError):
+        install_clidriver("12.1.0")
+
+    install_clidriver("12.1.0")
+    assert clidriver_install_command.call_count == 2
+
+
+def test_changing_clidriver_version_reinstalls(clidriver_install_command):
+    install_clidriver("11.5.9")
+    install_clidriver("12.1.0")
+    install_clidriver("12.1.0")
+
+    assert clidriver_install_command.call_count == 2
+
+
+def test_concurrent_clidriver_installation_is_serialized(clidriver_install_command):
+    installation_started = Event()
+    allow_installation_to_finish = Event()
+
+    def block_installation(_command):
+        installation_started.set()
+        assert allow_installation_to_finish.wait(timeout=5)
+
+    clidriver_install_command.side_effect = block_installation
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(install_clidriver, "12.1.0")
+        assert installation_started.wait(timeout=5)
+        second = executor.submit(install_clidriver, "12.1.0")
+        allow_installation_to_finish.set()
+
+        first.result(timeout=5)
+        second.result(timeout=5)
+
+    assert clidriver_install_command.call_count == 1


### PR DESCRIPTION
Backport of #32083 to 2.0. Original issue: #32081.

Caches a successfully installed DB2 CLI driver version for the ingestion process, serializes concurrent installation, keeps failed installs retryable, and reinstalls when the requested version changes.

The cherry-pick conflict was limited to release-branch lint annotations on function-local imports. The resolution preserves the 2.0 annotations and keeps the source fix semantics unchanged.

Validation: pytest -q tests/unit/source/database/db2 completed with 22 passed and 5 skipped.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport serializes DB2 CLI installation and caches successful installations by requested version while preserving retries after failures.
- Adds process-wide installation locking and successful-version state.
- Invalidates the cached `clidriver` module after successful installation.
- Adds unit coverage for reuse, retries, version changes, and concurrent requests.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The implementation appears safe to merge, with a non-blocking need to make the new installer tests verify observable behavior rather than subprocess call counts.

No concrete blocking regression remains, but the tests are coupled to installer internals and can pass without demonstrating that the requested driver becomes usable.

**Files Needing Attention:** ingestion/tests/unit/source/database/db2/test_clidriver.py
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/db2/utils.py | Adds a process-wide lock and successful-version cache around the existing DB2 CLI installation routine. |
| ingestion/src/metadata/ingestion/source/database/db2/connection.py | Removes connection-local module invalidation and reload because successful installation now performs invalidation centrally. |
| ingestion/tests/unit/source/database/db2/test_clidriver.py | Adds concurrency and caching tests, but verifies mocked subprocess call counts rather than observable installation outcomes. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DB2 connection requests CLI version] --> B[Acquire process-wide lock]
    B --> C{Requested version cached?}
    C -->|Yes| D[Reuse installed driver]
    C -->|No| E[Install requested driver]
    E --> F{Installation succeeded?}
    F -->|No| G[Leave state retryable]
    F -->|Yes| H[Invalidate clidriver module]
    H --> I[Cache requested version]
    D --> J[Continue DB2 connection setup]
    I --> J
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(db2): initialize CLI driver once per..."](https://github.com/open-metadata/openmetadata/commit/6aa80dff5b62c0a94c9fbf1851115d115d588914) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57416643)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))

<!-- /greptile_comment -->