### PR TITLE
fix(ingestion): clear CVE-2026-68082 in the trixie ingestion images (2.0 backport)

### DIFF
--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -47,10 +47,14 @@ RUN apt-get -qq update \
   # openssh -> 1:9.2p1-2+deb12u10, rsync -> 3.2.7-1+deb12u5,
   # curl/libcurl* -> 7.88.1-10+deb12u15, libmariadb3 -> 1:10.11.18-0+deb12u1,
   # wget, perl*, libnss3 -> tracked; upstream fix pending, no-op until Debian ships it).
-  # linux-libc-dev (source pkg "linux") -> kernel headers pulled by libc6-dev; only
-  # used at build time and the container runs the host kernel, so the kernel CVEs it
-  # reports (e.g. CVE-2026-68082, fixed 6.12.105-1) are not reachable at runtime.
-  # Upgraded here for scanner clearance; no-op until Debian security ships the fix.
+  # linux-libc-dev (source pkg "linux") -> kernel headers that libc6-dev pulls in for
+  # build-essential. A container runs the host kernel, so the headers are a build
+  # artifact and the kernel CVEs scanners report against them are not reachable at
+  # runtime. Tracked here so the image takes bookworm-security's kernel headers
+  # rather than whatever the base image froze. This does NOT clear CVE-2026-68082:
+  # that fix exists only in trixie-security (6.12.105-1, DSA-6466-1), and bookworm
+  # and bookworm-security are both still "vulnerable" on the 6.1 line. The image
+  # that reports it is trixie-based -- see ingestion/operators/docker/Dockerfile.
   # --only-upgrade is a no-op for packages not present in the base image.
   && apt-get -qq install -y --only-upgrade \
        libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \

--- a/ingestion/Dockerfile.ci
+++ b/ingestion/Dockerfile.ci
@@ -46,12 +46,20 @@ RUN dpkg --configure -a \
   # openssh -> 1:9.2p1-2+deb12u10, rsync -> 3.2.7-1+deb12u5,
   # curl/libcurl* -> 7.88.1-10+deb12u15, libmariadb3 -> 1:10.11.18-0+deb12u1,
   # wget, perl*, libnss3 -> tracked; upstream fix pending, no-op until Debian ships it).
+  # linux-libc-dev (source pkg "linux") -> kernel headers that libc6-dev pulls in for
+  # build-essential. A container runs the host kernel, so the headers are a build
+  # artifact and the kernel CVEs scanners report against them are not reachable at
+  # runtime. Tracked here so the image takes bookworm-security's kernel headers
+  # rather than whatever the base image froze. This does NOT clear CVE-2026-68082:
+  # that fix exists only in trixie-security (6.12.105-1, DSA-6466-1), and bookworm
+  # and bookworm-security are both still "vulnerable" on the 6.1 line. The image
+  # that reports it is trixie-based -- see ingestion/operators/docker/Dockerfile.
   # --only-upgrade is a no-op for packages not present in the base image.
   && apt-get -qq install -y --only-upgrade \
        libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
        libpam0g libpam-modules libpam-modules-bin libpam-runtime \
        curl libcurl4 libcurl3-gnutls libmariadb3 wget \
-       perl perl-base perl-modules-5.36 libperl5.36 libnss3 \
+       perl perl-base perl-modules-5.36 libperl5.36 libnss3 linux-libc-dev \
   && apt-get -qq purge -y \
        'imagemagick*' 'libmagick*' 'graphicsmagick*' \
   && apt-get -qq autoremove -y --purge \

--- a/ingestion/operators/docker/Dockerfile
+++ b/ingestion/operators/docker/Dockerfile
@@ -208,6 +208,14 @@ RUN pip install psycopg2 mysqlclient==2.1.1
 # 3.5.6-1~deb13u2, while trixie-security carries the CVE-2026-14457 fix in
 # 3.5.7-1~deb13u2. Querying the source package upgrades openssl, libssl3t64,
 # and libssl-dev together so no scanner-visible binary is left behind.
+# linux-libc-dev is the third, and the reason CVE-2026-68082 is reported against
+# this image: libc6-dev pulls the kernel headers in for build-essential, a
+# container runs the host kernel so they are a build artifact whose kernel CVEs
+# are not reachable at runtime, but scanners flag the installed version anyway.
+# trixie-security carries the fixed 6.12.105-1 (DSA-6466-1), so this clears the
+# finding on the next build rather than being a speculative no-op. Purging it
+# instead would cascade through libc6-dev to build-essential and break runtime
+# pip builds of C extensions.
 # The package sets are computed from dpkg rather than hand-listed. One source
 # package produces many binaries -- here util-linux, bsdutils, login, mount,
 # liblastlog2-2, libblkid1, libmount1, libsmartcols1 and libuuid1 -- and scanners
@@ -215,10 +223,11 @@ RUN pip install psycopg2 mysqlclient==2.1.1
 # binary it forgot, and liblastlog2-2 is exactly the one that is easy to forget.
 # Asking dpkg which installed packages came from the source cannot miss one, and
 # stays correct if Debian splits the source differently later.
