### PR TITLE
fix(k8s): add security context to automation and application jobs

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/k8s/K8sPipelineClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/k8s/K8sPipelineClient.java
@@ -1794,6 +1794,7 @@ public class K8sPipelineClient extends PipelineServiceClient {
                             new V1PodSpec()
                                 .serviceAccountName(k8sConfig.getServiceAccountName())
                                 .restartPolicy(RESTART_POLICY_NEVER)
+                                .securityContext(buildPodSecurityContext())
                                 .imagePullSecrets(
                                     k8sConfig.getImagePullSecrets().isEmpty()
                                         ? null
@@ -1806,6 +1807,7 @@ public class K8sPipelineClient extends PipelineServiceClient {
                                             .imagePullPolicy(k8sConfig.getImagePullPolicy())
                                             .command(List.of(PYTHON_MAIN_PY, RUN_AUTOMATION_PY))
                                             .env(envVars)
+                                            .securityContext(buildContainerSecurityContext())
                                             .resources(
                                                 new V1ResourceRequirements()
                                                     .requests(k8sConfig.getResourceRequests())
@@ -1832,6 +1834,7 @@ public class K8sPipelineClient extends PipelineServiceClient {
                             new V1PodSpec()
                                 .serviceAccountName(k8sConfig.getServiceAccountName())
                                 .restartPolicy(RESTART_POLICY_NEVER)
+                                .securityContext(buildPodSecurityContext())
                                 .imagePullSecrets(
                                     k8sConfig.getImagePullSecrets().isEmpty()
                                         ? null
@@ -1848,6 +1851,7 @@ public class K8sPipelineClient extends PipelineServiceClient {
                                                     APPLICATIONS_RUNNER,
                                                     APPLICATIONS_RUNNER_MODULE))
                                             .env(envVars)
+                                            .securityContext(buildContainerSecurityContext())
                                             .resources(
                                                 new V1ResourceRequirements()
                                                     .requests(k8sConfig.getResourceRequests())

--- a/openmetadata-service/src/test/java/org/openmetadata/service/clients/pipeline/k8s/K8sPipelineClientTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/clients/pipeline/k8s/K8sPipelineClientTest.java
@@ -50,8 +50,10 @@ import io.kubernetes.client.openapi.models.V1JobList;
 import io.kubernetes.client.openapi.models.V1JobStatus;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1PodList;
+import io.kubernetes.client.openapi.models.V1PodSecurityContext;
 import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1Secret;
+import io.kubernetes.client.openapi.models.V1SecurityContext;
 import io.kubernetes.client.openapi.models.V1Status;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -578,29 +580,7 @@ class K8sPipelineClientTest {
     ArgumentCaptor<V1Job> jobCaptor = ArgumentCaptor.forClass(V1Job.class);
     verify(batchApi).createNamespacedJob(eq(NAMESPACE), jobCaptor.capture());
 
-    V1Job createdJob = jobCaptor.getValue();
-    V1PodSpec podSpec = createdJob.getSpec().getTemplate().getSpec();
-
-    // Verify pod security context
-    assertNotNull(podSpec.getSecurityContext());
-    assertTrue(podSpec.getSecurityContext().getRunAsNonRoot());
-    assertEquals(1000L, podSpec.getSecurityContext().getRunAsUser());
-    assertEquals(1000L, podSpec.getSecurityContext().getRunAsGroup());
-    assertEquals(1000L, podSpec.getSecurityContext().getFsGroup());
-
-    // Verify container security context
-    assertNotNull(podSpec.getContainers().get(0).getSecurityContext());
-    assertTrue(podSpec.getContainers().get(0).getSecurityContext().getRunAsNonRoot());
-    assertFalse(podSpec.getContainers().get(0).getSecurityContext().getAllowPrivilegeEscalation());
-    assertNotNull(podSpec.getContainers().get(0).getSecurityContext().getCapabilities());
-    assertTrue(
-        podSpec
-            .getContainers()
-            .get(0)
-            .getSecurityContext()
-            .getCapabilities()
-            .getDrop()
-            .contains("ALL"));
+    assertSecurityContextIsSet(jobCaptor.getValue());
   }
 
   @Test
@@ -1149,6 +1129,34 @@ class K8sPipelineClientTest {
         applicationJob.getSpec().getTemplate().getSpec().getContainers().get(0).getCommand());
     assertEquals(
         "query-runner", applicationJob.getMetadata().getLabels().get("app.kubernetes.io/app-name"));
+  }
+
+  @Test
+  void testSecurityContextIsSetOnAutomationJob() throws Exception {
+    // Automation jobs must satisfy the same admission policies as ingestion jobs
+    when(batchApi.createNamespacedJob(eq(NAMESPACE), any())).thenReturn(createJobRequest);
+    when(createJobRequest.execute()).thenReturn(new V1Job());
+
+    client.runAutomationsWorkflow(createTestWorkflow("Nightly Cleanup"));
+
+    ArgumentCaptor<V1Job> jobCaptor = ArgumentCaptor.forClass(V1Job.class);
+    verify(batchApi).createNamespacedJob(eq(NAMESPACE), jobCaptor.capture());
+
+    assertSecurityContextIsSet(jobCaptor.getValue());
+  }
+
+  @Test
+  void testSecurityContextIsSetOnApplicationJob() throws Exception {
+    // Application jobs must satisfy the same admission policies as ingestion jobs
+    when(batchApi.createNamespacedJob(eq(NAMESPACE), any())).thenReturn(createJobRequest);
+    when(createJobRequest.execute()).thenReturn(new V1Job());
+
+    client.runApplicationFlow(createTestApplication("Query Runner"));
+
+    ArgumentCaptor<V1Job> jobCaptor = ArgumentCaptor.forClass(V1Job.class);
+    verify(batchApi).createNamespacedJob(eq(NAMESPACE), jobCaptor.capture());
+
+    assertSecurityContextIsSet(jobCaptor.getValue());
   }
 
   @Test
@@ -1954,6 +1962,26 @@ class K8sPipelineClientTest {
     Call listCall = mock(Call.class);
     when(listCall.execute()).thenReturn(jsonResponse(podListJson));
     when(httpClient.newCall(any(Request.class))).thenReturn(listCall);
+  }
+
+  private static void assertSecurityContextIsSet(V1Job job) {
+    V1PodSpec podSpec = job.getSpec().getTemplate().getSpec();
+
+    V1PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
+    assertNotNull(podSecurityContext);
+    assertTrue(podSecurityContext.getRunAsNonRoot());
+    assertEquals(1000L, podSecurityContext.getRunAsUser());
+    assertEquals(1000L, podSecurityContext.getRunAsGroup());
+    assertEquals(1000L, podSecurityContext.getFsGroup());
+
+    V1SecurityContext containerSecurityContext =
+        podSpec.getContainers().get(0).getSecurityContext();
+    assertNotNull(containerSecurityContext);
+    assertTrue(containerSecurityContext.getRunAsNonRoot());
+    assertEquals(1000L, containerSecurityContext.getRunAsUser());
+    assertFalse(containerSecurityContext.getAllowPrivilegeEscalation());
+    assertNotNull(containerSecurityContext.getCapabilities());
+    assertTrue(containerSecurityContext.getCapabilities().getDrop().contains("ALL"));
   }
 
   private static Workflow createTestWorkflow(String name) {


### PR DESCRIPTION
## Summary
Add missing `securityContext` to `buildAutomationJob` and `buildApplicationJob` in `K8sPipelineClient.java`, plus unit tests that lock the behavior.

Fixes #33209

## Problem
Automation jobs (test connections) and application jobs have neither a pod-level nor a container-level security context, while ingestion jobs have both. Clusters with security policies (Kyverno, OPA Gatekeeper, Pod Security Admission `restricted`) block these jobs because they require:
- `allowPrivilegeEscalation: false`
- `runAsNonRoot: true`
- Pod-level `fsGroup`, `runAsUser`, `runAsGroup`

## Solution
Apply the same security context that `buildIngestionJob` uses:
- `buildPodSecurityContext()` on the pod spec
- `buildContainerSecurityContext()` on the container

## Testing
- New unit tests `testSecurityContextIsSetOnAutomationJob` and `testSecurityContextIsSetOnApplicationJob` capture the created `V1Job` and assert the pod and container security contexts. Both tests fail without the production change.
- The assertions that `testSecurityContextIsSetOnJob` already made are now in a shared helper, used by all three job types.
- `mvn test -pl openmetadata-service -Dtest=K8sPipelineClientTest` — 72 tests, 0 failures.
- Deployed on a Kubernetes cluster with Kyverno policies: test connection jobs are blocked without this fix, and they pass admission with it.

## Checklist
- [x] Code changes
- [x] Unit tests
- [x] Documentation (no doc changes needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
