### PR TITLE
fix(ci): skip UI checkstyle steps whose tooling is absent on the branch

### DIFF
--- a/.github/workflows/ui-checkstyle.yml
+++ b/.github/workflows/ui-checkstyle.yml
@@ -191,7 +191,11 @@ jobs:
           # isolation — it would run the same command with the same privileges.
           if [ -n "$TS_FILES" ]; then
             yarn lint:base -f json $TS_FILES > /tmp/eslint.json 2>/dev/null || true
-            node scripts/eslint-pr-report.js /tmp/eslint.json >> "$GITHUB_OUTPUT"
+            if [ -f scripts/eslint-pr-report.js ]; then
+              node scripts/eslint-pr-report.js /tmp/eslint.json >> "$GITHUB_OUTPUT"
+            else
+              echo "has_findings=false" >> "$GITHUB_OUTPUT"
+            fi
             yarn organize-imports:cli $TS_FILES
           else
             echo "has_findings=false" >> "$GITHUB_OUTPUT"
@@ -400,6 +404,10 @@ jobs:
         continue-on-error: true
         working-directory: ${{ env.CORE_COMPONENTS_WORKING_DIRECTORY }}
         run: |
+          if ! grep -q '"check-i18n-all"' package.json; then
+            echo "check-i18n-all is not defined on this branch — skipping"
+            exit 0
+          fi
           yarn check-i18n-all
           if [ -n "$(git status --porcelain)" ]; then
             FILES=$(git status --porcelain | awk '{print "  - `" $2 "`"}' | head -20)
@@ -445,7 +453,7 @@ jobs:
 
       - name: Tailwind Audit (no hardcoded values)
         id: tw_audit
-        if: steps.changed-src-files.outputs.any_changed == 'true'
+        if: steps.changed-src-files.outputs.any_changed == 'true' && hashFiles('openmetadata-ui/src/main/resources/ui/scripts/tw-audit.js') != ''
         continue-on-error: true
         working-directory: ${{ env.UI_WORKING_DIRECTORY }}
         env:
@@ -467,7 +475,7 @@ jobs:
 
       - name: Antd + Less Deprecation Guard (no new debt)
         id: tw_guard
-        if: steps.changed-ui-files.outputs.any_changed == 'true'
+        if: steps.changed-ui-files.outputs.any_changed == 'true' && hashFiles('openmetadata-ui/src/main/resources/ui/scripts/tw-deprecation-guard.js') != ''
         continue-on-error: true
         env:
           BASE_SHA: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.pull_request.base.sha }}


### PR DESCRIPTION
## Problem

`ui-checkstyle.yml` runs on `pull_request_target`, so PRs targeting a release branch are checked by **main's** copy of the workflow. Four steps invoke tooling that exists only on `main`, so any 1.13 PR that touches a UI file dies before its code is ever examined.

From [run 33163875416](https://github.com/open-metadata/OpenMetadata/actions/runs/33163875416/job/98824705482) (PR #32232, an 11-line change to one `.tsx`):

```
1969: Cannot find module '.../ui/scripts/eslint-pr-report.js'
2255: error Command "check-i18n-all" not found.
2353: Cannot find module '.../ui/scripts/tw-audit.js'
2387: Cannot find module '.../ui/scripts/tw-deprecation-guard.js'
```

The lint itself is `|| true` and cannot fail the build — it is the missing scripts that do. The step runs under `bash -e`, so it aborts before reaching the `git status --porcelain` comparison that decides pass/fail.

## Impact

Every 1.13 PR touching any UI file is currently unmergeable through this check; PRs touching no UI files pass only because the steps skip:

| PR | files | ui-checkstyle |
|---|---|---|
| #32232 | 1 × `ui/src/**` | fail |
| #32237 | 10 × `ui/src/**` | fail |
| #32212 | 1 × `ui/playwright/**` | fail |
| #32202, #32187, #32171 | no UI files | pass (skipped) |

## Fix

Gate each step on the **tooling being present** rather than on a branch name, so older release branches skip what they cannot run. Guarding on files rather than branch names means 1.11 and future release branches are covered without further edits, and `main` is unaffected because it has every file.

The src lint step keeps running everywhere — only its optional PR-report enrichment is guarded — so 1.13 remains lint- and format-checked.

## Verification

- `hashFiles()` is evaluated against the checked-out tree; this job checks out `github.event.pull_request.head.sha`, so it correctly sees the PR branch's contents.
- The aggregator treats `skipped` as non-failing (`[ "skipped" = 'failure' ]`), so guarded steps no longer fail the job.
- YAML parses; all four step conditions resolve as intended.
- Ran main's `tw-audit.js` against the 1.13 file from #32232: `0 errors, 0 warnings, 1 info` — the checks themselves pass on 1.13 content once they can run at all.

Not yet exercised on a real CI run against a release branch; this PR's own run only covers the `main` path, where behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents UI Checkstyle from failing when a target branch lacks newer CI tooling.
- Guards optional ESLint report generation while preserving lint and formatting checks.
- Skips the core-components i18n command when its package script is absent.
- Runs Tailwind audit and deprecation steps only when their scripts exist in the checked-out tree.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the guarded paths and aggregate result handling aligned with the intended release-branch behavior.

The checkout precedes all file-presence checks, the paths match the workspace layout, available linting remains active, and skipped optional steps are not treated as failures.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ui-checkstyle.yml | Adds tooling-presence guards that preserve checks available on the checked-out branch and safely skip unavailable optional steps. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): skip UI checkstyle steps whose ..."](https://github.com/open-metadata/openmetadata/commit/c0a7944cb8e8262ccf314ee536ca0d9c2e4a2260) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57893452)</sub>

<!-- /greptile_comment -->