### PR TITLE
ci(playwright): run release-branch nightly E2E with 2 per-test retries

### DIFF
--- a/.github/workflows/mysql-nightly-e2e.yml
+++ b/.github/workflows/mysql-nightly-e2e.yml
@@ -76,5 +76,8 @@ jobs:
       full_suite: ${{ inputs.full_suite }}
       protocol: ${{ inputs.protocol }}
       coarse_bundle: ${{ inputs.coarse_bundle }}
+      # Release branches accumulate flakes faster than main; give each test
+      # two retries instead of the config default of one.
+      retries: "2"
       send_slack_notification: ${{ inputs.send_slack_notification }}
       slack_run_title: "MySQL Playwright E2E on ${{ inputs.branch }}"

--- a/.github/workflows/mysql-nightly-e2e.yml
+++ b/.github/workflows/mysql-nightly-e2e.yml
@@ -78,6 +78,6 @@ jobs:
       coarse_bundle: ${{ inputs.coarse_bundle }}
       # Release branches accumulate flakes faster than main; give each test
       # two retries instead of the config default of one.
-      retries: "2"
+      retries: 2
       send_slack_notification: ${{ inputs.send_slack_notification }}
       slack_run_title: "MySQL Playwright E2E on ${{ inputs.branch }}"

--- a/.github/workflows/playwright-e2e-reusable.yml
+++ b/.github/workflows/playwright-e2e-reusable.yml
@@ -64,6 +64,15 @@ on:
         required: false
         type: boolean
         default: true
+      retries:
+        description: >-
+          Per-test Playwright retry count for the sharded test job, exported to
+          playwright.config.ts as PLAYWRIGHT_RETRIES. Empty (default) keeps the
+          config's CI default of 1. Only the shard test step honours it — the
+          fixture populator and bundle-smoke keep their own behaviour.
+        required: false
+        type: string
+        default: ""
       send_slack_notification:
         description: Post a Slack summary once the run finishes.
         required: false
@@ -1482,6 +1491,7 @@ jobs:
           PW_SHARD_ID: ${{ matrix.shardId }}
           PW_SHARD_PLAN: ${{ steps.fast-inputs.outputs.plan }}
           PW_WORKERS: ${{ matrix.workers }}
+          PLAYWRIGHT_RETRIES: ${{ inputs.retries }}
           PLAYWRIGHT_IS_OSS: true
           PLAYWRIGHT_SNOWFLAKE_USERNAME: ${{ secrets.TEST_SNOWFLAKE_USERNAME }}
           PLAYWRIGHT_SNOWFLAKE_PASSWORD: ${{ secrets.TEST_SNOWFLAKE_PASSWORD }}

--- a/.github/workflows/playwright-e2e-reusable.yml
+++ b/.github/workflows/playwright-e2e-reusable.yml
@@ -66,13 +66,13 @@ on:
         default: true
       retries:
         description: >-
-          Per-test Playwright retry count for the sharded test job, exported to
-          playwright.config.ts as PLAYWRIGHT_RETRIES. Empty (default) keeps the
-          config's CI default of 1. Only the shard test step honours it — the
-          fixture populator and bundle-smoke keep their own behaviour.
+          Playwright per-test retry count, exported to playwright.config.ts as
+          PLAYWRIGHT_RETRIES on the shard test step only (the fixture populator
+          and bundle-smoke keep the config default). The default matches the
+          config's CI default of 1; release-branch nightlies raise it to 2.
         required: false
-        type: string
-        default: ""
+        type: number
+        default: 1
       send_slack_notification:
         description: Post a Slack summary once the run finishes.
         required: false

--- a/.github/workflows/postgresql-nightly-e2e.yml
+++ b/.github/workflows/postgresql-nightly-e2e.yml
@@ -77,5 +77,8 @@ jobs:
       full_suite: ${{ inputs.full_suite }}
       protocol: ${{ inputs.protocol }}
       coarse_bundle: ${{ inputs.coarse_bundle }}
+      # Release branches accumulate flakes faster than main; give each test
+      # two retries instead of the config default of one.
+      retries: "2"
       send_slack_notification: ${{ inputs.send_slack_notification }}
       slack_run_title: "PostgreSQL Playwright E2E on ${{ inputs.branch }}"

--- a/.github/workflows/postgresql-nightly-e2e.yml
+++ b/.github/workflows/postgresql-nightly-e2e.yml
@@ -79,6 +79,6 @@ jobs:
       coarse_bundle: ${{ inputs.coarse_bundle }}
       # Release branches accumulate flakes faster than main; give each test
       # two retries instead of the config default of one.
-      retries: "2"
+      retries: 2
       send_slack_notification: ${{ inputs.send_slack_notification }}
       slack_run_title: "PostgreSQL Playwright E2E on ${{ inputs.branch }}"

--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -132,8 +132,13 @@ export default defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 1 : 0,
+  /* Retry on CI only; PLAYWRIGHT_RETRIES (set per workflow via the reusable's
+   * `retries` input) overrides the CI default of 1. */
+  retries: process.env.PLAYWRIGHT_RETRIES
+    ? Number(process.env.PLAYWRIGHT_RETRIES)
+    : process.env.CI
+    ? 1
+    : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI
     ? Number(process.env.PW_WORKERS ?? shardPlan?.workers ?? 3)

