### PR TITLE
fix: preserve nested column metadata during soft-delete restore (#32234)

### DIFF
--- a/ingestion/src/metadata/ingestion/models/patch_request.py
+++ b/ingestion/src/metadata/ingestion/models/patch_request.py
@@ -569,6 +569,51 @@ def _should_update_restricted_field(source_value, dest_value, override_metadata:
     return override_metadata
 
 
+def _merge_nested_columns(
+    source_children: Optional[List],
+    dest_children: Optional[List],
+    restrict_set: set,
+    override_metadata: Optional[bool] = False,  # noqa: UP045
+):
+    """Recursively merge nested column metadata from source to destination.
+
+    When a column has children (nested/struct columns), the merge must
+    preserve user-editable metadata (description, tags, etc.) from the
+    source unless override_metadata is explicitly set.  This mirrors the
+    behaviour of _sort_array_entity_fields for top-level columns.
+    """
+    if not dest_children:
+        return dest_children
+    if not source_children:
+        return dest_children
+
+    source_child_dict = {_get_attribute_name(attr): attr for attr in source_children}
+    merged = []
+    for dest_child in dest_children:
+        source_child = source_child_dict.get(_get_attribute_name(dest_child))
+        if source_child:
+            update_dict = {}
+            for k, v in dest_child.__dict__.items():
+                if k not in dest_child.model_fields_set:
+                    continue
+                if k in restrict_set:
+                    src_val = getattr(source_child, k, None)
+                    if not _should_update_restricted_field(src_val, v, override_metadata):
+                        continue
+                if k == "children":
+                    v = _merge_nested_columns(
+                        getattr(source_child, "children", None),
+                        v,
+                        restrict_set,
+                        override_metadata,
+                    )
+                update_dict[k] = v
+            merged.append(source_child.model_copy(update=update_dict))
+        else:
+            merged.append(dest_child)
+    return merged
+
+
 def _sort_array_entity_fields(
     source: T,
     destination: T,
@@ -606,6 +651,13 @@ def _sort_array_entity_fields(
                             src_val = getattr(source_attr, k, None)
                             if not _should_update_restricted_field(src_val, v, override_metadata):
                                 continue
+                        if k == "children":
+                            v = _merge_nested_columns(
+                                getattr(source_attr, "children", None),
+                                v,
+                                restrict_set,
+                                override_metadata,
+                            )
                         update_dict[k] = v
                     updated_attributes.append(source_attr.model_copy(update=update_dict))
                 else:


### PR DESCRIPTION
Closes #32234

----
## Summary by Gitar

- **Metadata preservation:**
    - Added `_merge_nested_columns` in `patch_request.py` to recursively merge nested column metadata during soft-delete restore.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the existing destination-driven column merge to nested column trees so soft-delete restoration preserves curated metadata recursively.
- Matches nested source and destination children by name.
- Applies existing restricted-field and override rules at every nesting level.
- Retains destination ordering and recursively handles child additions and removals.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or non-blocking issues identified.

The recursive merge consistently applies the existing restricted-field policy while preserving destination-driven nested column structure and ordering.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/models/patch_request.py | Adds recursive nested-column merging that mirrors the established top-level metadata-preservation behavior; no actionable defect was established. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  S[Existing nested columns] --> M[Match children by name]
  D[Restored destination columns] --> M
  M --> R{Restricted field?}
  R -->|Yes| P[Apply metadata override policy]
  R -->|No| U[Use destination value]
  P --> C[Recurse into children]
  U --> C
  C --> O[Merged restored columns]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: preserve nested column metadata dur..."](https://github.com/open-metadata/openmetadata/commit/2f99e4e247d4d569efa85ad42c11264bac7c3283) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57944467)</sub>

<!-- /greptile_comment -->