### PR TITLE
fix(security): refresh OpenSSL in ingestion images (1.13 backport)

### DIFF
--- a/ingestion/operators/docker/Dockerfile
+++ b/ingestion/operators/docker/Dockerfile
@@ -200,6 +200,10 @@ RUN pip install psycopg2 mysqlclient==2.1.1
 # The util-linux upgrade rides along in the same root layer. trixie's base ships
 # 2.41-5, which carries CVE-2025-14104, CVE-2026-13595 and CVE-2026-27456;
 # trixie-security has 2.41.5-0+deb13u1.
+# openssl follows the same cache boundary. The early apt layer can retain
+# 3.5.6-1~deb13u2, while trixie-security carries the CVE-2026-14457 fix in
+# 3.5.7-1~deb13u2. Querying the source package upgrades openssl, libssl3t64,
+# and libssl-dev together so no scanner-visible binary is left behind.
 # The package set is computed from dpkg rather than hand-listed. One source
 # package produces many binaries -- here util-linux, bsdutils, login, mount,
 # liblastlog2-2, libblkid1, libmount1, libsmartcols1 and libuuid1 -- and scanners
@@ -218,8 +222,10 @@ USER root
 RUN set -eu; \
     pkgs="$(dpkg-query -W -f='${source:Package} ${Package}\n' | awk '$1=="util-linux"{print $2}')"; \
     [ -n "$pkgs" ] || { echo "no src:util-linux packages found; refusing to skip the CVE patch" >&2; exit 1; }; \
+    ossl="$(dpkg-query -W -f='${source:Package} ${Package}\n' | awk '$1=="openssl"{print $2}')"; \
+    [ -n "$ossl" ] || { echo "no src:openssl packages found; refusing to skip the OpenSSL CVE patch" >&2; exit 1; }; \
     apt-get -qq update; \
-    apt-get -qq install -y --only-upgrade $pkgs; \
+    apt-get -qq install -y --only-upgrade $pkgs $ossl; \
     apt-get -qq purge -y libmariadb-dev libmariadb-dev-compat libunbound8; \
     apt-mark manual libmariadb3 mariadb-common; \
     apt-get -qq autoremove -y --purge; \

--- a/ingestion/operators/docker/Dockerfile.ci
+++ b/ingestion/operators/docker/Dockerfile.ci
@@ -208,6 +208,10 @@ RUN pip install psycopg2 mysqlclient==2.1.1
 # The util-linux upgrade rides along in the same root layer. trixie's base ships
 # 2.41-5, which carries CVE-2025-14104, CVE-2026-13595 and CVE-2026-27456;
 # trixie-security has 2.41.5-0+deb13u1.
+# openssl follows the same cache boundary. The early apt layer can retain
+# 3.5.6-1~deb13u2, while trixie-security carries the CVE-2026-14457 fix in
+# 3.5.7-1~deb13u2. Querying the source package upgrades openssl, libssl3t64,
+# and libssl-dev together so no scanner-visible binary is left behind.
 # The package set is computed from dpkg rather than hand-listed. One source
 # package produces many binaries -- here util-linux, bsdutils, login, mount,
 # liblastlog2-2, libblkid1, libmount1, libsmartcols1 and libuuid1 -- and scanners
@@ -226,8 +230,10 @@ USER root
 RUN set -eu; \
     pkgs="$(dpkg-query -W -f='${source:Package} ${Package}\n' | awk '$1=="util-linux"{print $2}')"; \
     [ -n "$pkgs" ] || { echo "no src:util-linux packages found; refusing to skip the CVE patch" >&2; exit 1; }; \
+    ossl="$(dpkg-query -W -f='${source:Package} ${Package}\n' | awk '$1=="openssl"{print $2}')"; \
+    [ -n "$ossl" ] || { echo "no src:openssl packages found; refusing to skip the OpenSSL CVE patch" >&2; exit 1; }; \
     apt-get -qq update; \
-    apt-get -qq install -y --only-upgrade $pkgs; \
+    apt-get -qq install -y --only-upgrade $pkgs $ossl; \
     apt-get -qq purge -y libmariadb-dev libmariadb-dev-compat libunbound8; \
     apt-mark manual libmariadb3 mariadb-common; \
     apt-get -qq autoremove -y --purge; \

--- a/ingestion/tests/docker/base_image_cve_test.sh
+++ b/ingestion/tests/docker/base_image_cve_test.sh
@@ -10,7 +10,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-# Gates the ingestion-base image on (a) absence of the five Debian 12 OS CVEs
+# Gates the ingestion-base image on (a) absence of the tracked Debian OS CVEs
 # that failed the Collate Snyk gate, and (b) the native driver stack still
 # working after the OS rebase. A clean CVE result with a broken ODBC or Oracle
 # driver is not a pass.
@@ -31,7 +31,7 @@ UNFILTERED_SCAN_OUT=""
 # CVE-2026-66032 / CVE-2026-66034 and reports zero hits for them even on the
 # bookworm image that demonstrably carries the vulnerable libssh2-1 1.10.0-3+b1.
 # Those two are covered by the package-version assertion further down instead.
-TARGET_CVES="CVE-2023-45853 CVE-2026-34980 CVE-2026-45186"
+TARGET_CVES="CVE-2023-45853 CVE-2026-34980 CVE-2026-45186 CVE-2026-14457"
 
 fail() { echo "FAIL: $1"; FAILURES=$((FAILURES + 1)); }
 pass() { echo "PASS: $1"; }


### PR DESCRIPTION
Backport of #32148.

This updates the source-package-based OpenSSL refresh in both ingestion Dockerfiles and tracks CVE-2026-14457 in the base-image gate.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR refreshes all installed binaries produced by Debian’s OpenSSL source package in both operator ingestion images and adds CVE-2026-14457 to the base-image scan.

- Discovers installed OpenSSL binaries through `dpkg-query` and upgrades them from the refreshed trixie-security index.
- Applies identical package-refresh behavior to production and CI operator images.
- Extends the existing unfiltered Trivy CVE assertion list.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete changed-code defect identified.

The package query matches the installed Debian OpenSSL source-package binaries, upgrades them from the refreshed security index in both image variants, and extends the existing CVE scan consistently.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/operators/docker/Dockerfile | Correctly discovers and upgrades the installed OpenSSL source-package binaries alongside the existing util-linux refresh. |
| ingestion/operators/docker/Dockerfile.ci | Keeps the CI operator image’s OpenSSL refresh aligned with the production Dockerfile. |
| ingestion/tests/docker/base_image_cve_test.sh | Adds CVE-2026-14457 to the existing unfiltered scanner assertions without changing test control flow. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): refresh OpenSSL in ingest..."](https://github.com/open-metadata/openmetadata/commit/ed895258a5573411fcfd08e87911f8b3ae0b0914) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57811498)</sub>

<!-- /greptile_comment -->