### PR TITLE
Backport #32011 to 1.13: Allow assigning Data Products across domains from the UI

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesDisabled.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesDisabled.spec.ts
@@ -819,3 +819,63 @@ test.describe(
     });
   }
 );
+
+test.describe(
+  `Data Product Domain Validation Rule Disabled`,
+  {
+    tag: '@dataAssetRules',
+  },
+  () => {
+    const assetDomain = new Domain();
+    const productDomain = new Domain();
+    const crossDomainDataProduct = new DataProduct([productDomain]);
+    const crossTable = new TableClass();
+
+    test.beforeAll('Setup cross-domain data', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      await assetDomain.create(apiContext);
+      await productDomain.create(apiContext);
+      await crossDomainDataProduct.create(apiContext);
+      await crossTable.create(apiContext);
+      await afterAction();
+    });
+
+    test.afterAll('Cleanup cross-domain data', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      await crossTable.delete(apiContext);
+      await crossDomainDataProduct.delete(apiContext);
+      await productDomain.delete(apiContext);
+      await assetDomain.delete(apiContext);
+      await afterAction();
+    });
+
+    // With the "Data Product Domain Validation" rule disabled, the Data Product
+    // dropdown is no longer scoped to the asset's domain, so an asset can be
+    // assigned a Data Product that belongs to a different domain.
+    test('should allow assigning a Data Product from a different domain', async ({
+      page,
+    }) => {
+      await redirectToHomePage(page);
+      await crossTable.visitEntityPage(page);
+
+      // Asset belongs to assetDomain only.
+      await assignDomain(page, assetDomain.responseData);
+
+      // The Data Product from productDomain can be assigned even though the
+      // asset is in assetDomain, because the domain validation rule is disabled
+      // and the dropdown lists Data Products across all domains.
+      await assignDataProduct(page, assetDomain.responseData, [
+        crossDomainDataProduct.responseData,
+      ]);
+
+      await expect(
+        page
+          .getByTestId('KnowledgePanel.DataProducts')
+          .getByTestId('data-products-list')
+          .getByTestId(
+            `data-product-${crossDomainDataProduct.responseData.fullyQualifiedName}`
+          )
+      ).toBeVisible();
+    });
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesEnabled.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesEnabled.spec.ts
@@ -313,3 +313,87 @@ test.describe(
     });
   }
 );
