### PR TITLE
Fixes #32198: Create Knowledge Center articles through create_entity

### DIFF
--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateEntityTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateEntityTool.java
@@ -16,7 +16,10 @@ import org.openmetadata.schema.entity.classification.Classification;
 import org.openmetadata.schema.entity.classification.Tag;
 import org.openmetadata.schema.entity.context.ContextMemory;
 import org.openmetadata.schema.entity.context.ContextMemorySourceType;
+import org.openmetadata.schema.entity.data.Article;
 import org.openmetadata.schema.entity.data.Metric;
+import org.openmetadata.schema.entity.data.Page;
+import org.openmetadata.schema.entity.data.PageType;
 import org.openmetadata.schema.entity.domains.Domain;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.EventType;
@@ -33,6 +36,7 @@ import org.openmetadata.service.security.ImpersonationContext;
 import org.openmetadata.service.security.auth.CatalogSecurityContext;
 import org.openmetadata.service.security.policyevaluator.CreateResourceContext;
 import org.openmetadata.service.security.policyevaluator.OperationContext;
+import org.openmetadata.service.security.policyevaluator.ResourceContext;
 import org.openmetadata.service.util.DescriptionSanitizer;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.FullyQualifiedName;
@@ -72,10 +76,11 @@ public class CreateEntityTool implements McpTool {
     Boolean requestedMutuallyExclusive = requestedMutuallyExclusive(entity);
 
     applyRepositoryDefaults(entity);
-    authorizeCreate(authorizer, limits, securityContext, entityType, entity);
+    EntityRepository<EntityInterface> repository = type.typedRepository();
+    repository.prepareInternal(entity, false);
+    authorizeCreateOrUpdate(authorizer, limits, securityContext, entityType, entity);
     RuleEngine.getInstance().evaluate(entity);
-    RestUtil.PutResponse<EntityInterface> response =
-        persist(authorizer, securityContext, type, entity, userName);
+    RestUtil.PutResponse<EntityInterface> response = persist(repository, entity, userName);
 
     Map<String, Object> result =
         McpResponseUtils.compact(response.getEntity(), response.getChangeType());
@@ -85,33 +90,46 @@ public class CreateEntityTool implements McpTool {
   }
 
   /**
-   * CREATE rights first, then the overwrite check once {@code prepareInternal} has resolved the
-   * fully qualified name - {@code createOrUpdate} updates in place when the name is taken, so a
-   * caller holding only create rights must not be able to overwrite somebody else's entity.
+   * Authorizes the call as either a create or an overwrite, never both.
+   *
+   * <p>Mirrors {@code EntityResource.createOrUpdate}, which branches exclusively once the name is
+   * resolved: a name that is free is checked as {@link MetadataOperation#CREATE} and counted
+   * against the create quota, while a name already taken is an update, checked as {@link
+   * MetadataOperation#EDIT_ALL} against the existing entity and exempt from the quota.
+   *
+   * <p>Running the create leg unconditionally was stricter than REST in two ways that matter: a
+   * caller holding only edit rights could not update an entity it is allowed to edit, and an
+   * installation at its quota for a type could no longer edit existing entities of that type at
+   * all.
    */
-  private static void authorizeCreate(
+  private static void authorizeCreateOrUpdate(
       Authorizer authorizer,
       Limits limits,
       CatalogSecurityContext securityContext,
       String entityType,
       EntityInterface entity) {
-    OperationContext operationContext = new OperationContext(entityType, MetadataOperation.CREATE);
-    CreateResourceContext<EntityInterface> resourceContext =
-        new CreateResourceContext<>(entityType, entity);
-    limits.enforceLimits(securityContext, resourceContext, operationContext);
-    authorizer.authorize(securityContext, operationContext, resourceContext);
+    String fqn = entity.getFullyQualifiedName();
+    // Include.ALL because createOrUpdate finds the original with ALL: a soft-deleted entity at this
+    // name is still updated in place, so it is an update rather than a create.
+    boolean overwritesExisting =
+        fqn != null && CommonUtils.entityExistsByName(entityType, fqn, Include.ALL);
+    if (overwritesExisting) {
+      OperationContext editContext = new OperationContext(entityType, MetadataOperation.EDIT_ALL);
+      authorizer.authorize(
+          securityContext,
+          editContext,
+          new ResourceContext<EntityInterface>(entityType, null, fqn, Include.ALL));
+    } else {
+      OperationContext createContext = new OperationContext(entityType, MetadataOperation.CREATE);
+      CreateResourceContext<EntityInterface> createResourceContext =
+          new CreateResourceContext<>(entityType, entity);
+      limits.enforceLimits(securityContext, createResourceContext, createContext);
+      authorizer.authorize(securityContext, createContext, createResourceContext);
+    }
   }
 
   private static RestUtil.PutResponse<EntityInterface> persist(
-      Authorizer authorizer,
-      CatalogSecurityContext securityContext,
-      EntityCreationSpec type,
-      EntityInterface entity,
-      String userName) {
-    String entityType = type.entityType();
-    EntityRepository<EntityInterface> repository = type.typedRepository();
-    repository.prepareInternal(entity, false);
-    CommonUtils.authorizeOverwrite(authorizer, securityContext, entityType, entity);
+      EntityRepository<EntityInterface> repository, EntityInterface entity, String userName) {
     RestUtil.PutResponse<EntityInterface> response =
         repository.createOrUpdate(null, entity, userName, ImpersonationContext.getImpersonatedBy());
     McpChangeEventUtil.publishChangeEvent(response.getEntity(), response.getChangeType(), userName);
@@ -205,6 +223,28 @@ public class CreateEntityTool implements McpTool {
     }
     if (entity instanceof Metric metric) {
       validateMetric(metric);
+    }
+    if (entity instanceof Page page) {
+      applyPageBody(page);
+    }
+  }
+
+  /**
+   * An article's body carries nothing the caller has to supply - its markdown lives in {@code
+   * description} - so requiring the bare {@code page} object would fail every article creation on
+   * a field with no value to give it. A quick link's body is its destination, which cannot be
+   * guessed.
+   */
+  private static void applyPageBody(Page page) {
+    boolean needsBody = page.getPage() == null;
+    if (needsBody && PageType.ARTICLE.equals(page.getPageType())) {
+      page.setPage(new Article());
+    } else if (needsBody) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Attribute 'page' is required for a '%s' page and must carry its url, as"
+                  + " {\"url\": \"https://...\"}. Nothing was created.",
+              page.getPageType()));
     }
   }
 

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateEntityTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateEntityTool.java
@@ -2,6 +2,7 @@ package org.openmetadata.mcp.tools;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
+import jakarta.ws.rs.core.Response;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -62,6 +63,8 @@ public class CreateEntityTool implements McpTool {
   private static final String DESCRIPTION = "description";
   private static final String EXTENSION = "extension";
   private static final String ATTRIBUTES = "attributes";
+  private static final String PAGE = "page";
+  private static final String RELATED_ENTITIES = "relatedEntities";
 
   @Override
   public Map<String, Object> execute(
@@ -78,9 +81,14 @@ public class CreateEntityTool implements McpTool {
     applyRepositoryDefaults(entity);
     EntityRepository<EntityInterface> repository = type.typedRepository();
     repository.prepareInternal(entity, false);
-    authorizeCreateOrUpdate(authorizer, limits, securityContext, entityType, entity);
+    boolean updatesExisting = updatesExisting(entityType, entity);
+    authorizeCreateOrUpdate(
+        authorizer, limits, securityContext, entityType, entity, updatesExisting);
+    carryForwardOmittedPageBody(entity, params, updatesExisting);
+    requirePageBody(entity, updatesExisting);
     RuleEngine.getInstance().evaluate(entity);
-    RestUtil.PutResponse<EntityInterface> response = persist(repository, entity, userName);
+    RestUtil.PutResponse<EntityInterface> response =
+        persist(repository, entity, userName, updatesExisting);
 
     Map<String, Object> result =
         McpResponseUtils.compact(response.getEntity(), response.getChangeType());
@@ -107,13 +115,10 @@ public class CreateEntityTool implements McpTool {
       Limits limits,
       CatalogSecurityContext securityContext,
       String entityType,
-      EntityInterface entity) {
+      EntityInterface entity,
+      boolean updatesExisting) {
     String fqn = entity.getFullyQualifiedName();
-    // Include.ALL because createOrUpdate finds the original with ALL: a soft-deleted entity at this
-    // name is still updated in place, so it is an update rather than a create.
-    boolean overwritesExisting =
-        fqn != null && CommonUtils.entityExistsByName(entityType, fqn, Include.ALL);
-    if (overwritesExisting) {
+    if (updatesExisting) {
       OperationContext editContext = new OperationContext(entityType, MetadataOperation.EDIT_ALL);
       authorizer.authorize(
           securityContext,
@@ -128,12 +133,74 @@ public class CreateEntityTool implements McpTool {
     }
   }
 
+  /**
+   * Whether this call updates an entity that already exists under the prepared name.
+   *
+   * <p>{@link Include#ALL} because {@code createOrUpdate} finds the original with ALL: a
+   * soft-deleted entity at this name is still updated in place.
+   */
+  private static boolean updatesExisting(String entityType, EntityInterface entity) {
+    String fqn = entity.getFullyQualifiedName();
+    return fqn != null && CommonUtils.entityExistsByName(entityType, fqn, Include.ALL);
+  }
+
+  /**
+   * Creates through {@code create} and updates through {@code createOrUpdate}, the same split
+   * {@code EntityResource} makes.
+   *
+   * <p>Routing a create through {@code createOrUpdate} left a window in which a competing writer
+   * could take the name between the existence check and the write, after which the call would have
+   * updated that entity holding only CREATE rights. {@code create} fails on the taken name instead,
+   * and the retry is authorized as the update it now is.
+   */
   private static RestUtil.PutResponse<EntityInterface> persist(
-      EntityRepository<EntityInterface> repository, EntityInterface entity, String userName) {
+      EntityRepository<EntityInterface> repository,
+      EntityInterface entity,
+      String userName,
+      boolean updatesExisting) {
+    String impersonatedBy = ImpersonationContext.getImpersonatedBy();
     RestUtil.PutResponse<EntityInterface> response =
-        repository.createOrUpdate(null, entity, userName, ImpersonationContext.getImpersonatedBy());
+        updatesExisting
+            ? repository.createOrUpdate(null, entity, userName, impersonatedBy)
+            : new RestUtil.PutResponse<>(
+                Response.Status.CREATED,
+                repository.create(null, entity, userName, impersonatedBy),
+                EventType.ENTITY_CREATED);
     McpChangeEventUtil.publishChangeEvent(response.getEntity(), response.getChangeType(), userName);
     return response;
+  }
+
+  /**
+   * Keeps the stored page body when an update leaves {@code page} out.
+   *
+   * <p>An update replaces the entity, so the empty Article defaulted for a create would drop the
+   * publication date and delete every related-article relationship. The stored body is read with
+   * the related articles the updater compares against, so leaving the attribute out changes
+   * nothing.
+   */
+  private static void carryForwardOmittedPageBody(
+      EntityInterface entity, Map<String, Object> params, boolean updatesExisting) {
+    boolean bodyOmitted = !asMap(params.get(ATTRIBUTES)).containsKey(PAGE);
+    if (updatesExisting && bodyOmitted && entity instanceof Page page) {
+      Page stored =
+          Entity.getEntityByName(
+              Entity.PAGE, page.getFullyQualifiedName(), RELATED_ENTITIES, Include.ALL);
+      page.setPage(stored.getPage());
+    }
+  }
+
+  /**
+   * A quick link's body is its destination, which cannot be defaulted the way an article's can. It
+   * is required on a create only - an update that leaves it out has already kept the stored one.
+   */
+  private static void requirePageBody(EntityInterface entity, boolean updatesExisting) {
+    if (entity instanceof Page page && page.getPage() == null) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Attribute 'page' is required for a '%s' page and must carry its url, as"
+                  + " {\"url\": \"https://...\"}. Nothing was %s.",
+              page.getPageType(), updatesExisting ? "changed" : "created"));
+    }
   }
 
   /** Shared parameters plus attributes bound to the entity class owned by the repository. */
@@ -232,19 +299,11 @@ public class CreateEntityTool implements McpTool {
   /**
    * An article's body carries nothing the caller has to supply - its markdown lives in {@code
    * description} - so requiring the bare {@code page} object would fail every article creation on
-   * a field with no value to give it. A quick link's body is its destination, which cannot be
-   * guessed.
+   * a field with no value to give it.
    */
   private static void applyPageBody(Page page) {
-    boolean needsBody = page.getPage() == null;
-    if (needsBody && PageType.ARTICLE.equals(page.getPageType())) {
+    if (page.getPage() == null && PageType.ARTICLE.equals(page.getPageType())) {
       page.setPage(new Article());
-    } else if (needsBody) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Attribute 'page' is required for a '%s' page and must carry its url, as"
-                  + " {\"url\": \"https://...\"}. Nothing was created.",
-              page.getPageType()));
     }
   }
 

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateEntityTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateEntityTool.java
@@ -12,16 +12,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.openmetadata.schema.EntityInterface;
-import org.openmetadata.schema.api.domains.CreateDomain;
-import org.openmetadata.schema.entity.classification.Classification;
-import org.openmetadata.schema.entity.classification.Tag;
-import org.openmetadata.schema.entity.context.ContextMemory;
-import org.openmetadata.schema.entity.context.ContextMemorySourceType;
-import org.openmetadata.schema.entity.data.Article;
-import org.openmetadata.schema.entity.data.Metric;
-import org.openmetadata.schema.entity.data.Page;
-import org.openmetadata.schema.entity.data.PageType;
-import org.openmetadata.schema.entity.domains.Domain;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.EventType;
 import org.openmetadata.schema.type.Include;
@@ -40,7 +30,6 @@ import org.openmetadata.service.security.policyevaluator.OperationContext;
 import org.openmetadata.service.security.policyevaluator.ResourceContext;
 import org.openmetadata.service.util.DescriptionSanitizer;
 import org.openmetadata.service.util.EntityUtil;
-import org.openmetadata.service.util.FullyQualifiedName;
 import org.openmetadata.service.util.RestUtil;
 
 /**
@@ -76,23 +65,21 @@ public class CreateEntityTool implements McpTool {
     EntityCreationSpec type = EntityCreationSpec.resolve(entityType);
     String userName = CommonUtils.principal(securityContext);
     EntityInterface entity = buildEntity(type, params, userName);
-    Boolean requestedMutuallyExclusive = requestedMutuallyExclusive(entity);
+    Boolean requestedMutuallyExclusive = EntityTypeRules.requestedMutuallyExclusive(entity);
 
-    applyRepositoryDefaults(entity);
     EntityRepository<EntityInterface> repository = type.typedRepository();
     repository.prepareInternal(entity, false);
     boolean updatesExisting = updatesExisting(entityType, entity);
     authorizeCreateOrUpdate(
         authorizer, limits, securityContext, entityType, entity, updatesExisting);
-    carryForwardOmittedPageBody(entity, params, updatesExisting);
-    requirePageBody(entity, updatesExisting);
+    EntityTypeRules.applyBeforeWrite(entity, asMap(params.get(ATTRIBUTES)), updatesExisting);
     RuleEngine.getInstance().evaluate(entity);
     RestUtil.PutResponse<EntityInterface> response =
         persist(repository, entity, userName, updatesExisting);
 
     Map<String, Object> result =
         McpResponseUtils.compact(response.getEntity(), response.getChangeType());
-    addClassificationWarning(
+    EntityTypeRules.addWarnings(
         requestedMutuallyExclusive, response.getEntity(), response.getChangeType(), result);
     return result;
   }
@@ -170,39 +157,6 @@ public class CreateEntityTool implements McpTool {
     return response;
   }
 
-  /**
-   * Keeps the stored page body when an update leaves {@code page} out.
-   *
-   * <p>An update replaces the entity, so the empty Article defaulted for a create would drop the
-   * publication date and delete every related-article relationship. The stored body is read with
-   * the related articles the updater compares against, so leaving the attribute out changes
-   * nothing.
-   */
-  private static void carryForwardOmittedPageBody(
-      EntityInterface entity, Map<String, Object> params, boolean updatesExisting) {
-    boolean bodyOmitted = !asMap(params.get(ATTRIBUTES)).containsKey(PAGE);
-    if (updatesExisting && bodyOmitted && entity instanceof Page page) {
-      Page stored =
-          Entity.getEntityByName(
-              Entity.PAGE, page.getFullyQualifiedName(), RELATED_ENTITIES, Include.ALL);
-      page.setPage(stored.getPage());
-    }
-  }
-
-  /**
-   * A quick link's body is its destination, which cannot be defaulted the way an article's can. It
-   * is required on a create only - an update that leaves it out has already kept the stored one.
-   */
-  private static void requirePageBody(EntityInterface entity, boolean updatesExisting) {
-    if (entity instanceof Page page && page.getPage() == null) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Attribute 'page' is required for a '%s' page and must carry its url, as"
-                  + " {\"url\": \"https://...\"}. Nothing was %s.",
-              page.getPageType(), updatesExisting ? "changed" : "created"));
-    }
-  }
-
   /** Shared parameters plus attributes bound to the entity class owned by the repository. */
   private static EntityInterface buildEntity(
       EntityCreationSpec type, Map<String, Object> params, String userName) {
@@ -216,53 +170,8 @@ public class CreateEntityTool implements McpTool {
     requireFields(type, params, attributes);
     EntityInterface entity = convert(type, attributes);
     applySharedFields(entity, params, userName);
-    applyMcpDefaults(entity);
+    EntityTypeRules.applyDefaults(entity);
     return entity;
-  }
-
-  private static void applyRepositoryDefaults(EntityInterface entity) {
-    if (entity instanceof Tag tag) {
-      deriveTagClassification(tag);
-    }
-  }
-
-  private static void deriveTagClassification(Tag tag) {
-    EntityReference parent = tag.getParent();
-    EntityReference classification = tag.getClassification();
-    if (parent == null) {
-      if (classification == null) {
-        throw new IllegalArgumentException(
-            "Attribute 'classification' is required for a tag unless 'parent' identifies a parent"
-                + " tag. Nothing was created.");
-      }
-      tag.setClassification(Entity.getEntityReference(classification, Include.NON_DELETED));
-      return;
-    }
-
-    EntityReference resolvedParent = Entity.getEntityReference(parent, Include.NON_DELETED);
-    tag.setParent(resolvedParent);
-    String derivedClassification =
-        FullyQualifiedName.split(resolvedParent.getFullyQualifiedName())[0];
-    if (classification == null) {
-      classification =
-          new EntityReference()
-              .withType(Entity.CLASSIFICATION)
-              .withFullyQualifiedName(derivedClassification);
-    }
-
-    EntityReference resolvedClassification =
-        Entity.getEntityReference(classification, Include.NON_DELETED);
-    if (!derivedClassification.equals(resolvedClassification.getFullyQualifiedName())) {
-      throw new IllegalArgumentException(
-          "Tag classification '"
-              + resolvedClassification.getFullyQualifiedName()
-              + "' must match the root classification of parent '"
-              + resolvedParent.getFullyQualifiedName()
-              + "' (expected '"
-              + derivedClassification
-              + "'). Nothing was created.");
-    }
-    tag.setClassification(resolvedClassification);
   }
 
   private static void applySharedFields(
@@ -279,68 +188,6 @@ public class CreateEntityTool implements McpTool {
     entity.setExtension(CommonUtils.extension(params));
     entity.setUpdatedBy(userName);
     entity.setUpdatedAt(System.currentTimeMillis());
-  }
-
-  private static void applyMcpDefaults(EntityInterface entity) {
-    if (entity instanceof Domain domain && domain.getDomainType() == null) {
-      domain.setDomainType(CreateDomain.DomainType.AGGREGATE);
-    }
-    if (entity instanceof ContextMemory memory) {
-      memory.setSourceType(ContextMemorySourceType.REMEMBER_REQUEST);
-    }
-    if (entity instanceof Metric metric) {
-      validateMetric(metric);
-    }
-    if (entity instanceof Page page) {
-      applyPageBody(page);
-    }
-  }
-
-  /**
-   * An article's body carries nothing the caller has to supply - its markdown lives in {@code
-   * description} - so requiring the bare {@code page} object would fail every article creation on
-   * a field with no value to give it.
-   */
-  private static void applyPageBody(Page page) {
-    if (page.getPage() == null && PageType.ARTICLE.equals(page.getPageType())) {
-      page.setPage(new Article());
-    }
-  }
-
-  private static void validateMetric(Metric metric) {
-    boolean incomplete =
-        metric.getMetricExpression() == null
-            || metric.getMetricExpression().getLanguage() == null
-            || metric.getMetricExpression().getCode() == null
-            || metric.getMetricExpression().getCode().isBlank();
-    if (incomplete) {
-      throw new IllegalArgumentException(
-          "Attribute 'metricExpression' needs both 'language' and a non-empty 'code'. Nothing was"
-              + " created.");
-    }
-  }
-
-  private static Boolean requestedMutuallyExclusive(EntityInterface entity) {
-    return entity instanceof Classification classification
-        ? classification.getMutuallyExclusive()
-        : null;
-  }
-
-  private static void addClassificationWarning(
-      Boolean requested, EntityInterface saved, EventType changeType, Map<String, Object> result) {
-    if (requested != null
-        && saved instanceof Classification classification
-        && !EventType.ENTITY_CREATED.equals(changeType)
-        && !Objects.equals(requested, classification.getMutuallyExclusive())) {
-      result.put(
-          "_warning",
-          "mutuallyExclusive cannot be changed on an existing classification. Retained existing"
-              + " value: "
-              + classification.getMutuallyExclusive()
-              + ". Supplied value "
-              + requested
-              + " was ignored.");
-    }
   }
 
   /**

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/DescribeEntityTypeTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/DescribeEntityTypeTool.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.limits.Limits;
 import org.openmetadata.service.security.Authorizer;
@@ -44,6 +45,11 @@ public class DescribeEntityTypeTool implements McpTool {
           "extension");
 
   private static final Set<String> SHARED = Set.copyOf(SHARED_FIELDS);
+
+  /** How a reference is written, in place of the EntityReference schema's own description. */
+  private static final String REFERENCE_FORM =
+      "Another entity, as {\"type\": \"<entityType>\", \"fullyQualifiedName\": \"<fqn>\"}."
+          + " An id may be given instead of the name.";
 
   /** Entity fields decided by the persistence lifecycle rather than the caller. */
   private static final Set<String> SERVER_OWNED =
@@ -117,11 +123,27 @@ public class DescribeEntityTypeTool implements McpTool {
     if (!allowed.isEmpty()) {
       attribute.put("allowedValues", allowed);
     }
-    String description = property.getMetadata().getDescription();
+    String description = describeValue(property);
     if (description != null && !description.isBlank()) {
       attribute.put("description", description);
     }
     return attribute;
+  }
+
+  /**
+   * A reference attribute is described by the shape it takes, not by the EntityReference schema's
+   * own blurb: the blurb explains what a reference is to a reader who already knows, while what a
+   * caller needs is that the target can be named rather than looked up for its id first.
+   */
+  private static String describeValue(BeanPropertyDefinition property) {
+    return isReference(property.getPrimaryType())
+        ? REFERENCE_FORM
+        : property.getMetadata().getDescription();
+  }
+
+  private static boolean isReference(JavaType type) {
+    JavaType candidate = type.isCollectionLikeType() ? type.getContentType() : type;
+    return candidate != null && EntityReference.class.equals(candidate.getRawClass());
   }
 
   /**

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/DescribeEntityTypeTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/DescribeEntityTypeTool.java
@@ -73,10 +73,9 @@ public class DescribeEntityTypeTool implements McpTool {
     // attributes, so the caller is told the set rather than left to infer it from the two lists.
     result.put("alsoRequired", requiredFields(type));
     result.put("attributes", describe(type));
-    if (type.hasConditionalRequirements()) {
-      result.put(
-          "conditionalRequirements",
-          List.of("classification is required unless parent identifies a parent tag"));
+    List<String> conditionalRequirements = type.conditionalRequirements();
+    if (!conditionalRequirements.isEmpty()) {
+      result.put("conditionalRequirements", conditionalRequirements);
     }
     return result;
   }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/EntityCreationSpec.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/EntityCreationSpec.java
@@ -1,11 +1,14 @@
 package org.openmetadata.mcp.tools;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.ServiceEntityInterface;
 import org.openmetadata.schema.entity.classification.Tag;
 import org.openmetadata.schema.entity.context.ContextMemory;
+import org.openmetadata.schema.entity.data.Page;
 import org.openmetadata.schema.entity.domains.Domain;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
@@ -16,6 +19,25 @@ record EntityCreationSpec(
     String entityType,
     EntityRepository<? extends EntityInterface> repository,
     Class<? extends EntityInterface> entityClass) {
+
+  /**
+   * Knowledge page fields no create request carries: children and editors come from relationships,
+   * votes and the extraction fields from background work. Offering {@code children} was actively
+   * harmful - {@code storeRelationships} reads {@code child.getId()}, and a caller has no id.
+   */
+  private static final Set<String> PAGE_SYSTEM_FIELDS =
+      Set.of(
+          "children",
+          "childrenCount",
+          "editors",
+          "followers",
+          "votes",
+          "attachments",
+          "dataProducts",
+          "processingStatus",
+          "processingError",
+          "extractionStats",
+          "memoryCount");
 
   private static final Map<String, String> DEDICATED_CREATE_FLOWS =
       Map.of(
@@ -81,14 +103,26 @@ record EntityCreationSpec(
 
   boolean hasMcpDefault(String field) {
     return (Domain.class.equals(entityClass) && "domainType".equals(field))
-        || (Tag.class.equals(entityClass) && "classification".equals(field));
+        || (Tag.class.equals(entityClass) && "classification".equals(field))
+        || (Page.class.equals(entityClass) && "page".equals(field));
   }
 
   boolean isMcpOwned(String field) {
-    return ContextMemory.class.equals(entityClass) && "sourceType".equals(field);
+    return (ContextMemory.class.equals(entityClass) && "sourceType".equals(field))
+        || (Page.class.equals(entityClass) && PAGE_SYSTEM_FIELDS.contains(field));
   }
 
-  boolean hasConditionalRequirements() {
-    return Tag.class.equals(entityClass);
+  /** Requirements that hold only for some values of another field, in the caller's own terms. */
+  List<String> conditionalRequirements() {
+    List<String> requirements = List.of();
+    if (Tag.class.equals(entityClass)) {
+      requirements = List.of("classification is required unless parent identifies a parent tag");
+    } else if (Page.class.equals(entityClass)) {
+      requirements =
+          List.of(
+              "page is required when pageType is QuickLink and must carry its url; an Article"
+                  + " page body defaults to an empty article and its markdown goes in description");
+    }
+    return requirements;
   }
 }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/EntityTypeRules.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/EntityTypeRules.java
@@ -1,0 +1,187 @@
+package org.openmetadata.mcp.tools;
+
+import java.util.Map;
+import java.util.Objects;
+import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.api.domains.CreateDomain;
+import org.openmetadata.schema.entity.classification.Classification;
+import org.openmetadata.schema.entity.classification.Tag;
+import org.openmetadata.schema.entity.context.ContextMemory;
+import org.openmetadata.schema.entity.context.ContextMemorySourceType;
+import org.openmetadata.schema.entity.data.Article;
+import org.openmetadata.schema.entity.data.Metric;
+import org.openmetadata.schema.entity.data.Page;
+import org.openmetadata.schema.entity.data.PageType;
+import org.openmetadata.schema.entity.domains.Domain;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.EventType;
+import org.openmetadata.schema.type.Include;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.util.FullyQualifiedName;
+
+/**
+ * What {@code create_entity} has to do for one entity type and no other, kept here so the tool
+ * itself stays a single pipeline every type runs through.
+ *
+ * <p>Each rule exists because the type's own create request does work no generic binding can: a
+ * value the request derives, a field the caller cannot be asked for, or a value the repository
+ * refuses to change.
+ */
+final class EntityTypeRules {
+
+  private static final String PAGE_BODY = "page";
+  private static final String RELATED_ENTITIES = "relatedEntities";
+
+  private EntityTypeRules() {}
+
+  /** Values a type's create request would have filled in, applied before the entity is prepared. */
+  static void applyDefaults(EntityInterface entity) {
+    if (entity instanceof Domain domain && domain.getDomainType() == null) {
+      domain.setDomainType(CreateDomain.DomainType.AGGREGATE);
+    }
+    if (entity instanceof ContextMemory memory) {
+      memory.setSourceType(ContextMemorySourceType.REMEMBER_REQUEST);
+    }
+    if (entity instanceof Metric metric) {
+      requireMetricExpression(metric);
+    }
+    if (entity instanceof Page page) {
+      defaultArticleBody(page);
+    }
+    if (entity instanceof Tag tag) {
+      deriveTagClassification(tag);
+    }
+  }
+
+  /** The last word before the write, once it is known whether an entity exists under this name. */
+  static void applyBeforeWrite(
+      EntityInterface entity, Map<String, Object> attributes, boolean updatesExisting) {
+    if (entity instanceof Page page) {
+      keepStoredPageBody(page, attributes, updatesExisting);
+      requirePageBody(page, updatesExisting);
+    }
+  }
+
+  /**
+   * The one requested value the repository can refuse to change, read before the write because the
+   * saved entity may be the same object.
+   */
+  static Boolean requestedMutuallyExclusive(EntityInterface entity) {
+    return entity instanceof Classification classification
+        ? classification.getMutuallyExclusive()
+        : null;
+  }
+
+  /** Tells the caller when the repository kept a value the request asked to change. */
+  static void addWarnings(
+      Boolean requestedMutuallyExclusive,
+      EntityInterface saved,
+      EventType changeType,
+      Map<String, Object> result) {
+    if (requestedMutuallyExclusive != null
+        && saved instanceof Classification stored
+        && !EventType.ENTITY_CREATED.equals(changeType)
+        && !Objects.equals(requestedMutuallyExclusive, stored.getMutuallyExclusive())) {
+      result.put(
+          "_warning",
+          "mutuallyExclusive cannot be changed on an existing classification. Retained existing"
+              + " value: "
+              + stored.getMutuallyExclusive()
+              + ". Supplied value "
+              + requestedMutuallyExclusive
+              + " was ignored.");
+    }
+  }
+
+  /**
+   * An article's body carries nothing the caller has to supply - its markdown lives in {@code
+   * description} - so requiring the bare {@code page} object would fail every article creation on a
+   * field with no value to give it.
+   */
+  private static void defaultArticleBody(Page page) {
+    if (page.getPage() == null && PageType.ARTICLE.equals(page.getPageType())) {
+      page.setPage(new Article());
+    }
+  }
+
+  /**
+   * An update replaces the entity, so the body defaulted for a create would drop the publication
+   * date and delete every related-article relationship. Read with the related articles the updater
+   * compares against, leaving {@code page} out changes nothing.
+   */
+  private static void keepStoredPageBody(
+      Page page, Map<String, Object> attributes, boolean updatesExisting) {
+    if (updatesExisting && !attributes.containsKey(PAGE_BODY)) {
+      Page stored =
+          Entity.getEntityByName(
+              Entity.PAGE, page.getFullyQualifiedName(), RELATED_ENTITIES, Include.ALL);
+      page.setPage(stored.getPage());
+    }
+  }
+
+  /**
+   * A quick link's body is its destination, which cannot be defaulted the way an article's can. An
+   * update that leaves it out has already kept the stored one.
+   */
+  private static void requirePageBody(Page page, boolean updatesExisting) {
+    if (page.getPage() == null) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Attribute 'page' is required for a '%s' page and must carry its url, as"
+                  + " {\"url\": \"https://...\"}. Nothing was %s.",
+              page.getPageType(), updatesExisting ? "changed" : "created"));
+    }
+  }
+
+  private static void requireMetricExpression(Metric metric) {
+    boolean incomplete =
+        metric.getMetricExpression() == null
+            || metric.getMetricExpression().getLanguage() == null
+            || metric.getMetricExpression().getCode() == null
+            || metric.getMetricExpression().getCode().isBlank();
+    if (incomplete) {
+      throw new IllegalArgumentException(
+          "Attribute 'metricExpression' needs both 'language' and a non-empty 'code'. Nothing was"
+              + " created.");
+    }
+  }
+
+  /** A tag belongs to the classification its parent belongs to, and says so or says nothing. */
+  private static void deriveTagClassification(Tag tag) {
+    EntityReference parent = tag.getParent();
+    if (parent == null) {
+      tag.setClassification(classificationOf(tag));
+    } else {
+      EntityReference resolvedParent = Entity.getEntityReference(parent, Include.NON_DELETED);
+      tag.setParent(resolvedParent);
+      tag.setClassification(
+          matchingClassification(
+              tag, FullyQualifiedName.split(resolvedParent.getFullyQualifiedName())[0]));
+    }
+  }
+
+  private static EntityReference classificationOf(Tag tag) {
+    if (tag.getClassification() == null) {
+      throw new IllegalArgumentException(
+          "Attribute 'classification' is required for a tag unless 'parent' identifies a parent"
+              + " tag. Nothing was created.");
+    }
+    return Entity.getEntityReference(tag.getClassification(), Include.NON_DELETED);
+  }
+
+  private static EntityReference matchingClassification(Tag tag, String derived) {
+    EntityReference requested =
+        tag.getClassification() == null
+            ? new EntityReference().withType(Entity.CLASSIFICATION).withFullyQualifiedName(derived)
+            : tag.getClassification();
+    EntityReference resolved = Entity.getEntityReference(requested, Include.NON_DELETED);
+    if (!derived.equals(resolved.getFullyQualifiedName())) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Tag classification '%s' must match the root classification of parent '%s' (expected"
+                  + " '%s'). Nothing was created.",
+              resolved.getFullyQualifiedName(), tag.getParent().getFullyQualifiedName(), derived));
+    }
+    return resolved;
+  }
+}

