### PR TITLE
Backport #32007, #31852 from main[2.0]

### DIFF
--- a/ingestion/src/metadata/ingestion/source/api/api_service.py
+++ b/ingestion/src/metadata/ingestion/source/api/api_service.py
@@ -40,6 +40,7 @@ from metadata.ingestion.api.delete import delete_entity_from_source
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import Source
 from metadata.ingestion.api.topology_runner import TopologyRunnerMixin
+from metadata.ingestion.models.barrier import Barrier
 from metadata.ingestion.models.delete_entity import DeleteEntity
 from metadata.ingestion.models.topology import (
     NodeStage,
@@ -68,6 +69,15 @@ class ApiServiceTopology(ServiceTopology):
 
     We could have a topology validator. We can only consume
     data that has been produced by any parent node.
+
+    Collections and endpoints are two sibling nodes rather than two stages of one
+    node so that *every* collection is sunk and flushed before the first endpoint
+    is produced. Endpoints carry an ``apiCollection`` FQN the server resolves at
+    write time, so an endpoint that reaches the API before its collection is
+    rejected with ``apiCollection instance for <fqn> not found``. Interleaving the
+    two entity types in one node leaves that ordering up to how the sink's bulk
+    buffer happens to be chunked, which breaks once a document is large enough to
+    flush mid-collection.
     """
 
     root: Annotated[TopologyNode, Field(description="Root node for the topology")] = TopologyNode(
@@ -81,7 +91,7 @@ class ApiServiceTopology(ServiceTopology):
                 must_return=True,
             ),
         ],
-        children=["api_collection"],
+        children=["api_collection", "api_endpoint"],
         post_process=["mark_api_collections_as_deleted"],
     )
     api_collection: Annotated[TopologyNode, Field(description="API Collection Processing Node")] = TopologyNode(
@@ -93,6 +103,12 @@ class ApiServiceTopology(ServiceTopology):
                 processor="yield_api_collection",
                 consumer=["api_service"],
             ),
+        ],
+        post_process=["flush_api_collections"],
+    )
+    api_endpoint: Annotated[TopologyNode, Field(description="API Endpoint Processing Node")] = TopologyNode(
+        producer="get_api_collections",
+        stages=[
             NodeStage(
                 type_=APIEndpoint,
                 context="api_endpoints",
@@ -153,7 +169,12 @@ class ApiServiceSource(TopologyRunnerMixin, Source, ABC):
     def get_api_collections(self, *args, **kwargs) -> Iterable[Any]:
         """
         Method to list all collections to process.
-        Here is where filtering happens
+        Here is where filtering happens.
+
+        Both the collection and the endpoint node produce from this method, so an
+        implementation must be idempotent and must replay the same collection
+        objects on the second call - ``yield_api_collection`` enriches them in
+        place (``collection.url``) and ``yield_api_endpoint`` reads that back.
         """
 
     @abstractmethod
@@ -184,6 +205,11 @@ class ApiServiceSource(TopologyRunnerMixin, Source, ABC):
                 recursive=self.source_config.markDeletedApiCollections,
                 params={"service": self.context.get().api_service},
             )
+
+    def flush_api_collections(self) -> Iterable[Either[Barrier]]:
+        """Drain the sink's bulk buffer so every collection is committed before the
+        endpoint node starts producing endpoints that reference them."""
+        yield Either(right=Barrier(reason="api_collections_flush"))  # pyright: ignore[reportCallIssue]
 
     def register_record(self, collection_request: CreateAPICollectionRequest) -> None:
         """

--- a/ingestion/src/metadata/ingestion/source/api/rest/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/api/rest/metadata.py
@@ -11,7 +11,7 @@
 """REST source module"""
 
 import traceback
-from typing import Iterable, List, Optional  # noqa: UP035
+from typing import Iterable, List, Optional, Set  # noqa: UP035
 
 from pydantic import AnyUrl
 
@@ -64,6 +64,8 @@ class RestSource(ApiServiceSource):
 
     def __init__(self, config: WorkflowSource, metadata: OpenMetadata):
         super().__init__(config, metadata)
+        self.json_response: dict = {}
+        self._collections: Optional[List[RESTCollection]] = None  # noqa: UP006, UP045
 
     @classmethod
     def create(cls, config_dict, metadata: OpenMetadata, pipeline_name: Optional[str] = None):  # noqa: UP045
@@ -73,47 +75,109 @@ class RestSource(ApiServiceSource):
             raise InvalidSourceException(f"Expected RestConnection, but got {connection}")
         return cls(config, metadata)
 
-    def get_api_collections(self, *args, **kwargs) -> Iterable[RESTCollection]:
+    def _get_openapi_schema(self) -> dict:
+        """Fetch and parse the OpenAPI document once.
+
+        Both topology nodes produce from ``get_api_collections``, so without this a
+        large document would be downloaded and parsed twice.
         """
-        Method to list all collections to process.
-        Here is where filtering happens
-        """
-        try:
+        if not self.json_response:
             if isinstance(self.connection, dict):
                 self.json_response = self.connection
             else:
                 self.json_response = parse_openapi_schema(self.connection)
-            collections_list = []
-            tags_collection_set = set()
-            if self.json_response.get("tags", []):
-                # Works only if list of tags are present in schema so we can fetch collection names
-                for collection in self.json_response.get("tags", []):
-                    if not collection.get("name"):
-                        continue
-                    collections_list.append(collection)
-                    tags_collection_set.update({collection.get("name")})
-            # append default tag for endpoints that don't have any collection tag
-            if DEFAULT_TAG not in tags_collection_set:
-                tags_collection_set.update({DEFAULT_TAG})
-                collections_list.append({"name": DEFAULT_TAG})
-            # iterate through paths if there's any missing collection not present in tags
-            collections_set = set()
-            for path, methods in self.json_response.get("paths", {}).items():  # noqa: B007, PERF102
-                for method_type, info in methods.items():  # noqa: B007, PERF102
-                    collections_set.update({tag for tag in info.get("tags", [])})  # noqa: C416
-            for collection_name in collections_set:
-                if collection_name not in tags_collection_set:
-                    collections_list.append({"name": collection_name})  # noqa: PERF401
-            for collection in collections_list:
-                if filter_by_collection(
-                    self.source_config.apiCollectionFilterPattern,
-                    collection.get("name"),
-                ):
-                    self.status.filter(collection.get("name"), "Collection filtered out")
-                    continue
-                yield RESTCollection(**collection)
+        return self.json_response
+
+    def _tag_collections(self, json_response: dict) -> List[dict]:  # noqa: UP006
+        """Collection definitions declared in the document's root ``tags``.
+
+        Non-conforming entries (the spec requires an object with a ``name``) are
+        skipped instead of aborting: a tag only referenced from ``paths`` is still
+        recovered by ``_path_collection_names``.
+        """
+        collections_list = []
+        for collection in json_response.get("tags") or []:
+            if not isinstance(collection, dict):
+                logger.warning(f"Skipping malformed tag entry, expected an object with a name: {collection}")
+                continue
+            collection_name = collection.get("name")
+            if isinstance(collection_name, str) and collection_name:
+                collections_list.append({**collection, "name": collection_name})
+        return collections_list
+
+    def _path_collection_names(self, json_response: dict) -> Set[str]:  # noqa: UP006
+        """Tag names referenced by operations under ``paths``."""
+        collections_set: Set[str] = set()  # noqa: UP006
+        for methods in (json_response.get("paths") or {}).values():
+            if not isinstance(methods, dict):
+                continue
+            for info in methods.values():
+                if isinstance(info, dict):
+                    collections_set.update(tag for tag in info.get("tags") or [] if isinstance(tag, str))
+        return collections_set
+
+    def _derive_collections(self) -> List[RESTCollection]:  # noqa: UP006
+        """Derive every collection the document describes.
+
+        A collection that cannot be built is reported and skipped so one malformed
+        tag cannot silently drop the rest of the document - the previous single
+        try/except around the whole walk stopped the generator on the first bad
+        entry, leaving the service with few or no collections.
+        """
+        collections: List[RESTCollection] = []  # noqa: UP006
+        try:
+            json_response = self._get_openapi_schema()
         except Exception as err:
             logger.error(f"Error while fetching collections from schema URL :{err}")
+            logger.debug(traceback.format_exc())
+            return collections
+
+        collections_list = self._tag_collections(json_response)
+        tags_collection_set = {str(collection["name"]) for collection in collections_list}
+        # append default tag for endpoints that don't have any collection tag
+        if DEFAULT_TAG not in tags_collection_set:
+            tags_collection_set.add(DEFAULT_TAG)
+            collections_list.append({"name": DEFAULT_TAG})
+        # iterate through paths if there's any missing collection not present in tags
+        # sorted() so a rerun derives the collections in the same order every time
+        collections_list.extend(
+            {"name": collection_name}
+            for collection_name in sorted(self._path_collection_names(json_response))
+            if collection_name not in tags_collection_set
+        )
+
+        for collection in collections_list:
+            collection_name = str(collection["name"])
+            if filter_by_collection(
+                self.source_config.apiCollectionFilterPattern,
+                collection_name,
+            ):
+                self.status.filter(collection_name, "Collection filtered out")
+                continue
+            try:
+                collections.append(RESTCollection(**collection))
+            except Exception as exc:
+                self.status.failed(
+                    StackTraceError(
+                        name=collection_name,
+                        error=f"Error building api collection [{collection_name}]: {exc}",
+                        stackTrace=traceback.format_exc(),
+                    )
+                )
+        return collections
+
+    def get_api_collections(self, *args, **kwargs) -> Iterable[RESTCollection]:
+        """
+        Method to list all collections to process.
+        Here is where filtering happens
+
+        Memoized: the endpoint node replays this producer and needs the very same
+        objects, since ``yield_api_collection`` resolves ``collection.url`` in place
+        and ``_generate_endpoint_url`` builds endpoint URLs from it.
+        """
+        if self._collections is None:
+            self._collections = self._derive_collections()
+        yield from self._collections
 
     def yield_api_collection(self, collection: RESTCollection) -> Iterable[Either[CreateAPICollectionRequest]]:
         """Method to return api collection Entities"""

--- a/ingestion/src/metadata/ingestion/source/api/rest/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/api/rest/metadata.py
@@ -37,7 +37,7 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 )
 from metadata.generated.schema.type.apiSchema import APISchema
 from metadata.generated.schema.type.basic import FullyQualifiedEntityName, Markdown
-from metadata.generated.schema.type.schema import DataTypeTopic, FieldModel
+from metadata.generated.schema.type.schema import DataTypeTopic, FieldModel, FieldName
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
@@ -323,7 +323,11 @@ class RestSource(ApiServiceSource):
             logger.warning(f"Error resolving parameter reference: {err}")
             return None
 
-    def _parse_openapi_type(self, openapi_type: Optional[object]) -> DataTypeTopic:  # noqa: UP045
+    def _parse_openapi_type(
+        self,
+        openapi_type: Optional[object],  # noqa: UP045
+        openapi_format: Optional[object] = None,  # noqa: UP045
+    ) -> DataTypeTopic:
         """
         Parse OpenAPI type string to DataTypeTopic enum.
         Shared type conversion logic used across the codebase.
@@ -337,6 +341,11 @@ class RestSource(ApiServiceSource):
 
         if not openapi_type:
             return DataTypeTopic.UNKNOWN
+
+        if openapi_type.lower() == "number" and isinstance(openapi_format, str):
+            normalized_format = openapi_format.upper()
+            if normalized_format in {"FLOAT", "DOUBLE"}:
+                return DataTypeTopic[normalized_format]
 
         # Handle INTEGER -> INT conversion
         normalized_type = "INT" if openapi_type.upper() == "INTEGER" else openapi_type.upper()
@@ -354,14 +363,12 @@ class RestSource(ApiServiceSource):
             if not param_name:
                 return None
 
-            # Get type from parameter (Swagger 2.0 format)
-            param_type = param.get("type")
-
-            # Get type from schema (OpenAPI 3.0 format)
-            if not param_type and "schema" in param:
-                param_type = param["schema"].get("type")
-
-            data_type = self._parse_openapi_type(param_type)
+            param_schema = param.get("schema", {})
+            param_type = param.get("type") or param_schema.get("type")
+            param_format = param.get("format") or (
+                param_schema.get("format") if isinstance(param_schema, dict) else None
+            )
+            data_type = self._parse_openapi_type(param_type, param_format)
 
             # Handle array items
             children = None
@@ -369,7 +376,7 @@ class RestSource(ApiServiceSource):
                 items = param.get("items") or param.get("schema", {}).get("items")
                 if items:
                     item_type = items.get("type")
-                    child_data_type = self._parse_openapi_type(item_type)
+                    child_data_type = self._parse_openapi_type(item_type, items.get("format"))
                     children = [FieldModel(name="item", dataType=child_data_type)]
 
             return FieldModel(
@@ -382,33 +389,81 @@ class RestSource(ApiServiceSource):
             logger.warning(f"Error converting parameter to field: {err}")
             return None
 
+    def _process_array_items(
+        self,
+        items: dict,
+        parent_refs: List[str],  # noqa: UP006
+    ) -> Optional[List[FieldModel]]:  # noqa: UP006, UP045
+        if not items:
+            return None
+
+        items_ref = items.get("$ref")
+        if items_ref:
+            if items_ref in parent_refs:
+                logger.debug(f"Skipping array fields inside schema: {items_ref} to avoid infinite recursion")
+                return None
+
+            logger.debug(f"Processing array fields inside schema: {items_ref}")
+            children = self.process_schema_fields(items_ref, parent_refs)
+            logger.debug(f"Completed processing array fields inside schema: {items_ref}")
+            return children
+
+        properties = items.get("properties", {})
+        if properties:
+            return self._process_schema_properties(properties, parent_refs)
+
+        return [
+            FieldModel(
+                name=FieldName(root="item"),
+                dataType=self._parse_openapi_type(items.get("type"), items.get("format")),
+            )
+        ]
+
+    def _process_schema_properties(
+        self,
+        properties: dict,
+        parent_refs: List[str],  # noqa: UP006
+    ) -> List[FieldModel]:  # noqa: UP006
+        fields = []
+        for prop_name, prop_def in properties.items():
+            prop_type = prop_def.get("type")
+            children = None
+            data_type_display = None
+
+            if prop_type:
+                data_type = self._parse_openapi_type(prop_type, prop_def.get("format"))
+                if data_type == DataTypeTopic.ARRAY:
+                    children = self._process_array_items(prop_def.get("items", {}), parent_refs)
+            else:
+                data_type = DataTypeTopic.UNKNOWN
+                data_type_display = "OBJECT"
+                prop_ref = prop_def.get("$ref")
+                if prop_ref:
+                    if prop_ref not in parent_refs:
+                        children = self.process_schema_fields(prop_ref, parent_refs)
+                    else:
+                        logger.debug(f"Skipping object fields inside schema: {prop_ref} to avoid infinite recursion")
+                elif prop_def.get("properties"):
+                    children = self._process_schema_properties(prop_def["properties"], parent_refs)
+
+            description = prop_def.get("description")
+            description_obj = Markdown(root=description) if description is not None else None
+            fields.append(
+                FieldModel(
+                    name=prop_name,
+                    dataType=data_type,
+                    dataTypeDisplay=data_type_display,
+                    children=children,
+                    description=description_obj,
+                )
+            )
+
+        return fields
+
     def _process_inline_schema(self, properties: dict) -> Optional[APISchema]:  # noqa: UP045
         """Process inline schema properties (schemas without $ref)"""
         try:
-            fields = []
-            for prop_name, prop_def in properties.items():
-                prop_type = prop_def.get("type")
-
-                data_type = self._parse_openapi_type(prop_type)
-
-                # Handle array items
-                children = None
-                if data_type == DataTypeTopic.ARRAY:
-                    items = prop_def.get("items", {})
-                    if items:
-                        item_type = items.get("type")
-                        child_data_type = self._parse_openapi_type(item_type)
-                        children = [FieldModel(name="item", dataType=child_data_type)]
-
-                fields.append(
-                    FieldModel(
-                        name=prop_name,
-                        dataType=data_type,
-                        children=children,
-                        description=prop_def.get("description"),
-                    )
-                )
-
+            fields = self._process_schema_properties(properties, [])
             return APISchema(schemaFields=fields) if fields else None
         except Exception as err:
             logger.warning(f"Error processing inline schema: {err}")
@@ -499,76 +554,14 @@ class RestSource(ApiServiceSource):
                 return None
 
             parent_refs.append(schema_ref)
-            if self._parse_openapi_type(schema_fields.get("type")) == DataTypeTopic.ARRAY:
-                items_ref = schema_fields.get("items", {}).get("$ref")
-                if items_ref and items_ref not in parent_refs:
-                    fetched_fields = self.process_schema_fields(items_ref, parent_refs)
-                    parent_refs.pop()
-                    return fetched_fields
+            try:
+                if self._parse_openapi_type(schema_fields.get("type")) == DataTypeTopic.ARRAY:
+                    return self._process_array_items(schema_fields.get("items", {}), parent_refs) or []
 
-            fetched_fields = []
-            for key, val in schema_fields.get("properties", {}).items():
-                dtype = val.get("type")
-                if dtype:
-                    parsed_dtype = self._parse_openapi_type(dtype)
-                    children = None
-                    if parsed_dtype.value == DataTypeTopic.ARRAY.value:
-                        # If field of array type then parse children
-                        children_ref = val.get("items", {}).get("$ref")
-                        if children_ref:
-                            # check infinite recursion by checking pre-processed schemas(parent_refs)
-                            if children_ref not in parent_refs:
-                                logger.debug(f"Processing array fields inside schema: {children_ref}")
-                                children = self.process_schema_fields(children_ref, parent_refs)
-                                logger.debug(f"Completed processing array fields inside schema: {children_ref}")
-                            else:
-                                logger.debug(
-                                    f"Skipping array fields inside schema: {children_ref} to avoid infinite recursion"
-                                )
-                    # Extract description if available
-                    description = val.get("description")
-                    description_obj = Markdown(root=description) if description is not None else None
-
-                    fetched_fields.append(
-                        FieldModel(
-                            name=key,
-                            dataType=parsed_dtype,
-                            children=children,
-                            description=description_obj,
-                        )
-                    )
-                else:
-                    # If type of field is not defined then check for sub-schema
-                    # Check if it's `object` type field
-                    children = None
-                    if val.get("$ref"):
-                        # check infinite recursion by checking pre-processed schemas(parent_refs)
-                        if val.get("$ref") not in parent_refs:
-                            children = self.process_schema_fields(val.get("$ref"), parent_refs)
-                        else:
-                            logger.debug(
-                                f"Skipping object fields inside schema: {val.get('$ref')} to avoid infinite recursion"
-                            )
-                    # Extract description if available
-                    description = val.get("description")
-                    description_obj = Markdown(root=description) if description is not None else None
-
-                    fetched_fields.append(
-                        FieldModel(
-                            name=key,
-                            dataType=DataTypeTopic.UNKNOWN,
-                            dataTypeDisplay="OBJECT",
-                            children=children,
-                            description=description_obj,
-                        )
-                    )
-            if parent_refs and (schema_ref in parent_refs):
+                return self._process_schema_properties(schema_fields.get("properties", {}), parent_refs)
+            finally:
                 parent_refs.pop()
-            return fetched_fields  # noqa: TRY300
         except Exception as err:
             warning = f"Error while processing schema fields: {err}"
             logger.warning(warning)
-            if parent_refs and (schema_ref in parent_refs):
-                parent_refs.pop()
-                logger.debug(f"Popping {schema_ref} from parent_refs due to processing error")
         return None

--- a/ingestion/tests/unit/topology/api/test_rest.py
+++ b/ingestion/tests/unit/topology/api/test_rest.py
@@ -26,6 +26,9 @@ from pydantic_core import Url
 from metadata.generated.schema.api.data.createAPICollection import (
     CreateAPICollectionRequest,
 )
+from metadata.generated.schema.api.data.createAPIEndpoint import (
+    CreateAPIEndpointRequest,
+)
 from metadata.generated.schema.entity.services.apiService import (
     ApiConnection,
     ApiService,
@@ -45,6 +48,12 @@ from metadata.generated.schema.type.basic import (
 )
 from metadata.generated.schema.type.schema import DataTypeTopic
 from metadata.ingestion.api.models import Either
+from metadata.ingestion.models.barrier import Barrier
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.ingestion.sink.metadata_rest import (
+    MetadataRestSink,
+    MetadataRestSinkConfig,
+)
 from metadata.ingestion.source.api.rest.metadata import RestSource
 from metadata.ingestion.source.api.rest.models import RESTCollection, RESTEndpoint
 from metadata.ingestion.source.api.rest.parser import (
@@ -463,6 +472,28 @@ MOCK_OPENAPI_SCHEMA = {
     },
 }
 
+# Enough tags x paths to overflow MetadataRestSinkConfig.bulk_sink_batch_size (100)
+# several times, which is what separates the reporter's full document from the
+# reduced one that never reproduced the bug.
+LARGE_SCHEMA_COLLECTIONS = 8
+LARGE_SCHEMA_PATHS_PER_COLLECTION = 30
+
+
+def build_large_openapi_schema() -> dict:
+    return {
+        "tags": [{"name": f"collection_{index}"} for index in range(LARGE_SCHEMA_COLLECTIONS)],
+        "paths": {
+            f"/collection_{collection}/resource_{path}": {
+                "get": {
+                    "tags": [f"collection_{collection}"],
+                    "operationId": f"getCollection{collection}Resource{path}",
+                }
+            }
+            for collection in range(LARGE_SCHEMA_COLLECTIONS)
+            for path in range(LARGE_SCHEMA_PATHS_PER_COLLECTION)
+        },
+    }
+
 
 class TestRest:
     @pytest.fixture(autouse=True)
@@ -524,11 +555,23 @@ class TestRest:
             "new",
         }
 
+    def test_get_api_collections_on_unparseable_schema(self):
+        """An unparseable document yields nothing instead of raising.
+
+        Uses its own source: get_api_collections is memoized, so a source that has
+        already derived its collections replays them rather than re-parsing.
+        """
+        source = RestSource.create(
+            mock_rest_config["source"],
+            self.config.workflowConfig.openMetadataServerConfig,
+        )
+        source.connection = object()
+
         with patch(
             "metadata.ingestion.source.api.rest.metadata.parse_openapi_schema",
             side_effect=RuntimeError("invalid schema"),
         ):
-            assert list(self.rest_source.get_api_collections()) == []
+            assert list(source.get_api_collections()) == []
 
     def test_yield_api_collection(self):
         """test yield api collections"""
@@ -548,6 +591,166 @@ class TestRest:
         assert len(result) == 1
         assert result[0].left is not None
         assert "invalid collection" in result[0].left.error
+
+    def test_api_collections_flush_before_api_endpoints(self):
+        """Every collection, then a Barrier, then the endpoints (issue #30598)."""
+        records = list(
+            self.rest_source.process_nodes(
+                [
+                    self.rest_source.topology.api_collection,
+                    self.rest_source.topology.api_endpoint,
+                ]
+            )
+        )
+
+        right_types = [type(record.right) for record in records if record.right]
+        barrier_index = right_types.index(Barrier)
+        collection_count = len([entry for entry in right_types if entry is CreateAPICollectionRequest])
+
+        assert all(record.left is None for record in records)
+        assert collection_count == len(MOCK_COLLECTIONS) + 1  # + the "default" collection
+        assert right_types[:barrier_index] == [CreateAPICollectionRequest] * collection_count
+        assert set(right_types[barrier_index + 1 :]) == {CreateAPIEndpointRequest}
+
+    def test_large_document_never_sends_an_endpoint_before_its_collection(self):
+        """Drive the topology through the real bulk sink and replay the PUTs.
+
+        A document large enough to flush the sink's bulk buffer several times must
+        still have every apiCollection committed before any apiEndpoint that
+        references it, otherwise the server rejects the endpoint with
+        ``apiCollection instance for <fqn> not found`` (issue #30598).
+        """
+        put_calls = []
+
+        def capture_put(url, json=None, **kwargs):
+            put_calls.append((url, json or []))
+            return {
+                "status": "success",
+                "numberOfRowsProcessed": len(json or []),
+                "numberOfRowsFailed": 0,
+                "successRequest": [],
+                "failedRequest": [],
+            }
+
+        with (
+            patch(
+                "metadata.ingestion.source.api.api_service.create_connection",
+                side_effect=lambda *args, **kwargs: SimpleNamespace(
+                    client=build_large_openapi_schema(), close=lambda: None
+                ),
+            ),
+            patch.object(OpenMetadata, "validate_versions", return_value=None),
+        ):
+            metadata = OpenMetadata(self.config.workflowConfig.openMetadataServerConfig)
+            source = RestSource.create(
+                mock_rest_config["source"],
+                self.config.workflowConfig.openMetadataServerConfig,
+            )
+            source.context.get().__dict__["api_service"] = MOCK_API_SERVICE.fullyQualifiedName.root
+            sink = MetadataRestSink(MetadataRestSinkConfig(), metadata)
+            with patch.object(metadata.client, "put", side_effect=capture_put):
+                for record in source.process_nodes([source.topology.api_collection, source.topology.api_endpoint]):
+                    if record.right is not None:
+                        sink._run(record.right)
+                sink.close()
+
+        created_collections = set()
+        orphan_endpoints = []
+        for url, payloads in put_calls:
+            if "/apiCollections/bulk" in url:
+                created_collections.update(f"{payload['service']}.{payload['name']}" for payload in payloads)
+            elif "/apiEndpoints/bulk" in url:
+                orphan_endpoints.extend(
+                    payload["name"] for payload in payloads if payload["apiCollection"] not in created_collections
+                )
+
+        put_sequence = ["C" if "/apiCollections/bulk" in url else "E" for url, _ in put_calls]
+        assert orphan_endpoints == []
+        # Collections are fully persisted first, then endpoints - not interleaved
+        # ("C E C E ..."), which is what leaves an endpoint depending on a collection
+        # that shares its bulk batch.
+        assert put_sequence == ["C"] + ["E"] * (len(put_sequence) - 1)
+        # More than one endpoint flush: the buffer really did drain mid-run, which is
+        # the condition the reporter's large document hit and a small one never does.
+        assert put_sequence.count("E") > 1
+
+    def test_endpoint_urls_survive_the_second_producer_pass(self):
+        """The endpoint node replays the collections the collection node enriched.
+
+        ``yield_api_collection`` resolves ``collection.url`` in place; if the endpoint
+        node re-derived fresh RESTCollection objects it would see ``url=None`` and
+        silently fall back to the raw openAPISchemaURL for every endpointURL.
+        """
+        records = list(
+            self.rest_source.process_nodes(
+                [
+                    self.rest_source.topology.api_collection,
+                    self.rest_source.topology.api_endpoint,
+                ]
+            )
+        )
+
+        endpoint_urls = {
+            record.right.name.root: str(record.right.endpointURL)
+            for record in records
+            if isinstance(record.right, CreateAPIEndpointRequest)
+        }
+
+        assert endpoint_urls == {
+            "/pet/findByStatus/get": "https://petstore3.swagger.io/#/pet/findPetsByStatus",
+            "/store/order/post": "https://petstore3.swagger.io/#/store/placeOrder",
+            "/user/login/get": "https://petstore3.swagger.io/#/user/loginUser",
+        }
+
+    def test_get_api_collections_derives_once(self):
+        """Both nodes produce from get_api_collections; the document is parsed once
+        and a filtered collection is reported once, not per node."""
+        exclude_config = deepcopy(mock_rest_config)
+        exclude_config["source"]["sourceConfig"]["config"]["apiCollectionFilterPattern"] = {"excludes": ["store"]}
+        source = RestSource.create(
+            exclude_config["source"],
+            self.config.workflowConfig.openMetadataServerConfig,
+        )
+
+        with patch.object(RestSource, "_derive_collections", wraps=source._derive_collections) as derive:
+            first_pass = list(source.get_api_collections())
+            second_pass = list(source.get_api_collections())
+
+        assert derive.call_count == 1
+        assert first_pass == second_pass
+        assert [collection.name.root for collection in first_pass] == ["pet", "user", "default"]
+        assert source.status.filtered == [{"store": "Collection filtered out"}]
+
+    @pytest.mark.parametrize(
+        ("bad_tag", "expected_failures"),
+        [
+            pytest.param({"name": "x" * 300}, 1, id="name-over-entity-name-max-length"),
+            pytest.param({"name": "bad", "description": {"nested": "object"}}, 1, id="non-string-description"),
+            pytest.param("bad", 0, id="tag-entry-is-a-string-not-an-object"),
+        ],
+    )
+    def test_one_malformed_tag_does_not_drop_the_document(self, bad_tag, expected_failures):
+        """A tag the connector cannot turn into a collection is reported and skipped.
+
+        Regression for issue #30598: the whole derivation used to sit inside a single
+        try/except, so the first unparseable tag stopped the generator and the service
+        was left with few or no collections.
+        """
+        schema = deepcopy(MOCK_OPENAPI_SCHEMA)
+        schema["tags"].insert(1, bad_tag)
+
+        with patch(
+            "metadata.ingestion.source.api.api_service.create_connection",
+            side_effect=lambda *args, **kwargs: SimpleNamespace(client=schema, close=lambda: None),
+        ):
+            source = RestSource.create(
+                mock_rest_config["source"],
+                self.config.workflowConfig.openMetadataServerConfig,
+            )
+            collection_names = [collection.name.root for collection in source.get_api_collections()]
+
+        assert {"pet", "store", "user"}.issubset(set(collection_names))
+        assert len(source.status.failures) == expected_failures
 
     def test_all_collections(self):
         collections = list(self.rest_source.get_api_collections())

--- a/ingestion/tests/unit/topology/api/test_rest.py
+++ b/ingestion/tests/unit/topology/api/test_rest.py
@@ -408,6 +408,45 @@ MOCK_RESPONSE_NESTED_DATA_REF = {
 
 MOCK_RESPONSE_NO_SCHEMA = {"responses": {"200": {"description": "successful operation"}}}
 
+MOCK_RESPONSE_INLINE_OBJECT_ARRAY = {
+    "responses": {
+        "200": {
+            "description": "successful operation",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "order_list": {
+                                "type": "array",
+                                "description": "List of orders",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "order_id": {
+                                            "type": "integer",
+                                            "description": "Order ID",
+                                        },
+                                        "order_amount": {
+                                            "type": "number",
+                                            "format": "double",
+                                            "description": "Order amount in USD",
+                                        },
+                                        "order_status": {
+                                            "type": "string",
+                                            "description": "Order status",
+                                        },
+                                    },
+                                },
+                            }
+                        },
+                    }
+                }
+            },
+        }
+    }
+}
+
 # Canned OpenAPI document fed to the source instead of fetching the live
 # petstore URL declared in mock_rest_config, so the collection tests stay
 # hermetic and deterministic (no network).
