### PR TITLE
fix(ci): restore the python pipeline on 1.13

### DIFF
--- a/.github/scripts/classify_test_outcome.py
+++ b/.github/scripts/classify_test_outcome.py
@@ -1,0 +1,267 @@
+"""Classify a CI test process from its exit state, JUnit reports, and diagnostics."""
+
+import argparse
+import glob
+import hashlib
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from xml.etree import ElementTree
+
+HANG_EXIT_CODES = {124}
+DIAGNOSTIC_SCAN_BYTES = 2 * 1024 * 1024
+HANG_PATTERN = re.compile(
+    r"\bTimeout\s+\(>\d+(?:\.\d+)?s\)\s+from\s+pytest-timeout\b|"
+    r"(?:\bfork(?:ed)?(?:\s+(?:process|vm))?\b|\btest process\b|\bcommand\b|\bprocess\b)"
+    r".{0,80}\b(?:timed out|timeout)\b|"
+    r"\b(?:timed out|timeout)\b.{0,80}"
+    r"(?:\bfork(?:ed)?(?:\s+(?:process|vm))?\b|\btest process\b|\bcommand\b|\bprocess\b)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _junit_counts(
+    report_files: list[Path],
+) -> tuple[dict[str, int], list[dict[str, str]], list[str]]:
+    totals = {"tests": 0, "failures": 0, "errors": 0, "skipped": 0}
+    failed_tests = []
+    parse_errors = []
+    for report_file in report_files:
+        try:
+            root = ElementTree.parse(report_file).getroot()
+        except (ElementTree.ParseError, OSError) as error:
+            parse_errors.append(f"{report_file}: {error}")
+            continue
+
+        test_cases = [
+            element for element in root.iter() if _local_name(element.tag) == "testcase"
+        ]
+        if test_cases:
+            totals["tests"] += len(test_cases)
+            for test_case in test_cases:
+                children_by_name = {
+                    _local_name(child.tag): child for child in test_case
+                }
+                child_names = set(children_by_name)
+                totals["failures"] += int("failure" in child_names)
+                totals["errors"] += int("error" in child_names)
+                totals["skipped"] += int("skipped" in child_names)
+                for failure_type in ("failure", "error"):
+                    failure = children_by_name.get(failure_type)
+                    if failure is None:
+                        continue
+                    class_name = test_case.attrib.get("classname", "")
+                    test_name = test_case.attrib.get("name", "")
+                    failed_tests.append(
+                        {
+                            "id": f"{class_name}#{test_name}",
+                            "className": class_name,
+                            "name": test_name,
+                            "type": failure_type,
+                            "message": failure.attrib.get("message", "")[:1000],
+                            "report": str(report_file),
+                        }
+                    )
+            continue
+
+        if _local_name(root.tag) in {"testsuite", "testsuites"}:
+            for key in totals:
+                try:
+                    totals[key] += int(root.attrib.get(key, "0"))
+                except ValueError:
+                    parse_errors.append(
+                        f"{report_file}: invalid {key} count {root.attrib.get(key)!r}"
+                    )
+    return totals, failed_tests, parse_errors
+
+
+def _contains_process_timeout(diagnostic_files: list[Path]) -> bool:
+    for diagnostic_file in diagnostic_files:
+        try:
+            with diagnostic_file.open("rb") as file_handle:
+                file_handle.seek(0, os.SEEK_END)
+                size = file_handle.tell()
+                file_handle.seek(0)
+                if size <= DIAGNOSTIC_SCAN_BYTES:
+                    raw_content = file_handle.read()
+                else:
+                    segment_size = DIAGNOSTIC_SCAN_BYTES // 2
+                    head = file_handle.read(segment_size)
+                    file_handle.seek(-segment_size, os.SEEK_END)
+                    raw_content = head + file_handle.read(segment_size)
+                content = raw_content.decode("utf-8", errors="replace")
+        except OSError:
+            continue
+        if HANG_PATTERN.search(content):
+            return True
+    return False
+
+
+def _file_manifest(files: list[Path]) -> list[dict[str, object]]:
+    manifest = []
+    for file_path in files:
+        try:
+            digest = hashlib.sha256(file_path.read_bytes()).hexdigest()
+            manifest.append(
+                {
+                    "path": str(file_path),
+                    "bytes": file_path.stat().st_size,
+                    "sha256": digest,
+                }
+            )
+        except OSError as error:
+            manifest.append({"path": str(file_path), "error": str(error)})
+    return manifest
+
+
+def classify_outcome(
+    step_outcome: str,
+    exit_code: int | None,
+    report_files: list[Path],
+    diagnostic_files: list[Path],
+) -> dict[str, object]:
+    tests, failed_tests, parse_errors = _junit_counts(report_files)
+    reasons = []
+
+    if step_outcome == "cancelled":
+        classification = "cancelled"
+        reasons.append("The test step was cancelled.")
+    elif exit_code in HANG_EXIT_CODES or (
+        step_outcome != "success" and _contains_process_timeout(diagnostic_files)
+    ):
+        classification = "hung_test"
+        reasons.append("The test process exceeded its bounded execution time.")
+    elif tests["failures"] + tests["errors"] > 0:
+        classification = "test_failure"
+        reasons.append("JUnit reported a test failure or error.")
+    elif parse_errors:
+        classification = "infrastructure_failure"
+        reasons.append("One or more JUnit reports could not be parsed.")
+    elif step_outcome == "success" and tests["tests"] == 0:
+        classification = "missing_results"
+        reasons.append("The test step succeeded without reporting any tests.")
+    elif step_outcome in {"failure", "skipped", "unknown", ""} and tests["tests"] == 0:
+        classification = "setup_failure"
+        reasons.append("The test process did not produce a test result.")
+    elif step_outcome != "success" or exit_code not in {None, 0}:
+        classification = "infrastructure_failure"
+        reasons.append("Tests did not fail, but the surrounding test process failed.")
+    else:
+        classification = "passed"
+        reasons.append("The test process and every reported test passed.")
+
+    return {
+        "schemaVersion": 1,
+        "classification": classification,
+        "stepOutcome": step_outcome,
+        "exitCode": exit_code,
+        "tests": tests,
+        "failedTests": failed_tests,
+        "reportCount": len(report_files),
+        "reports": _file_manifest(report_files),
+        "reportParseErrors": parse_errors,
+        "diagnostics": _file_manifest(diagnostic_files),
+        "reasons": reasons,
+    }
+
+
+def _expand_globs(patterns: list[str]) -> list[Path]:
+    return sorted(
+        {
+            Path(match)
+            for pattern in patterns
+            for match in glob.glob(pattern, recursive=True)
+            if Path(match).is_file()
+        },
+        key=str,
+    )
+
+
+def _parse_exit_code(value: str) -> int | None:
+    return int(value) if value.strip() else None
+
+
+def _source_sha() -> str:
+    try:
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return os.environ.get("GITHUB_SHA", "")
+
+
+def _summary(result: dict[str, object]) -> str:
+    tests = result["tests"]
+    context = result.get("context", {})
+    return "\n".join(
+        [
+            "### Test outcome classification",
+            "",
+            f"- Classification: `{result['classification']}`",
+            f"- Source SHA: `{context.get('sourceSha', '')}`",
+            f"- Profile/lane: `{context.get('profile', '')}` / `{context.get('lane', '')}`",
+            f"- Step outcome: `{result['stepOutcome']}`",
+            f"- Exit code: `{result['exitCode']}`",
+            f"- JUnit: {tests['tests']} tests, {tests['failures']} failures, "
+            f"{tests['errors']} errors, {tests['skipped']} skipped",
+            f"- Reports: {result['reportCount']}",
+            f"- Diagnostics: {len(result['diagnostics'])}",
+            f"- Reason: {result['reasons'][0]}",
+            "",
+        ]
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--step-outcome", required=True)
+    parser.add_argument("--exit-code", default="")
+    parser.add_argument("--report-glob", action="append", default=[])
+    parser.add_argument("--diagnostic-glob", action="append", default=[])
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--summary")
+    args = parser.parse_args()
+
+    report_files = _expand_globs(args.report_glob)
+    diagnostic_files = _expand_globs(args.diagnostic_glob)
+    result = classify_outcome(
+        args.step_outcome,
+        _parse_exit_code(args.exit_code),
+        report_files,
+        diagnostic_files,
+    )
+    result["context"] = {
+        "sourceSha": _source_sha(),
+        "profile": os.environ.get("TEST_PROFILE", ""),
+        "lane": os.environ.get("TEST_LANE", ""),
+        "runId": os.environ.get("GITHUB_RUN_ID", ""),
+        "runAttempt": os.environ.get("GITHUB_RUN_ATTEMPT", ""),
+    }
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    summary = _summary(result)
+    summary_path = args.summary or os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with Path(summary_path).open("a", encoding="utf-8") as summary_file:
+            summary_file.write(summary)
+    print(summary, end="")
+
+    return int(args.step_outcome == "success" and result["classification"] != "passed")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/configure_docker_storage.sh
+++ b/.github/scripts/configure_docker_storage.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly docker_root="/mnt/docker"
+readonly minimum_free_kb=$((32 * 1024 * 1024))
+
+if [[ ! -d /mnt ]]; then
+  echo "::error::The runner does not provide /mnt"
+  exit 1
+fi
+
+if [[ "$(stat -c '%d' /)" == "$(stat -c '%d' /mnt)" ]]; then
+  available_kb="$(df --output=avail -k / | tail -n 1)"
+  if ((available_kb < minimum_free_kb)); then
+    echo "::error::The runner root has ${available_kb} KiB free; ${minimum_free_kb} KiB is required"
+    df -h / /mnt
+    exit 1
+  fi
+
+  echo "The runner uses one filesystem with ${available_kb} KiB free; keeping the existing Docker root"
+  docker info --format 'Docker root: {{.DockerRootDir}}'
+  df -h / /mnt
+  exit 0
+fi
+
+daemon_config="$(mktemp)"
+trap 'rm -f "$daemon_config"' EXIT
+
+if sudo test -s /etc/docker/daemon.json; then
+  sudo jq --arg root "$docker_root" '. + {"data-root": $root}' \
+    /etc/docker/daemon.json | tee "$daemon_config" > /dev/null
+else
+  jq -n --arg root "$docker_root" '{"data-root": $root}' > "$daemon_config"
+fi
+
+sudo systemctl stop docker
+sudo rm -rf "$docker_root"
+sudo mkdir -p "$docker_root"
+sudo install -m 0644 "$daemon_config" /etc/docker/daemon.json
+sudo systemctl start docker
+
+actual_root="$(docker info --format '{{.DockerRootDir}}')"
+if [[ "$actual_root" != "$docker_root" ]]; then
+  echo "::error::Docker data root is $actual_root; expected $docker_root"
+  exit 1
+fi
+
+docker info --format 'Docker root: {{.DockerRootDir}}'
+df -h / /mnt

--- a/ingestion/.basedpyright/baseline.json
+++ b/ingestion/.basedpyright/baseline.json
@@ -2,18 +2,10 @@
     "files": {
         "./src/_openmetadata_testutils/factories/base/polymorphic_subfactory.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportPrivateImportUsage",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 12,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 25,
+                    "startColumn": 20,
+                    "endColumn": 30,
                     "lineCount": 1
                 }
             },
@@ -44,18 +36,18 @@
         ],
         "./src/_openmetadata_testutils/factories/base/root_model.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportPrivateImportUsage",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 14,
+                    "startColumn": 31,
+                    "endColumn": 38,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportIncompatibleVariableOverride",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 17,
+                    "startColumn": 10,
+                    "endColumn": 14,
                     "lineCount": 1
                 }
             },
@@ -71,6 +63,22 @@
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 33,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 29,
                     "endColumn": 39,
                     "lineCount": 1
                 }
@@ -118,20 +126,10 @@
         ],
         "./src/_openmetadata_testutils/factories/base/test_polymorphic_subfactory.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportPrivateImportUsage",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/_openmetadata_testutils/factories/base/test_root_model.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
+                    "startColumn": 25,
+                    "endColumn": 32,
                     "lineCount": 1
                 }
             },
@@ -140,6 +138,144 @@
                 "range": {
                     "startColumn": 10,
                     "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/_openmetadata_testutils/factories/base/test_root_model.py": [
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 35,
                     "lineCount": 1
                 }
             },
@@ -154,50 +290,10 @@
         ],
         "./src/_openmetadata_testutils/factories/metadata/generated/schema/api/classification/create_classification.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportPrivateImportUsage",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/_openmetadata_testutils/factories/metadata/generated/schema/api/classification/create_tag.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/_openmetadata_testutils/factories/metadata/generated/schema/entity/classification/classification.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/_openmetadata_testutils/factories/metadata/generated/schema/entity/classification/tag.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/_openmetadata_testutils/factories/metadata/generated/schema/entity/data/table.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
+                    "startColumn": 46,
+                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -206,6 +302,262 @@
                 "range": {
                     "startColumn": 10,
                     "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 49,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/_openmetadata_testutils/factories/metadata/generated/schema/api/classification/create_tag.py": [
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/_openmetadata_testutils/factories/metadata/generated/schema/entity/classification/classification.py": [
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 46,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/_openmetadata_testutils/factories/metadata/generated/schema/entity/classification/tag.py": [
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/_openmetadata_testutils/factories/metadata/generated/schema/entity/data/table.py": [
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 31,
                     "lineCount": 1
                 }
             },
@@ -220,10 +572,10 @@
         ],
         "./src/_openmetadata_testutils/factories/metadata/generated/schema/type/basic.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportPrivateImportUsage",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
+                    "startColumn": 19,
+                    "endColumn": 31,
                     "lineCount": 1
                 }
             },
@@ -262,20 +614,100 @@
         ],
         "./src/_openmetadata_testutils/factories/metadata/generated/schema/type/entity_reference.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportPrivateImportUsage",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
+                    "startColumn": 28,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 30,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 35,
                     "lineCount": 1
                 }
             }
         ],
         "./src/_openmetadata_testutils/factories/metadata/generated/schema/type/recognizer.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportPrivateImportUsage",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
+                    "startColumn": 29,
+                    "endColumn": 36,
                     "lineCount": 1
                 }
             },
@@ -284,16 +716,288 @@
                 "range": {
                     "startColumn": 10,
                     "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 27,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 42,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 42,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 39,
                     "lineCount": 1
                 }
             }
         ],
         "./src/_openmetadata_testutils/factories/metadata/generated/schema/type/tag_label.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportPrivateImportUsage",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
+                    "startColumn": 19,
+                    "endColumn": 32,
                     "lineCount": 1
                 }
             },
@@ -304,14 +1008,134 @@
                     "endColumn": 14,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 30,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/_openmetadata_testutils/factories/metadata/pii/models.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportPrivateImportUsage",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
+                    "startColumn": 31,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 28,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
                     "lineCount": 1
                 }
             }
@@ -370,14 +1194,6 @@
         ],
         "./src/_openmetadata_testutils/helpers/login_user.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 23,
@@ -413,38 +1229,6 @@
             }
         ],
         "./src/_openmetadata_testutils/kafka/load_csv_data.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -788,18 +1572,18 @@
         ],
         "./src/airflow_provider_openmetadata/hooks/openmetadata.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 23,
+                    "startColumn": 31,
+                    "endColumn": 39,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportReturnType",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 19,
+                    "startColumn": 15,
+                    "endColumn": 34,
                     "lineCount": 1
                 }
             },
@@ -930,10 +1714,66 @@
         ],
         "./src/airflow_provider_openmetadata/lineage/config/loader.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 26,
+                    "startColumn": 23,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 66,
                     "lineCount": 1
                 }
             },
@@ -946,10 +1786,18 @@
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 9,
-                    "endColumn": 30,
+                    "startColumn": 25,
+                    "endColumn": 17,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 72,
                     "lineCount": 1
                 }
             }
@@ -960,14 +1808,6 @@
                 "range": {
                     "startColumn": 5,
                     "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 36,
                     "lineCount": 1
                 }
             },
@@ -989,22 +1829,6 @@
             }
         ],
         "./src/airflow_provider_openmetadata/lineage/runner.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportUndefinedVariable",
                 "range": {
@@ -1170,14 +1994,6 @@
                 "range": {
                     "startColumn": 35,
                     "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 31,
                     "lineCount": 1
                 }
             },
@@ -1371,30 +2187,6 @@
                 "code": "reportMissingImports",
                 "range": {
                     "startColumn": 9,
-                    "endColumn": 16,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 9,
                     "endColumn": 36,
                     "lineCount": 1
                 }
@@ -1426,6 +2218,14 @@
             {
                 "code": "reportArgumentType",
                 "range": {
+                    "startColumn": 43,
+                    "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
                     "startColumn": 22,
                     "endColumn": 62,
                     "lineCount": 1
@@ -1436,6 +2236,14 @@
                 "range": {
                     "startColumn": 20,
                     "endColumn": 58,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 41,
                     "lineCount": 1
                 }
             },
@@ -3950,25 +4758,9 @@
                     "endColumn": 80,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/clients/domo_client.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportCallIssue",
                 "range": {
@@ -8718,56 +9510,8 @@
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOperatorIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOperatorIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 21,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 61,
-                    "endColumn": 70,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 23,
+                    "startColumn": 51,
+                    "endColumn": 81,
                     "lineCount": 1
                 }
             },
@@ -9112,70 +9856,6 @@
         ],
         "./src/metadata/great_expectations/action.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 8,
@@ -9188,6 +9868,14 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 49,
                     "lineCount": 1
                 }
             },
@@ -9228,6 +9916,70 @@
                 "range": {
                     "startColumn": 65,
                     "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -9290,26 +10042,10 @@
         ],
         "./src/metadata/great_expectations/action1xx.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportIncompatibleMethodOverride",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 43,
+                    "startColumn": 8,
+                    "endColumn": 11,
                     "lineCount": 1
                 }
             },
@@ -9398,6 +10134,70 @@
                 "range": {
                     "startColumn": 37,
                     "endColumn": 75,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -9982,6 +10782,14 @@
                 "range": {
                     "startColumn": 6,
                     "endColumn": 12,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 28,
                     "lineCount": 1
                 }
             },
