### PR TITLE
fix(security): bump httpclient5 to 5.6.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -832,12 +832,14 @@
         Keep this in step with the httpcore5 pin above - Apache releases the two together
         and mixing lines breaks search. httpclient5 5.5/5.5.2 are built against httpcore5
         5.3.x; on 5.4.x their I/O reactor dispatchers die silently, leaking connection-pool
-        leases until every request fails with DeadlineTimeoutException. 5.6.3 declares
-        httpcore5 5.4.3, so client and core match.
+        leases until every request fails with DeadlineTimeoutException. 5.6.4 declares
+        httpcore5 5.4.3 (identical to 5.6.3), so client and core match.
 
-        5.6.3 is also the first release outside the CVE-2026-64607 range (affects
+        5.6.3 was the first release outside the CVE-2026-64607 range (affects
         5.0-alpha1 through 5.6.2: the classic i/o client leaks a connection when a response
-        carries an invalid Content-Encoding).
+        carries an invalid Content-Encoding). 5.6.4 additionally closes CVE-2026-71290
+        (improper certificate validation: HostnameVerificationPolicy#BUILTIN had no effect on
+        the async TLS upgrade path, so SSL parameters were not applied).
 
         The 5.6 line enables automatic content decompression in the async client, which the
         search transports also do - see disableContentCompression() in OpenSearchClient and
@@ -846,7 +848,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents.client5</groupId>
         <artifactId>httpclient5</artifactId>
-        <version>5.6.3</version>
+        <version>5.6.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
## Advisory

**CVE-2026-71290** — *Improper Certificate Validation* (CWE-295), **critical**, CVSS 9.1 (`CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N`). Fixed in httpclient5 **5.6.4**.

`HostnameVerificationPolicy#BUILTIN` has no effect in the async transport, so SSL parameters are not applied on the async TLS upgrade path. An attacker who can intercept and modify traffic can impersonate a server by presenting a certificate that is valid for a different domain.

Upstream fix commit: [`2422b6c8`](https://github.com/apache/httpcomponents-client/commit/2422b6c89aaacb8d25823b7535479a6fb5a09d0d) — "Corrects application of SSL parameters in the async TLS upgrade method".

## Change

Root `pom.xml` `dependencyManagement`: `httpclient5` `5.6.3` → `5.6.4`, plus the pin comment updated to record the CVE. 1 file.

## Why this is safe

- **httpcore5 pairing preserved.** 5.6.4 declares `httpcore5 5.4.3`, byte-identical to 5.6.3. The root pom pins `httpcore5`/`httpcore5-h2` at 5.4.3, so client and core stay matched — the `SingleCoreIOReactor` / OpenSearch lease-leak failure mode documented in the pin comment is not reintroduced.
- **Still within the 5.6 line.** The `disableContentCompression()` requirement on the `OpenSearchClient` / `ElasticSearchClient` search transports is unchanged.
- **Patch bump, not a line change.** Same override mechanism already in `dependencyManagement`; widens nothing.

## Relationship to Collate

Mirrors open-metadata/openmetadata-collate#6277. The OSS root `dependencyManagement` is the authority for the OSS build; Collate consumes OSS as a submodule and carries its own override, so both repos need the bump independently.

## Not tested

No build run — no `mvn clean package`, `mvn test`, or `mvn dependency:tree` to confirm 5.6.4 resolves through each affected module. The vulnerability was not reproduced; the fix was verified only by confirming the referenced commit is an ancestor of the 5.6.4 tag and absent from 5.6.3. Search was not exercised end-to-end against OpenSearch/Elasticsearch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR upgrades the managed Apache HttpClient 5 dependency from 5.6.3 to 5.6.4 to incorporate the async TLS hostname-verification fix while retaining the existing HttpCore 5.4.3 pairing.
- Updates the root `dependencyManagement` version for `httpclient5`.
- Documents the addressed certificate-validation vulnerability and preserved search-client compatibility constraints.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified in the dependency bump.

The managed HttpClient version remains paired with the existing HttpCore version, and the repository’s OpenSearch and Elasticsearch transports retain the configuration required for the 5.6 dependency line.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| pom.xml | Updates the HttpClient patch version and compatibility rationale without introducing an identified build, runtime, or dependency-alignment regression. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): bump httpclient5 to 5.6.4"](https://github.com/open-metadata/openmetadata/commit/5a6bb27f0099a2ddd66cbded5f84af00068ac51e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58515869)</sub>

<!-- /greptile_comment -->