### PR TITLE
fix(search): recurse into nested columns for columnDescriptionStatus

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/ColumnIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/ColumnIndex.java
@@ -84,14 +84,26 @@ public interface ColumnIndex extends SearchIndex {
   }
 
   default String getColumnDescriptionStatus(EntityInterface entity) {
+    String status = "COMPLETE";
     List<Class<?>> interfaces = Arrays.asList(entity.getClass().getInterfaces());
-    if (interfaces.contains(ColumnsEntityInterface.class)) {
-      for (Column col : ((ColumnsEntityInterface) entity).getColumns()) {
-        if (CommonUtil.nullOrEmpty(col.getDescription())) {
-          return "INCOMPLETE";
+    if (interfaces.contains(ColumnsEntityInterface.class)
+        && hasUndocumentedColumn(((ColumnsEntityInterface) entity).getColumns())) {
+      status = "INCOMPLETE";
+    }
+    return status;
+  }
+
+  private boolean hasUndocumentedColumn(List<Column> columns) {
+    boolean undocumented = false;
+    if (columns != null) {
+      for (Column col : columns) {
+        if (CommonUtil.nullOrEmpty(col.getDescription())
+            || hasUndocumentedColumn(col.getChildren())) {
+          undocumented = true;
+          break;
         }
       }
     }
-    return "COMPLETE";
+    return undocumented;
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/ColumnIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/ColumnIndex.java
@@ -1,7 +1,9 @@
 package org.openmetadata.service.search.indexes;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -94,20 +96,27 @@ public interface ColumnIndex extends SearchIndex {
   }
 
   private boolean hasUndocumentedColumn(List<Column> columns) {
-    return hasUndocumentedColumn(columns, 1, SearchFieldLimits.active());
-  }
-
-  private boolean hasUndocumentedColumn(List<Column> columns, int depth, SearchFieldLimits limits) {
     boolean undocumented = false;
-    if (columns != null && depth <= limits.getDepthLimit()) {
-      for (Column col : columns) {
-        if (CommonUtil.nullOrEmpty(col.getDescription())
-            || hasUndocumentedColumn(col.getChildren(), depth + 1, limits)) {
-          undocumented = true;
-          break;
-        }
+    Deque<Column> pending = new ArrayDeque<>();
+    pushColumns(pending, columns);
+    while (!pending.isEmpty() && !undocumented) {
+      Column col = pending.pop();
+      if (CommonUtil.nullOrEmpty(col.getDescription())) {
+        undocumented = true;
+      } else {
+        pushColumns(pending, col.getChildren());
       }
     }
     return undocumented;
+  }
+
+  private void pushColumns(Deque<Column> pending, List<Column> columns) {
+    if (columns != null) {
+      for (Column col : columns) {
+        if (col != null) {
+          pending.push(col);
+        }
+      }
+    }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/ColumnIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/ColumnIndex.java
@@ -94,11 +94,15 @@ public interface ColumnIndex extends SearchIndex {
   }
 
   private boolean hasUndocumentedColumn(List<Column> columns) {
+    return hasUndocumentedColumn(columns, 1, SearchFieldLimits.active());
+  }
+
+  private boolean hasUndocumentedColumn(List<Column> columns, int depth, SearchFieldLimits limits) {
     boolean undocumented = false;
-    if (columns != null) {
+    if (columns != null && depth <= limits.getDepthLimit()) {
       for (Column col : columns) {
         if (CommonUtil.nullOrEmpty(col.getDescription())
-            || hasUndocumentedColumn(col.getChildren())) {
+            || hasUndocumentedColumn(col.getChildren(), depth + 1, limits)) {
           undocumented = true;
           break;
         }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/indexes/ColumnIndexLimitTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/indexes/ColumnIndexLimitTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.service.configuration.elasticsearch.ElasticSearchConfiguration;
 import org.openmetadata.schema.service.configuration.elasticsearch.SearchIndexingLimits;
 import org.openmetadata.schema.type.Column;
@@ -138,6 +139,38 @@ class ColumnIndexLimitTest {
     new TestColumnIndex().parseColumns(siblings, flattened, null);
 
     assertEquals(4, flattened.size(), "must stop once max columns reached");
+  }
+
+  @Test
+  void columnDescriptionStatus_incomplete_when_nested_child_undocumented() {
+    Column undocumentedChild = new Column().withName("field1");
+    Column documentedStruct =
+        new Column()
+            .withName("struct")
+            .withDescription("documented")
+            .withChildren(List.of(undocumentedChild));
+    Table table = new Table().withColumns(List.of(documentedStruct));
+
+    assertEquals(
+        "INCOMPLETE",
+        new TestColumnIndex().getColumnDescriptionStatus(table),
+        "table with an undocumented nested/struct child must be INCOMPLETE");
+  }
+
+  @Test
+  void columnDescriptionStatus_complete_when_all_nested_documented() {
+    Column documentedChild = new Column().withName("field1").withDescription("child doc");
+    Column documentedStruct =
+        new Column()
+            .withName("struct")
+            .withDescription("documented")
+            .withChildren(List.of(documentedChild));
+    Table table = new Table().withColumns(List.of(documentedStruct));
+
+    assertEquals(
+        "COMPLETE",
+        new TestColumnIndex().getColumnDescriptionStatus(table),
+        "table with every column and nested child documented must be COMPLETE");
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/indexes/ColumnIndexLimitTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/indexes/ColumnIndexLimitTest.java
@@ -174,6 +174,22 @@ class ColumnIndexLimitTest {
   }
 
   @Test
+  void columnDescriptionStatus_ignores_columns_beyond_depth_limit() {
+    activateLimits(2, 10000);
+    Column beyondLimit = new Column().withName("c3");
+    Column withinLimit =
+        new Column().withName("c2").withDescription("d2").withChildren(List.of(beyondLimit));
+    Column top =
+        new Column().withName("c1").withDescription("d1").withChildren(List.of(withinLimit));
+    Table table = new Table().withColumns(List.of(top));
+
+    assertEquals(
+        "COMPLETE",
+        new TestColumnIndex().getColumnDescriptionStatus(table),
+        "columns beyond the indexing depth limit are not indexed and must not affect status");
+  }
+
+  @Test
   void flattenColumns_respects_depth_limit() {
     activateLimits(3, 10000);
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/indexes/ColumnIndexLimitTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/indexes/ColumnIndexLimitTest.java
@@ -174,19 +174,19 @@ class ColumnIndexLimitTest {
   }
 
   @Test
-  void columnDescriptionStatus_ignores_columns_beyond_depth_limit() {
-    activateLimits(2, 10000);
-    Column beyondLimit = new Column().withName("c3");
-    Column withinLimit =
-        new Column().withName("c2").withDescription("d2").withChildren(List.of(beyondLimit));
-    Column top =
-        new Column().withName("c1").withDescription("d1").withChildren(List.of(withinLimit));
-    Table table = new Table().withColumns(List.of(top));
+  void columnDescriptionStatus_handles_deep_nesting_without_stack_overflow() {
+    int depth = 20000;
+    Column current = new Column().withName("c" + depth);
+    for (int level = depth - 1; level >= 1; level--) {
+      current =
+          new Column().withName("c" + level).withDescription("d").withChildren(List.of(current));
+    }
+    Table table = new Table().withColumns(List.of(current));
 
     assertEquals(
-        "COMPLETE",
+        "INCOMPLETE",
         new TestColumnIndex().getColumnDescriptionStatus(table),
-        "columns beyond the indexing depth limit are not indexed and must not affect status");
+        "deeply nested undocumented column must be detected without StackOverflowError");
   }
 
   @Test


### PR DESCRIPTION
Fixes #32184


## Problem

The `columnDescriptionStatus` field powering the Explore **Column Description** filter is computed by `ColumnIndex.getColumnDescriptionStatus()`, which only iterated the **top-level** columns and never descended into nested/struct children (`col.getChildren()`).

As a result, a table whose top-level columns are documented but whose nested struct fields are all undocumented was indexed as `COMPLETE` — so the filter reported it as fully documented even though every field inside the nested column had no description.

Both `TableIndex` and `WorksheetIndex` call this shared default method, so both were affected.

## Fix

Walk the **full** column tree. A table/worksheet is `COMPLETE` only when **every** column at **every** depth has a description; the first column (top-level or nested) with an empty description makes it `INCOMPLETE`.

The traversal is done **iteratively with an explicit `Deque`** rather than recursion:

```java
private boolean hasUndocumentedColumn(List<Column> columns) {
  boolean undocumented = false;
  Deque<Column> pending = new ArrayDeque<>();
  pushColumns(pending, columns);
  while (!pending.isEmpty() && !undocumented) {
    Column col = pending.pop();
    if (CommonUtil.nullOrEmpty(col.getDescription())) {
      undocumented = true;
    } else {
      pushColumns(pending, col.getChildren());
    }
  }
  return undocumented;
}
```

### Why a `Deque` instead of recursion?

- **No `StackOverflowError`.** Recursion uses one JVM call-stack frame per nesting level, so a pathologically deep column tree could overflow the stack. An explicit `Deque` keeps the traversal state on the heap, so it is safe at any depth — without imposing an artificial depth cap.
- **Correct, uncoupled semantics.** We deliberately did *not* bound this by the search `mappingDepthLimit`. That limit exists for the paths that *emit* nested fields into the ES document (`parseColumns`, `flattenColumns`, `SchemaFieldFlattener`) so the doc doesn't exceed `index.mapping.depth.limit`. This method emits a single scalar keyword (adds no depth), so it should reflect the true documentation state of *all* columns.
- **Cheap at scale.** The deque holds column *references* (~a few MB worst case for very wide tables), not copies — the column objects are already in memory. It runs at **index time** (not on the query/API path), is a single `O(N)` pass that **early-exits** at the first undocumented column, and sits next to `parseColumns`, which already walks the same tree. So there is no measurable impact on API latency or large-table indexing.

## Testing

Regression tests in `ColumnIndexLimitTest` exercise the real `ColumnIndex` default method via a `Table` (no mocks):

- `columnDescriptionStatus_incomplete_when_nested_child_undocumented` — documented struct parent + undocumented child ⇒ `INCOMPLETE` (fails without the fix: `expected: <INCOMPLETE> but was: <COMPLETE>`).
- `columnDescriptionStatus_complete_when_all_nested_documented` — every column and nested child documented ⇒ `COMPLETE`.
- `columnDescriptionStatus_handles_deep_nesting_without_stack_overflow` — a 20,000-level deep chain is fully traversed and detected without a `StackOverflowError`.

Full class green (`Tests run: 9, Failures: 0`).




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates column-description status indexing to inspect nested column trees without recursive stack growth.
- Traverses top-level and nested columns using an explicit deque.
- Marks tables and worksheets incomplete when any nested column lacks a description.
- Adds regression coverage for documented, undocumented, and deeply nested column trees.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/ColumnIndex.java | Replaces top-level-only description checking with iterative traversal of the complete nested column tree. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/indexes/ColumnIndexLimitTest.java | Adds regression tests for nested documentation status and stack-safe handling of deeply nested columns. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Table or worksheet columns] --> B[Push columns onto deque]
  B --> C{Deque empty?}
  C -- Yes --> D[Status COMPLETE]
  C -- No --> E[Pop next column]
  E --> F{Description empty?}
  F -- Yes --> G[Status INCOMPLETE]
  F -- No --> H[Push child columns]
  H --> C
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(search): traverse nested columns ite..."](https://github.com/open-metadata/openmetadata/commit/29debf84d87aa34dd159c3a459525629f6c1b700) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57464579)</sub>

<!-- /greptile_comment -->