-# util-linux is asserted non-empty and expat deliberately is not: util-linux is
-# Essential, so an empty query there means dpkg-query misbehaved and the build
-# must not continue, whereas expat is transitive and an empty query is a
-# legitimate image with nothing to patch. Asserting one of the two is what the
+# util-linux and openssl are asserted non-empty; expat and linux-libc-dev
+# deliberately are not. util-linux and openssl are explicitly installed, so an
+# empty query there means dpkg-query misbehaved and the build must not continue,
+# whereas the other two are transitive and an empty query is a legitimate image
+# with nothing to patch. Asserting the required packages is what the
 # check is for -- `apt-get install --only-upgrade` with no package arguments
 # exits 0, so an all-empty query would give a green build that shipped the
 # vulnerable packages anyway. Fail closed.
@@ -233,8 +242,9 @@ RUN set -eu; \
     ex="$(dpkg-query -W -f='${source:Package} ${Package}\n' | awk '$1=="expat"{print $2}')"; \
     ossl="$(dpkg-query -W -f='${source:Package} ${Package}\n' | awk '$1=="openssl"{print $2}')"; \
     [ -n "$ossl" ] || { echo "no src:openssl packages found; refusing to skip the OpenSSL CVE patch" >&2; exit 1; }; \
+    kh="$(dpkg-query -W -f='${source:Package} ${Package}\n' | awk '$1=="linux"{print $2}')"; \
     apt-get -qq update; \
-    apt-get -qq install -y --only-upgrade $ul $ex $ossl; \
+    apt-get -qq install -y --only-upgrade $ul $ex $kh $ossl; \
     apt-get -qq purge -y libmariadb-dev libmariadb-dev-compat libunbound8; \
     apt-mark manual libmariadb3 mariadb-common; \
     apt-get -qq autoremove -y --purge; \

--- a/ingestion/operators/docker/Dockerfile.ci
+++ b/ingestion/operators/docker/Dockerfile.ci
@@ -216,6 +216,14 @@ RUN pip install psycopg2 mysqlclient==2.1.1
 # 3.5.6-1~deb13u2, while trixie-security carries the CVE-2026-14457 fix in
 # 3.5.7-1~deb13u2. Querying the source package upgrades openssl, libssl3t64,
 # and libssl-dev together so no scanner-visible binary is left behind.
+# linux-libc-dev is the third, and the reason CVE-2026-68082 is reported against
+# this image: libc6-dev pulls the kernel headers in for build-essential, a
+# container runs the host kernel so they are a build artifact whose kernel CVEs
+# are not reachable at runtime, but scanners flag the installed version anyway.
+# trixie-security carries the fixed 6.12.105-1 (DSA-6466-1), so this clears the
+# finding on the next build rather than being a speculative no-op. Purging it
+# instead would cascade through libc6-dev to build-essential and break runtime
+# pip builds of C extensions.
 # The package sets are computed from dpkg rather than hand-listed. One source
 # package produces many binaries -- here util-linux, bsdutils, login, mount,
 # liblastlog2-2, libblkid1, libmount1, libsmartcols1 and libuuid1 -- and scanners
@@ -223,10 +231,11 @@ RUN pip install psycopg2 mysqlclient==2.1.1
 # binary it forgot, and liblastlog2-2 is exactly the one that is easy to forget.
 # Asking dpkg which installed packages came from the source cannot miss one, and
 # stays correct if Debian splits the source differently later.
-# util-linux is asserted non-empty and expat deliberately is not: util-linux is
-# Essential, so an empty query there means dpkg-query misbehaved and the build
-# must not continue, whereas expat is transitive and an empty query is a
-# legitimate image with nothing to patch. Asserting one of the two is what the
+# util-linux and openssl are asserted non-empty; expat and linux-libc-dev
+# deliberately are not. util-linux and openssl are explicitly installed, so an
+# empty query there means dpkg-query misbehaved and the build must not continue,
+# whereas the other two are transitive and an empty query is a legitimate image
+# with nothing to patch. Asserting the required packages is what the
 # check is for -- `apt-get install --only-upgrade` with no package arguments
 # exits 0, so an all-empty query would give a green build that shipped the
 # vulnerable packages anyway. Fail closed.
@@ -241,8 +250,9 @@ RUN set -eu; \
     ex="$(dpkg-query -W -f='${source:Package} ${Package}\n' | awk '$1=="expat"{print $2}')"; \
     ossl="$(dpkg-query -W -f='${source:Package} ${Package}\n' | awk '$1=="openssl"{print $2}')"; \
     [ -n "$ossl" ] || { echo "no src:openssl packages found; refusing to skip the OpenSSL CVE patch" >&2; exit 1; }; \
+    kh="$(dpkg-query -W -f='${source:Package} ${Package}\n' | awk '$1=="linux"{print $2}')"; \
     apt-get -qq update; \