--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -133,12 +133,9 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only; PLAYWRIGHT_RETRIES (set per workflow via the reusable's
-   * `retries` input) overrides the CI default of 1. */
-  retries: process.env.PLAYWRIGHT_RETRIES
-    ? Number(process.env.PLAYWRIGHT_RETRIES)
-    : process.env.CI
-    ? 1
-    : 0,
+   * `retries` input) overrides the CI default of 1. The parens are semantic:
+   * without them `?? CI ? 1 : 0` collapses every override to 1. */
+  retries: Number(process.env.PLAYWRIGHT_RETRIES ?? (process.env.CI ? 1 : 0)),
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI
     ? Number(process.env.PW_WORKERS ?? shardPlan?.workers ?? 3)


### PR DESCRIPTION
### Describe your changes:

No linked issue — trivial CI-config change (the template header exempts trivial changes; happy to open one if reviewers prefer).

The MySQL and PostgreSQL release-branch nightly E2E runs were locked to Playwright's hardcoded CI retry count of 1 (`playwright.config.ts`). Release branches accumulate flakes faster than `main`, so these on-demand runs need more headroom without loosening the PR gate.

**How it works:**
- `playwright.config.ts` now reads a `PLAYWRIGHT_RETRIES` env override: `retries: Number(process.env.PLAYWRIGHT_RETRIES ?? (process.env.CI ? 1 : 0))`. The parens are semantic — without them the `??`/ternary precedence collapses every override to 1 (covered by a code comment).
- `playwright-e2e-reusable.yml` gains a `retries` input (`type: number`, `default: 1`, matching the config's CI default) and exports it as `PLAYWRIGHT_RETRIES` on the shard test step **only** — the fixture populator and bundle-smoke steps keep the config default.
- `mysql-nightly-e2e.yml` and `postgresql-nightly-e2e.yml` pass `retries: 2`.

**Blast radius:** the PostgreSQL PR gate and every other caller of the reusable are unchanged (default 1). Workflows that run Playwright with this config outside the reusable (`playwright-knowledge-graph-postgresql-e2e.yml`, `playwright-search-nightly.yml`, `playwright-sso-login-nightly.yml`, `playwright-visual.yml`) keep their existing 1 retry via the `CI` fallback — verified below.

Note: the nightlies check out the `branch:` input for test-path jobs, so the `playwright.config.ts` side must exist on the release branch under test — dispatches testing older release branches need this cherry-picked there.

#
### Type of change:
- [x] Improvement

#
### High-level design:

N/A — small change (design covered in the description above).

#
### Tests:

#### Use cases covered
- MySQL/PostgreSQL release-branch nightly dispatch → each failing test gets 3 attempts (2 retries)
- PostgreSQL PR gate and other reusable callers → unchanged 2 attempts (1 retry)
- Non-reusable CI Playwright workflows (search/SSO/visual/knowledge-graph) → unchanged 1 retry via `CI` fallback
- Local dev → unchanged 0 retries; explicit `PLAYWRIGHT_RETRIES=0` disables retries

#### Unit tests
Not applicable — CI workflow + test-runner config change; no product logic. Behavior verified empirically (see manual testing).

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes — this changes the retry policy of the runner itself).

#### Manual testing performed
1. `actionlint` on the reusable + all touched callers: no new findings (it also type-checks the callers' `with: retries` against the `number` input). The 9 pre-existing `jobs.<job>.result` warnings are identical on `main`.
2. Empirical retry probe: ran a deliberately failing spec through Playwright with the new expression and measured attempts via the JSON reporter — `CI=true, PLAYWRIGHT_RETRIES=2` → retries 2 / 3 attempts; `CI=true` unset → retries 1 / 2 attempts; explicit `0` → 1 attempt; local → retries 0.
3. Verified rejected simpler variants with the same probe: `Number(process.env.CI)` resolves to NaN (retries silently lost), and dropping the `CI` fallback would zero out retries for the four non-reusable Playwright workflows.
4. `prettier@2.8.8` (the repo-pinned version) `--check` passes on `playwright.config.ts`.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` — N/A, no linked issue (trivial CI change).
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above — N/A, see above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed — N/A, no schema changes.
- [x] For UI changes: I attached a screen recording and/or screenshots above — N/A, no UI changes.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above — no automated tests added; runner-config change verified empirically as listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes Playwright’s retry count configurable for reusable E2E jobs and raises it from one to two retries for MySQL and PostgreSQL release-branch nightlies.
- Adds a numeric `retries` input to the reusable Playwright workflow and exports it to shard test executions.
- Reads the retry override in Playwright configuration while preserving existing CI and local defaults.
- Configures both release-branch nightly workflows to use two retries.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified in the changed retry configuration.

Current callers provide validated retry values, existing workflows retain their prior defaults, and the release-branch compatibility limitation is explicitly documented.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/playwright-e2e-reusable.yml | Adds a validated numeric retry input and scopes its environment export to the Playwright shard test step. |
| openmetadata-ui/src/main/resources/ui/playwright.config.ts | Parses the optional retry override while retaining one retry on CI and zero retries locally. |
| .github/workflows/mysql-nightly-e2e.yml | Requests two per-test retries for MySQL release-branch nightly runs. |
| .github/workflows/postgresql-nightly-e2e.yml | Requests two per-test retries for PostgreSQL release-branch nightly runs. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(playwright): simplify retries fallbac..."](https://github.com/open-metadata/openmetadata/commit/5365c3949e95192a899d03728ab925f45d3b3f1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58518558)</sub>

<!-- /greptile_comment -->