### PR TITLE
ci(playwright): backport #32267 — 2 per-test retries for nightly E2E (2.0)

### DIFF
--- a/.github/workflows/mysql-nightly-e2e.yml
+++ b/.github/workflows/mysql-nightly-e2e.yml
@@ -118,6 +118,9 @@ jobs:
           fi
 
         env:
+          # Release branches accumulate flakes faster than main; give each test
+          # two retries instead of the config default of one.
+          PLAYWRIGHT_RETRIES: "2"
           PLAYWRIGHT_IS_OSS: true
           PLAYWRIGHT_SNOWFLAKE_USERNAME: ${{ secrets.TEST_SNOWFLAKE_USERNAME }}
           PLAYWRIGHT_SNOWFLAKE_PASSWORD: ${{ secrets.TEST_SNOWFLAKE_PASSWORD }}

--- a/.github/workflows/postgresql-nightly-e2e.yml
+++ b/.github/workflows/postgresql-nightly-e2e.yml
@@ -118,6 +118,9 @@ jobs:
           fi
 
         env:
+          # Release branches accumulate flakes faster than main; give each test
+          # two retries instead of the config default of one.
+          PLAYWRIGHT_RETRIES: "2"
           PLAYWRIGHT_IS_OSS: true
           PLAYWRIGHT_SNOWFLAKE_USERNAME: ${{ secrets.TEST_SNOWFLAKE_USERNAME }}
           PLAYWRIGHT_SNOWFLAKE_PASSWORD: ${{ secrets.TEST_SNOWFLAKE_PASSWORD }}

--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -122,8 +122,10 @@ export default defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 1 : 0,
+  /* Retry on CI only; PLAYWRIGHT_RETRIES (set by the release-branch nightly
+   * workflows) overrides the CI default of 1. The parens are semantic:
+   * without them `?? CI ? 1 : 0` collapses every override to 1. */
+  retries: Number(process.env.PLAYWRIGHT_RETRIES ?? (process.env.CI ? 1 : 0)),
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI
     ? Number(process.env.PW_WORKERS ?? shardPlan?.workers ?? 3)


### PR DESCRIPTION
### Describe your changes:

Adapted backport of #32267 (merged to `main` as 27ec0570d6) onto `2.0`, so dispatches of the MySQL/PostgreSQL nightly E2E on this release branch run Playwright with 2 per-test retries.

**Why adapted instead of a clean cherry-pick:** `main`'s version threads a `retries` input through `playwright-e2e-reusable.yml`, which does not exist on `2.0` — here the nightlies are self-contained workflows that invoke `npx playwright test` directly. The backport therefore:

- adds the same `PLAYWRIGHT_RETRIES` override hook to `playwright.config.ts` (`retries: Number(process.env.PLAYWRIGHT_RETRIES ?? (process.env.CI ? 1 : 0))` — parens are semantic, covered by a code comment);
- sets `PLAYWRIGHT_RETRIES: "2"` directly on the "Run Playwright tests" step env of `mysql-nightly-e2e.yml` and `postgresql-nightly-e2e.yml` (applies to all shard lanes of those runs).

**Blast radius:** every other workflow on `2.0` (PR gates, search/SSO/visual nightlies, java-playwright-nightly) leaves `PLAYWRIGHT_RETRIES` unset and keeps the existing CI default of 1 retry; local dev stays at 0.

Note: these nightlies check out `inputs.branch` for the test code, so runs get the 2 retries once dispatched against a ref containing this commit (i.e. `branch: 2.0` after merge).

#
### Type of change:
- [x] Improvement

#
### High-level design:

N/A — small backport; design in #32267 and the description above.

#
### Tests:

#### Use cases covered
- Nightly dispatch on 2.0 (MySQL or PostgreSQL) → each failing test gets 3 attempts (2 retries)
- All other 2.0 CI Playwright workflows → unchanged 1 retry via the `CI` fallback
- Local dev → unchanged 0 retries

#### Unit tests
Not applicable — CI workflow + test-runner config change. The override expression's behavior was verified empirically on the original PR (failing-spec probe measuring attempts via the JSON reporter across all env combinations).

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (changes the runner's retry policy, not the UI or the tests).

#### Manual testing performed
1. `actionlint` on both modified workflows: no findings.
2. `prettier@2.8.8` (repo-pinned) `--check` passes on `playwright.config.ts`.
3. Expression semantics verified on #32267: `PLAYWRIGHT_RETRIES=2` → 3 attempts; unset in CI → 2 attempts; explicit `0` → 1 attempt; local → 0 retries.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` — N/A, backport of #32267 (no linked issue).
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above — N/A, see above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed — N/A, no schema changes.
- [x] For UI changes: I attached a screen recording and/or screenshots above — N/A, no UI changes.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above — no automated tests; verified as listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport adds a configurable Playwright retry count while preserving the existing CI and local defaults.
- Sets two retries for every test step in the MySQL and PostgreSQL release-branch nightly workflows.
- Reads `PLAYWRIGHT_RETRIES` in the shared Playwright configuration, falling back to one retry in CI and none locally.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The fixed nightly override is correctly wired into the Playwright test steps, parses to two retries, and leaves all unset CI and local execution paths at their existing defaults.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/mysql-nightly-e2e.yml | Sets the valid `"2"` retry override directly on all MySQL nightly Playwright invocations without affecting other workflow steps. |
| .github/workflows/postgresql-nightly-e2e.yml | Sets the same valid retry override on all PostgreSQL nightly Playwright invocations. |
| openmetadata-ui/src/main/resources/ui/playwright.config.ts | Correctly parses the optional retry override and preserves the prior one-retry CI and zero-retry local defaults. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(playwright): backport 2 per-test retr..."](https://github.com/open-metadata/openmetadata/commit/105b0b69ec31d2d537a7f1e6411a511ce4842e05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58587545)</sub>

<!-- /greptile_comment -->