### PR TITLE
fix(security): move Reactor to the 2026.0 train (reactor-core/netty CVE-2026-47857/47874)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,10 +227,28 @@
         <artifactId>logging-interceptor</artifactId>
         <version>4.12.0</version>
       </dependency>
+      <!-- CVE-2026-47857: reactor-core < 3.8.7 (reached transitively via reactor-netty and the
+           azure/spring stacks). Pin the whole Reactor 2026.0 train together: reactor-core 3.8.7
+           and reactor-netty 1.3.7 are the aligned release, so mixing lines is avoided. -->
+      <dependency>
+        <groupId>io.projectreactor</groupId>
+        <artifactId>reactor-core</artifactId>
+        <version>3.8.7</version>
+      </dependency>
+      <!-- CVE-2026-47874: reactor-netty-http < 1.3.7. The fix ships only on the 1.3.x line (1.2.18
+           is the last 1.2.x GA, no backport), and reactor-netty 1.3.x requires Netty 4.2.x — see
+           the netty-bom pin below, raised to 4.2.x in lockstep so 1.3.x's Netty 4.2 APIs resolve.
+           Pin -core alongside -http so a path that reaches -core directly cannot drag the 1.2 line
+           back in. This mirrors ai-platform's ADR-0018, which moves the same three together. -->
+      <dependency>
+        <groupId>io.projectreactor.netty</groupId>
+        <artifactId>reactor-netty-core</artifactId>
+        <version>1.3.7</version>
+      </dependency>
       <dependency>
         <groupId>io.projectreactor.netty</groupId>
         <artifactId>reactor-netty-http</artifactId>
-        <version>1.2.18</version>
+        <version>1.3.7</version>
       </dependency>
       <!-- CVE-2026-45292: opentelemetry-api 1.37.0 (transitive of
            co.elastic.clients:elasticsearch-java, shaded into elasticsearch-deps)
@@ -741,12 +759,14 @@
         <version>1.15.2</version>
       </dependency>
       <!-- Pin all transitive io.netty:* to one patched line via the BOM (netty-codec-http et al.
-           arrive transitively through reactor-netty-http and others). 4.1.137.Final clears the
-           CorsHandler Vary-header cache-poisoning / info-disclosure issue, CVE-2026-59903. -->
+           arrive transitively through reactor-netty-http and others). Held on the 4.2.x line
+           because reactor-netty 1.3.x (pinned above) is built against Netty 4.2; 4.2.17.Final is
+           newer than the 4.1.137.Final we previously held, so it still clears the CorsHandler
+           Vary-header cache-poisoning / info-disclosure issue, CVE-2026-59903. -->
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.1.137.Final</version>
+        <version>4.2.17.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## What

Clears two HIGH Snyk findings that are reached transitively in the build:

| CVE | Artifact | Before | After |
|---|---|---|---|
| CVE-2026-47857 | `io.projectreactor:reactor-core` | 3.7.19 (transitive) | **3.8.7** (pinned) |
| CVE-2026-47874 | `io.projectreactor.netty:reactor-netty-http` | 1.2.18 (pinned) | **1.3.7** |

Both are unbounded-allocation highs.

## Why the coordinated bump

The `reactor-netty` fix ships **only on the 1.3.x line** — 1.2.18 is the last 1.2.x GA and there is no backport. `reactor-netty` 1.3.x is built against **Netty 4.2.x**, but this pom force-pinned `netty-bom` at `4.1.137.Final`. A `dependencyManagement` BOM import wins over reactor-netty's own Netty requests, so bumping reactor-netty without moving netty would run 1.3.x code against Netty 4.1 → `NoSuchMethodError`. The three move together:

- `reactor-core` → **3.8.7**
- `reactor-netty-core` → **1.3.7** (pinned alongside `-http` so a direct `-core` path can't drag the 1.2 line back)
- `reactor-netty-http` → **1.3.7**
- `netty-bom` → **4.1.137.Final → 4.2.17.Final**

`netty-bom` 4.2.17.Final is newer than the 4.1.137.Final it replaces, so it **retains** the CorsHandler cache-poisoning fix (CVE-2026-59903) the previous pin was held for.

This mirrors **ai-platform ADR-0018**, which already pins the same three artifacts on the same Netty line.

## Verification

`mvn dependency:tree` on `openmetadata-service` — `reactor-core`, `reactor-netty-{core,http}` and the `io.netty:*` artifacts all converge to **3.8.7 / 1.3.7 / 4.2.17.Final** with no version conflict; BUILD SUCCESS. `openmetadata-service` has no direct `io.netty`/`reactor` source imports, so the change is transitive-runtime only. The enforcer config uses `requireMavenVersion` only (no `dependencyConvergence`), so the bump is not blocked by convergence rules.



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR coordinates the Reactor and Netty dependency trains to versions containing the specified security fixes.
- Pins reactor-core at 3.8.7.
- Pins reactor-netty-core and reactor-netty-http at 1.3.7.
- Moves the Netty BOM to 4.2.17.Final to align with Reactor Netty 1.3.x.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| pom.xml | Coordinates the managed reactor-core, reactor-netty, and Netty BOM versions on their aligned release trains. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  RC[reactor-core 3.8.7] --> RN[reactor-netty core/http 1.3.7]
  NB[Netty BOM 4.2.17.Final] --> RN
  RN --> Consumers[Transitive runtime consumers]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(security): move Reactor to the 2026...."](https://github.com/open-metadata/openmetadata/commit/53e0635e20792a18231e64a35bc9433add7d24ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57455366)</sub>

<!-- /greptile_comment -->