### PR TITLE
Fixes 29026: Add search to test suite details (2.0 backport)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TestSuiteDetailsPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TestSuiteDetailsPage.spec.ts
@@ -28,6 +28,7 @@ import {
   toastNotification,
   uuid,
 } from '../../utils/common';
+import { verifyBundleSuitePageLoaded } from '../../utils/dataQuality';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import { test } from '../fixtures/pages';
 
@@ -95,16 +96,47 @@ test(
       await waitForAllLoadersToDisappear(page);
     });
 
-    await test.step('Open Add test case modal on details page', async () => {
-      const testCaseListResponse = page.waitForResponse(
-        '/api/v1/dataQuality/testCases/search/list*'
-      );
-      await page.goto(
-        `/test-suites/${encodeURIComponent(NEW_TEST_SUITE.name)}`
-      );
-      await testCaseListResponse;
+    await test.step('Find and open the test suite from the bundle suite list', async () => {
+      await page.goto('/data-quality/test-suites/bundle-suites');
       await waitForAllLoadersToDisappear(page);
 
+      const testSuiteSearchResponse = page.waitForResponse(
+        '/api/v1/dataQuality/testSuites/search/list*'
+      );
+      await page
+        .getByPlaceholder('Search Bundle Suites')
+        .fill(NEW_TEST_SUITE.name);
+      await testSuiteSearchResponse;
+
+      const testSuiteDetailsPage = page.waitForURL(
+        (url) => url.pathname === `/test-suites/${NEW_TEST_SUITE.name}`
+      );
+      await page
+        .getByRole('link', { exact: true, name: NEW_TEST_SUITE.name })
+        .click();
+      await testSuiteDetailsPage;
+      await verifyBundleSuitePageLoaded(page, NEW_TEST_SUITE.name, 1);
+    });
+
+    await test.step('Search test cases on the details page', async () => {
+      const searchInput = page.getByTestId('test-suite-test-case-search');
+
+      const testCaseSearchResponse = page.waitForResponse((response) => {
+        const responseUrl = new URL(response.url());
+
+        return (
+          responseUrl.pathname.includes(
+            '/api/v1/dataQuality/testCases/search/list'
+          ) && responseUrl.searchParams.get('q') === testCaseName1
+        );
+      });
+      await searchInput.fill(testCaseName1 ?? '');
+      await testCaseSearchResponse;
+
+      await expect(page.getByTestId(testCaseName1 ?? '')).toBeVisible();
+    });
+
+    await test.step('Open Add test case modal on details page', async () => {
       const modalListResponse = page.waitForResponse(
         '/api/v1/dataQuality/testCases/search/list*'
       );

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/TestSuiteDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/TestSuiteDetailsPage.component.tsx
@@ -16,6 +16,7 @@ import {
   Button,
   Dialog,
   DialogTrigger,
+  Input,
   Modal,
   ModalOverlay,
   Tooltip,
@@ -24,10 +25,11 @@ import {
 import { Copy01 } from '@untitledui/icons';
 import { Tabs, TabsProps } from 'antd';
 import classNames from 'classnames';
-import { useCallback, useMemo } from 'react';
+import { ComponentProps, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { ReactComponent as TestSuiteIcon } from '../../assets/svg/icon-test-suite.svg';
+import { useListSearchInput } from '../../components/common/atoms/navigation/useListSearchInput';
 import { DomainLabel } from '../../components/common/DomainLabel/DomainLabel.component';
 import Description from '../../components/common/EntityDescription/Description';
 import ManageButton from '../../components/common/EntityPageInfos/ManageButton/ManageButton';
@@ -58,6 +60,7 @@ const breakableTooltipText = (text?: string) => (
 
 const TestSuiteDetailsPage = () => {
   const { t } = useTranslation();
+  const testCasePluralLabel = t('label.test-case-plural');
   const navigate = useNavigate();
   const {
     testSuite,
@@ -67,6 +70,7 @@ const TestSuiteDetailsPage = () => {
     isLoading,
     isTestCaseLoading,
     testCaseResult,
+    testCaseSearchQuery,
     testSuitePermissions,
     permissions,
     extraDropdownContent,
@@ -83,6 +87,7 @@ const TestSuiteDetailsPage = () => {
     canAddMultipleUserOwners,
     canAddMultipleTeamOwner,
     fetchTestCases,
+    handleTestCaseSearch,
     handleSortTestCase,
     handleAddTestCaseSubmit,
     onUpdateOwner,
@@ -91,6 +96,19 @@ const TestSuiteDetailsPage = () => {
     handleDisplayNameChange,
     handleTestSuiteUpdate,
   } = useTestSuiteDetailsPage();
+
+  const { searchInputProps } = useListSearchInput({
+    searchQuery: testCaseSearchQuery,
+    onSearchChange: handleTestCaseSearch,
+  });
+  // UI core and Untitled icons currently resolve React types from separate
+  // package trees even though their runtime component contract is compatible.
+  const searchInputIcon = searchInputProps.icon as ComponentProps<
+    typeof Input
+  >['icon'];
+  const testCaseSearchLabel = t('label.search-entity', {
+    entity: testCasePluralLabel,
+  });
 
   const afterDeleteAction = () => {
     navigate(
@@ -146,7 +164,7 @@ const TestSuiteDetailsPage = () => {
           <TabsLabel
             count={pagingData.paging.total}
             id={EntityTabs.TEST_CASES}
-            name={t('label.test-case-plural')}
+            name={testCasePluralLabel}
           />
         ),
         children: (
@@ -157,10 +175,23 @@ const TestSuiteDetailsPage = () => {
                 afterDeleteAction={fetchTestCases}
                 breadcrumbData={incidentUrlState}
                 fetchTestCases={handleSortTestCase}
+                hasActiveFilters={Boolean(testCaseSearchQuery.trim())}
                 isLoading={isLoading || isTestCaseLoading}
                 pagingData={pagingData}
                 removeFromTestSuite={removeFromTestSuite}
                 showPagination={showPagination}
+                tableHeader={
+                  <Box align="center" className="tw:w-full" justify="end">
+                    <Input
+                      {...searchInputProps}
+                      aria-label={testCaseSearchLabel}
+                      className="tw:w-full tw:max-w-72"
+                      icon={searchInputIcon}
+                      inputDataTestId="test-suite-test-case-search"
+                      placeholder={testCaseSearchLabel}
+                    />
+                  </Box>
+                }
                 testCases={testCaseResult}
                 onTestCaseResultUpdate={handleTestSuiteUpdate}
                 onTestUpdate={handleTestSuiteUpdate}
@@ -200,6 +231,11 @@ const TestSuiteDetailsPage = () => {
     pagingData,
     showPagination,
     testCaseResult,
+    testCaseSearchQuery,
+    testCaseSearchLabel,
+    testCasePluralLabel,
+    searchInputIcon,
+    searchInputProps,
     handleTestSuiteUpdate,
     ingestionPipelineCount,
     t,
@@ -333,7 +369,7 @@ const TestSuiteDetailsPage = () => {
                     data-testid="add-test-case-btn"
                     size="md">
                     {t('label.add-entity', {
-                      entity: t('label.test-case-plural'),
+                      entity: testCasePluralLabel,
                     })}
                   </Button>
                   <ModalOverlay>
@@ -341,7 +377,7 @@ const TestSuiteDetailsPage = () => {
                       <Dialog
                         showCloseButton
                         title={t('label.add-entity', {
-                          entity: t('label.test-case-plural'),
+                          entity: testCasePluralLabel,
                         })}
                         onClose={() => setIsTestCaseModalOpen(false)}>
                         <Dialog.Content>

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/TestSuiteDetailsPage.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/TestSuiteDetailsPage.interface.ts
@@ -29,6 +29,7 @@ export interface UseTestSuiteDetailsPageResult {
   isLoading: boolean;
   isTestCaseLoading: boolean;
   testCaseResult: TestCase[];
+  testCaseSearchQuery: string;
   testSuitePermissions: OperationPermission;
   permissions: {
     hasViewPermission?: boolean;
@@ -51,6 +52,7 @@ export interface UseTestSuiteDetailsPageResult {
   canAddMultipleUserOwners: boolean;
   canAddMultipleTeamOwner: boolean;
   fetchTestCases: (param?: ListTestCaseParamsBySearch) => Promise<void>;
+  handleTestCaseSearch: (query: string) => void;
   handleSortTestCase: (apiParams?: ListTestCaseParamsBySearch) => Promise<void>;
   handleAddTestCaseSubmit: (payload: {
     selectAll: boolean;

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/TestSuiteDetailsPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/TestSuiteDetailsPage.test.tsx
@@ -10,13 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { usePermissionProvider } from '../../context/PermissionProvider/PermissionProvider';
 import { mockEntityPermissions } from '../../pages/DatabaseSchemaPage/mocks/DatabaseSchemaPage.mock';
@@ -27,6 +21,7 @@ import {
   getTestSuiteByName,
   updateTestSuiteById,
 } from '../../rest/testAPI';
+import { renderWithQueryClient } from '../../test/unit/test-utils';
 import observabilityRouterClassBase from '../../utils/ObservabilityRouterClassBase';
 import TestSuiteDetailsPage from './TestSuiteDetailsPage.component';
 
@@ -303,12 +298,13 @@ jest.mock(
   '../../components/Database/Profiler/DataQualityTab/DataQualityTab',
   () => {
     return jest.fn().mockImplementation((props) => {
-      const { onTestUpdate } = props;
+      const { onTestUpdate, tableHeader } = props;
       mockDataQualityTab(props);
 
       return (
         <div>
           DataQualityTab.component
+          {tableHeader}
           <button
             data-testid="update-test-btn"
             onClick={() =>
@@ -552,7 +548,7 @@ describe('TestSuiteDetailsPage component', () => {
 
   describe('Render & Initial State', () => {
     it('component should render without crashing', async () => {
-      render(<TestSuiteDetailsPage />);
+      renderWithQueryClient(<TestSuiteDetailsPage />);
 
       expect(
         await screen.findByText('HeaderBreadcrumb.component')
@@ -560,7 +556,7 @@ describe('TestSuiteDetailsPage component', () => {
     });
 
     it('should render all required UI elements', async () => {
-      render(<TestSuiteDetailsPage />);
+      renderWithQueryClient(<TestSuiteDetailsPage />);
 
       expect(
         await screen.findByText('HeaderBreadcrumb.component')
@@ -585,30 +581,54 @@ describe('TestSuiteDetailsPage component', () => {
       ).toBeInTheDocument();
     });
 
+    it('should search the suite test cases from the table header', async () => {
+      renderWithQueryClient(<TestSuiteDetailsPage />);
+
+      const searchInput = await screen.findByTestId(
+        'test-suite-test-case-search'
+      );
+      mockGetListTestCaseBySearch.mockClear();
+
+      fireEvent.change(searchInput, { target: { value: 'test_case_2' } });
+
+      await waitFor(() => {
+        expect(mockGetListTestCaseBySearch).toHaveBeenCalledWith(
+          expect.objectContaining({ offset: 0, q: 'test_case_2' }),
+          expect.objectContaining({ signal: expect.anything() })
+        );
+      });
+    });
+
     it('should show loader while loading', async () => {
       mockGetEntityPermissionByFqn.mockImplementation(
         () => new Promise(() => {}) // Never resolves
       );
 
-      render(<TestSuiteDetailsPage />);
+      renderWithQueryClient(<TestSuiteDetailsPage />);
 
       expect(screen.getByText('Loader.component')).toBeInTheDocument();
     });
 
     it('should fetch test suite data on mount', async () => {
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
-      expect(mockGetTestSuiteByName).toHaveBeenCalledWith('testSuiteFQN', {
-        fields: ['owners', 'domains', 'tests'],
-        include: 'all',
+      await waitFor(() => {
+        expect(mockGetTestSuiteByName).toHaveBeenCalledWith(
+          'testSuiteFQN',
+          {
+            fields: ['owners', 'domains', 'tests'],
+            include: 'all',
+          },
+          expect.objectContaining({ signal: expect.anything() })
+        );
       });
     });
 
     it('should fetch permissions on mount', async () => {
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       expect(mockGetEntityPermissionByFqn).toHaveBeenCalled();
@@ -617,7 +637,7 @@ describe('TestSuiteDetailsPage component', () => {
     describe('observabilityRouterClassBase migration', () => {
       it('DataQualityTab breadcrumbData should include test suite item with url from observabilityRouterClassBase.getTestSuitePath', async () => {
         await act(async () => {
-          render(<TestSuiteDetailsPage />);
+          renderWithQueryClient(<TestSuiteDetailsPage />);
         });
 
         await waitFor(() => {
@@ -655,7 +675,7 @@ describe('TestSuiteDetailsPage component', () => {
       }));
 
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       expect(
@@ -674,7 +694,7 @@ describe('TestSuiteDetailsPage component', () => {
       }));
 
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       await waitFor(() => {
@@ -686,7 +706,7 @@ describe('TestSuiteDetailsPage component', () => {
 
     it('should show add test case button if user has EditAll permission', async () => {
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       expect(
@@ -705,7 +725,7 @@ describe('TestSuiteDetailsPage component', () => {
       }));
 
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       expect(
@@ -717,7 +737,7 @@ describe('TestSuiteDetailsPage component', () => {
   describe('User Interactions - Test Case Management', () => {
     it('should open add test case modal when button is clicked', async () => {
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       const addButton = await screen.findByTestId('add-test-case-btn');
@@ -732,7 +752,7 @@ describe('TestSuiteDetailsPage component', () => {
 
     it('should close modal when cancel is clicked', async () => {
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       const addButton = await screen.findByTestId('add-test-case-btn');
@@ -752,7 +772,7 @@ describe('TestSuiteDetailsPage component', () => {
 
     it('should refetch test cases after adding new ones', async () => {
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       // Clear previous calls
@@ -777,7 +797,7 @@ describe('TestSuiteDetailsPage component', () => {
   describe('Add test cases — bulk API (IDS vs All mode)', () => {
     const openAddTestCaseModal = async () => {
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
       const addButton = await screen.findByTestId('add-test-case-btn');
       await act(async () => {
@@ -864,7 +884,7 @@ describe('TestSuiteDetailsPage component', () => {
   describe('User Interactions - Updates', () => {
     it('should handle owner update', async () => {
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       const updateOwnerBtn = await screen.findByTestId('update-owner-btn');
@@ -879,7 +899,7 @@ describe('TestSuiteDetailsPage component', () => {
 
     it('should handle domain update', async () => {
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       const updateDomainBtn = await screen.findByTestId('update-domain-btn');
@@ -894,7 +914,7 @@ describe('TestSuiteDetailsPage component', () => {
 
     it('should handle description update', async () => {
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       const editDescriptionBtn = await screen.findByTestId(
@@ -911,7 +931,7 @@ describe('TestSuiteDetailsPage component', () => {
 
     it('should handle test case update', async () => {
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       const updateTestBtn = await screen.findByTestId('update-test-btn');
@@ -934,7 +954,7 @@ describe('TestSuiteDetailsPage component', () => {
       });
 
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       await screen.findByTestId('test-cases');
@@ -949,7 +969,8 @@ describe('TestSuiteDetailsPage component', () => {
             'incidentStatus',
           ],
           testSuiteId: 'test-suite-id',
-        })
+        }),
+        expect.objectContaining({ signal: expect.anything() })
       );
     });
 
@@ -959,7 +980,7 @@ describe('TestSuiteDetailsPage component', () => {
         paging: { total: 5 },
       });
 
-      render(<TestSuiteDetailsPage />);
+      renderWithQueryClient(<TestSuiteDetailsPage />);
 
       await waitFor(() =>
         expect(mockGetIngestionPipelines).toHaveBeenCalledWith(
@@ -981,7 +1002,7 @@ describe('TestSuiteDetailsPage component', () => {
       mockGetTestSuiteByName.mockResolvedValue(customTestSuite);
 
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       await waitFor(() => {
@@ -998,7 +1019,7 @@ describe('TestSuiteDetailsPage component', () => {
       mockGetTestSuiteByName.mockRejectedValue(error);
 
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       await waitFor(() => {
@@ -1012,7 +1033,7 @@ describe('TestSuiteDetailsPage component', () => {
       );
 
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       await waitFor(() => {
@@ -1025,7 +1046,7 @@ describe('TestSuiteDetailsPage component', () => {
       mockGetEntityPermissionByFqn.mockRejectedValue(error);
 
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       await waitFor(() => {
@@ -1038,7 +1059,7 @@ describe('TestSuiteDetailsPage component', () => {
       mockAddTestCasesToLogicalTestSuiteBulk.mockRejectedValue(error);
 
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       const addButton = await screen.findByTestId('add-test-case-btn');
@@ -1061,7 +1082,7 @@ describe('TestSuiteDetailsPage component', () => {
       mockUpdateTestSuiteById.mockRejectedValue(error);
 
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       const updateOwnerBtn = await screen.findByTestId('update-owner-btn');
@@ -1078,12 +1099,12 @@ describe('TestSuiteDetailsPage component', () => {
       mockGetTestSuiteByName.mockResolvedValue(undefined);
 
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       // Component should still render without crashing
       expect(
-        screen.getByText('HeaderBreadcrumb.component')
+        await screen.findByText('HeaderBreadcrumb.component')
       ).toBeInTheDocument();
     });
 
@@ -1094,7 +1115,7 @@ describe('TestSuiteDetailsPage component', () => {
       });
 
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       await waitFor(() => {
@@ -1108,7 +1129,7 @@ describe('TestSuiteDetailsPage component', () => {
   describe('Tabs & Navigation', () => {
     it('should render test cases tab by default', async () => {
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       expect(await screen.findByTestId('test-cases')).toBeInTheDocument();
@@ -1116,7 +1137,7 @@ describe('TestSuiteDetailsPage component', () => {
 
     it('should render pipeline tab', async () => {
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       expect(await screen.findByTestId('pipeline')).toBeInTheDocument();
@@ -1124,13 +1145,15 @@ describe('TestSuiteDetailsPage component', () => {
 
     it('should navigate after delete action', async () => {
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       // The afterDeleteAction is passed to ManageButton
       // We can't directly test it without triggering the delete,
       // but we can verify the component renders
-      expect(screen.getByText('ManageButton.component')).toBeInTheDocument();
+      expect(
+        await screen.findByText('ManageButton.component')
+      ).toBeInTheDocument();
     });
   });
 
@@ -1142,7 +1165,7 @@ describe('TestSuiteDetailsPage component', () => {
       });
 
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       expect(await screen.findByTestId('owner-label')).toBeInTheDocument();
@@ -1155,7 +1178,7 @@ describe('TestSuiteDetailsPage component', () => {
       });
 
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       expect(
@@ -1170,7 +1193,7 @@ describe('TestSuiteDetailsPage component', () => {
       });
 
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       expect(
@@ -1185,7 +1208,7 @@ describe('TestSuiteDetailsPage component', () => {
       });
 
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       expect(
@@ -1195,7 +1218,7 @@ describe('TestSuiteDetailsPage component', () => {
 
     it('should handle test cases with no IDs', async () => {
       await act(async () => {
-        render(<TestSuiteDetailsPage />);
+        renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
       const addButton = await screen.findByTestId('add-test-case-btn');

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/TestSuiteDetailsPage.utils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/TestSuiteDetailsPage.utils.test.ts
@@ -14,7 +14,6 @@
 import {
   isTestCaseListSynchronized,
   isUnfilteredTestCaseRequest,
-  shouldResetTestCaseLoading,
 } from './TestSuiteDetailsPage.utils';
 
 describe('TestSuiteDetailsPage.utils', () => {
@@ -54,22 +53,6 @@ describe('TestSuiteDetailsPage.utils', () => {
       (indexedTotal, authoritativeTotal, expected) => {
         expect(
           isTestCaseListSynchronized(indexedTotal, authoritativeTotal)
-        ).toBe(expected);
-      }
-    );
-  });
-
-  describe('shouldResetTestCaseLoading', () => {
-    it.each([
-      [true, false, true],
-      [false, false, false],
-      [true, true, false],
-      [false, true, false],
-    ])(
-      'should report request-current %s and keep-loading %s as reset-loading: %s',
-      (isCurrentRequest, keepLoading, expected) => {
-        expect(
-          shouldResetTestCaseLoading(() => isCurrentRequest, keepLoading)
         ).toBe(expected);
       }
     );

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/TestSuiteDetailsPage.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/TestSuiteDetailsPage.utils.ts
@@ -32,8 +32,3 @@ export const isTestCaseListSynchronized = (
   indexedTotal === undefined ||
   authoritativeTotal === undefined ||
   indexedTotal >= authoritativeTotal;
-
-export const shouldResetTestCaseLoading = (
-  isCurrentRequest: () => boolean,
-  keepLoading: boolean
-) => isCurrentRequest() && !keepLoading;

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/hooks/useTestSuiteDetailsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/hooks/useTestSuiteDetailsPage.tsx
@@ -10,9 +10,15 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+import {
+  keepPreviousData,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { compare } from 'fast-json-patch';
 import { isArray, isEmpty } from 'lodash';
+import { PagingResponse } from 'Models';
 import {
   useCallback,
   useEffect,
@@ -27,7 +33,6 @@ import {
   NextPreviousProps,
   PagingHandlerParams,
 } from '../../../components/common/NextPrevious/NextPrevious.interface';
-import { TitleBreadcrumbProps } from '../../../components/common/TitleBreadcrumb/TitleBreadcrumb.interface';
 import { useEntityExportModalProvider } from '../../../components/Entity/EntityExportModalProvider/EntityExportModalProvider.component';
 import { EntityName } from '../../../components/Modals/EntityNameModal/EntityNameModal.interface';
 import {
@@ -40,16 +45,10 @@ import {
   OperationPermission,
   ResourceEntity,
 } from '../../../context/PermissionProvider/PermissionProvider.interface';
-import {
-  EntityTabs,
-  EntityType,
-  TabSpecificField,
-} from '../../../enums/entity.enum';
+import { EntityTabs, EntityType } from '../../../enums/entity.enum';
 import { Operation } from '../../../generated/entity/policies/policy';
-import { PipelineType } from '../../../generated/entity/services/ingestionPipelines/ingestionPipeline';
 import { TestCase } from '../../../generated/tests/testCase';
 import { EntityReference, TestSuite } from '../../../generated/tests/testSuite';
-import { Include } from '../../../generated/type/include';
 import { usePaging } from '../../../hooks/paging/usePaging';
 import { useChangeSummary } from '../../../hooks/useChangeSummary';
 import { useEntityRules } from '../../../hooks/useEntityRules';
@@ -58,11 +57,19 @@ import {
   DataQualityPageTabs,
   DataQualitySubTabs,
 } from '../../../pages/DataQuality/DataQualityPage.interface';
-import { getIngestionPipelines } from '../../../rest/ingestionPipelineAPI';
+import {
+  testSuiteDetailsQueryFn,
+  testSuiteDetailsQueryKey,
+  testSuiteIngestionPipelinesQueryFn,
+  testSuiteIngestionPipelinesQueryKey,
+  testSuiteTestCasesQueryFn,
+  testSuiteTestCasesQueryKey,
+  testSuiteTestCasesQueryKeyPrefix,
+  TEST_SUITE_TEST_CASE_FIELDS,
+} from '../../../rest/queries/testSuiteQuery';
 import {
   addTestCasesToLogicalTestSuiteBulk,
   getListTestCaseBySearch,
-  getTestSuiteByName,
   ListTestCaseParamsBySearch,
   updateTestSuiteById,
 } from '../../../rest/testAPI';
@@ -79,7 +86,6 @@ import { UseTestSuiteDetailsPageResult } from '../TestSuiteDetailsPage.interface
 import {
   isTestCaseListSynchronized,
   isUnfilteredTestCaseRequest,
-  shouldResetTestCaseLoading,
 } from '../TestSuiteDetailsPage.utils';
 
 /**
@@ -89,24 +95,32 @@ import {
  */
 export const useTestSuiteDetailsPage = (): UseTestSuiteDetailsPageResult => {
   const { t } = useTranslation();
+  const queryClient = useQueryClient();
   const { entityRules } = useEntityRules(EntityType.TEST_SUITE);
   const { getEntityPermissionByFqn, permissions: globalPermissions } =
     usePermissionProvider();
   const { fqn: testSuiteFQN } = useFqn();
+  // Query keys isolate stale GET responses, but a bulk mutation can still
+  // finish after navigation and must not start follow-up work for the old suite.
   const activeTestSuiteFQN = useRef(testSuiteFQN);
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<string>(EntityTabs.TEST_CASES);
   const { showModal } = useEntityExportModalProvider();
 
-  const [testSuite, setTestSuite] = useState<TestSuite>();
-  const [isTestCaseLoading, setIsTestCaseLoading] = useState(true);
-  const [testCaseResult, setTestCaseResult] = useState<Array<TestCase>>([]);
-  const testCaseRequestId = useRef(0);
-  const testSuiteRequestId = useRef(0);
-  const authoritativeTestCaseCount = useRef<{
-    testSuiteFQN: string;
-    total: number;
-  }>();
+  // Keep the raw value for the controlled input and normalize it only when
+  // deriving the query key and API request.
+  const [testCaseSearchQuery, setTestCaseSearchQuery] = useState('');
+  const [testCaseRequestParams, setTestCaseRequestParams] =
+    useState<ListTestCaseParamsBySearch>({
+      ...DEFAULT_SORT_ORDER,
+      offset: 0,
+    });
+  // Suite relationships update before the search index; retain the REST total
+  // until the keyed list query observes the indexed rows.
+  const [authoritativeTestCaseCount, setAuthoritativeTestCaseCount] =
+    useState<number>();
+  const [isSynchronizingTestCases, setIsSynchronizingTestCases] =
+    useState(false);
 
   const {
     currentPage,
@@ -117,35 +131,19 @@ export const useTestSuiteDetailsPage = (): UseTestSuiteDetailsPageResult => {
     handlePagingChange,
     showPagination,
   } = usePaging();
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [testSuitePermissions, setTestSuitePermissions] =
-    useState<OperationPermission>(DEFAULT_ENTITY_PERMISSION);
   const [isTestCaseModalOpen, setIsTestCaseModalOpen] =
     useState<boolean>(false);
-  const [sortOptions, setSortOptions] =
-    useState<ListTestCaseParamsBySearch>(DEFAULT_SORT_ORDER);
-  const [ingestionPipelineCount, setIngestionPipelineCount] =
-    useState<number>(0);
 
-  const [slashedBreadCrumb, setSlashedBreadCrumb] = useState<
-    TitleBreadcrumbProps['titleLinks']
-  >([]);
-
-  // The suite page mounts no GenericProvider, so the description
-  // attribution must be fetched directly instead of read from context.
-  const { changeSummary, refetch: refetchChangeSummary } = useChangeSummary(
-    EntityType.TEST_SUITE,
-    testSuite?.id ?? '',
-    { limit: 1000 }
-  );
-
-  const { testSuiteDescription, testSuiteId, testOwners } = useMemo(() => {
-    return {
-      testOwners: testSuite?.owners,
-      testSuiteId: testSuite?.id ?? '',
-      testSuiteDescription: testSuite?.description ?? '',
-    };
-  }, [testSuite]);
+  const {
+    data: testSuitePermissions = DEFAULT_ENTITY_PERMISSION,
+    error: testSuitePermissionError,
+    isLoading: isPermissionLoading,
+  } = useQuery<OperationPermission>({
+    queryKey: ['testSuite', 'permission', testSuiteFQN],
+    queryFn: () =>
+      getEntityPermissionByFqn(ResourceEntity.TEST_SUITE, testSuiteFQN),
+    enabled: Boolean(testSuiteFQN),
+  });
 
   const permissions = useMemo(() => {
     return {
@@ -159,6 +157,99 @@ export const useTestSuiteDetailsPage = (): UseTestSuiteDetailsPageResult => {
       hasDeletePermission: testSuitePermissions?.Delete,
     };
   }, [testSuitePermissions]);
+
+  const testSuiteQueryKey = useMemo(
+    () => testSuiteDetailsQueryKey(testSuiteFQN),
+    [testSuiteFQN]
+  );
+  const {
+    data: testSuite,
+    error: testSuiteError,
+    isLoading: isTestSuiteLoading,
+  } = useQuery({
+    queryKey: testSuiteQueryKey,
+    queryFn: testSuiteDetailsQueryFn(testSuiteFQN),
+    enabled: Boolean(testSuiteFQN && permissions.hasViewPermission),
+  });
+
+  // The suite page mounts no GenericProvider, so the description
+  // attribution must be fetched directly instead of read from context.
+  const { changeSummary, refetch: refetchChangeSummary } = useChangeSummary(
+    EntityType.TEST_SUITE,
+    testSuite?.id ?? '',
+    { limit: 1000 }
+  );
+
+  const testOwners = testSuite?.owners;
+  const testSuiteId = testSuite?.id ?? '';
+  const testSuiteDescription = testSuite?.description ?? '';
+  const normalizedTestCaseSearchQuery = testCaseSearchQuery.trim() || undefined;
+
+  const testCaseQueryParams = useMemo<ListTestCaseParamsBySearch>(
+    () => ({
+      fields: TEST_SUITE_TEST_CASE_FIELDS,
+      testSuiteId,
+      ...testCaseRequestParams,
+      q: normalizedTestCaseSearchQuery,
+      limit: pageSize,
+    }),
+    [
+      testSuiteId,
+      testCaseRequestParams,
+      normalizedTestCaseSearchQuery,
+      pageSize,
+    ]
+  );
+  const testCaseQueryKey = useMemo(
+    () => testSuiteTestCasesQueryKey(testSuiteId, testCaseQueryParams),
+    [testSuiteId, testCaseQueryParams]
+  );
+  const {
+    data: testCaseResponse,
+    error: testCaseError,
+    isFetching: isTestCaseQueryFetching,
+    refetch: refetchTestCases,
+  } = useQuery({
+    queryKey: testCaseQueryKey,
+    queryFn: testSuiteTestCasesQueryFn(testCaseQueryParams),
+    enabled: Boolean(testSuiteId),
+    placeholderData: keepPreviousData,
+  });
+
+  const { data: ingestionPipelineResponse, error: ingestionPipelineError } =
+    useQuery({
+      queryKey: testSuiteIngestionPipelinesQueryKey(testSuiteFQN),
+      queryFn: testSuiteIngestionPipelinesQueryFn(testSuiteFQN),
+      enabled: Boolean(testSuiteId),
+    });
+
+  const isUnfilteredTestCaseList = isUnfilteredTestCaseRequest({
+    ...testCaseRequestParams,
+    q: normalizedTestCaseSearchQuery,
+  });
+  const testCasePaging = useMemo(() => {
+    const responsePaging = testCaseResponse?.paging ?? { total: 0 };
+    const shouldUseAuthoritativeTotal =
+      isUnfilteredTestCaseList &&
+      authoritativeTestCaseCount !== undefined &&
+      responsePaging.total < authoritativeTestCaseCount;
+
+    return {
+      ...responsePaging,
+      total: shouldUseAuthoritativeTotal
+        ? authoritativeTestCaseCount
+        : responsePaging.total,
+    };
+  }, [
+    testCaseResponse?.paging,
+    isUnfilteredTestCaseList,
+    authoritativeTestCaseCount,
+  ]);
+
+  const testCaseResult = testCaseResponse?.data ?? [];
+  const ingestionPipelineCount = ingestionPipelineResponse?.paging.total ?? 0;
+  const isTestCaseLoading = isTestCaseQueryFetching || isSynchronizingTestCases;
+  const isLoading = isPermissionLoading || isTestSuiteLoading;
 
   const extraDropdownContent = useMemo(() => {
     const bulkImportExportTestCasePermission = {
@@ -186,6 +277,23 @@ export const useTestSuiteDetailsPage = (): UseTestSuiteDetailsPageResult => {
     );
   }, [globalPermissions, testSuite, navigate, showModal]);
 
+  const slashedBreadCrumb = useMemo(
+    () => [
+      {
+        name: t('label.test-suite-plural'),
+        url: observabilityRouterClassBase.getDataQualityPagePath(
+          DataQualityPageTabs.TEST_SUITES,
+          DataQualitySubTabs.BUNDLE_SUITES
+        ),
+      },
+      {
+        name: getEntityName(testSuite),
+        url: '',
+      },
+    ],
+    [testSuite, t]
+  );
+
   const incidentUrlState = useMemo(() => {
     return [
       {
@@ -202,151 +310,120 @@ export const useTestSuiteDetailsPage = (): UseTestSuiteDetailsPageResult => {
         ),
       },
     ];
-  }, [testSuite]);
+  }, [testSuite, t]);
 
-  const saveAndUpdateTestSuiteData = (updatedData: TestSuite) => {
-    const jsonPatch = compare(testSuite as TestSuite, updatedData);
+  const saveAndUpdateTestSuiteData = useCallback(
+    (updatedData: TestSuite) => {
+      const jsonPatch = compare(testSuite as TestSuite, updatedData);
 
-    return updateTestSuiteById(testSuiteId as string, jsonPatch);
-  };
+      return updateTestSuiteById(testSuiteId, jsonPatch);
+    },
+    [testSuite, testSuiteId]
+  );
 
-  const fetchTestSuitePermission = async () => {
-    setIsLoading(true);
-    try {
-      const response = await getEntityPermissionByFqn(
-        ResourceEntity.TEST_SUITE,
-        testSuiteFQN
-      );
-      setTestSuitePermissions(response);
-    } catch (error) {
-      showErrorToast(error as AxiosError);
-    } finally {
-      setIsLoading(false);
+  useEffect(() => {
+    if (testSuitePermissionError) {
+      showErrorToast(testSuitePermissionError as AxiosError);
     }
-  };
+  }, [testSuitePermissionError]);
 
-  const fetchIngestionPipelineCount = useCallback(
-    async (
-      shouldFetch: boolean,
-      isCurrentRequest: () => boolean
-    ): Promise<void> => {
-      if (!shouldFetch || !isCurrentRequest()) {
-        return;
-      }
+  useEffect(() => {
+    if (testSuiteError) {
+      showErrorToast(
+        testSuiteError as AxiosError,
+        t('server.entity-fetch-error', {
+          entity: t('label.test-suite'),
+        })
+      );
+    }
+  }, [testSuiteError, t]);
 
-      const { paging: ingestionPipelinePaging } = await getIngestionPipelines({
-        arrQueryFields: [],
-        testSuite: testSuiteFQN,
-        pipelineType: [PipelineType.TestSuite],
-        limit: 0,
-      });
+  useEffect(() => {
+    if (testCaseError) {
+      showErrorToast(
+        testCaseError as AxiosError,
+        t('server.entity-fetch-error', {
+          entity: t('label.test-case-plural'),
+        })
+      );
+    }
+  }, [testCaseError, t]);
 
-      if (isCurrentRequest()) {
-        setIngestionPipelineCount(ingestionPipelinePaging.total);
-      }
-    },
-    [testSuiteFQN]
-  );
+  useEffect(() => {
+    if (ingestionPipelineError) {
+      showErrorToast(ingestionPipelineError as AxiosError);
+    }
+  }, [ingestionPipelineError]);
 
-  const fetchTestCasesWithTotal = useCallback(
-    async (
-      param?: ListTestCaseParamsBySearch,
-      keepLoading = false,
-      shouldFetchIngestionPipelines = true
-    ): Promise<number | undefined> => {
-      const requestId = ++testCaseRequestId.current;
-      const requestedTestSuiteFQN = testSuiteFQN;
-      const isCurrentRequest = () =>
-        requestId === testCaseRequestId.current &&
-        requestedTestSuiteFQN === activeTestSuiteFQN.current;
-      setIsTestCaseLoading(true);
-      try {
-        const response = await getListTestCaseBySearch({
-          fields: [
-            TabSpecificField.TEST_CASE_RESULT,
-            TabSpecificField.TEST_DEFINITION,
-            TabSpecificField.TESTSUITE,
-            TabSpecificField.INCIDENT_ID,
-            TabSpecificField.INCIDENT_STATUS,
-          ],
-          testSuiteId,
-          ...sortOptions,
-          ...param,
-          limit: pageSize,
-        });
-        await fetchIngestionPipelineCount(
-          shouldFetchIngestionPipelines,
-          isCurrentRequest
-        );
+  useEffect(() => {
+    handlePagingChange(testCasePaging);
 
-        if (!isCurrentRequest()) {
-          return;
-        }
-
-        const authoritativeSnapshot = authoritativeTestCaseCount.current;
-        const isUnfilteredRequest = isUnfilteredTestCaseRequest(param);
-        const shouldUseAuthoritativeTotal =
-          isUnfilteredRequest &&
-          authoritativeSnapshot?.testSuiteFQN === testSuiteFQN &&
-          response.paging.total < authoritativeSnapshot.total;
-        setTestCaseResult(response.data);
-        handlePagingChange({
-          ...response.paging,
-          total: shouldUseAuthoritativeTotal
-            ? authoritativeSnapshot.total
-            : response.paging.total,
-        });
-
-        if (
-          authoritativeSnapshot &&
-          isUnfilteredRequest &&
-          !shouldUseAuthoritativeTotal
-        ) {
-          authoritativeTestCaseCount.current = undefined;
-        }
-
-        return response.paging.total;
-      } catch {
-        if (!isCurrentRequest()) {
-          return;
-        }
-
-        setTestCaseResult([]);
-        showErrorToast(
-          t('server.entity-fetch-error', {
-            entity: t('label.test-case-plural'),
-          })
-        );
-      } finally {
-        if (shouldResetTestCaseLoading(isCurrentRequest, keepLoading)) {
-          setIsTestCaseLoading(false);
-        }
-      }
-    },
-    [
-      testSuiteId,
-      testSuiteFQN,
-      sortOptions,
-      pageSize,
-      handlePagingChange,
-      fetchIngestionPipelineCount,
-      t,
-    ]
-  );
+    if (
+      isUnfilteredTestCaseList &&
+      authoritativeTestCaseCount !== undefined &&
+      (testCaseResponse?.paging.total ?? 0) >= authoritativeTestCaseCount
+    ) {
+      setAuthoritativeTestCaseCount(undefined);
+    }
+  }, [
+    testCasePaging,
+    handlePagingChange,
+    isUnfilteredTestCaseList,
+    authoritativeTestCaseCount,
+    testCaseResponse?.paging.total,
+  ]);
 
   const fetchTestCases = useCallback(
     async (param?: ListTestCaseParamsBySearch) => {
-      await fetchTestCasesWithTotal(param);
+      if (!param) {
+        await refetchTestCases();
+
+        return;
+      }
+
+      setTestCaseRequestParams((current) => ({
+        ...current,
+        ...param,
+      }));
     },
-    [fetchTestCasesWithTotal]
+    [refetchTestCases]
+  );
+
+  const handleTestCaseSearch = useCallback(
+    (query: string) => {
+      setTestCaseSearchQuery(query);
+      handlePageChange(INITIAL_PAGING_VALUE);
+      setTestCaseRequestParams((current) => ({
+        ...current,
+        offset: 0,
+      }));
+    },
+    [handlePageChange]
+  );
+
+  const fetchIndexedTestCaseTotal = useCallback(
+    async (targetTestSuiteId: string) => {
+      const response = await getListTestCaseBySearch({
+        testSuiteId: targetTestSuiteId,
+        limit: 1,
+      });
+
+      return response.paging.total;
+    },
+    []
   );
 
   const refreshTestCasesUntilIndexed = useCallback(
     async (
       authoritativeTotal: number | undefined,
-      isCurrentTestSuite: () => boolean
+      isCurrentTestSuite: () => boolean,
+      targetTestSuiteId: string
     ) => {
-      setIsTestCaseLoading(true);
+      if (!isCurrentTestSuite()) {
+        return;
+      }
+
+      setIsSynchronizingTestCases(true);
       try {
         for (
           let attempt = 0;
@@ -357,17 +434,25 @@ export const useTestSuiteDetailsPage = (): UseTestSuiteDetailsPageResult => {
             return;
           }
 
-          const indexedTotal = await fetchTestCasesWithTotal(
-            undefined,
-            true,
-            attempt === 0
-          );
+          // A transient failure polling the index (e.g. a dropped request)
+          // must not abandon the refresh — fall through to the invalidate
+          // below so the list still catches up to whatever is indexed now,
+          // instead of silently going stale.
+          let indexedTotal: number | undefined;
+          try {
+            // Polling reads only the index total so it cannot supersede or
+            // commit over a search, sort, or paging request made meanwhile.
+            indexedTotal = await fetchIndexedTestCaseTotal(targetTestSuiteId);
+          } catch {
+            break;
+          }
 
-          if (
-            !isCurrentTestSuite() ||
-            isTestCaseListSynchronized(indexedTotal, authoritativeTotal)
-          ) {
+          if (!isCurrentTestSuite()) {
             return;
+          }
+
+          if (isTestCaseListSynchronized(indexedTotal, authoritativeTotal)) {
+            break;
           }
 
           if (attempt < TEST_CASE_LIST_REFRESH_MAX_ATTEMPTS - 1) {
@@ -376,75 +461,30 @@ export const useTestSuiteDetailsPage = (): UseTestSuiteDetailsPageResult => {
             );
           }
         }
+
+        if (isCurrentTestSuite()) {
+          // Invalidating the suite prefix refetches whichever search, sort, or
+          // page query is active when indexing completes.
+          await queryClient.invalidateQueries({
+            queryKey: testSuiteTestCasesQueryKeyPrefix(targetTestSuiteId),
+          });
+        }
       } finally {
         if (isCurrentTestSuite()) {
-          setIsTestCaseLoading(false);
+          setIsSynchronizingTestCases(false);
         }
       }
     },
-    [fetchTestCasesWithTotal]
+    [fetchIndexedTestCaseTotal, queryClient]
   );
 
   const handleSortTestCase = useCallback(
     async (apiParams?: ListTestCaseParamsBySearch) => {
-      setSortOptions(apiParams ?? DEFAULT_SORT_ORDER);
       await fetchTestCases({ ...(apiParams ?? DEFAULT_SORT_ORDER), offset: 0 });
       handlePageChange(INITIAL_PAGING_VALUE);
     },
     [fetchTestCases, handlePageChange]
   );
-
-  const fetchTestSuiteByName = useCallback(async () => {
-    const requestId = ++testSuiteRequestId.current;
-    const requestedTestSuiteFQN = testSuiteFQN;
-    const isCurrentRequest = () =>
-      requestId === testSuiteRequestId.current &&
-      requestedTestSuiteFQN === activeTestSuiteFQN.current;
-
-    try {
-      const response = await getTestSuiteByName(testSuiteFQN, {
-        fields: [
-          TabSpecificField.OWNERS,
-          TabSpecificField.DOMAINS,
-          TabSpecificField.TESTS,
-        ],
-        include: Include.All,
-      });
-
-      if (!isCurrentRequest()) {
-        return;
-      }
-
-      setSlashedBreadCrumb([
-        {
-          name: t('label.test-suite-plural'),
-          url: observabilityRouterClassBase.getDataQualityPagePath(
-            DataQualityPageTabs.TEST_SUITES,
-            DataQualitySubTabs.BUNDLE_SUITES
-          ),
-        },
-        {
-          name: getEntityName(response),
-          url: '',
-        },
-      ]);
-      setTestSuite(response);
-
-      return response;
-    } catch (error) {
-      if (!isCurrentRequest()) {
-        return;
-      }
-
-      setTestSuite(undefined);
-      showErrorToast(
-        error as AxiosError,
-        t('server.entity-fetch-error', {
-          entity: t('label.test-suite'),
-        })
-      );
-    }
-  }, [testSuiteFQN, t]);
 
   const handleAddTestCaseSubmit = useCallback(
     async (payload: {
@@ -467,7 +507,10 @@ export const useTestSuiteDetailsPage = (): UseTestSuiteDetailsPageResult => {
         }
 
         setIsTestCaseModalOpen(false);
-        const updatedTestSuite = await fetchTestSuiteByName();
+        const updatedTestSuite = await queryClient.fetchQuery({
+          queryKey: testSuiteDetailsQueryKey(submittedTestSuiteFQN),
+          queryFn: testSuiteDetailsQueryFn(submittedTestSuiteFQN),
+        });
 
         if (!isCurrentTestSuite()) {
           return;
@@ -476,19 +519,13 @@ export const useTestSuiteDetailsPage = (): UseTestSuiteDetailsPageResult => {
         const authoritativeTotal = updatedTestSuite?.tests?.length;
 
         if (authoritativeTotal !== undefined) {
-          authoritativeTestCaseCount.current = {
-            testSuiteFQN,
-            total: authoritativeTotal,
-          };
-          handlePagingChange((currentPaging) => ({
-            ...currentPaging,
-            total: authoritativeTotal,
-          }));
+          setAuthoritativeTestCaseCount(authoritativeTotal);
         }
 
         await refreshTestCasesUntilIndexed(
           authoritativeTotal,
-          isCurrentTestSuite
+          isCurrentTestSuite,
+          testSuiteId
         );
       } catch (error) {
         if (isCurrentTestSuite()) {
@@ -496,23 +533,20 @@ export const useTestSuiteDetailsPage = (): UseTestSuiteDetailsPageResult => {
         }
       }
     },
-    [
-      testSuiteId,
-      testSuiteFQN,
-      fetchTestSuiteByName,
-      refreshTestCasesUntilIndexed,
-      handlePagingChange,
-    ]
+    [testSuiteId, testSuiteFQN, queryClient, refreshTestCasesUntilIndexed]
   );
 
-  const updateTestSuiteData = async (updatedTestSuite: TestSuite) => {
-    try {
-      const res = await saveAndUpdateTestSuiteData(updatedTestSuite);
-      setTestSuite(res);
-    } catch (error) {
-      showErrorToast(error as AxiosError);
-    }
-  };
+  const updateTestSuiteData = useCallback(
+    async (updatedTestSuite: TestSuite) => {
+      try {
+        const response = await saveAndUpdateTestSuiteData(updatedTestSuite);
+        queryClient.setQueryData(testSuiteQueryKey, response);
+      } catch (error) {
+        showErrorToast(error as AxiosError);
+      }
+    },
+    [queryClient, saveAndUpdateTestSuiteData, testSuiteQueryKey]
+  );
 
   const onUpdateOwner = useCallback(
     async (updatedOwners: TestSuite['owners']) => {
@@ -522,7 +556,7 @@ export const useTestSuiteDetailsPage = (): UseTestSuiteDetailsPageResult => {
 
       await updateTestSuiteData({ ...testSuite, owners: updatedOwners });
     },
-    [testSuite]
+    [testSuite, updateTestSuiteData]
   );
 
   const handleDomainUpdate = useCallback(
@@ -547,7 +581,7 @@ export const useTestSuiteDetailsPage = (): UseTestSuiteDetailsPageResult => {
 
       await updateTestSuiteData(updatedTestSuite);
     },
-    [testSuite]
+    [testSuite, updateTestSuiteData]
   );
 
   const onDescriptionUpdate = useCallback(
@@ -559,7 +593,7 @@ export const useTestSuiteDetailsPage = (): UseTestSuiteDetailsPageResult => {
             updatedTestSuite as TestSuite
           );
           if (response) {
-            setTestSuite(response);
+            queryClient.setQueryData(testSuiteQueryKey, response);
             refetchChangeSummary();
           } else {
             throw t('server.unexpected-response');
@@ -569,7 +603,14 @@ export const useTestSuiteDetailsPage = (): UseTestSuiteDetailsPageResult => {
         }
       }
     },
-    [testSuite, t, refetchChangeSummary]
+    [
+      testSuite,
+      t,
+      refetchChangeSummary,
+      saveAndUpdateTestSuiteData,
+      queryClient,
+      testSuiteQueryKey,
+    ]
   );
 
   const handleDisplayNameChange = useCallback(
@@ -587,57 +628,70 @@ export const useTestSuiteDetailsPage = (): UseTestSuiteDetailsPageResult => {
               updatedTestSuite as TestSuite
             );
 
-            setTestSuite(response);
+            queryClient.setQueryData(testSuiteQueryKey, response);
           }
         }
       } catch (error) {
         showErrorToast(error as AxiosError);
       }
     },
-    [testSuite]
+    [testSuite, saveAndUpdateTestSuiteData, queryClient, testSuiteQueryKey]
   );
 
-  const handleTestCasePaging = ({ currentPage }: PagingHandlerParams) => {
-    if (currentPage) {
-      handlePageChange(currentPage);
-      fetchTestCases({
-        offset: (currentPage - 1) * pageSize,
-      });
-    }
-  };
+  const handleTestCasePaging = useCallback(
+    ({ currentPage }: PagingHandlerParams) => {
+      if (currentPage) {
+        handlePageChange(currentPage);
+        fetchTestCases({
+          offset: (currentPage - 1) * pageSize,
+        });
+      }
+    },
+    [fetchTestCases, handlePageChange, pageSize]
+  );
 
-  const handleTestSuiteUpdate = useCallback((testCase?: TestCase) => {
-    if (testCase) {
-      setTestCaseResult((prev) =>
-        prev.map((test) =>
-          test.id === testCase.id ? { ...test, ...testCase } : test
-        )
-      );
-    }
-  }, []);
+  const handleTestSuiteUpdate = useCallback(
+    (testCase?: TestCase) => {
+      if (testCase) {
+        queryClient.setQueryData<PagingResponse<TestCase[]>>(
+          testCaseQueryKey,
+          (current) =>
+            current
+              ? {
+                  ...current,
+                  data: current.data.map((item) =>
+                    item.id === testCase.id ? { ...item, ...testCase } : item
+                  ),
+                }
+              : current
+        );
+      }
+    },
+    [queryClient, testCaseQueryKey]
+  );
 
   useLayoutEffect(() => {
     activeTestSuiteFQN.current = testSuiteFQN;
-    testCaseRequestId.current += 1;
-    testSuiteRequestId.current += 1;
-    authoritativeTestCaseCount.current = undefined;
+    setAuthoritativeTestCaseCount(undefined);
+    setTestCaseSearchQuery('');
+    setTestCaseRequestParams({
+      ...DEFAULT_SORT_ORDER,
+      offset: 0,
+    });
+    setIsSynchronizingTestCases(false);
+    setIsTestCaseModalOpen(false);
   }, [testSuiteFQN]);
 
-  useEffect(() => {
-    if (permissions.hasViewPermission) {
-      fetchTestSuiteByName();
-    }
-  }, [permissions, testSuiteFQN]);
-
-  useEffect(() => {
-    fetchTestSuitePermission();
-  }, [testSuiteFQN]);
-
-  useEffect(() => {
-    if (testSuiteId) {
-      fetchTestCases({ testSuiteId });
-    }
-  }, [testSuiteId, pageSize]);
+  const handleTestCasePageSizeChange = useCallback(
+    (size: number) => {
+      setTestCaseRequestParams((current) => ({
+        ...current,
+        offset: 0,
+      }));
+      handlePageSizeChange(size);
+    },
+    [handlePageSizeChange]
+  );
 
   const pagingData: NextPreviousProps = useMemo(
     () => ({
@@ -645,10 +699,16 @@ export const useTestSuiteDetailsPage = (): UseTestSuiteDetailsPageResult => {
       currentPage,
       pageSize,
       paging,
-      onShowSizeChange: handlePageSizeChange,
+      onShowSizeChange: handleTestCasePageSizeChange,
       pagingHandler: handleTestCasePaging,
     }),
-    [currentPage, paging, pageSize, handlePageSizeChange, handleTestCasePaging]
+    [
+      currentPage,
+      paging,
+      pageSize,
+      handleTestCasePageSizeChange,
+      handleTestCasePaging,
+    ]
   );
 
   return {
@@ -659,6 +719,7 @@ export const useTestSuiteDetailsPage = (): UseTestSuiteDetailsPageResult => {
     isLoading,
     isTestCaseLoading,
     testCaseResult,
+    testCaseSearchQuery,
     testSuitePermissions,
     permissions,
     extraDropdownContent,
@@ -675,6 +736,7 @@ export const useTestSuiteDetailsPage = (): UseTestSuiteDetailsPageResult => {
     canAddMultipleUserOwners: entityRules.canAddMultipleUserOwners,
     canAddMultipleTeamOwner: entityRules.canAddMultipleTeamOwner,
     fetchTestCases,
+    handleTestCaseSearch,
     handleSortTestCase,
     handleAddTestCaseSubmit,
     onUpdateOwner,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/useTestSuiteDetailsPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/useTestSuiteDetailsPage.test.tsx
@@ -10,7 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { SORT_ORDER } from '../../enums/common.enum';
 import { EntityTabs } from '../../enums/entity.enum';
 import { getIngestionPipelines } from '../../rest/ingestionPipelineAPI';
 import {
@@ -49,17 +52,25 @@ const mockGetEntityPermissionByFqn = jest
   .fn()
   .mockImplementation(() => Promise.resolve(mockPermissions));
 let mockTestSuiteFQN = 'bundle_suite_fqn';
+let queryClient: QueryClient;
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+const renderTestSuiteDetailsHook = () =>
+  renderHook(() => useTestSuiteDetailsPage(), { wrapper: Wrapper });
 
 const runTimeoutsImmediately = () => {
-  const originalSetTimeout = window.setTimeout;
+  const originalSetTimeout = window.setTimeout.bind(window);
 
   return jest
-    .spyOn(window, 'setTimeout')
+    .spyOn(global, 'setTimeout')
     .mockImplementation((callback, delay, ...args) => {
       if (delay === 500 && typeof callback === 'function') {
         callback();
 
-        return 0;
+        return originalSetTimeout(() => undefined, 0);
       }
 
       return originalSetTimeout(callback, delay, ...args);
@@ -124,6 +135,16 @@ jest.mock('../../utils/ToastUtils', () => ({
 describe('useTestSuiteDetailsPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          refetchOnWindowFocus: false,
+          gcTime: Infinity,
+        },
+        mutations: { retry: false },
+      },
+    });
     mockTestSuiteFQN = 'bundle_suite_fqn';
     (getTestSuiteByName as jest.Mock).mockResolvedValue(mockTestSuite);
     (getListTestCaseBySearch as jest.Mock).mockResolvedValue({
@@ -139,7 +160,7 @@ describe('useTestSuiteDetailsPage', () => {
   });
 
   it('should fetch permissions, the suite and its test cases on mount', async () => {
-    const { result } = renderHook(() => useTestSuiteDetailsPage());
+    const { result } = renderTestSuiteDetailsHook();
 
     await waitFor(() => {
       expect(result.current.testSuite).toEqual(mockTestSuite);
@@ -151,7 +172,8 @@ describe('useTestSuiteDetailsPage', () => {
     );
     expect(getTestSuiteByName).toHaveBeenCalledWith(
       'bundle_suite_fqn',
-      expect.objectContaining({ include: 'all' })
+      expect.objectContaining({ include: 'all' }),
+      expect.objectContaining({ signal: expect.anything() })
     );
 
     await waitFor(() => {
@@ -161,8 +183,149 @@ describe('useTestSuiteDetailsPage', () => {
     expect(result.current.ingestionPipelineCount).toBe(2);
   });
 
+  it('should search the current suite from the first page', async () => {
+    const { result } = renderTestSuiteDetailsHook();
+
+    await waitFor(() => {
+      expect(result.current.testSuite).toEqual(mockTestSuite);
+    });
+
+    (getListTestCaseBySearch as jest.Mock).mockClear();
+    (getIngestionPipelines as jest.Mock).mockClear();
+
+    await act(async () => {
+      await result.current.handleTestCaseSearch('tc_9');
+    });
+
+    expect(result.current.testCaseSearchQuery).toBe('tc_9');
+    expect(result.current.pagingData.currentPage).toBe(1);
+    expect(getListTestCaseBySearch).toHaveBeenCalledTimes(1);
+    expect(getListTestCaseBySearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        offset: 0,
+        q: 'tc_9',
+        testSuiteId: 'suite-id',
+      }),
+      expect.objectContaining({ signal: expect.anything() })
+    );
+    expect(getIngestionPipelines).not.toHaveBeenCalled();
+  });
+
+  it('should preserve search input whitespace while normalizing the request', async () => {
+    const { result } = renderTestSuiteDetailsHook();
+
+    await waitFor(() => {
+      expect(result.current.testSuite).toEqual(mockTestSuite);
+    });
+
+    (getListTestCaseBySearch as jest.Mock).mockClear();
+
+    await act(async () => {
+      await result.current.handleTestCaseSearch('tc_9 ');
+    });
+
+    expect(result.current.testCaseSearchQuery).toBe('tc_9 ');
+    expect(getListTestCaseBySearch).toHaveBeenCalledWith(
+      expect.objectContaining({ q: 'tc_9' }),
+      expect.any(Object)
+    );
+  });
+
+  it('should preserve the search query when changing pages', async () => {
+    const { result } = renderTestSuiteDetailsHook();
+
+    await waitFor(() => {
+      expect(result.current.testSuite).toEqual(mockTestSuite);
+    });
+
+    await act(async () => {
+      await result.current.handleTestCaseSearch('tc_9 ');
+    });
+    (getListTestCaseBySearch as jest.Mock).mockClear();
+
+    act(() => {
+      result.current.pagingData.pagingHandler({ currentPage: 2 });
+    });
+
+    await waitFor(() => {
+      expect(getListTestCaseBySearch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          offset: result.current.pagingData.pageSize,
+          q: 'tc_9',
+        }),
+        expect.any(Object)
+      );
+    });
+  });
+
+  it('should preserve the search query when sorting', async () => {
+    const { result } = renderTestSuiteDetailsHook();
+
+    await waitFor(() => {
+      expect(result.current.testSuite).toEqual(mockTestSuite);
+    });
+
+    await act(async () => {
+      await result.current.handleTestCaseSearch('tc_9');
+    });
+    (getListTestCaseBySearch as jest.Mock).mockClear();
+
+    await act(async () => {
+      await result.current.handleSortTestCase({
+        sortField: 'name',
+        sortType: SORT_ORDER.DESC,
+      });
+    });
+
+    expect(getListTestCaseBySearch).toHaveBeenCalledWith(
+      expect.objectContaining({ q: 'tc_9', sortType: 'desc' }),
+      expect.any(Object)
+    );
+  });
+
+  it('should clear the search and reload the first page', async () => {
+    const { result } = renderTestSuiteDetailsHook();
+
+    await waitFor(() => {
+      expect(result.current.testSuite).toEqual(mockTestSuite);
+    });
+
+    await act(async () => {
+      await result.current.handleTestCaseSearch('tc_9');
+    });
+    (getListTestCaseBySearch as jest.Mock).mockClear();
+
+    await act(async () => {
+      await result.current.handleTestCaseSearch('');
+    });
+
+    expect(result.current.testCaseSearchQuery).toBe('');
+    expect(result.current.pagingData.currentPage).toBe(1);
+    expect(getListTestCaseBySearch).toHaveBeenCalledWith(
+      expect.objectContaining({ offset: 0, q: undefined }),
+      expect.any(Object)
+    );
+  });
+
+  it('should clear the search when navigating to another suite', async () => {
+    const { result, rerender } = renderTestSuiteDetailsHook();
+
+    await waitFor(() => {
+      expect(result.current.testSuite).toEqual(mockTestSuite);
+    });
+
+    await act(async () => {
+      await result.current.handleTestCaseSearch('tc_9');
+    });
+
+    mockTestSuiteFQN = 'another_suite_fqn';
+    rerender();
+
+    expect(result.current.testCaseSearchQuery).toBe('');
+  });
+
   it('should default to the test cases tab and switch tabs', async () => {
-    const { result } = renderHook(() => useTestSuiteDetailsPage());
+    const { result } = renderTestSuiteDetailsHook();
 
     expect(result.current.activeTab).toBe(EntityTabs.TEST_CASES);
 
@@ -174,7 +337,7 @@ describe('useTestSuiteDetailsPage', () => {
   });
 
   it('should derive permission flags from the entity permissions', async () => {
-    const { result } = renderHook(() => useTestSuiteDetailsPage());
+    const { result } = renderTestSuiteDetailsHook();
 
     await waitFor(() => {
       expect(result.current.permissions.hasViewPermission).toBe(true);
@@ -192,7 +355,7 @@ describe('useTestSuiteDetailsPage', () => {
       ViewBasic: false,
     });
 
-    renderHook(() => useTestSuiteDetailsPage());
+    renderTestSuiteDetailsHook();
 
     await waitFor(() => {
       expect(mockGetEntityPermissionByFqn).toHaveBeenCalled();
@@ -202,7 +365,7 @@ describe('useTestSuiteDetailsPage', () => {
   });
 
   it('should patch the suite on owner update', async () => {
-    const { result } = renderHook(() => useTestSuiteDetailsPage());
+    const { result } = renderTestSuiteDetailsHook();
 
     await waitFor(() => {
       expect(result.current.testSuite).toEqual(mockTestSuite);
@@ -221,7 +384,7 @@ describe('useTestSuiteDetailsPage', () => {
   });
 
   it('should normalize single domain updates into an array patch', async () => {
-    const { result } = renderHook(() => useTestSuiteDetailsPage());
+    const { result } = renderTestSuiteDetailsHook();
 
     await waitFor(() => {
       expect(result.current.testSuite).toEqual(mockTestSuite);
@@ -243,7 +406,7 @@ describe('useTestSuiteDetailsPage', () => {
   });
 
   it('should skip description update when unchanged', async () => {
-    const { result } = renderHook(() => useTestSuiteDetailsPage());
+    const { result } = renderTestSuiteDetailsHook();
 
     await waitFor(() => {
       expect(result.current.testSuite).toEqual(mockTestSuite);
@@ -257,7 +420,7 @@ describe('useTestSuiteDetailsPage', () => {
   });
 
   it('should retry stale rows until the authoritative count is indexed', async () => {
-    const { result } = renderHook(() => useTestSuiteDetailsPage());
+    const { result } = renderTestSuiteDetailsHook();
 
     await waitFor(() => {
       expect(result.current.testSuite).toEqual(mockTestSuite);
@@ -297,6 +460,13 @@ describe('useTestSuiteDetailsPage', () => {
         resolveSecondFetchStarted();
 
         return indexedSearch;
+      })
+      .mockResolvedValueOnce({
+        data: [
+          { id: 'tc-1', name: 'tc_1' },
+          { id: 'tc-9', name: 'tc_9' },
+        ],
+        paging: { total: 2 },
       });
 
     const setTimeoutSpy = runTimeoutsImmediately();
@@ -344,7 +514,7 @@ describe('useTestSuiteDetailsPage', () => {
   });
 
   it('should stop retrying stale rows after five attempts', async () => {
-    const { result } = renderHook(() => useTestSuiteDetailsPage());
+    const { result } = renderTestSuiteDetailsHook();
 
     await waitFor(() => {
       expect(result.current.testSuite).toEqual(mockTestSuite);
@@ -375,21 +545,27 @@ describe('useTestSuiteDetailsPage', () => {
         });
       });
 
-      expect(setTimeoutSpy).toHaveBeenCalledTimes(4);
+      expect(
+        setTimeoutSpy.mock.calls.filter(([, delay]) => delay === 500)
+      ).toHaveLength(4);
     } finally {
       setTimeoutSpy.mockRestore();
     }
 
-    expect(getListTestCaseBySearch).toHaveBeenCalledTimes(5);
+    expect(getListTestCaseBySearch).toHaveBeenCalledTimes(6);
     expect(result.current.pagingData.paging.total).toBe(2);
     expect(result.current.isTestCaseLoading).toBe(false);
   });
 
-  it('should use the suite relationship count when search paging is stale after bulk add', async () => {
-    const { result } = renderHook(() => useTestSuiteDetailsPage());
+  it('should use the suite relationship count for whitespace-only search after bulk add', async () => {
+    const { result } = renderTestSuiteDetailsHook();
 
     await waitFor(() => {
       expect(result.current.pagingData.paging.total).toBe(1);
+    });
+
+    await act(async () => {
+      await result.current.handleTestCaseSearch(' ');
     });
 
     let resolveOlderSearch!: (value: {
@@ -417,6 +593,10 @@ describe('useTestSuiteDetailsPage', () => {
     (getListTestCaseBySearch as jest.Mock)
       .mockImplementationOnce(() => olderSearch)
       .mockImplementationOnce(() => refreshedSearch)
+      .mockResolvedValueOnce({
+        data: [{ id: 'tc-9', name: 'tc_9' }],
+        paging: { total: 2 },
+      })
       .mockResolvedValueOnce({
         data: [{ id: 'tc-9', name: 'tc_9' }],
         paging: { total: 2 },
@@ -488,11 +668,15 @@ describe('useTestSuiteDetailsPage', () => {
   });
 
   it('should preserve a filtered search total after bulk add', async () => {
-    const { result } = renderHook(() => useTestSuiteDetailsPage());
+    const { result } = renderTestSuiteDetailsHook();
 
     await waitFor(() => {
       expect(result.current.testSuite).toEqual(mockTestSuite);
       expect(result.current.pagingData.paging.total).toBe(1);
+    });
+
+    await act(async () => {
+      await result.current.handleTestCaseSearch('tc_9');
     });
 
     (getTestSuiteByName as jest.Mock).mockResolvedValue({
@@ -505,12 +689,11 @@ describe('useTestSuiteDetailsPage', () => {
     (getListTestCaseBySearch as jest.Mock).mockClear();
     (getListTestCaseBySearch as jest.Mock)
       .mockResolvedValueOnce({
-        data: [{ id: 'tc-9', name: 'tc_9' }],
-        paging: { total: 1 },
-      })
-      .mockResolvedValueOnce({
-        data: [{ id: 'tc-9', name: 'tc_9' }],
-        paging: { total: 1 },
+        data: [
+          { id: 'tc-1', name: 'tc_1' },
+          { id: 'tc-9', name: 'tc_9' },
+        ],
+        paging: { total: 2 },
       })
       .mockResolvedValueOnce({
         data: [{ id: 'tc-9', name: 'tc_9' }],
@@ -531,19 +714,98 @@ describe('useTestSuiteDetailsPage', () => {
       setTimeoutSpy.mockRestore();
     }
 
-    expect(result.current.pagingData.paging.total).toBe(2);
-
-    await act(async () => {
-      await result.current.fetchTestCases({ q: 'tc_9' });
-    });
-
     expect(result.current.pagingData.paging.total).toBe(1);
+    expect(result.current.testCaseResult).toEqual([
+      expect.objectContaining({ id: 'tc-9' }),
+    ]);
+    expect(getListTestCaseBySearch).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ q: 'tc_9' }),
+      expect.any(Object)
+    );
+  });
 
-    await act(async () => {
-      await result.current.fetchTestCases();
+  it('should refresh the latest query after bulk indexing completes', async () => {
+    const { result } = renderTestSuiteDetailsHook();
+
+    await waitFor(() => {
+      expect(result.current.testSuite).toEqual(mockTestSuite);
     });
 
-    expect(result.current.pagingData.paging.total).toBe(2);
+    await act(async () => {
+      await result.current.handleTestCaseSearch('old_query');
+    });
+
+    (getTestSuiteByName as jest.Mock).mockResolvedValue({
+      ...mockTestSuite,
+      tests: [
+        { id: 'tc-1', type: 'testCase' },
+        { id: 'tc-9', type: 'testCase' },
+      ],
+    });
+
+    let resolveBulkRefresh!: (value: {
+      data: Array<{ id: string; name: string }>;
+      paging: { total: number };
+    }) => void;
+    const bulkRefresh = new Promise<{
+      data: Array<{ id: string; name: string }>;
+      paging: { total: number };
+    }>((resolve) => {
+      resolveBulkRefresh = resolve;
+    });
+
+    (getListTestCaseBySearch as jest.Mock).mockClear();
+    (getListTestCaseBySearch as jest.Mock)
+      .mockReturnValueOnce(bulkRefresh)
+      .mockResolvedValueOnce({
+        data: [],
+        paging: { total: 0 },
+      })
+      .mockResolvedValueOnce({
+        data: [{ id: 'tc-new', name: 'new_query' }],
+        paging: { total: 1 },
+      });
+
+    let addRequest!: Promise<void>;
+    act(() => {
+      addRequest = result.current.handleAddTestCaseSubmit({
+        selectAll: false,
+        includeIds: ['tc-9'],
+        excludeIds: [],
+      });
+    });
+
+    await waitFor(() => {
+      expect(getListTestCaseBySearch).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      await result.current.handleTestCaseSearch('new_query');
+    });
+
+    await waitFor(() => {
+      expect(result.current.testCaseResult).toEqual([]);
+    });
+
+    await act(async () => {
+      resolveBulkRefresh({
+        data: [
+          { id: 'tc-1', name: 'tc_1' },
+          { id: 'tc-9', name: 'tc_9' },
+        ],
+        paging: { total: 2 },
+      });
+      await addRequest;
+    });
+
+    expect(getListTestCaseBySearch).toHaveBeenCalledTimes(3);
+    expect(result.current.testCaseSearchQuery).toBe('new_query');
+    expect(result.current.testCaseResult).toEqual([
+      expect.objectContaining({ id: 'tc-new' }),
+    ]);
+    expect(result.current.pagingData.paging.total).toBe(1);
+    expect(result.current.isTestCaseLoading).toBe(false);
   });
 
   it('should ignore a bulk add that finishes after navigating to another suite', async () => {
@@ -562,7 +824,7 @@ describe('useTestSuiteDetailsPage', () => {
       })
     );
 
-    const { result, rerender } = renderHook(() => useTestSuiteDetailsPage());
+    const { result, rerender } = renderTestSuiteDetailsHook();
 
     await waitFor(() => {
       expect(result.current.testSuite?.fullyQualifiedName).toBe(
@@ -605,7 +867,7 @@ describe('useTestSuiteDetailsPage', () => {
   it('should surface suite fetch errors via toast', async () => {
     (getTestSuiteByName as jest.Mock).mockRejectedValueOnce(new Error('boom'));
 
-    const { result } = renderHook(() => useTestSuiteDetailsPage());
+    const { result } = renderTestSuiteDetailsHook();
 
     await waitFor(() => {
       expect(showErrorToast).toHaveBeenCalled();
@@ -614,8 +876,30 @@ describe('useTestSuiteDetailsPage', () => {
     expect(result.current.testSuite).toBeUndefined();
   });
 
+  it('should clear stale test cases when a new search fails', async () => {
+    const { result } = renderTestSuiteDetailsHook();
+
+    await waitFor(() => {
+      expect(result.current.testCaseResult).toHaveLength(1);
+    });
+
+    (getListTestCaseBySearch as jest.Mock).mockRejectedValueOnce(
+      new Error('search failed')
+    );
+
+    await act(async () => {
+      await result.current.handleTestCaseSearch('missing_test_case');
+    });
+
+    await waitFor(() => {
+      expect(showErrorToast).toHaveBeenCalled();
+    });
+
+    expect(result.current.testCaseResult).toEqual([]);
+  });
+
   it('should update a test case in place via handleTestSuiteUpdate', async () => {
-    const { result } = renderHook(() => useTestSuiteDetailsPage());
+    const { result } = renderTestSuiteDetailsHook();
 
     await waitFor(() => {
       expect(result.current.testCaseResult).toHaveLength(1);
@@ -628,6 +912,8 @@ describe('useTestSuiteDetailsPage', () => {
       } as never);
     });
 
-    expect(result.current.testCaseResult[0].name).toBe('tc_1_renamed');
+    await waitFor(() => {
+      expect(result.current.testCaseResult[0].name).toBe('tc_1_renamed');
+    });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/rest/queries/testSuiteQuery.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/queries/testSuiteQuery.ts
@@ -1,0 +1,76 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { TabSpecificField } from '../../enums/entity.enum';
+import { PipelineType } from '../../generated/entity/services/ingestionPipelines/ingestionPipeline';
+import { Include } from '../../generated/type/include';
+import { getIngestionPipelines } from '../ingestionPipelineAPI';
+import {
+  getListTestCaseBySearch,
+  getTestSuiteByName,
+  ListTestCaseParamsBySearch,
+} from '../testAPI';
+
+const TEST_SUITE_FIELDS = [
+  TabSpecificField.OWNERS,
+  TabSpecificField.DOMAINS,
+  TabSpecificField.TESTS,
+];
+
+export const TEST_SUITE_TEST_CASE_FIELDS = [
+  TabSpecificField.TEST_CASE_RESULT,
+  TabSpecificField.TEST_DEFINITION,
+  TabSpecificField.TESTSUITE,
+  TabSpecificField.INCIDENT_ID,
+  TabSpecificField.INCIDENT_STATUS,
+];
+
+export const testSuiteDetailsQueryKey = (testSuiteFQN: string) =>
+  ['testSuite', 'details', testSuiteFQN] as const;
+
+export const testSuiteDetailsQueryFn =
+  (testSuiteFQN: string) =>
+  ({ signal }: { signal: AbortSignal }) =>
+    getTestSuiteByName(
+      testSuiteFQN,
+      {
+        fields: TEST_SUITE_FIELDS,
+        include: Include.All,
+      },
+      { signal }
+    );
+
+export const testSuiteTestCasesQueryKeyPrefix = (testSuiteId: string) =>
+  ['testSuite', 'testCases', testSuiteId] as const;
+
+export const testSuiteTestCasesQueryKey = (
+  testSuiteId: string,
+  params: ListTestCaseParamsBySearch
+) => [...testSuiteTestCasesQueryKeyPrefix(testSuiteId), params] as const;
+
+export const testSuiteTestCasesQueryFn =
+  (params: ListTestCaseParamsBySearch) =>
+  ({ signal }: { signal: AbortSignal }) =>
+    getListTestCaseBySearch(params, { signal });
+
+export const testSuiteIngestionPipelinesQueryKey = (testSuiteFQN: string) =>
+  ['testSuite', 'ingestionPipelines', testSuiteFQN] as const;
+
+export const testSuiteIngestionPipelinesQueryFn =
+  (testSuiteFQN: string) => () =>
+    getIngestionPipelines({
+      arrQueryFields: [],
+      testSuite: testSuiteFQN,
+      pipelineType: [PipelineType.TestSuite],
+      limit: 0,
+    });

--- a/openmetadata-ui/src/main/resources/ui/src/rest/testAPI.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/testAPI.test.ts
@@ -141,6 +141,34 @@ describe('testAPI tests', () => {
         );
       });
 
+      it('should forward request cancellation to the search request', async () => {
+        const mockGet = jest
+          .fn()
+          .mockResolvedValue({ data: mockPagingResponse });
+        jest.mock('./index', () => ({
+          __esModule: true,
+          default: {
+            get: mockGet,
+          },
+        }));
+
+        const { getListTestCaseBySearch } = require('./testAPI');
+        const controller = new AbortController();
+
+        await getListTestCaseBySearch(
+          { testSuiteId: 'suite-id' },
+          { signal: controller.signal }
+        );
+
+        expect(mockGet).toHaveBeenCalledWith(
+          '/dataQuality/testCases/search/list',
+          {
+            params: { testSuiteId: 'suite-id' },
+            signal: controller.signal,
+          }
+        );
+      });
+
       it('should handle API errors', async () => {
         const error = new Error('API Error');
         const mockGet = jest.fn().mockRejectedValue(error);
@@ -955,6 +983,36 @@ describe('testAPI tests', () => {
         expect(mockGet).toHaveBeenCalledWith(expect.any(String), {
           params: { includeRelations: 'owners:all' },
         });
+      });
+
+      it('should forward request cancellation to the suite request', async () => {
+        const mockGet = jest.fn().mockResolvedValue({ data: mockTestSuite });
+        jest.mock('./index', () => ({
+          __esModule: true,
+          default: {
+            get: mockGet,
+          },
+        }));
+
+        const { getTestSuiteByName } = require('./testAPI');
+        const controller = new AbortController();
+
+        await getTestSuiteByName(
+          'test.suite.name',
+          { fields: ['owners'] },
+          { signal: controller.signal }
+        );
+
+        expect(mockGet).toHaveBeenCalledWith(
+          expect.stringContaining('/dataQuality/testSuites/name/'),
+          {
+            params: {
+              fields: ['owners'],
+              includeRelations: 'owners:non-deleted,experts:non-deleted',
+            },
+            signal: controller.signal,
+          }
+        );
       });
 
       it('should encode FQN with special characters', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/rest/testAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/testAPI.ts
@@ -148,7 +148,8 @@ const testDefinitionUrl = '/dataQuality/testDefinitions';
 
 // testCase section
 export const getListTestCaseBySearch = async (
-  params?: ListTestCaseParamsBySearch
+  params?: ListTestCaseParamsBySearch,
+  config?: { signal?: AbortSignal }
 ) => {
   // The search endpoint accepts comma-separated statuses, while Axios' default
   // array format uses brackets that the JAX-RS query parameter does not bind.
@@ -164,6 +165,7 @@ export const getListTestCaseBySearch = async (
     `${testCaseUrl}/search/list`,
     {
       params: serializedParams,
+      ...(config?.signal && { signal: config.signal }),
     }
   );
 
@@ -423,7 +425,8 @@ export const createExecutableTestSuite = async (data: CreateTestSuite) => {
 
 export const getTestSuiteByName = async (
   name: string,
-  params?: ListTestCaseParams
+  params?: ListTestCaseParams,
+  config?: { signal?: AbortSignal }
 ) => {
   const response = await APIClient.get<TestSuite>(
     `${testSuiteUrl}/name/${getEncodedFqn(name)}`,
@@ -437,6 +440,7 @@ export const getTestSuiteByName = async (
         includeRelations:
           params?.includeRelations ?? 'owners:non-deleted,experts:non-deleted',
       },
+      ...(config?.signal && { signal: config.signal }),
     }
   );
 


### PR DESCRIPTION
### Describe your changes:

Fixes #29026

Backports #32020 to the `2.0` branch.

The backport is a direct cherry-pick of the merged source PR.

Adds a debounced, server-side search input to bundle test suite details so users can find test cases across all pages. The applied query persists through pagination, sorting, deletion refreshes, and bulk-add index synchronization, while stale requests cannot overwrite newer results.

<img width="1507" height="543" alt="Test suite details search" src="https://github.com/user-attachments/assets/ce6bc074-6a46-480f-b0f0-bb20290f1b8d" />

#
### Type of change:

- [x] Improvement

#
### High-level design:

- Reuses the existing test-case search API with `testSuiteId` and `q`; no backend or schema changes are required.
- Keeps the debounced input value local while the suite details hook owns the applied query and pagination state.
- Uses non-committing index-total probes after bulk additions, then refetches the latest visible query once the search index reaches the suite's authoritative test count.

#
### Tests:

#### Use cases covered

- Search test cases from the suite table header with debounced, server-side results.
- Preserve the query through pagination, sorting, clearing, and suite navigation.
- Preserve filtered paging and the latest query while bulk-added test cases are being indexed.
- Verify the Playwright workflow sends the expected server-side search query.

#### Unit tests

- [x] Component, hook, utility, and REST tests cover the changed behavior.
- Local result: 4 suites and 117 tests passed.

#### Backend integration tests

- [x] Not applicable (no backend API changes).

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Updated `TestSuiteDetailsPage.spec.ts` to search for a suite and a test case while awaiting the corresponding server responses.

#
### UI screen recording / screenshots:

The expected search treatment is shown above.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR is linked to a GitHub issue via `Fixes #29026` above.
- [x] I have reviewed the explanatory comments and preserved the non-obvious synchronization rationale.
- [x] For JSON Schema changes: not applicable; no schema changes.
- [x] For UI changes: the source PR screenshot is included above.
- [x] Tests are included and local verification passed.

### Verification

- Focused Jest: 4 suites, 117 tests passed.
- Changed source and Playwright files: organize-imports, ESLint (0 errors), and Prettier.
- `yarn license-header-check`
- `yarn check-i18n`
- `git diff --check origin/2.0...HEAD`


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds debounced server-side searching to bundle test-suite details and migrates suite, test-case, and ingestion-pipeline reads to keyed React Query queries.

- Adds a searchable test-case table header with query-aware sorting and pagination.
- Adds cancellation-aware query functions and cache updates for suite details.
- Polls index totals after bulk additions and refreshes the active test-case query.
- Expands Jest and Playwright coverage for search and synchronization behavior.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The stale authoritative total after deleting a test case during bulk-index synchronization should be fixed before merging.

The new synchronization state can override the post-deletion indexed total indefinitely, leaving the suite tab and pagination with a count that no longer matches the actual test cases.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/hooks/useTestSuiteDetailsPage.tsx
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/hooks/useTestSuiteDetailsPage.tsx | Migrates suite-detail state to React Query and coordinates search and bulk-index synchronization, but can retain a stale authoritative total after deletion. |
| openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/TestSuiteDetailsPage.component.tsx | Adds the translated core Input search control to the test-case table header. |
| openmetadata-ui/src/main/resources/ui/src/rest/queries/testSuiteQuery.ts | Defines stable suite-detail, test-case, and ingestion-pipeline query keys and cancellation-aware query functions. |
| openmetadata-ui/src/main/resources/ui/src/rest/testAPI.ts | Adds optional AbortSignal forwarding to test-case search and suite-detail GET requests. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TestSuiteDetailsPage.spec.ts | Extends the bundle-suite workflow to exercise server-side test-case search. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as User
  participant H as Suite details hook
  participant Q as React Query
  participant API as Test-case search API
  U->>H: Enter search query
  H->>H: Reset page and offset
  H->>Q: Select key for suite, query, sort, and page
  Q->>API: Search test cases
  API-->>Q: Rows and paging total
  Q-->>H: Current scoped result
  H-->>U: Render table and pagination
  U->>H: Bulk-add test cases
  H->>API: Poll unfiltered indexed total
  H->>Q: Invalidate suite test-case queries
  Q->>API: Refetch active scoped query
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fixes 29026: Add search to test suite de..."](https://github.com/open-metadata/openmetadata/commit/d777ddaae2bed2cb2d34be96148cbd6724387c40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57472462)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Catalog discovery experience](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/catalog-discovery-experience.md)
- Knowledge Base — [UI foundations](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/ui-foundations.md)

<!-- /greptile_comment -->