### PR TITLE
Backport #32083 to 1.13: initialize DB2 CLI driver once per process

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/db2/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/db2/connection.py
@@ -12,6 +12,7 @@
 """
 Source connection handler
 """
+
 from pathlib import Path
 from typing import Any, Dict, Optional
 from urllib.parse import quote_plus

--- a/ingestion/src/metadata/ingestion/source/database/db2/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/db2/connection.py
@@ -12,8 +12,6 @@
 """
 Source connection handler
 """
-import importlib
-import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
 from urllib.parse import quote_plus
@@ -105,17 +103,11 @@ def get_connection(connection: Db2Connection) -> Engine:
         clidriver_version = check_clidriver_version(clidriver_version)
         if clidriver_version:
             install_clidriver(clidriver_version.value)
-            # Invalidate cached clidriver module so the next import
-            # picks up the freshly installed path
-            sys.modules.pop("clidriver", None)
 
     # prepare license
     # pylint: disable=import-outside-toplevel
     if connection.license and connection.licenseFileName:
         import clidriver
-
-        if clidriver_version:
-            importlib.reload(clidriver)
 
         license_dir = Path(clidriver.__path__[0], "license")
         license_dir.mkdir(parents=True, exist_ok=True)

--- a/ingestion/src/metadata/ingestion/source/database/db2/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/db2/utils.py
@@ -12,6 +12,7 @@
 """
 Module to define overriden dialect methods
 """
+
 import sys
 from enum import Enum
 from threading import Lock

--- a/ingestion/src/metadata/ingestion/source/database/db2/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/db2/utils.py
@@ -12,7 +12,10 @@
 """
 Module to define overriden dialect methods
 """
+import sys
 from enum import Enum
+from threading import Lock
+from types import SimpleNamespace
 
 from sqlalchemy import and_, join, select, sql, text
 from sqlalchemy.engine import reflection
@@ -25,6 +28,9 @@ logger = ingestion_logger()
 BASE_CLIDRIVER_URL = (
     "https://public.dhe.ibm.com/ibmdl/export/pub/software/data/db2/drivers/odbc_cli"
 )
+
+_CLIDRIVER_INSTALL_LOCK = Lock()
+_CLIDRIVER_INSTALL_STATE = SimpleNamespace(version=None)
 
 
 class DB2CLIDriverVersions(Enum):
@@ -159,16 +165,25 @@ def check_clidriver_version(clidriver_version: str):
     return DB2CLIDriverVersions(clidriver_version)
 
 
-# pylint: disable=too-many-statements,too-many-branches
 def install_clidriver(clidriver_version: str) -> None:
-    """
-    Install the CLI Driver for DB2
-    """
+    """Install a DB2 CLI driver version once per process."""
+    with _CLIDRIVER_INSTALL_LOCK:
+        if _CLIDRIVER_INSTALL_STATE.version == clidriver_version:
+            return
+
+        _CLIDRIVER_INSTALL_STATE.version = None
+        if _install_clidriver(clidriver_version):
+            sys.modules.pop("clidriver", None)
+            _CLIDRIVER_INSTALL_STATE.version = clidriver_version
+
+
+# pylint: disable=too-many-statements,too-many-branches
+def _install_clidriver(clidriver_version: str) -> bool:
+    """Install the requested DB2 CLI driver version."""
     # pylint: disable=import-outside-toplevel
     import os
     import platform
     import subprocess
-    import sys
     from importlib.metadata import PackageNotFoundError, distribution
     from urllib.request import URLError, urlopen
 
@@ -216,9 +231,9 @@ def install_clidriver(clidriver_version: str) -> None:
             )
     else:
         logger.error(
-            f"Unsupported operating system for db2 driver installation: {system}"
+            "Unsupported operating system for db2 driver installation: %s", system
         )
-        return None
+        return False
 
     # set env variables for CLIDRIVER_VERSION and IBM_DB_INSTALLER_URL
     os.environ["CLIDRIVER_VERSION"] = clidriver_version
@@ -226,8 +241,8 @@ def install_clidriver(clidriver_version: str) -> None:
         os.environ["IBM_DB_INSTALLER_URL"] = clidriver_url
     else:
         os.environ["IBM_DB_INSTALLER_URL"] = default_clidriver_url
