### PR TITLE
refactor(ui): extract axios baseURL into swappable apiBaseUrl module

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/rest/apiBaseUrl.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/apiBaseUrl.ts
@@ -1,0 +1,21 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+// Same-origin default. Downstream distributions (e.g. CDN-served bundles where
+// the UI and API run on different hosts) swap this module at build time via a
+// Vite resolver alias — see collate-ui's `vite.config.cdn.ts`.
+import { getBasePath } from '../utils/HistoryUtils';
+
+export function getApiBaseUrl(): string {
+  return `${getBasePath()}/api/v1`;
+}

--- a/openmetadata-ui/src/main/resources/ui/src/rest/index.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/index.ts
@@ -13,14 +13,14 @@
 
 import axios from 'axios';
 import Qs from 'qs';
-import { getBasePath } from '../utils/HistoryUtils';
+import { getApiBaseUrl } from './apiBaseUrl';
 import {
   attachEtagInterceptor,
   DISABLE_ETAG_CONDITIONAL_READS_KEY,
 } from './etagInterceptor';
 
 const axiosClient = axios.create({
-  baseURL: `${getBasePath()}/api/v1`,
+  baseURL: getApiBaseUrl(),
   paramsSerializer: (params) => Qs.stringify(params, { arrayFormat: 'comma' }),
 });
 


### PR DESCRIPTION
## Summary

Extracts the axios client's `baseURL` expression out of `src/rest/index.ts` into a new sibling module `src/rest/apiBaseUrl.ts`. No behaviour change — `getApiBaseUrl()` returns `\`\${getBasePath()}/api/v1\``, exactly what the inline expression produced.

## Why

Downstream distributions where the UI is served from a different origin than the API (a static CDN in front of Dropwizard, for example) need to swap this expression at build time to derive an absolute API URL from `window.location.host`. Doing that today would either require patching this file in a fork or a runtime `process.env` branch in shared code. With the swap point extracted into its own module, the consumer's build tool can redirect the `./apiBaseUrl` import via a one-line `resolve.alias` (or a narrow `resolveId` hook) — no runtime branching, no `process.env` reads, no changes to shared OM code.

## Before

```ts
// src/rest/index.ts
import { getBasePath } from '../utils/HistoryUtils';

const axiosClient = axios.create({
  baseURL: \`\${getBasePath()}/api/v1\`,
  …
});
```

## After

```ts
// src/rest/apiBaseUrl.ts  (new)
import { getBasePath } from '../utils/HistoryUtils';

export function getApiBaseUrl(): string {
  return \`\${getBasePath()}/api/v1\`;
}

// src/rest/index.ts
import { getApiBaseUrl } from './apiBaseUrl';

const axiosClient = axios.create({
  baseURL: getApiBaseUrl(),
  …
});
```

## Impact

- No callers change (only `src/rest/index.ts` referenced the old expression).
- No runtime behaviour changes — same URL, same `getBasePath()` semantics.
- No tests need updating.
- The `apiBaseUrl.ts` module is trivially unit-testable if the extraction is judged worth covering.

## Companion PR (Collate downstream)

open-metadata/openmetadata-collate#6225 — CDN Vite config that consumes this swap point.

## Test plan

- [ ] `yarn build` produces the same axios `baseURL` as before (identity refactor).
- [ ] `yarn test` — no test changes; existing tests still pass.
- [ ] Manual: sign into a running OM UI, confirm API calls still resolve to `/api/v1/*` on the same origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Extracts the axios API base URL calculation into a dedicated, build-time-swappable module while preserving the existing same-origin default.
- Adds `getApiBaseUrl()` with the existing `${getBasePath()}/api/v1` behavior.
- Updates the shared axios client to obtain its base URL through the new module boundary.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the extraction preserves the existing axios base URL value and initialization behavior.

The new helper evaluates the same `getBasePath()` expression at axios client initialization, and the added relative module import is supported by the existing TypeScript, Vite, and Jest configuration.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/rest/apiBaseUrl.ts | Introduces the swappable API base URL function while preserving the previous URL expression and evaluation timing. |
| openmetadata-ui/src/main/resources/ui/src/rest/index.ts | Replaces the direct `getBasePath()` dependency with the new helper without changing axios client behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(ui): extract axios baseURL into..."](https://github.com/open-metadata/openmetadata/commit/98b50db7c86eb363c4bd403ea089e338c7b8d947) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57587738)</sub>

<!-- /greptile_comment -->