### PR TITLE
test(playwright): page to the app card; anchor the steward switch

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/eslint-suppressions.json
+++ b/openmetadata-ui/src/main/resources/ui/eslint-suppressions.json
@@ -262,7 +262,7 @@
   },
   "playwright/e2e/Features/DataQuality/TestDefinitionPermissions.spec.ts": {
     "om-playwright/no-positional-locator": {
-      "count": 5
+      "count": 3
     }
   },
   "playwright/e2e/Features/DataQuality/TestLibrary.spec.ts": {
@@ -949,11 +949,6 @@
     }
   },
   "playwright/e2e/Pages/Roles.spec.ts": {
-    "om-playwright/no-positional-locator": {
-      "count": 2
-    }
-  },
-  "playwright/e2e/Pages/SearchIndexApplication.spec.ts": {
     "om-playwright/no-positional-locator": {
       "count": 2
     }

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestDefinitionPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestDefinitionPermissions.spec.ts
@@ -267,16 +267,44 @@ test.describe(
   'Test Definition Permissions - Data Steward',
   { tag: `${DOMAIN_TAGS.OBSERVABILITY}:Rules_Library` },
   () => {
+    // Target the definition this spec creates rather than whichever row sorts
+    // first. The Test Library is shared across the whole run, and specs seed
+    // definitions named to sort to the top (TestLibrary.spec.ts creates
+    // `AaaaExternalTest*`); an external definition's toggle is disabled by
+    // design, so a positional locator asserts on a row this spec never owned.
+    const stewardDefinitionName = `aaaColumnTestDefinition-${uuid()}`;
+    let stewardDefinitionId: string | undefined;
+
     test.beforeAll(async ({ browser }) => {
       const { apiContext, afterAction } = await performAdminLogin(browser);
-      await apiContext.post('/api/v1/dataQuality/testDefinitions', {
-        data: {
-          name: `aaaColumnTestDefinition-${uuid()}`,
-          description: `A Column test definition`,
-          entityType: 'COLUMN',
-          testPlatforms: ['OpenMetadata'],
-        },
-      });
+      const response = await apiContext.post(
+        '/api/v1/dataQuality/testDefinitions',
+        {
+          data: {
+            name: stewardDefinitionName,
+            description: `A Column test definition`,
+            entityType: 'COLUMN',
+            testPlatforms: ['OpenMetadata'],
+          },
+        }
+      );
+      stewardDefinitionId = (await response.json())?.id;
+      await afterAction();
+    });
+
+    // Without this the definition outlives the run. The Test Library is
+    // paginated with no search, and every worker adds another `aaa*` row that
+    // sorts alongside this one, so leaked definitions eventually push the row
+    // this spec targets off the first page.
+    test.afterAll(async ({ browser }) => {
+      if (!stewardDefinitionId) {
+        return;
+      }
+
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      await apiContext.delete(
+        `/api/v1/dataQuality/testDefinitions/${stewardDefinitionId}?hardDelete=true`
+      );
       await afterAction();
     });
 
@@ -306,9 +334,11 @@ test.describe(
       await expect(addButton).not.toBeVisible();
 
       // Data Steward should be able to toggle enabled/disabled switches (EditAll permission)
-      const firstSwitch = dataStewardPage.getByRole('switch').first();
+      const stewardSwitch = dataStewardPage.getByTestId(
+        `enable-switch-${stewardDefinitionName}`
+      );
 
-      await expect(firstSwitch).toBeEnabled();
+      await expect(stewardSwitch).toBeEnabled();
 
       // Wait for API call
       const response = dataStewardPage.waitForResponse(
@@ -318,11 +348,11 @@ test.describe(
       );
 
       // Try to toggle the switch
-      await firstSwitch.click();
+      await stewardSwitch.click();
       await response;
 
       // Verify switch state changed
-      await expect(firstSwitch).toHaveAttribute(
+      await expect(stewardSwitch).toHaveAttribute(
         'aria-checked',
         String('false')
       );
@@ -333,16 +363,20 @@ test.describe(
           response.request().method() === 'PATCH'
       );
       // Toggle back to original state
-      await firstSwitch.click();
+      await stewardSwitch.click();
       await response2;
 
-      await expect(firstSwitch).toHaveAttribute('aria-checked', String('true'));
+      await expect(stewardSwitch).toHaveAttribute(
+        'aria-checked',
+        String('true')
+      );
 
       // Data Steward should NOT see delete buttons (no Delete permission)
-      const deleteButtons = dataStewardPage.getByTestId(
-        /delete-test-definition-/
-      );
-      await expect(deleteButtons.first()).toBeDisabled();
+      await expect(
+        dataStewardPage.getByTestId(
+          `delete-test-definition-${stewardDefinitionName}`
+        )
+      ).toBeDisabled();
     });
 
     test('should not be able to edit system test definitions', async ({

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LiveIndexingTab.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LiveIndexingTab.spec.ts
@@ -12,6 +12,10 @@
  */
 import test, { expect } from '@playwright/test';
 import { GlobalSettingOptions } from '../../constant/settings';
+import {
+  findApplicationCard,
+  openApplicationDetails,
+} from '../../utils/applications';
 import { getApiContext, redirectToHomePage } from '../../utils/common';
 import { settingClick } from '../../utils/sidebar';
 
@@ -93,11 +97,7 @@ test.describe(
         await redirectToHomePage(page);
         await settingClick(page, GlobalSettingOptions.APPLICATIONS);
 
-        await page
-          .locator(
-            '[data-testid="search-indexing-application-card"] [data-testid="config-btn"]'
-          )
-          .click();
+        await openApplicationDetails(page, 'search-indexing-application-card');
       });
 
       await test.step('Click Live Indexing tab', async () => {
@@ -144,11 +144,7 @@ test.describe(
         await redirectToHomePage(page);
         await settingClick(page, GlobalSettingOptions.APPLICATIONS);
 
-        await page
-          .locator(
-            '[data-testid="search-indexing-application-card"] [data-testid="config-btn"]'
-          )
-          .click();
+        await openApplicationDetails(page, 'search-indexing-application-card');
       });
 
       await test.step('Verify empty state message when queue is empty', async () => {
@@ -214,11 +210,7 @@ test.describe(
         await redirectToHomePage(page);
         await settingClick(page, GlobalSettingOptions.APPLICATIONS);
 
-        await page
-          .locator(
-            '[data-testid="search-indexing-application-card"] [data-testid="config-btn"]'
-          )
-          .click();
+        await openApplicationDetails(page, 'search-indexing-application-card');
       });
 
       await test.step('Mock and verify retry queue data', async () => {
@@ -278,13 +270,15 @@ test.describe(
       });
 
       await test.step('Verify Live Indexing tab is absent on non-search apps', async () => {
-        // Check if DataInsightsReportApplication card exists
-        const diCard = page.locator(
-          '[data-testid="data-insights-report-application-card"] [data-testid="config-btn"]'
-        );
+        // DataInsightsReportApplication is not installed on every deployment,
+        // so treat "not on any page" as nothing to assert rather than a failure.
+        const diCard = await findApplicationCard(
+          page,
+          'data-insights-report-application-card'
+        ).catch(() => null);
 
-        if (await diCard.isVisible()) {
-          await diCard.click();
+        if (diCard) {
+          await diCard.getByTestId('config-btn').click();
 
           const liveIndexingTab = page.getByRole('tab', {
             name: 'Live Indexing',

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchIndexApplication.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchIndexApplication.spec.ts
@@ -14,6 +14,13 @@ import test, { expect, Page, Response } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { GlobalSettingOptions } from '../../constant/settings';
 import {
+  APPLICATION_LIST,
+  expectApplicationInstalled,
+  expectApplicationNotInstalled,
+  findApplicationCard,
+  openApplicationDetails,
+} from '../../utils/applications';
+import {
   clickOutside,
   getApiContext,
   redirectToHomePage,
@@ -47,47 +54,13 @@ const installSearchIndexApplication = async (page: Page) => {
 
   expect(response.status()).toBe(200);
 
-  // Wait for at least one app card to be rendered before polling.
-  await page
-    .locator('[data-testid$="-application-card"]')
-    .first()
-    .waitFor({ state: 'visible' });
+  const marketplaceCard = await findApplicationCard(
+    page,
+    'search-indexing-application-card',
+    APPLICATION_LIST.marketplace
+  );
 
-  // Paginate through marketplace pages until the card is found.
-  let cardFound = await page
-    .locator('[data-testid="search-indexing-application-card"]')
-    .isVisible();
-
-  while (!cardFound) {
-    const nextButton = page.locator('[data-testid="next"]');
-
-    const isNextButtonVisible = await nextButton.isVisible();
-
-    if (!isNextButtonVisible || (await nextButton.isDisabled())) {
-      throw new Error(
-        'search-indexing-application-card not found in marketplace and next button is disabled'
-      );
-    }
-
-    const nextPageResponse = page.waitForResponse('/api/v1/apps/marketplace*');
-    await nextButton.click();
-    await nextPageResponse;
-
-    // Wait for the next page's cards to render before re-checking.
-    await page
-      .locator('[data-testid$="-application-card"]')
-      .first()
-      .waitFor({ state: 'visible' });
-
-    cardFound = await page
-      .locator('[data-testid="search-indexing-application-card"]')
-      .isVisible();
-  }
-
-  await page
-    .getByTestId('search-indexing-application-card')
-    .getByTestId('config-btn')
-    .click();
+  await marketplaceCard.getByTestId('config-btn').click();
 
   await page.getByTestId('install-application').waitFor({ state: 'visible' });
   await page.getByTestId('install-application').click();
@@ -117,9 +90,7 @@ const installSearchIndexApplication = async (page: Page) => {
 
   await getApplications;
 
-  await expect(
-    page.getByTestId('search-indexing-application-card')
-  ).toBeVisible();
+  await expectApplicationInstalled(page, 'search-indexing-application-card');
 };
 
 const verifyLastExecutionStatus = async (page: Page) => {
@@ -291,11 +262,7 @@ test.describe('Search Index Application', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       const statusAPI = page.waitForResponse(
         '/api/v1/apps/name/SearchIndexingApplication/status?offset=0&limit=1'
       );
-      await page
-        .locator(
-          '[data-testid="search-indexing-application-card"] [data-testid="config-btn"]'
-        )
-        .click();
+      await openApplicationDetails(page, 'search-indexing-application-card');
       const statusResponse = await statusAPI;
 
       expect(statusResponse.status()).toBe(200);
@@ -431,11 +398,10 @@ test.describe('Search Index Application', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
 
       await toastNotification(page, 'Application uninstalled successfully');
 
-      const card1 = page.locator(
-        '[data-testid="search-indexing-application-card"]'
+      await expectApplicationNotInstalled(
+        page,
+        'search-indexing-application-card'
       );
-
-      await expect(card1).toBeHidden();
     });
 
     await test.step('Install application', async () => {
@@ -446,9 +412,7 @@ test.describe('Search Index Application', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       await test.step('Run application and rerun with table-only config', async () => {
         test.slow(true); // Test time shouldn't exceed while re-fetching the history API.
 
-        await page.click(
-          '[data-testid="search-indexing-application-card"] [data-testid="config-btn"]'
-        );
+        await openApplicationDetails(page, 'search-indexing-application-card');
 
         const previousRunStartTime = await getLatestRunStartTime(page);
         const triggerPipelineResponse = page.waitForResponse(

--- a/openmetadata-ui/src/main/resources/ui/playwright/eslint-rules/tests/corpus.test.mjs
+++ b/openmetadata-ui/src/main/resources/ui/playwright/eslint-rules/tests/corpus.test.mjs
@@ -42,7 +42,7 @@ test('the suppressions baseline matches its recorded state exactly', () => {
   const EXPECTED = {
     'om-playwright/justified-rule-disable': 12,
     'om-playwright/no-blanket-test-slow': 83,
-    'om-playwright/no-positional-locator': 1328,
+    'om-playwright/no-positional-locator': 1324,
     'om-playwright/require-assertion-per-test': 1,
     'playwright/no-force-option': 11,
     'playwright/no-skipped-test': 4,

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/applications.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/applications.ts
@@ -10,7 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { APIRequestContext } from '@playwright/test';
+import { APIRequestContext, expect, Page } from '@playwright/test';
+import { clickAndWaitFor } from './waitHelpers';
 
 export const enableDisableAutoPilotApplication = async (
   apiContext: APIRequestContext,
@@ -22,4 +23,122 @@ export const enableDisableAutoPilotApplication = async (
       'Content-Type': 'application/json-patch+json',
     },
   });
+};
+
+const APPLICATION_CARD = '[data-testid$="-application-card"]';
+
+/**
+ * The two paginated application lists. They share a card testid and paging
+ * controls and differ only in the endpoint a page turn hits, so both are
+ * walked by the same code.
+ */
+export const APPLICATION_LIST = {
+  installed: { api: /\/api\/v1\/apps\?/, label: 'applications list' },
+  marketplace: { api: /\/api\/v1\/apps\/marketplace/, label: 'marketplace' },
+} as const;
+
+type ApplicationList = (typeof APPLICATION_LIST)[keyof typeof APPLICATION_LIST];
+
+const waitForApplicationCards = async (page: Page) => {
+  await expect(page.locator(APPLICATION_CARD)).not.toHaveCount(0);
+};
+
+/**
+ * Walk an application list from the current page onwards, stopping as soon as
+ * the card is on screen. Returns whether it was found anywhere.
+ *
+ * Both lists paginate at PAGE_SIZE_BASE (15) and the bundled app count grows
+ * whenever a new application ships, so a card sitting on page 1 today silently
+ * moves to page 2 the next time one is added. Anything that asserts on a
+ * card's presence or absence has to page, or it is really only asserting about
+ * page 1.
+ */
+const isOnAnyApplicationPage = async (
+  page: Page,
+  cardTestId: string,
+  list: ApplicationList
+) => {
+  await waitForApplicationCards(page);
+
+  const card = page.getByTestId(cardTestId);
+  const nextPage = page.getByTestId('next');
+
+  while (!(await card.isVisible())) {
+    const canPage =
+      (await nextPage.isVisible()) && (await nextPage.isEnabled());
+
+    if (!canPage) {
+      return false;
+    }
+
+    await clickAndWaitFor(page, nextPage, list.api);
+
+    // The list swaps its cards for skeletons while loading, so the next card
+    // to appear can only belong to the page we just moved to.
+    await waitForApplicationCards(page);
+  }
+
+  return true;
+};
+
+/**
+ * Bring an installed application's card on screen and return its locator,
+ * paging until it is found. Throws when no page holds it.
+ */
+export const findApplicationCard = async (
+  page: Page,
+  cardTestId: string,
+  list: ApplicationList = APPLICATION_LIST.installed
+) => {
+  const isFound = await isOnAnyApplicationPage(page, cardTestId, list);
+
+  if (!isFound) {
+    throw new Error(
+      `${cardTestId} was not found on any page of the ${list.label}`
+    );
+  }
+
+  return page.getByTestId(cardTestId);
+};
+
+/**
+ * Assert an application is installed, paging until its card is found. Use this
+ * rather than a bare toBeVisible(), which only ever asserts about page 1.
+ */
+export const expectApplicationInstalled = async (
+  page: Page,
+  cardTestId: string
+) => {
+  expect(
+    await isOnAnyApplicationPage(page, cardTestId, APPLICATION_LIST.installed),
+    `${cardTestId} should be on some page of the applications list`
+  ).toBe(true);
+};
+
+/**
+ * Assert an application is not installed. A bare toBeHidden() cannot tell
+ * "uninstalled" from "on a later page", so it passes even when the uninstall
+ * silently failed.
+ */
+export const expectApplicationNotInstalled = async (
+  page: Page,
+  cardTestId: string
+) => {
+  expect(
+    await isOnAnyApplicationPage(page, cardTestId, APPLICATION_LIST.installed),
+    `${cardTestId} should not be on any page of the applications list`
+  ).toBe(false);
+};
+
+/**
+ * Open an installed application's details page from Settings > Applications,
+ * paging to its card first. Assumes the applications list is already open.
+ */
+export const openApplicationDetails = async (
+  page: Page,
+  cardTestId: string
+) => {
+  const card = await findApplicationCard(page, cardTestId);
+
+  await card.getByTestId('config-btn').click();
 };


### PR DESCRIPTION
## Problem

Settings > Applications paginates at `PAGE_SIZE_BASE` (15). Adding `RdfInferenceApp` in #28042 took the bundled app count from 15 to 16 and pushed the **Search Indexing** card to page 2, so every test that clicked it without paging began failing as a 60s click timeout.

Observed in the 31 Aug AUT nightly (run `33363693882`), failing identically on both MySQL and PostgreSQL:

- `LiveIndexingTab.spec.ts:89`, `:140`, `:180`
- `SearchIndexApplication.spec.ts:258`

`LiveIndexingTab.spec.ts:89` was already flaky on postgres beforehand — the suite was sitting exactly on the page boundary, so any extra installed app tipped it. #28042 made that permanent.

This could not fail in this repo's own CI: pure OSS installs 9 applications, one page, so the card is always visible. Only Collate, which installs roughly eight more, crosses 15. #28042's PR run was also green because the impact-based selector never picked these two specs — they ran in none of its 19 shards.

## Changes

**Applications list — page instead of assuming page 1** (`playwright/utils/applications.ts`)

`isOnAnyApplicationPage` walks a list until the card appears; `findApplicationCard`, `expectApplicationInstalled` and `expectApplicationNotInstalled` build on it. The installed list and the marketplace share a card testid and paging controls and differ only in the endpoint a page turn hits, so `APPLICATION_LIST` selects between them and `installSearchIndexApplication`'s hand-rolled marketplace loop is gone (−35 lines).

Two assertions in `SearchIndexApplication.spec.ts` carried the same page-1 assumption and are also fixed:

- the post-install `toBeVisible()` would itself have failed once the reinstall took the count back to 16
- the post-uninstall `toBeHidden()` passed trivially whenever the card sat on a later page — it could not tell "uninstalled" from "on page 2"

**`TestDefinitionPermissions.spec.ts` — anchor the switch**

`getByRole('switch').first()` resolved to `enable-switch-AaaaExternalTest…`, seeded by `TestLibrary.spec.ts` and named to sort first. External test definitions disable their toggle by design, so the assertion was checking a row this spec never owned. It now targets the definition the spec itself creates, and deletes it in `afterAll` — the leak was harmless under `.first()` but not once the row's position is load-bearing, since the Test Library is paginated with no search.

This one passes in sharded PR CI because `TestLibrary.spec.ts` and `TestDefinitionPermissions.spec.ts` land in different shards, hence different backend instances. The AUT runs all 7752 tests against one instance with 39 workers, where the collision is possible.

## Notes

- `eslint-suppressions.json` shrinks by four positional-locator entries; `SearchIndexApplication.spec.ts` drops out entirely.
- Verified: `yarn lint:playwright` 0 errors, prettier clean, no new `tsc` errors. **The four tests have not been run** — I have no stack to run them against, so please let CI confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes Playwright application tests traverse paginated installed and marketplace lists instead of assuming the target card is on the first page. It also anchors the Data Steward permission checks to a uniquely created test definition and removes that definition after the suite.
- Adds shared helpers for finding application cards and asserting installation state across pages.
- Updates Search Indexing and Live Indexing tests to use the pagination-aware helpers.
- Replaces positional permission controls with locators tied to the test-owned definition.
- Updates the positional-locator suppression baseline.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/applications.ts | Introduces reusable pagination-aware helpers for locating application cards and checking installed or uninstalled state. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestDefinitionPermissions.spec.ts | Anchors permission assertions to the definition created by the suite and adds hard-delete cleanup. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchIndexApplication.spec.ts | Replaces page-one assumptions and a bespoke marketplace loop with shared application-list helpers. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LiveIndexingTab.spec.ts | Uses pagination-aware application navigation and conditionally checks the optional Data Insights application. |
| openmetadata-ui/src/main/resources/ui/eslint-suppressions.json | Reduces positional-locator suppressions to match the updated tests. |
| openmetadata-ui/src/main/resources/ui/playwright/eslint-rules/tests/corpus.test.mjs | Updates the expected positional-locator suppression count. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Open applications list] --> B[Wait for application cards]
  B --> C{Target card visible?}
  C -->|Yes| D[Return card or assert installed]
  C -->|No| E{Next page available?}
  E -->|Yes| F[Click Next and await list response]
  F --> B
  E -->|No| G[Report absent or throw not-found error]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(playwright): lower the recorded no-..."](https://github.com/open-metadata/openmetadata/commit/ccc7bb9a844fd5b705321fdb2b1cfda2522694e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58581324)</sub>

<!-- /greptile_comment -->