-    logger.info(f"Set IBM_DB_INSTALLER_URL to {os.environ['IBM_DB_INSTALLER_URL']}")
-    logger.info(f"Set CLIDRIVER_VERSION to {os.environ['CLIDRIVER_VERSION']}")
+    logger.info("Set IBM_DB_INSTALLER_URL to %s", os.environ["IBM_DB_INSTALLER_URL"])
+    logger.info("Set CLIDRIVER_VERSION to %s", os.environ["CLIDRIVER_VERSION"])
     # Uninstall ibm_db if it is already installed
     try:
         distribution("ibm_db")
@@ -251,7 +266,7 @@ def install_clidriver(clidriver_version: str) -> None:
             "--no-cache-dir",
         ]
     )
-    return None
+    return True
 
 
 _IBMI_PATCHED = False

--- a/ingestion/tests/unit/source/database/db2/test_clidriver.py
+++ b/ingestion/tests/unit/source/database/db2/test_clidriver.py
@@ -1,0 +1,91 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for DB2 CLI driver installation."""
+
+from concurrent.futures import ThreadPoolExecutor
+from importlib.metadata import PackageNotFoundError
+from subprocess import CalledProcessError
+from threading import Event
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from metadata.ingestion.source.database.db2.utils import install_clidriver
+
+UTILS_MODULE = "metadata.ingestion.source.database.db2.utils"
+
+
+@pytest.fixture
+def clidriver_install_command():
+    url_response = MagicMock()
+    url_response.__enter__.return_value = url_response
+    with (
+        patch(f"{UTILS_MODULE}._CLIDRIVER_INSTALL_STATE.version", None),
+        patch("platform.system", return_value="linux"),
+        patch("platform.architecture", return_value=("64bit", "")),
+        patch("urllib.request.urlopen", return_value=url_response),
+        patch(
+            "importlib.metadata.distribution",
+            side_effect=PackageNotFoundError("ibm_db"),
+        ),
+        patch("subprocess.check_call") as install_command,
+    ):
+        yield install_command
+
+
+def test_same_clidriver_version_is_installed_once(clidriver_install_command):
+    install_clidriver("12.1.0")
+    install_clidriver("12.1.0")
+
+    assert clidriver_install_command.call_count == 1
+
+
+def test_failed_clidriver_installation_is_retried(clidriver_install_command):
+    clidriver_install_command.side_effect = [
+        CalledProcessError(1, ["pip", "install"]),
+        None,
+    ]
+
+    with pytest.raises(CalledProcessError):
+        install_clidriver("12.1.0")
+
+    install_clidriver("12.1.0")
+    assert clidriver_install_command.call_count == 2
+
+
+def test_changing_clidriver_version_reinstalls(clidriver_install_command):
+    install_clidriver("11.5.9")
+    install_clidriver("12.1.0")
+    install_clidriver("12.1.0")
+
+    assert clidriver_install_command.call_count == 2
+
+
+def test_concurrent_clidriver_installation_is_serialized(clidriver_install_command):
+    installation_started = Event()
+    allow_installation_to_finish = Event()
+
+    def block_installation(_command):
+        installation_started.set()
+        assert allow_installation_to_finish.wait(timeout=5)
+
+    clidriver_install_command.side_effect = block_installation
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(install_clidriver, "12.1.0")
+        assert installation_started.wait(timeout=5)
+        second = executor.submit(install_clidriver, "12.1.0")
+        allow_installation_to_finish.set()
+
+        first.result(timeout=5)
+        second.result(timeout=5)
+
+    assert clidriver_install_command.call_count == 1


### PR DESCRIPTION
Backport of #32083 to 1.13. Original issue: #32081.

Caches a successfully installed DB2 CLI driver version for the ingestion process, serializes concurrent installation, keeps failed installs retryable, and reinstalls when the requested version changes.

The connection-file conflict was resolved in the 1.13 module-level get_connection shape: per-connection module invalidation and reload were removed there, while successful invalidation moved to the synchronized installer. The source fix behavior is otherwise unchanged.

Validation: pytest -q tests/unit/source/database/db2 completed with 16 passed and 5 skipped.