@@ -466,12 +505,49 @@ class TestRest:
         ]
         assert collections == expected_collections
 
+    def test_get_api_collections_parses_schema_variants(self):
+        self.rest_source.connection = object()
+        schema = {
+            "tags": [{}, {"name": "known"}],
+            "paths": {"/new": {"get": {"tags": ["new"]}}},
+        }
+
+        with patch(
+            "metadata.ingestion.source.api.rest.metadata.parse_openapi_schema",
+            return_value=schema,
+        ):
+            collections = list(self.rest_source.get_api_collections())
+
+        assert {collection.name.root for collection in collections} == {
+            "known",
+            "default",
+            "new",
+        }
+
+        with patch(
+            "metadata.ingestion.source.api.rest.metadata.parse_openapi_schema",
+            side_effect=RuntimeError("invalid schema"),
+        ):
+            assert list(self.rest_source.get_api_collections()) == []
+
     def test_yield_api_collection(self):
         """test yield api collections"""
         # deepcopy: yield_api_collection sets collection.url in place, which would
         # otherwise mutate the shared module-level MOCK_COLLECTIONS fixture.
         collection_request = list(self.rest_source.yield_api_collection(deepcopy(MOCK_COLLECTIONS[0])))
         assert collection_request == EXPECTED_COLLECTION_REQUEST
