### PR TITLE
Fixes 32235: make Query entities vector-indexable

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/QueryRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/QueryRepository.java
@@ -38,6 +38,7 @@ import org.openmetadata.schema.type.change.ChangeSource;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.resources.query.QueryResource;
+import org.openmetadata.service.search.vector.QueryBodyTextContributor;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.EntityUtil.RelationIncludes;
 import org.openmetadata.service.util.FullyQualifiedName;
@@ -63,6 +64,7 @@ public class QueryRepository extends EntityRepository<Query> {
         QUERY_PATCH_FIELDS,
         QUERY_UPDATE_FIELDS);
     supportsSearch = true;
+    QueryBodyTextContributor.INSTANCE.register();
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/QueryBodyTextContributor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/QueryBodyTextContributor.java
@@ -1,0 +1,100 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.search.vector;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.entity.data.Query;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.search.vector.VectorDocBuilder.BodyTextExtractor;
+
+/**
+ * Body text contributor for {@link Query}. A query is retrieved by matching a natural-language
+ * question against it, so the intent text — displayName and description — leads the body and the
+ * SQL follows as supporting signal (its table and column identifiers are what a question about a
+ * specific asset lands on).
+ *
+ * <p>Without this contributor the default extractor emits description alone, and
+ * {@code QueryRepository.prepare} names an unnamed query after the MD5 of its SQL — so an
+ * ingested query with no description embeds as little more than a hex string.
+ *
+ * <p>The SQL is capped: a several-thousand-character statement would otherwise dominate the pooled
+ * vector and push the intent text out of the first chunk.
+ */
+public final class QueryBodyTextContributor implements VectorBodyTextContributor {
+
+  public static final QueryBodyTextContributor INSTANCE = new QueryBodyTextContributor();
+
+  static final int MAX_SQL_CHARS = 2000;
+
+  private QueryBodyTextContributor() {}
+
+  @Override
+  public String entityType() {
+    return Entity.QUERY;
+  }
+
+  @Override
+  public BodyTextExtractor extractor() {
+    return QueryBodyTextContributor::extractBodyText;
+  }
+
+  static String extractBodyText(EntityInterface entity) {
+    if (!(entity instanceof Query query)) {
+      return null;
+    }
+    List<String> parts = new ArrayList<>();
+    appendIfPresent(parts, "displayName", query.getDisplayName());
+    appendIfPresent(parts, "description", query.getDescription());
+    appendIfPresent(parts, "sql", cap(query.getQuery()));
+    appendRefs(parts, "usedIn", query.getQueryUsedIn());
+    return parts.isEmpty() ? "" : String.join("; ", parts);
+  }
+
+  /**
+   * {@code queryUsedIn} is stripped from the stored JSON and only repopulated when a caller asks
+   * for the field, so it is absent on some write paths. Absent means "omit", never "no tables".
+   */
+  private static void appendRefs(List<String> parts, String label, List<EntityReference> refs) {
+    if (refs == null || refs.isEmpty()) {
+      return;
+    }
+    List<String> names = new ArrayList<>();
+    for (EntityReference ref : refs) {
+      String value =
+          ref.getFullyQualifiedName() != null ? ref.getFullyQualifiedName() : ref.getName();
+      if (value != null && !value.isBlank()) {
+        names.add(value.strip());
+      }
+    }
+    if (!names.isEmpty()) {
+      parts.add(label + ": " + String.join(", ", names));
+    }
+  }
+
+  private static String cap(String sql) {
+    if (sql == null || sql.length() <= MAX_SQL_CHARS) {
+      return sql;
+    }
+    return sql.substring(0, MAX_SQL_CHARS) + "...";
+  }
+
+  private static void appendIfPresent(List<String> parts, String label, String value) {
+    if (value == null || value.isBlank()) {
+      return;
+    }
+    parts.add(label + ": " + value.strip());
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/utils/AvailableEntityTypes.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/utils/AvailableEntityTypes.java
@@ -40,6 +40,7 @@ public final class AvailableEntityTypes {
           "container",
           "testSuite",
           "testCase",
+          "query",
           // AI Governance Studio assets. The execution types (agentExecution, mcpExecution) and the
           // framework/report leaves are deliberately excluded: they are drill-downs reached from a
           // parent, not things a user searches for by name.

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/QueryBodyTextContributorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/QueryBodyTextContributorTest.java
@@ -1,0 +1,104 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.search.vector;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.entity.data.Query;
+import org.openmetadata.schema.tests.TestSuite;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.service.Entity;
+
+class QueryBodyTextContributorTest {
+
+  private static Query query() {
+    return new Query()
+        .withId(UUID.randomUUID())
+        .withName("9f1c0c0d5b2e4a6f8c3d1e7b9a5f2c40")
+        .withDisplayName("Monthly revenue by region")
+        .withDescription("Total completed order revenue per region for the last full month.")
+        .withQuery("SELECT region, SUM(amount) FROM sales.orders GROUP BY region")
+        .withQueryUsedIn(
+            List.of(
+                new EntityReference()
+                    .withName("orders")
+                    .withFullyQualifiedName("snowflake.sales.public.orders")
+                    .withType(Entity.TABLE)));
+  }
+
+  @Test
+  void bodyTextCarriesIntentSqlAndLinkedTables() {
+    String body = QueryBodyTextContributor.extractBodyText(query());
+
+    assertTrue(body.contains("Monthly revenue by region"), "displayName should be present");
+    assertTrue(body.contains("last full month"), "description should be present");
+    assertTrue(body.contains("SUM(amount)"), "SQL should be present");
+    assertTrue(
+        body.contains("snowflake.sales.public.orders"), "linked table FQN should be present");
+  }
+
+  @Test
+  void intentTextLeadsTheSqlSoItSurvivesChunking() {
+    String body = QueryBodyTextContributor.extractBodyText(query());
+
+    assertTrue(
+        body.indexOf("Monthly revenue by region") < body.indexOf("SUM(amount)"),
+        "displayName must precede the SQL: chunking would otherwise strand the intent text");
+  }
+
+  @Test
+  void longSqlIsCapped() {
+    String longSql = "SELECT " + "a, ".repeat(4000) + "b FROM t";
+    String body =
+        QueryBodyTextContributor.extractBodyText(query().withQuery(longSql).withQueryUsedIn(null));
+
+    assertTrue(body.endsWith("..."), "capped SQL should be marked as truncated");
+    assertTrue(
+        body.length() < longSql.length(), "capped body must be shorter than the raw statement");
+    assertTrue(
+        body.contains("sql: SELECT a, "), "the head of the statement should survive the cap");
+  }
+
+  @Test
+  void absentUsedInIsOmittedRatherThanRenderedEmpty() {
+    // queryUsedIn is stripped from stored JSON, so null must not be reported as "no tables".
+    String body = QueryBodyTextContributor.extractBodyText(query().withQueryUsedIn(null));
+
+    assertFalse(body.contains("usedIn"), "absent queryUsedIn should contribute nothing");
+  }
+
+  @Test
+  void ingestedQueryWithNoIntentTextStillEmbedsItsSql() {
+    // The ingestion path leaves name = MD5(sql) and no description; the SQL is all there is.
+    Query ingested =
+        new Query()
+            .withId(UUID.randomUUID())
+            .withName("9f1c0c0d5b2e4a6f8c3d1e7b9a5f2c40")
+            .withQuery("SELECT * FROM sales.orders");
+
+    assertEquals(
+        "sql: SELECT * FROM sales.orders", QueryBodyTextContributor.extractBodyText(ingested));
+  }
+
+  @Test
+  void extractorReturnsNullForWrongEntityType() {
+    // Wrong-type input must fall back to the default extractor (null signals fallback).
+    assertNull(QueryBodyTextContributor.extractBodyText(new TestSuite()));
+  }
+}

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/query_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/query_index_mapping.json
@@ -80,6 +80,24 @@
   },
   "mappings": {
     "properties": {
+      "fingerprint": {
+        "type": "keyword"
+      },
+      "textToLLMContext": {
+        "type": "text"
+      },
+      "textToEmbed": {
+        "type": "text"
+      },
+      "chunkIndex": {
+        "type": "integer"
+      },
+      "chunkCount": {
+        "type": "integer"
+      },
+      "parentId": {
+        "type": "keyword"
+      },
       "deleted": {
         "type": "boolean"
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/indexMapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/indexMapping.json
@@ -230,7 +230,7 @@
     "indexName": "query_search_index",
     "indexMappingFile": "/elasticsearch/%s/query_index_mapping.json",
     "alias": "query",
-    "parentAliases": ["all"],
+    "parentAliases": ["all", "dataAssetEmbeddings"],
     "childAliases": []
   },
   "mlmodel": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/query_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/query_index_mapping.json
@@ -64,6 +64,24 @@
   },
   "mappings": {
     "properties": {
+      "fingerprint": {
+        "type": "keyword"
+      },
+      "textToLLMContext": {
+        "type": "text"
+      },
+      "textToEmbed": {
+        "type": "text"
+      },
+      "chunkIndex": {
+        "type": "integer"
+      },
+      "chunkCount": {
+        "type": "integer"
+      },
+      "parentId": {
+        "type": "keyword"
+      },
       "deleted": {
         "type": "boolean"
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/query_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/query_index_mapping.json
@@ -94,6 +94,24 @@
   },
   "mappings": {
     "properties": {
+      "fingerprint": {
+        "type": "keyword"
+      },
+      "textToLLMContext": {
+        "type": "text"
+      },
+      "textToEmbed": {
+        "type": "text"
+      },
+      "chunkIndex": {
+        "type": "integer"
+      },
+      "chunkCount": {
+        "type": "integer"
+      },
+      "parentId": {
+        "type": "keyword"
+      },
       "deleted": {
         "type": "boolean"
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/query_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/query_index_mapping.json
@@ -75,6 +75,24 @@
   },
   "mappings": {
     "properties": {
+      "fingerprint": {
+        "type": "keyword"
+      },
+      "textToLLMContext": {
+        "type": "text"
+      },
+      "textToEmbed": {
+        "type": "text"
+      },
+      "chunkIndex": {
+        "type": "integer"
+      },
+      "chunkCount": {
+        "type": "integer"
+      },
+      "parentId": {
+        "type": "keyword"
+      },
       "deleted": {
         "type": "boolean"
       },


### PR DESCRIPTION
### Describe your changes:

Fixes #32235

`Query` entities were absent from all three gates that vector search requires, so a hybrid search scoped to `entityType=query` returned nothing at all — silently, with no error to explain it. This PR opens all three, and gives `query` a body-text extractor so what gets embedded is the question the query answers rather than the MD5 of its SQL.

#
### Type of change:
- [x] New feature

#
### High-level design:

`AvailableEntityTypesConsistencyTest` documents and pins the three gates. All three had to move together:

| Gate | Change |
|---|---|
| Write path — `AvailableEntityTypes.LIST` | `query` added. The bulk sink and `VectorEmbeddingHandler` only embed types listed here. |
| Read path — `dataAssetEmbeddings` in `indexMapping.json` | `query` joins the alias. Chunk-winner hydration re-queries the searched alias for the entity doc, so a non-member index yields a sparse, id-less `_source` that consumers drop. |
| knn_vector — `query_index_mapping.json` (en/jp/ru/zh) | the six embedding fields added. `OsUtils.addKnnVectorSettings` detects embedding support by the presence of `fingerprint` and skips the `embedding` field without it. |

`query` deliberately does **not** join the `dataAsset` alias. That alias backs Explore; a saved query is something you match a question against, not something you browse for.

**`QueryBodyTextContributor`.** The default extractor emits `description` alone, and `QueryRepository.prepare` names an unnamed query after `EntityUtil.hash(query)` — so an ingested query with no description would embed as roughly `"Query 9f1c0c0d… . description: "`. The contributor follows the `ContextMemoryBodyTextContributor` / `TestSuiteBodyTextContributor` pattern and emits `displayName; description; sql; usedIn`, registered from the `QueryRepository` constructor.

Two ordering decisions in it are load-bearing:

- **Intent text leads.** `buildBodyText` output is chunked, so a several-thousand-character statement placed first would strand the question in a later chunk — or push it out entirely.
- **The SQL is capped at 2000 chars.** Same reason, plus a long statement otherwise dominates the pooled vector with identifier tokens.

`queryUsedIn` is stripped from the stored JSON and only repopulated when a caller asks for the field, so it is absent on some write paths. The contributor treats absent as "omit", never as "no tables".

**Alternative rejected:** a dedicated embeddings index or alias for queries, so generic searches could not see them. Chunk documents for every entity type share one physical index (`data_asset_embeddings_chunks`), and the consistency test asserts exact equality between `AvailableEntityTypes.SET` and the alias members — there is no seam to split on. Keeping queries out of ordinary asset search is a read-time concern, solved downstream with an entityType allowlist, exactly as `contextMemory` is today.

**Rollout note.** Consumers that scope generic search to user-facing entity types derive that list from `AvailableEntityTypes.LIST`. Until such a consumer excludes `query` the way it excludes `contextMemory`, saved SQL will start appearing in generic asset search results. A companion change on the consumer side should land alongside this one.

The mapping change is picked up by `IndexMappingVersionTracker`, so existing deployments reindex `query_search_index` on the next start; embeddings are backfilled by the normal reindex path.

#
### Tests:

#### Use cases covered
- A query saved with a natural-language `displayName`/`description` is retrievable by semantic hybrid search on `entityType=query`.
- A query ingested from usage (no description, name = MD5 of the SQL) still embeds its statement rather than a hex string.
- A query whose statement is longer than the cap keeps its intent text intact.

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Files added/updated:
  - `openmetadata-service/src/test/java/org/openmetadata/service/search/vector/QueryBodyTextContributorTest.java` (new, 6 tests)
  - `AvailableEntityTypesConsistencyTest` — existing, and the reason all three gates had to move together; it fails on any one of them alone.

#### Backend integration tests
- [x] Not applicable (no API changes — indexing/search configuration only).

#### Ingestion integration tests
- [x] Not applicable.

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Verified by the pinned suite rather than by hand — the three-way drift this PR closes is exactly what `AvailableEntityTypesConsistencyTest` exists to catch, and it fails if any gate is left shut:

```
mvn -o test -pl openmetadata-service -Dtest='org.openmetadata.service.search.**'
Tests run: 2231, Failures: 0, Errors: 0, Skipped: 0
```

`mvn spotless:check -pl openmetadata-service,openmetadata-spec` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes Query entities available to vector search and supplies query-specific semantic body text.
- Adds `query` to the vector-indexable entity list and embeddings alias.
- Adds embedding metadata fields to all localized query index mappings.
- Registers an extractor that prioritizes intent text, caps SQL, and includes linked entities when available.
- Adds focused unit coverage for extraction order, truncation, optional fields, and fallback behavior.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/QueryRepository.java | Registers the query body-text contributor when the Query repository is initialized. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/vector/QueryBodyTextContributor.java | Builds query embedding text from intent fields, capped SQL, and optional usage references. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/vector/utils/AvailableEntityTypes.java | Adds Query entities to the vector embedding write-path allowlist. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/vector/QueryBodyTextContributorTest.java | Covers the contributor’s field inclusion, ordering, truncation, null handling, and type fallback. |
| openmetadata-spec/src/main/resources/elasticsearch/indexMapping.json | Adds the query search index to the embeddings hydration alias without adding it to the Explore dataAsset alias. |
| openmetadata-spec/src/main/resources/elasticsearch/en/query_index_mapping.json | Adds the metadata fields required for English query vector indexing. |
| openmetadata-spec/src/main/resources/elasticsearch/jp/query_index_mapping.json | Adds the metadata fields required for Japanese query vector indexing. |
| openmetadata-spec/src/main/resources/elasticsearch/ru/query_index_mapping.json | Adds the metadata fields required for Russian query vector indexing. |
| openmetadata-spec/src/main/resources/elasticsearch/zh/query_index_mapping.json | Adds the metadata fields required for Chinese query vector indexing. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Q[Query entity] --> C[QueryBodyTextContributor]
  C --> B[Intent text + capped SQL + usedIn]
  B --> V[Vector embedding pipeline]
  V --> K[data_asset_embeddings_chunks]
  K --> A[dataAssetEmbeddings alias]
  A --> H[Hybrid search scoped to query]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Fixes 32235: make Query entities vector-..."](https://github.com/open-metadata/openmetadata/commit/f35739b39b13ea7f28b7a2d1e5ec3387361811c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57869788)</sub>

<!-- /greptile_comment -->