### PR TITLE
Backport #32011 to 1.13: Allow assigning Data Products across domains from the UI

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesDisabled.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesDisabled.spec.ts
@@ -819,3 +819,91 @@ test.describe(
     });
   }
 );
+
+test.describe(
+  `Data Product Domain Validation Rule Disabled`,
+  {
+    tag: '@dataAssetRules',
+  },
+  () => {
+    // With the "Data Product Domain Validation" rule disabled, the Data Product
+    // dropdown is no longer scoped to the asset's domain, so an asset can be
+    // assigned a Data Product that belongs to a different domain.
+    test('should allow assigning a Data Product from a different domain', async ({
+      page,
+      browser,
+    }) => {
+      test.slow(true);
+
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      const assetDomain = new Domain();
+      const productDomain = new Domain();
+      const crossDomainDataProduct = new DataProduct([productDomain]);
+      const crossTable = new TableClass();
+
+      try {
+        await assetDomain.create(apiContext);
+        await productDomain.create(apiContext);
+        await crossDomainDataProduct.create(apiContext);
+        await crossTable.create(apiContext);
+
+        await redirectToHomePage(page);
+        await crossTable.visitEntityPage(page);
+
+        // Asset belongs to assetDomain only.
+        await assignDomainWidget(page, assetDomain.responseData);
+
+        const dataProductWidget = page
+          .getByTestId('KnowledgePanel.DataProducts')
+          .getByTestId('data-products-container');
+
+        await dataProductWidget.getByTestId('add-data-product').click();
+
+        const dpFqn = crossDomainDataProduct.responseData.fullyQualifiedName;
+        const dpTag = page.getByTestId(`tag-${dpFqn}`);
+
+        // The Data Product from productDomain is offered even though the asset
+        // is in assetDomain, because the domain validation rule is disabled.
+        await expect(async () => {
+          const searchResponse = page.waitForResponse((response) =>
+            response.url().includes('/api/v1/search/query')
+          );
+          await page
+            .locator('[data-testid="data-product-selector"] input')
+            .clear();
+          await page
+            .locator('[data-testid="data-product-selector"] input')
+            .fill(crossDomainDataProduct.data.displayName);
+          await searchResponse;
+          await expect(dpTag).toBeVisible({ timeout: 2_000 });
+        }).toPass({ timeout: 30_000, intervals: [1_000, 2_000, 5_000] });
+
+        await dpTag.click();
+
+        const patchReq = page.waitForResponse(
+          (req) =>
+            req.request().method() === 'PATCH' &&
+            req.url().includes(`/api/v1/${crossTable.endpoint}/`)
+        );
+        await page
+          .getByTestId('data-product-dropdown-actions')
+          .getByTestId('saveAssociatedTag')
+          .click();
+        await patchReq;
+
+        await expect(
+          page
+            .getByTestId('KnowledgePanel.DataProducts')
+            .getByTestId('data-products-list')
+            .getByTestId(`data-product-${dpFqn}`)
+        ).toBeVisible();
+      } finally {
+        await crossTable.delete(apiContext);
+        await crossDomainDataProduct.delete(apiContext);
+        await productDomain.delete(apiContext);
+        await assetDomain.delete(apiContext);
+        await afterAction();
+      }
+    });
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesDisabled.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesDisabled.spec.ts
@@ -826,55 +826,56 @@ test.describe(
     tag: '@dataAssetRules',
   },
   () => {
+    const assetDomain = new Domain();
+    const productDomain = new Domain();
+    const crossDomainDataProduct = new DataProduct([productDomain]);
+    const crossTable = new TableClass();
+
+    test.beforeAll('Setup cross-domain data', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      await assetDomain.create(apiContext);
+      await productDomain.create(apiContext);
+      await crossDomainDataProduct.create(apiContext);
+      await crossTable.create(apiContext);
+      await afterAction();
+    });
+
+    test.afterAll('Cleanup cross-domain data', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      await crossTable.delete(apiContext);
+      await crossDomainDataProduct.delete(apiContext);
+      await productDomain.delete(apiContext);
+      await assetDomain.delete(apiContext);
+      await afterAction();
+    });
+
     // With the "Data Product Domain Validation" rule disabled, the Data Product
     // dropdown is no longer scoped to the asset's domain, so an asset can be
     // assigned a Data Product that belongs to a different domain.
     test('should allow assigning a Data Product from a different domain', async ({
       page,
-      browser,
     }) => {
-      test.slow(true);
+      await redirectToHomePage(page);
+      await crossTable.visitEntityPage(page);
 
-      const { apiContext, afterAction } = await performAdminLogin(browser);
-      const assetDomain = new Domain();
-      const productDomain = new Domain();
-      const crossDomainDataProduct = new DataProduct([productDomain]);
-      const crossTable = new TableClass();
+      // Asset belongs to assetDomain only.
+      await assignDomain(page, assetDomain.responseData);
 
-      try {
-        await assetDomain.create(apiContext);
-        await productDomain.create(apiContext);
-        await crossDomainDataProduct.create(apiContext);
-        await crossTable.create(apiContext);
+      // The Data Product from productDomain can be assigned even though the
+      // asset is in assetDomain, because the domain validation rule is disabled
+      // and the dropdown lists Data Products across all domains.
+      await assignDataProduct(page, assetDomain.responseData, [
+        crossDomainDataProduct.responseData,
+      ]);
 
-        await redirectToHomePage(page);
-        await crossTable.visitEntityPage(page);
-
-        // Asset belongs to assetDomain only.
-        await assignDomain(page, assetDomain.responseData);
-
-        // The Data Product from productDomain can be assigned even though the
-        // asset is in assetDomain, because the domain validation rule is
-        // disabled and the dropdown lists Data Products across all domains.
-        await assignDataProduct(page, assetDomain.responseData, [
-          crossDomainDataProduct.responseData,
-        ]);
-
-        await expect(
-          page
-            .getByTestId('KnowledgePanel.DataProducts')
-            .getByTestId('data-products-list')
-            .getByTestId(
-              `data-product-${crossDomainDataProduct.responseData.fullyQualifiedName}`
-            )
-        ).toBeVisible();
-      } finally {
-        await crossTable.delete(apiContext);
-        await crossDomainDataProduct.delete(apiContext);
-        await productDomain.delete(apiContext);
-        await assetDomain.delete(apiContext);
-        await afterAction();
-      }
+      await expect(
+        page
+          .getByTestId('KnowledgePanel.DataProducts')
+          .getByTestId('data-products-list')
+          .getByTestId(
+            `data-product-${crossDomainDataProduct.responseData.fullyQualifiedName}`
+          )
+      ).toBeVisible();
     });
   }
 );

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesDisabled.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesDisabled.spec.ts
@@ -851,51 +851,22 @@ test.describe(
         await crossTable.visitEntityPage(page);
 
         // Asset belongs to assetDomain only.
-        await assignDomainWidget(page, assetDomain.responseData);
+        await assignDomain(page, assetDomain.responseData);
 
-        const dataProductWidget = page
-          .getByTestId('KnowledgePanel.DataProducts')
-          .getByTestId('data-products-container');
-
-        await dataProductWidget.getByTestId('add-data-product').click();
-
-        const dpFqn = crossDomainDataProduct.responseData.fullyQualifiedName;
-        const dpTag = page.getByTestId(`tag-${dpFqn}`);
-
-        // The Data Product from productDomain is offered even though the asset
-        // is in assetDomain, because the domain validation rule is disabled.
-        await expect(async () => {
-          const searchResponse = page.waitForResponse((response) =>
-            response.url().includes('/api/v1/search/query')
-          );
-          await page
-            .locator('[data-testid="data-product-selector"] input')
-            .clear();
-          await page
-            .locator('[data-testid="data-product-selector"] input')
-            .fill(crossDomainDataProduct.data.displayName);
-          await searchResponse;
-          await expect(dpTag).toBeVisible({ timeout: 2_000 });
-        }).toPass({ timeout: 30_000, intervals: [1_000, 2_000, 5_000] });
-
-        await dpTag.click();
-
-        const patchReq = page.waitForResponse(
-          (req) =>
-            req.request().method() === 'PATCH' &&
-            req.url().includes(`/api/v1/${crossTable.endpoint}/`)
-        );
-        await page
-          .getByTestId('data-product-dropdown-actions')
-          .getByTestId('saveAssociatedTag')
-          .click();
-        await patchReq;
+        // The Data Product from productDomain can be assigned even though the
+        // asset is in assetDomain, because the domain validation rule is
+        // disabled and the dropdown lists Data Products across all domains.
+        await assignDataProduct(page, assetDomain.responseData, [
+          crossDomainDataProduct.responseData,
+        ]);
 
         await expect(
           page
             .getByTestId('KnowledgePanel.DataProducts')
             .getByTestId('data-products-list')
-            .getByTestId(`data-product-${dpFqn}`)
+            .getByTestId(
+              `data-product-${crossDomainDataProduct.responseData.fullyQualifiedName}`
+            )
         ).toBeVisible();
       } finally {
         await crossTable.delete(apiContext);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesEnabled.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesEnabled.spec.ts
@@ -320,81 +320,80 @@ test.describe(
     tag: '@dataAssetRules',
   },
   () => {
+    const assetDomain = new Domain();
+    const productDomain = new Domain();
+    const sameDomainDataProduct = new DataProduct([assetDomain]);
+    const otherDomainDataProduct = new DataProduct([productDomain]);
+    const crossTable = new TableClass();
+
+    test.beforeAll('Setup cross-domain data', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      await assetDomain.create(apiContext);
+      await productDomain.create(apiContext);
+      await sameDomainDataProduct.create(apiContext);
+      await otherDomainDataProduct.create(apiContext);
+      await crossTable.create(apiContext);
+      await afterAction();
+    });
+
+    test.afterAll('Cleanup cross-domain data', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      await crossTable.delete(apiContext);
+      await sameDomainDataProduct.delete(apiContext);
+      await otherDomainDataProduct.delete(apiContext);
+      await productDomain.delete(apiContext);
+      await assetDomain.delete(apiContext);
+      await afterAction();
+    });
+
     // With the "Data Product Domain Validation" rule enabled, the Data Product
     // dropdown stays scoped to the asset's domain, so a Data Product from a
     // different domain is not offered.
     test('should not list Data Products from a different domain', async ({
       page,
-      browser,
     }) => {
-      test.slow(true);
+      await authenticateAdminPage(page);
+      await crossTable.visitEntityPage(page);
 
-      const { apiContext, afterAction } = await performAdminLogin(browser);
-      const assetDomain = new Domain();
-      const productDomain = new Domain();
-      const sameDomainDataProduct = new DataProduct([assetDomain]);
-      const otherDomainDataProduct = new DataProduct([productDomain]);
-      const crossTable = new TableClass();
+      await assignDomainWidget(page, assetDomain.responseData);
 
-      try {
-        await assetDomain.create(apiContext);
-        await productDomain.create(apiContext);
-        await sameDomainDataProduct.create(apiContext);
-        await otherDomainDataProduct.create(apiContext);
-        await crossTable.create(apiContext);
+      await page
+        .getByTestId('KnowledgePanel.DataProducts')
+        .getByTestId('data-products-container')
+        .getByTestId('add-data-product')
+        .click();
 
-        await authenticateAdminPage(page);
-        await crossTable.visitEntityPage(page);
+      const selectorInput = page.locator(
+        '[data-testid="data-product-selector"] input'
+      );
+      const sameDomainFqn =
+        sameDomainDataProduct.responseData.fullyQualifiedName;
+      const otherDomainFqn =
+        otherDomainDataProduct.responseData.fullyQualifiedName;
 
-        await assignDomainWidget(page, assetDomain.responseData);
-
-        await page
-          .getByTestId('KnowledgePanel.DataProducts')
-          .getByTestId('data-products-container')
-          .getByTestId('add-data-product')
-          .click();
-
-        const selectorInput = page.locator(
-          '[data-testid="data-product-selector"] input'
-        );
-        const sameDomainFqn =
-          sameDomainDataProduct.responseData.fullyQualifiedName;
-        const otherDomainFqn =
-          otherDomainDataProduct.responseData.fullyQualifiedName;
-
-        // Positive control: a Data Product in the asset's domain is listed.
-        await expect(async () => {
-          const searchResponse = page.waitForResponse((response) =>
-            response.url().includes('/api/v1/search/query')
-          );
-          await selectorInput.clear();
-          await selectorInput.fill(sameDomainDataProduct.data.displayName);
-          await searchResponse;
-          await expect(page.getByTestId(`tag-${sameDomainFqn}`)).toBeVisible({
-            timeout: 2_000,
-          });
-        }).toPass({ timeout: 30_000, intervals: [1_000, 2_000, 5_000] });
-
-        // Scoped to the asset's domain, so a Data Product from another domain is
-        // not offered.
-        const otherSearchResponse = page.waitForResponse((response) =>
+      // Positive control: a Data Product in the asset's domain is listed.
+      await expect(async () => {
+        const searchResponse = page.waitForResponse((response) =>
           response.url().includes('/api/v1/search/query')
         );
         await selectorInput.clear();
-        await selectorInput.fill(otherDomainDataProduct.data.displayName);
-        await otherSearchResponse;
+        await selectorInput.fill(sameDomainDataProduct.data.displayName);
+        await searchResponse;
+        await expect(page.getByTestId(`tag-${sameDomainFqn}`)).toBeVisible({
+          timeout: 2_000,
+        });
+      }).toPass({ timeout: 30_000, intervals: [1_000, 2_000, 5_000] });
 
-        await expect(
-          page.getByTestId(`tag-${otherDomainFqn}`)
-        ).not.toBeVisible();
-      } finally {
-        await crossTable.delete(apiContext);
-        await sameDomainDataProduct.delete(apiContext);
-        await otherDomainDataProduct.delete(apiContext);
-        await productDomain.delete(apiContext);
-        await assetDomain.delete(apiContext);
-        await afterAction();
-      }
+      // Scoped to the asset's domain, so a Data Product from another domain is
+      // not offered.
+      const otherSearchResponse = page.waitForResponse((response) =>
+        response.url().includes('/api/v1/search/query')
+      );
+      await selectorInput.clear();
+      await selectorInput.fill(otherDomainDataProduct.data.displayName);
+      await otherSearchResponse;
+
+      await expect(page.getByTestId(`tag-${otherDomainFqn}`)).not.toBeVisible();
     });
   }
 );

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesEnabled.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesEnabled.spec.ts
@@ -370,9 +370,9 @@ test.describe(
           await selectorInput.clear();
           await selectorInput.fill(sameDomainDataProduct.data.displayName);
           await searchResponse;
-          await expect(
-            page.getByTestId(`tag-${sameDomainFqn}`)
-          ).toBeVisible({ timeout: 2_000 });
+          await expect(page.getByTestId(`tag-${sameDomainFqn}`)).toBeVisible({
+            timeout: 2_000,
+          });
         }).toPass({ timeout: 30_000, intervals: [1_000, 2_000, 5_000] });
 
         // Scoped to the asset's domain, so a Data Product from another domain is

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesEnabled.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesEnabled.spec.ts
@@ -313,3 +313,88 @@ test.describe(
     });
   }
 );
