### PR TITLE
fix: warn when DB-persisted security config overrides yaml/env (#31786)

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/SecurityConfigurationManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/SecurityConfigurationManager.java
@@ -19,6 +19,7 @@ import static org.openmetadata.schema.settings.SettingsType.MCP_CONFIGURATION;
 
 import io.dropwizard.core.setup.Environment;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +29,7 @@ import org.openmetadata.schema.api.security.AuthorizerConfiguration;
 import org.openmetadata.schema.api.security.ClientType;
 import org.openmetadata.schema.configuration.SecurityConfiguration;
 import org.openmetadata.schema.services.connections.metadata.AuthProvider;
+import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplication;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
@@ -118,6 +120,7 @@ public class SecurityConfigurationManager {
           currentState.authenticationConfiguration() != null
               ? currentState.authenticationConfiguration().getProvider()
               : "null");
+      warnIfDbConfigDiffersFromYaml(config);
     } catch (Exception e) {
       LOG.warn(
           "Failed to load configuration from database, falling back to YAML: {}", e.getMessage());
@@ -262,5 +265,42 @@ public class SecurityConfigurationManager {
 
   public static boolean isNativePasswordProvider(AuthProvider provider) {
     return AuthProvider.BASIC.equals(provider) || AuthProvider.OPENMETADATA.equals(provider);
+  }
+
+  /**
+   * Warn if the DB-persisted security configuration differs from the yaml/env configuration.
+   * This prevents silent overrides in Helm/GitOps deployments where the yaml/env changes are
+   * ignored because a DB row already exists.
+   */
+  private void warnIfDbConfigDiffersFromYaml(OpenMetadataApplicationConfig config) {
+    AuthenticationConfiguration yamlAuthConfig = config.getAuthenticationConfiguration();
+    AuthorizerConfiguration yamlAuthzConfig = config.getAuthorizerConfiguration();
+    AuthenticationConfiguration dbAuthConfig = currentState.authenticationConfiguration();
+    AuthorizerConfiguration dbAuthzConfig = currentState.authorizerConfiguration();
+
+    // Compare yaml/env config with DB config. If yaml config is null, DB was seeded from
+    // yaml on first boot, so they should match — no need to warn.
+    if (yamlAuthConfig == null && yamlAuthzConfig == null) {
+      return;
+    }
+
+    boolean authDiffers =
+        yamlAuthConfig != null
+            && !Objects.equals(
+                JsonUtils.pojoToJson(yamlAuthConfig), JsonUtils.pojoToJson(dbAuthConfig));
+    boolean authzDiffers =
+        yamlAuthzConfig != null
+            && !Objects.equals(
+                JsonUtils.pojoToJson(yamlAuthzConfig), JsonUtils.pojoToJson(dbAuthzConfig));
+
+    if (authDiffers || authzDiffers) {
+      LOG.warn(
+          "DB-persisted security configuration differs from yaml/env configuration. "
+              + "The DB configuration will be used. "
+              + "To use the yaml/env configuration, remove the DB-persisted config via "
+              + "'./bootstrap/openmetadata-ops.sh remove-security-config' or "
+              + "DELETE FROM openmetadata_settings WHERE configType IN "
+              + "('authenticationConfiguration','authorizerConfiguration') and restart the server.");
+    }
   }
 }


### PR DESCRIPTION
## Describe the issue

Closes #31786

DB-persisted security configuration (set via UI) silently overrides yaml/env auth config on every startup. Once a row exists in `openmetadata_settings`, any auth config delivered via env vars (docker-compose, Helm chart values, ArgoCD) is ignored — with no warning, no error, and no documented precedence rule.

## Fix

Added `warnIfDbConfigDiffersFromYaml()` in `SecurityConfigurationManager.initialize()` that compares the DB-loaded security configuration with the yaml/env configuration. When they differ, a WARN log is emitted with clear instructions on how to reset to use the yaml/env configuration.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds startup diagnostics when DB-persisted authentication or authorization settings override different YAML/environment configuration.
- Compares loaded DB security settings with deployment configuration after initialization.
- Logs reset instructions when a difference is detected.
- Currently omits differences where the corresponding YAML/environment section is absent.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until the comparison warns when a persisted security section remains after its YAML/environment section is removed.

The new warning path handles differing non-null configurations but skips reachable null-versus-persisted states, preserving the silent override behavior the change is intended to diagnose.

**Files Needing Attention:** openmetadata-service/src/main/java/org/openmetadata/service/security/auth/SecurityConfigurationManager.java
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/security/auth/SecurityConfigurationManager.java | Adds DB-versus-YAML warning logic, but null-side guards miss persisted settings whose deployment section was removed. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Y[YAML / environment security config] --> I[SecurityConfigurationManager.initialize]
  D[(Persisted security settings)] --> I
  I --> C{Configurations differ?}
  C -->|Yes| W[Emit override warning]
  C -->|No| A[Continue with DB configuration]
  C -. YAML section absent .-> A
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: warn when DB-persisted security con..."](https://github.com/open-metadata/openmetadata/commit/b3f2e41dc31dd40b3e03cdbdcd8e0a6653064ab4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57947684)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))
- Knowledge Base — [Platform security and governance](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/platform-security-governance.md)

<!-- /greptile_comment -->