--- a/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
+++ b/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
@@ -473,13 +473,13 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "description": "Create an entity through the repository registered for its entityType. Fields every type shares are top-level parameters; fields specific to the entity go in 'attributes'. Call describe_entity_type first when the requirements are not known. Reference-valued attributes use EntityReference objects containing the target type and id; find those entities first rather than guessing ids. Unknown entity types and attributes are rejected before anything is written. Entity types whose resource endpoint performs required authentication, scheduling, specialized authorization, or secret-handling work are rejected with the dedicated API to use. Creating with a name that is already taken UPDATES that entity in place and needs edit rights as well as create rights. To create a test case use create_test_case; for lineage use create_lineage. Writes take effect immediately - confirm the target with the user before calling.",
+      "description": "Create an entity through the repository registered for its entityType. Fields every type shares are top-level parameters; fields specific to the entity go in 'attributes'. Call describe_entity_type first when the requirements are not known. Reference-valued attributes use EntityReference objects containing the target type and id; find those entities first rather than guessing ids. Unknown entity types and attributes are rejected before anything is written. Entity types whose resource endpoint performs required authentication, scheduling, specialized authorization, or secret-handling work are rejected with the dedicated API to use. Creating with a name that is already taken UPDATES that entity in place and needs edit rights as well as create rights. To create a test case use create_test_case; for lineage use create_lineage. A Knowledge Center article is entityType 'page' with attributes {\"pageType\": \"Article\"}, its markdown body in 'description', the assets it documents in 'relatedEntities' and an optional 'parent' page to nest it under. Writes take effect immediately - confirm the target with the user before calling.",
       "parameters": {
         "type": "object",
         "properties": {
           "entityType": {
             "type": "string",
-            "description": "Registered entity type to create, e.g. 'glossary', 'glossaryTerm', 'domain', 'metric', 'team' or 'chart'. Types requiring a dedicated create lifecycle, including users, bots, apps, event subscriptions, ingestion pipelines, test cases, services and automation workflows, are rejected."
+            "description": "Registered entity type to create, e.g. 'glossary', 'glossaryTerm', 'domain', 'metric', 'team', 'chart' or 'page' for a Knowledge Center article. Types requiring a dedicated create lifecycle, including users, bots, apps, event subscriptions, ingestion pipelines, test cases, services and automation workflows, are rejected."
           },
           "name": {
             "type": "string",

--- a/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
+++ b/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
@@ -473,7 +473,7 @@
         "idempotentHint": false,
         "openWorldHint": false
       },
-      "description": "Create an entity through the repository registered for its entityType. Fields every type shares are top-level parameters; fields specific to the entity go in 'attributes'. Call describe_entity_type first when the requirements are not known. Reference-valued attributes use EntityReference objects containing the target type and id; find those entities first rather than guessing ids. Unknown entity types and attributes are rejected before anything is written. Entity types whose resource endpoint performs required authentication, scheduling, specialized authorization, or secret-handling work are rejected with the dedicated API to use. Creating with a name that is already taken UPDATES that entity in place and needs edit rights as well as create rights. To create a test case use create_test_case; for lineage use create_lineage. A Knowledge Center article is entityType 'page' with attributes {\"pageType\": \"Article\"}, its markdown body in 'description', the assets it documents in 'relatedEntities' and an optional 'parent' page to nest it under. Writes take effect immediately - confirm the target with the user before calling.",
+      "description": "Create an entity through the repository registered for its entityType. Fields every type shares are top-level parameters; fields specific to the entity go in 'attributes'. Call describe_entity_type first when the requirements are not known. Reference-valued attributes take EntityReference objects naming the target, such as {'type': 'glossary', 'fullyQualifiedName': 'Finance'}; an id may be given instead of the name. Unknown entity types and attributes are rejected before anything is written. Entity types whose resource endpoint performs required authentication, scheduling, specialized authorization, or secret-handling work are rejected with the dedicated API to use. Creating with a name that is already taken UPDATES that entity in place and needs edit rights as well as create rights. To create a test case use create_test_case; for lineage use create_lineage. A Knowledge Center article is entityType 'page' with attributes {\"pageType\": \"Article\"}, its markdown body in 'description', the assets it documents in 'relatedEntities' and an optional 'parent' page to nest it under. Writes take effect immediately - confirm the target with the user before calling.",
       "parameters": {
         "type": "object",
         "properties": {
@@ -527,7 +527,7 @@
           },
           "attributes": {
             "type": "object",
-            "description": "Fields specific to this entityType. Values match the entity schema returned by describe_entity_type. EntityReference fields use objects such as {'type': 'glossary', 'id': '<uuid>'}; arrays of references use arrays of those objects."
+            "description": "Fields specific to this entityType. Values match the entity schema returned by describe_entity_type. EntityReference fields use objects such as {'type': 'glossary', 'fullyQualifiedName': 'Finance'} or {'type': 'glossary', 'id': '<uuid>'}; arrays of references use arrays of those objects."
           }
         },
         "required": [

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/CreateEntityToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/CreateEntityToolTest.java
@@ -3,11 +3,14 @@ package org.openmetadata.mcp.tools;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -26,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
@@ -39,15 +43,20 @@ import org.openmetadata.schema.entity.classification.Classification;
 import org.openmetadata.schema.entity.classification.Tag;
 import org.openmetadata.schema.entity.context.ContextMemory;
 import org.openmetadata.schema.entity.context.ContextMemorySourceType;
+import org.openmetadata.schema.entity.data.Article;
 import org.openmetadata.schema.entity.data.Glossary;
 import org.openmetadata.schema.entity.data.GlossaryTerm;
 import org.openmetadata.schema.entity.data.Metric;
+import org.openmetadata.schema.entity.data.Page;
+import org.openmetadata.schema.entity.data.PageType;
 import org.openmetadata.schema.entity.domains.Domain;
 import org.openmetadata.schema.entity.services.DatabaseService;
 import org.openmetadata.schema.entity.teams.Team;
 import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.EntityStatus;
 import org.openmetadata.schema.type.EventType;
 import org.openmetadata.schema.type.Include;
+import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
@@ -58,6 +67,9 @@ import org.openmetadata.service.security.AuthorizationException;
 import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.security.auth.CatalogSecurityContext;
 import org.openmetadata.service.security.policyevaluator.CreateResourceContext;
+import org.openmetadata.service.security.policyevaluator.OperationContext;
+import org.openmetadata.service.security.policyevaluator.ResourceContext;
+import org.openmetadata.service.security.policyevaluator.ResourceContextInterface;
 import org.openmetadata.service.util.RestUtil;
 
 class CreateEntityToolTest {
@@ -88,12 +100,13 @@ class CreateEntityToolTest {
         ruleEngine,
         () -> new CreateEntityTool().execute(authorizer, limits, securityContext(), glossary()));
 
-    InOrder ordered = inOrder(limits, authorizer, ruleEngine, repository);
+    // prepareInternal first: it resolves the name, and the name decides whether this call is a
+    // create or an update - and so which permission and quota apply.
+    InOrder ordered = inOrder(repository, limits, authorizer, ruleEngine);
+    ordered.verify(repository).prepareInternal(any(), anyBoolean());
     ordered.verify(limits).enforceLimits(any(), any(), any());
     ordered.verify(authorizer).authorize(any(), any(), any());
     ordered.verify(ruleEngine).evaluate(any());
-    ordered.verify(repository).prepareInternal(any(), anyBoolean());
-    ordered.verify(authorizer).authorize(any(), any(), any());
     ordered.verify(repository).createOrUpdate(isNull(), any(), anyString(), any());
   }
 
@@ -217,6 +230,12 @@ class CreateEntityToolTest {
                           .withFullyQualifiedName("PII"),
                       Include.NON_DELETED))
           .thenReturn(resolvedClassification);
+      entities
+          .when(
+              () ->
+                  Entity.getEntityReferenceByName(
+                      eq(Entity.TAG), eq(saved.getFullyQualifiedName()), any(Include.class)))
+          .thenThrow(new EntityNotFoundException("not found"));
       rules.when(RuleEngine::getInstance).thenReturn(ruleEngine);
 
       new CreateEntityTool().execute(authorizer, mock(Limits.class), securityContext(), input);
@@ -233,10 +252,10 @@ class CreateEntityToolTest {
     verify(authorizer).authorize(any(), any(), contextCaptor.capture());
     Tag authorized = (Tag) contextCaptor.getValue().getEntity();
     assertEquals(resolvedClassification.getId(), authorized.getClassification().getId());
-    InOrder ordered = inOrder(authorizer, ruleEngine, repository);
+    InOrder ordered = inOrder(repository, authorizer, ruleEngine);
+    ordered.verify(repository).prepareInternal(prepared, false);
     ordered.verify(authorizer).authorize(any(), any(), any());
     ordered.verify(ruleEngine).evaluate(prepared);
-    ordered.verify(repository).prepareInternal(prepared, false);
 
     Map<String, Object> described =
         withRepository(
@@ -395,9 +414,230 @@ class CreateEntityToolTest {
                     new CreateEntityTool()
                         .execute(authorizer, mock(Limits.class), securityContext(), glossary())));
 
+    // prepareInternal runs first now - it only validates and names the entity, nothing is written -
+    // so what a denial has to stop is the rule evaluation and the write itself.
     verify(ruleEngine, never()).evaluate(any());
-    verify(repository, never()).prepareInternal(any(), anyBoolean());
     verify(repository, never()).createOrUpdate(isNull(), any(), anyString(), any());
+  }
+
+  @Test
+  void anArticlePageBodyDefaultsSoOnlyItsPageTypeIsNeeded() {
+    // page.json requires the 'page' body, but for an article that body carries nothing a caller
+    // has to supply - without a default every article creation failed on a required bare Object.
+    EntityRepository<EntityInterface> repository = repositoryFor(Page.class);
+    Page saved = new Page().withId(UUID.randomUUID()).withName("runbook");
+    saved.setFullyQualifiedName("runbook");
+    when(repository.createOrUpdate(isNull(), any(), anyString(), any()))
+        .thenReturn(new RestUtil.PutResponse<>(null, saved, EventType.ENTITY_CREATED));
+    setPreparedFqn(repository, "runbook");
+    Map<String, Object> params = params(Entity.PAGE);
+    params.put("attributes", Map.of("pageType", PageType.ARTICLE.value()));
+
+    withRepository(
+        Entity.PAGE,
+        repository,
+        () ->
+            new CreateEntityTool()
+                .execute(mock(Authorizer.class), mock(Limits.class), securityContext(), params));
+
+    ArgumentCaptor<EntityInterface> captor = ArgumentCaptor.forClass(EntityInterface.class);
+    verify(repository).createOrUpdate(isNull(), captor.capture(), anyString(), any());
+    Page created = (Page) captor.getValue();
+    assertEquals(PageType.ARTICLE, created.getPageType());
+    assertTrue(created.getPage() instanceof Article, String.valueOf(created.getPage()));
+
+    Map<String, Object> described =
+        withRepository(
+            Entity.PAGE,
+            repository,
+            () ->
+                new DescribeEntityTypeTool()
+                    .execute(null, null, Map.of("entityType", Entity.PAGE)));
+    assertTrue(described.get("alsoRequired").toString().contains("pageType"));
+    assertFalse(described.get("alsoRequired").toString().contains("page,"));
+    assertTrue(described.get("conditionalRequirements").toString().contains("QuickLink"));
+  }
+
+  @Test
+  void aQuickLinkPageIsRejectedWithoutItsUrl() {
+    // Only the article body is defaultable: a quick link with no page body would be stored with a
+    // null destination and read back as a broken link.
+    EntityRepository<EntityInterface> repository = repositoryFor(Page.class);
+    Map<String, Object> params = params(Entity.PAGE);
+    params.put("attributes", Map.of("pageType", PageType.QUICK_LINK.value()));
+
+    IllegalArgumentException failure =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                withRepository(
+                    Entity.PAGE,
+                    repository,
+                    () -> new CreateEntityTool().execute(null, null, securityContext(), params)));
+
+    assertTrue(failure.getMessage().contains("page"), failure.getMessage());
+    assertTrue(failure.getMessage().contains("url"), failure.getMessage());
+    verify(repository, never()).prepareInternal(any(), anyBoolean());
+  }
+
+  @Test
+  void anArticleBodySuppliedByTheCallerIsKept() {
+    EntityRepository<EntityInterface> repository = repositoryFor(Page.class);
+    Page saved = new Page().withId(UUID.randomUUID()).withName("runbook");
+    saved.setFullyQualifiedName("runbook");
+    when(repository.createOrUpdate(isNull(), any(), anyString(), any()))
+        .thenReturn(new RestUtil.PutResponse<>(null, saved, EventType.ENTITY_CREATED));
+    setPreparedFqn(repository, "runbook");
+    Map<String, Object> params = params(Entity.PAGE);
+    params.put(
+        "attributes",
+        Map.of(
+            "pageType",
+            PageType.ARTICLE.value(),
+            "page",
+            Map.of("publicationDate", "2026-08-28T00:00:00.000Z"),
+            "entityStatus",
+            EntityStatus.DRAFT.value()));
+
+    withRepository(
+        Entity.PAGE,
+        repository,
+        () ->
+            new CreateEntityTool()
+                .execute(mock(Authorizer.class), mock(Limits.class), securityContext(), params));
+
+    ArgumentCaptor<EntityInterface> captor = ArgumentCaptor.forClass(EntityInterface.class);
+    verify(repository).createOrUpdate(isNull(), captor.capture(), anyString(), any());
+    Page created = (Page) captor.getValue();
+    assertNotNull(
+        JsonUtils.convertValue(created.getPage(), Article.class).getPublicationDate(),
+        "the caller's article body must not be replaced by the default");
+    assertEquals(EntityStatus.DRAFT, created.getEntityStatus());
+  }
+
+  @Test
+  void aPageOffersOnlyTheFieldsItsCreateRequestCarries() {
+    // Binding straight to the entity class exposed fields no caller sets - children and editors are
+    // written from relationships, votes and the extraction fields by background work. Offering
+    // 'children' was the harmful one: storeRelationships reads child.getId() and a caller has no id
+    // to give, so an accepted value would have written a relationship row with a null id.
+    EntityRepository<EntityInterface> repository = repositoryFor(Page.class);
+
+    Map<String, Object> described =
+        withRepository(
+            Entity.PAGE,
+            repository,
+            () ->
+                new DescribeEntityTypeTool()
+                    .execute(null, null, Map.of("entityType", Entity.PAGE)));
+
+    assertEquals(
+        Set.of("pageType", "page", "parent", "relatedEntities", "entityStatus"),
+        attributeNames(described));
+
+    Map<String, Object> params = params(Entity.PAGE);
+    params.put(
+        "attributes",
+        Map.of("pageType", PageType.ARTICLE.value(), "children", List.of(Map.of("type", "page"))));
+    IllegalArgumentException failure =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                withRepository(
+                    Entity.PAGE,
+                    repository,
+                    () -> new CreateEntityTool().execute(null, null, securityContext(), params)));
+
+    assertTrue(failure.getMessage().contains("children"), failure.getMessage());
+    verify(repository, never()).prepareInternal(any(), anyBoolean());
+  }
+
+  @Test
+  void aNameThatIsFreeIsAuthorizedAsCreateAndCountsAgainstTheQuota() {
+    Authorizer authorizer = mock(Authorizer.class);
+    Limits limits = mock(Limits.class);
+
+    createGlossary(authorizer, limits, nameIsFree());
+
+    ArgumentCaptor<OperationContext> operations = ArgumentCaptor.forClass(OperationContext.class);
+    ArgumentCaptor<ResourceContextInterface> resources =
+        ArgumentCaptor.forClass(ResourceContextInterface.class);
+    verify(authorizer).authorize(any(), operations.capture(), resources.capture());
+    assertInstanceOf(CreateResourceContext.class, resources.getValue());
+    assertTrue(
+        operations
+            .getValue()
+            .getOperations(resources.getValue())
+            .contains(MetadataOperation.CREATE));
+    verify(limits).enforceLimits(any(), any(), any());
+  }
+
+  @Test
+  void anExistingNameIsAuthorizedAsAnEditAndSkipsTheCreateQuota() {
+    // createOrUpdate updates in place when the name is taken, so the call is an edit. Authorizing
+    // it as a create as well locked out a caller holding only edit rights, and ran the create quota
+    // against an update - EntityResource.createOrUpdate takes one leg or the other, never both.
+    Authorizer authorizer = mock(Authorizer.class);
+    Limits limits = mock(Limits.class);
+
+    createGlossary(
+        authorizer,
+        limits,
+        entities ->
+            entities
+                .when(
+                    () ->
+                        Entity.getEntityReferenceByName(
+                            eq(Entity.GLOSSARY), eq("Finance"), any(Include.class)))
+                .thenReturn(new EntityReference().withType(Entity.GLOSSARY).withName("Finance")));
+
+    ArgumentCaptor<OperationContext> operations = ArgumentCaptor.forClass(OperationContext.class);
+    ArgumentCaptor<ResourceContextInterface> resources =
+        ArgumentCaptor.forClass(ResourceContextInterface.class);
+    verify(authorizer).authorize(any(), operations.capture(), resources.capture());
+    assertInstanceOf(ResourceContext.class, resources.getValue());
+    assertTrue(
+        operations
+            .getValue()
+            .getOperations(resources.getValue())
+            .contains(MetadataOperation.EDIT_ALL));
+    verify(limits, never()).enforceLimits(any(), any(), any());
+  }
+
+  private static void createGlossary(
+      Authorizer authorizer, Limits limits, Consumer<MockedStatic<Entity>> existence) {
+    EntityRepository<EntityInterface> repository = repositoryFor(Glossary.class);
+    Glossary saved = new Glossary().withId(UUID.randomUUID()).withName("Finance");
+    saved.setFullyQualifiedName("Finance");
+    when(repository.createOrUpdate(isNull(), any(), anyString(), any()))
+        .thenReturn(new RestUtil.PutResponse<>(null, saved, EventType.ENTITY_CREATED));
+    setPreparedFqn(repository, "Finance");
+
+    try (MockedStatic<Entity> entities = mockStatic(Entity.class);
+        MockedStatic<RuleEngine> rules = mockStatic(RuleEngine.class);
+        MockedStatic<McpChangeEventUtil> events = mockStatic(McpChangeEventUtil.class)) {
+      entities.when(() -> Entity.getEntityRepository(Entity.GLOSSARY)).thenReturn(repository);
+      entities
+          .when(() -> Entity.getEntityTypeFromClass(Glossary.class))
+          .thenReturn(Entity.GLOSSARY);
+      existence.accept(entities);
+      rules.when(RuleEngine::getInstance).thenReturn(mock(RuleEngine.class));
+      new CreateEntityTool().execute(authorizer, limits, securityContext(), glossary());
+    }
+  }
+
+  /**
+   * The existence check reads a missing entity off the exception, so a free name has to throw -
+   * a stub returning null would be read as "the name is taken".
+   */
+  private static Consumer<MockedStatic<Entity>> nameIsFree() {
+    return entities ->
+        entities
+            .when(
+                () ->
+                    Entity.getEntityReferenceByName(
+                        eq(Entity.GLOSSARY), eq("Finance"), any(Include.class)))
+            .thenThrow(new EntityNotFoundException("not found"));
   }
 
   @SuppressWarnings("unchecked")
