### PR TITLE
fix(playwright): narrow add-reactions locator to fix strict mode violation

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityFeed.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityFeed.spec.ts
@@ -747,7 +747,11 @@ test.describe('Mention notifications in Notification Box', () => {
             new URL(response.url()).pathname
           ) && response.request().method() === 'PUT'
       );
-      await message.locator('[data-testid="add-reactions"]').click();
+      await message
+        .locator('[data-testid="feed-card-footer"]')
+        .filter({ has: user1Page.locator('[data-testid="reply-button"]') })
+        .locator('[data-testid="add-reactions"]')
+        .click();
       await user1Page.locator('[title="rocket"]').click();
       await reactionResponse;
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/FeedCardFooter/FeedCardFooterNew.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/FeedCardFooter/FeedCardFooterNew.tsx
@@ -79,7 +79,10 @@ function FeedCardFooterNew({
 
   return (
     <Row align="top" className={classNames({ 'm-y-md': isReply })}>
-      <Col className="footer-container" data-testid="feed-card-footer" span={24}>
+      <Col
+        className="footer-container"
+        data-testid="feed-card-footer"
+        span={24}>
         <div>
           <div className="flex items-center gap-2 w-full rounded-8">
             {postLength > 0 && !isReply && (

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/FeedCardFooter/FeedCardFooterNew.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/FeedCardFooter/FeedCardFooterNew.tsx
@@ -79,7 +79,7 @@ function FeedCardFooterNew({
 
   return (
     <Row align="top" className={classNames({ 'm-y-md': isReply })}>
-      <Col className="footer-container" span={24}>
+      <Col className="footer-container" data-testid="feed-card-footer" span={24}>
         <div>
           <div className="flex items-center gap-2 w-full rounded-8">
             {postLength > 0 && !isReply && (


### PR DESCRIPTION
### Describe your changes:

I worked on narrowing the `add-reactions` locator in the Mention notification Playwright test because it was resolving to multiple elements (one per reply card inside `message-container`), causing Playwright's strict mode to abort the test.

- Added `data-testid="feed-card-footer"` to the `Col` in `FeedCardFooterNew.tsx` so tests can target the footer by test ID instead of a CSS class.
- Updated the failing locator in `ActivityFeed.spec.ts` to scope `add-reactions` to the footer that contains `reply-button` — which only exists on the main message footer (`isReply=false`), never on reply card footers — making the locator uniquely match regardless of how many replies are in the thread.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Mention notification shows correct user details in Notification box (the failing test)

#### Unit tests
- [ ] Not applicable (no logic changes).

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Fixed existing Playwright E2E test: `playwright/e2e/Features/ActivityFeed.spec.ts`

#### Manual testing performed
N/A — test-only fix; the locator change corrects strict mode resolution.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR stabilizes the mention-notification Playwright test by giving activity-feed footers a dedicated test ID and selecting the main message footer through its reply button.
- Adds `data-testid="feed-card-footer"` to the activity-feed footer component.
- Scopes the reaction control locator to the non-reply footer.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityFeed.spec.ts | Narrows the reaction locator to the main message footer, avoiding strict-mode collisions with reply-card reaction controls. |
| openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/FeedCardFooter/FeedCardFooterNew.tsx | Adds a stable test identifier to both main and reply footers while retaining the reply button only on the main footer. |

</details>

<sub>Reviews (2): Last reviewed commit: ["lint fix"](https://github.com/open-metadata/openmetadata/commit/0cf3e71d4bc45d3454a9dd01f12e50483ffcc1fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58542491)</sub>

<!-- /greptile_comment -->