### PR TITLE
fix(ui): full-width ER diagram drawer and column panel double-close

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
@@ -1180,9 +1180,16 @@ export const openColumnDetailPanel = async ({
 };
 
 export const closeColumnDetailPanel = async (page: Page) => {
+  // Snapshot the column URL. If the panel reopens (bug), it navigates back to this URL.
+  const columnUrl = page.url();
   const panelContainer = page.locator('.column-detail-panel');
   await panelContainer.getByTestId('close-button').click();
 
+  // 1. Immediate visibility check.
+  await expect(page.locator('.column-detail-panel')).not.toBeVisible();
+  // 2. Verify the URL did not bounce back (a reopen re-navigates to the column URL).
+  await expect(page).not.toHaveURL(columnUrl);
+  // 3. After URL has settled, verify the panel is still not visible.
   await expect(page.locator('.column-detail-panel')).not.toBeVisible();
 };
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
@@ -1179,7 +1179,10 @@ export const openColumnDetailPanel = async ({
   return panelContainer;
 };
 
-export const closeColumnDetailPanel = async (page: Page) => {
+export const closeColumnDetailPanel = async (
+  page: Page,
+  entityUrl?: string
+) => {
   // Snapshot the column URL. If the panel reopens (bug), it navigates back to this URL.
   const columnUrl = page.url();
   const panelContainer = page.locator('.column-detail-panel');
@@ -1187,8 +1190,13 @@ export const closeColumnDetailPanel = async (page: Page) => {
 
   // 1. Immediate visibility check.
   await expect(page.locator('.column-detail-panel')).not.toBeVisible();
-  // 2. Verify the URL did not bounce back (a reopen re-navigates to the column URL).
-  await expect(page).not.toHaveURL(columnUrl);
+  // 2. Positive URL check: assert the URL has settled at the entity path, not bounced back.
+  //    Callers should pass entityUrl (the FQN-less entity path) for the strongest guard.
+  if (entityUrl) {
+    await expect(page).toHaveURL(entityUrl);
+  } else {
+    await expect(page).not.toHaveURL(columnUrl);
+  }
   // 3. After URL has settled, verify the panel is still not visible.
   await expect(page.locator('.column-detail-panel')).not.toBeVisible();
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.tsx
@@ -236,8 +236,9 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
     (column: ColumnOrTask) => {
       const columnFqn = column.fullyQualifiedName;
 
-      // If the column is already selected, don't do anything to avoid loops
-      if (selectedColumn?.fullyQualifiedName === columnFqn) {
+      // Use ref so the callback is not recreated on every selection change,
+      // which would cause useFqnDeepLink to re-run and reopen the panel on close.
+      if (selectedColumnRef.current?.fullyQualifiedName === columnFqn) {
         return;
       }
 
@@ -267,7 +268,6 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
       routeTab,
       navigate,
       location.pathname,
-      selectedColumn?.fullyQualifiedName,
       extractedColumns,
     ]
   );

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/entity-summary-panel.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/entity-summary-panel.less
@@ -17,6 +17,7 @@
 .entity-summary-panel-container,
 .column-detail-panel-container {
   height: 100%;
+  width: 100%;
   background: var(--tw-color-bg-primary);
 
   &.explore {


### PR DESCRIPTION
### Describe your changes:

I worked on two UI drawer bugs:

1. **ER Diagram drawer not full-width** — `entity-summary-panel-container` had `height: 100%` but no `width`, so the panel didn't fill the Ant Design Drawer body when opened from the ER Diagram tab. Fixed by adding `width: 100%` to the shared container rule in `entity-summary-panel.less`.

2. **Column detail panel double-close** — `openColumnDetailPanel` had `selectedColumn?.fullyQualifiedName` in its `useCallback` deps, causing it to be recreated when `closeColumnDetailPanel` cleared the selection. This triggered `useFqnDeepLink` to re-run and reopen the panel before the URL update propagated. Fixed by switching the guard to use `selectedColumnRef.current` (already kept in sync) and removing the dep.

3. **Playwright regression guard** — Strengthened `closeColumnDetailPanel` helper with a URL bounce-back check (`expect(page).not.toHaveURL(columnUrl)`) and a second visibility assertion, so the double-close bug is caught in all existing tests that close the column panel.

Issue:- 
<img width="1512" height="864" alt="Screenshot 2026-08-31 at 7 59 24 PM" src="https://github.com/user-attachments/assets/d29caf42-d35b-49d7-b325-10102b3b30e8" />

Fix:-
<img width="1508" height="828" alt="Screenshot 2026-08-31 at 7 59 12 PM" src="https://github.com/user-attachments/assets/b4818667-cf83-4d57-b9d5-00806dece0b1" />



#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- ER Diagram tab: clicking a table opens the summary drawer at full width
- Schema tab: clicking a column name and closing the panel closes it on the first click

#### Unit tests
- [ ] Not applicable (CSS + hook dep fix, no new logic branches)

#### Backend integration tests
- [x] Not applicable (no backend API changes)

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes)

#### Playwright (UI) tests
- [x] Strengthened existing `closeColumnDetailPanel` helper in `playwright/utils/entity.ts` — all tests that call it now assert the panel stays closed and the URL doesn't bounce back.

#### Manual testing performed
1. Opened table entity on ER Diagram tab (Collate env), clicked a related table — drawer now fills full width
2. Opened column detail panel from Schema tab, clicked X once — panel closed and stayed closed

#
### UI screen recording / screenshots:
<!-- Attach before/after for ER diagram drawer width fix when available -->

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have added tests (Playwright) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing.



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR stabilizes column-detail panel closing and makes entity-summary containers fill their parent width.
- Uses the selected-column ref to keep the panel-opening callback stable during close navigation.
- Adds full-width styling to entity-summary and column-detail containers.
- Strengthens the shared Playwright close helper with URL and post-navigation visibility checks.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.tsx | Replaces the selected-column state dependency with the synchronized ref so deep-link effects do not reopen the panel during close. |
| openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/entity-summary-panel.less | Makes the shared entity-summary and column-detail container rule fill its parent width. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts | Adds URL-settlement and repeated hidden-state assertions to the column-panel close helper. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(playwright): use positive toHaveURL ..."](https://github.com/open-metadata/openmetadata/commit/38bc4af0a2db6b9f5ca60afb91c2c5c767548fb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58642493)</sub>

<!-- /greptile_comment -->