### PR TITLE
fix(security): backport httpclient5 5.6.4 + jsoup 1.23.2 to 1.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -778,12 +778,14 @@
         Keep this in step with the httpcore5 pin above - Apache releases the two together
         and mixing lines breaks search. httpclient5 5.5/5.5.2 are built against httpcore5
         5.3.x; on 5.4.x their I/O reactor dispatchers die silently, leaking connection-pool
-        leases until every request fails with DeadlineTimeoutException. 5.6.3 declares
-        httpcore5 5.4.3, so client and core match.
+        leases until every request fails with DeadlineTimeoutException. 5.6.4 declares
+        httpcore5 5.4.3 (identical to 5.6.3), so client and core match.
 
-        5.6.3 is also the first release outside the CVE-2026-64607 range (affects
+        5.6.3 was the first release outside the CVE-2026-64607 range (affects
         5.0-alpha1 through 5.6.2: the classic i/o client leaks a connection when a response
-        carries an invalid Content-Encoding).
+        carries an invalid Content-Encoding). 5.6.4 additionally closes CVE-2026-71290
+        (improper certificate validation: HostnameVerificationPolicy#BUILTIN had no effect on
+        the async TLS upgrade path, so SSL parameters were not applied).
 
         The 5.6 line enables automatic content decompression in the async client, which the
         search transports also do - see disableContentCompression() in OpenSearchClient and
@@ -792,7 +794,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents.client5</groupId>
         <artifactId>httpclient5</artifactId>
-        <version>5.6.3</version>
+        <version>5.6.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -801,6 +801,17 @@
         <artifactId>commons-compress</artifactId>
         <version>1.26.0</version>
       </dependency>
+      <!-- CVE-2026-75140: quadratic memory in XmlTreeBuilder namespace-map copying lets a
+           deeply nested, uniquely-namespaced XML document exhaust the heap. Vulnerable through
+           1.23.1; the fix (jsoup PR #2556) ships in 1.23.2. jsoup is not declared by any module -
+           it arrives only as a transitive of flexmark-html2md-converter, which declares 1.15.4.
+           That is a soft requirement, so managing it here overrides it. Remove this pin only if
+           flexmark ever ships a release declaring 1.23.2 or newer itself (0.64.8 is its latest). -->
+      <dependency>
+        <groupId>org.jsoup</groupId>
+        <artifactId>jsoup</artifactId>
+        <version>1.23.2</version>
+      </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcpkix-jdk18on</artifactId>


### PR DESCRIPTION
Backport of two security dependency pins to the 1.13 release branch. Combines:

- **#32264** — `httpclient5` 5.6.3 → 5.6.4 (CVE-2026-71290)
- **#32266** — `jsoup` transitive pin → 1.23.2 (CVE-2026-75140)

Both are `dependencyManagement` edits to the root `pom.xml`; clean cherry-picks with no conflicts.

## CVE-2026-71290 — httpclient5 (CWE-295, Improper Certificate Validation, critical, CVSS 9.1)

`HostnameVerificationPolicy#BUILTIN` has no effect in the async transport, so SSL parameters are not applied on the async TLS upgrade path — a MITM attacker can impersonate a server with a certificate valid for a different domain. Fixed in httpclient5 5.6.4 (upstream commit `2422b6c8`).

- httpcore5 stays pinned at 5.4.3; 5.6.4 declares the same httpcore5 5.4.3, so the client/core pairing (and the `SingleCoreIOReactor` lease-leak guard documented in the pin comment) is preserved.
- Still within the 5.6 line, so the `disableContentCompression()` requirement on the OpenSearch/Elasticsearch transports is unchanged.

## CVE-2026-75140 — jsoup (CWE-770, Uncontrolled Resource Consumption, CVSS 8.7)

jsoup's `XmlTreeBuilder` copies the whole inherited namespace map on every start element; a deeply nested, uniquely-namespaced XML document costs quadratic time/memory and can drive the JVM to `OutOfMemoryError`. Fixed in jsoup 1.23.2 (PR #2556, commit `862ba2f`, ancestor of the `jsoup-1.23.2` tag).

- jsoup is declared by no module — it arrives only transitively via `flexmark-html2md-converter:0.64.8`, which declares 1.15.4 as a soft requirement, so the root pin overrides it without a resolver conflict. 0.64.8 is flexmark's latest release, so there is no owner bump available.

## Not tested

Cherry-pick only — no build or tests run on this branch. See #32264 and #32266 for the verification performed on `main`. CI is the first real compile here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates two centrally managed dependencies to patched security releases while preserving the existing HTTP client/core pairing.
- Upgrades Apache HttpClient 5 from 5.6.3 to 5.6.4 to address async hostname-verification behavior.
- Pins transitive jsoup to 1.23.2 to address quadratic XML namespace processing.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The dependency-only security backport appears safe to merge, with no concrete blocking or non-blocking defect identified.

The retained HTTP core pairing and compression configuration remain consistent, and the jsoup consumers use APIs compatible with the newly managed release.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| pom.xml | Updates the managed httpclient5 version and adds a managed jsoup pin; no concrete compatibility or build defect was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): bump jsoup to 1.23.2"](https://github.com/open-metadata/openmetadata/commit/7b0396998c42f27dba5d2bef3ca5606e99a93df9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58579263)</sub>

<!-- /greptile_comment -->