@@ -10676,22 +11484,6 @@
                 "range": {
                     "startColumn": 19,
                     "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 88,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 67,
-                    "endColumn": 87,
                     "lineCount": 1
                 }
             },
@@ -13366,6 +14158,14 @@
                 "range": {
                     "startColumn": 31,
                     "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 54,
                     "lineCount": 1
                 }
             }
@@ -20106,10 +20906,10 @@
         ],
         "./src/metadata/ingestion/source/dashboard/domodashboard/connection.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 11,
+                    "startColumn": 21,
+                    "endColumn": 39,
                     "lineCount": 1
                 }
             },
@@ -21236,14 +22036,6 @@
         ],
         "./src/metadata/ingestion/source/dashboard/looker/bulk_parser.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 39,
@@ -21270,10 +22062,18 @@
         ],
         "./src/metadata/ingestion/source/dashboard/looker/columns.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 32,
+                    "startColumn": 16,
+                    "endColumn": 65,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 46,
                     "lineCount": 1
                 }
             },
@@ -21284,22 +22084,86 @@
                     "endColumn": 53,
                     "lineCount": 1
                 }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/looker/connection.py": [
+            },
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 17,
+                    "startColumn": 42,
+                    "endColumn": 52,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 33,
+                    "startColumn": 28,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 1,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 1,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOperatorIssue",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 74,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 1,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 1,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/dashboard/looker/connection.py": [
+            {
+                "code": "reportOptionalIterable",
+                "range": {
+                    "startColumn": 51,
+                    "endColumn": 87,
                     "lineCount": 1
                 }
             },
@@ -21313,54 +22177,6 @@
             }
         ],
         "./src/metadata/ingestion/source/dashboard/looker/metadata.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportUnreachable",
                 "range": {
@@ -21414,6 +22230,14 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 12,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAssignmentType",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 88,
                     "lineCount": 1
                 }
             },
@@ -21474,6 +22298,14 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 58,
+                    "endColumn": 80,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportReturnType",
                 "range": {
                     "startColumn": 19,
@@ -21486,6 +22318,38 @@
                 "range": {
                     "startColumn": 41,
                     "endColumn": 79,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 63,
+                    "endColumn": 80,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 42,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -21562,6 +22426,14 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 22,
@@ -21610,6 +22482,22 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 68,
+                    "endColumn": 78,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportReturnType",
                 "range": {
                     "startColumn": 31,
@@ -21618,10 +22506,26 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 58,
+                    "endColumn": 74,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
                     "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 45,
                     "lineCount": 1
                 }
             },
@@ -21690,11 +22594,35 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportOptionalIterable",
                 "range": {
-                    "startColumn": 18,
-                    "endColumn": 13,
-                    "lineCount": 7
+                    "startColumn": 32,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 71,
+                    "endColumn": 80,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 56,
+                    "lineCount": 1
                 }
             },
             {
@@ -21703,6 +22631,30 @@
                     "startColumn": 18,
                     "endColumn": 13,
                     "lineCount": 7
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 13,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 35,
+                    "lineCount": 1
                 }
             },
             {
@@ -21710,6 +22662,22 @@
                 "range": {
                     "startColumn": 45,
                     "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 49,
+                    "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 52,
+                    "endColumn": 71,
                     "lineCount": 1
                 }
             },
@@ -21722,10 +22690,26 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 61,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportReturnType",
                 "range": {
                     "startColumn": 31,
                     "endColumn": 74,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 59,
                     "lineCount": 1
                 }
             },
@@ -21858,6 +22842,14 @@
                 }
             },
             {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 54,
@@ -21886,6 +22878,14 @@
                 "range": {
                     "startColumn": 58,
                     "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 51,
                     "lineCount": 1
                 }
             },
@@ -21959,6 +22959,22 @@
                     "startColumn": 18,
                     "endColumn": 13,
                     "lineCount": 7
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 48,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 68,
+                    "endColumn": 80,
+                    "lineCount": 1
                 }
             },
             {
@@ -22106,6 +23122,30 @@
                 }
             },
             {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 49,
+                    "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 20,
@@ -22142,6 +23182,14 @@
                 "range": {
                     "startColumn": 14,
                     "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 48,
                     "lineCount": 1
                 }
             },
@@ -22252,6 +23300,14 @@
             {
                 "code": "reportArgumentType",
                 "range": {
+                    "startColumn": 25,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
                     "startColumn": 42,
                     "endColumn": 51,
                     "lineCount": 1
@@ -22330,10 +23386,66 @@
                 }
             },
             {
+                "code": "reportOptionalIterable",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 52,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 58,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 30,
                     "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 54,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             },
@@ -22359,6 +23471,30 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 7
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 13,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 21,
+                    "lineCount": 5
                 }
             },
             {
@@ -22418,6 +23554,22 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 66,
+                    "endColumn": 79,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalOperand",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 98,
@@ -22439,6 +23591,14 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 8
+                }
+            },
+            {
+                "code": "reportOptionalOperand",
+                "range": {
+                    "startColumn": 51,
+                    "endColumn": 64,
+                    "lineCount": 1
                 }
             },
             {
@@ -22493,14 +23653,6 @@
             }
         ],
         "./src/metadata/ingestion/source/dashboard/looker/parser.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
@@ -31204,14 +32356,6 @@
         ],
         "./src/metadata/ingestion/source/dashboard/ssrs/client.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 37,
@@ -32606,22 +33750,6 @@
         ],
         "./src/metadata/ingestion/source/dashboard/tableau/client.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 17,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 8,
@@ -32704,10 +33832,10 @@
         ],
         "./src/metadata/ingestion/source/dashboard/tableau/connection.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 26,
+                    "startColumn": 32,
+                    "endColumn": 51,
                     "lineCount": 1
                 }
             },
@@ -32764,6 +33892,14 @@
                 "range": {
                     "startColumn": 45,
                     "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 23,
                     "lineCount": 1
                 }
             }
@@ -33034,58 +34170,10 @@
                 }
             },
             {
-                "code": "reportUnreachable",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 67,
-                    "endColumn": 71,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
                     "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 58,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalIterable",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 72,
-                    "endColumn": 81,
                     "lineCount": 1
                 }
             },
@@ -33166,22 +34254,6 @@
                 "range": {
                     "startColumn": 34,
                     "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalIterable",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalIterable",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 51,
                     "lineCount": 1
                 }
             },
@@ -36500,10 +37572,10 @@
         ],
         "./src/metadata/ingestion/source/database/athena/metadata.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 29,
+                    "startColumn": 36,
+                    "endColumn": 55,
                     "lineCount": 1
                 }
             },
@@ -37099,14 +38171,6 @@
             }
         ],
         "./src/metadata/ingestion/source/database/athena/utils.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportUnusedFunction",
                 "range": {
@@ -39446,14 +40510,6 @@
         ],
         "./src/metadata/ingestion/source/database/bigquery/connection.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 41,
@@ -39537,7 +40593,15 @@
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 17,
-                    "endColumn": 27,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 35,
                     "lineCount": 1
                 }
             },
@@ -39672,24 +40736,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/bigquery/incremental_table_processor.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/bigquery/lineage.py": [
             {
                 "code": "reportArgumentType",
@@ -39701,14 +40747,6 @@
             }
         ],
         "./src/metadata/ingestion/source/database/bigquery/metadata.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -40096,16 +41134,16 @@
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 50,
+                    "startColumn": 31,
+                    "endColumn": 39,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 52,
-                    "endColumn": 63,
+                    "startColumn": 34,
+                    "endColumn": 45,
                     "lineCount": 1
                 }
             },
@@ -40884,14 +41922,6 @@
         ],
         "./src/metadata/ingestion/source/database/bigtable/client.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 10,
@@ -40949,14 +41979,6 @@
             }
         ],
         "./src/metadata/ingestion/source/database/bigtable/connection.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
@@ -41023,30 +42045,6 @@
             }
         ],
         "./src/metadata/ingestion/source/database/bigtable/metadata.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -41116,16 +42114,6 @@
                 "range": {
                     "startColumn": 55,
                     "endColumn": 58,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/bigtable/models.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 30,
                     "lineCount": 1
                 }
             }
@@ -41584,30 +42572,6 @@
         ],
         "./src/metadata/ingestion/source/database/cassandra/connection.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 19,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 43,
@@ -41636,6 +42600,14 @@
                 "range": {
                     "startColumn": 50,
                     "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 51,
+                    "endColumn": 78,
                     "lineCount": 1
                 }
             },
@@ -41700,6 +42672,14 @@
                 "range": {
                     "startColumn": 16,
                     "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 57,
+                    "endColumn": 64,
                     "lineCount": 1
                 }
             },
@@ -41784,30 +42764,6 @@
         ],
         "./src/metadata/ingestion/source/database/clickhouse/metadata.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 12,
@@ -41834,8 +42790,48 @@
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
+                    "startColumn": 38,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
                     "startColumn": 10,
                     "endColumn": 25,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 33,
                     "lineCount": 1
                 }
             },
@@ -42149,22 +43145,6 @@
             }
         ],
         "./src/metadata/ingestion/source/database/clickhouse/utils.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportUnusedFunction",
                 "range": {
@@ -44620,14 +45600,6 @@
         ],
         "./src/metadata/ingestion/source/database/column_type_parser.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportReturnType",
                 "range": {
                     "startColumn": 15,
@@ -44698,22 +45670,6 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 34,
                     "lineCount": 1
                 }
             }
@@ -45820,30 +46776,6 @@
         ],
         "./src/metadata/ingestion/source/database/couchbase/connection.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 31,
@@ -45852,10 +46784,18 @@
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 9,
-                    "endColumn": 26,
+                    "startColumn": 45,
+                    "endColumn": 65,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 48,
                     "lineCount": 1
                 }
             },
@@ -45938,14 +46878,6 @@
                 "range": {
                     "startColumn": 19,
                     "endColumn": 75,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 33,
                     "lineCount": 1
                 }
             },
@@ -47122,14 +48054,6 @@
         ],
         "./src/metadata/ingestion/source/database/databricks/metadata.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 4,
@@ -47670,6 +48594,62 @@
                 "range": {
                     "startColumn": 55,
                     "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 42,
                     "lineCount": 1
                 }
             },
@@ -48407,14 +49387,6 @@
             }
         ],
         "./src/metadata/ingestion/source/database/datalake/clients/azure_blob.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -49796,6 +50768,62 @@
                     "endColumn": 42,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/ingestion/source/database/dbt/dbt_config.py": [
@@ -50166,14 +51194,6 @@
                 "range": {
                     "startColumn": 35,
                     "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 48,
                     "lineCount": 1
                 }
             },
@@ -51300,14 +52320,6 @@
                 }
             },
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 20,
@@ -51526,22 +52538,6 @@
         ],
         "./src/metadata/ingestion/source/database/deltalake/clients/s3.py": [
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 12,
@@ -51698,6 +52694,14 @@
                 "range": {
                     "startColumn": 30,
                     "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 25,
                     "lineCount": 1
                 }
             },
@@ -52422,10 +53426,10 @@
         ],
         "./src/metadata/ingestion/source/database/domodatabase/connection.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 11,
+                    "startColumn": 21,
+                    "endColumn": 39,
                     "lineCount": 1
                 }
             },
@@ -53056,18 +54060,18 @@
         ],
         "./src/metadata/ingestion/source/database/doris/metadata.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 23,
+                    "startColumn": 13,
+                    "endColumn": 37,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 31,
+                    "startColumn": 33,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             },
@@ -53140,6 +54144,30 @@
                 "range": {
                     "startColumn": 54,
                     "endColumn": 61,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 24,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 27,
                     "lineCount": 1
                 }
             },
@@ -57610,14 +58638,6 @@
         ],
         "./src/metadata/ingestion/source/database/hive/connection.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 31,
@@ -57716,50 +58736,50 @@
         ],
         "./src/metadata/ingestion/source/database/hive/custom_hive_connection.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 38,
+                    "startColumn": 26,
+                    "endColumn": 40,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 31,
+                    "startColumn": 47,
+                    "endColumn": 55,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
+                    "startColumn": 4,
                     "endColumn": 16,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 5,
+                    "startColumn": 4,
+                    "endColumn": 15,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 4,
                     "endColumn": 16,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 16,
+                    "startColumn": 4,
+                    "endColumn": 17,
                     "lineCount": 1
                 }
             },
@@ -57910,24 +58930,16 @@
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 81,
+                    "startColumn": 48,
+                    "endColumn": 59,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 34,
+                    "startColumn": 54,
+                    "endColumn": 58,
                     "lineCount": 1
                 }
             }
@@ -57968,10 +58980,10 @@
         ],
         "./src/metadata/ingestion/source/database/hive/metadata.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 27,
+                    "startColumn": 32,
+                    "endColumn": 49,
                     "lineCount": 1
                 }
             },
@@ -58012,6 +59024,14 @@
                 "range": {
                     "startColumn": 75,
                     "endColumn": 82,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 69,
                     "lineCount": 1
                 }
             },
@@ -58658,14 +59678,6 @@
         ],
         "./src/metadata/ingestion/source/database/hive/utils.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 4,
@@ -59032,14 +60044,6 @@
         ],
         "./src/metadata/ingestion/source/database/impala/metadata.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 35,
@@ -59302,6 +60306,22 @@
                     "endColumn": 13,
                     "lineCount": 3
                 }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 42,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/ingestion/source/database/impala/service_spec.py": [
@@ -59470,22 +60490,6 @@
         ],
         "./src/metadata/ingestion/source/database/life_cycle_query_mixin.py": [
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 22,
@@ -59570,30 +60574,6 @@
                 "range": {
                     "startColumn": 27,
                     "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 53,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 51,
-                    "endColumn": 66,
                     "lineCount": 1
                 }
             },
@@ -63762,10 +64742,42 @@
         ],
         "./src/metadata/ingestion/source/database/mongodb/connection.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 12,
+                    "startColumn": 36,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 40,
                     "lineCount": 1
                 }
             },
@@ -63779,14 +64791,6 @@
             }
         ],
         "./src/metadata/ingestion/source/database/mongodb/metadata.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 19,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -66998,14 +68002,6 @@
                 }
             },
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 31,
@@ -67876,22 +68872,6 @@
         ],
         "./src/metadata/ingestion/source/database/oracle/connection.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 15,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 28,
@@ -68028,14 +69008,6 @@
                 "range": {
                     "startColumn": 10,
                     "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 34,
                     "lineCount": 1
                 }
             },
@@ -68816,14 +69788,6 @@
                 }
             },
             {
-                "code": "reportUnusedFunction",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 25,
@@ -68876,6 +69840,166 @@
                 "range": {
                     "startColumn": 81,
                     "endColumn": 83,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 65,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 69,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 52,
+                    "endColumn": 58,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 67,
+                    "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 57,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 72,
+                    "endColumn": 74,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 25,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 51,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 66,
+                    "endColumn": 68,
                     "lineCount": 1
                 }
             },
@@ -69243,14 +70367,6 @@
             }
         ],
         "./src/metadata/ingestion/source/database/pinotdb/metadata.py": [
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -75016,14 +76132,6 @@
         ],
         "./src/metadata/ingestion/source/database/presto/metadata.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 4,
@@ -75124,6 +76232,14 @@
                 "range": {
                     "startColumn": 67,
                     "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 51,
                     "lineCount": 1
                 }
             },
@@ -76502,18 +77618,18 @@
         ],
         "./src/metadata/ingestion/source/database/redshift/metadata.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 32,
+                    "startColumn": 10,
+                    "endColumn": 26,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 10,
-                    "endColumn": 26,
+                    "startColumn": 16,
+                    "endColumn": 38,
                     "lineCount": 1
                 }
             },
@@ -78988,6 +80104,38 @@
                     "endColumn": 24,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 27,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 27,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/ingestion/source/database/redshift/query_parser.py": [
@@ -79278,14 +80426,6 @@
         ],
         "./src/metadata/ingestion/source/database/redshift/utils.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUnusedFunction",
                 "range": {
                     "startColumn": 4,
@@ -79498,6 +80638,14 @@
                 "range": {
                     "startColumn": 36,
                     "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 6,
+                    "endColumn": 22,
                     "lineCount": 1
                 }
             },
@@ -80024,11 +81172,27 @@
         ],
         "./src/metadata/ingestion/source/database/salesforce/connection.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 26,
+                    "startColumn": 17,
+                    "endColumn": 79,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 55,
+                    "lineCount": 2
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 56,
+                    "lineCount": 2
                 }
             },
             {
@@ -85890,22 +87054,6 @@
         ],
         "./src/metadata/ingestion/source/database/snowflake/metadata.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 40,
@@ -85917,6 +87065,70 @@
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 42,
+                    "endColumn": 58,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 39,
                     "endColumn": 58,
                     "lineCount": 1
                 }
@@ -87988,18 +89200,26 @@
         ],
         "./src/metadata/ingestion/source/database/snowflake/utils.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 29,
                     "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 51,
                     "lineCount": 1
                 }
             },
@@ -89794,18 +91014,26 @@
         ],
         "./src/metadata/ingestion/source/database/teradata/metadata.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportFunctionMemberAccess",
                 "range": {
                     "startColumn": 12,
                     "endColumn": 21,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 38,
                     "lineCount": 1
                 }
             },
@@ -97392,14 +98620,6 @@
         ],
         "./src/metadata/ingestion/source/database/vertica/metadata.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 4,
@@ -97588,6 +98808,30 @@
                 "range": {
                     "startColumn": 49,
                     "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 37,
                     "lineCount": 1
                 }
             },
