### PR TITLE
feat(search): add onnx as a local embedding provider

### DIFF
--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -638,7 +638,7 @@ llmConfiguration:
   # (bedrock.awsConfig, openai.apiKey/endpoint, google.apiKey); this section only selects the
   # embedding provider + model. The embedding provider may differ from the chat provider above.
   embeddings:
-    provider: ${EMBEDDING_PROVIDER:-bedrock}  # bedrock | openai | google | djl
+    provider: ${EMBEDDING_PROVIDER:-bedrock}  # bedrock | openai | google | djl | onnx
     maxConcurrentRequests: ${MAX_CONCURRENT_EMBEDDING_REQUESTS:-10}
     bedrock:
       embeddingModelId: ${AWS_BEDROCK_EMBED_MODEL_ID:-"amazon.titan-embed-text-v2:0"}
@@ -651,6 +651,10 @@ llmConfiguration:
       embeddingDimension: ${GOOGLE_EMBEDDING_DIMENSION:-768}
     djl:
       embeddingModel: ${DJL_EMBEDDING_MODEL:-"ai.djl.huggingface.pytorch/sentence-transformers/all-MiniLM-L6-v2"}
+    # In-process ONNX. No credentials and no model download: the weights ship with the server, so
+    # this is the provider that works in an air-gapped deployment.
+    onnx:
+      embeddingModel: ${ONNX_EMBEDDING_MODEL:-"all-MiniLM-L6-v2"}
 
 eventMonitoringConfiguration:
   eventMonitor: ${EVENT_MONITOR:-prometheus}  # Possible values are "prometheus", "cloudwatch"

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -569,6 +569,14 @@
       <version>0.34.0</version>
     </dependency>
 