+
+    def test_yield_api_collection_returns_error(self):
+        with patch.object(
+            self.rest_source,
+            "_generate_collection_url",
+            side_effect=RuntimeError("invalid collection"),
+        ):
+            result = list(self.rest_source.yield_api_collection(deepcopy(MOCK_COLLECTIONS[0])))
+
+        assert len(result) == 1
+        assert result[0].left is not None
+        assert "invalid collection" in result[0].left.error
 
     def test_all_collections(self):
         collections = list(self.rest_source.get_api_collections())
@@ -491,10 +567,44 @@ class TestRest:
         collection_url = self.rest_source._generate_collection_url("store")
         assert collection_url == MOCK_STORE_URL
 
+    def test_url_helpers_use_fallbacks(self):
+        connection_config = self.rest_source.config.serviceConnection.root.config
+        assert self.rest_source._get_fallback_url() is None
+
+        connection_config.docURL = AnyUrl("https://example.com/#")
+        assert str(self.rest_source._generate_collection_url("store")) == "https://example.com/#/store"
+
+        connection_config.docURL = None
+        assert self.rest_source._generate_collection_url("store") is None
+
+        collection = deepcopy(MOCK_SINGLE_COLLECTION)
+        collection.url = None
+        assert self.rest_source._generate_endpoint_url(collection, MOCK_SINGLE_ENDPOINT) is None
+
+    def test_url_helpers_recover_from_errors(self):
+        with patch(
+            "metadata.ingestion.source.api.rest.metadata.clean_uri",
+            side_effect=RuntimeError("invalid URL"),
+        ):
+            assert self.rest_source._generate_collection_url("store") is None
+
+        with patch(
+            "metadata.ingestion.source.api.rest.metadata.AnyUrl",
+            side_effect=RuntimeError("invalid URL"),
+        ):
+            assert self.rest_source._generate_endpoint_url(MOCK_SINGLE_COLLECTION, MOCK_SINGLE_ENDPOINT) is None
+
     def test_generate_endpoint_url(self):
         """test generate endpoint url"""
         endpoint_url = self.rest_source._generate_endpoint_url(MOCK_SINGLE_COLLECTION, MOCK_SINGLE_ENDPOINT)
         assert endpoint_url == MOCK_STORE_ORDER_URL
