### PR TITLE
Fixes #32320: Enforce ingestion pipeline action permissions

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineOwnerInheritanceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineOwnerInheritanceIT.java
@@ -42,16 +42,16 @@ import org.openmetadata.sdk.exceptions.ForbiddenException;
 import org.openmetadata.sdk.network.HttpMethod;
 
 /**
- * Integration tests for IngestionPipeline owner inheritance and trigger authorization.
+ * Integration tests for IngestionPipeline owner inheritance and action authorization.
  *
- * <p>Covers two coordinated changes that fix GH-27962 (Pylon-19838):
+ * <p>Covers owner inheritance and authorization for ingestion pipeline actions:
  *
  * <ul>
  *   <li>{@code IngestionPipelineRepository.setInheritedFields} now inherits owners from the
  *       referenced service / TestSuite / App, so {@code isOwner()} conditions on pipeline policies
  *       evaluate correctly.
- *   <li>{@code POST /v1/services/ingestionPipelines/trigger/{id}} now authorizes against {@code
- *       MetadataOperation.TRIGGER}.
+ *   <li>Action endpoints authorize against their resource-specific operation before invoking the
+ *       external pipeline runner.
  * </ul>
  */
 @Execution(ExecutionMode.CONCURRENT)
@@ -118,16 +118,20 @@ public class IngestionPipelineOwnerInheritanceIT {
   }
 
   @Test