+    <!-- Dependencies for vector embedding (in-process ONNX). The model weights are bundled in the
+         artifact, which is what lets the onnx provider embed without any download or credential. -->
+    <dependency>
+      <groupId>dev.langchain4j</groupId>
+      <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId>
+      <version>${langchain4j-embeddings.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
@@ -1015,11 +1015,13 @@ public class SystemRepository {
 
       return switch (provider.toLowerCase()) {
         case "djl" -> getDjlEmbeddingMessage(embeddings);
+        case "onnx" -> getOnnxEmbeddingMessage(embeddings);
         case "bedrock" -> getBedrockEmbeddingMessage(llmConfig, embeddings);
         case "openai" -> getOpenAiEmbeddingMessage(llmConfig, embeddings);
         case "google" -> getGoogleEmbeddingMessage(llmConfig, embeddings);
         default -> String.format(
-            "Unknown provider '%s'. Supported providers: djl, bedrock, openai, google", provider);
+            "Unknown provider '%s'. Supported providers: djl, onnx, bedrock, openai, google",
+            provider);
       };
     } catch (Exception e) {
       LOG.error("Error getting embedding configuration", e);
@@ -1033,6 +1035,16 @@ public class SystemRepository {
       message =
           String.format(
               "DJL configuration: embeddingModel: %s", embeddings.getDjl().getEmbeddingModel());
+    }
+    return message;
+  }
+
+  private String getOnnxEmbeddingMessage(LLMEmbeddingsConfig embeddings) {
+    String message = "ONNX provider selected but onnx configuration block is missing";
+    if (embeddings.getOnnx() != null) {
+      message =
+          String.format(
+              "ONNX configuration: embeddingModel: %s", embeddings.getOnnx().getEmbeddingModel());
     }
     return message;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -172,6 +172,7 @@ import org.openmetadata.service.search.vector.client.BedrockEmbeddingClient;
 import org.openmetadata.service.search.vector.client.DjlEmbeddingClient;
 import org.openmetadata.service.search.vector.client.EmbeddingClient;
 import org.openmetadata.service.search.vector.client.GoogleEmbeddingClient;
+import org.openmetadata.service.search.vector.client.OnnxEmbeddingClient;
 import org.openmetadata.service.search.vector.client.OpenAIEmbeddingClient;
 import org.openmetadata.service.security.policyevaluator.SubjectContext;
 import org.openmetadata.service.seeding.SeedDataGate;
@@ -4615,6 +4616,13 @@ public class SearchRepository {
           throw new IllegalStateException("DJL configuration is required when using djl provider");
         }
         yield new DjlEmbeddingClient(llmConfig);
+      }
+      case "onnx" -> {
+        if (embeddings.getOnnx() == null) {
+          throw new IllegalStateException(
+              "ONNX configuration is required when using onnx provider");
+        }
+        yield new OnnxEmbeddingClient(llmConfig);
       }
       default -> throw new IllegalArgumentException("Unknown embedding provider: " + provider);
     };

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/client/OnnxEmbeddingClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/client/OnnxEmbeddingClient.java
@@ -1,0 +1,100 @@
+package org.openmetadata.service.search.vector.client;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2.AllMiniLmL6V2EmbeddingModel;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.configuration.LLMConfiguration;
+import org.openmetadata.schema.configuration.LLMOnnxEmbeddingConfig;
+
+/**
+ * Embedding client backed by an ONNX model running in the OpenMetadata process. The weights ship
+ * inside the application, so unlike {@link DjlEmbeddingClient} there is no model download at
+ * startup, and unlike the hosted providers there is no credential and no outbound call. That makes
+ * it the provider that works in an air-gapped deployment.
+ */
+@Slf4j
+public class OnnxEmbeddingClient extends EmbeddingClient {
+
+  public static final String ALL_MINILM_L6_V2 = "all-MiniLM-L6-v2";
+
+  /** Placeholder embedded in place of blank input so batch indices stay aligned. */
+  private static final String BLANK_PLACEHOLDER = "placeholder";
+
+  private final AllMiniLmL6V2EmbeddingModel model;
+  private final String modelName;
+  private final int dimension;
+
+  public OnnxEmbeddingClient(LLMConfiguration config) {
+    super(resolveMaxConcurrent(config));
+    LLMOnnxEmbeddingConfig onnxCfg =
+        config.getEmbeddings() != null ? config.getEmbeddings().getOnnx() : null;
+    if (onnxCfg == null) {
+      throw new IllegalArgumentException("ONNX configuration is required");
+    }
+    String configuredModel =
+        onnxCfg.getEmbeddingModel() != null ? onnxCfg.getEmbeddingModel() : ALL_MINILM_L6_V2;
+    if (!ALL_MINILM_L6_V2.equalsIgnoreCase(configuredModel)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Unsupported ONNX embedding model '%s'. Supported models: %s",
+              configuredModel, ALL_MINILM_L6_V2));
+    }
+    // Canonical casing rather than whatever was configured: getModelId() is stamped into the index
+    // _meta, and a case-only difference there reads as a model change and forces a reindex.
+    this.modelName = ALL_MINILM_L6_V2;
+    this.model = new AllMiniLmL6V2EmbeddingModel();
+    this.dimension = model.dimension();
+    LOG.info("Initialized OnnxEmbeddingClient with model={}, dimension={}", modelName, dimension);
+  }
+
+  @Override
+  protected float[] doEmbed(String text) {
+    if (text == null || text.isBlank()) {
+      LOG.debug("Null or blank text, returning zero vector");
+      return new float[dimension];
+    }
+    return model.embed(text).content().vector();
+  }
+
+  @Override
+  public List<float[]> embedBatch(List<String> texts) {
+    if (texts == null || texts.isEmpty()) {
+      return List.of();
+    }
+
+    List<TextSegment> segments = new ArrayList<>(texts.size());
+    List<Integer> blankIndices = new ArrayList<>();
+    for (int i = 0; i < texts.size(); i++) {
+      String text = texts.get(i);
+      if (text == null || text.isBlank()) {
+        blankIndices.add(i);
+        segments.add(TextSegment.from(BLANK_PLACEHOLDER));
+      } else {
+        segments.add(TextSegment.from(text));
+      }
+    }
+
+    List<Embedding> embeddings = model.embedAll(segments).content();
+    List<float[]> vectors = new ArrayList<>(embeddings.size());
+    for (Embedding embedding : embeddings) {
+      vectors.add(embedding.vector());
+    }
+    for (int index : blankIndices) {
+      vectors.set(index, new float[dimension]);
+    }
+    return vectors;
+  }
+
+  @Override
+  public int getDimension() {
+    return dimension;
+  }
+
+  @Override
+  public String getModelId() {
+    return modelName;
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
@@ -2958,6 +2958,10 @@ class SearchRepositoryBehaviorTest {
     assertThrows(
         IllegalStateException.class,
         () -> repository.createEmbeddingClient(embeddingConfigWithProvider(Provider.DJL)));
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> repository.createEmbeddingClient(embeddingConfigWithProvider(Provider.ONNX)));
   }
 
   private LLMConfiguration embeddingConfigWithProvider(Provider provider) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/client/OnnxEmbeddingClientTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/client/OnnxEmbeddingClientTest.java
