### PR TITLE
fix(deps): bump Spring to 7.0.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <httpasyncclient.version>4.1.5</httpasyncclient.version>
     <openapiswagger.version>2.2.25</openapiswagger.version>
     <httpclient.version>4.5.14</httpclient.version>
-    <spring.version>6.2.19</spring.version>
+    <spring.version>7.0.9</spring.version>
     <log4j.version>2.25.5</log4j.version>
     <org.junit.jupiter.version>5.11.4</org.junit.jupiter.version>
     <org.junit.platform.version>1.11.4</org.junit.platform.version>


### PR DESCRIPTION
## Summary

- Bump the shared Spring Framework version from 6.2.19 to 7.0.9.
- This resolves the OpenMetadata-managed spring-expression and spring-beans dependencies.
- Remediates CVE-2026-47886, CVE-2026-59282, and CVE-2026-59283.
- Paired Collate PR #6230 upgrades the explicitly managed spring-web dependency.

## Validation

- mvn -pl openmetadata-service -am -DskipTests dependency:tree -Dincludes=org.springframework:spring-expression,org.springframework:spring-beans resolves both artifacts to 7.0.9.
- Verified the remote PR diff changes only the root pom.xml.

### Combined local runtime validation

Validated this OMD change with the Collate #6230 checkout against fresh isolated MySQL and Elasticsearch instances:

- Created, listed, and searched 50 users through the API.
- Authenticated a non-admin user; self-permission debug returned 200, while cross-user debug correctly returned 403.
- Ran 50 live permission evaluations, executing 250 SpEL condition evaluations.
- Valid SpEL boolean, role, and ternary conditions returned 204; type references, constructors, and bean references were rejected with 400.
- Verified the service health endpoint returned 200 and non-admin search returned 200.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the shared Spring Framework version from 6.2.19 to 7.0.9 to address the listed security advisories.
- Applies Spring 7.0.9 to the root-managed `spring-core` dependency.
- Propagates the version to service dependencies that consume the shared property.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge based on the reviewed dependency declarations and current repository usage.

The change consistently updates the shared Spring version, and the review found no concrete incompatible API, mixed-major dependency, or reachable build or runtime failure.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| pom.xml | Bumps the shared Spring Framework property to 7.0.9; no concrete compatibility defect was established from the changed declaration and repository usage. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(deps): bump Spring to 7.0.9"](https://github.com/open-metadata/openmetadata/commit/9f03e7c06eebd0b00ed39a5385369771d91e8c10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57536980)</sub>

<!-- /greptile_comment -->