@@ -101558,22 +102802,6 @@
         ],
         "./src/metadata/ingestion/source/drive/sftp/connection.py": [
             {
-                "code": "reportMissingModuleSource",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 15,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingModuleSource",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 13,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 31,
@@ -102182,54 +103410,6 @@
         ],
         "./src/metadata/ingestion/source/messaging/common_broker_source.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 41,
@@ -102446,6 +103626,14 @@
                 }
             },
             {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 31,
@@ -102526,6 +103714,14 @@
                 }
             },
             {
+                "code": "reportUnusedExcept",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 25,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 22,
@@ -102543,38 +103739,6 @@
             }
         ],
         "./src/metadata/ingestion/source/messaging/kafka/connection.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -103174,22 +104338,6 @@
         ],
         "./src/metadata/ingestion/source/messaging/pubsub/connection.py": [
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 45,
@@ -103199,22 +104347,6 @@
             }
         ],
         "./src/metadata/ingestion/source/messaging/pubsub/metadata.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
@@ -104442,18 +105574,10 @@
         ],
         "./src/metadata/ingestion/source/metadata/amundsen/client.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 12,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 10,
+                    "startColumn": 17,
+                    "endColumn": 57,
                     "lineCount": 1
                 }
             }
@@ -107074,6 +108198,14 @@
                 }
             },
             {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 48,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 26,
@@ -107227,30 +108359,6 @@
             }
         ],
         "./src/metadata/ingestion/source/pipeline/airflow/connection.py": [
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -107439,62 +108547,6 @@
             }
         ],
         "./src/metadata/ingestion/source/pipeline/airflow/metadata.py": [
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 57,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -108600,6 +109652,14 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 58,
@@ -108692,6 +109752,22 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 36,
                     "lineCount": 1
                 }
             },
@@ -109035,22 +110111,6 @@
             }
         ],
         "./src/metadata/ingestion/source/pipeline/dagster/client.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportArgumentType",
                 "range": {
@@ -110604,10 +111664,18 @@
         ],
         "./src/metadata/ingestion/source/pipeline/domopipeline/connection.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportReturnType",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 11,
+                    "startColumn": 15,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 41,
                     "lineCount": 1
                 }
             },
@@ -111058,40 +112126,8 @@
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
                     "startColumn": 39,
                     "endColumn": 62,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 69,
-                    "endColumn": 79,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 69,
-                    "endColumn": 79,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 65,
-                    "endColumn": 75,
                     "lineCount": 1
                 }
             },
@@ -111658,14 +112694,6 @@
         ],
         "./src/metadata/ingestion/source/pipeline/kafkaconnect/client.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 70,
@@ -111686,6 +112714,14 @@
                 "range": {
                     "startColumn": 94,
                     "endColumn": 110,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 66,
+                    "endColumn": 76,
                     "lineCount": 1
                 }
             },
@@ -111718,6 +112754,14 @@
                 "range": {
                     "startColumn": 21,
                     "endColumn": 25,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 87,
                     "lineCount": 1
                 }
             },
@@ -113102,86 +114146,6 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 29,
-                    "lineCount": 8
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 72,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 29,
-                    "lineCount": 8
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 72,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 85,
-                    "endColumn": 106,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 104,
-                    "endColumn": 111,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 135,
-                    "endColumn": 142,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportReturnType",
                 "range": {
                     "startColumn": 31,
@@ -113708,6 +114672,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 40,
@@ -114004,22 +114976,6 @@
         ],
         "./src/metadata/ingestion/source/pipeline/openlineage/connection.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 56,
@@ -114030,80 +114986,8 @@
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 57,
-                    "endColumn": 62,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 65,
+                    "startColumn": 64,
                     "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 57,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 70,
-                    "endColumn": 75,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 67,
                     "lineCount": 1
                 }
             },
@@ -114464,8 +115348,16 @@
             {
                 "code": "reportOperatorIssue",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 52,
+                    "startColumn": 23,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOperatorIssue",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 75,
                     "lineCount": 1
                 }
             },
@@ -115230,14 +116122,6 @@
         ],
         "./src/metadata/ingestion/source/search/elasticsearch/connection.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 19,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 21,
@@ -115518,6 +116402,14 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 45,
@@ -115527,14 +116419,6 @@
             }
         ],
         "./src/metadata/ingestion/source/search/elasticsearch/metadata.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 19,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportArgumentType",
                 "range": {
@@ -115592,6 +116476,14 @@
                 }
             },
             {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -115644,6 +116536,14 @@
                 "range": {
                     "startColumn": 45,
                     "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 35,
                     "lineCount": 1
                 }
             },
@@ -115781,14 +116681,6 @@
             }
         ],
         "./src/metadata/ingestion/source/search/opensearch/connection.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 17,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportArgumentType",
                 "range": {
@@ -116054,6 +116946,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 45,
@@ -116063,14 +116963,6 @@
             }
         ],
         "./src/metadata/ingestion/source/search/opensearch/metadata.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 17,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportArgumentType",
                 "range": {
@@ -116128,6 +117020,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 51,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -116180,6 +117080,30 @@
                 "range": {
                     "startColumn": 41,
                     "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 20,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 31,
                     "lineCount": 1
                 }
             },
@@ -117836,18 +118760,18 @@
         ],
         "./src/metadata/ingestion/source/storage/gcs/client.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 10,
                     "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 48,
                     "lineCount": 1
                 }
             },
@@ -117902,14 +118826,6 @@
         ],
         "./src/metadata/ingestion/source/storage/gcs/connection.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 60,
@@ -117926,6 +118842,46 @@
                 }
             },
             {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 45,
@@ -117935,14 +118891,6 @@
             }
         ],
         "./src/metadata/ingestion/source/storage/gcs/metadata.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -118940,6 +119888,14 @@
                 "range": {
                     "startColumn": 29,
                     "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 46,
                     "lineCount": 1
                 }
             },
@@ -119996,34 +120952,18 @@
         ],
         "./src/metadata/profiler/adaptors/mongodb.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 16,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUnusedParameter",
                 "range": {
                     "startColumn": 28,
                     "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 51,
                     "lineCount": 1
                 }
             },
@@ -120850,14 +121790,6 @@
         ],
         "./src/metadata/profiler/interface/sqlalchemy/athena/profiler_interface.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 38,
@@ -121186,14 +122118,6 @@
                 "range": {
                     "startColumn": 52,
                     "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 43,
                     "lineCount": 1
                 }
             },
@@ -124504,22 +125428,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 9,
-                    "lineCount": 3
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 80,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 27,
@@ -125314,22 +126222,6 @@
                     "endColumn": 64,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/profiler/orm/converter/snowflake/converter.py": [
@@ -125350,18 +126242,10 @@
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportReturnType",
                 "range": {
-                    "startColumn": 17,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 33,
+                    "startColumn": 12,
+                    "endColumn": 19,
                     "lineCount": 1
                 }
             }
@@ -129566,14 +130450,6 @@
                     "endColumn": 45,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/profiler/source/database/mariadb/functions/median.py": [
@@ -130550,14 +131426,6 @@
                 "range": {
                     "startColumn": 61,
                     "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 41,
                     "lineCount": 1
                 }
             }
@@ -131560,26 +132428,10 @@
                 }
             },
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 26,
                     "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 22,
                     "lineCount": 1
                 }
             },
@@ -131618,26 +132470,10 @@
                 }
             },
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 26,
                     "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 23,
                     "lineCount": 1
                 }
             },
@@ -131674,14 +132510,6 @@
                 }
             },
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 15,
@@ -131690,18 +132518,18 @@
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 13,
-                    "endColumn": 18,
+                    "startColumn": 55,
+                    "endColumn": 73,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 55,
-                    "endColumn": 73,
+                    "startColumn": 25,
+                    "endColumn": 70,
                     "lineCount": 1
                 }
             },
@@ -131734,6 +132562,86 @@
                 "range": {
                     "startColumn": 59,
                     "endColumn": 70,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
                     "lineCount": 1
                 }
             },
@@ -131986,14 +132894,6 @@
                 }
             },
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUndefinedVariable",
                 "range": {
                     "startColumn": 26,
@@ -132042,26 +132942,18 @@
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 13,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 18,
+                    "startColumn": 55,
+                    "endColumn": 73,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 55,
-                    "endColumn": 73,
+                    "startColumn": 25,
+                    "endColumn": 70,
                     "lineCount": 1
                 }
             },
@@ -132094,6 +132986,86 @@
                 "range": {
                     "startColumn": 59,
                     "endColumn": 70,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
                     "lineCount": 1
                 }
             },
@@ -132116,14 +133088,6 @@
                 }
             },
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 31,
@@ -132140,22 +133104,6 @@
                 }
             },
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportReturnType",
                 "range": {
                     "startColumn": 19,
@@ -132164,26 +133112,18 @@
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 13,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 20,
+                    "startColumn": 55,
+                    "endColumn": 73,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 55,
-                    "endColumn": 73,
+                    "startColumn": 25,
+                    "endColumn": 70,
                     "lineCount": 1
                 }
             },
@@ -132220,6 +133160,86 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportReturnType",
                 "range": {
                     "startColumn": 19,
@@ -132232,14 +133252,6 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 19,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 20,
                     "lineCount": 1
                 }
             },
@@ -132266,22 +133278,6 @@
                 "range": {
                     "startColumn": 7,
                     "endColumn": 9,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 17,
                     "lineCount": 1
                 }
             },
@@ -132606,14 +133602,6 @@
                 }
             },
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 55,
@@ -132654,6 +133642,14 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 74,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 48,
@@ -132682,6 +133678,86 @@
                 "range": {
                     "startColumn": 63,
                     "endColumn": 74,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 33,
                     "lineCount": 1
                 }
             },
@@ -133708,6 +134784,14 @@
                 "range": {
                     "startColumn": 49,
                     "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 36,
                     "lineCount": 1
                 }
             },
@@ -138910,14 +139994,6 @@
                 }
             },
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 41,
@@ -138988,10 +140064,10 @@
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 9,
-                    "endColumn": 30,
+                    "startColumn": 21,
+                    "endColumn": 34,
                     "lineCount": 1
                 }
             },
@@ -139038,10 +140114,10 @@
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 9,
-                    "endColumn": 30,
+                    "startColumn": 58,
+                    "endColumn": 68,
                     "lineCount": 1
                 }
             },
@@ -139071,14 +140147,6 @@
             }
         ],
         "./src/metadata/utils/secrets/kubernetes_secrets_manager.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {

--- a/ingestion/.basedpyright/baseline.json
+++ b/ingestion/.basedpyright/baseline.json
@@ -1156,6 +1156,30 @@
                     "endColumn": 27,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportGeneralTypeIssues",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportGeneralTypeIssues",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 27,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/_openmetadata_testutils/helpers/docker.py": [
@@ -7200,6 +7224,14 @@
                 }
             },
             {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 33,
@@ -9856,6 +9888,14 @@
         ],
         "./src/metadata/great_expectations/action.py": [
             {
+                "code": "reportIncompatibleMethodOverride",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 12,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 8,
@@ -9868,6 +9908,14 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 49,
                     "lineCount": 1
                 }
             },
@@ -9930,8 +9978,24 @@
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
+                    "startColumn": 33,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
                     "startColumn": 50,
                     "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 46,
                     "lineCount": 1
                 }
             },
@@ -9962,8 +10026,24 @@
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
+                    "startColumn": 33,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
                     "startColumn": 50,
                     "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 46,
                     "lineCount": 1
                 }
             },
@@ -9988,6 +10068,14 @@
                 "range": {
                     "startColumn": 47,
                     "endColumn": 68,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAssignmentType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 62,
                     "lineCount": 1
                 }
             },
@@ -10148,8 +10236,24 @@
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
+                    "startColumn": 33,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
                     "startColumn": 50,
                     "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 46,
                     "lineCount": 1
                 }
             },
@@ -10180,8 +10284,24 @@
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
+                    "startColumn": 33,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
                     "startColumn": 50,
                     "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 46,
                     "lineCount": 1
                 }
             },
@@ -16774,6 +16894,30 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 51,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 60,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalCall",
                 "range": {
                     "startColumn": 47,
@@ -16810,7 +16954,7 @@
         ],
         "./src/metadata/ingestion/ometa/utils.py": [
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportPrivateImportUsage",
                 "range": {
                     "startColumn": 27,
                     "endColumn": 32,
@@ -21240,6 +21384,22 @@
                 }
             },
             {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportReturnType",
                 "range": {
                     "startColumn": 29,
@@ -24645,14 +24805,6 @@
             }
         ],
         "./src/metadata/ingestion/source/dashboard/mode/client.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -33906,7 +34058,7 @@
         ],
         "./src/metadata/ingestion/source/dashboard/tableau/metadata.py": [
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportPrivateImportUsage",
                 "range": {
                     "startColumn": 27,
                     "endColumn": 35,
@@ -50816,14 +50968,6 @@
                     "endColumn": 43,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/database/dbt/dbt_config.py": [
@@ -50864,6 +51008,30 @@
                 "range": {
                     "startColumn": 1,
                     "endColumn": 25,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 43,
+                    "endColumn": 54,
                     "lineCount": 1
                 }
             },
@@ -88776,14 +88944,6 @@
         ],
         "./src/metadata/ingestion/source/database/snowflake/models.py": [
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 13,
@@ -98830,8 +98990,24 @@
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
+                    "startColumn": 37,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
                     "startColumn": 15,
                     "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 52,
                     "lineCount": 1
                 }
             },
@@ -102176,6 +102352,14 @@
                 "range": {
                     "startColumn": 56,
                     "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 81,
                     "lineCount": 1
                 }
             },
@@ -114672,14 +114856,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 40,
@@ -118850,10 +119026,26 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 37,
                     "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 54,
                     "lineCount": 1
                 }
             },
@@ -123556,6 +123748,30 @@
                 }
             },
             {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 65,
+                    "endColumn": 77,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 65,
+                    "endColumn": 77,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 65,
+                    "endColumn": 77,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOperatorIssue",
                 "range": {
                     "startColumn": 12,
@@ -123566,8 +123782,24 @@
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 27,
+                    "startColumn": 61,
+                    "endColumn": 73,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 61,
+                    "endColumn": 73,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 61,
+                    "endColumn": 73,
                     "lineCount": 1
                 }
             }
@@ -124092,6 +124324,46 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 58,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 42,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportGeneralTypeIssues",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 52,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 28,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -124558,6 +124830,46 @@
                 "range": {
                     "startColumn": 58,
                     "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 58,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 42,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportGeneralTypeIssues",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 52,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 28,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 42,
                     "lineCount": 1
                 }
             },
@@ -125152,6 +125464,222 @@
                     "endColumn": 77,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 66,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 66,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 66,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 66,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 66,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 66,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 66,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 66,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 66,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 66,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 66,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOperatorIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportGeneralTypeIssues",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOperatorIssue",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 65,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/profiler/metrics/static/sum.py": [
@@ -125736,6 +126264,14 @@
                 }
             },
             {
+                "code": "reportGeneralTypeIssues",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 52,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 55,
@@ -126042,6 +126578,14 @@
                 "range": {
                     "startColumn": 61,
                     "endColumn": 65,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportGeneralTypeIssues",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 52,
                     "lineCount": 1
                 }
             },
@@ -132486,6 +133030,14 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 38,
@@ -137380,6 +137932,14 @@
                     "endColumn": 21,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 25,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/utils/custom_thread_pool.py": [
@@ -137691,6 +138251,14 @@
             }
         ],
         "./src/metadata/utils/entity_link.py": [
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -140102,6 +140670,14 @@
                 "range": {
                     "startColumn": 21,
                     "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 58,
+                    "endColumn": 68,
                     "lineCount": 1
                 }
             },

