### PR TITLE
fix(deps): bump Spring to 7.0.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <httpasyncclient.version>4.1.5</httpasyncclient.version>
     <openapiswagger.version>2.2.25</openapiswagger.version>
     <httpclient.version>4.5.14</httpclient.version>
-    <spring.version>6.2.19</spring.version>
+    <spring.version>7.0.9</spring.version>
     <log4j.version>2.25.5</log4j.version>
     <org.junit.jupiter.version>5.11.4</org.junit.jupiter.version>
     <org.junit.platform.version>1.11.4</org.junit.platform.version>


### PR DESCRIPTION
## Summary

- Bump the shared Spring Framework version from 6.2.19 to 7.0.9.
- Remediates CVE-2026-47886, CVE-2026-59282, and CVE-2026-59283.

## Validation

- `mvn -pl openmetadata-service -am -DskipTests dependency:tree -Dincludes=org.springframework:spring-expression,org.springframework:spring-beans`
- Both `spring-expression` and `spring-beans` resolve to 7.0.9.
- Remote diff changes only the root `pom.xml`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the shared Spring Framework version from 6.2.19 to 7.0.9 to remediate reported vulnerabilities.
- Aligns spring-core, spring-beans, and spring-expression on Spring 7.0.9.
- No concrete build, dependency-alignment, or runtime compatibility defect was identified.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or non-blocking defects identified.

The affected Spring artifacts resolve through the same shared version, the project’s Java baseline is compatible, and inspected Spring API usage does not rely on behavior removed by this upgrade.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| pom.xml | Bumps the shared Spring version to 7.0.9; inspected consumers remain aligned and no actionable compatibility issue was established. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(deps): bump Spring to 7.0.9"](https://github.com/open-metadata/openmetadata/commit/d4df96ca1a2101993ed09d477d2d4ae7a1c8ea85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57833410)</sub>

<!-- /greptile_comment -->