+
+test.describe(
+  `Data Product Domain Validation Rule Enabled`,
+  {
+    tag: '@dataAssetRules',
+  },
+  () => {
+    const assetDomain = new Domain();
+    const productDomain = new Domain();
+    const sameDomainDataProduct = new DataProduct([assetDomain]);
+    const otherDomainDataProduct = new DataProduct([productDomain]);
+    const crossTable = new TableClass();
+
+    test.beforeAll('Setup cross-domain data', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      await assetDomain.create(apiContext);
+      await productDomain.create(apiContext);
+      await sameDomainDataProduct.create(apiContext);
+      await otherDomainDataProduct.create(apiContext);
+      await crossTable.create(apiContext);
+      await afterAction();
+    });
+
+    test.afterAll('Cleanup cross-domain data', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      await crossTable.delete(apiContext);
+      await sameDomainDataProduct.delete(apiContext);
+      await otherDomainDataProduct.delete(apiContext);
+      await productDomain.delete(apiContext);
+      await assetDomain.delete(apiContext);
+      await afterAction();
+    });
+
+    // With the "Data Product Domain Validation" rule enabled, the Data Product
+    // dropdown stays scoped to the asset's domain, so a Data Product from a
+    // different domain is not offered.
+    test('should not list Data Products from a different domain', async ({
+      page,
+    }) => {
+      await authenticateAdminPage(page);
+      await crossTable.visitEntityPage(page);
+
+      await assignDomainWidget(page, assetDomain.responseData);
+
+      await page
+        .getByTestId('KnowledgePanel.DataProducts')
+        .getByTestId('data-products-container')
+        .getByTestId('add-data-product')
+        .click();
+
+      const selectorInput = page.locator(
+        '[data-testid="data-product-selector"] input'
+      );
+      const sameDomainFqn =
+        sameDomainDataProduct.responseData.fullyQualifiedName;
+      const otherDomainFqn =
+        otherDomainDataProduct.responseData.fullyQualifiedName;
+
+      // Positive control: a Data Product in the asset's domain is listed.
+      await expect(async () => {
+        const searchResponse = page.waitForResponse((response) =>
+          response.url().includes('/api/v1/search/query')
+        );
+        await selectorInput.clear();
+        await selectorInput.fill(sameDomainDataProduct.data.displayName);
+        await searchResponse;
+        await expect(page.getByTestId(`tag-${sameDomainFqn}`)).toBeVisible({
+          timeout: 2_000,
+        });
+      }).toPass({ timeout: 30_000, intervals: [1_000, 2_000, 5_000] });
+
+      // Scoped to the asset's domain, so a Data Product from another domain is
+      // not offered.
+      const otherSearchResponse = page.waitForResponse((response) =>
+        response.url().includes('/api/v1/search/query')
+      );
+      await selectorInput.clear();
+      await selectorInput.fill(otherDomainDataProduct.data.displayName);
+      await otherSearchResponse;
+
+      await expect(page.getByTestId(`tag-${otherDomainFqn}`)).not.toBeVisible();
+    });
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -499,10 +499,13 @@ export const assignDataProduct = async (
     );
 
     await expect(async () => {
-      const searchDataProduct = page.waitForResponse(
-        (response) =>
-          response.url().includes('/api/v1/search/query') &&
-          response.url().includes(encodeURIComponent(domain.name))
+      // Match any Data Product search response. The dropdown filters by the
+      // asset's domain only when the "Data Product Domain Validation" rule is
+      // enabled; when it is disabled the query carries no domain, so we cannot
+      // key the wait on the domain name. The tag visibility check below is the
+      // real synchronization guard.
+      const searchDataProduct = page.waitForResponse((response) =>
+        response.url().includes('/api/v1/search/query')
       );
       await page.locator('[data-testid="data-product-selector"] input').clear();
       await page

--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.interface.ts
@@ -55,6 +55,7 @@ export interface GenericContextType<T extends Omit<EntityReference, 'type'>> {
   updateActiveTagDropdownKey: (key: string | null) => void;
   muiTags: boolean;
   entityRules: DataAssetRuleValidation;
+  isRulesLoaded: boolean;
   selectedColumn: ColumnOrTask | null;
   isColumnDetailOpen: boolean;
   openColumnDetailPanel: (column: ColumnOrTask) => void;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.tsx
@@ -115,7 +115,7 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
     [selectedColumn]
   );
 
-  const { entityRules } = useEntityRules(type);
+  const { entityRules, isRulesLoaded } = useEntityRules(type);
 
   // limit=1000 is the backend max. Entities with more tracked field changes
   // will have entries beyond this limit silently omitted. Use fieldPrefix
@@ -422,6 +422,7 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
     () => ({
       data,
       entityRules,
+      isRulesLoaded,
       type,
       onUpdate,
       isVersionView,
@@ -444,6 +445,7 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
     [
       data,
       entityRules,
+      isRulesLoaded,
       type,
       onUpdate,
       isVersionView,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/CommonWidgets/CommonWidgets.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/CommonWidgets/CommonWidgets.tsx
@@ -103,8 +103,15 @@ export const CommonWidgets = ({
   entityType,
   showTaskHandler = true,
 }: CommonWidgetsProps) => {
-  const { data, type, entityRules, onUpdate, permissions, isVersionView } =
-    useGenericContext<GenericEntity>();
+  const {
+    data,
+    type,
+    entityRules,
+    isRulesLoaded,
+    onUpdate,
+    permissions,
+    isVersionView,
+  } = useGenericContext<GenericEntity>();
   const [tagsUpdating, setTagsUpdating] = useState<TagLabel[]>();
 
   const updatedData = useMemo(() => {
@@ -296,6 +303,9 @@ export const CommonWidgets = ({
         dataProducts={dataProducts ?? []}
         hasPermission={editDataProductPermission}
         multiple={entityRules.canAddMultipleDataProducts}
+        requireDomainForDataProduct={
+          !isRulesLoaded || entityRules.requireDomainForDataProduct
+        }
         onSave={handleDataProductsSave}
       />
     );
@@ -303,6 +313,9 @@ export const CommonWidgets = ({
     dataProducts,
     domains,
     editDataProductPermission,
+    entityRules.canAddMultipleDataProducts,
+    entityRules.requireDomainForDataProduct,
+    isRulesLoaded,
     handleDataProductsSave,
   ]);
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsContainer/DataProductsContainer.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsContainer/DataProductsContainer.component.test.tsx
@@ -1,0 +1,170 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { EntityReference } from '../../../generated/entity/type';
+import DataProductsContainer from './DataProductsContainer.component';
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn().mockReturnValue(jest.fn()),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn().mockReturnValue({
+    t: (key: string, options?: Record<string, unknown>) =>
+      options ? `${key} - ${JSON.stringify(options)}` : key,
+  }),
+}));
+
+jest.mock('../../../rest/dataProductAPI', () => ({
+  fetchDataProductsElasticSearch: jest
+    .fn()
+    .mockResolvedValue({ data: [], paging: { total: 0 } }),
+}));
+
+jest.mock('../DataProductsSelectList/DataProductsSelectList', () => ({
+  __esModule: true,
+  default: jest
+    .fn()
+    .mockImplementation(
+      ({
+        fetchOptions,
+      }: {
+        fetchOptions?: (searchText: string, page?: number) => void;
+      }) => (
+        <button
+          data-testid="dps-fetch"
+          onClick={() => fetchOptions?.('term', 2)}>
+          Fetch
+        </button>
+      )
+    ),
+}));
+
+jest.mock('../../common/WidgetActionButton/WidgetActionButton', () => ({
+  WidgetPlusButton: jest
+    .fn()
+    .mockImplementation(({ onClick, disabled, ...props }) => (
+      <button
+        data-testid="add-data-product"
+        disabled={disabled}
+        onClick={onClick}
+        {...props}>
+        Add
+      </button>
+    )),
+  WidgetEditButton: jest.fn().mockImplementation(({ onClick, ...props }) => (
+    <button data-testid="edit-button" onClick={onClick} {...props}>
+      Edit
+    </button>
+  )),
+}));
+
+jest.mock('../../common/WidgetCard/WidgetCard', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(({ children, headerExtra }) => (
+    <div data-testid="widget-card">
+      {headerExtra}
+      {children}
+    </div>
+  )),
+}));
+
+jest.mock('../../Tag/TagsV1/TagsV1.component', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => <div>Tag</div>),
+}));
+
+const domains: EntityReference[] = [
+  { id: 'd-1', fullyQualifiedName: 'domainA', type: 'domain' },
+];
+
+const defaultProps = {
+  newLook: true,
+  hasPermission: true,
+  dataProducts: [] as EntityReference[],
+  activeDomains: domains,
+  onSave: jest.fn(),
+};
+
+describe('DataProductsContainer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('scopes the fetch to active domains by default (rule enabled)', async () => {
+    const { fetchDataProductsElasticSearch } = jest.requireMock(
+      '../../../rest/dataProductAPI'
+    );
+
+    render(<DataProductsContainer {...defaultProps} />);
+
+    fireEvent.click(screen.getByTestId('add-data-product'));
+    fireEvent.click(screen.getByTestId('dps-fetch'));
+
+    await waitFor(() => {
+      expect(fetchDataProductsElasticSearch).toHaveBeenCalledWith(
+        'term',
+        ['domainA'],
+        2
+      );
+    });
+  });
+
+  it('fetches across all domains when rule is disabled', async () => {
+    const { fetchDataProductsElasticSearch } = jest.requireMock(
+      '../../../rest/dataProductAPI'
+    );
+
+    render(
+      <DataProductsContainer
+        {...defaultProps}
+        requireDomainForDataProduct={false}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('add-data-product'));
+    fireEvent.click(screen.getByTestId('dps-fetch'));
+
+    await waitFor(() => {
+      expect(fetchDataProductsElasticSearch).toHaveBeenCalledWith(
+        'term',
+        [],
+        2
+      );
+    });
+  });
+
+  it('disables add button with no domain when rule is enabled', () => {
+    render(<DataProductsContainer {...defaultProps} activeDomains={[]} />);
+
+    expect(screen.getByTestId('add-data-product')).toBeDisabled();
+    expect(
+      screen.getByText('message.select-domain-to-add-data-product')
+    ).toBeInTheDocument();
+  });
+
+  it('enables add button with no domain when rule is disabled', () => {
+    render(
+      <DataProductsContainer
+        {...defaultProps}
+        activeDomains={[]}
+        requireDomainForDataProduct={false}
+      />
+    );
+
+    expect(screen.getByTestId('add-data-product')).not.toBeDisabled();
+    expect(
+      screen.queryByText('message.select-domain-to-add-data-product')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsContainer/DataProductsContainer.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsContainer/DataProductsContainer.component.test.tsx
@@ -50,30 +50,26 @@ jest.mock('../DataProductsSelectList/DataProductsSelectList', () => ({
     ),
 }));
 
-jest.mock('../../common/WidgetActionButton/WidgetActionButton', () => ({
-  WidgetPlusButton: jest
-    .fn()
-    .mockImplementation(({ onClick, disabled, ...props }) => (
-      <button
-        data-testid="add-data-product"
-        disabled={disabled}
-        onClick={onClick}
-        {...props}>
-        Add
-      </button>
-    )),
-  WidgetEditButton: jest.fn().mockImplementation(({ onClick, ...props }) => (
-    <button data-testid="edit-button" onClick={onClick} {...props}>
+// 1.13 uses PlusIconButton / EditIconButton, not WidgetPlusButton / WidgetEditButton
+jest.mock('../../common/IconButtons/EditIconButton', () => ({
+  PlusIconButton: jest.fn().mockImplementation(({ onClick, ...props }) => (
+    <button onClick={onClick} {...props}>
+      Add
+    </button>
+  )),
+  EditIconButton: jest.fn().mockImplementation(({ onClick, ...props }) => (
+    <button onClick={onClick} {...props}>
       Edit
     </button>
   )),
 }));
 
-jest.mock('../../common/WidgetCard/WidgetCard', () => ({
+// 1.13 wraps content in ExpandableCard, not WidgetCard
+jest.mock('../../common/ExpandableCard/ExpandableCard', () => ({
   __esModule: true,
-  default: jest.fn().mockImplementation(({ children, headerExtra }) => (
-    <div data-testid="widget-card">
-      {headerExtra}
+  default: jest.fn().mockImplementation(({ children, header }) => (
+    <div data-testid="expandable-card">
+      {header}
       {children}
     </div>
   )),
@@ -144,16 +140,18 @@ describe('DataProductsContainer', () => {
     });
   });
 
-  it('disables add button with no domain when rule is enabled', () => {
+  // In 1.13 the add button is conditionally rendered (not rendered-and-disabled):
+  // when domainMissing is true, showAddTagButton is false so PlusIconButton is absent.
+  it('hides add button and shows domain prompt when no domain and rule is enabled', () => {
     render(<DataProductsContainer {...defaultProps} activeDomains={[]} />);
 
-    expect(screen.getByTestId('add-data-product')).toBeDisabled();
+    expect(screen.queryByTestId('add-data-product')).not.toBeInTheDocument();
     expect(
       screen.getByText('message.select-domain-to-add-data-product')
     ).toBeInTheDocument();
   });
 
-  it('enables add button with no domain when rule is disabled', () => {
+  it('shows add button and hides domain prompt when no domain and rule is disabled', () => {
     render(
       <DataProductsContainer
         {...defaultProps}
@@ -162,7 +160,7 @@ describe('DataProductsContainer', () => {
       />
     );
 
-    expect(screen.getByTestId('add-data-product')).not.toBeDisabled();
+    expect(screen.getByTestId('add-data-product')).toBeInTheDocument();
     expect(
       screen.queryByText('message.select-domain-to-add-data-product')
     ).not.toBeInTheDocument();

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsContainer/DataProductsContainer.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsContainer/DataProductsContainer.component.tsx
@@ -39,6 +39,7 @@ interface DataProductsContainerProps {
   onSave?: (dataProducts: DataProduct[]) => Promise<void>;
   newLook?: boolean;
   multiple?: boolean;
+  requireDomainForDataProduct?: boolean;
 }
 
 const DataProductsContainer = ({
@@ -49,10 +50,16 @@ const DataProductsContainer = ({
   onSave,
   newLook = false,
   multiple = true,
+  requireDomainForDataProduct = true,
 }: DataProductsContainerProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [isEditMode, setIsEditMode] = useState(false);
+
+  // When the "Data Product Domain Validation" rule is disabled a Data Product
+  // can be assigned regardless of the asset's domains, so the domain gate is
+  // lifted and the dropdown lists Data Products across all domains.
+  const domainMissing = requireDomainForDataProduct && isEmpty(activeDomains);
 
   const handleAddClick = () => {
     setIsEditMode(true);
@@ -61,12 +68,13 @@ const DataProductsContainer = ({
   const fetchAPI = useCallback(
     (searchValue: string, page = 1) => {
       const searchText = searchValue ?? '';
-      const domainFQNs =
-        activeDomains?.map((domain) => domain.fullyQualifiedName ?? '') ?? [];
+      const domainFQNs = requireDomainForDataProduct
+        ? activeDomains?.map((domain) => domain.fullyQualifiedName ?? '') ?? []
+        : [];
 
       return fetchDataProductsElasticSearch(searchText, domainFQNs, page);
     },
-    [activeDomains]
+    [activeDomains, requireDomainForDataProduct]
   );
 
   const redirectLink = useCallback(
@@ -117,8 +125,8 @@ const DataProductsContainer = ({
   }, [handleCancel, handleSave, dataProducts, fetchAPI]);
 
   const showAddTagButton = useMemo(
-    () => hasPermission && !isEmpty(activeDomains) && isEmpty(dataProducts),
-    [hasPermission, dataProducts, activeDomains]
+    () => hasPermission && !domainMissing && isEmpty(dataProducts),
+    [hasPermission, dataProducts, domainMissing]
   );
 
   const renderDataProducts = useMemo(() => {
@@ -126,7 +134,7 @@ const DataProductsContainer = ({
       return NO_DATA_PLACEHOLDER;
     }
 
-    if (isEmpty(dataProducts) && hasPermission && isEmpty(activeDomains)) {
+    if (isEmpty(dataProducts) && hasPermission && domainMissing) {
       return (
         <Typography.Text className="text-sm text-grey-muted">
           {t('message.select-domain-to-add-data-product')}
@@ -157,7 +165,7 @@ const DataProductsContainer = ({
         </Tag>
       );
     });
-  }, [dataProducts, activeDomains]);
+  }, [dataProducts, activeDomains, domainMissing]);
 
   const header = useMemo(() => {
     return (
@@ -176,7 +184,7 @@ const DataProductsContainer = ({
               onClick={handleAddClick}
             />
           )}
-          {hasPermission && !isEmpty(activeDomains) && (
+          {hasPermission && !domainMissing && (
             <Row gutter={12}>
               {!isEmpty(dataProducts) && (
                 <Col>
@@ -196,7 +204,7 @@ const DataProductsContainer = ({
         </Space>
       )
     );
-  }, [showHeader, dataProducts, hasPermission, showAddTagButton]);
+  }, [showHeader, dataProducts, hasPermission, showAddTagButton, domainMissing]);
 
   const addTagButton = useMemo(
     () =>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTab.component.tsx
@@ -38,6 +38,7 @@ import {
   TestCaseParameterValue,
 } from '../../../../generated/tests/testCase';
 import { TestDefinition } from '../../../../generated/tests/testDefinition';
+import { useEntityRules } from '../../../../hooks/useEntityRules';
 import { useTestCaseStore } from '../../../../pages/IncidentManager/IncidentManagerDetailPage/useTestCase.store';
 import {
   getTestDefinitionById,
@@ -367,6 +368,8 @@ const TestCaseResultTab = () => {
     isVersionPage,
   ]);
 
+  const { entityRules, isRulesLoaded } = useEntityRules(EntityType.TEST_CASE);
+
   const renderParameterRows = useCallback(
     (items: Array<{ label?: string; value: string | React.ReactNode }>) => {
       if (items.length === 0) {
@@ -637,6 +640,9 @@ const TestCaseResultTab = () => {
                 activeDomains={testCaseData?.domains ?? []}
                 dataProducts={testCaseData?.dataProducts ?? []}
                 hasPermission={!isVersionPage && (hasEditPermission ?? false)}
+                requireDomainForDataProduct={
+                  !isRulesLoaded || entityRules.requireDomainForDataProduct
+                }
                 onSave={handleDataProductsSave}
               />
             </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTab.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTab.test.tsx
@@ -114,6 +114,17 @@ jest.mock(
     return jest.fn().mockImplementation(() => <div>DataProductsContainer</div>);
   }
 );
+jest.mock('../../../../hooks/useEntityRules', () => ({
+  useEntityRules: jest.fn().mockReturnValue({
+    entityRules: {
+      canAddMultipleDataProducts: true,
+      requireDomainForDataProduct: false,
+    },
+    rules: [],
+    isRulesLoaded: true,
+    isLoading: false,
+  }),
+}));
 jest.mock('../../AddDataQualityTest/EditTestCaseModal', () => {
   return jest.fn().mockImplementation(({ onUpdate, testCase, onCancel }) => (
     <div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityRightPanel/EntityRightPanel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityRightPanel/EntityRightPanel.tsx
@@ -64,7 +64,7 @@ const EntityRightPanel = <T extends ExtentionEntitiesKeys>({
   onDataProductUpdate,
   viewCustomPropertiesPermission,
 }: EntityRightPanelProps<T>) => {
-  const { entityRules } = useEntityRules(entityType);
+  const { entityRules, isRulesLoaded } = useEntityRules(entityType);
   const KnowledgeArticles =
     entityRightPanelClassBase.getKnowLedgeArticlesWidget();
   const { fqn: entityFQN } = useFqn();
@@ -88,6 +88,9 @@ const EntityRightPanel = <T extends ExtentionEntitiesKeys>({
               dataProducts={dataProducts}
               hasPermission={editDataProductPermission ?? false}
               multiple={entityRules.canAddMultipleDataProducts}
+              requireDomainForDataProduct={
+                !isRulesLoaded || entityRules.requireDomainForDataProduct
+              }
               onSave={onDataProductUpdate}
             />
           </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DataProductsSection/DataProductsSection.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DataProductsSection/DataProductsSection.test.tsx
@@ -244,6 +244,7 @@ describe('DataProductsSection', () => {
         requireDomainForDataProduct: false,
       },
       rules: [],
+      isRulesLoaded: true,
       isLoading: false,
     });
   });
@@ -532,7 +533,17 @@ describe('DataProductsSection', () => {
   });
 
   describe('Fetch Options', () => {
-    it('calls fetch API with search and active domains', async () => {
+    it('scopes fetch to active domains when domain validation rule is enabled', async () => {
+      (useEntityRules as jest.Mock).mockReturnValue({
+        entityRules: {
+          canAddMultipleDataProducts: true,
+          maxDataProducts: Infinity,
+          requireDomainForDataProduct: true,
+        },
+        rules: [],
+        isRulesLoaded: true,
+        isLoading: false,
+      });
       const { fetchDataProductsElasticSearch } = jest.requireMock(
         '../../../rest/dataProductAPI'
       );
@@ -552,6 +563,105 @@ describe('DataProductsSection', () => {
           2
         );
       });
+    });
+
+    it('fetches across all domains when domain validation rule is disabled', async () => {
+      const { fetchDataProductsElasticSearch } = jest.requireMock(
+        '../../../rest/dataProductAPI'
+      );
+
+      render(<DataProductsSection {...defaultProps} />);
+
+      const editIcon = screen.getByTestId('edit-data-products');
+      if (editIcon) {
+        fireEvent.click(editIcon);
+      }
+      fireEvent.click(screen.getByTestId('dps-fetch'));
+
+      await waitFor(() => {
+        expect(fetchDataProductsElasticSearch).toHaveBeenCalledWith(
+          'term',
+          [],
+          2
+        );
+      });
+    });
+
+    it('stays domain-scoped while entity rules are still loading', async () => {
+      (useEntityRules as jest.Mock).mockReturnValue({
+        entityRules: {
+          canAddMultipleDataProducts: true,
+          maxDataProducts: Infinity,
+          requireDomainForDataProduct: false,
+        },
+        rules: [],
+        isRulesLoaded: false,
+        isLoading: true,
+      });
+      const { fetchDataProductsElasticSearch } = jest.requireMock(
+        '../../../rest/dataProductAPI'
+      );
+
+      render(<DataProductsSection {...defaultProps} />);
+
+      const editIcon = screen.getByTestId('edit-data-products');
+      if (editIcon) {
+        fireEvent.click(editIcon);
+      }
+      fireEvent.click(screen.getByTestId('dps-fetch'));
+
+      await waitFor(() => {
+        expect(fetchDataProductsElasticSearch).toHaveBeenCalledWith(
+          'term',
+          ['domain'],
+          2
+        );
+      });
+    });
+  });
+
+  describe('Domain Requirement Gating', () => {
+    it('prompts to select a domain when no domains and rule is enabled', () => {
+      (useEntityRules as jest.Mock).mockReturnValue({
+        entityRules: {
+          canAddMultipleDataProducts: true,
+          maxDataProducts: Infinity,
+          requireDomainForDataProduct: true,
+        },
+        rules: [],
+        isRulesLoaded: true,
+        isLoading: false,
+      });
+
+      render(
+        <DataProductsSection
+          {...defaultProps}
+          activeDomains={[]}
+          dataProducts={[]}
+        />
+      );
+
+      expect(
+        screen.getByText('message.select-domain-to-add-data-product')
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('edit-data-products')
+      ).not.toBeInTheDocument();
+    });
+
+    it('allows editing with no domains when rule is disabled', () => {
+      render(
+        <DataProductsSection
+          {...defaultProps}
+          activeDomains={[]}
+          dataProducts={[]}
+        />
+      );
+
+      expect(
+        screen.queryByText('message.select-domain-to-add-data-product')
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId('edit-data-products')).toBeInTheDocument();
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DataProductsSection/DataProductsSection.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DataProductsSection/DataProductsSection.tsx
@@ -46,7 +46,14 @@ const DataProductsSectionV1: React.FC<DataProductsSectionProps> = ({
   const [showAllDataProducts, setShowAllDataProducts] = useState(false);
   const [displayActiveDomains, setDisplayActiveDomains] =
     useState<EntityReference[]>(activeDomains);
-  const { entityRules } = useEntityRules(entityType);
+  const { entityRules, isRulesLoaded } = useEntityRules(entityType);
+
+  // Hold the strict domain-scoped behavior until the rules have actually loaded
+  // (an empty rule set from the backend is indistinguishable from "not fetched
+  // yet"), otherwise a cross-domain product could be selected before an enabled
+  // rule resolves and then rejected by the backend on save.
+  const requireDomainForDataProduct =
+    !isRulesLoaded || entityRules.requireDomainForDataProduct;
 
   const {
     isEditing,
@@ -95,14 +102,17 @@ const DataProductsSectionV1: React.FC<DataProductsSectionProps> = ({
   const fetchAPI = useCallback(
     async (searchValue: string, page = 1) => {
       const searchText = searchValue ?? '';
-      const domainFQNs =
-        displayActiveDomains?.map(
-          (domain) => domain.fullyQualifiedName ?? ''
-        ) ?? [];
+      // When the "Data Product Domain Validation" rule is disabled, list Data
+      // Products across all domains instead of scoping to the asset's domains.
+      const domainFQNs = requireDomainForDataProduct
+        ? displayActiveDomains?.map(
+            (domain) => domain.fullyQualifiedName ?? ''
+          ) ?? []
+        : [];
 
       return fetchDataProductsElasticSearch(searchText, domainFQNs, page);
     },
-    [displayActiveDomains]
+    [displayActiveDomains, requireDomainForDataProduct]
   );
 
   const handleSaveWithDataProducts = useCallback(
@@ -204,7 +214,10 @@ const DataProductsSectionV1: React.FC<DataProductsSectionProps> = ({
       return editingState;
     }
 
-    if (!displayActiveDomains || displayActiveDomains.length === 0) {
+    if (
+      requireDomainForDataProduct &&
+      (!displayActiveDomains || displayActiveDomains.length === 0)
+    ) {
       return (
         <Typography.Text className="no-data-placeholder">
           {t('message.select-domain-to-add-data-product')}
@@ -219,7 +232,14 @@ const DataProductsSectionV1: React.FC<DataProductsSectionProps> = ({
         })}
       </span>
     );
-  }, [isLoading, isEditing, editingState, displayActiveDomains, t]);
+  }, [
+    isLoading,
+    isEditing,
+    editingState,
+    displayActiveDomains,
+    requireDomainForDataProduct,
+    t,
+  ]);
 
   const dataProductsDisplay = useMemo(
     () => (
@@ -272,11 +292,11 @@ const DataProductsSectionV1: React.FC<DataProductsSectionProps> = ({
     return dataProductsDisplay;
   }, [isLoading, isEditing, editingState, dataProductsDisplay]);
 
+  const canAssignDataProduct =
+    displayActiveDomains?.length > 0 || !requireDomainForDataProduct;
+
   const canShowEditButton =
-    showEditButton &&
-    hasPermission &&
-    !isLoading &&
-    displayActiveDomains?.length > 0;
+    showEditButton && hasPermission && !isLoading && canAssignDataProduct;
 
   if (!displayDataProducts?.length) {
     return (

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useEntityRules.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useEntityRules.test.ts
@@ -92,6 +92,26 @@ describe('useEntityRules', () => {
 
       expect(result.current.isLoading).toBe(true);
     });
+
+    it('should report isRulesLoaded false until the entity rules are fetched', () => {
+      const { result } = renderHook(() => useEntityRules(EntityType.TABLE));
+
+      expect(result.current.isRulesLoaded).toBe(false);
+    });
+
+    it('should report isRulesLoaded true once the entity rules are present', () => {
+      (useRuleEnforcementProvider as jest.Mock).mockReturnValue({
+        rules: { [EntityType.TABLE]: mockParsedRules },
+        fetchRulesForEntity: mockFetchRulesForEntity,
+        getRulesForEntity: mockGetRulesForEntity,
+        getEntityRuleValidation: mockGetEntityRuleValidation,
+        isLoading: false,
+      });
+
+      const { result } = renderHook(() => useEntityRules(EntityType.TABLE));
+
+      expect(result.current.isRulesLoaded).toBe(true);
+    });
   });
 
   describe('Entity type changes', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useEntityRules.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useEntityRules.ts
@@ -36,6 +36,15 @@ export const useEntityRules = (entityType: EntityType) => {
     [allEntityRules, entityType]
   );
 
+  // The backend only returns *enabled* rules, so an empty rule set is
+  // indistinguishable from "not fetched yet". Track whether the rules for this
+  // entity have actually loaded so consumers can hold the strict default (e.g.
+  // domain-scoped Data Products) until the real rule state is known.
+  const isRulesLoaded = useMemo(
+    () => Boolean(allEntityRules?.[entityType]),
+    [allEntityRules, entityType]
+  );
+
   useEffect(() => {
     if (entityType) {
       fetchRulesForEntity(entityType);
@@ -45,6 +54,7 @@ export const useEntityRules = (entityType: EntityType) => {
   return {
     rules,
     entityRules,
+    isRulesLoaded,
     isLoading,
   };
 };


### PR DESCRIPTION
## Backport of #32011 → `1.13`

Cherry-pick of merge commit `1637b795` (Fixes #31329) onto `1.13`.

### Conflict resolutions (1.13 diverges from main in 4 files)

| File | Resolution |
|---|---|
| `DataProductsContainer.component.tsx` | 1.13 uses `PlusIconButton`/`EditIconButton` (not `WidgetPlusButton`/`WidgetEditButton`). Kept 1.13 components; changed the edit-button gate from `!isEmpty(activeDomains)` → `!domainMissing` to apply the rule. |
| `GenericProvider.tsx` | Incoming commit bundled an unrelated `useEffect` syncing `selectedColumnRef` (a main-only ref). Dropped that `useEffect`; kept only the `isRulesLoaded` destructuring addition. |
| `TestCaseResultTab.component.tsx` | 1.13 uses the pre-refactor component (no `useTestCaseResultTab` hook). Kept 1.13 body; added only `useEntityRules` import + hook call + `requireDomainForDataProduct` prop on `DataProductsContainer`. |
| `TestCaseResultTab.test.tsx` | 1.13 mocks `EditTestCaseModal`; main uses `TestCaseFormDrawer`. Kept 1.13 modal mock; added the `useEntityRules` mock. |
| `KnowledgePageDetailRightPanel.tsx` | File does not exist in 1.13 (KnowledgeCenter not shipped). Removed from the cherry-pick. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The backport makes Data Product selection domain-scoped only when the corresponding entity rule requires it, while retaining strict behavior until rules load.
- Adds rule-aware Data Product selectors to shared asset, entity-panel, and test-case surfaces.
- Exposes entity-rule loading state through the generic provider.
- Adds unit and Playwright coverage for enabled and disabled domain-validation behavior.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/hooks/useEntityRules.ts | Adds an explicit loaded-state signal based on the presence of the entity-type entry in the provider’s rules map. |
| openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsContainer/DataProductsContainer.component.tsx | Makes domain gating and Data Product search scope conditional on the domain-validation rule. |
| openmetadata-ui/src/main/resources/ui/src/components/common/DataProductsSection/DataProductsSection.tsx | Applies rule-aware domain gating while retaining strict behavior during rule loading. |
| openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.tsx | Propagates entity-rule loading state to generic entity consumers. |
| openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTab.component.tsx | Applies test-case entity rules to the Data Product assignment control. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Load entity rules] --> B{Rules loaded?}
    B -->|No| C[Require asset domain]
    B -->|Yes| D{Domain validation enabled?}
    D -->|Yes| C
    D -->|No| E[Search Data Products across domains]
    C --> F[Search Data Products in active domains]
    E --> G[Authorized user selects and saves]
    F --> G
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(test): adapt DataProductsContainer t..."](https://github.com/open-metadata/openmetadata/commit/d277d66e2cc8926337b7d73dff71d2914d27ce53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57827482)</sub>

<!-- /greptile_comment -->