### PR TITLE
[DO NOT MERGE] Test run for #32150 — verify schema auto-update fires

### DIFF
--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/messaging/natsConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/messaging/natsConnection.json
@@ -64,6 +64,11 @@
     }
   },
   "properties": {
+    "clientName": {
+      "title": "Client Name",
+      "description": "Client name reported to the NATS server. Probe field for verifying schema auto-update; not for merge.",
+      "type": "string"
+    },
     "type": {
       "title": "Service Type",
       "description": "Service Type",

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/automations/createWorkflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/automations/createWorkflow.ts
@@ -2002,6 +2002,11 @@ export interface Connection {
      */
     additionalConfig?: { [key: string]: any };
     /**
+     * Client name reported to the NATS server. Probe field for verifying schema auto-update;
+     * not for merge.
+     */
+    clientName?: string;
+    /**
      * NATS server URLs as comma-separated values. Ex: nats://host1:4222,nats://host2:4222
      */
     natsServers?: string;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createMessagingService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createMessagingService.ts
@@ -160,6 +160,11 @@ export interface Connection {
      */
     authType?: AuthenticationType;
     /**
+     * Client name reported to the NATS server. Probe field for verifying schema auto-update;
+     * not for merge.
+     */
+    clientName?: string;
+    /**
      * NATS server URLs as comma-separated values. Ex: nats://host1:4222,nats://host2:4222
      */
     natsServers?: string;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
@@ -5035,6 +5035,11 @@ export interface Connection {
      */
     additionalConfig?: { [key: string]: any };
     /**
+     * Client name reported to the NATS server. Probe field for verifying schema auto-update;
+     * not for merge.
+     */
+    clientName?: string;
+    /**
      * NATS server URLs as comma-separated values. Ex: nats://host1:4222,nats://host2:4222
      */
     natsServers?: string;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/testServiceConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/testServiceConnection.ts
@@ -1884,6 +1884,11 @@ export interface Connection {
      */
     additionalConfig?: { [key: string]: any };
     /**
+     * Client name reported to the NATS server. Probe field for verifying schema auto-update;
+     * not for merge.
+     */
+    clientName?: string;
+    /**
      * NATS server URLs as comma-separated values. Ex: nats://host1:4222,nats://host2:4222
      */
     natsServers?: string;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/workflow.ts
@@ -2570,6 +2570,11 @@ export interface Connection {
      */
     additionalConfig?: { [key: string]: any };
     /**
+     * Client name reported to the NATS server. Probe field for verifying schema auto-update;
+     * not for merge.
+     */
+    clientName?: string;
+    /**
      * NATS server URLs as comma-separated values. Ex: nats://host1:4222,nats://host2:4222
      */
     natsServers?: string;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/messaging/natsConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/messaging/natsConnection.ts
@@ -23,6 +23,11 @@ export interface NatsConnection {
      */
     authType?: AuthenticationType;
     /**
+     * Client name reported to the NATS server. Probe field for verifying schema auto-update;
+     * not for merge.
+     */
+    clientName?: string;
+    /**
      * NATS server URLs as comma-separated values. Ex: nats://host1:4222,nats://host2:4222
      */
     natsServers: string;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
@@ -1874,6 +1874,11 @@ export interface Connection {
      */
     additionalConfig?: { [key: string]: any };
     /**
+     * Client name reported to the NATS server. Probe field for verifying schema auto-update;
+     * not for merge.
+     */
+    clientName?: string;
+    /**
      * NATS server URLs as comma-separated values. Ex: nats://host1:4222,nats://host2:4222
      */
     natsServers?: string;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
@@ -5565,6 +5565,11 @@ export interface Connection {
      */
     additionalConfig?: { [key: string]: any };
     /**
+     * Client name reported to the NATS server. Probe field for verifying schema auto-update;
+     * not for merge.
+     */
+    clientName?: string;
+    /**
      * NATS server URLs as comma-separated values. Ex: nats://host1:4222,nats://host2:4222
      */
     natsServers?: string;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/serviceProgressEvent.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/serviceProgressEvent.ts
@@ -5696,6 +5696,11 @@ export interface Connection {
      */
     additionalConfig?: { [key: string]: any };
     /**
+     * Client name reported to the NATS server. Probe field for verifying schema auto-update;
+     * not for merge.
+     */
+    clientName?: string;
+    /**
      * NATS server URLs as comma-separated values. Ex: nats://host1:4222,nats://host2:4222
      */
     natsServers?: string;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/messagingService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/messagingService.ts
@@ -290,6 +290,11 @@ export interface Connection {
      */
     authType?: AuthenticationType;
     /**
+     * Client name reported to the NATS server. Probe field for verifying schema auto-update;
+     * not for merge.
+     */
+    clientName?: string;
+    /**
      * NATS server URLs as comma-separated values. Ex: nats://host1:4222,nats://host2:4222
      */
     natsServers?: string;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
@@ -1972,6 +1972,11 @@ export interface Connection {
      */
     additionalConfig?: { [key: string]: any };
     /**
+     * Client name reported to the NATS server. Probe field for verifying schema auto-update;
+     * not for merge.
+     */
+    clientName?: string;
+    /**
      * NATS server URLs as comma-separated values. Ex: nats://host1:4222,nats://host2:4222
      */
     natsServers?: string;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
@@ -1963,6 +1963,11 @@ export interface Connection {
      */
     additionalConfig?: { [key: string]: any };
     /**
+     * Client name reported to the NATS server. Probe field for verifying schema auto-update;
+     * not for merge.
+     */
+    clientName?: string;
+    /**
      * NATS server URLs as comma-separated values. Ex: nats://host1:4222,nats://host2:4222
      */
     natsServers?: string;


### PR DESCRIPTION
### Describe your changes:

**Throwaway PR. Do not merge. Will be closed once #32150 is reviewed.**

Requested by @chirag-madlani as a test run before #32150 goes in.

Based on `fix/track-generated-ui-jsons` rather than `main` on purpose: `typescript-type-generation.yml` triggers on `pull_request_target`, which evaluates the workflow definition from the **base** branch. Basing on `main` would exercise the current workflow, not the changed one.

**Setup:** one probe property (`clientName`) added to `natsConnection.json` in `openmetadata-spec/`. `src/jsons/` and `src/generated/` deliberately left **not** regenerated, simulating a contributor who edits a spec and doesn't know the derived files exist.

**Expected:** the workflow regenerates both, auto-commits to this branch, and posts the "Generated Sources Auto-Updated" comment. The commit should touch `serviceConnection.json`, `workflow.json`, and `testSuitePipeline.json` in addition to `natsConnection.json` — the NATS schema is inlined into all three by dereferencing, which is why the job regenerates the whole tree rather than the edited file.

**Fails if:** no commit appears, or the commit misses `src/jsons/`. Either would mean committed schemas can silently rot against the spec, which is strictly worse than the pre-#32150 state.

Local results are in the #32150 description.











<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This throwaway PR verifies schema-derived source regeneration by adding a temporary optional NATS property and observing its propagation into committed TypeScript models.
- Adds the `clientName` probe property to the NATS connection schema.
- Propagates the property through the direct NATS interface and dereferenced workflow, automation, messaging-service, and ingestion-pipeline interfaces.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe for its stated throwaway validation purpose, with no blocking failure remaining.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-spec/src/main/resources/json/schema/entity/services/connections/messaging/natsConnection.json | Adds the optional temporary `clientName` probe to the source NATS connection contract. |
| openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/messaging/natsConnection.ts | Reflects the probe in the direct generated NATS TypeScript interface. |
| openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts | Propagates the probe into the dereferenced service-connection interface. |
| openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts | Propagates the probe into the generated metadata-ingestion workflow contract. |
| openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts | Propagates the probe into the generated test-suite pipeline contract. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    S[NATS JSON schema] --> D[Dereferenced schemas]
    D --> N[Direct NATS TypeScript model]
    D --> M[Messaging service models]
    D --> W[Workflow and automation models]
    D --> I[Ingestion pipeline models]
```
</details>

<sub>Reviews (6): Last reviewed commit: ["Update generated TypeScript types"](https://github.com/open-metadata/openmetadata/commit/4d8aaa8e7751711901c6f626c1d9b72b139a8a21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57416749)</sub>

**Context used:**

- Knowledge Base — [Metadata contracts and clients](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/metadata-contracts-clients.md)
- Knowledge Base — [Metadata schema contracts](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/metadata-schema-contracts.md)

<!-- /greptile_comment -->