### PR TITLE
Fixes 20966: clear sourceHash on PATCH so the bulk fast-path resyncs edited entities

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BulkSourceHashFastPathIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BulkSourceHashFastPathIT.java
@@ -3,6 +3,7 @@ package org.openmetadata.it.tests;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,6 +29,7 @@ import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.entity.services.DatabaseService;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.ColumnDataType;
+import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.api.BulkOperationResult;
 
 /**
@@ -161,6 +163,47 @@ public class BulkSourceHashFastPathIT {
         "soft-deleted table must be restored by the bulk path");
   }
 
+  @Test
+  void test_manualPatchClearsSourceHash_soSameHashReappliesTags(TestNamespace ns) throws Exception {
+    String schemaFqn = setupSchema(ns);
+    String tagFqn = createClassificationAndTag(ns);
+    TagLabel tag =
+        new TagLabel()
+            .withTagFQN(tagFqn)
+            .withSource(TagLabel.TagSource.CLASSIFICATION)
+            .withLabelType(TagLabel.LabelType.MANUAL);
+
+    CreateTable original =
+        table(ns, schemaFqn, "fp_patch_tags", "desc", "hash-patch-tags").withTags(List.of(tag));
+    BulkApi.upsert("tables", List.of(original));
+
+    String fqn = tableFqn(schemaFqn, original.getName());
+    Table created = getTable(fqn);
+    assertTrue(
+        created.getTags() != null
+            && created.getTags().stream().anyMatch(t -> tagFqn.equals(t.getTagFQN())),
+        "tag must be applied on create");
+
+    // Simulate a UI/automation edit that removes the tag via PATCH (out-of-band vs. ingestion).
+    patchTableTagsToEmpty(created.getId().toString());
+
+    Table patched = getTable(fqn);
+    assertTrue(
+        patched.getTags() == null || patched.getTags().isEmpty(),
+        "tag must be cleared by the manual PATCH");
+    assertNull(patched.getSourceHash(), "PATCH must clear the stored sourceHash");
+
+    // Re-ingest the same source content with the same sourceHash. The fast-path must NOT skip the
+    // entity (the stored hash was cleared above), so the source tag is re-applied.
+    BulkApi.upsert("tables", List.of(original));
+
+    Table after = getTable(fqn);
+    assertTrue(
+        after.getTags() != null
+            && after.getTags().stream().anyMatch(t -> tagFqn.equals(t.getTagFQN())),
+        "tag must be re-applied on re-ingest even with a matching sourceHash");
+  }
+
   // ===================================================================
   // HELPERS
   // ===================================================================
@@ -187,6 +230,61 @@ public class BulkSourceHashFastPathIT {
     return schemaFqn + "." + tableName;
   }
 
+  /** Creates a classification + tag over raw HTTP and returns the tag's fully qualified name. */
+  private String createClassificationAndTag(TestNamespace ns) throws Exception {
+    String baseUrl = SdkClients.getServerUrl();
+    String adminToken = SdkClients.getAdminToken();
+
+    String clsName = ns.prefix("fp_cls");
+    String clsBody = "{\"name\":\"" + clsName + "\",\"description\":\"regression classification\"}";
+    HttpResponse<String> clsResp =
+        HTTP_CLIENT.send(
+            HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + "/v1/classifications"))
+                .header("Authorization", "Bearer " + adminToken)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(clsBody))
+                .build(),
+            HttpResponse.BodyHandlers.ofString());
+    assertTrue(
+        clsResp.statusCode() == 200 || clsResp.statusCode() == 201,
+        "create classification: " + clsResp.statusCode() + " " + clsResp.body());
+    String clsFqn = OBJECT_MAPPER.readTree(clsResp.body()).get("fullyQualifiedName").asText();
+
+    String tagBody =
+        "{\"name\":\"fp_tag\",\"description\":\"regression tag\",\"classification\":\""
+            + clsFqn
+            + "\"}";
+    HttpResponse<String> tagResp =
+        HTTP_CLIENT.send(
+            HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + "/v1/tags"))
+                .header("Authorization", "Bearer " + adminToken)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(tagBody))
+                .build(),
+            HttpResponse.BodyHandlers.ofString());
+    assertTrue(
+        tagResp.statusCode() == 200 || tagResp.statusCode() == 201,
+        "create tag: " + tagResp.statusCode() + " " + tagResp.body());
+    return OBJECT_MAPPER.readTree(tagResp.body()).get("fullyQualifiedName").asText();
+  }
+
+  /** PATCHes the table to replace its tags with an empty list (a manual, out-of-band edit). */
+  private void patchTableTagsToEmpty(String tableId) throws Exception {
+    String patchBody = "[{\"op\":\"replace\",\"path\":\"/tags\",\"value\":[]}]";
+    HttpResponse<String> response =
+        HTTP_CLIENT.send(
+            HttpRequest.newBuilder()
+                .uri(URI.create(SdkClients.getServerUrl() + "/v1/tables/" + tableId))
+                .header("Authorization", "Bearer " + SdkClients.getAdminToken())
+                .header("Content-Type", "application/json-patch+json")
+                .method("PATCH", HttpRequest.BodyPublishers.ofString(patchBody))
+                .build(),
+            HttpResponse.BodyHandlers.ofString());
+    assertEquals(200, response.statusCode(), "PATCH table tags: " + response.body());
+  }
+
   private Table getTable(String fqn) throws Exception {
     HttpRequest request =
         HttpRequest.newBuilder()
@@ -195,7 +293,7 @@ public class BulkSourceHashFastPathIT {
                     SdkClients.getServerUrl()
                         + "/v1/tables/name/"
                         + fqn
-                        + "?fields=sourceHash&include=all"))
+                        + "?fields=sourceHash,tags&include=all"))
             .header("Authorization", "Bearer " + SdkClients.getAdminToken())
             .GET()
             .build();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -4373,6 +4373,11 @@ public abstract class EntityRepository<T extends EntityInterface> {
       updated = restorePatchSecrets(original, updated);
     }
 
