### PR TITLE
ci: scope ui-checkstyle pull_request_target to main

### DIFF
--- a/.github/workflows/ui-checkstyle.yml
+++ b/.github/workflows/ui-checkstyle.yml
@@ -18,6 +18,13 @@ on:
   # inside the workflow via dorny/paths-filter so PRs without UI changes skip
   # the expensive jobs while still reporting a passing status.
   pull_request_target:
+    # main only. Release branches carry their own ui-checkstyle.yml and must be
+    # validated by it: this workflow assumes tooling (eslint-pr-report,
+    # tw-audit, tw-deprecation-guard, core-components check-i18n-all) that older
+    # branches do not have, so running it against them fails on MODULE_NOT_FOUND
+    # before the PR's code is ever examined.
+    branches:
+      - main
     types:
       - opened
       - synchronize


### PR DESCRIPTION
One line: this workflow validates release-branch PRs with **main's** definition, which assumes tooling those branches don't have. Scope it to `main` so every branch is checked by the file that ships with it.

---

## The problem

`ui-checkstyle.yml` answers `pull_request_target` for every base branch, not just `main`. A PR based on `1.13` is therefore validated by main's copy of this workflow — which calls four things that exist only on `main`:

| Called by this workflow | On `main` | On `1.13` |
|---|---|---|
| `ui/scripts/eslint-pr-report.js` | ✅ | ❌ |
| `ui/scripts/tw-audit.js` | ✅ | ❌ |
| `ui/scripts/tw-deprecation-guard.js` | ✅ | ❌ |
| core-components `check-i18n-all` | ✅ | ❌ |

Node exits `MODULE_NOT_FOUND`. From [run 33163875416](https://github.com/open-metadata/OpenMetadata/actions/runs/33163875416/job/98824705482) — PR #32232, an **eleven-line change to one `.tsx` file**:

```
1969: Cannot find module '.../ui/scripts/eslint-pr-report.js'
2255: error Command "check-i18n-all" not found.
2353: Cannot find module '.../ui/scripts/tw-audit.js'
2387: Cannot find module '.../ui/scripts/tw-deprecation-guard.js'
```

### The contributor's code is never examined

Inside the lint step, the crash lands *before* the check that decides pass/fail. The step runs under `bash -e`, so it aborts on the spot:

```bash
yarn lint:base -f json $TS_FILES … || true    # 1. runs — `|| true`, cannot fail the build
node scripts/eslint-pr-report.js …            # 2. CRASHES HERE — file absent on 1.13
yarn organize-imports:cli $TS_FILES           #    never runs
yarn lint:base --fix $CHANGED_FILES           #    never runs
yarn pretty:base --write $CHANGED_FILES       #    never runs
if [ -n "$(git status --porcelain)" ]; then   #    never runs  ← the actual gate
  exit 1
fi
```

The lint that would judge the PR is suffixed `|| true` and cannot fail the build. Only the missing file does. #32232's `.tsx` is clean — locally, ESLint reports zero problems and Prettier reports "All files formatted correctly."

### Scope

Every 1.13 PR touching a UI file is unmergeable through this check. Ones touching no UI files pass only because the steps skip:

| PR | Files touched | `ui-checkstyle` |
|---|---|---|
| #32232 | 1 × `ui/src/**` | ❌ fail |
| #32237 | 10 × `ui/src/**` | ❌ fail |
| #32212 | 1 × `ui/playwright/**` | ❌ fail |
| #32202 | Java only | ✅ pass (skipped) |
| #32187 | `.github/`, `ingestion/` | ✅ pass (skipped) |