@@ -438,6 +678,11 @@ class CreateEntityToolTest {
       entities
           .when(() -> Entity.getEntityTypeFromClass(repository.getEntityClass()))
           .thenReturn(entityType);
+      // Nothing exists at the prepared name unless a test says otherwise, so these exercise the
+      // create leg; a null return would instead be read as an overwrite.
+      entities
+          .when(() -> Entity.getEntityReferenceByName(anyString(), anyString(), any(Include.class)))
+          .thenThrow(new EntityNotFoundException("not found"));
       rules.when(RuleEngine::getInstance).thenReturn(ruleEngine);
       return action.get();
     }

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/CreateEntityToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/CreateEntityToolTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -87,8 +88,7 @@ class CreateEntityToolTest {
     EntityRepository<EntityInterface> repository = repositoryFor(Glossary.class);
     Glossary saved = new Glossary().withId(UUID.randomUUID()).withName("Finance");
     saved.setFullyQualifiedName("Finance");
-    when(repository.createOrUpdate(isNull(), any(), anyString(), any()))
-        .thenReturn(new RestUtil.PutResponse<>(null, saved, EventType.ENTITY_CREATED));
+    stubWrite(repository, saved);
     setPreparedFqn(repository, "Finance");
     Authorizer authorizer = mock(Authorizer.class);
     Limits limits = mock(Limits.class);
@@ -107,7 +107,7 @@ class CreateEntityToolTest {
     ordered.verify(limits).enforceLimits(any(), any(), any());
     ordered.verify(authorizer).authorize(any(), any(), any());
     ordered.verify(ruleEngine).evaluate(any());
-    ordered.verify(repository).createOrUpdate(isNull(), any(), anyString(), any());
+    ordered.verify(repository).create(isNull(), any(), anyString(), any());
   }
 
   @Test
@@ -201,8 +201,7 @@ class CreateEntityToolTest {
             .withFullyQualifiedName("PII");
     Tag saved = new Tag().withId(UUID.randomUUID()).withName("Restricted");
     saved.setFullyQualifiedName("PII.Sensitive.Restricted");
-    when(repository.createOrUpdate(isNull(), any(), anyString(), any()))
-        .thenReturn(new RestUtil.PutResponse<>(null, saved, EventType.ENTITY_CREATED));
+    stubWrite(repository, saved);
     setPreparedFqn(repository, saved.getFullyQualifiedName());
     Authorizer authorizer = mock(Authorizer.class);
     RuleEngine ruleEngine = mock(RuleEngine.class);
@@ -342,8 +341,7 @@ class CreateEntityToolTest {
     EntityRepository<EntityInterface> repository = repositoryFor(Domain.class);
     Domain saved = new Domain().withId(UUID.randomUUID()).withName("Marketing");
     saved.setFullyQualifiedName("Marketing");
-    when(repository.createOrUpdate(isNull(), any(), anyString(), any()))
-        .thenReturn(new RestUtil.PutResponse<>(null, saved, EventType.ENTITY_CREATED));
+    stubWrite(repository, saved);
     setPreparedFqn(repository, "Marketing");
     Map<String, Object> params = params();
     params.put("entityType", Entity.DOMAIN);
@@ -357,7 +355,7 @@ class CreateEntityToolTest {
                 .execute(mock(Authorizer.class), mock(Limits.class), securityContext(), params));
 
     ArgumentCaptor<EntityInterface> captor = ArgumentCaptor.forClass(EntityInterface.class);
-    verify(repository).createOrUpdate(isNull(), captor.capture(), anyString(), any());
+    verify(repository).create(isNull(), captor.capture(), anyString(), any());
     assertEquals(CreateDomain.DomainType.AGGREGATE, ((Domain) captor.getValue()).getDomainType());
   }
 
@@ -366,8 +364,7 @@ class CreateEntityToolTest {
     EntityRepository<EntityInterface> repository = repositoryFor(ContextMemory.class);
     ContextMemory saved = new ContextMemory().withId(UUID.randomUUID()).withName("memory");
     saved.setFullyQualifiedName("memory");
-    when(repository.createOrUpdate(isNull(), any(), anyString(), any()))
-        .thenReturn(new RestUtil.PutResponse<>(null, saved, EventType.ENTITY_CREATED));
+    stubWrite(repository, saved);
     setPreparedFqn(repository, "memory");
     Map<String, Object> params = params();
     params.put("entityType", Entity.CONTEXT_MEMORY);
@@ -381,7 +378,7 @@ class CreateEntityToolTest {
                 .execute(mock(Authorizer.class), mock(Limits.class), securityContext(), params));
 
     ArgumentCaptor<EntityInterface> captor = ArgumentCaptor.forClass(EntityInterface.class);
-    verify(repository).createOrUpdate(isNull(), captor.capture(), anyString(), any());
+    verify(repository).create(isNull(), captor.capture(), anyString(), any());
     assertEquals(
         ContextMemorySourceType.REMEMBER_REQUEST,
         ((ContextMemory) captor.getValue()).getSourceType());
@@ -427,8 +424,7 @@ class CreateEntityToolTest {
     EntityRepository<EntityInterface> repository = repositoryFor(Page.class);
     Page saved = new Page().withId(UUID.randomUUID()).withName("runbook");
     saved.setFullyQualifiedName("runbook");
-    when(repository.createOrUpdate(isNull(), any(), anyString(), any()))
-        .thenReturn(new RestUtil.PutResponse<>(null, saved, EventType.ENTITY_CREATED));
+    stubWrite(repository, saved);
     setPreparedFqn(repository, "runbook");
     Map<String, Object> params = params(Entity.PAGE);
     params.put("attributes", Map.of("pageType", PageType.ARTICLE.value()));
@@ -441,7 +437,7 @@ class CreateEntityToolTest {
                 .execute(mock(Authorizer.class), mock(Limits.class), securityContext(), params));
 
     ArgumentCaptor<EntityInterface> captor = ArgumentCaptor.forClass(EntityInterface.class);
-    verify(repository).createOrUpdate(isNull(), captor.capture(), anyString(), any());
+    verify(repository).create(isNull(), captor.capture(), anyString(), any());
     Page created = (Page) captor.getValue();
     assertEquals(PageType.ARTICLE, created.getPageType());
     assertTrue(created.getPage() instanceof Article, String.valueOf(created.getPage()));
@@ -459,10 +455,58 @@ class CreateEntityToolTest {
   }
 
   @Test
+  void anUpdateThatOmitsThePageBodyKeepsTheStoredOne() {
+    // An update replaces the entity, so defaulting an empty Article here would drop the publication
+    // date and delete every related-article relationship the updater compares against.
+    EntityRepository<EntityInterface> repository = repositoryFor(Page.class);
+    Page saved = new Page().withId(UUID.randomUUID()).withName("runbook");
+    saved.setFullyQualifiedName("runbook");
+    stubWrite(repository, saved);
+    setPreparedFqn(repository, "runbook");
+    Article storedBody =
+        new Article()
+            .withPublicationDate(new Date(0))
+            .withRelatedArticles(
+                List.of(new EntityReference().withType(Entity.PAGE).withId(UUID.randomUUID())));
+    Page stored =
+        new Page().withName("runbook").withPageType(PageType.ARTICLE).withPage(storedBody);
+    Map<String, Object> params = params(Entity.PAGE);
+    params.put("attributes", Map.of("pageType", PageType.ARTICLE.value()));
+
+    try (MockedStatic<Entity> entities = mockStatic(Entity.class);
+        MockedStatic<RuleEngine> rules = mockStatic(RuleEngine.class);
+        MockedStatic<McpChangeEventUtil> events = mockStatic(McpChangeEventUtil.class)) {
+      entities.when(() -> Entity.getEntityRepository(Entity.PAGE)).thenReturn(repository);
+      entities.when(() -> Entity.getEntityTypeFromClass(Page.class)).thenReturn(Entity.PAGE);
+      entities
+          .when(
+              () ->
+                  Entity.getEntityReferenceByName(
+                      eq(Entity.PAGE), eq("runbook"), any(Include.class)))
+          .thenReturn(new EntityReference().withType(Entity.PAGE).withName("runbook"));
+      entities
+          .when(
+              () ->
+                  Entity.getEntityByName(
+                      eq(Entity.PAGE), eq("runbook"), anyString(), any(Include.class)))
+          .thenReturn(stored);
+      rules.when(RuleEngine::getInstance).thenReturn(mock(RuleEngine.class));
+
+      new CreateEntityTool()
+          .execute(mock(Authorizer.class), mock(Limits.class), securityContext(), params);
+    }
+
+    ArgumentCaptor<EntityInterface> captor = ArgumentCaptor.forClass(EntityInterface.class);
+    verify(repository).createOrUpdate(isNull(), captor.capture(), anyString(), any());
+    assertEquals(storedBody, ((Page) captor.getValue()).getPage());
+  }
+
+  @Test
   void aQuickLinkPageIsRejectedWithoutItsUrl() {
     // Only the article body is defaultable: a quick link with no page body would be stored with a
     // null destination and read back as a broken link.
     EntityRepository<EntityInterface> repository = repositoryFor(Page.class);
+    setPreparedFqn(repository, "runbook");
     Map<String, Object> params = params(Entity.PAGE);
     params.put("attributes", Map.of("pageType", PageType.QUICK_LINK.value()));
 
@@ -473,11 +517,18 @@ class CreateEntityToolTest {
                 withRepository(
                     Entity.PAGE,
                     repository,
-                    () -> new CreateEntityTool().execute(null, null, securityContext(), params)));
+                    () ->
+                        new CreateEntityTool()
+                            .execute(
+                                mock(Authorizer.class),
+                                mock(Limits.class),
+                                securityContext(),
+                                params)));
 
     assertTrue(failure.getMessage().contains("page"), failure.getMessage());
     assertTrue(failure.getMessage().contains("url"), failure.getMessage());
-    verify(repository, never()).prepareInternal(any(), anyBoolean());
+    verify(repository, never()).create(isNull(), any(), anyString(), any());
+    verify(repository, never()).createOrUpdate(isNull(), any(), anyString(), any());
   }
 
   @Test
@@ -485,8 +536,7 @@ class CreateEntityToolTest {
     EntityRepository<EntityInterface> repository = repositoryFor(Page.class);
     Page saved = new Page().withId(UUID.randomUUID()).withName("runbook");
     saved.setFullyQualifiedName("runbook");
-    when(repository.createOrUpdate(isNull(), any(), anyString(), any()))
-        .thenReturn(new RestUtil.PutResponse<>(null, saved, EventType.ENTITY_CREATED));
+    stubWrite(repository, saved);
     setPreparedFqn(repository, "runbook");
     Map<String, Object> params = params(Entity.PAGE);
     params.put(
@@ -507,7 +557,7 @@ class CreateEntityToolTest {
                 .execute(mock(Authorizer.class), mock(Limits.class), securityContext(), params));
 
     ArgumentCaptor<EntityInterface> captor = ArgumentCaptor.forClass(EntityInterface.class);
-    verify(repository).createOrUpdate(isNull(), captor.capture(), anyString(), any());
+    verify(repository).create(isNull(), captor.capture(), anyString(), any());
     Page created = (Page) captor.getValue();
     assertNotNull(
         JsonUtils.convertValue(created.getPage(), Article.class).getPublicationDate(),
@@ -573,6 +623,29 @@ class CreateEntityToolTest {
   }
 
   @Test
+  void aFreeNameIsWrittenThroughCreateSoARacingWriterCannotBeOverwritten() {
+    // createOrUpdate would silently update whatever took the name between the check and the write,
+    // with only CREATE authorized. create fails on the taken name, and the retry is authorized as
+    // the update it has become.
+    EntityRepository<EntityInterface> repository = repositoryFor(Glossary.class);
+    Glossary saved = new Glossary().withId(UUID.randomUUID()).withName("Finance");
+    saved.setFullyQualifiedName("Finance");
+    stubWrite(repository, saved);
+    setPreparedFqn(repository, "Finance");
+
+    withRepository(
+        Entity.GLOSSARY,
+        repository,
+        () ->
+            new CreateEntityTool()
+                .execute(
+                    mock(Authorizer.class), mock(Limits.class), securityContext(), glossary()));
+
+    verify(repository).create(isNull(), any(), anyString(), any());
+    verify(repository, never()).createOrUpdate(isNull(), any(), anyString(), any());
+  }
+
+  @Test
   void anExistingNameIsAuthorizedAsAnEditAndSkipsTheCreateQuota() {
     // createOrUpdate updates in place when the name is taken, so the call is an edit. Authorizing
     // it as a create as well locked out a caller holding only edit rights, and ran the create quota
@@ -609,8 +682,7 @@ class CreateEntityToolTest {
     EntityRepository<EntityInterface> repository = repositoryFor(Glossary.class);
     Glossary saved = new Glossary().withId(UUID.randomUUID()).withName("Finance");
     saved.setFullyQualifiedName("Finance");
-    when(repository.createOrUpdate(isNull(), any(), anyString(), any()))
-        .thenReturn(new RestUtil.PutResponse<>(null, saved, EventType.ENTITY_CREATED));
+    stubWrite(repository, saved);
     setPreparedFqn(repository, "Finance");
 
     try (MockedStatic<Entity> entities = mockStatic(Entity.class);
@@ -648,6 +720,17 @@ class CreateEntityToolTest {
     when(repository.getParentEntity(any(), anyString()))
         .thenThrow(new EntityNotFoundException("no parent"));
     return repository;
+  }
+
+  /**
+   * A create is written through {@code create} and an update through {@code createOrUpdate}, so a
+   * test that does not say which leg it is on stubs both.
+   */
+  private static void stubWrite(
+      EntityRepository<EntityInterface> repository, EntityInterface saved) {
+    when(repository.create(isNull(), any(), anyString(), any())).thenReturn(saved);
+    when(repository.createOrUpdate(isNull(), any(), anyString(), any()))
+        .thenReturn(new RestUtil.PutResponse<>(null, saved, EventType.ENTITY_CREATED));
   }
 
   private static void setPreparedFqn(

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/CreateEntityToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/CreateEntityToolTest.java
@@ -455,6 +455,29 @@ class CreateEntityToolTest {
   }
 
   @Test
+  void aReferenceAttributeSaysItTakesAFullyQualifiedName() {
+    // The eight tools this one replaced took references as plain FQN strings. The generic path
+    // still resolves a name-only reference, but callers were told to send ids and given the
+    // EntityReference schema blurb, so they spent a lookup they did not need.
+    EntityRepository<EntityInterface> repository = repositoryFor(Page.class);
+
+    Map<String, Object> described =
+        withRepository(
+            Entity.PAGE,
+            repository,
+            () ->
+                new DescribeEntityTypeTool()
+                    .execute(null, null, Map.of("entityType", Entity.PAGE)));
+
+    String parent = String.valueOf(attribute(described, "parent").get("description"));
+    assertTrue(parent.contains("fullyQualifiedName"), parent);
+    assertFalse(parent.contains("This schema defines"), parent);
+    assertTrue(
+        String.valueOf(attribute(described, "relatedEntities").get("description"))
+            .contains("fullyQualifiedName"));
+  }
+
+  @Test
   void anUpdateThatOmitsThePageBodyKeepsTheStoredOne() {
     // An update replaces the entity, so defaulting an empty Article here would drop the publication
     // date and delete every related-article relationship the updater compares against.

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KnowledgePageRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KnowledgePageRepository.java
@@ -384,6 +384,11 @@ public class KnowledgePageRepository extends EntityRepository<Page> {
 
   @Override
   public void prepare(Page knowledgePage, boolean b) {
+    // storeRelationships reads parent.getId() directly, so a parent given by name alone has to be
+    // resolved here or the CONTAINS row is written with a null id and the page loses its parent.
+    knowledgePage.withParent(
+        Entity.getEntityReference(knowledgePage.getParent(), Include.NON_DELETED));
+
     // Validate Related Entities
     List<EntityReference> relatedEntities = knowledgePage.getRelatedEntities();
     if (!nullOrEmpty(relatedEntities)) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/KnowledgePageParentResolutionTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/KnowledgePageParentResolutionTest.java
@@ -1,0 +1,75 @@
+package org.openmetadata.service.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.openmetadata.schema.entity.data.Article;
+import org.openmetadata.schema.entity.data.Page;
+import org.openmetadata.schema.entity.data.PageType;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.Include;
+import org.openmetadata.service.Entity;
+
+/**
+ * {@code storeRelationships} reads {@code parent.getId()} directly, so a parent that arrives as a
+ * name-only reference has to be resolved during {@code prepare} - otherwise the CONTAINS row is
+ * written with a null id and the page is silently orphaned.
+ */
+class KnowledgePageParentResolutionTest {
+
+  private static final String PARENT_FQN = "Engineering";
+
+  @Test
+  void aNameOnlyParentIsResolvedToAReferenceCarryingAnId() {
+    Page page =
+        article()
+            .withParent(
+                new EntityReference().withType(Entity.PAGE).withFullyQualifiedName(PARENT_FQN));
+    UUID parentId = UUID.randomUUID();
+
+    prepare(page, resolved(parentId));
+
+    assertEquals(parentId, page.getParent().getId());
+    assertEquals(PARENT_FQN, page.getParent().getFullyQualifiedName());
+  }
+
+  @Test
+  void aPageWithoutAParentIsLeftAlone() {
+    Page page = article();
+
+    prepare(page, resolved(UUID.randomUUID()));
+
+    assertNull(page.getParent());
+  }
+
+  private static void prepare(Page page, EntityReference resolvedParent) {
+    KnowledgePageRepository repository = mock(KnowledgePageRepository.class, CALLS_REAL_METHODS);
+    try (MockedStatic<Entity> entity = mockStatic(Entity.class)) {
+      // Mirrors the real helper, which hands a null reference straight back rather than looking
+      // anything up - a stub returning the resolved parent for every argument would hide that.
+      entity
+          .when(() -> Entity.getEntityReference(any(), eq(Include.NON_DELETED)))
+          .thenAnswer(call -> call.getArgument(0) == null ? null : resolvedParent);
+      repository.prepare(page, false);
+    }
+  }
+
+  private static EntityReference resolved(UUID id) {
+    return new EntityReference()
+        .withId(id)
+        .withType(Entity.PAGE)
+        .withFullyQualifiedName(PARENT_FQN);
+  }
+
+  private static Page article() {
+    return new Page().withName("runbook").withPageType(PageType.ARTICLE).withPage(new Article());
+  }
+}


### PR DESCRIPTION
Fixes #32198

- `create_entity` creates Knowledge Center pages: the article body defaults, and page attributes are limited to what `CreatePage` carries.
- `KnowledgePageRepository.prepare()` resolves a name-only parent, which `storeRelationships` needs an id for.
- `create_entity` branches create vs update like `EntityResource.createOrUpdate`: an existing name is an edit, so EDIT_ALL only, no create check and no create quota.






<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the generic MCP entity-creation path to Knowledge Center pages and aligns create-versus-update authorization and persistence behavior.
- Adds page-specific defaults, validation, field filtering, and stored-body preservation.
- Resolves name-only Knowledge Page parents before relationship persistence.
- Separates repository create and update calls according to the prepared entity name.
- Improves reference descriptions and adds page lifecycle tests.
</details>


<details open><summary><h3>Confidence Score: 1/5</h3></summary>

This PR is not yet safe to merge because page updates can persist incompatible body types or overwrite concurrent page state, while the previously reported deletion race still permits unauthorized replacement creation.

Omitted-body updates copy an independently read mutable body without validating page-type transitions or protecting against intervening writes, and update-classified requests can still become creates after a concurrent deletion without CREATE authorization or quota enforcement.

**Files Needing Attention:** openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/EntityTypeRules.java, openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateEntityTool.java, openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateEntityTool.java | Splits create and update authorization/persistence, but the previously reported deletion race remains on the update-classified path. |
| openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/EntityTypeRules.java | Adds page defaults and omitted-body preservation, but type-changing updates can retain an incompatible body and the separate preservation read can overwrite concurrent changes. |
| openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/EntityCreationSpec.java | Restricts Page attributes to caller-owned fields and describes page-specific conditional requirements. |
| openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/DescribeEntityTypeTool.java | Describes reference-valued attributes using the supported name-or-ID input form. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KnowledgePageRepository.java | Resolves name-only parent references before relationship storage. |
| openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/CreateEntityToolTest.java | Expands coverage for page creation, preservation, authorization branching, and reference descriptions, without covering type transitions or concurrent preservation updates. |

</details>

<sub>Reviews (3): Last reviewed commit: ["refactor(mcp): move per-type create rule..."](https://github.com/open-metadata/openmetadata/commit/1ff187c8271b142f90194265832fa5fe260f287f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57662754)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->