### PR TITLE
fix(security): bump jsoup to 1.23.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -853,6 +853,17 @@
         <artifactId>commons-compress</artifactId>
         <version>1.26.0</version>
       </dependency>
+      <!-- CVE-2026-75140: quadratic memory in XmlTreeBuilder namespace-map copying lets a
+           deeply nested, uniquely-namespaced XML document exhaust the heap. Vulnerable through
+           1.23.1; the fix (jsoup PR #2556) ships in 1.23.2. jsoup is not declared by any module -
+           it arrives only as a transitive of flexmark-html2md-converter, which declares 1.15.4.
+           That is a soft requirement, so managing it here overrides it. Remove this pin only if
+           flexmark ever ships a release declaring 1.23.2 or newer itself (0.64.8 is its latest). -->
+      <dependency>
+        <groupId>org.jsoup</groupId>
+        <artifactId>jsoup</artifactId>
+        <version>1.23.2</version>
+      </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcpkix-jdk18on</artifactId>


### PR DESCRIPTION
## Advisory

**CVE-2026-75140** — *jsoup Uncontrolled Resource Consumption in XmlTreeBuilder*. CVSS **8.7**, CWE-770. Snyk ID `SNYK-JAVA-ORGJSOUP-19233597`.

> jsoup … contains an uncontrolled resource consumption vulnerability in `XmlTreeBuilder` that allows remote attackers to exhaust JVM heap memory by supplying a deeply nested XML document with uniquely-namespaced elements. The builder copies the entire inherited namespace map on every start element, causing quadratic time and memory complexity, which attackers can exploit to trigger an `OutOfMemoryError` and terminate the application.
> — OSV `CVE-2026-75140`

## Raw scanner finding

From `server-dep-scan.json`, security-scan run [33345460291](https://github.com/open-metadata/OpenMetadata/actions/runs/33345460291) (head `7b1bc6b6a1`):

```
severity=high  package=org.jsoup:jsoup  version=1.15.4
  title="Allocation of Resources Without Limits or Throttling"  cvss=8.7  CWE-770  CVE-2026-75140
  id=SNYK-JAVA-ORGJSOUP-19233597  fixedIn=['1.23.2']
  from=['org.open-metadata:openmetadata-dist@2.0.0-SNAPSHOT',
        'org.open-metadata:openmetadata-service@2.0.0-SNAPSHOT',
        'com.vladsch.flexmark:flexmark-html2md-converter@0.64.8',
        'org.jsoup:jsoup@1.15.4']
```

## Why this is being fixed now, after two runs of being called unfixable

The previous two triage runs classified this **unfixable**: Snyk reported `fixedIn: []`, and OSV's prose said *"jsoup through 1.23.2, fixed in commit 862ba2f"* — i.e. the fix existed only as an unreleased commit while 1.23.2 was already the newest release. Snyk has since flipped to `fixedIn: ['1.23.2']`. Rather than trust either scanner flipping its answer, this was re-derived from upstream:

- **jsoup PR [#2556](https://github.com/jhy/jsoup/pull/2556)** ("Optimize XML namespace scope tracking") merged **2026-08-09**, merge commit `862ba2f1d48e` — the exact commit OSV names as the fix.
- **The `jsoup-1.23.2` tag is commit `fbc7775c46`.** GitHub compare `862ba2f…jsoup-1.23.2` returns `status: ahead, ahead_by: 39, behind_by: 0` — so **`862ba2f` is an ancestor of the 1.23.2 tag**; the fix is in the release.
- **jsoup's own `CHANGES.md` at tag `jsoup-1.23.2`** lists it under `## 1.23.2 (2026-Aug-26)`: *"Improved XML parser performance and memory use for documents with many nested namespace declarations by recording namespace changes within each element scope. #2556"*.
- OSV's structured `GIT` range now carries **two** `fixed` events — `862ba2f…` and `fbc7775c…` (the 1.23.2 tag). Its free-text `details` field still reads "through 1.23.2" and is stale.

So 1.23.2 genuinely fixes it, and this is a real bucket-D finding rather than an advisory artefact.

## Why a `dependencyManagement` pin rather than bumping the owner

`jsoup` is declared in **no** module POM — `mvn dependency:tree -pl openmetadata-service -Dincludes='org.jsoup:*'` shows exactly one path, `\- org.jsoup:jsoup:jar:1.15.4:compile`, under `flexmark-html2md-converter`.

`flexmark-html2md-converter:0.64.8`'s POM declares `<version>1.15.4</version>` for jsoup. In Maven that is a **soft** requirement, not a hard range, so root `dependencyManagement` overrides it without a resolver conflict. **0.64.8 is flexmark's current `<release>` on Maven Central**, so there is no owner bump available — the pin is the only path.

## What was verified

- **The fix version is real.** `org.jsoup:jsoup` `maven-metadata.xml` `<release>` is `1.23.2`; the jar's `Last-Modified` is 2026-08-26. (Maven Central's `solrsearch` API reports 1.21.1 as newest — it is stale for several artifacts; `maven-metadata.xml` is authoritative.)
- **Binary compatibility of flexmark against jsoup 1.23.2 — checked at the bytecode level, not assumed.** `flexmark-html2md-converter-0.64.8.jar` was disassembled (`javap -p -v` over all 31 classes) and every constant-pool reference into `org.jsoup` extracted: **39 distinct members**. Each was checked against the declared-member set of jsoup 1.23.2 (`javap -p -v` over all 315 classes).
  - 37 resolve directly.
  - The 2 apparent misses are `Element.nextElementSibling()` and `Element.previousElementSibling()`. These **moved from `Element` up to its superclass `Node` in 1.23.2, keeping the identical descriptor `()Lorg/jsoup/nodes/Element;`**. `Element extends Node`, so JVM method resolution (JVMS §5.4.3.3) finds them via the superclass — binary compatible. Confirmed by `javap -p` on both `Element.class` and `Node.class` in the 1.23.2 jar.
  - A control run of the same extractor against jsoup **1.15.4** flags 7 of the 39 as "missing" too; those are inherited members (`Element.attr`, `Elements.get/size/isEmpty/iterator`) that the declared-member extractor cannot see. That control is what isolates the 2 genuine moves from extractor noise.
- **First-party source compatibility.** `openmetadata-service/.../notifications/channels/HtmlToMarkdownAdapter.java` is the only first-party file importing jsoup (`org.jsoup.nodes.Element`, `org.jsoup.select.Elements`). Every member it calls — `selectFirst(String)`, `select(String)`, `wholeText()`, `className()`, `text()`, `attr(String)`, `parent()`, `tagName()` — is present in 1.23.2 with a matching signature, verified with `javap`.
- **Resolution confirmed against the reactor:** `mvn dependency:tree -pl openmetadata-service -Dincludes='org.jsoup:*'` → BUILD SUCCESS, `\- org.jsoup:jsoup:jar:1.23.2:compile`.
- **`mvn -N validate`** on the edited root pom: exit 0.

## Manifests touched

- `pom.xml` — new `<dependencyManagement>` entry pinning `org.jsoup:jsoup` to `1.23.2`, with a comment recording the CVE, why the pin exists, and the condition under which it should be removed.

No lockfile applies (Maven). No module POM needed a change; the root pin covers all four modules Snyk flagged (`openmetadata-dist`, `openmetadata-service`, `openmetadata-mcp`, `openmetadata-k8s-operator`).

## What was NOT tested

- **`mvn compile` on `openmetadata-service` could not be used as a signal on this machine.** It fails at baseline: **410 errors, all Lombok-generated members** (`variable LOG` ×78, `method builder()` ×14, `@Getter` accessors), because the local JDK is **22.0.2** while the project targets Java 21. To confirm this is unrelated to the change, the same compile was run on **unmodified `origin/main`** and on this branch: **both produce 410 errors and the two error sets are byte-identical (`diff` empty).** Zero errors mention jsoup, flexmark, or `HtmlToMarkdownAdapter` in either run. So the pin demonstrably changes nothing about the compile — but **this branch has not been observed compiling green anywhere.** CI is the first real compile.
- **No tests of any kind.** No unit tests, no ITs, no `HtmlToMarkdownAdapter` exercise. HTML→Markdown conversion output was not compared before/after across 8 minor jsoup versions (1.15.4 → 1.23.2).
- **CVE not reproduced**; no deeply-nested-XML input was run against either version.
- **One behaviour change in 1.23.2 worth a reviewer's eye, not covered by the API check:** its changelog records *"Aligned the XML parser stack depth and lookups to the configured maximum, which now defaults to 512 for both HTML and XML"* (`Parser#setMaxDepth(int)`). HTML nested deeper than 512 levels may now be handled differently by `FlexmarkHtmlConverter`. Not exercised.

That gap is why this is a draft. Please let CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR pins the transitive `org.jsoup:jsoup` dependency to version 1.23.2 at the root dependency-management level to remediate CVE-2026-75140.
- Overrides the older jsoup version brought in by `flexmark-html2md-converter`
- Applies the fixed version across inheriting Maven modules and packaged service dependencies
- Documents the reason for the pin and its removal condition
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, subject to the normal CI compile checks already identified in the PR description.

The root dependency-management entry reaches the only jsoup consumer and the distribution packaging path, while the available compatibility evidence does not reveal a broken API or runtime contract.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| pom.xml | Adds an effective root-level jsoup 1.23.2 dependency-management pin; no actionable correctness or compatibility defect was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): bump jsoup to 1.23.2"](https://github.com/open-metadata/openmetadata/commit/99e150d21ca2c481b907b21105e938597958bf8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58518745)</sub>

<!-- /greptile_comment -->