### PR TITLE
fix(migrations): v201 AutoPilotWorkflow BPMN redeploy + task supersede fallback

### DIFF
--- a/bootstrap/sql/migrations/native/2.0.1/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/2.0.1/mysql/postDataMigrationSQLScript.sql
@@ -1,1 +1,0 @@
--- OpenMetadata 2.0.1 - no post-data-migration SQL. See v201 Java migration.

--- a/bootstrap/sql/migrations/native/2.0.1/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/2.0.1/mysql/postDataMigrationSQLScript.sql
@@ -1,0 +1,1 @@
+-- OpenMetadata 2.0.1 - no post-data-migration SQL. See v201 Java migration.

--- a/bootstrap/sql/migrations/native/2.0.1/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/2.0.1/mysql/schemaChanges.sql
@@ -1,0 +1,6 @@
+-- OpenMetadata 2.0.1
+-- No schema changes. This patch ships a Java-only data migration
+-- (org.openmetadata.service.migration.{mysql,postgres}.v201.Migration) that re-deploys every
+-- governance workflow definition so the Flowable BPMN is regenerated against the current delegate
+-- classes (fixes the AutoPilotWorkflow "non-existent field pipelineServiceClientExpr" injection
+-- failure after upgrade).

--- a/bootstrap/sql/migrations/native/2.0.1/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/2.0.1/mysql/schemaChanges.sql
@@ -1,6 +1,0 @@
--- OpenMetadata 2.0.1
--- No schema changes. This patch ships a Java-only data migration
--- (org.openmetadata.service.migration.{mysql,postgres}.v201.Migration) that re-deploys every
--- governance workflow definition so the Flowable BPMN is regenerated against the current delegate
--- classes (fixes the AutoPilotWorkflow "non-existent field pipelineServiceClientExpr" injection
--- failure after upgrade).

--- a/bootstrap/sql/migrations/native/2.0.1/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/2.0.1/postgres/postDataMigrationSQLScript.sql
@@ -1,1 +1,0 @@
--- OpenMetadata 2.0.1 - no post-data-migration SQL. See v201 Java migration.

--- a/bootstrap/sql/migrations/native/2.0.1/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/2.0.1/postgres/postDataMigrationSQLScript.sql
@@ -1,0 +1,1 @@
+-- OpenMetadata 2.0.1 - no post-data-migration SQL. See v201 Java migration.

--- a/bootstrap/sql/migrations/native/2.0.1/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/2.0.1/postgres/schemaChanges.sql
@@ -1,0 +1,6 @@
+-- OpenMetadata 2.0.1
+-- No schema changes. This patch ships a Java-only data migration
+-- (org.openmetadata.service.migration.{mysql,postgres}.v201.Migration) that re-deploys every
+-- governance workflow definition so the Flowable BPMN is regenerated against the current delegate
+-- classes (fixes the AutoPilotWorkflow "non-existent field pipelineServiceClientExpr" injection
+-- failure after upgrade).

--- a/bootstrap/sql/migrations/native/2.0.1/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/2.0.1/postgres/schemaChanges.sql
@@ -1,6 +1,0 @@
--- OpenMetadata 2.0.1
--- No schema changes. This patch ships a Java-only data migration
--- (org.openmetadata.service.migration.{mysql,postgres}.v201.Migration) that re-deploys every
--- governance workflow definition so the Flowable BPMN is regenerated against the current delegate
--- classes (fixes the AutoPilotWorkflow "non-existent field pipelineServiceClientExpr" injection
--- failure after upgrade).

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/userTask/CreateTask.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/userTask/CreateTask.java
@@ -49,6 +49,7 @@ import org.flowable.task.service.delegate.DelegateTask;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.entity.tasks.Task;
 import org.openmetadata.schema.governance.workflows.WorkflowDefinition;
+import org.openmetadata.schema.governance.workflows.WorkflowInstance;
 import org.openmetadata.schema.type.ChangeEvent;
 import org.openmetadata.schema.type.DataAccessRequestPayload;
 import org.openmetadata.schema.type.EntityReference;
@@ -74,6 +75,7 @@ import org.openmetadata.service.governance.workflows.elements.nodes.userTask.hel
 import org.openmetadata.service.governance.workflows.util.ChangePreviewUtils;
 import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.TaskRepository;
+import org.openmetadata.service.jdbi3.WorkflowInstanceRepository;
 import org.openmetadata.service.resources.feeds.MessageParser;
 import org.openmetadata.service.tasks.TaskWorkflowLifecycleResolver;
 import org.openmetadata.service.tasks.TaskWorkflowLifecycleResolver.WorkflowStartVariables;