@@ -1,0 +1,131 @@
+package org.openmetadata.service.search.vector.client;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.configuration.LLMConfiguration;
+import org.openmetadata.schema.configuration.LLMEmbeddingsConfig;
+import org.openmetadata.schema.configuration.LLMOnnxEmbeddingConfig;
+
+/**
+ * Exercises the real in-process ONNX model rather than a mock: the whole point of this provider is
+ * that it needs no network and no credentials, so the model it ships with is available to the test.
+ */
+class OnnxEmbeddingClientTest {
+  private static final int MINILM_DIMENSION = 384;
+
+  private static OnnxEmbeddingClient client;
+
+  @BeforeAll
+  static void setUp() {
+    client = new OnnxEmbeddingClient(config(null));
+  }
+
+  @Test
+  void missingOnnxBlockIsRejected() {
+    LLMConfiguration noEmbeddings = new LLMConfiguration();
+    assertThrows(IllegalArgumentException.class, () -> new OnnxEmbeddingClient(noEmbeddings));
+
+    LLMConfiguration noOnnxBlock = new LLMConfiguration().withEmbeddings(new LLMEmbeddingsConfig());
+    assertThrows(IllegalArgumentException.class, () -> new OnnxEmbeddingClient(noOnnxBlock));
+  }
+
+  @Test
+  void unsupportedModelIsRejected() {
+    LLMConfiguration config = config("bge-small-en-v1.5");
+    IllegalArgumentException failure =
+        assertThrows(IllegalArgumentException.class, () -> new OnnxEmbeddingClient(config));
+    assertTrue(failure.getMessage().contains("bge-small-en-v1.5"), failure.getMessage());
+  }
+
+  @Test
+  void configuredModelNameIsCaseInsensitive() {
+    assertEquals(
+        OnnxEmbeddingClient.ALL_MINILM_L6_V2,
+        new OnnxEmbeddingClient(config("all-minilm-l6-v2")).getModelId());
+  }
+
+  @Test
+  void defaultsToMiniLmWhenModelIsUnset() {
+    assertEquals(OnnxEmbeddingClient.ALL_MINILM_L6_V2, client.getModelId());
+    assertEquals(MINILM_DIMENSION, client.getDimension());
+  }
+
+  @Test
+  void embedProducesADeterministicNonZeroVector() {
+    float[] first = client.embed("customer lifetime value table");
+    float[] second = client.embed("customer lifetime value table");
+
+    assertEquals(MINILM_DIMENSION, first.length);
+    assertArrayEquals(first, second);
+    assertTrue(magnitude(first) > 0.0f, "embedding should not be the zero vector");
+  }
+
+  @Test
+  void blankTextEmbedsToTheZeroVector() {
+    assertArrayEquals(new float[MINILM_DIMENSION], client.embed(null));
+    assertArrayEquals(new float[MINILM_DIMENSION], client.embed("   "));
+  }
+
+  @Test
+  void relatedTextsEmbedCloserThanUnrelatedOnes() {
+    float[] orders = client.embed("table of customer orders and invoices");
+    float[] purchases = client.embed("table of customer purchases and receipts");
+    float[] weather = client.embed("hourly rainfall measurements by weather station");
+
+    assertTrue(
+        cosine(orders, purchases) > cosine(orders, weather),
+        "related descriptions should be closer than unrelated ones");
+  }
+
+  @Test
+  void embedBatchMatchesSingleEmbeddingsAndKeepsIndicesAligned() {
+    List<String> texts = Arrays.asList("first table", null, "second table", "  ");
+
+    List<float[]> batch = client.embedBatch(texts);
+
+    assertEquals(texts.size(), batch.size());
+    assertArrayEquals(client.embed("first table"), batch.get(0));
+    assertArrayEquals(new float[MINILM_DIMENSION], batch.get(1));
+    assertArrayEquals(client.embed("second table"), batch.get(2));
+    assertArrayEquals(new float[MINILM_DIMENSION], batch.get(3));
+    assertNotEquals(0.0f, magnitude(batch.get(2)));
+  }
+
+  @Test
+  void embedBatchOfNothingReturnsNothing() {
+    assertEquals(List.of(), client.embedBatch(null));
+    assertEquals(List.of(), client.embedBatch(Collections.emptyList()));
+  }
+
+  private static LLMConfiguration config(String embeddingModel) {
+    return new LLMConfiguration()
+        .withEmbeddings(
+            new LLMEmbeddingsConfig()
+                .withOnnx(new LLMOnnxEmbeddingConfig().withEmbeddingModel(embeddingModel)));
+  }
+
+  private static float magnitude(float[] vector) {
+    double sum = 0.0;
+    for (float value : vector) {
+      sum += (double) value * value;
+    }
+    return (float) Math.sqrt(sum);
+  }
+
+  private static float cosine(float[] left, float[] right) {
+    double dot = 0.0;
+    for (int i = 0; i < left.length; i++) {
+      dot += (double) left[i] * right[i];
+    }
+    return (float) (dot / (magnitude(left) * magnitude(right)));
+  }
+}