+
+    def test_endpoint_helpers_handle_invalid_input(self):
+        self.rest_source.json_response = {"paths": None}
+
+        assert self.rest_source._filter_collection_endpoints(MOCK_SINGLE_COLLECTION) is None
+        assert self.rest_source._prepare_endpoint_data("/store", "get", None, MOCK_SINGLE_COLLECTION) is None
+        assert self.rest_source._get_api_request_method("unsupported") is None
 
     def test_collection_filter_pattern(self):
         """test collection filter pattern"""
@@ -684,6 +794,21 @@ class TestRest:
         assert result.description.root == "Page number"
         assert result.children is None
 
+    @pytest.mark.parametrize("schema", [None, "invalid"])
+    def test_convert_parameter_to_field_uses_top_level_type_with_non_object_schema(self, schema):
+        param = {
+            "in": "query",
+            "name": "page",
+            "type": "integer",
+            "schema": schema,
+        }
+
+        result = self.rest_source._convert_parameter_to_field(param)
+
+        assert result is not None
+        assert result.name.root == "page"
+        assert result.dataType == DataTypeTopic.INT
+
     def test_convert_parameter_to_field_openapi_3(self):
         """Test converting OpenAPI 3.0 parameter to FieldModel"""
         param = {
@@ -800,6 +925,40 @@ class TestRest:
         page_field = next(f for f in result.schemaFields if f.name.root == "page")
         assert page_field.dataType == DataTypeTopic.INT
         assert page_field.description.root == "Page number"
+
+    def test_get_request_schema_resolves_parameter_references(self):
+        parameter = {
+            "in": "query",
+            "name": "limit",
+            "type": "integer",
+        }
+        self.rest_source.json_response = {"parameters": {"Limit": parameter}}
+        info = {
+            "parameters": [
+                {"$ref": "#/parameters/Limit"},
+                {"$ref": "#/parameters/Missing"},
+            ]
+        }
+
+        result = self.rest_source._get_request_schema(info)
+
+        assert result is not None
+        assert result.schemaFields is not None
+        assert [field.name.root for field in result.schemaFields] == ["limit"]
+
+    def test_resolve_parameter_ref_variants(self):
+        parameter = {"in": "query", "name": "limit", "type": "integer"}
+
+        self.rest_source.json_response = {"parameters": {"Limit": parameter}}
+        assert self.rest_source._resolve_parameter_ref("#/parameters/Limit") == parameter
+
+        self.rest_source.json_response = {"components": {"parameters": {"Limit": parameter}}}
+        assert self.rest_source._resolve_parameter_ref("#/parameters/Limit") == parameter
+
+        self.rest_source.json_response = {}
+        assert self.rest_source._resolve_parameter_ref("#/parameters/Limit") is None
+        assert self.rest_source._resolve_parameter_ref("invalid") is None
+        assert self.rest_source._resolve_parameter_ref(1) is None
 
     def test_get_request_schema_openapi_3_query_parameters(self):
         """Test extracting request schema from OpenAPI 3.0 query parameters"""
@@ -980,6 +1139,10 @@ class TestRest:
         result = self.rest_source._parse_openapi_type("BOOLEAN")
         assert result == DataTypeTopic.BOOLEAN
 
+    @pytest.mark.parametrize("openapi_type", [[], ""])
+    def test_parse_openapi_type_empty_values(self, openapi_type):
+        assert self.rest_source._parse_openapi_type(openapi_type) == DataTypeTopic.UNKNOWN
+
     def test_process_schema_fields_with_nullable_type(self):
         self.rest_source.json_response = {
             "components": {
@@ -1075,6 +1238,44 @@ class TestRest:
         assert len(result.schemaFields) == 1
         assert result.schemaFields[0].dataType == DataTypeTopic.UNKNOWN
 
+    def test_process_inline_schema_expands_untyped_object_properties(self):
+        properties = {
+            "metadata": {
+                "description": "Nested metadata",
+                "properties": {
+                    "identifier": {
+                        "type": "integer",
+                        "description": "Metadata identifier",
+                    }
+                },
+            }
+        }
+
+        result = self.rest_source._process_inline_schema(properties)
+
+        assert result is not None
+        assert result.schemaFields is not None
+        metadata_field = result.schemaFields[0]
+        assert metadata_field.dataType == DataTypeTopic.UNKNOWN
+        assert metadata_field.dataTypeDisplay == "OBJECT"
+        assert metadata_field.description == Markdown(root="Nested metadata")
+        assert metadata_field.children is not None
+        assert len(metadata_field.children) == 1
+        assert metadata_field.children[0].name.root == "identifier"
+        assert metadata_field.children[0].dataType == DataTypeTopic.INT
+        assert metadata_field.children[0].description == Markdown(root="Metadata identifier")
+
+    def test_schema_helpers_handle_invalid_input(self):
+        assert self.rest_source._process_array_items({}, []) is None
+        assert self.rest_source._process_inline_schema({"field": None}) is None
+        assert self.rest_source._convert_parameter_to_field({"name": "field", "schema": None}) is None
+        assert self.rest_source._get_response_schema(None) is None
+
+        self.rest_source.json_response = {}
+        schema_ref = "#/components/schemas/Missing"
+        assert self.rest_source._resolve_schema_ref(schema_ref) is None
+        assert self.rest_source.process_schema_fields(schema_ref) is None
+
     def test_get_response_schema_inline_properties(self):
         """Test _get_response_schema handles inline schemas without $ref"""
         self.rest_source.json_response = {}
@@ -1099,6 +1300,84 @@ class TestRest:
 
         assert result is not None
         assert len(result.schemaFields) == 2
+
+    def test_get_response_schema_inline_object_array_properties(self):
+        self.rest_source.json_response = {}
+
+        result = self.rest_source._get_response_schema(MOCK_RESPONSE_INLINE_OBJECT_ARRAY)
+
+        assert result is not None
+        assert result.schemaFields is not None
+        assert len(result.schemaFields) == 1
+
+        order_list = result.schemaFields[0]
+        assert order_list.name.root == "order_list"
+        assert order_list.dataType == DataTypeTopic.ARRAY
+        assert order_list.description == Markdown(root="List of orders")
+        assert order_list.children is not None
+        assert [child.name.root for child in order_list.children] == [
+            "order_id",
+            "order_amount",
+            "order_status",
+        ]
+        assert [child.dataType for child in order_list.children] == [
+            DataTypeTopic.INT,
+            DataTypeTopic.DOUBLE,
+            DataTypeTopic.STRING,
+        ]
+        assert [child.description.root for child in order_list.children] == [
+            "Order ID",
+            "Order amount in USD",
+            "Order status",
+        ]
+
+    def test_get_response_schema_referenced_inline_object_array_properties(self):
+        schema = deepcopy(
+            MOCK_RESPONSE_INLINE_OBJECT_ARRAY["responses"]["200"]["content"]["application/json"]["schema"]
+        )
+        self.rest_source.json_response = {"components": {"schemas": {"Orders": schema}}}
+        info = {
+            "responses": {"200": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/Orders"}}}}}
+        }
+
+        result = self.rest_source._get_response_schema(info)
+
+        assert result is not None
+        assert result.schemaFields is not None
+        order_list = result.schemaFields[0]
+        assert order_list.dataType == DataTypeTopic.ARRAY
+        assert order_list.description == Markdown(root="List of orders")
+        assert order_list.children is not None
+        assert [child.name.root for child in order_list.children] == [
+            "order_id",
+            "order_amount",
+            "order_status",
+        ]
+        assert [child.dataType for child in order_list.children] == [
+            DataTypeTopic.INT,
+            DataTypeTopic.DOUBLE,
+            DataTypeTopic.STRING,
+        ]
+        assert [child.description.root for child in order_list.children] == [
+            "Order ID",
+            "Order amount in USD",
+            "Order status",
+        ]
+
+    def test_process_inline_schema_number_formats(self):
+        properties = {
+            "float_amount": {"type": "number", "format": "float"},
+            "double_amount": {"type": "number", "format": "double"},
+        }
+
+        result = self.rest_source._process_inline_schema(properties)
+
+        assert result is not None
+        assert result.schemaFields is not None
+        assert [field.dataType for field in result.schemaFields] == [
+            DataTypeTopic.FLOAT,
+            DataTypeTopic.DOUBLE,
+        ]
 
     def test_get_response_schema_201_fallback(self):
         """Test _get_response_schema falls back to 201 when 200 not found"""

--- a/openmetadata-airflow-apis/tests/unit/ingestion_pipeline/test_get_dagbag.py
+++ b/openmetadata-airflow-apis/tests/unit/ingestion_pipeline/test_get_dagbag.py
@@ -67,7 +67,7 @@ def test_get_dagbag_does_not_collect_the_dag_folder(dags_folder):
     This is the regression lock: any change that repopulates the bag from the folder
     reintroduces an O(total DAGs) cost on every deploy.
     """
-    from openmetadata_managed_apis.api import utils
+    from openmetadata_managed_apis.api import utils  # noqa: PLC0415
 
     with patch.object(utils.settings, "DAGS_FOLDER", str(dags_folder)):
         dag_bag = utils.get_dagbag()
@@ -80,7 +80,7 @@ def test_get_dagbag_does_not_collect_the_dag_folder(dags_folder):
 @patch.dict(os.environ, {"AIRFLOW_HOME": "/tmp"})
 def test_get_dagbag_never_calls_collect_dags(dags_folder):
     """DagBag collects the folder in its constructor unless told not to"""
-    from openmetadata_managed_apis.api import utils
+    from openmetadata_managed_apis.api import utils  # noqa: PLC0415
 
     with (
         patch.object(utils.settings, "DAGS_FOLDER", str(dags_folder)),
@@ -103,7 +103,7 @@ def test_process_file_bags_the_deployed_dag(dags_folder):
     `file_last_changed` for every file it walks and `process_file` then hits its
     `only_if_updated` early return.
     """
-    from openmetadata_managed_apis.api import utils
+    from openmetadata_managed_apis.api import utils  # noqa: PLC0415
 
     deployed = _write_dag_file(dags_folder, "the_deployed_dag")
 


### PR DESCRIPTION
- Backporting https://github.com/open-metadata/OpenMetadata/commit/8f3504b7fd9348a0e4b3668724cb9dbdf0c9acc9 & https://github.com/open-metadata/OpenMetadata/commit/56d0d27f0289c8a08fd0769da6fe765f82e1ea7c from main to 2.0

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR backports REST API ingestion fixes that separate collection and endpoint topology passes, insert a sink barrier between dependent writes, and make OpenAPI collection and schema parsing more resilient.

- Processes and flushes all API collections before producing endpoints.
- Memoizes collection objects so endpoint URL generation can reuse collection enrichment.
- Adds support for nested inline array objects and numeric OpenAPI formats.
- Expands regression coverage for malformed schemas, ordering, URL fallbacks, references, and recursive field parsing.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with one non-blocking concern about retaining an unbounded collection cache for large OpenAPI inputs.

The new topology ordering and schema handling are covered by targeted tests, while the only accepted concern is input-proportional collection retention rather than a demonstrated correctness failure.

**Files Needing Attention:** ingestion/src/metadata/ingestion/source/api/rest/metadata.py
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/api/api_service.py | Splits collections and endpoints into ordered sibling topology nodes and emits a barrier after collection processing. |
| ingestion/src/metadata/ingestion/source/api/rest/metadata.py | Adds resilient collection derivation and richer schema parsing, but introduces an unbounded source-lifetime collection cache. |
| ingestion/tests/unit/topology/api/test_rest.py | Adds comprehensive regression tests for bulk ordering, malformed documents, URL handling, schema references, and nested fields. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant R as REST source
  participant S as Metadata REST sink
  participant O as OpenMetadata
  R->>S: API collection requests
  S->>S: Buffer collection writes
  R->>S: Barrier
  S->>O: Flush all collections
  R->>S: API endpoint requests
  S->>O: Publish endpoints with resolved collection references
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fixes #30598: persist all API collection..."](https://github.com/open-metadata/openmetadata/commit/51f833a99c2d827581e92b2058c39a161c02db5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58529170)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))
- Knowledge Base — [Metadata ingestion](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/metadata-ingestion.md)
- Knowledge Base — [Ingestion connectors](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/ingestion-connectors.md)
</details>


<!-- /greptile_comment -->