+
+test.describe(
+  `Data Product Domain Validation Rule Enabled`,
+  {
+    tag: '@dataAssetRules',
+  },
+  () => {
+    // With the "Data Product Domain Validation" rule enabled, the Data Product
+    // dropdown stays scoped to the asset's domain, so a Data Product from a
+    // different domain is not offered.
+    test('should not list Data Products from a different domain', async ({
+      page,
+      browser,
+    }) => {
+      test.slow(true);
+
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      const assetDomain = new Domain();
+      const productDomain = new Domain();
+      const sameDomainDataProduct = new DataProduct([assetDomain]);
+      const otherDomainDataProduct = new DataProduct([productDomain]);
+      const crossTable = new TableClass();
+
+      try {
+        await assetDomain.create(apiContext);
+        await productDomain.create(apiContext);
+        await sameDomainDataProduct.create(apiContext);
+        await otherDomainDataProduct.create(apiContext);
+        await crossTable.create(apiContext);
+
+        await authenticateAdminPage(page);
+        await crossTable.visitEntityPage(page);
+
+        await assignDomainWidget(page, assetDomain.responseData);
+
+        await page
+          .getByTestId('KnowledgePanel.DataProducts')
+          .getByTestId('data-products-container')
+          .getByTestId('add-data-product')
+          .click();
+
+        const selectorInput = page.locator(
+          '[data-testid="data-product-selector"] input'
+        );
+        const sameDomainFqn =
+          sameDomainDataProduct.responseData.fullyQualifiedName;
+        const otherDomainFqn =
+          otherDomainDataProduct.responseData.fullyQualifiedName;
+
+        // Positive control: a Data Product in the asset's domain is listed.
+        await expect(async () => {
+          const searchResponse = page.waitForResponse((response) =>
+            response.url().includes('/api/v1/search/query')
+          );
+          await selectorInput.clear();
+          await selectorInput.fill(sameDomainDataProduct.data.displayName);
+          await searchResponse;
+          await expect(
+            page.getByTestId(`tag-${sameDomainFqn}`)
+          ).toBeVisible({ timeout: 2_000 });
+        }).toPass({ timeout: 30_000, intervals: [1_000, 2_000, 5_000] });
+
+        // Scoped to the asset's domain, so a Data Product from another domain is
+        // not offered.
+        const otherSearchResponse = page.waitForResponse((response) =>
+          response.url().includes('/api/v1/search/query')
+        );
+        await selectorInput.clear();
+        await selectorInput.fill(otherDomainDataProduct.data.displayName);
+        await otherSearchResponse;
+
+        await expect(
+          page.getByTestId(`tag-${otherDomainFqn}`)
+        ).not.toBeVisible();
+      } finally {
+        await crossTable.delete(apiContext);
+        await sameDomainDataProduct.delete(apiContext);
+        await otherDomainDataProduct.delete(apiContext);
+        await productDomain.delete(apiContext);
+        await assetDomain.delete(apiContext);
+        await afterAction();
+      }
+    });
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -499,10 +499,13 @@ export const assignDataProduct = async (
     );
 
     await expect(async () => {
-      const searchDataProduct = page.waitForResponse(
-        (response) =>
-          response.url().includes('/api/v1/search/query') &&
-          response.url().includes(encodeURIComponent(domain.name))
+      // Match any Data Product search response. The dropdown filters by the
+      // asset's domain only when the "Data Product Domain Validation" rule is
+      // enabled; when it is disabled the query carries no domain, so we cannot
+      // key the wait on the domain name. The tag visibility check below is the
+      // real synchronization guard.
+      const searchDataProduct = page.waitForResponse((response) =>
+        response.url().includes('/api/v1/search/query')
       );
       await page.locator('[data-testid="data-product-selector"] input').clear();
       await page

--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.interface.ts
@@ -55,6 +55,7 @@ export interface GenericContextType<T extends Omit<EntityReference, 'type'>> {
   updateActiveTagDropdownKey: (key: string | null) => void;
   muiTags: boolean;
   entityRules: DataAssetRuleValidation;
+  isRulesLoaded: boolean;
   selectedColumn: ColumnOrTask | null;
   isColumnDetailOpen: boolean;
   openColumnDetailPanel: (column: ColumnOrTask) => void;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.tsx
@@ -115,7 +115,7 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
     [selectedColumn]
   );
 
-  const { entityRules } = useEntityRules(type);
+  const { entityRules, isRulesLoaded } = useEntityRules(type);
 
   // limit=1000 is the backend max. Entities with more tracked field changes
   // will have entries beyond this limit silently omitted. Use fieldPrefix
@@ -422,6 +422,7 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
     () => ({
       data,
       entityRules,
+      isRulesLoaded,
       type,
       onUpdate,
       isVersionView,
@@ -444,6 +445,7 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
     [
       data,
       entityRules,
+      isRulesLoaded,
       type,
       onUpdate,
       isVersionView,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/CommonWidgets/CommonWidgets.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/CommonWidgets/CommonWidgets.tsx
@@ -103,8 +103,15 @@ export const CommonWidgets = ({
   entityType,
   showTaskHandler = true,
 }: CommonWidgetsProps) => {
-  const { data, type, entityRules, onUpdate, permissions, isVersionView } =
-    useGenericContext<GenericEntity>();
+  const {
+    data,
+    type,
+    entityRules,
+    isRulesLoaded,
+    onUpdate,
+    permissions,
+    isVersionView,
+  } = useGenericContext<GenericEntity>();
   const [tagsUpdating, setTagsUpdating] = useState<TagLabel[]>();
 
   const updatedData = useMemo(() => {
@@ -296,7 +303,9 @@ export const CommonWidgets = ({
         dataProducts={dataProducts ?? []}
         hasPermission={editDataProductPermission}
         multiple={entityRules.canAddMultipleDataProducts}
-        requireDomainForDataProduct={entityRules.requireDomainForDataProduct}
+        requireDomainForDataProduct={
+          !isRulesLoaded || entityRules.requireDomainForDataProduct
+        }
         onSave={handleDataProductsSave}
       />
     );
@@ -306,6 +315,7 @@ export const CommonWidgets = ({
     editDataProductPermission,
     entityRules.canAddMultipleDataProducts,
     entityRules.requireDomainForDataProduct,
+    isRulesLoaded,
     handleDataProductsSave,
   ]);
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/CommonWidgets/CommonWidgets.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/CommonWidgets/CommonWidgets.tsx
@@ -296,6 +296,7 @@ export const CommonWidgets = ({
         dataProducts={dataProducts ?? []}
         hasPermission={editDataProductPermission}
         multiple={entityRules.canAddMultipleDataProducts}
+        requireDomainForDataProduct={entityRules.requireDomainForDataProduct}
         onSave={handleDataProductsSave}
       />
     );
@@ -303,6 +304,8 @@ export const CommonWidgets = ({
     dataProducts,
     domains,
     editDataProductPermission,
+    entityRules.canAddMultipleDataProducts,
+    entityRules.requireDomainForDataProduct,
     handleDataProductsSave,
   ]);
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsContainer/DataProductsContainer.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsContainer/DataProductsContainer.component.test.tsx
@@ -1,0 +1,168 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { EntityReference } from '../../../generated/entity/type';
+import DataProductsContainer from './DataProductsContainer.component';
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn().mockReturnValue(jest.fn()),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn().mockReturnValue({
+    t: (key: string, options?: Record<string, unknown>) =>
+      options ? `${key} - ${JSON.stringify(options)}` : key,
+  }),
+}));
+
+jest.mock('../../../rest/dataProductAPI', () => ({
+  fetchDataProductsElasticSearch: jest
+    .fn()
+    .mockResolvedValue({ data: [], paging: { total: 0 } }),
+}));
+
+jest.mock('../DataProductsSelectList/DataProductsSelectList', () => ({
+  __esModule: true,
+  default: jest
+    .fn()
+    .mockImplementation(
+      ({
+        fetchOptions,
+      }: {
+        fetchOptions?: (searchText: string, page?: number) => void;
+      }) => (
+        <button
+          data-testid="dps-fetch"
+          onClick={() => fetchOptions?.('term', 2)}>
+          Fetch
+        </button>
+      )
+    ),
+}));
+
+jest.mock('../../common/WidgetActionButton/WidgetActionButton', () => ({
+  WidgetPlusButton: jest
+    .fn()
+    .mockImplementation(({ onClick, disabled, ...props }) => (
+      <button
+        data-testid="add-data-product"
+        disabled={disabled}
+        onClick={onClick}
+        {...props}>
+        Add
+      </button>
+    )),
+  WidgetEditButton: jest.fn().mockImplementation(({ onClick, ...props }) => (
+    <button data-testid="edit-button" onClick={onClick} {...props}>
+      Edit
+    </button>
+  )),
+}));
+
+jest.mock('../../common/WidgetCard/WidgetCard', () => ({
+  __esModule: true,
+  default: jest
+    .fn()
+    .mockImplementation(({ children, headerExtra }) => (
+      <div data-testid="widget-card">
+        {headerExtra}
+        {children}
+      </div>
+    )),
+}));
+
+jest.mock('../../Tag/TagsV1/TagsV1.component', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => <div>Tag</div>),
+}));
+
+const domains: EntityReference[] = [
+  { id: 'd-1', fullyQualifiedName: 'domainA', type: 'domain' },
+];
+
+const defaultProps = {
+  newLook: true,
+  hasPermission: true,
+  dataProducts: [] as EntityReference[],
+  activeDomains: domains,
+  onSave: jest.fn(),
+};
+
+describe('DataProductsContainer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('scopes the fetch to active domains by default (rule enabled)', async () => {
+    const { fetchDataProductsElasticSearch } = jest.requireMock(
+      '../../../rest/dataProductAPI'
+    );
+
+    render(<DataProductsContainer {...defaultProps} />);
+
+    fireEvent.click(screen.getByTestId('add-data-product'));
+    fireEvent.click(screen.getByTestId('dps-fetch'));
+
+    await waitFor(() => {
+      expect(fetchDataProductsElasticSearch).toHaveBeenCalledWith(
+        'term',
+        ['domainA'],
+        2
+      );
+    });
+  });
+
+  it('fetches across all domains when rule is disabled', async () => {
+    const { fetchDataProductsElasticSearch } = jest.requireMock(
+      '../../../rest/dataProductAPI'
+    );
+
+    render(
+      <DataProductsContainer
+        {...defaultProps}
+        requireDomainForDataProduct={false}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('add-data-product'));
+    fireEvent.click(screen.getByTestId('dps-fetch'));
+
+    await waitFor(() => {
+      expect(fetchDataProductsElasticSearch).toHaveBeenCalledWith('term', [], 2);
+    });
+  });
+
+  it('disables add button with no domain when rule is enabled', () => {
+    render(<DataProductsContainer {...defaultProps} activeDomains={[]} />);
+
+    expect(screen.getByTestId('add-data-product')).toBeDisabled();
+    expect(
+      screen.getByText('message.select-domain-to-add-data-product')
+    ).toBeInTheDocument();
+  });
+
+  it('enables add button with no domain when rule is disabled', () => {
+    render(
+      <DataProductsContainer
+        {...defaultProps}
+        activeDomains={[]}
+        requireDomainForDataProduct={false}
+      />
+    );
+
+    expect(screen.getByTestId('add-data-product')).not.toBeDisabled();
+    expect(
+      screen.queryByText('message.select-domain-to-add-data-product')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsContainer/DataProductsContainer.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsContainer/DataProductsContainer.component.test.tsx
@@ -71,14 +71,12 @@ jest.mock('../../common/WidgetActionButton/WidgetActionButton', () => ({
 
 jest.mock('../../common/WidgetCard/WidgetCard', () => ({
   __esModule: true,
-  default: jest
-    .fn()
-    .mockImplementation(({ children, headerExtra }) => (
-      <div data-testid="widget-card">
-        {headerExtra}
-        {children}
-      </div>
-    )),
+  default: jest.fn().mockImplementation(({ children, headerExtra }) => (
+    <div data-testid="widget-card">
+      {headerExtra}
+      {children}
+    </div>
+  )),
 }));
 
 jest.mock('../../Tag/TagsV1/TagsV1.component', () => ({
@@ -138,7 +136,11 @@ describe('DataProductsContainer', () => {
     fireEvent.click(screen.getByTestId('dps-fetch'));
 
     await waitFor(() => {
-      expect(fetchDataProductsElasticSearch).toHaveBeenCalledWith('term', [], 2);
+      expect(fetchDataProductsElasticSearch).toHaveBeenCalledWith(
+        'term',
+        [],
+        2
+      );
     });
   });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsContainer/DataProductsContainer.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsContainer/DataProductsContainer.component.tsx
@@ -39,6 +39,7 @@ interface DataProductsContainerProps {
   onSave?: (dataProducts: DataProduct[]) => Promise<void>;
   newLook?: boolean;
   multiple?: boolean;
+  requireDomainForDataProduct?: boolean;
 }
 
 const DataProductsContainer = ({
@@ -49,10 +50,16 @@ const DataProductsContainer = ({
   onSave,
   newLook = false,
   multiple = true,
+  requireDomainForDataProduct = true,
 }: DataProductsContainerProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [isEditMode, setIsEditMode] = useState(false);
+
+  // When the "Data Product Domain Validation" rule is disabled a Data Product
+  // can be assigned regardless of the asset's domains, so the domain gate is
+  // lifted and the dropdown lists Data Products across all domains.
+  const domainMissing = requireDomainForDataProduct && isEmpty(activeDomains);
 
   const handleAddClick = () => {
     setIsEditMode(true);
@@ -61,12 +68,13 @@ const DataProductsContainer = ({
   const fetchAPI = useCallback(
     (searchValue: string, page = 1) => {
       const searchText = searchValue ?? '';
-      const domainFQNs =
-        activeDomains?.map((domain) => domain.fullyQualifiedName ?? '') ?? [];
+      const domainFQNs = requireDomainForDataProduct
+        ? activeDomains?.map((domain) => domain.fullyQualifiedName ?? '') ?? []
+        : [];
 
       return fetchDataProductsElasticSearch(searchText, domainFQNs, page);
     },
-    [activeDomains]
+    [activeDomains, requireDomainForDataProduct]
   );
 
   const redirectLink = useCallback(
@@ -117,8 +125,8 @@ const DataProductsContainer = ({
   }, [handleCancel, handleSave, dataProducts, fetchAPI]);
 
   const showAddTagButton = useMemo(
-    () => hasPermission && !isEmpty(activeDomains) && isEmpty(dataProducts),
-    [hasPermission, dataProducts, activeDomains]
+    () => hasPermission && !domainMissing && isEmpty(dataProducts),
+    [hasPermission, dataProducts, domainMissing]
   );
 
   const renderDataProducts = useMemo(() => {
@@ -126,7 +134,7 @@ const DataProductsContainer = ({
       return NO_DATA_PLACEHOLDER;
     }
 
-    if (isEmpty(dataProducts) && hasPermission && isEmpty(activeDomains)) {
+    if (isEmpty(dataProducts) && hasPermission && domainMissing) {
       return (
         <Typography.Text className="text-sm text-grey-muted">
           {t('message.select-domain-to-add-data-product')}
@@ -157,7 +165,7 @@ const DataProductsContainer = ({
         </Tag>
       );
     });
-  }, [dataProducts, activeDomains]);
+  }, [dataProducts, activeDomains, domainMissing]);
 
   const header = useMemo(() => {
     return (
@@ -176,7 +184,7 @@ const DataProductsContainer = ({
               onClick={handleAddClick}
             />
           )}
-          {hasPermission && !isEmpty(activeDomains) && (
+          {hasPermission && !domainMissing && (
             <Row gutter={12}>
               {!isEmpty(dataProducts) && (
                 <Col>
@@ -196,7 +204,7 @@ const DataProductsContainer = ({
         </Space>
       )
     );
-  }, [showHeader, dataProducts, hasPermission, showAddTagButton]);
+  }, [showHeader, dataProducts, hasPermission, showAddTagButton, domainMissing]);
 
   const addTagButton = useMemo(
     () =>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTab.component.tsx
@@ -38,6 +38,7 @@ import {
   TestCaseParameterValue,
 } from '../../../../generated/tests/testCase';
 import { TestDefinition } from '../../../../generated/tests/testDefinition';
+import { useEntityRules } from '../../../../hooks/useEntityRules';
 import { useTestCaseStore } from '../../../../pages/IncidentManager/IncidentManagerDetailPage/useTestCase.store';
 import {
   getTestDefinitionById,
@@ -367,6 +368,8 @@ const TestCaseResultTab = () => {
     isVersionPage,
   ]);
 
+  const { entityRules, isRulesLoaded } = useEntityRules(EntityType.TEST_CASE);
+
   const renderParameterRows = useCallback(
     (items: Array<{ label?: string; value: string | React.ReactNode }>) => {
       if (items.length === 0) {
@@ -637,6 +640,9 @@ const TestCaseResultTab = () => {
                 activeDomains={testCaseData?.domains ?? []}
                 dataProducts={testCaseData?.dataProducts ?? []}
                 hasPermission={!isVersionPage && (hasEditPermission ?? false)}
+                requireDomainForDataProduct={
+                  !isRulesLoaded || entityRules.requireDomainForDataProduct
+                }
                 onSave={handleDataProductsSave}
               />
             </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTab.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTab.test.tsx
@@ -114,6 +114,17 @@ jest.mock(
     return jest.fn().mockImplementation(() => <div>DataProductsContainer</div>);
   }
 );
+jest.mock('../../../../hooks/useEntityRules', () => ({
+  useEntityRules: jest.fn().mockReturnValue({
+    entityRules: {
+      canAddMultipleDataProducts: true,
+      requireDomainForDataProduct: false,
+    },
+    rules: [],
+    isRulesLoaded: true,
+    isLoading: false,
+  }),
+}));
 jest.mock('../../AddDataQualityTest/EditTestCaseModal', () => {
   return jest.fn().mockImplementation(({ onUpdate, testCase, onCancel }) => (
     <div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityRightPanel/EntityRightPanel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityRightPanel/EntityRightPanel.tsx
@@ -64,7 +64,7 @@ const EntityRightPanel = <T extends ExtentionEntitiesKeys>({
   onDataProductUpdate,
   viewCustomPropertiesPermission,
 }: EntityRightPanelProps<T>) => {
-  const { entityRules } = useEntityRules(entityType);
+  const { entityRules, isRulesLoaded } = useEntityRules(entityType);
   const KnowledgeArticles =
     entityRightPanelClassBase.getKnowLedgeArticlesWidget();
   const { fqn: entityFQN } = useFqn();
@@ -89,7 +89,7 @@ const EntityRightPanel = <T extends ExtentionEntitiesKeys>({
               hasPermission={editDataProductPermission ?? false}
               multiple={entityRules.canAddMultipleDataProducts}
               requireDomainForDataProduct={
-                entityRules.requireDomainForDataProduct
+                !isRulesLoaded || entityRules.requireDomainForDataProduct
               }
               onSave={onDataProductUpdate}
             />

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityRightPanel/EntityRightPanel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityRightPanel/EntityRightPanel.tsx
@@ -88,6 +88,9 @@ const EntityRightPanel = <T extends ExtentionEntitiesKeys>({
               dataProducts={dataProducts}
               hasPermission={editDataProductPermission ?? false}
               multiple={entityRules.canAddMultipleDataProducts}
+              requireDomainForDataProduct={
+                entityRules.requireDomainForDataProduct
+              }
               onSave={onDataProductUpdate}
             />
           </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DataProductsSection/DataProductsSection.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DataProductsSection/DataProductsSection.test.tsx
@@ -532,7 +532,16 @@ describe('DataProductsSection', () => {
   });
 
   describe('Fetch Options', () => {
-    it('calls fetch API with search and active domains', async () => {
+    it('scopes fetch to active domains when domain validation rule is enabled', async () => {
+      (useEntityRules as jest.Mock).mockReturnValue({
+        entityRules: {
+          canAddMultipleDataProducts: true,
+          maxDataProducts: Infinity,
+          requireDomainForDataProduct: true,
+        },
+        rules: [],
+        isLoading: false,
+      });
       const { fetchDataProductsElasticSearch } = jest.requireMock(
         '../../../rest/dataProductAPI'
       );
@@ -552,6 +561,68 @@ describe('DataProductsSection', () => {
           2
         );
       });
+    });
+
+    it('fetches across all domains when domain validation rule is disabled', async () => {
+      const { fetchDataProductsElasticSearch } = jest.requireMock(
+        '../../../rest/dataProductAPI'
+      );
+
+      render(<DataProductsSection {...defaultProps} />);
+
+      const editIcon = screen.getByTestId('edit-data-products');
+      if (editIcon) {
+        fireEvent.click(editIcon);
+      }
+      fireEvent.click(screen.getByTestId('dps-fetch'));
+
+      await waitFor(() => {
+        expect(fetchDataProductsElasticSearch).toHaveBeenCalledWith('term', [], 2);
+      });
+    });
+  });
+
+  describe('Domain Requirement Gating', () => {
+    it('prompts to select a domain when no domains and rule is enabled', () => {
+      (useEntityRules as jest.Mock).mockReturnValue({
+        entityRules: {
+          canAddMultipleDataProducts: true,
+          maxDataProducts: Infinity,
+          requireDomainForDataProduct: true,
+        },
+        rules: [],
+        isLoading: false,
+      });
+
+      render(
+        <DataProductsSection
+          {...defaultProps}
+          activeDomains={[]}
+          dataProducts={[]}
+        />
+      );
+
+      expect(
+        screen.getByText('message.select-domain-to-add-data-product')
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('edit-data-products')
+      ).not.toBeInTheDocument();
+    });
+
+    it('allows editing with no domains when rule is disabled', () => {
+      render(
+        <DataProductsSection
+          {...defaultProps}
+          activeDomains={[]}
+          dataProducts={[]}
+        />
+      );
+
+      expect(
+        screen.queryByText('message.select-domain-to-add-data-product')
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId('edit-data-products')).toBeInTheDocument();
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DataProductsSection/DataProductsSection.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DataProductsSection/DataProductsSection.test.tsx
@@ -244,6 +244,7 @@ describe('DataProductsSection', () => {
         requireDomainForDataProduct: false,
       },
       rules: [],
+      isRulesLoaded: true,
       isLoading: false,
     });
   });
@@ -540,6 +541,7 @@ describe('DataProductsSection', () => {
           requireDomainForDataProduct: true,
         },
         rules: [],
+        isRulesLoaded: true,
         isLoading: false,
       });
       const { fetchDataProductsElasticSearch } = jest.requireMock(
@@ -577,7 +579,43 @@ describe('DataProductsSection', () => {
       fireEvent.click(screen.getByTestId('dps-fetch'));
 
       await waitFor(() => {
-        expect(fetchDataProductsElasticSearch).toHaveBeenCalledWith('term', [], 2);
+        expect(fetchDataProductsElasticSearch).toHaveBeenCalledWith(
+          'term',
+          [],
+          2
+        );
+      });
+    });
+
+    it('stays domain-scoped while entity rules are still loading', async () => {
+      (useEntityRules as jest.Mock).mockReturnValue({
+        entityRules: {
+          canAddMultipleDataProducts: true,
+          maxDataProducts: Infinity,
+          requireDomainForDataProduct: false,
+        },
+        rules: [],
+        isRulesLoaded: false,
+        isLoading: true,
+      });
+      const { fetchDataProductsElasticSearch } = jest.requireMock(
+        '../../../rest/dataProductAPI'
+      );
+
+      render(<DataProductsSection {...defaultProps} />);
+
+      const editIcon = screen.getByTestId('edit-data-products');
+      if (editIcon) {
+        fireEvent.click(editIcon);
+      }
+      fireEvent.click(screen.getByTestId('dps-fetch'));
+
+      await waitFor(() => {
+        expect(fetchDataProductsElasticSearch).toHaveBeenCalledWith(
+          'term',
+          ['domain'],
+          2
+        );
       });
     });
   });
@@ -591,6 +629,7 @@ describe('DataProductsSection', () => {
           requireDomainForDataProduct: true,
         },
         rules: [],
+        isRulesLoaded: true,
         isLoading: false,
       });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DataProductsSection/DataProductsSection.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DataProductsSection/DataProductsSection.tsx
@@ -46,7 +46,14 @@ const DataProductsSectionV1: React.FC<DataProductsSectionProps> = ({
   const [showAllDataProducts, setShowAllDataProducts] = useState(false);
   const [displayActiveDomains, setDisplayActiveDomains] =
     useState<EntityReference[]>(activeDomains);
-  const { entityRules } = useEntityRules(entityType);
+  const { entityRules, isRulesLoaded } = useEntityRules(entityType);
+
+  // Hold the strict domain-scoped behavior until the rules have actually loaded
+  // (an empty rule set from the backend is indistinguishable from "not fetched
+  // yet"), otherwise a cross-domain product could be selected before an enabled
+  // rule resolves and then rejected by the backend on save.
+  const requireDomainForDataProduct =
+    !isRulesLoaded || entityRules.requireDomainForDataProduct;
 
   const {
     isEditing,
@@ -97,7 +104,7 @@ const DataProductsSectionV1: React.FC<DataProductsSectionProps> = ({
       const searchText = searchValue ?? '';
       // When the "Data Product Domain Validation" rule is disabled, list Data
       // Products across all domains instead of scoping to the asset's domains.
-      const domainFQNs = entityRules.requireDomainForDataProduct
+      const domainFQNs = requireDomainForDataProduct
         ? displayActiveDomains?.map(
             (domain) => domain.fullyQualifiedName ?? ''
           ) ?? []
@@ -105,7 +112,7 @@ const DataProductsSectionV1: React.FC<DataProductsSectionProps> = ({
 
       return fetchDataProductsElasticSearch(searchText, domainFQNs, page);
     },
-    [displayActiveDomains, entityRules.requireDomainForDataProduct]
+    [displayActiveDomains, requireDomainForDataProduct]
   );
 
   const handleSaveWithDataProducts = useCallback(
@@ -208,7 +215,7 @@ const DataProductsSectionV1: React.FC<DataProductsSectionProps> = ({
     }
 
     if (
-      entityRules.requireDomainForDataProduct &&
+      requireDomainForDataProduct &&
       (!displayActiveDomains || displayActiveDomains.length === 0)
     ) {
       return (
@@ -230,7 +237,7 @@ const DataProductsSectionV1: React.FC<DataProductsSectionProps> = ({
     isEditing,
     editingState,
     displayActiveDomains,
-    entityRules.requireDomainForDataProduct,
+    requireDomainForDataProduct,
     t,
   ]);
 
@@ -286,8 +293,7 @@ const DataProductsSectionV1: React.FC<DataProductsSectionProps> = ({
   }, [isLoading, isEditing, editingState, dataProductsDisplay]);
 
   const canAssignDataProduct =
-    displayActiveDomains?.length > 0 ||
-    !entityRules.requireDomainForDataProduct;
+    displayActiveDomains?.length > 0 || !requireDomainForDataProduct;
 
   const canShowEditButton =
     showEditButton && hasPermission && !isLoading && canAssignDataProduct;

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DataProductsSection/DataProductsSection.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DataProductsSection/DataProductsSection.tsx
@@ -95,14 +95,17 @@ const DataProductsSectionV1: React.FC<DataProductsSectionProps> = ({
   const fetchAPI = useCallback(
     async (searchValue: string, page = 1) => {
       const searchText = searchValue ?? '';
-      const domainFQNs =
-        displayActiveDomains?.map(
-          (domain) => domain.fullyQualifiedName ?? ''
-        ) ?? [];
+      // When the "Data Product Domain Validation" rule is disabled, list Data
+      // Products across all domains instead of scoping to the asset's domains.
+      const domainFQNs = entityRules.requireDomainForDataProduct
+        ? displayActiveDomains?.map(
+            (domain) => domain.fullyQualifiedName ?? ''
+          ) ?? []
+        : [];
 
       return fetchDataProductsElasticSearch(searchText, domainFQNs, page);
     },
-    [displayActiveDomains]
+    [displayActiveDomains, entityRules.requireDomainForDataProduct]
   );
 
   const handleSaveWithDataProducts = useCallback(
@@ -204,7 +207,10 @@ const DataProductsSectionV1: React.FC<DataProductsSectionProps> = ({
       return editingState;
     }
 
-    if (!displayActiveDomains || displayActiveDomains.length === 0) {
+    if (
+      entityRules.requireDomainForDataProduct &&
+      (!displayActiveDomains || displayActiveDomains.length === 0)
+    ) {
       return (
         <Typography.Text className="no-data-placeholder">
           {t('message.select-domain-to-add-data-product')}
@@ -219,7 +225,14 @@ const DataProductsSectionV1: React.FC<DataProductsSectionProps> = ({
         })}
       </span>
     );
-  }, [isLoading, isEditing, editingState, displayActiveDomains, t]);
+  }, [
+    isLoading,
+    isEditing,
+    editingState,
+    displayActiveDomains,
+    entityRules.requireDomainForDataProduct,
+    t,
+  ]);
 
   const dataProductsDisplay = useMemo(
     () => (
@@ -272,11 +285,12 @@ const DataProductsSectionV1: React.FC<DataProductsSectionProps> = ({
     return dataProductsDisplay;
   }, [isLoading, isEditing, editingState, dataProductsDisplay]);
 
+  const canAssignDataProduct =
+    displayActiveDomains?.length > 0 ||
+    !entityRules.requireDomainForDataProduct;
+
   const canShowEditButton =
-    showEditButton &&
-    hasPermission &&
-    !isLoading &&
-    displayActiveDomains?.length > 0;
+    showEditButton && hasPermission && !isLoading && canAssignDataProduct;
 
   if (!displayDataProducts?.length) {
     return (

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useEntityRules.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useEntityRules.test.ts
@@ -92,6 +92,26 @@ describe('useEntityRules', () => {
 
       expect(result.current.isLoading).toBe(true);
     });
+
+    it('should report isRulesLoaded false until the entity rules are fetched', () => {
+      const { result } = renderHook(() => useEntityRules(EntityType.TABLE));
+
+      expect(result.current.isRulesLoaded).toBe(false);
+    });
+
+    it('should report isRulesLoaded true once the entity rules are present', () => {
+      (useRuleEnforcementProvider as jest.Mock).mockReturnValue({
+        rules: { [EntityType.TABLE]: mockParsedRules },
+        fetchRulesForEntity: mockFetchRulesForEntity,
+        getRulesForEntity: mockGetRulesForEntity,
+        getEntityRuleValidation: mockGetEntityRuleValidation,
+        isLoading: false,
+      });
+
+      const { result } = renderHook(() => useEntityRules(EntityType.TABLE));
+
+      expect(result.current.isRulesLoaded).toBe(true);
+    });
   });
 
   describe('Entity type changes', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useEntityRules.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useEntityRules.ts
@@ -36,6 +36,15 @@ export const useEntityRules = (entityType: EntityType) => {
     [allEntityRules, entityType]
   );
 
+  // The backend only returns *enabled* rules, so an empty rule set is
+  // indistinguishable from "not fetched yet". Track whether the rules for this
+  // entity have actually loaded so consumers can hold the strict default (e.g.
+  // domain-scoped Data Products) until the real rule state is known.
+  const isRulesLoaded = useMemo(
+    () => Boolean(allEntityRules?.[entityType]),
+    [allEntityRules, entityType]
+  );
+
   useEffect(() => {
     if (entityType) {
       fetchRulesForEntity(entityType);
@@ -45,6 +54,7 @@ export const useEntityRules = (entityType: EntityType) => {
   return {
     rules,
     entityRules,
+    isRulesLoaded,
     isLoading,
   };
 };


### PR DESCRIPTION
## Backport of #32011 → `1.13`

Backports the Data Product cross-domain assignment fix (Fixes #31329) to the 1.13 release branch.

### What was cherry-picked

| Commit | Description |
|---|---|
| `6132d81` | fix(ui): allow assigning Data Products across domains when domain validation rule is disabled |
| `4594b15` | fix(ui): hold strict Data Product domain scoping until entity rules load |
| `2c0f55b` | test(ui): fix data-asset-rules Playwright regression from cross-domain Data Products |
| `4cb0460` | fix(ui): apply Data Product domain-scoping rule to Test Case result tab |
| `3b3412b` | test(ui): move cross-domain Data Product test data to beforeAll/afterAll |

### Skipped

- `a6d218f` — "fix(ui): apply Data Product domain-scoping rule to Knowledge Article panel" was **skipped** because `KnowledgeCenter/KnowledgePageDetailRightPanel` does not exist in the 1.13 codebase.

### Conflict resolutions

1. **`DataProductsContainer.component.tsx`** — 1.13 uses `PlusIconButton`/`EditIconButton` (not `WidgetPlusButton`/`WidgetEditButton` from main). Kept the 1.13 UI components but applied the key logic change: replaced `!isEmpty(activeDomains)` gate with `!domainMissing` (where `domainMissing = requireDomainForDataProduct && isEmpty(activeDomains)`).

2. **`GenericProvider.tsx`** — The second commit bundled an unrelated `useEffect` syncing `selectedColumnRef` (a main-only ref). Dropped that `useEffect`; kept only the `isRulesLoaded` addition to the `useEntityRules` destructuring.

3. **`TestCaseResultTab.component.tsx`** — 1.13 still uses the pre-refactor component (no `useTestCaseResultTab` hook). Kept the entire 1.13 body; added only the `useEntityRules` import and `const { entityRules, isRulesLoaded } = useEntityRules(EntityType.TEST_CASE)` call, plus the `requireDomainForDataProduct` prop on `DataProductsContainer` (which was already placed correctly by the partial cherry-pick).

4. **`TestCaseResultTab.test.tsx`** — Kept the 1.13 `EditTestCaseModal` mock (main uses `TestCaseFormDrawer`); added the `useEntityRules` mock from the incoming commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport makes Data Product assignment domain-unscoped when the corresponding entity rule is disabled while retaining strict scoping until rules load.
- Adds rule-load state to the entity-rules hook and generic context.
- Applies conditional Data Product scoping across generic widgets, entity panels, summary panels, and Test Case results.
- Adds unit and Playwright coverage for enabled and disabled rule states.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until the newly added DataProductsContainer test is corrected so the UI test workflow can pass.

The production rule propagation is internally consistent, but the new test mocks controls that this 1.13 component does not import and then requires an add button that the real component intentionally omits.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsContainer/DataProductsContainer.component.test.tsx
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/hooks/useEntityRules.ts | Adds a per-entity loaded-state signal so consumers retain strict behavior until a successful rules fetch. |
| openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsContainer/DataProductsContainer.component.tsx | Makes the domain gate and search-domain filter conditional on the entity rule. |
| openmetadata-ui/src/main/resources/ui/src/components/common/DataProductsSection/DataProductsSection.tsx | Applies the same loaded-state and conditional-domain behavior to the summary-panel editor. |
| openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTab.component.tsx | Applies Test Case entity rules to Data Product assignment in the result tab. |
| openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsContainer/DataProductsContainer.component.test.tsx | Adds focused rule-state tests, but an incorrect backport mock path makes the no-domain test fail. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Open Data Product selector] --> B{Entity rules loaded?}
  B -->|No| C[Require asset domain and scope search]
  B -->|Yes| D{Domain validation enabled?}
  D -->|Yes| C
  D -->|No| E[Allow assignment and search across domains]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): move cross-domain Data Product..."](https://github.com/open-metadata/openmetadata/commit/28263256829fc4cc7ee47cfb70811fb58a9aad0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57825838)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->