### PR TITLE
fix(search): swap hybrid default values keyword vs semantic (#31968) (2.0 backport)

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v201/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v201/Migration.java
@@ -27,5 +27,6 @@ public class Migration extends MigrationProcessImpl {
               + "AutoPilot BPMN may still reference stale delegate fields until server restart.",
           e);
     }
+    MigrationUtil.alignHybridSearchWeightsWithDefaults();
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v201/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v201/Migration.java
@@ -27,5 +27,6 @@ public class Migration extends MigrationProcessImpl {
               + "AutoPilot BPMN may still reference stale delegate fields until server restart.",
           e);
     }
+    MigrationUtil.alignHybridSearchWeightsWithDefaults();
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v201/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v201/MigrationUtil.java
@@ -1,17 +1,26 @@
 package org.openmetadata.service.migration.utils.v201;
 
 import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.api.search.GlobalSettings;
+import org.openmetadata.schema.api.search.SearchSettings;
 import org.openmetadata.schema.governance.workflows.WorkflowDefinition;
+import org.openmetadata.schema.settings.Settings;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.governance.workflows.Workflow;
 import org.openmetadata.service.governance.workflows.WorkflowHandler;
 import org.openmetadata.service.jdbi3.WorkflowDefinitionRepository;
+import org.openmetadata.service.migration.utils.SearchSettingsMergeUtil;
 import org.openmetadata.service.util.EntityUtil;
 
 @Slf4j
 public final class MigrationUtil {
   private static final String AUTOPILOT_WORKFLOW_NAME = "AutoPilotWorkflow";
+  private static final double PREVIOUS_KEYWORD_WEIGHT = 0.4;
+  private static final double PREVIOUS_SEMANTIC_WEIGHT = 0.6;
+  private static final double KEYWORD_WEIGHT = 0.6;
+  private static final double SEMANTIC_WEIGHT = 0.4;
+  private static final double WEIGHT_TOLERANCE = 1e-9;
 
   private MigrationUtil() {}
 
@@ -49,5 +58,56 @@ public final class MigrationUtil {
       LOG.warn("[v201] Failed to load AutoPilotWorkflow: {}", e.getMessage());
     }
     return result;
+  }
+
+  /**
+   * Aligns the hybrid search weights in the stored search settings with the shipped defaults.
+   *
+   * <p>The weights are seeded into the settings row from the schema defaults on first startup, so
+   * every installation carries an explicit pair that takes precedence over a later default. Only a
+   * pair equal to the previous default is rewritten; any other pair is an operator choice.
+   */
+  public static void alignHybridSearchWeightsWithDefaults() {
+    try {
+      Settings storedSettings = SearchSettingsMergeUtil.getSearchSettingsFromDatabase();
+      if (storedSettings == null) {
+        LOG.warn("[v201] Search settings not found in database; skipping hybrid weight alignment");
+      } else {
+        alignStoredHybridWeights(storedSettings);
+      }
+    } catch (Exception e) {
+      LOG.error("[v201] Error aligning hybrid search weights in stored search settings", e);
+    }
+  }
+
+  private static void alignStoredHybridWeights(Settings storedSettings) {
+    SearchSettings searchSettings = SearchSettingsMergeUtil.loadSearchSettings(storedSettings);
+    if (swapPreviousHybridWeights(searchSettings)) {
+      SearchSettingsMergeUtil.saveSearchSettings(storedSettings, searchSettings);
+      LOG.info(
+          "[v201] Hybrid search weights aligned to keyword={}, semantic={}",
+          KEYWORD_WEIGHT,
+          SEMANTIC_WEIGHT);
+    } else {
+      LOG.info("[v201] Stored hybrid search weights are not the previous defaults; left unchanged");
+    }
+  }
+
+  /** Returns true when the previous default pair was found and swapped. */
+  public static boolean swapPreviousHybridWeights(SearchSettings searchSettings) {
+    GlobalSettings globalSettings = searchSettings.getGlobalSettings();
+    boolean carriesPreviousDefaults =
+        globalSettings != null
+            && weightIs(globalSettings.getKeywordWeight(), PREVIOUS_KEYWORD_WEIGHT)
+            && weightIs(globalSettings.getSemanticWeight(), PREVIOUS_SEMANTIC_WEIGHT);
+    if (carriesPreviousDefaults) {
+      globalSettings.setKeywordWeight(KEYWORD_WEIGHT);
+      globalSettings.setSemanticWeight(SEMANTIC_WEIGHT);
+    }
+    return carriesPreviousDefaults;
+  }
+
+  private static boolean weightIs(Double weight, double expected) {
+    return weight != null && Math.abs(weight - expected) < WEIGHT_TOLERANCE;
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -798,9 +798,9 @@ public class SearchRepository {
 
     ElasticSearchConfiguration cfg = getSearchConfiguration();
     NaturalLanguageSearchConfiguration nlConfig = cfg.getNaturalLanguageSearch();
-    double keywordWeight = nlConfig.getKeywordWeight() != null ? nlConfig.getKeywordWeight() : 0.4;
+    double keywordWeight = nlConfig.getKeywordWeight() != null ? nlConfig.getKeywordWeight() : 0.6;
     double semanticWeight =
-        nlConfig.getSemanticWeight() != null ? nlConfig.getSemanticWeight() : 0.6;
+        nlConfig.getSemanticWeight() != null ? nlConfig.getSemanticWeight() : 0.4;
 
     try {
       SearchSettings ss =

--- a/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v201/HybridSearchWeightSwapTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v201/HybridSearchWeightSwapTest.java
@@ -1,0 +1,88 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.migration.utils.v201;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.api.search.GlobalSettings;
+import org.openmetadata.schema.api.search.SearchSettings;
+
+class HybridSearchWeightSwapTest {
+
+  private SearchSettings settingsWithWeights(Double keywordWeight, Double semanticWeight) {
+    GlobalSettings globalSettings = new GlobalSettings();
+    globalSettings.setKeywordWeight(keywordWeight);
+    globalSettings.setSemanticWeight(semanticWeight);
+    SearchSettings settings = new SearchSettings();
+    settings.setGlobalSettings(globalSettings);
+    return settings;
+  }
+
+  @Test
+  void swapsThePreviousDefaultPair() {
+    SearchSettings settings = settingsWithWeights(0.4, 0.6);
+
+    assertTrue(MigrationUtil.swapPreviousHybridWeights(settings));
+
+    assertEquals(0.6, settings.getGlobalSettings().getKeywordWeight());
+    assertEquals(0.4, settings.getGlobalSettings().getSemanticWeight());
+  }
+
+  @Test
+  void leavesOperatorTunedWeightsUntouched() {
+    SearchSettings settings = settingsWithWeights(0.7, 0.3);
+
+    assertFalse(MigrationUtil.swapPreviousHybridWeights(settings));
+
+    assertEquals(0.7, settings.getGlobalSettings().getKeywordWeight());
+    assertEquals(0.3, settings.getGlobalSettings().getSemanticWeight());
+  }
+
+  @Test
+  void isIdempotentOnAlreadySwappedWeights() {
+    SearchSettings settings = settingsWithWeights(0.6, 0.4);
+
+    assertFalse(MigrationUtil.swapPreviousHybridWeights(settings));
+
+    assertEquals(0.6, settings.getGlobalSettings().getKeywordWeight());
+    assertEquals(0.4, settings.getGlobalSettings().getSemanticWeight());
+  }
+
+  @Test
+  void leavesAHalfMatchingPairUntouched() {
+    SearchSettings settings = settingsWithWeights(0.4, 0.4);
+
+    assertFalse(MigrationUtil.swapPreviousHybridWeights(settings));
+
+    assertEquals(0.4, settings.getGlobalSettings().getKeywordWeight());
+    assertEquals(0.4, settings.getGlobalSettings().getSemanticWeight());
+  }
+
+  @Test
+  void toleratesAbsentWeights() {
+    SearchSettings settings = settingsWithWeights(null, null);
+
+    assertFalse(MigrationUtil.swapPreviousHybridWeights(settings));
+
+    assertNull(settings.getGlobalSettings().getKeywordWeight());
+  }
+
+  @Test
+  void toleratesAbsentGlobalSettings() {
+    assertFalse(MigrationUtil.swapPreviousHybridWeights(new SearchSettings()));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
@@ -2999,7 +2999,7 @@ class SearchRepositoryBehaviorTest {
     assertSame(embeddingClient, spyRepository.getEmbeddingClient());
     assertSame(vectorService, spyRepository.getVectorIndexService());
     assertNotNull(spyRepository.getVectorEmbeddingHandler());
-    verify(vectorService).ensureHybridSearchPipeline(0.4, 0.6);
+    verify(vectorService).ensureHybridSearchPipeline(0.6, 0.4);
   }
 
   @Test

--- a/openmetadata-spec/src/main/resources/json/schema/configuration/elasticSearchConfiguration.json
+++ b/openmetadata-spec/src/main/resources/json/schema/configuration/elasticSearchConfiguration.json
@@ -190,12 +190,12 @@
         "keywordWeight": {
           "description": "Weight for BM25 keyword search results in hybrid RRF pipeline (0.0-1.0)",
           "type": "number",
-          "default": 0.4
+          "default": 0.6
         },
         "semanticWeight": {
           "description": "Weight for semantic vector search results in hybrid RRF pipeline (0.0-1.0)",
           "type": "number",
-          "default": 0.6
+          "default": 0.4
         },
         "knnNumCandidatesMultiplier": {
           "description": "Multiplier applied to k when computing num_candidates for Elasticsearch kNN vector search. num_candidates = max(k * multiplier, 100). Higher values improve recall at the cost of latency. Defaults to 2.",

--- a/openmetadata-spec/src/main/resources/json/schema/configuration/searchSettings.json
+++ b/openmetadata-spec/src/main/resources/json/schema/configuration/searchSettings.json
@@ -56,12 +56,12 @@
         "keywordWeight": {
           "description": "Weight for BM25 keyword search in hybrid RRF pipeline (0.0-1.0)",
           "type": "number",
-          "default": 0.4
+          "default": 0.6
         },
         "semanticWeight": {
           "description": "Weight for semantic vector search in hybrid RRF pipeline (0.0-1.0)",
           "type": "number",
-          "default": 0.6
+          "default": 0.4
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
### Describe your changes:

Fixes #31967

Backport of #31968 (`965fd21a287`) to `2.0`.

Swaps the hybrid search default weights from keyword `0.4` / semantic `0.6` to keyword `0.6` / semantic `0.4`:
- `SearchRepository` runtime fallback values
- `searchSettings.json` and `elasticSearchConfiguration.json` schema defaults
- A data-migration step that rewrites persisted `SEARCH_SETTINGS` still carrying the previous default pair, so upgraded instances pick up the new weights (the seeded row otherwise takes precedence over the new schema default).

**Backport note — migration re-homed to 2.0.1.** On `main` the alignment step lives in the 2.1.0 migration (`v210`). The `2.0` branch has no 2.1.0 migration, so here it is wired into the existing, unreleased 2.0.1 migration: `mysql/v201/Migration`, `postgres/v201/Migration`, and `utils/v201/MigrationUtil`. The step is guarded and idempotent — only the exact `0.4/0.6` pair is rewritten, operator-tuned values are left untouched, and failures are logged rather than aborting the upgrade — so it is safe when a 2.0.1 instance later upgrades to 2.1.0 and the same step runs again there.

#
### Type of change:
- [x] Improvement

#
### High-level design:

N/A — small change (see backport note above).

#
### Tests:

#### Use cases covered
- Fresh install gets keyword `0.6` / semantic `0.4` from the schema defaults.
- Upgraded 2.0.0 instance with the seeded `0.4/0.6` pair is migrated to `0.6/0.4`.
- Upgraded instance with operator-tuned weights (e.g. `0.7/0.3`), a half-matching pair (`0.4/0.4`), or absent weights is left unchanged.
- Re-running the migration on already-swapped settings is a no-op.

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Files added/updated:
  - `openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v201/HybridSearchWeightSwapTest.java` (moved from `v210` on main) — 6 tests, all passing.
  - `openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java` — expected `ensureHybridSearchPipeline(0.6, 0.4)`.

#### Backend integration tests
- [x] Not applicable (no API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. `mvn -pl openmetadata-spec install -DskipTests` on the `2.0` branch.
2. `mvn -pl openmetadata-service test -Dtest=HybridSearchWeightSwapTest` → 6/6 pass, module compiles.
3. `mvn -pl openmetadata-service spotless:check` → clean.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EgeAs6Fx6m3rb9g7XHc8F




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR changes hybrid-search defaults to favor keyword ranking and adds an idempotent 2.0.1 data-migration step for persisted settings.
- Changes keyword and semantic defaults from 0.4/0.6 to 0.6/0.4 across runtime fallbacks and schemas.
- Adds MySQL and PostgreSQL migration hooks that rewrite the exact previous default pair.
- Adds migration and search-repository behavior tests.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v201/MigrationUtil.java | Adds guarded detection and replacement of the previous persisted hybrid-search weight pair. |
| openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v201/Migration.java | Invokes hybrid-weight alignment during the MySQL 2.0.1 data-migration phase. |
| openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v201/Migration.java | Invokes hybrid-weight alignment during the PostgreSQL 2.0.1 data-migration phase. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java | Swaps the runtime hybrid-search fallback weights to keyword 0.6 and semantic 0.4. |
| openmetadata-spec/src/main/resources/json/schema/configuration/searchSettings.json | Swaps the persisted search-settings schema defaults. |
| openmetadata-spec/src/main/resources/json/schema/configuration/elasticSearchConfiguration.json | Swaps the Elasticsearch configuration schema defaults. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Trigger CI"](https://github.com/open-metadata/openmetadata/commit/3171e202fb4e6c8f419c1a724e5719a18289a4a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58624121)</sub>

<!-- /greptile_comment -->