--- a/ingestion/.dockerignore
+++ b/ingestion/.dockerignore
@@ -1,0 +1,12 @@
+# Applies only to builds whose context is ingestion/ (currently the Airflow test image).
+# Dockerfile.ci builds from the repository root and uses the top-level .dockerignore.
+build/
+dist/
+tests/
+examples/
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+**/__pycache__/
+**/*.py[cod]

--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -445,7 +445,7 @@ dev = {
     "pre-commit",
     "pycln",
     "pylint~=3.2.0",  # 3.3.0+ breaks our current linting
-    "basedpyright~=1.39.0",
+    "basedpyright==1.39.3",
     # For publishing
     "twine",
     "build",

--- a/ingestion/tests/integration/airflow/Dockerfile
+++ b/ingestion/tests/integration/airflow/Dockerfile
@@ -1,0 +1,40 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Airflow carrying the working tree's OpenMetadata lineage provider. Build context is
+# ingestion/, so src/metadata/generated must already exist (make generate).
+
+FROM apache/airflow:3.3.0-python3.10
+
+USER airflow
+COPY --chown=airflow:0 . /tmp/ingestion
+
+# airflow-constraints-3.3.0.txt is deliberately NOT applied: it pins chardet==7.5.1
+# against openmetadata-ingestion's chardet==4.0.0. Dockerfile.ci installs the package
+# unconstrained for the same reason. apache-airflow is pinned so the resolver cannot move it.
+RUN pip install --no-cache-dir uv \
+ && uv pip install --no-cache "apache-airflow==3.3.0" /tmp/ingestion \
+ && rm -rf /tmp/ingestion
+
+# Migrating at build time keeps container start to a few seconds.
+RUN airflow db migrate \
+ && echo '{"admin": "admin"}' > /opt/airflow/simple_auth_manager_passwords.json
+
+# A file, not a `bash -c` string: passing a multi-line command through the container
+# runtime mangles the newlines and bash silently starts nothing.
+RUN printf '%s\n' \
+      '#!/usr/bin/env bash' \
+      'set -e' \
+      'airflow dag-processor &' \
+      'airflow scheduler &' \
+      'exec airflow api-server --port 8080' \
+      > /opt/airflow/start-test-airflow.sh \
+ && chmod +x /opt/airflow/start-test-airflow.sh

--- a/ingestion/tests/integration/airflow/conftest.py
+++ b/ingestion/tests/integration/airflow/conftest.py
@@ -1,0 +1,174 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Airflow container fixtures.
+
+Runs Airflow with the OpenMetadata lineage provider in a testcontainer, so the suite owns
+its own DAGs and connections instead of depending on the compose ingestion service.
+"""
+
+import json
+import shutil
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+import requests
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.docker_client import DockerClient
+
+AIRFLOW_BASE_IMAGE = "apache/airflow:3.3.0-python3.10"
+AIRFLOW_TEST_IMAGE = "om-airflow-lineage-test:local"
+
+# Fixed network name declared by docker/development/docker-compose.yml, so the container
+# resolves `openmetadata-server` exactly as the OM connection below expects.
+OM_NETWORK = "ometa_network"
+OM_SERVER_HOST = "openmetadata-server"
+OM_SERVER_PORT = 8585
+
+AIRFLOW_ADMIN = "admin"
+OM_CONNECTION_ID = "openmetadata_conn_id"
+OM_JWT = (
+    "eyJraWQiOiJHYjM4OWEtOWY3Ni1nZGpzLWE5MmotMDI0MmJrOTQzNTYiLCJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9"
+    ".eyJzdWIiOiJhZG1pbiIsImlzQm90IjpmYWxzZSwiaXNzIjoib3Blbi1tZXRhZGF0YS5vcmciLCJpYXQiOjE2NjM5Mzg0"
+    "NjIsImVtYWlsIjoiYWRtaW5Ab3Blbm1ldGFkYXRhLm9yZyJ9.tS8um_5DKu7HgzGBzS1VTA5uUjKWOCU0B_j08WXBiEC0"
+    "mr0zNREkqVfwFDD-d24HlNEbrqioLsBuFRiwIWKc1m_ZlVQbG7P36RUxhuv2vbSp80FKyNM-Tj93FDzq91jsyNmsQhyNv"
+    "_fNr3TXfzzSPjHt8Go0FMMP66weoKMgW2PbXlhVKwEuXUHyakLLzewm9UMeQaEiRzhiTMU3UkLXcKbYEJJvfNFcLwSl9W"
+    "8JCO_l0Yj3ud-qt_nQYEZwqW6u5nfdQllN133iikV4fM5QZsMCnm8Rq1mvLR0y9bmJiD7fwM1tmJ791TUWqmKaTnP49U4"
+    "93VanKpUAfzIiOiIbhg"
+)
+
+_DOCKERFILE = "tests/integration/airflow/Dockerfile"
+
+# A list, and via bash: the base image's entrypoint prefixes anything it does not
+# recognise with `airflow`, and a single string would be re-split by the runtime.
+_START_AIRFLOW = ["bash", "/opt/airflow/start-test-airflow.sh"]
+
+
+def _ingestion_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _auth_token(host: str, port: str) -> str | None:
+    """Airflow JWT for the admin user, or None while the API is still starting."""
+    try:
+        response = requests.post(
+            f"http://{host}:{port}/auth/token",
+            json={"username": AIRFLOW_ADMIN, "password": AIRFLOW_ADMIN},
+            timeout=10,
+        )
+    except requests.RequestException:
+        return None
+    return (
+        response.json().get("access_token")
+        if response.status_code in (200, 201)
+        else None
+    )
+
+
+def _wait_for_airflow_api(container, timeout: int = 420) -> None:
+    """Block until the Airflow API issues tokens. Raises TimeoutError otherwise."""
+    host = container.get_container_host_ip()
+    port = container.get_exposed_port(8080)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if _auth_token(host, port):
+            return
+        time.sleep(5)
+
+    stdout, stderr = container.get_logs()
+    raise TimeoutError(
+        f"Airflow API did not become ready within {timeout}s.\n"
+        f"--- container stdout ---\n{stdout.decode(errors='replace')[-4000:]}\n"
+        f"--- container stderr ---\n{stderr.decode(errors='replace')[-4000:]}"
+    )
+
+
+@pytest.fixture(scope="session")
+def airflow_image():
+    """Build the Airflow image carrying the working tree's lineage provider."""
+    DockerClient().client.images.build(
+        path=str(_ingestion_root()),
+        dockerfile=_DOCKERFILE,
+        tag=AIRFLOW_TEST_IMAGE,
+        rm=True,
+    )
+    return AIRFLOW_TEST_IMAGE
+
+
+@pytest.fixture(scope="module")
+def airflow_dag_dir():
+    """Host directory mounted as the Airflow DAG folder; tests write their DAGs here."""
+    # Not tmp_path_factory: its 0700 dirs are unreadable to the container's airflow user
+    # on Linux, and Docker Desktop's uid translation hides that everywhere but CI.
+    dag_dir = Path(tempfile.mkdtemp(prefix="airflow_dags_"))
+    dag_dir.chmod(0o755)
+
+    yield dag_dir
+
+    shutil.rmtree(dag_dir, ignore_errors=True)
+
+
+@pytest.fixture(scope="module")
+def airflow_container(airflow_image, airflow_dag_dir):
+    """Airflow reachable on the host, joined to the OpenMetadata compose network."""
+    connection = json.dumps(
+        {
+            "conn_type": "openmetadata",
+            "host": OM_SERVER_HOST,
+            "schema": "http",
+            "port": OM_SERVER_PORT,
+            "password": OM_JWT,
+        }
+    )
+
+    container = (
+        DockerContainer(AIRFLOW_TEST_IMAGE)
+        .with_kwargs(network=OM_NETWORK)
+        .with_exposed_ports(8080)
+        .with_volume_mapping(str(airflow_dag_dir), "/opt/airflow/dags", "ro")
+        .with_env("AIRFLOW__CORE__EXECUTOR", "LocalExecutor")
+        .with_env("AIRFLOW__CORE__LOAD_EXAMPLES", "False")
+        .with_env("AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_USERS", f"{AIRFLOW_ADMIN}:admin")
+        .with_env(
+            "AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_PASSWORDS_FILE",
+            "/opt/airflow/simple_auth_manager_passwords.json",
+        )
+        # Default is 300s; a DAG written after start would otherwise take 5 minutes to appear.
+        .with_env("AIRFLOW__DAG_PROCESSOR__REFRESH_INTERVAL", "5")
+        .with_env(f"AIRFLOW_CONN_{OM_CONNECTION_ID.upper()}", connection)
+        .with_command(_START_AIRFLOW)
+    )
+
+    with container:
+        _wait_for_airflow_api(container)
+        yield container
+
+
+@pytest.fixture(scope="module")
+def airflow_api(airflow_container):
+    """Base URL of the Airflow REST API as seen from the host."""
+    host = airflow_container.get_container_host_ip()
+    port = airflow_container.get_exposed_port(8080)
+    return f"http://{host}:{port}/api/v2"
+
+
+@pytest.fixture(scope="module")
+def airflow_headers(airflow_container):
+    """Authorization headers carrying a freshly minted Airflow JWT."""
+    token = _auth_token(
+        airflow_container.get_container_host_ip(),
+        airflow_container.get_exposed_port(8080),
+    )
+    assert token, "Airflow refused to issue a token"
+
+    return {"Content-Type": "application/json", "Authorization": f"Bearer {token}"}

--- a/ingestion/tests/integration/airflow/test_airflow_lineage.py
+++ b/ingestion/tests/integration/airflow/test_airflow_lineage.py
@@ -8,19 +8,17 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
 """
-Test airflow lineage operator and hook.
+Validate that the OpenMetadata Lineage Operator ingests a DAG run and its inlets/outlets.
 
-This test is coupled with the example DAG `lineage_tutorial_operator`.
-
-With the `docker compose up` setup, you can debug the progress
-by setting breakpoints in this file.
+The DAG, the Airflow connection and the OpenMetadata entities are all created here, so the
+suite depends on nothing beyond a reachable OpenMetadata server.
 """
+
 import time
-from typing import Optional
-from unittest import TestCase
+from datetime import datetime, timezone
 
+import pytest
 import requests
 
 from metadata.generated.schema.api.data.createDatabase import CreateDatabaseRequest
@@ -28,68 +26,73 @@ from metadata.generated.schema.api.data.createDatabaseSchema import (
     CreateDatabaseSchemaRequest,
 )
 from metadata.generated.schema.api.data.createTable import CreateTableRequest
-from metadata.generated.schema.api.services.createDatabaseService import (
-    CreateDatabaseServiceRequest,
-)
 from metadata.generated.schema.entity.data.pipeline import Pipeline, StatusType
 from metadata.generated.schema.entity.data.table import Column, DataType, Table
-from metadata.generated.schema.entity.services.connections.database.common.basicAuth import (
-    BasicAuth,
-)
-from metadata.generated.schema.entity.services.connections.database.mysqlConnection import (
-    MysqlConnection,
-)
-from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
-    OpenMetadataConnection,
-)
-from metadata.generated.schema.entity.services.databaseService import (
-    DatabaseConnection,
-    DatabaseService,
-    DatabaseServiceType,
-)
+from metadata.generated.schema.entity.services.databaseService import DatabaseService
 from metadata.generated.schema.entity.services.pipelineService import PipelineService
-from metadata.generated.schema.security.client.openMetadataJWTClientConfig import (
-    OpenMetadataJWTClientConfig,
-)
-from metadata.ingestion.ometa.ometa_api import OpenMetadata
 
-# These variables are just here to validate elements in the local deployment
-OM_HOST_PORT = "http://localhost:8585/api"
-OM_JWT = "eyJraWQiOiJHYjM4OWEtOWY3Ni1nZGpzLWE5MmotMDI0MmJrOTQzNTYiLCJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhZG1pbiIsImlzQm90IjpmYWxzZSwiaXNzIjoib3Blbi1tZXRhZGF0YS5vcmciLCJpYXQiOjE2NjM5Mzg0NjIsImVtYWlsIjoiYWRtaW5Ab3Blbm1ldGFkYXRhLm9yZyJ9.tS8um_5DKu7HgzGBzS1VTA5uUjKWOCU0B_j08WXBiEC0mr0zNREkqVfwFDD-d24HlNEbrqioLsBuFRiwIWKc1m_ZlVQbG7P36RUxhuv2vbSp80FKyNM-Tj93FDzq91jsyNmsQhyNv_fNr3TXfzzSPjHt8Go0FMMP66weoKMgW2PbXlhVKwEuXUHyakLLzewm9UMeQaEiRzhiTMU3UkLXcKbYEJJvfNFcLwSl9W8JCO_l0Yj3ud-qt_nQYEZwqW6u5nfdQllN133iikV4fM5QZsMCnm8Rq1mvLR0y9bmJiD7fwM1tmJ791TUWqmKaTnP49U493VanKpUAfzIiOiIbhg"
-AIRFLOW_HOST = "http://localhost:8080"
-AIRFLOW_API_ROOT = f"{AIRFLOW_HOST}/api/v2/"
-AIRFLOW_USERNAME = "admin"
-AIRFLOW_PASSWORD = "admin"
-DEFAULT_OM_AIRFLOW_CONNECTION = "openmetadata_conn_id"
-OM_LINEAGE_DAG_NAME = "lineage_tutorial_operator"
+from ..integration_base import get_create_service
+from .conftest import OM_CONNECTION_ID
+
+DAG_ID = "lineage_tutorial_operator"
+DAG_DESCRIPTION = "A simple tutorial DAG"
 PIPELINE_SERVICE_NAME = "airflow_lineage_op_service"
 
+DB_SERVICE_NAME = "test-service-table-lineage"
+DATABASE_NAME = "test-db"
+SCHEMA_NAME = "test-schema"
+INLET_NAMES = ("lineage-test-inlet", "lineage-test-inlet2")
+OUTLET_NAME = "lineage-test-outlet"
+SCHEMA_FQN = f"{DB_SERVICE_NAME}.{DATABASE_NAME}.{SCHEMA_NAME}"
 
-def get_airflow_jwt_token() -> str:
-    """Get JWT token from Airflow 3.x auth endpoint"""
-    token_url = f"{AIRFLOW_HOST}/auth/token"
-    payload = {"username": AIRFLOW_USERNAME, "password": AIRFLOW_PASSWORD}
-    response = requests.post(token_url, json=payload, timeout=10)
-    if response.status_code in (200, 201):
-        return response.json().get("access_token")
-    raise RuntimeError(
-        f"Failed to get JWT token: {response.status_code} - {response.text}"
+DAG_SOURCE = f'''
+"""DAG owned by tests/integration/airflow/test_airflow_lineage.py."""
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.providers.standard.operators.bash import BashOperator
+
+from airflow_provider_openmetadata.hooks.openmetadata import OpenMetadataHook
+from airflow_provider_openmetadata.lineage.operator import OpenMetadataLineageOperator
+
+with DAG(
+    "{DAG_ID}",
+    default_args={{"owner": "openmetadata", "retries": 0, "retry_delay": timedelta(seconds=5)}},
+    description="{DAG_DESCRIPTION}",
+    schedule=None,
+    is_paused_upon_creation=True,
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
+) as dag:
+    print_date = BashOperator(
+        task_id="print_date",
+        bash_command="date",
+        outlets=[{{"tables": ["{SCHEMA_FQN}.{OUTLET_NAME}"]}}],
     )
 
+    sleep = BashOperator(
+        task_id="sleep",
+        bash_command="sleep 1",
+        inlets=[{{"tables": ["{SCHEMA_FQN}.{INLET_NAMES[0]}", "{SCHEMA_FQN}.{INLET_NAMES[1]}"]}}],
+    )
 
-def get_airflow_headers() -> dict:
-    """Get authentication headers for Airflow 3.x API requests"""
-    jwt_token = get_airflow_jwt_token()
-    return {
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {jwt_token}",
-    }
+    templated = BashOperator(
+        task_id="templated",
+        bash_command='echo "{{{{ ds }}}}"',
+    )
+
+    lineage_op = OpenMetadataLineageOperator(
+        task_id="lineage_op",
+        server_config=OpenMetadataHook("{OM_CONNECTION_ID}").get_conn(),
+        service_name="{PIPELINE_SERVICE_NAME}",
+        only_keep_dag_lineage=True,
+    )
+
+    print_date >> [sleep, templated] >> lineage_op
+'''
 
 
-def get_task_status_type_by_name(pipeline: Pipeline, name: str) -> Optional[StatusType]:
-    """
-    Given a pipeline, get its status by name
-    """
+def _task_status(pipeline: Pipeline, name: str):
     return next(
         (
             status.executionStatus
@@ -100,240 +103,166 @@ def get_task_status_type_by_name(pipeline: Pipeline, name: str) -> Optional[Stat
     )
 
 
-class AirflowLineageTest(TestCase):
-    """
-    This test will trigger an Airflow DAG and validate that the
-    OpenMetadata Lineage Operator can properly handle the
-    metadata ingestion and processes inlets and outlets.
-    """
-
-    server_config = OpenMetadataConnection(
-        hostPort=OM_HOST_PORT,
-        authProvider="openmetadata",
-        securityConfig=OpenMetadataJWTClientConfig(jwtToken=OM_JWT),
+@pytest.fixture(scope="module")
+def om_entities(metadata):
+    """The database service, schema and tables the DAG declares as inlets and outlets."""
+    service = metadata.create_or_update(
+        data=get_create_service(entity=DatabaseService, name=DB_SERVICE_NAME)
     )
-    metadata = OpenMetadata(server_config)
-
-    assert metadata.health_check()
-
-    service = CreateDatabaseServiceRequest(
-        name="test-service-table-lineage",
-        serviceType=DatabaseServiceType.Mysql,
-        connection=DatabaseConnection(
-            config=MysqlConnection(
-                username="username",
-                authType=BasicAuth(password="password"),
-                hostPort="http://localhost:1234",
-            )
-        ),
+    database = metadata.create_or_update(
+        data=CreateDatabaseRequest(
+            name=DATABASE_NAME, service=service.fullyQualifiedName
+        )
     )
-    service_type = "databaseService"
-
-    @classmethod
-    def setUpClass(cls) -> None:
-        """
-        Prepare ingredients: Table Entity + DAG
-        """
-
-        service_entity = cls.metadata.create_or_update(data=cls.service)
-
-        create_db = CreateDatabaseRequest(
-            name="test-db",
-            service=service_entity.fullyQualifiedName,
+    db_schema = metadata.create_or_update(
+        data=CreateDatabaseSchemaRequest(
+            name=SCHEMA_NAME, database=database.fullyQualifiedName
         )
+    )
 
-        create_db_entity = cls.metadata.create_or_update(data=create_db)
-
-        create_schema = CreateDatabaseSchemaRequest(
-            name="test-schema",
-            database=create_db_entity.fullyQualifiedName,
-        )
-
-        create_schema_entity = cls.metadata.create_or_update(data=create_schema)
-
-        create_inlet = CreateTableRequest(
-            name="lineage-test-inlet",
-            databaseSchema=create_schema_entity.fullyQualifiedName,
-            columns=[Column(name="id", dataType=DataType.BIGINT)],
-        )
-
-        create_inlet_2 = CreateTableRequest(
-            name="lineage-test-inlet2",
-            databaseSchema=create_schema_entity.fullyQualifiedName,
-            columns=[Column(name="id", dataType=DataType.BIGINT)],
-        )
-
-        create_outlet = CreateTableRequest(
-            name="lineage-test-outlet",
-            databaseSchema=create_schema_entity.fullyQualifiedName,
-            columns=[Column(name="id", dataType=DataType.BIGINT)],
-        )
-
-        cls.metadata.create_or_update(data=create_inlet)
-        cls.metadata.create_or_update(data=create_inlet_2)
-        cls.table_outlet = cls.metadata.create_or_update(data=create_outlet)
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        """
-        Clean up
-        """
-
-        db_service = cls.metadata.get_by_name(
-            entity=DatabaseService, fqn="test-service-table-lineage"
-        )
-        if db_service:
-            service_id = str(db_service.id.root)
-            cls.metadata.delete(
-                entity=DatabaseService,
-                entity_id=service_id,
-                recursive=True,
-                hard_delete=True,
+    tables = {}
+    for table_name in (*INLET_NAMES, OUTLET_NAME):
+        tables[table_name] = metadata.create_or_update(
+            data=CreateTableRequest(
+                name=table_name,
+                databaseSchema=db_schema.fullyQualifiedName,
+                columns=[Column(name="id", dataType=DataType.BIGINT)],
             )
-
-        # Service ID created from the Airflow Lineage Operator in the
-        # example DAG
-        pipeline_service = cls.metadata.get_by_name(
-            entity=PipelineService, fqn=PIPELINE_SERVICE_NAME
-        )
-        if pipeline_service:
-            pipeline_service_id = str(pipeline_service.id.root)
-            cls.metadata.delete(
-                entity=PipelineService,
-                entity_id=pipeline_service_id,
-                recursive=True,
-                hard_delete=True,
-            )
-
-    def test_dag_runs(self) -> None:
-        """
-        Trigger the Airflow DAG and wait until it runs.
-
-        Note that the DAG definition is in examples/airflow_lineage_operator.py
-        and it is expected to fail. This will allow us to validate
-        the task status afterward.
-        """
-
-        headers = get_airflow_headers()
-
-        # 1. Validate that the OpenMetadata connection exists
-        res = requests.get(
-            AIRFLOW_API_ROOT + f"connections/{DEFAULT_OM_AIRFLOW_CONNECTION}",
-            headers=headers,
-        )
-        if res.status_code != 200:
-            raise RuntimeError(
-                f"Could not fetch {DEFAULT_OM_AIRFLOW_CONNECTION} connection: {res.status_code} - {res.text}"
-            )
-
-        # 2. Enable the DAG
-        res = requests.patch(
-            AIRFLOW_API_ROOT + f"dags/{OM_LINEAGE_DAG_NAME}",
-            json={"is_paused": False},
-            headers=headers,
-        )
-        if res.status_code != 200:
-            raise RuntimeError(
-                f"Could not enable {OM_LINEAGE_DAG_NAME} DAG: {res.status_code} - {res.text}"
-            )
-
-        # 3. Trigger the DAG (Airflow 3.x requires logical_date)
-        from datetime import datetime, timezone
-
-        res = requests.post(
-            AIRFLOW_API_ROOT + f"dags/{OM_LINEAGE_DAG_NAME}/dagRuns",
-            json={"logical_date": datetime.now(timezone.utc).isoformat()},
-            headers=headers,
-        )
-        if res.status_code != 200:
-            raise RuntimeError(
-                f"Could not trigger {OM_LINEAGE_DAG_NAME} DAG: {res.status_code} - {res.text}"
-            )
-        dag_run_id = res.json()["dag_run_id"]
-
-        # 4. Wait until the DAG is flagged as `successful` or `failed`
-        state = "queued"
-        tries = 0
-        max_tries = 12  # 60 seconds total (12 * 5 seconds)
-        while state not in ("success", "failed") and tries < max_tries:
-            tries += 1
-            time.sleep(5)
-
-            res = requests.get(
-                AIRFLOW_API_ROOT + f"dags/{OM_LINEAGE_DAG_NAME}/dagRuns/{dag_run_id}",
-                headers=headers,
-            )
-            dag_run_data = res.json()
-            state = dag_run_data.get("state")
-            print(f"Try {tries}/{max_tries}: DAG state = {state}")
-
-        if state not in ("success", "failed"):
-            raise RuntimeError(
-                f"DAG {OM_LINEAGE_DAG_NAME} has not finished on time. Last state: {state}"
-            )
-
-    def test_pipeline_created(self) -> None:
-        """
-        Validate that the pipeline has been created
-        """
-        pipeline_service: PipelineService = self.metadata.get_by_name(
-            entity=PipelineService, fqn=PIPELINE_SERVICE_NAME
-        )
-        self.assertIsNotNone(pipeline_service)
-
-        pipeline: Pipeline = self.metadata.get_by_name(
-            entity=Pipeline,
-            fqn=f"{PIPELINE_SERVICE_NAME}.{OM_LINEAGE_DAG_NAME}",
-            fields=["tasks", "pipelineStatus"],
-        )
-        self.assertIsNotNone(pipeline)
-
-        expected_task_names = set((task.name for task in pipeline.tasks))
-        self.assertEqual(
-            expected_task_names, {"print_date", "sleep", "templated", "lineage_op"}
         )
 
-        self.assertEqual(pipeline.description.root, "A simple tutorial DAG")
+    yield tables
 
-        # Validate status
-        self.assertIsNotNone(
-            pipeline.pipelineStatus, "Pipeline status should be collected via REST API"
-        )
-        self.assertEqual(
-            get_task_status_type_by_name(pipeline, "print_date"), StatusType.Successful
-        )
-        self.assertEqual(
-            get_task_status_type_by_name(pipeline, "sleep"), StatusType.Successful
-        )
-        self.assertEqual(
-            get_task_status_type_by_name(pipeline, "templated"), StatusType.Successful
+    metadata.delete(
+        entity=DatabaseService, entity_id=service.id, recursive=True, hard_delete=True
+    )
+    pipeline_service = metadata.get_by_name(
+        entity=PipelineService, fqn=PIPELINE_SERVICE_NAME
+    )
+    if pipeline_service:
+        metadata.delete(
+            entity=PipelineService,
+            entity_id=pipeline_service.id,
+            recursive=True,
+            hard_delete=True,
         )
 
-    def test_pipeline_lineage(self) -> None:
-        """
-        Validate that the pipeline has proper lineage
-        """
-        root_name = "test-service-table-lineage.test-db.test-schema"
 
-        # Check that both inlets have the same outlet
-        for inlet_table in [
-            f"{root_name}.lineage-test-inlet",
-            f"{root_name}.lineage-test-inlet2",
-        ]:
-            lineage = self.metadata.get_lineage_by_name(
-                entity=Table,
-                fqn=inlet_table,
-            )
-            node_names = set((node["name"] for node in lineage.get("nodes") or []))
-            self.assertEqual(node_names, {"lineage-test-outlet"})
-            self.assertEqual(len(lineage.get("downstreamEdges")), 1)
-            self.assertEqual(
-                lineage["downstreamEdges"][0]["toEntity"],
-                str(self.table_outlet.id.root),
-            )
-            self.assertEqual(
-                lineage["downstreamEdges"][0]["lineageDetails"]["pipeline"][
-                    "fullyQualifiedName"
-                ],
-                f"{PIPELINE_SERVICE_NAME}.{OM_LINEAGE_DAG_NAME}",
-            )
+@pytest.fixture(scope="module")
+def registered_dag(
+    airflow_container, airflow_dag_dir, airflow_api, airflow_headers, om_entities
+):
+    """DAG_ID, once the dag-processor has picked the file up."""
+    dag_file = airflow_dag_dir / f"{DAG_ID}.py"
+    dag_file.write_text(DAG_SOURCE)
+    dag_file.chmod(0o644)
+
+    deadline = time.monotonic() + 180
+    while time.monotonic() < deadline:
+        response = requests.get(
+            f"{airflow_api}/dags/{DAG_ID}", headers=airflow_headers, timeout=30
+        )
+        if response.status_code == 200:
+            return DAG_ID
+        time.sleep(5)
+
+    errors = requests.get(
+        f"{airflow_api}/importErrors", headers=airflow_headers, timeout=30
+    )
+    # An empty importErrors list means the processor never read the file at all, so show
+    # it what it can actually see in the mount.
+    listing = airflow_container.exec("ls -la /opt/airflow/dags")
+    raise TimeoutError(
+        f"{DAG_ID} never registered.\nImport errors: {errors.text}\n"
+        f"Container view of /opt/airflow/dags:\n{listing.output.decode(errors='replace')}"
+    )
+
+
+@pytest.fixture(scope="module")
+def dag_run(airflow_api, airflow_headers, registered_dag):
+    """A finished run of the lineage DAG."""
+    unpause = requests.patch(
+        f"{airflow_api}/dags/{registered_dag}",
+        json={"is_paused": False},
+        headers=airflow_headers,
+        timeout=30,
+    )
+    assert (
+        unpause.status_code == 200
+    ), f"Could not unpause {registered_dag}: {unpause.text}"
+
+    triggered = requests.post(
+        f"{airflow_api}/dags/{registered_dag}/dagRuns",
+        json={"logical_date": datetime.now(timezone.utc).isoformat()},
+        headers=airflow_headers,
+        timeout=30,
+    )
+    assert triggered.status_code in (
+        200,
+        201,
+    ), f"Could not trigger {registered_dag}: {triggered.text}"
+    run_id = triggered.json()["dag_run_id"]
+
+    deadline = time.monotonic() + 300
+    state = "queued"
+    while state not in ("success", "failed") and time.monotonic() < deadline:
+        time.sleep(5)
+        response = requests.get(
+            f"{airflow_api}/dags/{registered_dag}/dagRuns/{run_id}",
+            headers=airflow_headers,
+            timeout=30,
+        )
+        state = response.json().get("state")
+
+    assert state in (
+        "success",
+        "failed",
+    ), f"{registered_dag} did not finish in time. Last state: {state}"
+
+    return run_id
+
+
+def test_pipeline_created(metadata, dag_run):
+    assert (
+        metadata.get_by_name(entity=PipelineService, fqn=PIPELINE_SERVICE_NAME)
+        is not None
+    )
+
+    pipeline = metadata.get_by_name(
+        entity=Pipeline,
+        fqn=f"{PIPELINE_SERVICE_NAME}.{DAG_ID}",
+        fields=["tasks", "pipelineStatus"],
+    )
+
+    assert pipeline is not None
+    assert {task.name for task in pipeline.tasks} == {
+        "print_date",
+        "sleep",
+        "templated",
+        "lineage_op",
+    }
+    assert pipeline.description.root == DAG_DESCRIPTION
+    assert (
+        pipeline.pipelineStatus is not None
+    ), "Pipeline status should be collected via REST API"
+    assert _task_status(pipeline, "print_date") == StatusType.Successful
+    assert _task_status(pipeline, "sleep") == StatusType.Successful
+    assert _task_status(pipeline, "templated") == StatusType.Successful
+
+
+def test_pipeline_lineage(metadata, om_entities, dag_run):
+    outlet_id = str(om_entities[OUTLET_NAME].id.root)
+
+    for inlet_name in INLET_NAMES:
+        lineage = metadata.get_lineage_by_name(
+            entity=Table, fqn=f"{SCHEMA_FQN}.{inlet_name}"
+        )
+
+        assert {node["name"] for node in lineage.get("nodes") or []} == {OUTLET_NAME}
+        assert len(lineage.get("downstreamEdges")) == 1
+        assert lineage["downstreamEdges"][0]["toEntity"] == outlet_id
+        assert (
+            lineage["downstreamEdges"][0]["lineageDetails"]["pipeline"][
+                "fullyQualifiedName"
+            ]
+            == f"{PIPELINE_SERVICE_NAME}.{DAG_ID}"
+        )

--- a/ingestion/tests/integration/alationsink/test_alationsink.py
+++ b/ingestion/tests/integration/alationsink/test_alationsink.py
@@ -11,19 +11,28 @@
 """
 Test Alation Sink using the integration testing
 """
-from unittest import TestCase
+
 from unittest.mock import patch
 
+import pytest
+
+from metadata.generated.schema.api.data.createDatabase import CreateDatabaseRequest
+from metadata.generated.schema.api.data.createDatabaseSchema import (
+    CreateDatabaseSchemaRequest,
+)
+from metadata.generated.schema.api.data.createTable import (
+    CreateTableRequest as CreateOMTableRequest,
+)
 from metadata.generated.schema.entity.data.database import Database
 from metadata.generated.schema.entity.data.databaseSchema import DatabaseSchema
-from metadata.generated.schema.entity.data.table import Table
-from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
-    OpenMetadataConnection,
+from metadata.generated.schema.entity.data.table import (
+    Column,
+    Constraint,
+    DataType,
+    Table,
+    TableType,
 )
-from metadata.generated.schema.metadataIngestion.workflow import (
-    OpenMetadataWorkflowConfig,
-)
-from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.generated.schema.entity.services.databaseService import DatabaseService
 from metadata.ingestion.ometa.utils import model_str
 from metadata.ingestion.source.metadata.alationsink.metadata import AlationsinkSource
 from metadata.ingestion.source.metadata.alationsink.models import (
@@ -33,6 +42,8 @@ from metadata.ingestion.source.metadata.alationsink.models import (
     CreateSchemaRequest,
     CreateTableRequest,
 )
+
+from ..integration_base import generate_name, get_create_service  # noqa: TID252
 
 mock_alation_sink_config = {
     "source": {
@@ -45,7 +56,7 @@ mock_alation_sink_config = {
                 "projectName": "Test",
                 "paginationLimit": 50,
                 "datasourceLinks": {
-                    "112": "sample_data.ecommerce_db",
+                    "112": "my_service.my_database",
                 },
             }
         },
@@ -70,13 +81,17 @@ mock_alation_sink_config = {
 
 MOCK_ALATION_DATASOURCE_ID = 34
 
+DATABASE_NAME = "my_database"
+DATABASE_DESCRIPTION = "Mock database for the Alation sink request builders."
+SCHEMA_NAME = "my_schema"
+SCHEMA_DESCRIPTION = "Mock schema for the Alation sink request builders."
 
-def mock_write_entities(self, ds_id, create_request):  # pylint: disable=unused-argument
-    return {"job_id": "10378"}
-
-
-def mock_write_entity(self, create_request):  # pylint: disable=unused-argument
-    return {"ds_id": "13"}
+# `::>` is not an FQN separator; it guards against a builder that over-quotes names.
+QUOTED_TABLE_NAME = "dim_::>address"
+REGULAR_TABLE_NAME = "dim_address"
+VIEW_TABLE_NAME = "dim_address_clean"
+TABLE_DESCRIPTION = "Mock dimension table holding customer addresses."
+VIEW_DESCRIPTION = "Created from dim_address after a small cleanup."
 
 
 def mock_list_connectors():
@@ -89,241 +104,98 @@ def mock_list_connectors():
     }
 
 
+# get_create_service builds a Mysql service, which SERVICE_TYPE_MAPPER resolves to the
+# "MySQL OCF Connector" entry above.
+EXPECTED_CONNECTOR_ID = 116
+
+TABLE_COLUMNS = [
+    Column(
+        name="address_id",
+        dataType=DataType.NUMERIC,
+        dataTypeDisplay="numeric",
+        description="Unique identifier for the address.",
+        constraint=Constraint.PRIMARY_KEY,
+        ordinalPosition=1,
+    ),
+    Column(
+        name="shop_id",
+        dataType=DataType.NUMERIC,
+        dataTypeDisplay="numeric",
+        description="The ID of the store.",
+        constraint=Constraint.NOT_NULL,
+        ordinalPosition=2,
+    ),
+    Column(
+        name="city",
+        dataType=DataType.VARCHAR,
+        dataLength=100,
+        dataTypeDisplay="varchar(100)",
+        description="The city of the address.",
+        constraint=Constraint.NULL,
+        ordinalPosition=3,
+    ),
+]
+
 EXPECTED_DATASOURCE_REQUEST = CreateDatasourceRequest(
     uri="None",
-    connector_id=115,
+    connector_id=EXPECTED_CONNECTOR_ID,
     db_username="Test",
     db_password=None,
-    title="ecommerce_db",
-    description="This **mock** database contains schemas related to shopify sales and orders with related dimension tables.",
+    title=DATABASE_NAME,
+    description=DATABASE_DESCRIPTION,
 )
 
 EXPECTED_SCHEMA_REQUEST = CreateSchemaRequest(
-    key="34.shopify",
-    title="shopify",
-    description="This **mock** database contains schema related to shopify sales and orders with related dimension tables.",
+    key=f"{MOCK_ALATION_DATASOURCE_ID}.{SCHEMA_NAME}",
+    title=SCHEMA_NAME,
+    description=SCHEMA_DESCRIPTION,
 )
-
-
-BASE_DESC = "This dimension table contains the billing and shipping addresses of customers. You can join this table with the sales table to generate lists of the billing and shipping addresses. Customers can enter their addresses more than once, so the same address can appear in more than one row in this table. This table contains one row per customer address."
 
 EXPECTED_TABLES = [
     CreateTableRequest(
-        key="34.shopify.dim_::>address",
-        title="dim_::>address",
-        description=BASE_DESC,
+        key=f"{MOCK_ALATION_DATASOURCE_ID}.{SCHEMA_NAME}.{QUOTED_TABLE_NAME}",
+        title=QUOTED_TABLE_NAME,
+        description=TABLE_DESCRIPTION,
         table_type="TABLE",
         sql=None,
     ),
     CreateTableRequest(
-        key="34.shopify.dim_address",
-        title="dim_address",
-        description=BASE_DESC,
+        key=f"{MOCK_ALATION_DATASOURCE_ID}.{SCHEMA_NAME}.{REGULAR_TABLE_NAME}",
+        title=REGULAR_TABLE_NAME,
+        description=TABLE_DESCRIPTION,
         table_type="TABLE",
         sql=None,
     ),
     CreateTableRequest(
-        key="34.shopify.dim_address_clean",
-        title="dim_address_clean",
-        description="Created from dim_address after a small cleanup.",
+        key=f"{MOCK_ALATION_DATASOURCE_ID}.{SCHEMA_NAME}.{VIEW_TABLE_NAME}",
+        title=VIEW_TABLE_NAME,
+        description=VIEW_DESCRIPTION,
         table_type="VIEW",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.dim_customer",
-        title="dim_customer",
-        description="The dimension table contains data about your customers. The customers table contains one row per customer. It includes historical metrics (such as the total amount that each customer has spent in your store) as well as forward-looking metrics (such as the predicted number of days between future orders and the expected order value in the next 30 days). This table also includes columns that segment customers into various categories (such as new, returning, promising, at risk, dormant, and loyal), which you can use to target marketing activities.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.dim_location",
-        title="dim_location",
-        description="The dimension table contains metrics about your Shopify POS. This table contains one row per Shopify POS location. You can use this table to generate a list of the Shopify POS locations or you can join the table with the sales table to measure sales performance.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.dim_staff",
-        title="dim_staff",
-        description="This dimension table contains information about the staff accounts in the store. It contains one row per staff account. Use this table to generate a list of your staff accounts, or join it with the sales, API clients and locations tables to analyze staff performance at Shopify POS locations.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key='34.shopify."dim.api/client"',
-        title="dim.api/client",
-        description="This dimension table contains a row for each channel or app that your customers use to create orders. Some examples of these include Facebook and Online Store. You can join this table with the sales table to measure channel performance.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key='34.shopify."dim.product"',
-        title="dim.product",
-        description="This dimension table contains information about each of the products in your store. This table contains one row per product. This table reflects the current state of products in your Shopify admin.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key='34.shopify."dim.product.variant"',
-        title="dim.product.variant",
-        description="This dimension table contains current information about each of the product variants in your store. This table contains one row per product variant.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key='34.shopify."dim.shop"',
-        title="dim.shop",
-        description="This dimension table contains online shop information. This table contains one shop per row.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.dim(shop)",
-        title="dim(shop)",
-        description="This dimension table contains online shop information with weird characters.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.fact_line_item_Lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_sed_do_eiusmod_tempor_incididunt_ut_labore_et_dolore_magna_aliqua_Ut_enim_ad_minim_veniam_quis_nostrud_exercitation_ullamco_laboris_nisi_ut_aliquip_ex_ea_commodo_consequat_Duis_aute_iru",
-        title="fact_line_item_Lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_sed_do_eiusmod_tempor_incididunt_ut_labore_et_dolore_magna_aliqua_Ut_enim_ad_minim_veniam_quis_nostrud_exercitation_ullamco_laboris_nisi_ut_aliquip_ex_ea_commodo_consequat_Duis_aute_iru",
-        description="The fact table contains information about the line items in orders. Each row in the table is a line item in an order. It contains product and product variant details as they were at the time of the order. This table does not include information about returns. Join this table with the TODO fact_sales table to get the details of the product on the day it was sold. This data will match what appears on the order in your Shopify admin as well as the in the Sales reports.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.fact_order",
-        title="fact_order",
-        description="The orders table contains information about each order in your store. Although this table is good for generating order lists and joining with the dim_customer, use the sales table instead for computing financial or other metrics.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.fact_sale",
-        title="fact_sale",
-        description="The fact table captures the value of products sold or returned, as well as the values of other charges such as taxes and shipping costs. The sales table contains one row per order line item, one row per returned line item, and one row per shipping charge. Use this table when you need financial metrics.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.fact_session",
-        title="fact_session",
-        description="This fact table contains information about the visitors to your online store. This table has one row per session, where one session can contain many page views. If you use Urchin Traffic Module (UTM) parameters in marketing campaigns, then you can use this table to track how many customers they direct to your store.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.raw_customer",
-        title="raw_customer",
-        description="This is a raw customers table as represented in our online DB. This contains personal, shipping and billing addresses and details of the customer store and customer profile. This table is used to build our dimensional and fact tables",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.raw_order",
-        title="raw_order",
-        description="This is a raw orders table as represented in our online DB. This table contains all the orders by the customers and can be used to buid our dim and fact tables",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.raw_product_catalog",
-        title="raw_product_catalog",
-        description="This is a raw product catalog table contains the product listing, price, seller etc.. represented in our online DB. ",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.магазин",
-        title="магазин",
-        description="This dimension table contains online shop information with weird characters.",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.icemarketdata_global",
-        title="icemarketdata_global",
-        description=BASE_DESC,
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.global_market",
-        title="global_market",
-        description=BASE_DESC,
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.global",
-        title="global",
-        description=BASE_DESC,
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.ice_global",
-        title="ice_global",
-        description=BASE_DESC,
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.mortgage",
-        title="mortgage",
-        description=BASE_DESC,
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.funds_closingprocessdocumentsrelationship",
-        title="funds_closingprocessdocumentsrelationship",
-        description=BASE_DESC,
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.big_data_table_with_nested_columns",
-        title="big_data_table_with_nested_columns",
-        description="A large table with thousands of columns including nested "
-        "structures for testing pagination and search performance",
-        table_type="TABLE",
-        sql=None,
-    ),
-    CreateTableRequest(
-        key="34.shopify.performance_test_table",
-        title="performance_test_table",
-        description="A table with thousands of columns designed for testing the "
-        "performance of paginated column APIs. This table contains 2000 columns "
-        "with various data types to simulate real-world scenarios where tables "
-        "have large numbers of columns.",
-        table_type="TABLE",
         sql=None,
     ),
 ]
 
 EXPECTED_COLUMNS = [
     CreateColumnRequest(
-        key="34.shopify.dim_address.address_id",
+        key=f"{MOCK_ALATION_DATASOURCE_ID}.{SCHEMA_NAME}.{REGULAR_TABLE_NAME}.address_id",
         column_type="numeric",
         title="address_id",
         description="Unique identifier for the address.",
         nullable=None,
         position="1",
         index=ColumnIndex(
-            isPrimaryKey=None,
+            isPrimaryKey=True,
             isForeignKey=None,
             referencedColumnId=None,
             isOtherIndex=None,
         ),
     ),
     CreateColumnRequest(
-        key="34.shopify.dim_address.shop_id",
+        key=f"{MOCK_ALATION_DATASOURCE_ID}.{SCHEMA_NAME}.{REGULAR_TABLE_NAME}.shop_id",
         column_type="numeric",
         title="shop_id",
-        description="The ID of the store. This column is a foreign key reference to the shop_id column in the dim_shop table.",
-        nullable=None,
+        description="The ID of the store.",
+        nullable=False,
         position="2",
         index=ColumnIndex(
             isPrimaryKey=None,
@@ -333,138 +205,12 @@ EXPECTED_COLUMNS = [
         ),
     ),
     CreateColumnRequest(
-        key="34.shopify.dim_address.first_name",
-        column_type="varchar",
-        title="first_name",
-        description="First name of the customer.",
-        nullable=None,
-        position="3",
-        index=ColumnIndex(
-            isPrimaryKey=None,
-            isForeignKey=None,
-            referencedColumnId=None,
-            isOtherIndex=None,
-        ),
-    ),
-    CreateColumnRequest(
-        key="34.shopify.dim_address.last_name",
-        column_type="varchar",
-        title="last_name",
-        description="Last name of the customer.",
-        nullable=None,
-        position="4",
-        index=ColumnIndex(
-            isPrimaryKey=None,
-            isForeignKey=None,
-            referencedColumnId=None,
-            isOtherIndex=None,
-        ),
-    ),
-    CreateColumnRequest(
-        key="34.shopify.dim_address.address1",
-        column_type="varchar",
-        title="address1",
-        description="The first address line. For example, 150 Elgin St.",
-        nullable=None,
-        position="5",
-        index=ColumnIndex(
-            isPrimaryKey=None,
-            isForeignKey=None,
-            referencedColumnId=None,
-            isOtherIndex=None,
-        ),
-    ),
-    CreateColumnRequest(
-        key="34.shopify.dim_address.address2",
-        column_type="varchar",
-        title="address2",
-        description="The second address line. For example, Suite 800.",
-        nullable=None,
-        position="6",
-        index=ColumnIndex(
-            isPrimaryKey=None,
-            isForeignKey=None,
-            referencedColumnId=None,
-            isOtherIndex=None,
-        ),
-    ),
-    CreateColumnRequest(
-        key="34.shopify.dim_address.company",
-        column_type="varchar",
-        title="company",
-        description="The name of the customer's business, if one exists.",
-        nullable=None,
-        position="7",
-        index=ColumnIndex(
-            isPrimaryKey=None,
-            isForeignKey=None,
-            referencedColumnId=None,
-            isOtherIndex=None,
-        ),
-    ),
-    CreateColumnRequest(
-        key="34.shopify.dim_address.city",
-        column_type="varchar",
+        key=f"{MOCK_ALATION_DATASOURCE_ID}.{SCHEMA_NAME}.{REGULAR_TABLE_NAME}.city",
+        column_type="varchar(100)",
         title="city",
-        description="The name of the city. For example, Palo Alto.",
-        nullable=None,
-        position="8",
-        index=ColumnIndex(
-            isPrimaryKey=None,
-            isForeignKey=None,
-            referencedColumnId=None,
-            isOtherIndex=None,
-        ),
-    ),
-    CreateColumnRequest(
-        key="34.shopify.dim_address.region",
-        column_type="varchar",
-        title="region",
-        description="The name of the region, such as a province or state, where the customer is located. For example, Ontario or New York. This column is the same as CustomerAddress.province in the Admin API.",
-        nullable=None,
-        position="9",
-        index=ColumnIndex(
-            isPrimaryKey=None,
-            isForeignKey=None,
-            referencedColumnId=None,
-            isOtherIndex=None,
-        ),
-    ),
-    CreateColumnRequest(
-        key="34.shopify.dim_address.zip",
-        column_type="varchar",
-        title="zip",
-        description="The ZIP or postal code. For example, 90210.",
-        nullable=None,
-        position="10",
-        index=ColumnIndex(
-            isPrimaryKey=None,
-            isForeignKey=None,
-            referencedColumnId=None,
-            isOtherIndex=None,
-        ),
-    ),
-    CreateColumnRequest(
-        key="34.shopify.dim_address.country",
-        column_type="varchar",
-        title="country",
-        description="The full name of the country. For example, Canada.",
-        nullable=None,
-        position="11",
-        index=ColumnIndex(
-            isPrimaryKey=None,
-            isForeignKey=None,
-            referencedColumnId=None,
-            isOtherIndex=None,
-        ),
-    ),
-    CreateColumnRequest(
-        key="34.shopify.dim_address.phone",
-        column_type="varchar",
-        title="phone",
-        description="The phone number of the customer.",
-        nullable=None,
-        position="12",
+        description="The city of the address.",
+        nullable=True,
+        position="3",
         index=ColumnIndex(
             isPrimaryKey=None,
             isForeignKey=None,
@@ -475,97 +221,117 @@ EXPECTED_COLUMNS = [
 ]
 
 
-class AlationSinkTest(TestCase):
-    """
-    Implements the necessary methods to extract
-    Alation Sink Metadata Unit Test
-    """
+@pytest.fixture(scope="module")
+def alation_sink_source(metadata):
+    """AlationsinkSource whose connector listing is stubbed to mock_list_connectors."""
+    with patch.object(AlationsinkSource, "test_connection", return_value=False):
+        source = AlationsinkSource.create(mock_alation_sink_config["source"], metadata)
+    source.connectors = mock_list_connectors()
+    return source
 
-    @patch(
-        "metadata.ingestion.source.metadata.alationsink.metadata.AlationsinkSource.test_connection"
+
+@pytest.fixture(scope="module")
+def om_database(metadata):
+    """A Mysql service holding one database, one schema and three tables."""
+    service = metadata.create_or_update(
+        data=get_create_service(entity=DatabaseService, name=generate_name())
     )
-    def __init__(self, methodName, test_connection) -> None:
-        super().__init__(methodName)
-        test_connection.return_value = False
-        self.config = OpenMetadataWorkflowConfig.model_validate(
-            mock_alation_sink_config
+    database = metadata.create_or_update(
+        data=CreateDatabaseRequest(
+            name=DATABASE_NAME,
+            description=DATABASE_DESCRIPTION,
+            service=service.fullyQualifiedName,
         )
-        self.alation_sink_source = AlationsinkSource.create(
-            mock_alation_sink_config["source"],
-            OpenMetadata(self.config.workflowConfig.openMetadataServerConfig),
+    )
+    db_schema = metadata.create_or_update(
+        data=CreateDatabaseSchemaRequest(
+            name=SCHEMA_NAME,
+            description=SCHEMA_DESCRIPTION,
+            database=database.fullyQualifiedName,
         )
-        self.alation_sink_source.connectors = mock_list_connectors()
-        self.metadata = OpenMetadata(
-            OpenMetadataConnection.model_validate(
-                mock_alation_sink_config["workflowConfig"]["openMetadataServerConfig"]
+    )
+    for name, description, table_type in (
+        (QUOTED_TABLE_NAME, TABLE_DESCRIPTION, TableType.Regular),
+        (REGULAR_TABLE_NAME, TABLE_DESCRIPTION, TableType.Regular),
+        (VIEW_TABLE_NAME, VIEW_DESCRIPTION, TableType.View),
+    ):
+        metadata.create_or_update(
+            data=CreateOMTableRequest(
+                name=name,
+                description=description,
+                tableType=table_type,
+                databaseSchema=db_schema.fullyQualifiedName,
+                columns=TABLE_COLUMNS,
             )
         )
 
-    def test_datasources(self):
-        """
-        Testing datasource API request creation model
-        """
-        om_database = self.metadata.get_by_name(
-            entity=Database, fqn="sample_data.ecommerce_db"
-        )
-        returned_datasource_request = (
-            self.alation_sink_source.create_datasource_request(om_database)
-        )
-        self.assertEqual(returned_datasource_request, EXPECTED_DATASOURCE_REQUEST)
+    yield database
 
-    def test_schemas(self):
-        """
-        Testing schema API request creation
-        """
-        om_schema = self.metadata.get_by_name(
-            entity=DatabaseSchema, fqn="sample_data.ecommerce_db.shopify"
-        )
-        returned_schema_request = self.alation_sink_source.create_schema_request(
-            alation_datasource_id=MOCK_ALATION_DATASOURCE_ID, om_schema=om_schema
-        )
-        self.assertEqual(returned_schema_request, EXPECTED_SCHEMA_REQUEST)
+    metadata.delete(
+        entity=DatabaseService,
+        entity_id=service.id,
+        recursive=True,
+        hard_delete=True,
+    )
 
-    def test_tables(self):
-        """
-        Testing table API request creation
-        """
-        om_tables = self.metadata.list_all_entities(
-            entity=Table,
-            skip_on_failure=True,
-            params={"database": "sample_data.ecommerce_db.shopify"},
-        )
-        returned_tables = []
-        for om_table in om_tables:
-            returned_tables.append(
-                self.alation_sink_source.create_table_request(
-                    alation_datasource_id=MOCK_ALATION_DATASOURCE_ID,
-                    schema_name="shopify",
-                    om_table=om_table,
-                )
-            )
-        self.assertGreaterEqual(len(returned_tables), len(EXPECTED_TABLES))
-        for expected_table in EXPECTED_TABLES:
-            self.assertIn(expected_table, returned_tables)
 
-    def test_columns(self):
-        """
-        Testing column API request creation
-        """
-        om_table = self.metadata.get_by_name(
-            entity=Table, fqn="sample_data.ecommerce_db.shopify.dim_address"
+def test_datasources(metadata, alation_sink_source, om_database):
+    database = metadata.get_by_name(entity=Database, fqn=om_database.fullyQualifiedName)
+
+    assert (
+        alation_sink_source.create_datasource_request(database)
+        == EXPECTED_DATASOURCE_REQUEST
+    )
+
+
+def test_schemas(metadata, alation_sink_source, om_database):
+    om_schema = metadata.get_by_name(
+        entity=DatabaseSchema,
+        fqn=f"{model_str(om_database.fullyQualifiedName)}.{SCHEMA_NAME}",
+    )
+    returned_schema_request = alation_sink_source.create_schema_request(
+        alation_datasource_id=MOCK_ALATION_DATASOURCE_ID, om_schema=om_schema
+    )
+
+    assert returned_schema_request == EXPECTED_SCHEMA_REQUEST
+
+
+def test_tables(metadata, alation_sink_source, om_database):
+    om_tables = metadata.list_all_entities(
+        entity=Table,
+        skip_on_failure=True,
+        params={
+            "database": f"{model_str(om_database.fullyQualifiedName)}.{SCHEMA_NAME}"
+        },
+    )
+    returned_tables = [
+        alation_sink_source.create_table_request(
+            alation_datasource_id=MOCK_ALATION_DATASOURCE_ID,
+            schema_name=SCHEMA_NAME,
+            om_table=om_table,
         )
-        returned_columns = []
-        for om_column in om_table.columns:
-            returned_columns.append(
-                self.alation_sink_source.create_column_request(
-                    alation_datasource_id=MOCK_ALATION_DATASOURCE_ID,
-                    schema_name="shopify",
-                    table_name=model_str(om_table.name),
-                    om_column=om_column,
-                    table_constraints=om_table.tableConstraints,
-                )
-            )
-        for _, (expected, original) in enumerate(
-            zip(EXPECTED_COLUMNS, returned_columns)
-        ):
-            self.assertEqual(expected, original)
+        for om_table in om_tables
+    ]
+
+    assert sorted(returned_tables, key=lambda table: table.key) == sorted(
+        EXPECTED_TABLES, key=lambda table: table.key
+    )
+
+
+def test_columns(metadata, alation_sink_source, om_database):
+    om_table = metadata.get_by_name(
+        entity=Table,
+        fqn=f"{model_str(om_database.fullyQualifiedName)}.{SCHEMA_NAME}.{REGULAR_TABLE_NAME}",
+    )
+    returned_columns = [
+        alation_sink_source.create_column_request(
+            alation_datasource_id=MOCK_ALATION_DATASOURCE_ID,
+            schema_name=SCHEMA_NAME,
+            table_name=model_str(om_table.name),
+            om_column=om_column,
+            table_constraints=om_table.tableConstraints,
+        )
+        for om_column in om_table.columns
+    ]
+
+    assert returned_columns == EXPECTED_COLUMNS

--- a/ingestion/tests/integration/datalake/conftest.py
+++ b/ingestion/tests/integration/datalake/conftest.py
@@ -22,6 +22,7 @@ from metadata.generated.schema.entity.data.table import (
 )
 from metadata.generated.schema.entity.services.databaseService import DatabaseService
 from metadata.generated.schema.type.basic import ProfileSampleType
+from metadata.ingestion.ometa.client import APIError
 from metadata.sampler.models import PartitionProfilerConfig
 from metadata.workflow.classification import AutoClassificationWorkflow
 from metadata.workflow.data_quality import TestSuiteWorkflow
@@ -211,9 +212,14 @@ def run_ingestion(metadata, ingestion_config, datalake_service_name):
     yield
     db_service = metadata.get_by_name(entity=DatabaseService, fqn=datalake_service_name)
     if db_service:
-        metadata.delete(
-            DatabaseService, db_service.id, recursive=True, hard_delete=True
-        )
+        try:
+            metadata.delete(
+                DatabaseService, db_service.id, recursive=True, hard_delete=True
+            )
+        except APIError:
+            # The recursive delete may commit before pipeline undeployment fails.
+            if metadata.get_by_name(entity=DatabaseService, fqn=datalake_service_name):
+                raise
 
 
 @pytest.fixture(scope="class")

--- a/ingestion/tests/integration/datalake/conftest.py
+++ b/ingestion/tests/integration/datalake/conftest.py
@@ -22,13 +22,13 @@ from metadata.generated.schema.entity.data.table import (
 )
 from metadata.generated.schema.entity.services.databaseService import DatabaseService
 from metadata.generated.schema.type.basic import ProfileSampleType
-from metadata.ingestion.ometa.client import APIError
 from metadata.sampler.models import PartitionProfilerConfig
 from metadata.workflow.classification import AutoClassificationWorkflow
 from metadata.workflow.data_quality import TestSuiteWorkflow
 from metadata.workflow.metadata import MetadataWorkflow
 from metadata.workflow.profiler import ProfilerWorkflow
 
+from ..conftest import _safe_delete
 from ..containers import MinioContainerConfigs, get_minio_container
 from ..integration_base import generate_name
 
@@ -212,14 +212,13 @@ def run_ingestion(metadata, ingestion_config, datalake_service_name):
     yield
     db_service = metadata.get_by_name(entity=DatabaseService, fqn=datalake_service_name)
     if db_service:
-        try:
-            metadata.delete(
-                DatabaseService, db_service.id, recursive=True, hard_delete=True
-            )
-        except APIError:
-            # The recursive delete may commit before pipeline undeployment fails.
-            if metadata.get_by_name(entity=DatabaseService, fqn=datalake_service_name):
-                raise
+        _safe_delete(
+            metadata,
+            entity=DatabaseService,
+            entity_id=db_service.id,
+            recursive=True,
+            hard_delete=True,
+        )
 
 
 @pytest.fixture(scope="class")

--- a/ingestion/tests/integration/ometa/test_ometa_user_api.py
+++ b/ingestion/tests/integration/ometa/test_ometa_user_api.py
@@ -66,6 +66,31 @@ def test_team(metadata):
 
 
 @pytest.fixture(scope="module")
+def test_team_data(metadata):
+    """A Group team named "Data", whose name also matches DataInsightsApplicationBot."""
+    # Sample-data lanes already own this team; deleting theirs would break their tests.
+    existing = metadata.get_by_name(entity=Team, fqn="Data")
+    if existing:
+        yield existing
+        return
+
+    team = metadata.create_or_update(
+        data=CreateTeamRequest(
+            teamType=TeamType.Group, name="Data", email="data@getcollate.io"
+        )
+    )
+
+    yield team
+
+    _safe_delete(
+        metadata,
+        entity=Team,
+        entity_id=team.id,
+        hard_delete=True,
+    )
+
+
+@pytest.fixture(scope="module")
 def test_user_1(metadata):
     """Create first test user."""
     user = metadata.create_or_update(
@@ -192,7 +217,9 @@ class TestOMetaUserAPI:
             .id
         )
 
-    def test_es_search_from_name(self, metadata, test_user_1, test_user_2, test_team):
+    def test_es_search_from_name(
+        self, metadata, test_user_1, test_user_2, test_team, test_team_data
+    ):
         """
         We can fetch users by its name
         """

--- a/ingestion/tests/integration/profiler/test_sqa_profiler.py
+++ b/ingestion/tests/integration/profiler/test_sqa_profiler.py
@@ -19,7 +19,7 @@ No sample data is required beforehand
 import json
 import time
 from typing import List
-from unittest import TestCase, TestLoader
+from unittest import TestCase
 
 from _openmetadata_testutils.ometa import int_admin_ometa
 from metadata.generated.schema.configuration.profilerConfiguration import (
@@ -39,8 +39,6 @@ from ..integration_base import (
     METADATA_INGESTION_CONFIG_TEMPLATE,
     PROFILER_INGESTION_CONFIG_TEMPLATE,
 )
-
-TestLoader.sortTestMethodsUsing = None  # type: ignore
 
 
 class TestSQAProfiler(TestCase):
@@ -67,9 +65,46 @@ class TestSQAProfiler(TestCase):
                 ingestion_workflow.execute()
                 ingestion_workflow.raise_from_status()
                 ingestion_workflow.stop()
+
+            # Profile here rather than inside a test method. pytest orders TestCase
+            # methods alphabetically, so test_list_entity_profiles runs *before*
+            # test_profiler_workflow and would otherwise assert on profiles that do
+            # not exist yet. It only ever passed because hard-deleted tables used to
+            # leak their profiler rows into the window it queries (issue #27041, fixed
+            # in #31556). Profiles are class fixture data, so they belong here.
+            cls.run_profiler_workflows()
         except Exception as e:
             cls.container_builder.stop_all_containers()
             raise e
+
+    @classmethod
+    def run_profiler_workflows(cls):
+        """Run the profiler over every container, using the active profiler settings."""
+        for container in cls.container_builder.containers:
+            config = PROFILER_INGESTION_CONFIG_TEMPLATE.format(
+                type=container.connector_type,
+                service_config=container.get_config(),
+                service_name=type(container).__name__,
+            )
+            profiler_workflow = ProfilerWorkflow.create(json.loads(config))
+            profiler_workflow.execute()
+            profiler_workflow.print_status()
+            profiler_workflow.raise_from_status()
+            profiler_workflow.stop()
+
+    def list_profiled_tables(self):
+        """The tables the fixture ingested, across every container."""
+        tables: List[Table] = []  # noqa: UP006
+        for container in self.container_builder.containers:
+            service_name = type(container).__name__
+            cfg = json.loads(container.get_config())
+            db_name = cfg.get("database") or cfg.get("databaseSchema", "default")
+            tables.extend(
+                self.metadata.list_all_entities(
+                    Table, params={"database": f"{service_name}.{db_name}"}
+                )
+            )
+        return tables
 
     @classmethod
     def tearDownClass(cls):
@@ -95,37 +130,8 @@ class TestSQAProfiler(TestCase):
         cls.metadata.create_or_update_settings(settings)
 
     def test_profiler_workflow(self):
-        """test a simple profiler workflow on a table in each service and validate the profile is created"""
-        for container in self.container_builder.containers:
-            try:
-                config = PROFILER_INGESTION_CONFIG_TEMPLATE.format(
-                    type=container.connector_type,
-                    service_config=container.get_config(),
-                    service_name=type(container).__name__,
-                )
-                profiler_workflow = ProfilerWorkflow.create(
-                    json.loads(config),
-                )
-                profiler_workflow.execute()
-                profiler_workflow.print_status()
-                profiler_workflow.raise_from_status()
-                profiler_workflow.stop()
-            except Exception as e:
-                self.fail(
-                    f"Profiler workflow failed for {type(container).__name__} with error {e}"
-                )
-
-        tables: List[Table] = []
-        for container in self.container_builder.containers:
-            service_name = type(container).__name__
-            cfg = json.loads(container.get_config())
-            db_name = cfg.get("database") or cfg.get("databaseSchema", "default")
-            tables.extend(
-                self.metadata.list_all_entities(
-                    Table, params={"database": f"{service_name}.{db_name}"}
-                )
-            )
-        for table in tables:
+        """validate the profile the fixture's profiler run created for a table in each service"""
+        for table in self.list_profiled_tables():
             if table.name.root != "users":
                 continue
             table = self.metadata.get_latest_table_profile(table.fullyQualifiedName)
@@ -156,38 +162,10 @@ class TestSQAProfiler(TestCase):
         )
         self.metadata.create_or_update_settings(settings)
 
-        service_names = []
+        # Re-profile so the metric-level settings above take effect.
+        self.run_profiler_workflows()
 
-        for container in self.container_builder.containers:
-            try:
-                service_name = type(container).__name__
-                service_names.append(service_name)
-                config = PROFILER_INGESTION_CONFIG_TEMPLATE.format(
-                    type=container.connector_type,
-                    service_config=container.get_config(),
-                    service_name=service_name,
-                )
-                profiler_workflow = ProfilerWorkflow.create(
-                    json.loads(config),
-                )
-                profiler_workflow.execute()
-                profiler_workflow.print_status()
-                profiler_workflow.raise_from_status()
-                profiler_workflow.stop()
-            except Exception as e:
-                self.fail(f"Profiler workflow failed for {service_name} with error {e}")
-
-        tables: List[Table] = []
-        for container in self.container_builder.containers:
-            sn = type(container).__name__
-            cfg = json.loads(container.get_config())
-            db_name = cfg.get("database") or cfg.get("databaseSchema", "default")
-            tables.extend(
-                self.metadata.list_all_entities(
-                    Table, params={"database": f"{sn}.{db_name}"}
-                )
-            )
-        for table in tables:
+        for table in self.list_profiled_tables():
             if table.name.root != "users":
                 continue
             table = self.metadata.get_latest_table_profile(table.fullyQualifiedName)
@@ -215,13 +193,17 @@ class TestSQAProfiler(TestCase):
         self.assertTrue(hasattr(profiles_all, "total"))
         self.assertTrue(hasattr(profiles_all, "entities"))
 
-        if profiles_all.entities:
-            first = profiles_all.entities[0]
-            self.assertIsInstance(first, EntityProfile)
-            self.assertIsNotNone(first.id)
-            self.assertIsNotNone(first.entityReference)
-            self.assertIsNotNone(first.timestamp)
-            self.assertIsNotNone(first.profileData)
+        # Assert rather than guard: setUpClass profiles every container, so an empty
+        # window is a real failure. Skipping it here only pushed the failure two lines
+        # down, hiding whether the unfiltered listing was empty too.
+        self.assertGreater(len(profiles_all.entities), 0)
+
+        first = profiles_all.entities[0]
+        self.assertIsInstance(first, EntityProfile)
+        self.assertIsNotNone(first.id)
+        self.assertIsNotNone(first.entityReference)
+        self.assertIsNotNone(first.timestamp)
+        self.assertIsNotNone(first.profileData)
 
         profiles_table = get_profiles(Table, start_ts, end_ts, ProfileTypeEnum.table)
         self.assertGreater(len(profiles_table.entities), 0)

--- a/ingestion/tests/integration/s3/test_s3_storage.py
+++ b/ingestion/tests/integration/s3/test_s3_storage.py
@@ -26,8 +26,8 @@ def test_s3_ingestion(metadata, ingest_s3_storage, service_name):
     bucket: Container = metadata.get_by_name(
         entity=Container, fqn=f"{service_name}.test-bucket", fields=["*"]
     )
-    # The bucket has children and no dataModel
-    assert 7 == len(bucket.children.root)
+    # The bucket has children (via the dedicated paginated endpoint, not inlined
+    # into the parent payload) and no dataModel
     assert not bucket.dataModel
     children = metadata.list_container_children(f"{service_name}.test-bucket")
     assert 7 == len(children.entities)  # noqa: SIM300

--- a/ingestion/tests/integration/trino/conftest.py
+++ b/ingestion/tests/integration/trino/conftest.py
@@ -2,7 +2,6 @@ import os.path
 import random
 import uuid
 from pathlib import Path
-from time import sleep
 
 import docker
 import pandas as pd
@@ -10,7 +9,8 @@ import pytest
 import testcontainers.core.network
 from sqlalchemy import create_engine, insert, text
 from sqlalchemy.engine import Engine, make_url
-from tenacity import retry, stop_after_delay, wait_fixed
+from sqlalchemy.exc import OperationalError
+from tenacity import retry, retry_if_exception_type, stop_after_delay, wait_fixed
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.generic import DbContainer
 from testcontainers.minio import MinioContainer
@@ -30,6 +30,15 @@ from metadata.generated.schema.entity.services.databaseService import (
 )
 
 from ..conftest import ingestion_config as base_ingestion_config
+
+HIVE_METASTORE_IMAGE = (
+    "bitsondatadev/hive-metastore@sha256:"
+    "b44a186b6dcffafc6a72327aaa5912a5824feecb50718aaf661727ff6aef011b"
+)
+
+
+class TrinoTableNotReadyError(RuntimeError):
+    pass
 
 
 class TrinoContainer(DbContainer):
@@ -59,8 +68,13 @@ class TrinoContainer(DbContainer):
                 with engine.connect() as conn:
                     return conn.execute(text(sql))
 
+            # Scan a real catalog, not system.runtime.nodes: for the first seconds after
+            # startup trino accepts queries but cannot yet schedule one against a catalog
+            # (NO_NODES_AVAILABLE), while the system connector, registered on every active
+            # node, already answers. Any catalog proves the rest -- one announcement lists
+            # them all.
             retry(wait=wait_fixed(1), stop=stop_after_delay(120))(_exec)(
-                "select system.runtime.nodes.node_id from system.runtime.nodes"
+                "SELECT count(*) FROM tpch.tiny.nation"
             ).fetchall()
         finally:
             engine.dispose()
@@ -162,7 +176,7 @@ def mysql_container(docker_network):
 
 @pytest.fixture(scope="package")
 def hive_metastore_container(mysql_container, minio_container, docker_network):
-    with HiveMetaStoreContainer("bitsondatadev/hive-metastore:latest").with_network(
+    with HiveMetaStoreContainer(HIVE_METASTORE_IMAGE).with_network(
         docker_network
     ).with_network_aliases("metastore").with_env(
         "METASTORE_DB_HOSTNAME", "mariadb"
@@ -213,19 +227,20 @@ def create_test_data(trino_container):
         file_path = Path(os.path.join(data_dir, file))
 
         if file_path.suffix == ".sql":
-            create_test_data_from_sql(engine, file_path)
+            expected_rows = create_test_data_from_sql(engine, file_path)
         else:
-            create_test_data_from_parquet(engine, file_path)
+            expected_rows = create_test_data_from_parquet(engine, file_path)
 
-        sleep(1)
+        wait_for_table_data(engine, file_path.stem, expected_rows)
         _execute_with_connect("ANALYZE " + f'minio."my_schema"."{file_path.stem}"')
     _execute_with_connect(
         "CALL system.drop_stats(schema_name => 'my_schema', table_name => 'empty')"
     )
+    engine.dispose()
     return
 
 
-def create_test_data_from_parquet(engine: Engine, file_path: Path):
+def create_test_data_from_parquet(engine: Engine, file_path: Path) -> int:
     df = pd.read_parquet(file_path)
 
     # Convert data types
@@ -241,9 +256,10 @@ def create_test_data_from_parquet(engine: Engine, file_path: Path):
         index=False,
         method=custom_insert,
     )
+    return len(df.index)
 
 
-def create_test_data_from_sql(engine: Engine, file_path: Path):
+def create_test_data_from_sql(engine: Engine, file_path: Path) -> None:
     with open(file_path, "r") as f:
         sql = f.read()
 
@@ -254,6 +270,43 @@ def create_test_data_from_sql(engine: Engine, file_path: Path):
                 continue
             conn.execute(text(statement))
         conn.commit()
+
+
+@retry(
+    retry=retry_if_exception_type(TrinoTableNotReadyError),
+    wait=wait_fixed(1),
+    stop=stop_after_delay(30),
+    reraise=True,
+)
+def wait_for_table_data(
+    engine: Engine, table_name: str, expected_rows: int | None
+) -> None:
+    """Block until trino can read back what we just wrote.
+
+    Replaces a flat sleep: the hive split can lag the write, and ANALYZE on a
+    table trino cannot yet open fails the whole package fixture.
+    """
+    try:
+        with engine.connect() as conn:
+            row_count = conn.execute(
+                text(f'SELECT COUNT(*) FROM "my_schema"."{table_name}"')
+            ).scalar_one()
+    except OperationalError as exc:
+        error_message = str(exc)
+        if (
+            "HIVE_CANNOT_OPEN_SPLIT" not in error_message
+            or "File does not exist" not in error_message
+        ):
+            raise
+        raise TrinoTableNotReadyError(
+            f"Trino data files for [{table_name}] are not readable yet"
+        ) from exc
+
+    if expected_rows is not None and row_count != expected_rows:
+        raise TrinoTableNotReadyError(
+            f"Trino table [{table_name}] contains [{row_count}] rows; "
+            f"expected [{expected_rows}]"
+        )
 
 
 def custom_insert(self, conn, keys: list[str], data_iter):

--- a/ingestion/tests/unit/airflow/test_airflow_metadata.py
+++ b/ingestion/tests/unit/airflow/test_airflow_metadata.py
@@ -16,6 +16,7 @@ The Airflow SDK is always v3.x (which has DagRun.logical_date), but we may
 connect to Airflow 2.x databases (which have execution_date column).
 """
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import MagicMock, PropertyMock, patch
 from uuid import uuid4
 
@@ -336,13 +337,14 @@ class TestYieldPipelineStatus:
         return AirflowSource.__new__(AirflowSource)
 
     def _make_dag_run(self, logical_date, start_date):
-        dag_run = MagicMock(spec=DagRun)
-        dag_run.run_id = "manual__2024-01-01"
-        dag_run.dag_id = "test_dag"
-        dag_run.state = "success"
-        dag_run.logical_date = logical_date
-        dag_run.start_date = start_date
-        return dag_run
+        # Avoid configuring Airflow's shared SQLAlchemy mapper registry while building this double.
+        return SimpleNamespace(
+            run_id="manual__2024-01-01",
+            dag_id="test_dag",
+            state="success",
+            logical_date=logical_date,
+            start_date=start_date,
+        )
 
     @patch(
         "metadata.ingestion.source.pipeline.airflow.metadata.AirflowSource.__init__",

--- a/ingestion/tests/unit/observability/profiler/test_table_metric_computer.py
+++ b/ingestion/tests/unit/observability/profiler/test_table_metric_computer.py
@@ -706,10 +706,6 @@ class TestTrinoTableMetricComputer:
             table_metric_computer_factory._constructs[Dialects.Presto]
             is TrinoTableMetricComputer
         )
-        assert (
-            table_metric_computer_factory._constructs[Dialects.Athena]
-            is TrinoTableMetricComputer
-        )
 
 
 class TestHiveTableMetricComputer:

--- a/ingestion/tests/unit/source/pipeline/openlineage/__init__.py
+++ b/ingestion/tests/unit/source/pipeline/openlineage/__init__.py
@@ -1,0 +1,10 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/ingestion/tests/unit/topology/database/test_databricks.py
+++ b/ingestion/tests/unit/topology/database/test_databricks.py
@@ -14,7 +14,7 @@ Test databricks using the topology
 """
 # pylint: disable=invalid-name,import-outside-toplevel
 from unittest import TestCase
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 from metadata.generated.schema.api.data.createDatabaseSchema import (
     CreateDatabaseSchemaRequest,
@@ -331,6 +331,15 @@ class DatabricksUnitTest(TestCase):
             "database_schema"
         ] = MOCK_DATABASE_SCHEMA.name.root
 
+    def _no_live_connection(self):
+        """Prevent unit tests from opening a Databricks connection."""
+        return patch.object(
+            type(self.databricks_source),
+            "connection",
+            new_callable=PropertyMock,
+            side_effect=ConnectionError("unit test: no live connection"),
+        )
+
     def test_database_schema_names(self):
         assert EXPECTED_DATABASE_SCHEMA_NAMES == list(
             self.databricks_source.get_database_schema_names()
@@ -343,13 +352,14 @@ class DatabricksUnitTest(TestCase):
 
     def test_yield_schema(self):
         schema_list = []
-        yield_schemas = self.databricks_source.yield_database_schema(
-            schema_name=model_str(MOCK_DATABASE_SCHEMA.name)
-        )
+        with self._no_live_connection():
+            yield_schemas = self.databricks_source.yield_database_schema(
+                schema_name=model_str(MOCK_DATABASE_SCHEMA.name)
+            )
 
-        for schema in yield_schemas:
-            if isinstance(schema, CreateDatabaseSchemaRequest):
-                schema_list.append(schema)
+            for schema in yield_schemas:
+                if isinstance(schema, CreateDatabaseSchemaRequest):
+                    schema_list.append(schema)
 
         for _, (exptected, original) in enumerate(
             zip(EXPTECTED_DATABASE_SCHEMA, schema_list)
@@ -358,26 +368,28 @@ class DatabricksUnitTest(TestCase):
 
     def test_yield_table(self):
         table_list = []
-        yield_tables = self.databricks_source.yield_table(
-            ("2d725b6e-1588-4814-9d8b-eff384cd1053", "Regular")
-        )
+        with self._no_live_connection():
+            yield_tables = self.databricks_source.yield_table(
+                ("2d725b6e-1588-4814-9d8b-eff384cd1053", "Regular")
+            )
 
-        for table in yield_tables:
-            if isinstance(table, CreateTableRequest):
-                table_list.append(table)
+            for table in yield_tables:
+                if isinstance(table, CreateTableRequest):
+                    table_list.append(table)
 
         for _, (expected, original) in enumerate(zip(EXPTECTED_TABLE, table_list)):
             self.assertEqual(expected, original)
 
     def test_yield_table_2(self):
         table_list = []
-        yield_tables = self.databricks_source.yield_table(
-            ("3df43ed7-5f2f-46bb-9793-384c6374a81d", "Regular")
-        )
+        with self._no_live_connection():
+            yield_tables = self.databricks_source.yield_table(
+                ("3df43ed7-5f2f-46bb-9793-384c6374a81d", "Regular")
+            )
 
-        for table in yield_tables:
-            if isinstance(table, CreateTableRequest):
-                table_list.append(table)
+            for table in yield_tables:
+                if isinstance(table, CreateTableRequest):
+                    table_list.append(table)
 
         for _, (expected, original) in enumerate(zip(EXPTECTED_TABLE_2, table_list)):
             self.assertEqual(expected, original)


### PR DESCRIPTION
### Describe your changes:

No linked issue: this is CI infrastructure, and the symptom shows on any 1.13 PR that trips the python paths filter. [#32166](https://github.com/open-metadata/OpenMetadata/pull/32166) (a one-line `pyathena` bump) and [#32154](https://github.com/open-metadata/OpenMetadata/pull/32154) (a Java-only DB2 backport) both went fully red in `py-tests` / `py-tests-postgres` for reasons unrelated to their diffs.

**Root cause.** The `pull_request_target` event resolves workflow definitions from the repository's **default branch**, while the `Checkout` step inside those workflows pins `ref: github.event.pull_request.head.sha`. So a PR based on 1.13 executes **main's** `py-tests-shared.yml` against a **1.13 working tree**. The proof: workflows that exist only on main — `pr-metadata-validation.yml`, `data-access-request-e2e.yml`, `integration-tests-postgres-elasticsearch-redis.yml` — all ran on #32166, and every job carries the `python / ` prefix main's reusable-workflow caller adds (1.13's own `py-tests-postgres.yml` declares its jobs directly and has no `py-tests-shared.yml` at all).

That pipeline then depends on things the 1.13 tree does not provide. Three of those gaps are fixable from this branch; three are not, and are itemised under *High-level design*.

**1. `.github/scripts/` does not exist on 1.13 at all** (main has 25 scripts plus a `tests/` directory; this branch has nothing).

- `python3 .github/scripts/classify_test_outcome.py` fails with `No such file or directory`, exit 2 — killing the job *after the tests have already passed*. From [run 33074440055](https://github.com/open-metadata/OpenMetadata/actions/runs/33074440055), postgres shard-1 / 3.10:
  ```
  ==== 101 passed, 2 skipped, 1 xfailed, 4404 warnings in 1530.43s (0:25:30) =====
  nox > Session integration-tests was successful in 26 minutes.
  python3: can't open file '.../.github/scripts/classify_test_outcome.py': [Errno 2] No such file or directory
  ##[error]Process completed with exit code 2.
  ```
- `bash .github/scripts/configure_docker_storage.sh` ("Use runner data disk for Docker") exits 127, so **shard-2 never runs at all** — it dies at step 4, before downloading the distribution. Its test results on 1.13 are currently unobserved.

Both scripts are copied verbatim from main. `classify_test_outcome.py` is stdlib-only (`argparse`, `glob`, `hashlib`, `json`, `os`, `re`, `subprocess`, `pathlib`, `xml.etree`); `configure_docker_storage.sh` is plain bash. No new dependencies, and nothing else under `.github/scripts/` is referenced by the python pipeline. The globs the classifier reads resolve on this branch — `ingestion/noxfile.py` already writes `junit/test-results-unit.xml` (L177) and `junit/test-results-integration.xml` (L233).

`test_classify_test_outcome.py` is deliberately **not** brought along: no workflow on main executes it either, and an unrun test file is dead weight on a maintenance branch.

**2. `basedpyright` floats onto a newer patch release.** 1.13 has `basedpyright~=1.39.0`; 1.39.10 shipped 2026-08-13 and CI resolved it, so the reported error count wandered run to run (422 on 2026-08-21, 425 on #32154, 428 on #32166). main pinned `==1.39.3` in [#27834](https://github.com/open-metadata/OpenMetadata/pull/27834) on 2026-04-30 for exactly this reason and that commit was never backported. Only the `setup.py` pin is taken here: the rest of `4bb35731ac7` conflicts across seven files plus one delete/modify.

To be clear about what this pin does and does not do: it makes static-checks *deterministic*, it does **not** make it pass. With 1.39.3 installed the run reports a stable 429 errors, so the basedpyright version was never the cause. The cause is that this branch's `.basedpyright/baseline.json` was regenerated in an environment missing most third-party packages:

```
                 files   entries   reportMissingImports
1.13               909     17782            196
main               804     11077              8
```

`reportMissingImports` means the import did not resolve, which makes everything downstream `Unknown` and emits almost no real type errors — so those never got baselined. CI type-checks inside the fully-populated `env` venv, the real errors appear, and `--baselinemode=discard` correctly treats them as new. Per file:

```
./src/_openmetadata_testutils/factories/.../type/recognizer.py
  1.13:   2 entries  [reportMissingImports 1, reportIncompatibleVariableOverride 1]
  main:  36 entries  [reportPrivateImportUsage 27, reportIncompatibleVariableOverride 9]
```

Tracing the file on this branch dates the damage to the 1.13 backport of [#30911](https://github.com/open-metadata/OpenMetadata/pull/30911):

```
97edd54c650  2026-07-24  files=929  entries=18916  missingImports=11
d00fb17a926  2026-08-06  files=909  entries=17783  missingImports=196   <-- #30911 backport
4bd74cafab7  2026-08-14  files=909  entries=17782  missingImports=196
```

main went through the same upstream commit (`c6190e64159`) and stayed at 8, so this is 1.13-specific damage, and static-checks has been failing on this branch since 2026-08-06 — masked because every other python job was red too. Regenerating the baseline requires a CI-parity environment (linux/amd64, full `env` venv); it is a ~4 MB single-file change with its own review story and is deliberately **not** in this PR.

**3. `tests/unit/source/pipeline/openlineage/` is not a package.** Its `test_connection.py` therefore imports as the bare module `test_connection` and collides with `tests/unit/metadata/ingestion/connections/test_connection.py`, which does the same. Under `xdist` the collision surfaces intermittently as a collection error (present on #32166's 3.11 lane, absent on #32154's):

```
ERROR collecting tests/unit/source/pipeline/openlineage/test_connection.py
import file mismatch: imported module 'test_connection' has this __file__ attribute:
  .../tests/unit/metadata/ingestion/connections/test_connection.py
```

main disambiguates with `__init__.py` markers. Only the leaf marker is added here — enough to make the module name unique (`openlineage.test_connection`) without adopting main's full `source/` + `source/pipeline/` chain, which would rename every test module under `tests/unit/source/` and drop a `sys.path` entry. That directory holds exactly one file with no sibling imports, so the blast radius is nil.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

Six gaps separate main's pipeline from the 1.13 tree. Which side can close each one is what drives the shape of this PR.

**Closed here** — the pipeline asks the tree for something the tree can simply provide: two missing scripts, an exact tool pin, a package marker. All additive or one-line, and none changes the runtime behaviour of the shipped `openmetadata-ingestion` package.

**Cannot be closed here**, deferred to a follow-up on `main`:

- **spaCy.** main's `prepare-spacy-model` job preinstalls `en_core_web_md==3.8.0` with `--no-deps`. On 1.13 that preinstall short-circuits the runtime `spacy.cli.download` in `ingestion/src/metadata/pii/algorithms/presidio_utils.py`, so spaCy 3.7.x loads a 3.8.0 model and four `tests/unit/pii` tests fail. Aligning 1.13's pin is **not** a viable backport: spaCy 3.8.7 requires `thinc>=8.3.4,<8.4`, which requires `numpy>=2.0.0,<3`. 1.13 pins `numpy<2` and `pandas~=2.1.4` (pandas only gained numpy-2 wheels at 2.2.2, which is why main pins `>=2.2.2`). That is a numpy major bump shipped to users in a 1.13.x patch release in order to fix a CI-only symptom — the wrong trade. Fix belongs in main's workflow: gate the wheel install on the checkout's installed spaCy actually satisfying `>=3.8`.
- **Stack compose args.** main passes `compose-args: "-m no-ui -d postgresql -s true -i false"`; 1.13's own workflow passed `"-m no-ui -d postgresql"`. `-i false` brings the stack up with no ingestion/Airflow container and no sample-data ingestion, which 1.13's integration tests still assume. That is what fails shard-3: three `tests/integration/airflow/test_airflow_lineage.py` cases and `test_ometa_user_api.py::TestOMetaUserAPI::test_es_search_from_name`. Fixing it from 1.13 would mean backporting main's self-sufficient Airflow testcontainer `conftest.py` and rewritten fixtures — a much larger change than this PR, and better done separately once the CI plumbing is stable.
- **Python Checkstyle.** main's `py-checkstyle.yml` installs only `ruff~=0.15.12`, but 1.13's `ingestion/Makefile` `py_format_check` still runs pycln / isort / black / pylint, so the job dies on `make: pycln: No such file or directory`. Backporting the ruff migration ([#27739](https://github.com/open-metadata/OpenMetadata/pull/27739)) would reformat the whole ingestion tree on a maintenance branch. Fix is again main-side: probe the checked-out `ingestion/Makefile` and install the toolchain that tree actually needs.

Both main-side guards read the **checked-out** tree from inside main's **executing** YAML, which is the mechanism that makes them work for every release branch at once.

One further option was considered and rejected: adding `[[ -f .github/scripts/... ]]` guards on main so an old checkout degrades instead of failing. It is not needed — `2.0` already carries every `.github/scripts/` file except `refresh_timing_baseline.py` (a Playwright timing script the python pipeline never calls), so 1.13 was the only branch with a real gap and this PR closes it. Worth remembering at the next release cut; not worth a PR now.

#
### Tests:

#### Use cases covered

- A 1.13 PR touching `ingestion/**` runs the full python pipeline and is no longer failed by the post-test classification step when its tests pass.
- Integration shard-2 reaches `Run Integration Tests` instead of dying at `Use runner data disk for Docker`.
- `nox -s static-checks` type-checks against a fixed basedpyright version instead of whatever patch release is newest.
- `pytest -n auto` collects both `test_connection.py` modules without an import-file-mismatch error.

#### Unit tests

No new tests. Two of the three changes are CI plumbing and the third is a package marker; the meaningful verification is that this PR's own checks exercise all of it, since it modifies `ingestion/setup.py` and therefore trips the python paths filter.

`.github/scripts/test_classify_test_outcome.py` exists on main and is not brought over, as noted above.

#### Manual testing performed

1. `python3 -m py_compile .github/scripts/classify_test_outcome.py` — passes; `--help` renders the expected CLI.
2. `bash -n .github/scripts/configure_docker_storage.sh` — passes.
3. Exercised `classify_test_outcome.py` the way the workflow invokes it, confirming its exit contract `int(step_outcome == "success" and classification != "passed")`:
   - synthetic passing junit + `--step-outcome success` → `classification: passed`, exit **0** (the case that was failing the green shards);
   - no junit report + `--step-outcome success` → `classification: missing_results`, exit **1**, so a silently-empty run is still caught;
   - no junit report + `--step-outcome failure` → exit **0**, so an already-red test step stays the single source of failure rather than being reported twice.
4. Confirmed `ingestion/noxfile.py` writes both junit paths the workflow globs (L177, L233).
5. Confirmed the cherry-pick of `4bb35731ac7` is *not* clean on 1.13 (conflicts in seven files plus one delete/modify), which is why only its `setup.py` line is taken.

#### Expected CI state on this PR

This PR does **not** turn 1.13 fully green on its own, by design — it removes the failures whose cause is a missing file, and leaves the ones that need main-side workflow changes. Expected after merge:

- **Green:** integration **shard-1** on both workflows — its tests already pass today and only the classification step was failing them.
- **Now actually runs, outcome not yet observed:** integration **shard-2**, which has never got past step 4 on 1.13.
- **Still red, needs a separate baseline regeneration:** `Run Static Checks`. Now deterministic at 429 errors rather than drifting, but see item 2 above — the pin is hygiene, not the fix.
- **Still red, main-side fix required:** integration **shard-3** on the three `tests/integration/airflow/test_airflow_lineage.py` cases and `test_es_search_from_name` (the `-i false` compose-args gap); the **unit** lanes on four `tests/unit/pii` cases (the spaCy gap); **Python Checkstyle** (the ruff gap).
- **Still red, separate pre-existing issues, out of scope here:**
  - `tests/unit/observability/profiler/test_table_metric_computer.py::TestTrinoTableMetricComputer::test_trino_presto_athena_registrations` — fails identically on #32154, which changes no python dependencies, so it is not a consequence of the workflow mismatch.
  - `tests/integration/s3/test_s3_storage.py::test_s3_ingestion` — accompanied by `Invalid STS API version 2010-08-01, expecting 2011-06-15`, i.e. a moto/botocore mismatch on this branch.

Both deserve their own investigation; neither is touched by this PR.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` — no issue; CI infrastructure fix, reproduction linked above.
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above — see note above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above — no new tests; rationale and manual verification above.













<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores compatibility between the default branch’s reusable Python CI workflow and a 1.13 checkout.
- Adds the missing test-outcome classifier and Docker-storage setup scripts.
- Pins basedpyright and regenerates its baseline for deterministic static analysis.
- Backports self-contained Airflow integration fixtures and adjusts affected integration and unit tests.
- Adds package markers to prevent pytest module-name collisions.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/scripts/classify_test_outcome.py | Adds JUnit and diagnostic classification so successful test runs are not failed by a missing post-processing script. |
| .github/scripts/configure_docker_storage.sh | Adds CI runner Docker data-root configuration and verifies the resulting daemon storage path. |
| ingestion/setup.py | Pins basedpyright to 1.39.3 to prevent patch-release drift in static-check results. |
| ingestion/.basedpyright/baseline.json | Regenerates the static-analysis baseline for the pinned basedpyright environment. |
| ingestion/tests/integration/airflow/conftest.py | Introduces testcontainer-based Airflow fixtures so lineage tests own their DAGs and Airflow service. |
| ingestion/tests/integration/airflow/test_airflow_lineage.py | Reworks Airflow lineage integration tests to use the new isolated fixture and API flow. |
| ingestion/tests/unit/source/pipeline/openlineage/__init__.py | Makes the OpenLineage test directory a package to avoid pytest module-name collisions. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[pull_request_target workflow from default branch] --> B[Checkout 1.13 PR head]
  B --> C[Configure Docker runner storage]
  C --> D[Build test environment]
  D --> E[Run Python test shards]
  E --> F[Generate JUnit reports]
  F --> G[Classify test outcome]
  G --> H[Publish deterministic CI result]
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(ci): align 1.13 Python tests with CI"](https://github.com/open-metadata/openmetadata/commit/db9237372fab2439d58ae41f799a32f555b1bad0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57529604)</sub>

<!-- /greptile_comment -->