@@ -88,7 +90,7 @@ import org.openmetadata.service.util.WebsocketNotificationHandler;
  *
  * <p>Key differences from the legacy CreateApprovalTaskImpl:
  * - Creates Task entity instead of Thread entity
- * - Persists through TaskRepository
+ * - Uses TaskRepository instead of FeedRepository
  * - Links task to WorkflowInstance via workflowInstanceId
  * - Cleaner separation from Feed/Thread complexity
  */
@@ -780,7 +782,29 @@ public class CreateTask implements TaskListener {
         && prior.getWorkflowInstanceId() != null
         && !isTerminalTaskStatus(prior.getStatus())
         && !prior.getWorkflowInstanceId().equals(currentWorkflowInstanceId)
-        && currentWorkflowDefinitionId.equals(prior.getWorkflowDefinitionId());
+        && currentWorkflowDefinitionId.equals(resolvePriorWorkflowDefinitionId(prior));
+  }
+
+  /**
+   * Resolve the prior task's workflow definition id, falling back to its workflow instance when the
+   * task itself carries none. Tasks migrated from the pre-2.0 thread model were wired to a workflow
+   * instance but never stamped with a workflowDefinitionId, which would otherwise make the supersede
+   * comparison above fail against a null and leave duplicate approval tasks on re-edit. The lookup is
+   * a single indexed read of the instance record and only runs on the null-definition fallback path.
+   */
+  private static UUID resolvePriorWorkflowDefinitionId(Task prior) {
+    UUID definitionId = prior.getWorkflowDefinitionId();
+    if (definitionId == null && prior.getWorkflowInstanceId() != null) {
+      WorkflowInstanceRepository workflowInstanceRepository =
+          (WorkflowInstanceRepository)
+              Entity.getEntityTimeSeriesRepository(Entity.WORKFLOW_INSTANCE);
+      WorkflowInstance priorInstance =
+          workflowInstanceRepository.getById(prior.getWorkflowInstanceId());
+      if (priorInstance != null) {
+        definitionId = priorInstance.getWorkflowDefinitionId();
+      }
+    }
+    return definitionId;
   }
 
   private void cancelAndTerminatePriorApproval(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v201/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v201/Migration.java
@@ -1,0 +1,31 @@
+package org.openmetadata.service.migration.mysql.v201;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.service.migration.api.MigrationProcessImpl;
+import org.openmetadata.service.migration.utils.MigrationFile;
+import org.openmetadata.service.migration.utils.v201.MigrationUtil;
+
+@Slf4j
+public class Migration extends MigrationProcessImpl {
+
+  public Migration(MigrationFile migrationFile) {
+    super(migrationFile);
+  }
+
+  @Override
+  @SneakyThrows
+  public void runDataMigration() {
+    // Wrap WorkflowHandler init + AutoPilot re-deploy so a handler failure logs and continues
+    // instead of aborting the rest of the migration. Matches v200's pattern.
+    try {
+      initializeWorkflowHandler();
+      MigrationUtil.redeployAutoPilotWorkflow();
+    } catch (Exception e) {
+      LOG.error(
+          "v201: failed to initialize WorkflowHandler or re-deploy AutoPilotWorkflow. "
+              + "AutoPilot BPMN may still reference stale delegate fields until server restart.",
+          e);
+    }
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v201/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v201/Migration.java
@@ -1,0 +1,31 @@
+package org.openmetadata.service.migration.postgres.v201;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.service.migration.api.MigrationProcessImpl;
+import org.openmetadata.service.migration.utils.MigrationFile;
+import org.openmetadata.service.migration.utils.v201.MigrationUtil;
+
+@Slf4j
+public class Migration extends MigrationProcessImpl {
+
+  public Migration(MigrationFile migrationFile) {
+    super(migrationFile);
+  }
+
+  @Override
+  @SneakyThrows
+  public void runDataMigration() {
+    // Wrap WorkflowHandler init + AutoPilot re-deploy so a handler failure logs and continues
+    // instead of aborting the rest of the migration. Matches v200's pattern.
+    try {
+      initializeWorkflowHandler();
+      MigrationUtil.redeployAutoPilotWorkflow();
+    } catch (Exception e) {
+      LOG.error(
+          "v201: failed to initialize WorkflowHandler or re-deploy AutoPilotWorkflow. "
+              + "AutoPilot BPMN may still reference stale delegate fields until server restart.",
+          e);
+    }
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v201/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v201/MigrationUtil.java
@@ -1,0 +1,53 @@
+package org.openmetadata.service.migration.utils.v201;
+
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.governance.workflows.WorkflowDefinition;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.exception.EntityNotFoundException;
+import org.openmetadata.service.governance.workflows.Workflow;
+import org.openmetadata.service.governance.workflows.WorkflowHandler;
+import org.openmetadata.service.jdbi3.WorkflowDefinitionRepository;
+import org.openmetadata.service.util.EntityUtil;
+
+@Slf4j
+public final class MigrationUtil {
+  private static final String AUTOPILOT_WORKFLOW_NAME = "AutoPilotWorkflow";
+
+  private MigrationUtil() {}
+
+  /**
+   * Re-deploy AutoPilotWorkflow so its Flowable process definition is regenerated from the current
+   * node/delegate code. When {@code CreateIngestionPipelineDelegate}'s {@code
+   * pipelineServiceClientExpr} field was removed in #28741, the BPMN deployed by the previous
+   * release still declared that field and Flowable field injection threw {@code "Field definition
+   * uses non-existent field ..."} at runtime. Scoped to AutoPilotWorkflow because it is the only
+   * definition whose delegate contract drifted across the 2.0.0 → 2.0.1 boundary. Best-effort: a
+   * failure only warns.
+   */
+  public static void redeployAutoPilotWorkflow() {
+    WorkflowDefinitionRepository repository =
+        (WorkflowDefinitionRepository) Entity.getEntityRepository(Entity.WORKFLOW_DEFINITION);
+    WorkflowDefinition autoPilotWorkflow = loadAutoPilotWorkflow(repository);
+    if (autoPilotWorkflow == null) {
+      return;
+    }
+    try {
+      WorkflowHandler.getInstance().deploy(new Workflow(autoPilotWorkflow));
+      LOG.info("[v201] Re-deployed AutoPilotWorkflow to realign BPMN with current delegates");
+    } catch (Exception e) {
+      LOG.warn("[v201] Failed to re-deploy AutoPilotWorkflow: {}", e.getMessage());
+    }
+  }
+
+  private static WorkflowDefinition loadAutoPilotWorkflow(WorkflowDefinitionRepository repository) {
+    WorkflowDefinition result = null;
+    try {
+      result = repository.getByName(null, AUTOPILOT_WORKFLOW_NAME, EntityUtil.Fields.EMPTY_FIELDS);
+    } catch (EntityNotFoundException e) {
+      LOG.info("[v201] AutoPilotWorkflow not present; skipping re-deploy");
+    } catch (Exception e) {
+      LOG.warn("[v201] Failed to load AutoPilotWorkflow: {}", e.getMessage());
+    }
+    return result;
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/elements/nodes/userTask/CreateTaskTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/elements/nodes/userTask/CreateTaskTest.java
@@ -33,15 +33,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.openmetadata.schema.entity.tasks.Task;
+import org.openmetadata.schema.governance.workflows.WorkflowInstance;
 import org.openmetadata.schema.type.DataAccessRequestPayload;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.TaskEntityStatus;
 import org.openmetadata.schema.type.TaskEntityType;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.jdbi3.TaskRepository;
+import org.openmetadata.service.jdbi3.WorkflowInstanceRepository;
 
 class CreateTaskTest {
 
@@ -841,6 +845,50 @@ class CreateTaskTest {
             .withWorkflowInstanceId(UUID.randomUUID());
 
     assertFalse(CreateTask.isSupersedablePriorApprovalTask(prior, workflowDefinitionId, null));
+  }
+
+  @Test
+  void testIsSupersedableWhenPriorMissingDefinitionIdButInstanceResolvesIt() {
+    // Tasks migrated from the pre-2.0 thread model carry a workflowInstanceId but no
+    // workflowDefinitionId. The fallback resolves the definition id from the instance so the
+    // supersede match still fires instead of comparing against null and leaving a duplicate.
+    UUID workflowDefinitionId = UUID.randomUUID();
+    UUID priorInstanceId = UUID.randomUUID();
+    Task prior = new Task().withId(UUID.randomUUID()).withWorkflowInstanceId(priorInstanceId);
+    WorkflowInstanceRepository workflowInstanceRepository =
+        Mockito.mock(WorkflowInstanceRepository.class);
+    when(workflowInstanceRepository.getById(priorInstanceId))
+        .thenReturn(new WorkflowInstance().withWorkflowDefinitionId(workflowDefinitionId));
+
+    try (MockedStatic<Entity> entityMock = Mockito.mockStatic(Entity.class)) {
+      entityMock
+          .when(() -> Entity.getEntityTimeSeriesRepository(Entity.WORKFLOW_INSTANCE))
+          .thenReturn(workflowInstanceRepository);
+
+      assertTrue(
+          CreateTask.isSupersedablePriorApprovalTask(
+              prior, workflowDefinitionId, UUID.randomUUID()));
+    }
+  }
+
+  @Test
+  void testIsNotSupersedableWhenPriorDefinitionIdUnresolvable() {
+    // No workflowDefinitionId on the task and the instance record is gone (getById -> null): the
+    // fallback yields null, so the task is left alone rather than wrongly superseded.
+    UUID priorInstanceId = UUID.randomUUID();
+    Task prior = new Task().withId(UUID.randomUUID()).withWorkflowInstanceId(priorInstanceId);
+    WorkflowInstanceRepository workflowInstanceRepository =
+        Mockito.mock(WorkflowInstanceRepository.class);
+    when(workflowInstanceRepository.getById(priorInstanceId)).thenReturn(null);
+
+    try (MockedStatic<Entity> entityMock = Mockito.mockStatic(Entity.class)) {
+      entityMock
+          .when(() -> Entity.getEntityTimeSeriesRepository(Entity.WORKFLOW_INSTANCE))
+          .thenReturn(workflowInstanceRepository);
+
+      assertFalse(
+          CreateTask.isSupersedablePriorApprovalTask(prior, UUID.randomUUID(), UUID.randomUUID()));
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

Two focused changes, one PR:

### 1. AutoPilotWorkflow BPMN redeploy (v201)

**#28741** removed `pipelineServiceClientExpr` from `CreateIngestionPipelineDelegate`, but the BPMN deployed by earlier releases still declares that field. On upgrade to a build that carries #28741, every AutoPilotWorkflow run fails at Flowable field injection with:

```
Field definition uses non-existent field 'pipelineServiceClientExpr' of class
org.openmetadata.service.governance.workflows.elements.nodes.automatedTask
  .createAndRunIngestionPipeline.CreateIngestionPipelineDelegate
```

A new v201 (2.0.1) Java migration re-deploys AutoPilotWorkflow so its Flowable process definition is regenerated from the current delegate class, restoring runtime execution.

### 2. Task supersede fallback (defensive only)

`CreateTask.isSupersedablePriorApprovalTask` compares `currentWorkflowDefinitionId.equals(prior.getWorkflowDefinitionId())`. When the prior task carries a `workflowInstanceId` but no `workflowDefinitionId`, the equality check runs against `null` and supersede silently no-ops, leaving stranded Flowable process instances and duplicate approval tasks on the same entity.

This PR adds a defensive fallback only: when the prior task's `workflowDefinitionId` is missing, resolve it from its `workflowInstance` before the equality check. One lazy indexed read per null case; no bulk backfill, no writes to task rows.

## Test plan

- [x] Unit: `MigrationProcessImplTest`, `MigrationWorkflowTest`, `CreateTaskTest` (2 new fallback tests) all green.
- [x] End-to-end: verified locally by upgrading a 1.13 → 2.0 → 2.0.1 build; AutoPilotWorkflow instance progresses without the `pipelineServiceClientExpr` field-injection error; a prior task with a missing `workflowDefinitionId` is now correctly superseded on the next edit and its Flowable instance terminates.



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a v201 migration to redeploy AutoPilotWorkflow with the current delegate contract and adds a fallback for resolving missing task workflow-definition IDs.
- Adds matching MySQL and PostgreSQL v201 migration entry points and native migration placeholders.
- Redeploys the stored AutoPilotWorkflow definition during upgrade.
- Resolves legacy tasks’ workflow definition through their workflow instance before superseding them.
- Adds unit coverage for resolvable and missing workflow-instance fallback cases.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because a failed AutoPilot redeployment can still be permanently recorded as a successful v201 migration.

The migration continues to catch workflow initialization, repository lookup, and Flowable deployment failures without propagating them, so the migration framework can persist successful completion even though the stale AutoPilot BPMN remains and will not receive a targeted retry.

**Files Needing Attention:** openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v201/MigrationUtil.java, openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v201/Migration.java, openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v201/Migration.java
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v201/MigrationUtil.java | Implements the targeted AutoPilot redeployment, but still converts repository and deployment failures into normal completion. |
| openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v201/Migration.java | Registers the MySQL v201 Java migration while suppressing initialization and redeployment failures. |
| openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v201/Migration.java | Mirrors the MySQL v201 migration and its failure-suppression behavior for PostgreSQL. |
| openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/userTask/CreateTask.java | Adds a null-only fallback that resolves a prior task’s workflow definition from its workflow instance. |
| openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/elements/nodes/userTask/CreateTaskTest.java | Covers successful and unresolvable workflow-definition fallback behavior. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore(migrations): empty 2.0.1 SQL stubs..."](https://github.com/open-metadata/openmetadata/commit/58cdb48f835c7eecdc0a0cafbeb1c3b8bd59b538) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57426245)</sub>

<!-- /greptile_comment -->