### PR TITLE
test(ui): stop export/import tests from cluttering the admin background-jobs tray (#31928) [2.0]

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
@@ -183,6 +183,10 @@ let viewOnlyRole: RolesClass;
 let metricEditorUser: UserClass;
 let metricEditorPolicy: PolicyClass;
 let metricEditorRole: RolesClass;
+// Dedicated admin user for export/import tests so that completed background
+// jobs accumulate in this user's tray instead of the shared admin session,
+// preventing the tray from blocking other admin tests in the same worker.
+let metricExportUser: UserClass;
 let metricTypeId: string | undefined;
 let metricCustomPropertyName: string;
 
@@ -970,6 +974,9 @@ test.describe('Metrics bulk import, export, and edit', () => {
         },
       ],
     });
+
+    metricExportUser = new UserClass(undefined, true);
+    await metricExportUser.create(apiContext);
   });
 
   test.afterAll(async () => {
@@ -981,6 +988,7 @@ test.describe('Metrics bulk import, export, and edit', () => {
       metricEditorUser?.delete(apiContext),
       metricEditorRole?.delete(apiContext),
       metricEditorPolicy?.delete(apiContext),
+      metricExportUser?.delete(apiContext),
     ]);
     await cleanupFixtures();
     await cleanupMetricCustomProperty();
@@ -988,84 +996,94 @@ test.describe('Metrics bulk import, export, and edit', () => {
   });
 
   test('Admin starts exactly one async export job from the metrics listing', async ({
-    page,
+    browser,
   }) => {
-    await redirectToHomePage(page);
-    await waitForMetricsPage(page);
-    await filterMetrics(page, fixtures.prefix);
-    await openMetricActions(page);
+    const page = await browser.newPage();
+    await metricExportUser.login(page);
+    try {
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      await filterMetrics(page, fixtures.prefix);
+      await openMetricActions(page);
 
-    let exportRequestCount = 0;
-    page.on('request', (request) => {
-      if (request.url().includes('/api/v1/metrics/name/*/exportAsync')) {
-        exportRequestCount += 1;
-      }
-    });
+      let exportRequestCount = 0;
+      page.on('request', (request) => {
+        if (request.url().includes('/api/v1/metrics/name/*/exportAsync')) {
+          exportRequestCount += 1;
+        }
+      });
 
-    const exportResponse = page.waitForResponse(
-      (response) =>
-        response.url().includes('/api/v1/metrics/name/*/exportAsync') &&
-        response.request().method() === 'GET'
-    );
+      const exportResponse = page.waitForResponse(
+        (response) =>
+          response.url().includes('/api/v1/metrics/name/*/exportAsync') &&
+          response.request().method() === 'GET'
+      );
 
-    await clickMetricAction(page, 'Export');
-    const response = await exportResponse;
-    expect(response.ok()).toBeTruthy();
-    // Verify exactly one export request was fired (no duplicate calls).
-    await expect.poll(() => exportRequestCount).toBe(1);
-    await expect(page.locator('.csv-jobs-tray-launcher')).toBeVisible({
-      timeout: 30000,
-    });
-    await page.locator('.csv-jobs-tray-launcher').click();
-    await expect(page.locator('.csv-jobs-tray-popover')).toBeVisible();
-    // Verify the export job appears in the tray. Parallel workers share the
-    // admin identity and may have their own active jobs; checking an exact
-    // count is fragile. Instead, assert that a tray item carrying the export
-    // label is visible — the exportRequestCount check above already guarantees
-    // exactly one export request was sent.
-    await expect(
-      page
-        .locator('.csv-jobs-tray-item')
-        .filter({ hasText: /Exporting Metrics|Exported Metrics/ })
-    ).toBeVisible();
+      await clickMetricAction(page, 'Export');
+      const response = await exportResponse;
+      expect(response.status()).toBe(202);
+      // Verify exactly one export request was fired (no duplicate calls).
+      await expect.poll(() => exportRequestCount).toBe(1);
+      await expect(page.locator('.csv-jobs-tray-launcher')).toBeVisible({
+        timeout: 30000,
+      });
+      await page.locator('.csv-jobs-tray-launcher').click();
+      await expect(page.locator('.csv-jobs-tray-popover')).toBeVisible();
+      // Verify the export job appears in the tray. Each test uses a dedicated
+      // user session so only this test's own job is visible — checking the
+      // label is sufficient.
+      await expect(
+        page
+          .locator('.csv-jobs-tray-item')
+          .filter({ hasText: /Exporting Metrics|Exported Metrics/ })
+      ).toBeVisible();
+    } finally {
+      await page.close();
+    }
   });
 
   test('Admin imports a metric CSV through preview and async apply', async ({
-    page,
+    browser,
   }) => {
     test.slow();
-    const importedMetricName = `${fixtures.prefix}_imported`;
-    fixtures.metrics.push({
-      id: '',
-      name: importedMetricName,
-      fullyQualifiedName: importedMetricName,
-    });
+    const page = await browser.newPage();
+    await metricExportUser.login(page);
+    try {
+      const importedMetricName = `${fixtures.prefix}_imported`;
+      fixtures.metrics.push({
+        id: '',
+        name: importedMetricName,
+        fullyQualifiedName: importedMetricName,
+      });
 
-    await redirectToHomePage(page);
-    await waitForMetricsPage(page);
-    await openMetricActions(page);
-    await clickMetricAction(page, 'Import');
-    await expect(page).toHaveURL(/\/bulk\/import\/metric\/\*/);
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      await openMetricActions(page);
+      await clickMetricAction(page, 'Import');
+      await expect(page).toHaveURL(/\/bulk\/import\/metric\/\*/);
 
-    const csvPath = createMetricCsvFile(importedMetricName);
-    await uploadMetricCsvAndWaitForPreview(page, csvPath);
-    await expect(
-      page.getByRole('gridcell', { exact: true, name: importedMetricName })
-    ).toBeVisible();
-    await expect(
-      page.getByRole('button', { name: /Start Import/i })
-    ).toBeVisible();
+      const csvPath = createMetricCsvFile(importedMetricName);
+      await uploadMetricCsvAndWaitForPreview(page, csvPath);
+      await expect(
+        page.getByRole('gridcell', { exact: true, name: importedMetricName })
+      ).toBeVisible();
+      await expect(
+        page.getByRole('button', { name: /Start Import/i })
+      ).toBeVisible();
 
-    const applyResponse = waitForMetricImportResponse(page, false);
-    await page.getByRole('button', { name: /Start Import/i }).click();
-    await applyResponse;
-    await expectMetricImportStatus(page, {
-      processed: '1',
-      passed: '1',
-      failed: '0',
-    });
+      const applyResponse = waitForMetricImportResponse(page, false);
+      await page.getByRole('button', { name: /Start Import/i }).click();
+      await applyResponse;
+      await expectMetricImportStatus(page, {
+        processed: '1',
+        passed: '1',
+        failed: '0',
+      });
 
-    await expectImportedMetricComplexFields(importedMetricName);
+      await expectImportedMetricComplexFields(importedMetricName);
+    } finally {
+      await page.close();
+    }
   });
 
   test('Admin sees metric CSV validation failures for missing names and invalid references', async ({
@@ -1093,66 +1111,74 @@ test.describe('Metrics bulk import, export, and edit', () => {
   });
 
   test('Admin imports a CSV update for an existing metric', async ({
-    page,
+    browser,
   }) => {
     test.slow();
-    const existingMetricName = fixtures.metrics[1].name;
-    const updatedDisplayName = `${fixtures.prefix} Import Updated`;
-    const csv = createCsv([
-      [
-        existingMetricName,
-        updatedDisplayName,
-        'Metric updated from Playwright CSV',
-        'COUNT',
-        'COUNT',
-        '',
-        'MONTH',
-        'SQL',
-        'COUNT(order_id)',
-        fixtures.metrics[0].fullyQualifiedName,
-        fixtures.secondTag.fullyQualifiedName,
-        fixtures.nestedGlossaryTerm.fullyQualifiedName,
-        'Tier.Tier3',
-        `user:${fixtures.owner.name}`,
-        `team:${fixtures.reviewer.name}`,
-        fixtures.domain.fullyQualifiedName,
-        fixtures.dataProduct.fullyQualifiedName,
-        'Approved',
-        `${metricCustomPropertyName}:updated custom value`,
-      ],
-    ]);
-    const csvPath = test.info().outputPath(`${existingMetricName}-update.csv`);
-    fs.writeFileSync(csvPath, csv);
+    const page = await browser.newPage();
+    await metricExportUser.login(page);
+    try {
+      const existingMetricName = fixtures.metrics[1].name;
+      const updatedDisplayName = `${fixtures.prefix} Import Updated`;
+      const csv = createCsv([
+        [
+          existingMetricName,
+          updatedDisplayName,
+          'Metric updated from Playwright CSV',
+          'COUNT',
+          'COUNT',
+          '',
+          'MONTH',
+          'SQL',
+          'COUNT(order_id)',
+          fixtures.metrics[0].fullyQualifiedName,
+          fixtures.secondTag.fullyQualifiedName,
+          fixtures.nestedGlossaryTerm.fullyQualifiedName,
+          'Tier.Tier3',
+          `user:${fixtures.owner.name}`,
+          `team:${fixtures.reviewer.name}`,
+          fixtures.domain.fullyQualifiedName,
+          fixtures.dataProduct.fullyQualifiedName,
+          'Approved',
+          `${metricCustomPropertyName}:updated custom value`,
+        ],
+      ]);
+      const csvPath = test
+        .info()
+        .outputPath(`${existingMetricName}-update.csv`);
+      fs.writeFileSync(csvPath, csv);
 
-    await redirectToHomePage(page);
-    await waitForMetricsPage(page);
-    await openMetricActions(page);
-    await clickMetricAction(page, 'Import');
-    await expect(page).toHaveURL(/\/bulk\/import\/metric\/\*/);
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      await openMetricActions(page);
+      await clickMetricAction(page, 'Import');
+      await expect(page).toHaveURL(/\/bulk\/import\/metric\/\*/);
 
-    await uploadMetricCsvAndWaitForPreview(page, csvPath);
-    await expect(page.getByText(updatedDisplayName)).toBeVisible();
+      await uploadMetricCsvAndWaitForPreview(page, csvPath);
+      await expect(page.getByText(updatedDisplayName)).toBeVisible();
 
-    const applyResponse = waitForMetricImportResponse(page, false);
-    await page.getByRole('button', { name: /Start Import/i }).click();
-    const response = await applyResponse;
-    expect(response.ok()).toBeTruthy();
-    await expectMetricImportStatus(page, {
-      processed: '1',
-      passed: '1',
-      failed: '0',
-    });
+      const applyResponse = waitForMetricImportResponse(page, false);
+      await page.getByRole('button', { name: /Start Import/i }).click();
+      const response = await applyResponse;
+      expect(response.status()).toBe(200);
+      await expectMetricImportStatus(page, {
+        processed: '1',
+        passed: '1',
+        failed: '0',
+      });
 
-    const updatedMetric = await parseResponse<MetricResponse>(
-      await apiContext.get(
-        `/api/v1/metrics/name/${existingMetricName}?fields=extension&include=all`
-      ),
-      'fetch CSV-updated metric'
-    );
-    expect(updatedMetric.displayName).toBe(updatedDisplayName);
-    expect(updatedMetric.extension).toMatchObject({
-      [metricCustomPropertyName]: 'updated custom value',
-    });
+      const updatedMetric = await parseResponse<MetricResponse>(
+        await apiContext.get(
+          `/api/v1/metrics/name/${existingMetricName}?fields=extension&include=all`
+        ),
+        'fetch CSV-updated metric'
+      );
+      expect(updatedMetric.displayName).toBe(updatedDisplayName);
+      expect(updatedMetric.extension).toMatchObject({
+        [metricCustomPropertyName]: 'updated custom value',
+      });
+    } finally {
+      await page.close();
+    }
   });
 
   test('Admin bulk edits filtered metrics from the listing API without export jobs', async ({
@@ -1193,7 +1219,7 @@ test.describe('Metrics bulk import, export, and edit', () => {
     const updateResponse = waitForMetricImportResponse(page, false);
     await page.getByRole('button', { name: 'Update' }).click();
     const response = await updateResponse;
-    expect(response.ok()).toBeTruthy();
+    expect(response.status()).toBe(200);
     await page.waitForURL(/\/metrics/, { timeout: 90000 });
 
     const updatedMetric = await parseResponse<MetricResponse>(
@@ -1695,46 +1721,38 @@ test.describe('Metrics bulk import, export, and edit', () => {
     await expect(page.locator('.metric-list-selection-bar')).not.toBeVisible();
   });
 
-    test('MetricListPage clicking anywhere in a row navigates to metric details', async ({
-      page,
-    }) => {
-      await redirectToHomePage(page);
-      await waitForMetricsPage(page);
-      const searchResponse = waitForMetricsSearchResponse(page);
-      await filterMetrics(page, fixtures.prefix);
-      await searchResponse;
+  test('MetricListPage clicking anywhere in a row navigates to metric details', async ({
+    page,
+  }) => {
+    await redirectToHomePage(page);
+    await waitForMetricsPage(page);
+    const searchResponse = waitForMetricsSearchResponse(page);
+    await filterMetrics(page, fixtures.prefix);
+    await searchResponse;
 
-      const row = page
-        .locator('tr')
-        .filter({ hasText: fixtures.prefix })
-        .first();
-      await expect(row).toBeVisible();
+    const row = page.locator('tr').filter({ hasText: fixtures.prefix }).first();
+    await expect(row).toBeVisible();
 
-      await row.locator('.metric-status-pill').first().click();
+    await row.locator('.metric-status-pill').first().click();
 
-      await expect(page).toHaveURL(/\/metric\//);
-    });
+    await expect(page).toHaveURL(/\/metric\//);
+  });
 
-    test('MetricListPage clicking the row checkbox selects without navigating', async ({
-      page,
-    }) => {
-      await redirectToHomePage(page);
-      await waitForMetricsPage(page);
-      const searchResponse = waitForMetricsSearchResponse(page);
-      await filterMetrics(page, fixtures.prefix);
-      await searchResponse;
+  test('MetricListPage clicking the row checkbox selects without navigating', async ({
+    page,
+  }) => {
+    await redirectToHomePage(page);
+    await waitForMetricsPage(page);
+    const searchResponse = waitForMetricsSearchResponse(page);
+    await filterMetrics(page, fixtures.prefix);
+    await searchResponse;
 
-      const row = page
-        .locator('tr')
-        .filter({ hasText: fixtures.prefix })
-        .first();
-      await expect(row).toBeVisible();
+    const row = page.locator('tr').filter({ hasText: fixtures.prefix }).first();
+    await expect(row).toBeVisible();
 
-      await row.locator('label[slot="selection"]').click();
+    await row.locator('label[slot="selection"]').click();
 
-      await expect(page.locator('.metric-list-selection-count')).toHaveText(
-        '1'
-      );
-      await expect(page).toHaveURL(/\/metrics/);
-    });
+    await expect(page.locator('.metric-list-selection-count')).toHaveText('1');
+    await expect(page).toHaveURL(/\/metrics/);
+  });
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
@@ -11,9 +11,14 @@
  *  limitations under the License.
  */
 
-import { APIRequestContext, expect, Page } from '@playwright/test';
+import { APIRequestContext, expect, Page, test } from '@playwright/test';
+import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
-import { clickOutside, redirectToExplorePage } from '../../utils/common';
+import {
+  clickOutside,
+  getApiContext,
+  redirectToExplorePage,
+} from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import {
   clickUpdateButtonIfVisible,
@@ -22,7 +27,11 @@ import {
   getExportModalContent,
   openExportScopeModal,
 } from '../../utils/explore';
-import { test } from '../fixtures/pages';
+
+// Dedicated admin user so that completed search-export background jobs
+// accumulate in this user's tray instead of the shared admin session,
+// preventing the tray from blocking other admin tests in the same worker.
+let searchExportUser: UserClass;
 
 const startAsyncExport = async (page: Page) => {
   const exportAsyncPromise = page.waitForResponse(
@@ -96,12 +105,24 @@ test.describe('Search Export', { tag: ['@Features', '@Discovery'] }, () => {
           headers: { 'Content-Type': 'application/json-patch+json' },
         }
       );
+    }
 
+    searchExportUser = new UserClass(undefined, true);
+    await searchExportUser.create(apiContext);
+
+    await afterAction();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    if (searchExportUser) {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      await searchExportUser.delete(apiContext);
       await afterAction();
     }
   });
 
   test.beforeEach(async ({ page }) => {
+    await searchExportUser.login(page);
     await redirectToExplorePage(page);
   });
 
@@ -165,7 +186,6 @@ test.describe('Search Export', { tag: ['@Features', '@Discovery'] }, () => {
 
   test('Search mode visible export downloads CSV with tab-specific row count', async ({
     page,
-    browser,
   }) => {
     test.slow();
 
@@ -192,7 +212,7 @@ test.describe('Search Export', { tag: ['@Features', '@Discovery'] }, () => {
     const jobId = await startAsyncExport(page);
 
     await test.step('CSV row count matches the displayed tab count', async () => {
-      const { apiContext, afterAction } = await performAdminLogin(browser);
+      const { apiContext, afterAction } = await getApiContext(page);
       const csvText = await fetchCompletedExportCsv(apiContext, jobId);
 
       expect(countCsvResponseRows(csvText)).toBe(expectedCount);
@@ -244,7 +264,6 @@ test.describe('Search Export', { tag: ['@Features', '@Discovery'] }, () => {
 
   test('Filtered search visible export downloads CSV with the filtered record count', async ({
     page,
-    browser,
   }) => {
     test.slow();
 
@@ -313,7 +332,7 @@ test.describe('Search Export', { tag: ['@Features', '@Discovery'] }, () => {
     const jobId = await startAsyncExport(page);
 
     await test.step('CSV row count matches the filtered record count', async () => {
-      const { apiContext, afterAction } = await performAdminLogin(browser);
+      const { apiContext, afterAction } = await getApiContext(page);
       const csvText = await fetchCompletedExportCsv(apiContext, jobId);
 
       expect(countCsvResponseRows(csvText)).toBe(filteredCount);
@@ -324,7 +343,6 @@ test.describe('Search Export', { tag: ['@Features', '@Discovery'] }, () => {
 
   test('Browse mode visible export downloads CSV with current page row count', async ({
     page,
-    browser,
   }) => {
     test.slow();
 
@@ -369,7 +387,7 @@ test.describe('Search Export', { tag: ['@Features', '@Discovery'] }, () => {
     const jobId = await startAsyncExport(page);
 
     await test.step('CSV row count matches the displayed page count', async () => {
-      const { apiContext, afterAction } = await performAdminLogin(browser);
+      const { apiContext, afterAction } = await getApiContext(page);
       const csvText = await fetchCompletedExportCsv(apiContext, jobId);
 
       expect(countCsvResponseRows(csvText)).toBe(expectedCount);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
@@ -49,10 +49,11 @@ import {
 } from '../../utils/importUtils';
 import { settingClick, sidebarClick } from '../../utils/sidebar';
 
-// use the admin user to login
-test.use({
-  storageState: 'playwright/.auth/admin.json',
-});
+// Dedicated admin user for glossary import/export tests. Using a fresh user
+// instead of the shared admin.json session prevents completed export/import
+// jobs from accumulating in the admin background-jobs tray and blocking other
+// admin tests that run in the same CI worker.
+const glossaryExportUser = new UserClass(undefined, true);
 
 const user1 = new UserClass();
 const user2 = new UserClass();
@@ -109,6 +110,7 @@ test.describe('Glossary Bulk Import Export', () => {
   test.beforeAll('setup pre-test', async () => {
     const { apiContext, afterAction } = await createAdminApiContext();
 
+    await glossaryExportUser.create(apiContext);
     await user1.create(apiContext);
     await user2.create(apiContext);
     await user3.create(apiContext);
@@ -123,6 +125,7 @@ test.describe('Glossary Bulk Import Export', () => {
   test.afterAll('Cleanup', async () => {
     const { apiContext, afterAction } = await createAdminApiContext();
 
+    await glossaryExportUser.delete(apiContext);
     await user1.delete(apiContext);
     await user2.delete(apiContext);
     await user3.delete(apiContext);
@@ -133,6 +136,7 @@ test.describe('Glossary Bulk Import Export', () => {
   });
 
   test.beforeEach(async ({ page }) => {
+    await glossaryExportUser.login(page);
     await redirectToHomePage(page);
 
     // Tests in this file run in parallel as the same admin user, so their CSV


### PR DESCRIPTION
Backport of #31928 to the `2.0` release branch.

`2.0` was missing this change entirely — the auto-cherry-pick bot never ran on
it, because #31928 was merged without the `To release` label.

## What #31928 does

Export/import Playwright specs ran as the shared `admin.json` session, so every
completed CSV job piled up in the admin background-jobs tray. A full tray
overlays the UI and blocks unrelated admin tests sharing that worker. The fix
runs each of these specs as its own dedicated user, so a test only ever sees its
own jobs.

## Conflict resolution

A plain cherry-pick conflicted in all three files, almost entirely on
indentation: `main` wraps these specs in the 3-arg
`test.describe(name, { tag: [...] }, () => {})` form, `2.0` does not, so every
line sits one indent level apart. Re-running with `-Xignore-all-space` reduced
that to a single real conflict, and the result was re-formatted with the repo's
own prettier (2.8.8, `.prettierrc.yaml`).

The one real conflict is in `SearchExport.spec.ts`. #31928 rewrote the tray
step's job-completion polling to use `getApiContext(page)`; on `2.0` that whole
polling block does not exist, because #30937 deliberately removed it in favour
of the 90s `jobRow` visibility wait. **2.0's simplification is kept** — the
block is not reintroduced. `getApiContext` still replaces `performAdminLogin` in
the three CSV-row-count steps, which is the part that matters: `csvAsyncJobs`
filters by requesting user, so those polls have to run as the job's creator.

## Verification

- No conflict markers; `waitForExportJobCompleted` is still a used local helper
  and every import is still referenced.
- Parses clean under `tsc` (remaining diagnostics are pre-existing `lib`/
  `@types/node` gaps from the standalone invocation, not from this change).
- Formatting is prettier-clean, so the UI checkstyle gate has nothing to rewrite.

Not run locally: the Playwright specs themselves — they need a live server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport isolates CSV import/export Playwright activity from the shared admin session by creating dedicated administrative users and ensuring user-scoped API polling uses the initiating session.
- Adds lifecycle-managed users for metric, search, and glossary import/export suites.
- Logs affected browser pages into those dedicated accounts and closes manually created pages reliably.
- Updates response assertions and preserves the 2.0 branch’s existing export-job wait behavior.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issues identified.

The dedicated-user lifecycle, clean-page login flow, initiating-user API context, job-ID scoping, and worker isolation align without leaving a reachable test failure introduced by the backport.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts | Adds a dedicated admin user and isolated pages for CSV tests, with cleanup and explicit successful response-status checks. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts | Replaces the pre-authenticated page fixture with clean pages logged in as worker-scoped dedicated users and polls jobs using the initiating user’s token. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts | Replaces shared admin storage state with a lifecycle-managed dedicated admin user while retaining tray suppression. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): stop export/import tests from ..."](https://github.com/open-metadata/openmetadata/commit/f0a6a193993cf28aa2adeb60326caf678726ebf9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57660006)</sub>

<!-- /greptile_comment -->