-  void test_isOwnerPolicy_appliesToEditAndTrigger(TestNamespace ns) {
+  void test_isOwnerPolicy_appliesToEditTriggerAndDeploy(TestNamespace ns) {
     OpenMetadataClient adminClient = SdkClients.adminClient();
     String unique = UUID.randomUUID().toString().substring(0, 8);
 
     Rule ownerRule =
         new Rule()
-            .withName("pipelineOwnerEditAndTrigger")
-            .withDescription("Allow owners to edit and trigger ingestion pipelines")
+            .withName("pipelineOwnerActions")
+            .withDescription("Allow owners to edit, trigger, and deploy ingestion pipelines")
             .withEffect(Rule.Effect.ALLOW)
-            .withOperations(List.of(MetadataOperation.EDIT_ALL, MetadataOperation.TRIGGER))
+            .withOperations(
+                List.of(
+                    MetadataOperation.EDIT_ALL,
+                    MetadataOperation.TRIGGER,
+                    MetadataOperation.DEPLOY))
             .withResources(List.of("ingestionPipeline"))
             .withCondition("isOwner()");
     Policy ownerPolicy =
@@ -217,6 +221,18 @@ public class IngestionPipelineOwnerInheritanceIT {
               String triggerPath = "/v1/services/ingestionPipelines/trigger/" + pipeline.getId();
               ownerClient.getHttpClient().execute(HttpMethod.POST, triggerPath, null, Void.class);
 
+              String deployPath = "/v1/services/ingestionPipelines/deploy/" + pipeline.getId();
+              ownerClient.getHttpClient().execute(HttpMethod.POST, deployPath, null, Void.class);
+
+              String bulkDeployPath = "/v1/services/ingestionPipelines/bulk/deploy";
+              ownerClient
+                  .getHttpClient()
+                  .execute(HttpMethod.POST, bulkDeployPath, List.of(pipeline.getId()), Void.class);
+
+              String togglePath =
+                  "/v1/services/ingestionPipelines/toggleIngestion/" + pipeline.getId();
+              ownerClient.getHttpClient().execute(HttpMethod.POST, togglePath, null, Void.class);
+
               // Non-owner cannot trigger.
               assertThrows(
                   Exception.class,
@@ -225,6 +241,34 @@ public class IngestionPipelineOwnerInheritanceIT {
                           .getHttpClient()
                           .execute(HttpMethod.POST, triggerPath, null, Void.class),
                   "Non-owner trigger should be forbidden");
+
+              assertThrows(
+                  ForbiddenException.class,
+                  () ->
+                      otherClient
+                          .getHttpClient()
+                          .execute(HttpMethod.POST, deployPath, null, Void.class),
+                  "Non-owner deploy should be forbidden");
+
+              assertThrows(
+                  ForbiddenException.class,
+                  () ->
+                      otherClient
+                          .getHttpClient()
+                          .execute(
+                              HttpMethod.POST,
+                              bulkDeployPath,
+                              List.of(pipeline.getId()),
+                              Void.class),
+                  "Non-owner bulk deploy should be forbidden");
+
+              assertThrows(
+                  ForbiddenException.class,
+                  () ->
+                      otherClient
+                          .getHttpClient()
+                          .execute(HttpMethod.POST, togglePath, null, Void.class),
+                  "Non-owner toggle should be forbidden");
             } finally {
               adminClient.ingestionPipelines().delete(pipeline.getId().toString());
             }
@@ -247,7 +291,7 @@ public class IngestionPipelineOwnerInheritanceIT {
   }
 
   @Test
-  void test_ingestionPipelineDescriptorExposesTrigger() {
+  void test_ingestionPipelineDescriptorExposesActionPermissions() {
     OpenMetadataClient adminClient = SdkClients.adminClient();
     ResourceDescriptorList resources =
         adminClient
@@ -263,6 +307,99 @@ public class IngestionPipelineOwnerInheritanceIT {
         descriptor.getOperations().contains(MetadataOperation.TRIGGER),
         "ingestionPipeline descriptor must expose Trigger so it is grantable scoped to "
             + "Ingestion Pipeline in the policy editor");
+    assertTrue(
+        descriptor.getOperations().contains(MetadataOperation.DEPLOY),
+        "ingestionPipeline descriptor must expose Deploy so it is grantable scoped to "
+            + "Ingestion Pipeline in the policy editor");
+  }
+
+  @Test
+  void test_explicitDeployPermissionAllowsNonOwner(TestNamespace ns) {
+    OpenMetadataClient adminClient = SdkClients.adminClient();
+    String unique = UUID.randomUUID().toString().substring(0, 8);
+
+    Policy deployPolicy =
+        adminClient
+            .policies()
+            .create(
+                new CreatePolicy()
+                    .withName("ipdeployPolicy_" + unique)
+                    .withDescription("Deploy-only access to ingestion pipelines")
+                    .withRules(
+                        List.of(
+                            new Rule()
+                                .withName("pipelineDeployOnly")
+                                .withEffect(Rule.Effect.ALLOW)
+                                .withOperations(List.of(MetadataOperation.DEPLOY))
+                                .withResources(List.of("ingestionPipeline")))));
+
+    try {
+      Role deployRole =
+          adminClient
+              .roles()
+              .create(
+                  new CreateRole()
+                      .withName("ipdeployRole_" + unique)
+                      .withPolicies(List.of(deployPolicy.getFullyQualifiedName())));
+
+      try {
+        String deployerName = "ipdeployer_" + unique;
+        User deployer =
+            adminClient
+                .users()
+                .create(
+                    new CreateUser()
+                        .withName(deployerName)
+                        .withEmail(deployerName + "@test.openmetadata.org")
+                        .withRoles(List.of(deployRole.getId())));
+
+        try {
+          DashboardService service = DashboardServiceTestFactory.createMetabase(ns);
+
+          try {
+            IngestionPipeline pipeline =
+                adminClient
+                    .ingestionPipelines()
+                    .create(
+                        new CreateIngestionPipeline()
+                            .withName(ns.prefix("ipdeployPipeline_" + unique))
+                            .withPipelineType(PipelineType.METADATA)
+                            .withService(service.getEntityReference())
+                            .withSourceConfig(
+                                new SourceConfig()
+                                    .withConfig(new DashboardServiceMetadataPipeline()))
+                            .withAirflowConfig(new AirflowConfig().withStartDate(START_DATE)));
+
+            try {
+              OpenMetadataClient deployerClient =
+                  SdkClients.createClient(deployerName, deployerName, new String[] {});
+              String deployPath = "/v1/services/ingestionPipelines/deploy/" + pipeline.getId();
+              deployerClient.getHttpClient().execute(HttpMethod.POST, deployPath, null, Void.class);
+              deployerClient
+                  .getHttpClient()
+                  .execute(
+                      HttpMethod.POST,
+                      "/v1/services/ingestionPipelines/bulk/deploy",
+                      List.of(pipeline.getId()),
+                      Void.class);
+            } finally {
+              adminClient.ingestionPipelines().delete(pipeline.getId().toString());
+            }
+          } finally {
+            adminClient
+                .dashboardServices()
+                .delete(
+                    service.getId().toString(), Map.of("hardDelete", "true", "recursive", "true"));
+          }
+        } finally {
+          adminClient.users().delete(deployer.getId());
+        }
+      } finally {
+        adminClient.roles().delete(deployRole.getId());
+      }
+    } finally {
+      adminClient.policies().delete(deployPolicy.getId());
+    }
   }
 
   @Test

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineOwnerInheritanceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineOwnerInheritanceIT.java
@@ -36,9 +36,11 @@ import org.openmetadata.schema.metadataIngestion.SourceConfig;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.ResourceDescriptor;
+import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.exceptions.ForbiddenException;
+import org.openmetadata.sdk.exceptions.InvalidRequestException;
 import org.openmetadata.sdk.network.HttpMethod;
 
 /**
@@ -118,20 +120,16 @@ public class IngestionPipelineOwnerInheritanceIT {
   }
 
   @Test
-  void test_isOwnerPolicy_appliesToEditTriggerAndDeploy(TestNamespace ns) {
+  void test_isOwnerPolicy_appliesToEditTriggerDeployAndToggle(TestNamespace ns) {
     OpenMetadataClient adminClient = SdkClients.adminClient();
     String unique = UUID.randomUUID().toString().substring(0, 8);
 
     Rule ownerRule =
         new Rule()
             .withName("pipelineOwnerActions")
-            .withDescription("Allow owners to edit, trigger, and deploy ingestion pipelines")
+            .withDescription("Allow owners to edit and trigger ingestion pipelines")
             .withEffect(Rule.Effect.ALLOW)
-            .withOperations(
-                List.of(
-                    MetadataOperation.EDIT_ALL,
-                    MetadataOperation.TRIGGER,
-                    MetadataOperation.DEPLOY))
+            .withOperations(List.of(MetadataOperation.EDIT_ALL, MetadataOperation.TRIGGER))
             .withResources(List.of("ingestionPipeline"))
             .withCondition("isOwner()");
     Policy ownerPolicy =
@@ -311,6 +309,24 @@ public class IngestionPipelineOwnerInheritanceIT {
         descriptor.getOperations().contains(MetadataOperation.DEPLOY),
         "ingestionPipeline descriptor must expose Deploy so it is grantable scoped to "
             + "Ingestion Pipeline in the policy editor");
+  }
+
+  @Test
+  void test_bulkDeployRejectsNullRequestBody() {
+    OpenMetadataClient adminClient = SdkClients.adminClient();
+    InvalidRequestException exception =
+        assertThrows(
+            InvalidRequestException.class,
+            () ->
+                adminClient
+                    .getHttpClient()
+                    .execute(
+                        HttpMethod.POST,
+                        "/v1/services/ingestionPipelines/bulk/deploy",
+                        JsonUtils.readTree("null"),
+                        Void.class));
+
+    assertTrue(exception.getMessage().contains("must not be null"));
   }
 
   @Test

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineOwnerInheritanceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineOwnerInheritanceIT.java
@@ -60,6 +60,7 @@ import org.openmetadata.sdk.network.HttpMethod;
 @ExtendWith(TestNamespaceExtension.class)
 public class IngestionPipelineOwnerInheritanceIT {
 
+  private static final String BULK_DEPLOY_PATH = "/v1/services/ingestionPipelines/bulk/deploy";
   private static final Date START_DATE = Date.from(Instant.parse("2022-06-10T15:06:47Z"));
 
   @Test
@@ -222,10 +223,10 @@ public class IngestionPipelineOwnerInheritanceIT {
               String deployPath = "/v1/services/ingestionPipelines/deploy/" + pipeline.getId();
               ownerClient.getHttpClient().execute(HttpMethod.POST, deployPath, null, Void.class);
 
-              String bulkDeployPath = "/v1/services/ingestionPipelines/bulk/deploy";
               ownerClient
                   .getHttpClient()
-                  .execute(HttpMethod.POST, bulkDeployPath, List.of(pipeline.getId()), Void.class);
+                  .execute(
+                      HttpMethod.POST, BULK_DEPLOY_PATH, List.of(pipeline.getId()), Void.class);
 
               String togglePath =
                   "/v1/services/ingestionPipelines/toggleIngestion/" + pipeline.getId();
@@ -255,7 +256,7 @@ public class IngestionPipelineOwnerInheritanceIT {
                           .getHttpClient()
                           .execute(
                               HttpMethod.POST,
-                              bulkDeployPath,
+                              BULK_DEPLOY_PATH,
                               List.of(pipeline.getId()),
                               Void.class),
                   "Non-owner bulk deploy should be forbidden");
@@ -321,12 +322,57 @@ public class IngestionPipelineOwnerInheritanceIT {
                 adminClient
                     .getHttpClient()
                     .execute(
-                        HttpMethod.POST,
-                        "/v1/services/ingestionPipelines/bulk/deploy",
-                        JsonUtils.readTree("null"),
-                        Void.class));
+                        HttpMethod.POST, BULK_DEPLOY_PATH, JsonUtils.readTree("null"), Void.class));
 
     assertTrue(exception.getMessage().contains("must not be null"));
+  }
+
+  @Test
+  void test_bulkDeployRejectsEmptyPipelineIds() {
+    InvalidRequestException exception =
+        assertThrows(
+            InvalidRequestException.class,
+            () ->
+                SdkClients.adminClient()
+                    .getHttpClient()
+                    .execute(HttpMethod.POST, BULK_DEPLOY_PATH, List.of(), Void.class));
+
+    assertTrue(exception.getMessage().contains("pipeline IDs must not be empty"));
+  }
+
+  @Test
+  void test_bulkDeployRejectsNullPipelineId() {
+    InvalidRequestException exception =
+        assertThrows(
+            InvalidRequestException.class,
+            () ->
+                SdkClients.adminClient()
+                    .getHttpClient()
+                    .execute(
+                        HttpMethod.POST,
+                        BULK_DEPLOY_PATH,
+                        JsonUtils.readTree("[null]"),
+                        Void.class));
+
+    assertTrue(exception.getMessage().contains("pipeline IDs must not contain null values"));
+  }
+
+  @Test
+  void test_bulkDeployRejectsDuplicatePipelineIds() {
+    UUID pipelineId = UUID.randomUUID();
+    InvalidRequestException exception =
+        assertThrows(
+            InvalidRequestException.class,
+            () ->
+                SdkClients.adminClient()
+                    .getHttpClient()
+                    .execute(
+                        HttpMethod.POST,
+                        BULK_DEPLOY_PATH,
+                        List.of(pipelineId, pipelineId),
+                        Void.class));
+
+    assertTrue(exception.getMessage().contains("pipeline IDs must not contain duplicates"));
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java
@@ -35,6 +35,7 @@ import jakarta.json.JsonPatch;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
@@ -784,7 +785,7 @@ public class IngestionPipelineResource
   public List<PipelineServiceClientResponse> bulkDeployIngestion(
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
-      @Valid List<UUID> pipelineIdList) {
+      @NotNull @Valid List<UUID> pipelineIdList) {
     pipelineIdList.forEach(
         id -> authorizePipelineOperation(securityContext, id, MetadataOperation.DEPLOY));
 
@@ -1521,22 +1522,30 @@ public class IngestionPipelineResource
 
   private void authorizePipelineOperation(
       SecurityContext securityContext, UUID id, MetadataOperation operation) {
-    OperationContext operationContext = new OperationContext(entityType, operation);
-    authorizer.authorize(securityContext, operationContext, getResourceContextById(id));
+    authorizer.authorizeRequests(
+        securityContext, getPipelineOperationAuthRequests(id, operation), AuthorizationLogic.ANY);
   }
 
-  // Requiring EditAll to persist the runner's result would reject an allowed action after its
-  // external side effect has already happened.
+  // Preserve existing EditAll access while allowing roles to grant only the scoped action.
+  private List<AuthRequest> getPipelineOperationAuthRequests(UUID id, MetadataOperation operation) {
+    ResourceContext<IngestionPipeline> resourceContext = getResourceContextById(id);
+    return List.of(
+        new AuthRequest(new OperationContext(entityType, operation), resourceContext),
+        new AuthRequest(
+            new OperationContext(entityType, MetadataOperation.EDIT_ALL), resourceContext));
+  }
+
   private Response createOrUpdateAfterPipelineOperation(
       UriInfo uriInfo,
       SecurityContext securityContext,
       IngestionPipeline ingestionPipeline,
       MetadataOperation operation) {
-    OperationContext operationContext = new OperationContext(entityType, operation);
-    AuthRequest authRequest =
-        new AuthRequest(operationContext, getResourceContextById(ingestionPipeline.getId()));
     return createOrUpdate(
-        uriInfo, securityContext, List.of(authRequest), AuthorizationLogic.ALL, ingestionPipeline);
+        uriInfo,
+        securityContext,
+        getPipelineOperationAuthRequests(ingestionPipeline.getId(), operation),
+        AuthorizationLogic.ANY,
+        ingestionPipeline);
   }
 
   public PipelineServiceClientResponse triggerPipelineInternal(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java
@@ -59,9 +59,12 @@ import jakarta.ws.rs.core.UriInfo;
 import jakarta.ws.rs.sse.Sse;
 import jakarta.ws.rs.sse.SseEventSink;
 import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -786,6 +789,7 @@ public class IngestionPipelineResource
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @NotNull @Valid List<UUID> pipelineIdList) {
+    validateBulkDeployPipelineIds(pipelineIdList);
     pipelineIdList.forEach(
         id -> authorizePipelineOperation(securityContext, id, MetadataOperation.DEPLOY));
 
@@ -804,6 +808,19 @@ public class IngestionPipelineResource
               }
             })
         .collect(Collectors.toList());
+  }
+
+  private static void validateBulkDeployPipelineIds(List<UUID> pipelineIds) {
+    if (nullOrEmpty(pipelineIds)) {
+      throw new BadRequestException("pipeline IDs must not be empty");
+    }
+    if (pipelineIds.stream().anyMatch(Objects::isNull)) {
+      throw new BadRequestException("pipeline IDs must not contain null values");
+    }
+    Set<UUID> uniquePipelineIds = new HashSet<>(pipelineIds);
+    if (uniquePipelineIds.size() != pipelineIds.size()) {
+      throw new BadRequestException("pipeline IDs must not contain duplicates");
+    }
   }
 
   @POST

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java
@@ -102,7 +102,9 @@ import org.openmetadata.service.resources.EntityResource;
 import org.openmetadata.service.secrets.SecretsManager;
 import org.openmetadata.service.secrets.SecretsManagerFactory;
 import org.openmetadata.service.secrets.masker.EntityMaskerFactory;
+import org.openmetadata.service.security.AuthRequest;
 import org.openmetadata.service.security.AuthorizationException;
+import org.openmetadata.service.security.AuthorizationLogic;
 import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.security.policyevaluator.CreateResourceContext;
 import org.openmetadata.service.security.policyevaluator.OperationContext;
@@ -209,6 +211,7 @@ public class IngestionPipelineResource
     return listOf(
         MetadataOperation.CREATE_INGESTION_PIPELINE_AUTOMATOR,
         MetadataOperation.EDIT_INGESTION_PIPELINE_STATUS,
+        MetadataOperation.DEPLOY,
         MetadataOperation.TRIGGER);
   }
 
@@ -757,6 +760,7 @@ public class IngestionPipelineResource
           @PathParam("id")
           UUID id,
       @Context SecurityContext securityContext) {
+    authorizePipelineOperation(securityContext, id, MetadataOperation.DEPLOY);
     return deployPipelineInternal(id, uriInfo, securityContext);
   }
 
@@ -781,6 +785,8 @@ public class IngestionPipelineResource
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Valid List<UUID> pipelineIdList) {
+    pipelineIdList.forEach(
+        id -> authorizePipelineOperation(securityContext, id, MetadataOperation.DEPLOY));
 
     return pipelineIdList.stream()
         .map(
@@ -846,6 +852,8 @@ public class IngestionPipelineResource
           @PathParam("id")
           UUID id,
       @Context SecurityContext securityContext) {
+    authorizePipelineOperation(
+        securityContext, id, MetadataOperation.EDIT_INGESTION_PIPELINE_STATUS);
     Fields fields = getFields(FIELD_OWNERS);
     IngestionPipeline pipeline = repository.get(uriInfo, id, fields);
     // This call updates the state in Airflow as well as the `enabled` field on the
@@ -855,7 +863,9 @@ public class IngestionPipelineResource
     }
     decryptOrNullify(securityContext, pipeline, true);
     pipelineServiceClient.toggleIngestion(pipeline);
-    Response response = createOrUpdate(uriInfo, securityContext, pipeline);
+    Response response =
+        createOrUpdateAfterPipelineOperation(
+            uriInfo, securityContext, pipeline, MetadataOperation.EDIT_INGESTION_PIPELINE_STATUS);
     decryptOrNullify(securityContext, (IngestionPipeline) response.getEntity(), false);
     return response;
   }
@@ -1503,9 +1513,30 @@ public class IngestionPipelineResource
     PipelineServiceClientResponse status =
         repository.deployIngestionPipeline(ingestionPipeline, service);
     if (status.getCode() == 200) {
-      createOrUpdate(uriInfo, securityContext, ingestionPipeline);
+      createOrUpdateAfterPipelineOperation(
+          uriInfo, securityContext, ingestionPipeline, MetadataOperation.DEPLOY);
     }
     return status;
+  }
+
+  private void authorizePipelineOperation(
+      SecurityContext securityContext, UUID id, MetadataOperation operation) {
+    OperationContext operationContext = new OperationContext(entityType, operation);
+    authorizer.authorize(securityContext, operationContext, getResourceContextById(id));
+  }
+
+  // Requiring EditAll to persist the runner's result would reject an allowed action after its
+  // external side effect has already happened.
+  private Response createOrUpdateAfterPipelineOperation(
+      UriInfo uriInfo,
+      SecurityContext securityContext,
+      IngestionPipeline ingestionPipeline,
+      MetadataOperation operation) {
+    OperationContext operationContext = new OperationContext(entityType, operation);
+    AuthRequest authRequest =
+        new AuthRequest(operationContext, getResourceContextById(ingestionPipeline.getId()));
+    return createOrUpdate(
+        uriInfo, securityContext, List.of(authRequest), AuthorizationLogic.ALL, ingestionPipeline);
   }
 
   public PipelineServiceClientResponse triggerPipelineInternal(

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/PipelineActions/PipelineActions.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/PipelineActions/PipelineActions.test.tsx
@@ -76,6 +76,7 @@ describe('PipelineAction', () => {
             ...DEFAULT_ENTITY_PERMISSION,
             Deploy: true,
           }}
+          pipeline={{ ...mockPipelineActionsProps.pipeline, enabled: true }}
         />,
         {
           wrapper: MemoryRouter,
@@ -95,6 +96,11 @@ describe('PipelineAction', () => {
             ...DEFAULT_ENTITY_PERMISSION,
             Trigger: true,
           }}
+          pipeline={{
+            ...mockPipelineActionsProps.pipeline,
+            deployed: true,
+            enabled: true,
+          }}
         />,
         {
           wrapper: MemoryRouter,
@@ -103,6 +109,50 @@ describe('PipelineAction', () => {
     });
 
     expect(screen.getByText('PipelineActionsDropdown')).toBeInTheDocument();
+  });
+
+  it('should not render PipelineActionsDropdown with only Deploy permission when pipeline is disabled', async () => {
+    await act(async () => {
+      render(
+        <PipelineActions
+          {...mockPipelineActionsProps}
+          ingestionPipelinePermissions={{
+            ...DEFAULT_ENTITY_PERMISSION,
+            Deploy: true,
+          }}
+          pipeline={{ ...mockPipelineActionsProps.pipeline, enabled: false }}
+        />,
+        {
+          wrapper: MemoryRouter,
+        }
+      );
+    });
+
+    expect(screen.queryByText('PipelineActionsDropdown')).toBeNull();
+  });
+
+  it('should not render PipelineActionsDropdown with only Trigger permission when pipeline is not deployed', async () => {
+    await act(async () => {
+      render(
+        <PipelineActions
+          {...mockPipelineActionsProps}
+          ingestionPipelinePermissions={{
+            ...DEFAULT_ENTITY_PERMISSION,
+            Trigger: true,
+          }}
+          pipeline={{
+            ...mockPipelineActionsProps.pipeline,
+            deployed: false,
+            enabled: true,
+          }}
+        />,
+        {
+          wrapper: MemoryRouter,
+        }
+      );
+    });
+
+    expect(screen.queryByText('PipelineActionsDropdown')).toBeNull();
   });
 
   it('should not render PipelineActionsDropdown without an action permission', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/PipelineActions/PipelineActions.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/PipelineActions/PipelineActions.test.tsx
@@ -67,7 +67,45 @@ describe('PipelineAction', () => {
     expect(screen.getByText('PipelineActionsDropdown')).toBeInTheDocument();
   });
 
-  it('should not render PipelineActionsDropdown if both EditAll and delete permission is not present', async () => {
+  it('should render PipelineActionsDropdown if only Deploy permission is present', async () => {
+    await act(async () => {
+      render(
+        <PipelineActions
+          {...mockPipelineActionsProps}
+          ingestionPipelinePermissions={{
+            ...DEFAULT_ENTITY_PERMISSION,
+            Deploy: true,
+          }}
+        />,
+        {
+          wrapper: MemoryRouter,
+        }
+      );
+    });
+
+    expect(screen.getByText('PipelineActionsDropdown')).toBeInTheDocument();
+  });
+
+  it('should render PipelineActionsDropdown if only Trigger permission is present', async () => {
+    await act(async () => {
+      render(
+        <PipelineActions
+          {...mockPipelineActionsProps}
+          ingestionPipelinePermissions={{
+            ...DEFAULT_ENTITY_PERMISSION,
+            Trigger: true,
+          }}
+        />,
+        {
+          wrapper: MemoryRouter,
+        }
+      );
+    });
+
+    expect(screen.getByText('PipelineActionsDropdown')).toBeInTheDocument();
+  });
+
+  it('should not render PipelineActionsDropdown without an action permission', async () => {
     await act(async () => {
       render(
         <PipelineActions

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/PipelineActions/PipelineActions.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/PipelineActions/PipelineActions.tsx
@@ -44,24 +44,28 @@ function PipelineActions({
   const { openLogs, logsModal } = useLogsModal();
   const [currPauseId, setCurrPauseId] = useState({ id: '', state: '' });
 
-  const { pipelineId, pipelineName } = useMemo(
-    () => ({
-      pipelineId: pipeline.id ?? '',
-      pipelineName: pipeline.name ?? '',
-    }),
-    [pipeline]
-  );
+  const pipelineId = pipeline.id ?? '';
 
-  const { editPermission, deletePermission, editStatusPermission } =
-    useMemo(() => {
-      return {
-        editPermission: ingestionPipelinePermissions?.[Operation.EditAll],
-        deletePermission: ingestionPipelinePermissions?.[Operation.Delete],
-        editStatusPermission:
-          ingestionPipelinePermissions?.[Operation.EditAll] ||
-          ingestionPipelinePermissions?.[Operation.EditIngestionPipelineStatus],
-      };
-    }, [ingestionPipelinePermissions, pipelineName]);
+  const {
+    editPermission,
+    deletePermission,
+    deployPermission,
+    triggerPermission,
+    editStatusPermission,
+  } = useMemo(() => {
+    return {
+      editPermission: ingestionPipelinePermissions?.[Operation.EditAll],
+      deletePermission: ingestionPipelinePermissions?.[Operation.Delete],
+      deployPermission: ingestionPipelinePermissions?.[Operation.Deploy],
+      triggerPermission: ingestionPipelinePermissions?.[Operation.Trigger],
+      editStatusPermission:
+        ingestionPipelinePermissions?.[Operation.EditAll] ||
+        ingestionPipelinePermissions?.[Operation.EditIngestionPipelineStatus],
+    };
+  }, [ingestionPipelinePermissions]);
+
+  const hasDropdownPermission =
+    editPermission || deletePermission || deployPermission || triggerPermission;
 
   const onPauseUnpauseClick = useCallback(
     async (id: string) => {
@@ -157,7 +161,7 @@ function PipelineActions({
               {t('label.log-plural')}
             </Button>
           </Col>
-          {(editPermission || deletePermission) && (
+          {hasDropdownPermission && (
             <Col>
               <PipelineActionsDropdown
                 deployIngestion={deployIngestion}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/PipelineActions/PipelineActions.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/PipelineActions/PipelineActions.tsx
@@ -56,7 +56,9 @@ function PipelineActions({
     return {
       editPermission: ingestionPipelinePermissions?.[Operation.EditAll],
       deletePermission: ingestionPipelinePermissions?.[Operation.Delete],
-      deployPermission: ingestionPipelinePermissions?.[Operation.Deploy],
+      deployPermission:
+        ingestionPipelinePermissions?.[Operation.EditAll] ||
+        ingestionPipelinePermissions?.[Operation.Deploy],
       triggerPermission: ingestionPipelinePermissions?.[Operation.Trigger],
       editStatusPermission:
         ingestionPipelinePermissions?.[Operation.EditAll] ||
@@ -64,8 +66,10 @@ function PipelineActions({
     };
   }, [ingestionPipelinePermissions]);
 
+  const canDeploy = pipeline.enabled && deployPermission;
+  const canTrigger = pipeline.enabled && pipeline.deployed && triggerPermission;
   const hasDropdownPermission =
-    editPermission || deletePermission || deployPermission || triggerPermission;
+    editPermission || deletePermission || canDeploy || canTrigger;
 
   const onPauseUnpauseClick = useCallback(
     async (id: string) => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/PipelineActions/PipelineActionsDropdown.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/PipelineActions/PipelineActionsDropdown.test.tsx
@@ -137,8 +137,8 @@ describe('PipelineActionsDropdown', () => {
 
   it('should hide deploy button when Deploy permission is absent', async () => {
     const permissions = {
-      ...ENTITY_PERMISSIONS,
-      [Operation.Deploy]: false,
+      ...DEFAULT_ENTITY_PERMISSION,
+      [Operation.Delete]: true,
     } as OperationPermission;
 
     await act(async () => {
@@ -161,7 +161,35 @@ describe('PipelineActionsDropdown', () => {
     await clickOnMoreActions();
 
     expect(screen.queryByTestId('deploy-button')).toBeNull();
-    expect(screen.getByTestId('edit-button')).toBeInTheDocument();
+    expect(screen.getByTestId('delete-button')).toBeInTheDocument();
+  });
+
+  it('should display deploy button with EditAll when Deploy permission is absent', async () => {
+    const permissions = {
+      ...DEFAULT_ENTITY_PERMISSION,
+      [Operation.EditAll]: true,
+    } as OperationPermission;
+
+    await act(async () => {
+      render(
+        <PipelineActionsDropdown
+          {...mockPipelineActionsDropdownProps}
+          ingestion={{
+            ...mockPipelineActionsDropdownProps.ingestion,
+            deployed: false,
+            enabled: true,
+          }}
+          ingestionPipelinePermissions={permissions}
+        />,
+        {
+          wrapper: MemoryRouter,
+        }
+      );
+    });
+
+    await clickOnMoreActions();
+
+    expect(screen.getByTestId('deploy-button')).toBeInTheDocument();
   });
 
   it('should display deploy button with only Deploy permission', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/PipelineActions/PipelineActionsDropdown.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/PipelineActions/PipelineActionsDropdown.test.tsx
@@ -18,6 +18,7 @@ import { OperationPermission } from '../../../../../../context/PermissionProvide
 import { Operation } from '../../../../../../generated/entity/policies/accessControl/resourceDescriptor';
 import { mockPipelineActionsDropdownProps } from '../../../../../../mocks/IngestionListTable.mock';
 import { ENTITY_PERMISSIONS } from '../../../../../../mocks/Permissions.mock';
+import { DEFAULT_ENTITY_PERMISSION } from '../../../../../../utils/PermissionsUtils';
 import PipelineActionsDropdown from './PipelineActionsDropdown';
 
 jest.mock(
@@ -35,8 +36,7 @@ const clickOnMoreActions = async () => {
 
   fireEvent.click(moreActions);
 
-  // Wait for dropdown menu items to appear
-  await screen.findByTestId('edit-button');
+  await screen.findByTestId('actions-dropdown');
 };
 
 describe('PipelineActionsDropdown', () => {
@@ -133,6 +133,64 @@ describe('PipelineActionsDropdown', () => {
     expect(screen.queryByTestId('run-button')).toBeNull();
     expect(screen.getByTestId('re-deploy-button')).toBeInTheDocument();
     expect(screen.getByTestId('edit-button')).toBeInTheDocument();
+  });
+
+  it('should hide deploy button when Deploy permission is absent', async () => {
+    const permissions = {
+      ...ENTITY_PERMISSIONS,
+      [Operation.Deploy]: false,
+    } as OperationPermission;
+
+    await act(async () => {
+      render(
+        <PipelineActionsDropdown
+          {...mockPipelineActionsDropdownProps}
+          ingestion={{
+            ...mockPipelineActionsDropdownProps.ingestion,
+            deployed: false,
+            enabled: true,
+          }}
+          ingestionPipelinePermissions={permissions}
+        />,
+        {
+          wrapper: MemoryRouter,
+        }
+      );
+    });
+
+    await clickOnMoreActions();
+
+    expect(screen.queryByTestId('deploy-button')).toBeNull();
+    expect(screen.getByTestId('edit-button')).toBeInTheDocument();
+  });
+
+  it('should display deploy button with only Deploy permission', async () => {
+    const permissions = {
+      ...DEFAULT_ENTITY_PERMISSION,
+      [Operation.Deploy]: true,
+    } as OperationPermission;
+
+    await act(async () => {
+      render(
+        <PipelineActionsDropdown
+          {...mockPipelineActionsDropdownProps}
+          ingestion={{
+            ...mockPipelineActionsDropdownProps.ingestion,
+            deployed: false,
+            enabled: true,
+          }}
+          ingestionPipelinePermissions={permissions}
+        />,
+        {
+          wrapper: MemoryRouter,
+        }
+      );
+    });
+
+    await clickOnMoreActions();
+
+    expect(screen.getByTestId('deploy-button')).toBeInTheDocument();
+    expect(screen.queryByTestId('edit-button')).toBeNull();
   });
 
   it('should call deployIngestion when clicked on deploy button', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/PipelineActions/PipelineActionsDropdown.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/PipelineActions/PipelineActionsDropdown.tsx
@@ -76,7 +76,9 @@ function PipelineActionsDropdown({
       editPermission: ingestionPipelinePermissions?.[Operation.EditAll],
       deletePermission: ingestionPipelinePermissions?.[Operation.Delete],
       deployPermission:
-        ingestionPipelinePermissions?.[Operation.Deploy] ?? false,
+        ingestionPipelinePermissions?.[Operation.EditAll] ||
+        ingestionPipelinePermissions?.[Operation.Deploy] ||
+        false,
       triggerPermission:
         ingestionPipelinePermissions?.[Operation.Trigger] ?? false,
     };

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/PipelineActions/PipelineActionsDropdown.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/PipelineActions/PipelineActionsDropdown.tsx
@@ -66,15 +66,21 @@ function PipelineActionsDropdown({
     id = '',
   } = useMemo(() => ingestion, [ingestion]);
 
-  const { editPermission, deletePermission, triggerPermission } =
-    useMemo(() => {
-      return {
-        editPermission: ingestionPipelinePermissions?.[Operation.EditAll],
-        deletePermission: ingestionPipelinePermissions?.[Operation.Delete],
-        triggerPermission:
-          ingestionPipelinePermissions?.[Operation.Trigger] ?? false,
-      };
-    }, [ingestionPipelinePermissions]);
+  const {
+    editPermission,
+    deletePermission,
+    deployPermission,
+    triggerPermission,
+  } = useMemo(() => {
+    return {
+      editPermission: ingestionPipelinePermissions?.[Operation.EditAll],
+      deletePermission: ingestionPipelinePermissions?.[Operation.Delete],
+      deployPermission:
+        ingestionPipelinePermissions?.[Operation.Deploy] ?? false,
+      triggerPermission:
+        ingestionPipelinePermissions?.[Operation.Trigger] ?? false,
+    };
+  }, [ingestionPipelinePermissions]);
 
   const handleTriggerIngestion = useCallback(
     async (id: string, displayName: string) => {
@@ -179,7 +185,7 @@ function PipelineActionsDropdown({
                 id,
                 <ReloadIcon height={12} width={12} />
               ),
-              hidden: !editPermission,
+              hidden: !deployPermission,
               onClick: () =>
                 handleDeployIngestion(id, getEntityName(ingestion)),
               key: 're-deploy-button',
@@ -194,14 +200,21 @@ function PipelineActionsDropdown({
                 id,
                 <DeployIcon height={12} width={12} />
               ),
-              hidden: !editPermission,
+              hidden: !deployPermission,
               onClick: () =>
                 handleDeployIngestion(id, getEntityName(ingestion)),
               key: 'deploy-button',
               'data-testid': 'deploy-button',
             },
           ],
-    [ingestion, currTrigger, id, currDeploy, triggerPermission, editPermission]
+    [
+      ingestion,
+      currTrigger,
+      id,
+      currDeploy,
+      triggerPermission,
+      deployPermission,
+    ]
   );
 
   const menuItems = useMemo(() => {

--- a/openmetadata-ui/src/main/resources/ui/src/mocks/Permissions.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/mocks/Permissions.mock.ts
@@ -15,6 +15,7 @@ import { OperationPermission } from '../context/PermissionProvider/PermissionPro
 export const ENTITY_PERMISSIONS = {
   Create: true,
   Delete: true,
+  Deploy: true,
   EditAll: true,
   EditCustomFields: true,
   EditDataProfile: true,


### PR DESCRIPTION
### Describe your changes:

Fixes #32320

Align ingestion pipeline actions with their scoped permissions across the backend and UI:

- Expose `Deploy` as a grantable ingestion pipeline operation.
- Authorize single and bulk deployments with `Deploy` while retaining existing `EditAll` access.
- Reject malformed bulk deployment requests before authorization or runner interaction.
- Authorize enable and disable actions with `EditIngestionPipelineStatus`.
- Show deploy and run actions when their corresponding permissions are granted.
- Add regression coverage for owners, unauthorized users, and deploy-only roles.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

Action endpoints authorize the resource-specific operation at the request boundary, with `EditAll` retained as a compatibility fallback. When an external pipeline action succeeds and its resulting state is persisted, the same authorization choices are used for the update. Bulk deployment validates its request and authorizes every pipeline before starting any deployment. The UI maps menu visibility to usable actions for the pipeline's current state.

There are no schema, migration, or API contract changes.

#
### Tests:

#### Use cases covered

- A pipeline owner with the configured action permissions can trigger, deploy, bulk deploy, and toggle a pipeline.
- A user without the required permissions cannot deploy, bulk deploy, or toggle a pipeline.
- A non-owner role with only `Deploy` can deploy and bulk deploy a pipeline.
- Existing roles with `EditAll` retain deploy and toggle access.
- The UI exposes deploy and trigger actions with only their matching permission.
- The UI does not render an empty action menu for disabled or undeployed pipelines.
- The ingestion pipeline resource descriptor exposes `Deploy`.
- A null bulk deployment request returns a client error.
- Empty bulk deployment lists, null IDs, and duplicate IDs return client errors.

#### Unit tests

- [x] Updated UI component tests for action-menu and deploy visibility.
- Files updated: `PipelineActions.test.tsx`, `PipelineActionsDropdown.test.tsx`
- Result: 2 suites and 27 tests passed.

#### Backend integration tests

- [x] Updated `IngestionPipelineOwnerInheritanceIT` for action authorization and scoped deployment.
- Result: 9 tests passed.

#### Ingestion integration tests

- [x] Not applicable (no ingestion framework changes).

#### Playwright (UI) tests

- Not added; focused component tests cover the permission-driven visibility changes.

#### Manual testing performed

- Java reactor build completed successfully with Java 21.
- Java Spotless and the changed-file UI checkstyle sequence completed successfully.
- Changed UI files have no TypeScript diagnostics; the repository-wide check remains affected by unrelated baseline diagnostics.

#
### UI screen recording / screenshots:

Not attached; this change only updates permission-driven action visibility and is covered by focused component tests.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable; there are no schema changes.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests and listed them above.

#### Bug fix

- [x] I have added tests that cover the exact scenarios being fixed.