-    apt-get -qq install -y --only-upgrade $ul $ex $ossl; \
+    apt-get -qq install -y --only-upgrade $ul $ex $kh $ossl; \
     apt-get -qq purge -y libmariadb-dev libmariadb-dev-compat libunbound8; \
     apt-mark manual libmariadb3 mariadb-common; \
     apt-get -qq autoremove -y --purge; \


### PR DESCRIPTION
### Describe your changes:

Completes the 2.0 backport of #32146. That PR had **two** commits and #32169 carried only the first, `c525581fdf`, which touches `ingestion/Dockerfile` alone. This cherry-picks the second, `28030b4bad`, which is the one that covers `ingestion/operators/docker/Dockerfile*`.

That distinction is the whole point: `ingestion/Dockerfile` builds the bookworm airflow image, and per its own comment the change is a no-op for CVE-2026-68082, since bookworm and bookworm-security are both still vulnerable on the 6.1 line. The 204 findings are reported against `ingestion-slim`, which is built from the two `operators/docker` Dockerfiles. So the merged backport cleared nothing.

Evidence from the 2026-08-29 nightly (`2.0n77`, build tag `2.0-202608290000`):

- `linux` is still **204 findings at 6.12.101**, unchanged from the 08-28 scan, on a genuinely rebuilt image (digest `974e3b67…` to `df341429…`).
- `openssl` went **8 to 0** in that same build, from the same `--only-upgrade` line, which is what makes the omission visible.
- A fresh `python:3.12-slim-trixie` resolves `linux-libc-dev` to `6.12.107-1` today, newer than the `0:6.12.105-1` Inspector asks for, so the upgrade is reachable. The image sits at 6.12.101 only because the frozen top-of-file apt layer installed it and nothing lifts it.

Clears 204 findings, 44 Critical and 159 High.

The equivalent fix for 1.13 is on #32168.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

Cherry-pick, not a new approach. Both slim Dockerfiles conflicted because 2.0 gained the openssl upgrade (#32215) after main's commit was written. Resolved by keeping both, so the late `--only-upgrade` block is byte-identical to main:

    apt-get -qq install -y --only-upgrade $ul $ex $kh $ossl; \

The assertion comment is also restored to main's current wording, which names openssl. That hunk applied cleanly rather than conflicting and would otherwise have silently reverted to pre-openssl text contradicting the code below it.

`kh` is deliberately not asserted non-empty, matching main, because it is transitive.

#
### Tests:

#### Use cases covered
- A rebuilt 2.0 `ingestion-slim` ships `linux-libc-dev` at the current trixie-security version rather than 6.12.101.
- The 204 `linux` findings clear on the next nightly scan.

#### Unit tests
Not applicable. Container build configuration, no application code.

#### Backend integration tests
Not applicable. No backend API changes.

#### Ingestion integration tests
Not applicable. No connector or framework code changes.

#### Playwright (UI) tests
Not applicable. No UI changes.

#### Manual testing performed

1. Confirmed the fix is reachable in the base image:

       docker run --rm python:3.12-slim-trixie sh -c 'apt-get -qq update && apt-cache policy linux-libc-dev'
       Candidate: 6.12.107-1   (trixie-security)

2. Verified both slim Dockerfiles now contain the `src:linux` query and that the comment plus code region is byte-identical to `origin/main`.
3. Verified no duplicate `linux-libc-dev` entry in either airflow Dockerfile's `--only-upgrade` list.
4. `docker build --check` passes on all four Dockerfiles.

Full image builds not run locally. CI covers those.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: N/A.
- [ ] For UI changes: N/A.
- [ ] I have added tests: N/A, container build configuration change. Manual verification listed above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR completes the CVE-2026-68082 backport by refreshing installed packages sourced from Debian’s `linux` package in both trixie-based slim ingestion images.
- Adds the late `linux-libc-dev` upgrade to production and CI slim-image builds so cached package indexes do not retain vulnerable headers.
- Aligns the Airflow CI Dockerfile with the corresponding production upgrade list.
- Clarifies why the bookworm images cannot clear this trixie-specific scanner finding.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or build regressions identified.

The changed package query follows the existing source-package upgrade pattern, operates after a fresh apt index update, tolerates an absent transitive package, and is applied consistently to both trixie slim-image variants.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/Dockerfile | Rewords the existing kernel-header explanation to distinguish the unaffected bookworm image from the trixie-based slim image. |
| ingestion/Dockerfile.ci | Adds `linux-libc-dev` to the existing bookworm security-upgrade list and aligns its explanatory comments with production. |
| ingestion/operators/docker/Dockerfile | Discovers installed binaries sourced from Debian’s `linux` package and includes them in the late trixie-security upgrade. |
| ingestion/operators/docker/Dockerfile.ci | Mirrors the production slim-image kernel-header upgrade in the CI image definition. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ingestion): clear CVE-2026-68082 in ..."](https://github.com/open-metadata/openmetadata/commit/bc5a5df010762be452b1d32402cdea3c177862a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58278171)</sub>

<!-- /greptile_comment -->