### PR TITLE
fix(ci): skip Python checkstyle for 1.13 PRs

### DIFF
--- a/.github/workflows/py-checkstyle.yml
+++ b/.github/workflows/py-checkstyle.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   py-checkstyle:
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft && (github.event_name != 'pull_request_target' || github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
+    if: ${{ (github.event_name != 'pull_request_target' || github.base_ref != '1.13') && !github.event.pull_request.draft && (github.event_name != 'pull_request_target' || github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
     permissions:
       pull-requests: write
 


### PR DESCRIPTION
### Describe your changes

Prevent the Python Checkstyle job from running for pull requests targeting the 1.13 branch. Pull requests targeting main and merge queue runs remain unchanged.

This avoids running the current main-branch formatting toolchain against the older 1.13 branch. Follow-up to #32187.

### Type of change

- [x] Bug fix

### Verification

- `actionlint .github/workflows/py-checkstyle.yml`
- Parsed and asserted the exact job condition with `yq`
- `git diff --check origin/main...HEAD`

### UI screen recording / screenshots

Not applicable.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents Python Checkstyle from running for `pull_request_target` events targeting the `1.13` branch while preserving existing behavior for other pull requests and merge-queue runs.

- Adds a `github.base_ref != '1.13'` guard scoped to `pull_request_target`.
- Retains the existing draft and `safe to test` label conditions.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the workflow condition matching its stated branch-specific behavior.

The new predicate excludes only `pull_request_target` events whose base branch is exactly `1.13`; merge-group events and pull requests targeting other branches continue through the existing conditions.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/py-checkstyle.yml | The job condition narrowly skips Python Checkstyle for 1.13-targeted pull requests without changing merge-group execution. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): skip Python checkstyle for 1.13..."](https://github.com/open-metadata/openmetadata/commit/e7a8d2d48dd37f873b888dd85ae13b8ff82e74f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57911317)</sub>

<!-- /greptile_comment -->