### PR TITLE
Fixes #32256: Queries tab shows parent table's description provenance

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityDescription/Description.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityDescription/Description.test.tsx
@@ -340,6 +340,7 @@ describe('Description', () => {
   it('should render the authored-by footer when change metadata is present', () => {
     mockUseGenericContext.mockReturnValue({
       isVersionView: false,
+      type: EntityType.TABLE,
       changeSummary: {
         description: {
           changeSource: ChangeSource.Manual,
@@ -353,6 +354,27 @@ describe('Description', () => {
     render(<Description {...defaultProps} />);
 
     expect(screen.getByTestId('authored-by-footer')).toBeInTheDocument();
+  });
+
+  it('should not inherit the page-level change summary when entityType differs from the context entity', () => {
+    // Regression test for #32256: a Query rendered on a Table page must not pick up the
+    // table's description-provenance from the GenericProvider context.
+    mockUseGenericContext.mockReturnValue({
+      isVersionView: false,
+      type: EntityType.TABLE,
+      changeSummary: {
+        description: {
+          changeSource: ChangeSource.Suggested,
+          changedBy: 'admin',
+          changedAt: 1700000000000,
+        },
+      },
+      onThreadLinkSelect: mockOnThreadLinkSelect,
+    });
+
+    render(<Description {...defaultProps} entityType={EntityType.QUERY} />);
+
+    expect(screen.queryByTestId('authored-by-footer')).not.toBeInTheDocument();
   });
 
   it('should not render the authored-by footer when change metadata is absent', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityDescription/Description.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityDescription/Description.tsx
@@ -74,10 +74,20 @@ const Description = ({
   changeSummaryEntry,
 }: DescriptionProps) => {
   const navigate = useNavigate();
-  const { isVersionView, changeSummary, onThreadLinkSelect } =
-    useGenericContext<Domain>();
+  const {
+    isVersionView,
+    changeSummary,
+    onThreadLinkSelect,
+    type: contextEntityType,
+  } = useGenericContext<Domain>();
+  // The context's changeSummary belongs to the page-level entity. Only fall back to it
+  // when the entity being rendered is that same entity — otherwise a nested Description
+  // (e.g. a Query in TableQueryRightPanel) inherits the parent table's provenance.
   const descriptionChangeSummary =
-    changeSummaryEntry ?? changeSummary?.['description'];
+    changeSummaryEntry ??
+    (entityType === contextEntityType
+      ? changeSummary?.['description']
+      : undefined);
   const { suggestions, selectedUserSuggestions } = useSuggestionsContext();
   const [isEditDescription, setIsEditDescription] = useState(false);
   const { fqn } = useFqn();


### PR DESCRIPTION
### Describe your changes:

Fixes #32256

The `Description` component silently fell back to the page-level `GenericProvider` change summary whenever `changeSummaryEntry` was not passed. `TableQueryRightPanel` renders a `Query` description on a Table page without that prop, so any query showed the **table's** provenance ("Accepted by admin • 6 days ago") — regardless of who actually authored the query. This changes the fallback to only apply when the rendered `entityType` matches the context entity's `type`, which fixes the reported symptom and also prevents the same misattribution class-of-bug in any future caller.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change (single 5-line fix in `Description.tsx` + a regression test).

#
### Tests:

#### Use cases covered
- On a table whose description came from an accepted AI suggestion, opening the **Queries** tab no longer shows the table's "Accepted by … 6 days ago" line under a freshly-created query's description.
- Rendering `<Description>` for an entity that matches the surrounding `GenericProvider` (e.g. the table's own description on the table page) still shows the page-level change summary as before.

#### Unit tests
- Added: `should not inherit the page-level change summary when entityType differs from the context entity` in `openmetadata-ui/.../EntityDescription/Description.test.tsx` — regression test for #32256.
- Updated: `should render the authored-by footer when change metadata is present` now sets `type: EntityType.TABLE` in the mock context, matching the new stricter fallback rule.
- Result: `Description.test.tsx` 26/26 pass, `TableQueryRightPanel.test.tsx` 6/6 pass.

#### Backend integration tests
- [x] Not applicable (UI-only change).

#### Ingestion integration tests
- [x] Not applicable (UI-only change).

#### Playwright (UI) tests
- [x] Not applicable — this is a stateless render bug covered fully by the unit regression test; adding an E2E to assert a missing footer would require constructing a table + query with accepted-AI-suggestion change summaries via API and gives no signal the unit test doesn't.

#### Manual testing performed
1. Reproduced against a locally-running instance on `:8585`: on a table whose description was accepted from an AI suggestion, the Queries tab's right panel showed "Accepted by admin • 6 days ago" under a query created seconds earlier.
2. Verified the fix path with the unit regression test above.

#
### UI screen recording / screenshots:

Not applicable — the change removes an incorrect metadata line under an existing panel; no visual redesign, and the reproduction is best documented by the code path referenced in the issue.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added a test that covers the exact scenario we are fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents nested descriptions from inheriting provenance metadata belonging to the surrounding page-level entity.
- Restricts the `GenericProvider` change-summary fallback to matching entity types.
- Adds regression coverage for a query description rendered within a table page.
- Preserves fallback behavior when the rendered and contextual entity types match.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code failure identified.

The fallback now distinguishes page-level and nested entities while preserving provenance for verified same-entity callers, and the regression test covers the reported query-on-table scenario.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/common/EntityDescription/Description.tsx | Safely scopes page-level description provenance to matching entity types, with no established regression in current callers. |
| openmetadata-ui/src/main/resources/ui/src/components/common/EntityDescription/Description.test.tsx | Adds focused regression coverage for cross-entity provenance leakage and updates the matching-entity test setup. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fixes #32256: Queries tab shows parent t..."](https://github.com/open-metadata/openmetadata/commit/8a305cc33fde77ae04e1268129bab27304260f62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58568177)</sub>

<!-- /greptile_comment -->