+    // A PATCH modifies the entity outside the bulk ingestion path. Clear the sourceHash so the
+    // next ingestion's bulk fast-path does not skip a re-sync of the source content (e.g. tags
+    // removed by a UI edit must be re-applied on the next run). The next bulk update re-stamps it.
+    updated.setSourceHash(null);
+
     updated.setUpdatedBy(user);
     updated.setUpdatedAt(System.currentTimeMillis());
 

--- a/openmetadata-spec/src/main/java/org/openmetadata/schema/EntityInterface.java
+++ b/openmetadata-spec/src/main/java/org/openmetadata/schema/EntityInterface.java
@@ -143,6 +143,10 @@ public interface EntityInterface {
     return null;
   }
 
+  default void setSourceHash(String sourceHash) {
+    // No-op for entities that do not declare sourceHash; overridden by generated classes that do.
+  }
+
   void setId(UUID id);
 
   void setDescription(String description);


### PR DESCRIPTION
## Why

Closes #20966.

The bulk `PUT /api/v1/tables/bulk` fast-path (introduced in #28155) skips any entity whose
connector-supplied `sourceHash` matches the stored value, before any field hydration or diffing.
The stored `sourceHash` is **never cleared when an entity is edited out-of-band via PATCH**, so a
manual edit (e.g. a tag removed in the UI) is silently lost on the next ingestion run: the identical
`sourceHash` compares equal and the entity is skipped.

Concretely:
1. Ingestion writes a table with tags -> stored `sourceHash = H(tags)`.
2. Tags are cleared via PATCH (UI/automation/direct API) -> stored `sourceHash` stays `H(tags)`.
3. Next ingestion re-derives the same tags from source -> same hash `H(tags)`.
4. The fast-path sees `H(tags) == H(tags)` -> skip -> tags never restored.

Before 2.0.0 the bulk path processed every entity, so tags always re-synced from source. This is a
regression from the sourceHash feature.

## Fix

Clear `sourceHash` on every PATCH. All PATCH endpoints funnel through
`EntityRepository.patchCommonWithOptimisticLocking`, so this is a single point of change. The next
bulk run then sees a null stored hash, `isSourceHashUnchanged` returns false, and the full diff path
re-applies the source content. The next ingestion re-stamps the hash, so the fix costs at most one
extra reprocess after a manual edit rather than losing the edit permanently.

- `EntityInterface`: add a `default void setSourceHash(String)` no-op (mirrors the existing
  `default String getSourceHash()`); generated entity POJOs that declare `sourceHash` already
  override it with a real setter.
- `EntityRepository.patchCommonWithOptimisticLocking`: set `updated.setSourceHash(null)` before
  persisting, after `restorePatchSecrets` so no hook can restore it.

### Trade-off

Clearing on **every** PATCH also affects ingestion-driven PATCHes (e.g. lineage or bulk description
patches), disabling the fast-path for those entities on the next bulk run. That is a performance
cost, not a correctness one, and only until the next successful ingestion re-stamps the hash. If
that matters for high-volume PATCH connectors, a follow-up could restrict the clear to patches not
authored by the ingestion bot.

## Test

Adds `test_manualPatchClearsSourceHash_soSameHashReappliesTags` to `BulkSourceHashFastPathIT`:
creates a table with a tag and a `sourceHash`, PATCH-clears the tag (asserting the stored
`sourceHash` becomes null), then re-ingests the identical batch and asserts the tag is re-applied -
proving the fast-path does not skip after a manual PATCH edit.

Verified with `mvn spotless:apply` on the touched modules and `mvn compile` on
`openmetadata-spec` (clean). `openmetadata-service` compiles the changed files clean; the full module
build is blocked in this environment by a pre-existing relocated-ES-class error in
`ElasticSearchClient`/`SearchUtils` unrelated to this change.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR invalidates an entity’s stored source hash after a meaningful PATCH so the next bulk ingestion performs a full reconciliation instead of incorrectly taking the unchanged-hash fast path.
- Adds a common optional source-hash setter to the entity interface.
- Clears sourceHash during the shared PATCH lifecycle before persistence.
- Adds an integration test covering tag removal followed by same-hash bulk re-ingestion.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge; the only identified issue is non-blocking redundant commentary in the regression test.

The shared PATCH flow clears and persists sourceHash for meaningful edits, allowing the next bulk ingestion to perform reconciliation, and no blocking correctness or security failure remains.

**Files Needing Attention:** openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BulkSourceHashFastPathIT.java
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java | Clears sourceHash in the common PATCH path; changed PATCHes persist the invalidation without creating a sourceHash-only version event. |
| openmetadata-spec/src/main/java/org/openmetadata/schema/EntityInterface.java | Adds an optional no-op setter so generic repository code can invalidate hashes on generated entities that expose the property. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BulkSourceHashFastPathIT.java | Covers PATCH invalidation and same-hash tag restoration, with minor redundant comments in the new test helpers. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant Patch as PATCH lifecycle
  participant Store
  participant Bulk as Bulk ingestion
  Client->>Patch: Edit entity metadata
  Patch->>Patch: Clear sourceHash
  Patch->>Store: Persist edited entity
  Bulk->>Store: Read stored entity
  Store-->>Bulk: sourceHash is null
  Bulk->>Bulk: Bypass unchanged-hash fast path
  Bulk->>Store: Reconcile source metadata and stamp hash
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fixes 20966: clear sourceHash on PATCH s..."](https://github.com/open-metadata/openmetadata/commit/9fb96f36b36e4e8a8d25b0d25fdfb7f49f407cc3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57911781)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))
- Knowledge Base — [Metadata entity lifecycle](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/metadata-entity-lifecycle.md)
- Knowledge Base — [Metadata schema contracts](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/metadata-schema-contracts.md)
</details>


<!-- /greptile_comment -->