--- a/openmetadata-spec/src/main/resources/json/schema/configuration/llmConfiguration.json
+++ b/openmetadata-spec/src/main/resources/json/schema/configuration/llmConfiguration.json
@@ -96,12 +96,12 @@
     "embeddings": {
       "type": "object",
       "javaType": "org.openmetadata.schema.configuration.LLMEmbeddingsConfig",
-      "description": "Vector embedding configuration for semantic search. Credentials are reused from the sibling provider blocks (bedrock.awsConfig, openai.apiKey/endpoint, google.apiKey/endpoint); this section selects the embedding provider and per-provider embedding model. The embedding provider may differ from the chat completion provider.",
+      "description": "Vector embedding configuration for semantic search. Credentials are reused from the sibling provider blocks (bedrock.awsConfig, openai.apiKey/endpoint, google.apiKey/endpoint); this section selects the embedding provider and per-provider embedding model. The embedding provider may differ from the chat completion provider. The local providers (djl, onnx) need no credentials.",
       "properties": {
         "provider": {
           "description": "Embedding provider to use for semantic search vectors.",
           "type": "string",
-          "enum": ["bedrock", "openai", "google", "djl"],
+          "enum": ["bedrock", "openai", "google", "djl", "onnx"],
           "default": "bedrock"
         },
         "maxConcurrentRequests": {
@@ -140,8 +140,18 @@
         "djl": {
           "type": "object",
           "javaType": "org.openmetadata.schema.configuration.LLMDjlEmbeddingConfig",
+          "description": "DJL embeddings. The model is downloaded from the DJL model zoo on first use, so the server needs outbound network access at startup.",
           "properties": {
             "embeddingModel": { "type": "string", "default": "ai.djl.huggingface.pytorch/sentence-transformers/all-MiniLM-L6-v2" }
+          },
+          "additionalProperties": false
+        },
+        "onnx": {
+          "type": "object",
+          "javaType": "org.openmetadata.schema.configuration.LLMOnnxEmbeddingConfig",
+          "description": "In-process ONNX embeddings. The model weights ship with the application, so there is no download, no outbound network call and no credential; suitable for air-gapped deployments.",
+          "properties": {
+            "embeddingModel": { "type": "string", "default": "all-MiniLM-L6-v2" }
           },
           "additionalProperties": false
         }

--- a/openmetadata-ui/src/main/resources/ui/src/generated/configuration/llmConfiguration.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/configuration/llmConfiguration.ts
@@ -21,7 +21,8 @@ export interface LlmConfiguration {
      * Vector embedding configuration for semantic search. Credentials are reused from the
      * sibling provider blocks (bedrock.awsConfig, openai.apiKey/endpoint,
      * google.apiKey/endpoint); this section selects the embedding provider and per-provider
-     * embedding model. The embedding provider may differ from the chat completion provider.
+     * embedding model. The embedding provider may differ from the chat completion provider. The
+     * local providers (djl, onnx) need no credentials.
      */
     embeddings?: Embeddings;
     /**
@@ -104,17 +105,27 @@ export interface AWSBaseConfig {
  * Vector embedding configuration for semantic search. Credentials are reused from the
  * sibling provider blocks (bedrock.awsConfig, openai.apiKey/endpoint,
  * google.apiKey/endpoint); this section selects the embedding provider and per-provider
- * embedding model. The embedding provider may differ from the chat completion provider.
+ * embedding model. The embedding provider may differ from the chat completion provider. The
+ * local providers (djl, onnx) need no credentials.
  */
 export interface Embeddings {
     bedrock?: EmbeddingsBedrock;
-    djl?:     Djl;
-    google?:  EmbeddingsGoogle;
+    /**
+     * DJL embeddings. The model is downloaded from the DJL model zoo on first use, so the
+     * server needs outbound network access at startup.
+     */
+    djl?:    Djl;
+    google?: EmbeddingsGoogle;
     /**
      * Maximum number of concurrent embedding requests.
      */
     maxConcurrentRequests?: number;
-    openai?:                EmbeddingsOpenai;
+    /**
+     * In-process ONNX embeddings. The model weights ship with the application, so there is no
+     * download, no outbound network call and no credential; suitable for air-gapped deployments.
+     */
+    onnx?:   Onnx;
+    openai?: EmbeddingsOpenai;
     /**
      * Embedding provider to use for semantic search vectors.
      */
@@ -126,6 +137,10 @@ export interface EmbeddingsBedrock {
     embeddingModelId?:   string;
 }
 
+/**
+ * DJL embeddings. The model is downloaded from the DJL model zoo on first use, so the
+ * server needs outbound network access at startup.
+ */
 export interface Djl {
     embeddingModel?: string;
 }
@@ -133,6 +148,14 @@ export interface Djl {
 export interface EmbeddingsGoogle {
     embeddingDimension?: number;
     embeddingModelId?:   string;
+}
+
+/**
+ * In-process ONNX embeddings. The model weights ship with the application, so there is no
+ * download, no outbound network call and no credential; suitable for air-gapped deployments.
+ */
+export interface Onnx {
+    embeddingModel?: string;
 }
 
 export interface EmbeddingsOpenai {
@@ -147,6 +170,7 @@ export enum Provider {
     Bedrock = "bedrock",
     Djl = "djl",
     Google = "google",
+    Onnx = "onnx",
     Openai = "openai",
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,7 @@
     <commonmark.version>0.26.0</commonmark.version>
     <flexmark.version>0.64.8</flexmark.version>
     <owasp-html-sanitizer.version>20260101.1</owasp-html-sanitizer.version>
+    <langchain4j-embeddings.version>1.14.1-beta24</langchain4j-embeddings.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## Describe your changes

Adds an `onnx` embedding provider that runs `all-MiniLM-L6-v2` in process via langchain4j. Purely additive — `djl` and every cloud provider stay, and the default stays `bedrock`.

The difference from `djl` is where the model comes from:

| | `djl` | `onnx` |
|---|---|---|
| Jar cost | 100 KB stub | **+168.8 MB** |
| Startup | downloads **~276 MB** from `publish.djl.ai` | none |
| Air-gapped | impossible | works |
| Models | any HF sentence-transformers model | frozen to all-MiniLM-L6-v2 |
| Deterministic in CI | no (network) | yes |

Both resolve to the same model at 384 dimensions, so the two are index-compatible.

Worth knowing: nothing persists `~/.djl.ai` — not the compose files, not the helm chart — so DJL's 276 MB is paid on **every fresh container**, not once.

### The cost, stated plainly

Measured from the built distribution:

```
langchain4j-embeddings-all-minilm-l6-v2   79.2 MB   (model weights)
com.microsoft.onnxruntime:onnxruntime      88.7 MB   (all-platform natives)
langchain4j-core + langchain4j-embeddings   0.8 MB
                                          -------
                                          168.8 MB
```

`openmetadata-dist/src/main/assembly/binary.xml` puts every runtime dep in `libs/`, so all of it lands in the release tarball and the Docker image (verified: image 455 MB → 623 MB). **Everyone pays it** — including deployments on bedrock/openai/google, and those with embeddings switched off entirely.

### The argument against merging this as-is

I'd rather put this up front than have it found in review.

1. **#32182 fixes DJL.** The original driver was partly that DJL didn't work on the alpine image. It does now, on the distroless base — verified end to end (`Initialized DjlEmbeddingClient … dimension=384`, zero linkage errors). So "we have no working local provider" is no longer true.
2. **The other driver was a test seam.** Collate's `NlqHybridSearchEndpointIT` uses a test-only `MiniLmEmbeddingClient` behind a system property; promoting it to a real provider would let that seam be deleted. But that seam can also be removed by pointing the IT at `provider=djl` plus an `actions/cache` step on `~/.djl.ai` — no OSS change, no 168.8 MB.
3. **The remaining unique capability is air-gapped deployment**, which DJL cannot do at any price. That's real, but nobody has asked for it yet.

If reviewers want the capability without the weight, the alternative is an optional module resolved reflectively (the `McpServerProvider` pattern already in the codebase) rather than the compile-time `switch` case here — the `case "onnx" ->` is precisely what forces the class, and therefore the jars, into the default build. Happy to rework it that way.

## Type of change

- [x] Improvement

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) documentation
- [x] I have commented on my code, particularly in hard-to-understand areas

## Tests

`OnnxEmbeddingClientTest` — 9 tests against the **real in-process model**, no mocks, ~1.7 s:

- rejects a missing `onnx` config block and an unsupported model name
- defaults to MiniLM, reports dimension 384
- `embed` is deterministic and non-zero; the same text twice gives an identical vector
- null / blank text embeds to the zero vector
- related descriptions land closer than unrelated ones (cosine)
- `embedBatch` matches single embeddings and keeps blank entries index-aligned as zero vectors
- empty and null batches return empty

Plus `Provider.ONNX` added to `SearchRepositoryBehaviorTest`'s reject-incomplete-config case, and `NaturalLanguageSearchConfigTest` proves the new `onnx:` block in `conf/openmetadata.yaml` deserializes.

```
Tests run: 164, Failures: 0, Errors: 0, Skipped: 0   BUILD SUCCESS
  OnnxEmbeddingClientTest                     9
  SearchRepositoryBehaviorTest              127
  EmbeddingClientTest                         9
  EmbeddingModelChangeDetectionTest          10
  SystemRepositoryEmbeddingsValidationTest    7
  NaturalLanguageSearchConfigTest             2
```

Also verified in a real container on the #32182 base — server boots with `EMBEDDING_PROVIDER=onnx`:

```
OnnxEmbeddingClient        - Initialized OnnxEmbeddingClient with model=all-MiniLM-L6-v2, dimension=384
ElasticSearchVectorService - initialized with model=all-MiniLM-L6-v2, dimension=384
SearchRepository           - Vector search service initialized with provider=onnx, dimension=384
```

Zero `UnsatisfiedLinkError` / `NoClassDefFoundError`. Model load costs ~5.5 s of startup, and the tokenizer native is extracted from the jar rather than downloaded — no network at any point.

### One design note

`getModelId()` is stamped into the index `_meta`, so the client normalises the configured name to canonical `all-MiniLM-L6-v2` casing. Without that, `embeddingModel: all-minilm-l6-v2` in config would read as a model change and force a full reindex. A unit test caught this.

## Note for maintainers

No issue is linked because I couldn't find an existing one covering a local/air-gapped embedding provider — #26700 is the DJL-on-alpine bug and is already claimed by #32182. If this direction is wanted, an issue should be filed first; if it isn't, closing this is a perfectly good outcome and the analysis above is the deliverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
