### PR TITLE
fix(security): bump httpclient5 to 5.6.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -832,12 +832,18 @@
         Keep this in step with the httpcore5 pin above - Apache releases the two together
         and mixing lines breaks search. httpclient5 5.5/5.5.2 are built against httpcore5
         5.3.x; on 5.4.x their I/O reactor dispatchers die silently, leaking connection-pool
-        leases until every request fails with DeadlineTimeoutException. 5.6.3 declares
+        leases until every request fails with DeadlineTimeoutException. 5.6.4 declares
         httpcore5 5.4.3, so client and core match.
 
-        5.6.3 is also the first release outside the CVE-2026-64607 range (affects
+        5.6.3 was the first release outside the CVE-2026-64607 range (affects
         5.0-alpha1 through 5.6.2: the classic i/o client leaks a connection when a response
         carries an invalid Content-Encoding).
+
+        5.6.4 clears CVE-2026-71290: on 5.4 through 5.6.3 HostnameVerificationPolicy#BUILTIN
+        has no effect on the async client, so TLS hostname verification is silently skipped
+        and a MITM can present a certificate for any domain. Both search transports build
+        async clients (ClientTlsStrategyBuilder in OpenSearchClient/ElasticSearchClient), so
+        this pin is what enforces hostname verification there. Do not drop below 5.6.4.
 
         The 5.6 line enables automatic content decompression in the async client, which the
         search transports also do - see disableContentCompression() in OpenSearchClient and
@@ -846,7 +852,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents.client5</groupId>
         <artifactId>httpclient5</artifactId>
-        <version>5.6.3</version>
+        <version>5.6.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
## Advisory

**CVE-2026-71290** — *Apache HttpComponents Client: TLS hostname verification silently disabled on the async transport (default config, MITM)*. CVSS **9.1**, CWE-295 (Improper Certificate Validation). Snyk ID `SNYK-JAVA-ORGAPACHEHTTPCOMPONENTSCLIENT5-19432178`.

> Improper TLS hostname verification vulnerability in Apache HttpComponents Client 5.4 or newer. `HostnameVerificationPolicy#BUILTIN` setting has no effect when used with the async version of HttpClient. An attacker that can intercept and modify traffic between the client and the server can impersonate the server by presenting a valid certificate for a different domain. Please note the classic version of HttpClient is not affected by this vulnerability. Affected users are recommended to upgrade to at least version 5.6.4, which fixes the issue.
> — OSV `CVE-2026-71290`, references [oss-security 2026/08/13](http://www.openwall.com/lists/oss-security/2026/08/13/6)

## Raw scanner finding

From `server-dep-scan.json`, security-scan run [33345460291](https://github.com/open-metadata/OpenMetadata/actions/runs/33345460291) (head `7b1bc6b6a1`):

```
severity=critical  package=org.apache.httpcomponents.client5:httpclient5  version=5.6.3
  title="Improper Certificate Validation"  cvss=9.1  CWE-295  CVE-2026-71290
  id=SNYK-JAVA-ORGAPACHEHTTPCOMPONENTSCLIENT5-19432178  fixedIn=['5.6.4']
  from=['org.open-metadata:openmetadata-dist@2.0.0-SNAPSHOT',
        'org.open-metadata:openmetadata-service@2.0.0-SNAPSHOT',
        'org.apache.calcite:calcite-core@1.42.0',
        'org.apache.calcite.avatica:avatica-core@1.28.0',
        'org.apache.httpcomponents.client5:httpclient5@5.6.3']
```

Reported against 6 Maven projects: `openmetadata-dist`, `openmetadata-service`, `openmetadata-mcp`, `openmetadata-k8s-operator`, `elasticsearch-deps`, `opensearch-deps`.

## Why this repo is genuinely exposed

The CVE only affects the **async** transport. OpenMetadata's search clients are async and build their own TLS strategy:

- `openmetadata-service/.../search/elasticsearch/ElasticSearchClient.java:833-886` — `httpAsyncClientBuilder` callback, `ClientTlsStrategyBuilder.create().setSslContext(...)` at :852-853
- `openmetadata-service/.../search/opensearch/OpenSearchClient.java:906-907` — same `ClientTlsStrategyBuilder` path

So any deployment talking to Elasticsearch/OpenSearch over TLS is on the affected code path.

## What was verified

- **The fix version is real.** `httpclient5-5.6.4.pom` and `.jar` both return HTTP 200 from repo1.maven.org. (Maven Central's `solrsearch` API reports 5.6.1 as newest — it is stale; `maven-metadata.xml` and direct artifact fetch are authoritative and both confirm 5.6.4.)
- **`httpcore5` alignment holds — this is the constraint the existing pom comment exists to protect.** `httpclient5-parent:5.6.4` declares `<httpcore.version>5.4.3</httpcore.version>`, byte-identical to `httpclient5-parent:5.6.3`. The root pom's separate `httpcore5`/`httpcore5-h2` pins at 5.4.3 stay correct and unchanged.
- **Resolution confirmed against the reactor, not assumed:** `mvn dependency:tree -pl openmetadata-service -Dincludes='org.apache.httpcomponents.client5:*,org.apache.httpcomponents.core5:*'` → BUILD SUCCESS, resolving `httpclient5:5.6.4` with `httpcore5-h2:5.4.3` and `httpcore5:5.4.3`.
- **`mvn -N validate`** on the edited root pom: exit 0.
- **Patch bump inside the 5.6 line**, so the async content-decompression behaviour the pom comment warns about is unchanged; the `disableContentCompression()` calls in both search clients are untouched.
- **No other pin to keep in sync** — `git grep` finds no other `httpclient5` 5.6.3 reference anywhere in the repo.

## Manifests touched

- `pom.xml` — `httpclient5` `5.6.3` → `5.6.4` (one version line), plus the surrounding explanatory comment updated so the next person touching this pin knows why it must not drop below 5.6.4.

No lockfile applies (Maven).

## What was NOT tested

- **No build beyond dependency resolution.** `mvn compile`/`package` was not run; no unit tests, no integration tests, no `openmetadata-service` startup.
- **No search-path exercise.** Neither `ElasticSearchClient` nor `OpenSearchClient` was run against a live Elasticsearch or OpenSearch, over TLS or otherwise. Connection behaviour, content-compression handling and connection-pool behaviour on 5.6.4 are unverified empirically.
- **CVE not reproduced**, and hostname verification was not observed being enforced after the bump — the claim rests on the upstream advisory.
- **No diff of 5.6.3 → 5.6.4 behaviour** beyond confirming the declared `httpcore5` version is unchanged.

That gap is why this is a draft. Please let CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
