### PR TITLE
fix(security): refresh OpenSSL in ingestion images (2.0 backport)

### DIFF
--- a/ingestion/operators/docker/Dockerfile
+++ b/ingestion/operators/docker/Dockerfile
@@ -204,6 +204,10 @@ RUN pip install psycopg2 mysqlclient==2.1.1
 # -- it arrives transitively from the top-of-file apt layer -- and that layer's
 # frozen index is exactly why the image keeps shipping 2.8.2 and being reported
 # for CVE-2026-72522 while trixie-security has 2.8.3-1~deb13u1.
+# openssl follows the same cache boundary. The early apt layer can retain
+# 3.5.6-1~deb13u2, while trixie-security carries the CVE-2026-14457 fix in
+# 3.5.7-1~deb13u2. Querying the source package upgrades openssl, libssl3t64,
+# and libssl-dev together so no scanner-visible binary is left behind.
 # The package sets are computed from dpkg rather than hand-listed. One source
 # package produces many binaries -- here util-linux, bsdutils, login, mount,
 # liblastlog2-2, libblkid1, libmount1, libsmartcols1 and libuuid1 -- and scanners
@@ -227,8 +231,10 @@ RUN set -eu; \
     ul="$(dpkg-query -W -f='${source:Package} ${Package}\n' | awk '$1=="util-linux"{print $2}')"; \
     [ -n "$ul" ] || { echo "no src:util-linux packages found; refusing to skip the CVE patch" >&2; exit 1; }; \
     ex="$(dpkg-query -W -f='${source:Package} ${Package}\n' | awk '$1=="expat"{print $2}')"; \
+    ossl="$(dpkg-query -W -f='${source:Package} ${Package}\n' | awk '$1=="openssl"{print $2}')"; \
+    [ -n "$ossl" ] || { echo "no src:openssl packages found; refusing to skip the OpenSSL CVE patch" >&2; exit 1; }; \
     apt-get -qq update; \
-    apt-get -qq install -y --only-upgrade $ul $ex; \
+    apt-get -qq install -y --only-upgrade $ul $ex $ossl; \
     apt-get -qq purge -y libmariadb-dev libmariadb-dev-compat libunbound8; \
     apt-mark manual libmariadb3 mariadb-common; \
     apt-get -qq autoremove -y --purge; \

--- a/ingestion/operators/docker/Dockerfile.ci
+++ b/ingestion/operators/docker/Dockerfile.ci
@@ -212,6 +212,10 @@ RUN pip install psycopg2 mysqlclient==2.1.1
 # -- it arrives transitively from the top-of-file apt layer -- and that layer's
 # frozen index is exactly why the image keeps shipping 2.8.2 and being reported
 # for CVE-2026-72522 while trixie-security has 2.8.3-1~deb13u1.
+# openssl follows the same cache boundary. The early apt layer can retain
+# 3.5.6-1~deb13u2, while trixie-security carries the CVE-2026-14457 fix in
+# 3.5.7-1~deb13u2. Querying the source package upgrades openssl, libssl3t64,
+# and libssl-dev together so no scanner-visible binary is left behind.
 # The package sets are computed from dpkg rather than hand-listed. One source
 # package produces many binaries -- here util-linux, bsdutils, login, mount,
 # liblastlog2-2, libblkid1, libmount1, libsmartcols1 and libuuid1 -- and scanners
@@ -235,8 +239,10 @@ RUN set -eu; \
     ul="$(dpkg-query -W -f='${source:Package} ${Package}\n' | awk '$1=="util-linux"{print $2}')"; \
     [ -n "$ul" ] || { echo "no src:util-linux packages found; refusing to skip the CVE patch" >&2; exit 1; }; \
     ex="$(dpkg-query -W -f='${source:Package} ${Package}\n' | awk '$1=="expat"{print $2}')"; \
+    ossl="$(dpkg-query -W -f='${source:Package} ${Package}\n' | awk '$1=="openssl"{print $2}')"; \
+    [ -n "$ossl" ] || { echo "no src:openssl packages found; refusing to skip the OpenSSL CVE patch" >&2; exit 1; }; \
     apt-get -qq update; \
-    apt-get -qq install -y --only-upgrade $ul $ex; \
+    apt-get -qq install -y --only-upgrade $ul $ex $ossl; \
     apt-get -qq purge -y libmariadb-dev libmariadb-dev-compat libunbound8; \
     apt-mark manual libmariadb3 mariadb-common; \
     apt-get -qq autoremove -y --purge; \

--- a/ingestion/tests/docker/base_image_cve_test.sh
+++ b/ingestion/tests/docker/base_image_cve_test.sh
@@ -10,7 +10,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-# Gates the ingestion-base image on (a) absence of the five Debian 12 OS CVEs
+# Gates the ingestion-base image on (a) absence of the tracked Debian OS CVEs
 # that failed the Collate Snyk gate, and (b) the native driver stack still
 # working after the OS rebase. A clean CVE result with a broken ODBC or Oracle
 # driver is not a pass.
@@ -31,7 +31,7 @@ UNFILTERED_SCAN_OUT=""
 # CVE-2026-66032 / CVE-2026-66034 and reports zero hits for them even on the
 # bookworm image that demonstrably carries the vulnerable libssh2-1 1.10.0-3+b1.
 # Those two are covered by the package-version assertion further down instead.
-TARGET_CVES="CVE-2023-45853 CVE-2026-34980 CVE-2026-45186"
+TARGET_CVES="CVE-2023-45853 CVE-2026-34980 CVE-2026-45186 CVE-2026-14457"
 
 fail() { echo "FAIL: $1"; FAILURES=$((FAILURES + 1)); }
 pass() { echo "PASS: $1"; }


### PR DESCRIPTION
Backport of #32148.

This updates the source-package-based OpenSSL refresh in both ingestion Dockerfiles and tracks CVE-2026-14457 in the base-image gate.



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport refreshes the OpenSSL package family from Debian security repositories in both operator ingestion images and extends the base-image scan to track CVE-2026-14457.
- Discovers installed binaries originating from the `openssl` source package and upgrades them together.
- Fails image builds when no OpenSSL source packages are discovered.
- Adds CVE-2026-14457 to the unfiltered Trivy assertions.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/operators/docker/Dockerfile | Adds a fail-closed source-package-based OpenSSL upgrade to the release ingestion image. |
| ingestion/operators/docker/Dockerfile.ci | Mirrors the OpenSSL security refresh in the CI ingestion image. |
| ingestion/tests/docker/base_image_cve_test.sh | Adds CVE-2026-14457 to the base-image Trivy assertions. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;2.0&#39; into backport/cve-202..."](https://github.com/open-metadata/openmetadata/commit/e3bd4d9cf94db8d16e77503076e6b8687ed81d79) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57810820)</sub>

<!-- /greptile_comment -->