### PR TITLE
Fixes 32206: stop linking a table to itself from the Databricks system lineage tables

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py
@@ -120,6 +120,12 @@ class UnitycatalogLineageSource(Source):
             with self.engine.connect() as conn:
                 rows = conn.execute(text(UNITY_CATALOG_TABLE_LINEAGE.format(query_log_duration=query_log_duration)))
                 for row in rows:
+                    # A table never derives from itself. The system tables record
+                    # access rather than derivation, so a streaming or CDC write
+                    # legitimately names its target as its own source. Kept as
+                    # lineage it renders as a loop on the node and says nothing.
+                    if row.source_table_full_name == row.target_table_full_name:
+                        continue
                     self.table_lineage_map[row.target_table_full_name].add(row.source_table_full_name)
             logger.info(
                 f"Cached table lineage: {sum(len(v) for v in self.table_lineage_map.values())} edges "

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py
@@ -139,6 +139,10 @@ class UnitycatalogLineageSource(Source):
             with self.engine.connect() as conn:
                 rows = conn.execute(text(UNITY_CATALOG_COLUMN_LINEAGE.format(query_log_duration=query_log_duration)))
                 for row in rows:
+                    # The table pair this belongs to is dropped above, so caching the
+                    # columns only grows the map with entries nothing can read.
+                    if row.source_table_full_name == row.target_table_full_name:
+                        continue
                     table_key = (
                         row.source_table_full_name,
                         row.target_table_full_name,

--- a/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/metadata.py
@@ -1098,6 +1098,14 @@ class DatabrickspipelineSource(PipelineServiceSource):
                     if not (source_table_full_name and target_table_full_name):
                         continue
 
+                    # A table never derives from itself. The system tables record
+                    # access rather than derivation, so a streaming or CDC write
+                    # legitimately names its target as its own source. Kept as
+                    # lineage it renders as a loop on the node and says nothing.
+                    if source_table_full_name == target_table_full_name:
+                        logger.debug(f"Skipping self-referencing lineage row for {source_table_full_name}")
+                        continue
+
                     source = fqn.split_table_name(source_table_full_name)
                     target = fqn.split_table_name(target_table_full_name)
                     for dbservicename in self.get_db_service_names() or ["*"]:

--- a/ingestion/tests/unit/topology/database/test_unitycatalog_self_referencing_lineage.py
+++ b/ingestion/tests/unit/topology/database/test_unitycatalog_self_referencing_lineage.py
@@ -1,0 +1,78 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+A table is never cached as its own upstream.
+
+`system.access.table_lineage` records table access rather than derivation, so a
+streaming or CDC write legitimately names its target table as its own source.
+Those rows must not reach the lineage map, or the table ends up in its own
+upstream set and is later emitted as an edge pointing at itself.
+"""
+
+from collections import defaultdict
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.source.database.unitycatalog.lineage import (
+    UnitycatalogLineageSource,
+)
+
+CATALOG, SCHEMA = "analytics", "sales"
+EVENT_LOG = f"{CATALOG}.{SCHEMA}.orders_event_log"
+SNAPSHOT = f"{CATALOG}.{SCHEMA}.orders_snapshot"
+
+
+def _row(source_table: str, target_table: str) -> SimpleNamespace:
+    return SimpleNamespace(source_table_full_name=source_table, target_table_full_name=target_table)
+
+
+def _source(rows):
+    """The real caching method, with only the SQL connection stubbed."""
+    with patch.object(UnitycatalogLineageSource, "__init__", lambda s: None):
+        source = UnitycatalogLineageSource()
+
+    source.table_lineage_map = defaultdict(set)
+    source.source_config = MagicMock()
+    source.source_config.queryLogDuration = 1
+
+    connection = MagicMock()
+    connection.execute.return_value = rows
+    engine = MagicMock()
+    engine.connect.return_value.__enter__ = MagicMock(return_value=connection)
+    engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    source.engine = engine
+    return source
+
+
+class TestSelfReferencingLineageCache:
+    def test_a_self_referencing_row_is_not_cached(self):
+        source = _source([_row(EVENT_LOG, EVENT_LOG)])
+        source._cache_lineage()
+        assert EVENT_LOG not in source.table_lineage_map.get(EVENT_LOG, set())
+        assert sum(len(v) for v in source.table_lineage_map.values()) == 0
+
+    def test_a_normal_row_is_still_cached(self):
+        source = _source([_row(EVENT_LOG, SNAPSHOT)])
+        source._cache_lineage()
+        assert source.table_lineage_map[SNAPSHOT] == {EVENT_LOG}
+
+    def test_only_the_self_reference_is_dropped(self):
+        """The guard must not suppress real upstreams of the same table."""
+        source = _source(
+            [
+                _row(EVENT_LOG, SNAPSHOT),
+                _row(SNAPSHOT, SNAPSHOT),
+                _row(EVENT_LOG, EVENT_LOG),
+            ]
+        )
+        source._cache_lineage()
+        assert source.table_lineage_map[SNAPSHOT] == {EVENT_LOG}
+        assert source.table_lineage_map.get(EVENT_LOG, set()) == set()

--- a/ingestion/tests/unit/topology/database/test_unitycatalog_self_referencing_lineage.py
+++ b/ingestion/tests/unit/topology/database/test_unitycatalog_self_referencing_lineage.py
@@ -34,7 +34,16 @@ def _row(source_table: str, target_table: str) -> SimpleNamespace:
     return SimpleNamespace(source_table_full_name=source_table, target_table_full_name=target_table)
 
 
-def _source(rows):
+def _column_row(source_table: str, target_table: str, column: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        source_table_full_name=source_table,
+        target_table_full_name=target_table,
+        source_column_name=column,
+        target_column_name=column,
+    )
+
+
+def _source(rows, column_rows=None):
     """The real caching method, with only the SQL connection stubbed."""
     with patch.object(UnitycatalogLineageSource, "__init__", lambda s: None):
         source = UnitycatalogLineageSource()
@@ -43,8 +52,11 @@ def _source(rows):
     source.source_config = MagicMock()
     source.source_config.queryLogDuration = 1
 
+    source.column_lineage_map = defaultdict(list)
+
     connection = MagicMock()
-    connection.execute.return_value = rows
+    # _cache_lineage runs the table query first, then the column query
+    connection.execute.side_effect = [rows, column_rows if column_rows is not None else []]
     engine = MagicMock()
     engine.connect.return_value.__enter__ = MagicMock(return_value=connection)
     engine.connect.return_value.__exit__ = MagicMock(return_value=False)
@@ -76,3 +88,24 @@ class TestSelfReferencingLineageCache:
         source._cache_lineage()
         assert source.table_lineage_map[SNAPSHOT] == {EVENT_LOG}
         assert source.table_lineage_map.get(EVENT_LOG, set()) == set()
+
+
+class TestSelfReferencingColumnLineageCache:
+    """A self-pair's columns are unreadable once its table pair is dropped."""
+
+    def test_self_referencing_columns_are_not_cached(self):
+        source = _source(
+            [_row(EVENT_LOG, EVENT_LOG)],
+            column_rows=[_column_row(EVENT_LOG, EVENT_LOG, "id")],
+        )
+        source._cache_lineage()
+        assert (EVENT_LOG, EVENT_LOG) not in source.column_lineage_map
+        assert sum(len(v) for v in source.column_lineage_map.values()) == 0
+
+    def test_normal_columns_are_still_cached(self):
+        source = _source(
+            [_row(EVENT_LOG, SNAPSHOT)],
+            column_rows=[_column_row(EVENT_LOG, SNAPSHOT, "id")],
+        )
+        source._cache_lineage()
+        assert source.column_lineage_map[(EVENT_LOG, SNAPSHOT)] == [("id", "id")]

--- a/ingestion/tests/unit/topology/pipeline/test_databricks_self_referencing_lineage.py
+++ b/ingestion/tests/unit/topology/pipeline/test_databricks_self_referencing_lineage.py
@@ -1,0 +1,115 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+A table is never linked to itself.
+
+`system.access.table_lineage` records table access rather than derivation, so a
+streaming or CDC write legitimately names its target table as its own source.
+Carried through as lineage it renders as a loop on the node and tells the reader
+nothing, so those rows are dropped before an edge is built.
+"""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+from metadata.generated.schema.entity.data.table import Table
+from metadata.ingestion.source.pipeline.databrickspipeline.metadata import (
+    DatabrickspipelineSource,
+)
+from metadata.ingestion.source.pipeline.databrickspipeline.models import (
+    DataBrickPipelineDetails,
+)
+
+CATALOG, SCHEMA = "analytics", "sales"
+EVENT_LOG = f"{CATALOG}.{SCHEMA}.orders_event_log"
+SNAPSHOT = f"{CATALOG}.{SCHEMA}.orders_snapshot"
+
+
+def _table(fqn: str) -> Table:
+    table = MagicMock(spec=Table)
+    table.id = uuid.uuid4()
+    table.fullyQualifiedName = fqn
+    table.name = fqn.rsplit(".", 1)[-1]
+    table.columns = []
+    return table
+
+
+def _source(table_lineage_rows):
+    """The real connector with the Databricks and OpenMetadata sides stubbed."""
+    with patch.object(DatabrickspipelineSource, "__init__", lambda s, a, b: None):
+        source = DatabrickspipelineSource(None, None)
+
+    source.client = MagicMock()
+    source.client.get_table_lineage.return_value = table_lineage_rows
+    source.client.get_column_lineage.return_value = []
+    source.context = MagicMock()
+    source.get_db_service_names = MagicMock(return_value=["unity"])
+    source._table_lookup_cache = {}
+    source._yield_kafka_lineage = MagicMock(return_value=iter(()))
+
+    pipeline_entity = MagicMock()
+    pipeline_entity.id.root = uuid.uuid4()
+
+    def get_by_name(entity=None, fqn=None, **_):
+        # every table resolves, so a missing edge can only be the self-reference guard
+        return pipeline_entity if entity is not Table else _table(str(fqn))
+
+    source.metadata = MagicMock()
+    source.metadata.get_by_name.side_effect = get_by_name
+    return source
+
+
+def _edges(source):
+    details = DataBrickPipelineDetails(pipeline_id="11111111-2222-3333-4444-555555555555", name="orders")
+    with patch(
+        "metadata.ingestion.source.pipeline.databrickspipeline.metadata.fqn.build",
+        side_effect=lambda **kwargs: (
+            f"{kwargs.get('service_name')}.{kwargs.get('database_name')}."
+            f"{kwargs.get('schema_name')}.{kwargs.get('table_name')}"
+            if kwargs.get("table_name")
+            else "svc.pipeline"
+        ),
+    ):
+        results = list(source.yield_pipeline_lineage_details(details))
+    return [r.right for r in results if getattr(r, "right", None) is not None]
+
+
+class TestSelfReferencingTableLineage:
+    def test_a_self_referencing_row_yields_no_edge(self):
+        source = _source([{"source_table_full_name": EVENT_LOG, "target_table_full_name": EVENT_LOG}])
+        assert _edges(source) == []
+
+    def test_a_normal_row_still_yields_an_edge(self):
+        source = _source([{"source_table_full_name": EVENT_LOG, "target_table_full_name": SNAPSHOT}])
+        assert len(_edges(source)) == 1
+
+    def test_only_the_self_reference_is_dropped(self):
+        """The guard must not suppress real lineage produced by the same pipeline."""
+        source = _source(
+            [
+                {"source_table_full_name": EVENT_LOG, "target_table_full_name": EVENT_LOG},
+                {"source_table_full_name": EVENT_LOG, "target_table_full_name": SNAPSHOT},
+                {"source_table_full_name": SNAPSHOT, "target_table_full_name": SNAPSHOT},
+            ]
+        )
+        edges = _edges(source)
+        assert len(edges) == 1
+        edge = edges[0].edge
+        assert edge.fromEntity.id != edge.toEntity.id
+
+    def test_rows_with_a_missing_name_are_still_skipped(self):
+        source = _source(
+            [
+                {"source_table_full_name": None, "target_table_full_name": SNAPSHOT},
+                {"source_table_full_name": EVENT_LOG, "target_table_full_name": None},
+            ]
+        )
+        assert _edges(source) == []


### PR DESCRIPTION
### Describe your changes:

Fixes #32206

`system.access.table_lineage` can return rows where `source_table_full_name` equals `target_table_full_name`. That is legitimate for Unity Catalog, which records table *access* rather than derivation, so a streaming or CDC write genuinely touches its target table as both reader and writer.

The Databricks Pipeline connector and the Unity Catalog connector both read that table and neither checked whether the two names were the same, so the row became a lineage edge from a table to itself. It renders as a loop on the node and says nothing, since a table does not derive from itself.

I added the source-equals-target check to both, which is the same rule the SQL DLT parser already applies with the comment "A dataset never depends on itself".

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change. Two guard clauses, 14 source lines, no API or schema impact.

#
### Tests:

#### Use cases covered
- A Unity Catalog lineage row whose source and target are the same table produces no edge, in both the Databricks Pipeline connector and the Unity Catalog connector.
- Genuine lineage through the same pipeline is unaffected: an `orders_event_log -> orders_snapshot` edge is still emitted.
- A run containing both kinds of row drops only the self-reference and keeps the real edge.
- Rows with a missing source or target name are still skipped, as before.

#### Unit tests
- [x] I added unit tests for the changed logic.
- Files added:
  - `ingestion/tests/unit/topology/pipeline/test_databricks_self_referencing_lineage.py` (4 tests)
  - `ingestion/tests/unit/topology/database/test_unitycatalog_self_referencing_lineage.py` (3 tests)
- Verified they fail without the fix: reverting both guards fails exactly the 4 self-reference tests while the 3 control tests still pass, so the guard is shown to drop only self-pairs.
- Coverage, measured with `pytest --cov` over the Databricks pipeline and Unity Catalog suites:
  - `databrickspipeline/metadata.py` 65%
  - `unitycatalog/lineage.py` 26%
  - Both are pre-existing module-level figures on large files. The changed lines themselves are fully covered: `metadata.py` 1105-1107 and `lineage.py` 127-128 all execute under the new tests.
- No regressions: 140 passing across `test_databricks_pipeline.py`, `test_databricks_kafka_lineage.py`, `test_databricks_kafka_parser.py` and the four `test_unitycatalog_*` suites.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable. The change is a guard inside an existing lineage loop, covered by unit tests. Exercising it end to end needs a workspace whose system tables already contain a self-referencing row, which is the open question noted in the issue.

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. Queried a production instance where the bad edge exists and confirmed the shape: `fromEntity.id == toEntity.id`, `source: PipelineLineage`, pipeline attributed to the DLT pipeline, and column lineage mapping all 8 columns to themselves.
2. Confirmed the origin from the ingestion run log: the connector's own DLT source parsing emitted `depends_on=[]` for that table and created only the two correct edges, so the self-edge could only have come from the system-table path.
3. Confirmed the same run showed self-pairs for at least eight other tables, so it is systemic rather than one bad table.
4. Ran a controlled DLT pipeline on a clean workspace (streaming table with change data feed plus `APPLY CHANGES INTO`) and confirmed it produces correct lineage and no self-pair, so the trigger is still unknown. Recorded in the issue rather than claimed as a reproduction.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable, no schema change.
- [x] For UI changes: not applicable, no UI change.
- [x] I have added tests and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents Databricks system-table records from producing self-referential lineage.
- Skips source-equals-target rows in the Unity Catalog table and column lineage caches.
- Skips equivalent rows before the Databricks Pipeline connector resolves entities and emits edges.
- Adds focused tests covering self-references, normal lineage, mixed inputs, column mappings, and missing names.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py | Filters exact self-references from table and column lineage caches before they can contribute to emitted lineage. |
| ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/metadata.py | Skips exact self-referencing system-table rows before FQN resolution and lineage-edge construction. |
| ingestion/tests/unit/topology/database/test_unitycatalog_self_referencing_lineage.py | Covers self-reference suppression and preservation of normal table and column lineage. |
| ingestion/tests/unit/topology/pipeline/test_databricks_self_referencing_lineage.py | Covers self-reference suppression, mixed rows, normal edges, and missing-name behavior in the pipeline connector. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(unitycatalog): skip self-referencing..."](https://github.com/open-metadata/openmetadata/commit/d9f721b8ff3779784680fb5c6e8ceca9d1386dd1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57809755)</sub>

<!-- /greptile_comment -->