### PR TITLE
Fix user patch permissions

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BotImpersonationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BotImpersonationIT.java
@@ -243,9 +243,8 @@ public class BotImpersonationIT {
 
   @Test
   void test_nonAdminRole_deniesAdminTargetOnAdminOnlyEndpoint(TestNamespace ns) {
-    // GET /v1/system/settings is guarded only by authorizeAdmin, which short-circuits on the
-    // effective subject's isAdmin(). Without the impersonation check on that path a bot could
-    // borrow the impersonated admin's privileges while its own policy denies admin targets.
+    // GET /v1/system/settings is guarded by authorizeAdmin, which resolves the effective subject
+    // rather than the bot, so the bot's impersonation policy still decides the outcome.
     User botUser = createBotUser(ns, "adminguard");
     createBot(ns.prefix("imp_adminguard_bot"), botUser, true);
     swapImpersonationRole(botUser, BOT_NON_ADMIN_IMPERSONATION_ROLE);

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BotImpersonationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BotImpersonationIT.java
@@ -386,6 +386,60 @@ public class BotImpersonationIT {
         "Rejected non-admin revoke must leave the grant intact");
   }
 
+  @Test
+  void test_revokePersonalAccessToken_whileImpersonating_rejected(TestNamespace ns) {
+    // The create path already blocks minting a PAT under impersonation; revoke is the same
+    // self-scoped operation and must be blocked too, even for a bot otherwise allowed to
+    // impersonate the target (the default policy permits regular users).
+    User target = createRegularUser(ns, "revoketarget");
+    User botUser = createBotUser(ns, "revokepat");
+    createBot(ns.prefix("imp_revokepat_bot"), botUser, true);
+    String botToken = generateBotToken(botUser);
+
+    OpenMetadataClient asTarget = impersonationClient(botToken, target.getName());
+    Exception denied =
+        assertThrows(
+            Exception.class,
+            () ->
+                asTarget
+                    .getHttpClient()
+                    .executeForString(
+                        HttpMethod.PUT,
+                        "/v1/users/security/token/revoke?removeAll=false",
+                        "{\"tokenIds\":[\"" + UUID.randomUUID() + "\"]}"),
+            "Revoking a personal access token while impersonating must be rejected");
+    assertTrue(
+        denied.getMessage().contains("while impersonated by"),
+        "Revoke must be blocked by the impersonation guard: " + denied.getMessage());
+  }
+
+  @Test
+  void test_impersonation_withRotatedBotToken_rejected(TestNamespace ns) {
+    // Bot tokens are revoked by rotation (the stored token changes). A leaked, since-rotated token
+    // must not keep working just because an X-Impersonate-User header is attached.
+    User target = createRegularUser(ns, "rotatetarget");
+    User botUser = createBotUser(ns, "rotate");
+    createBot(ns.prefix("imp_rotate_bot"), botUser, true);
+
+    String oldToken =
+        SdkClients.adminClient()
+            .users()
+            .generateToken(botUser.getId(), JWTTokenExpiry.Seven)
+            .getJWTToken();
+    // Rotate: the previously issued token is now stale.
+    SdkClients.adminClient().users().generateToken(botUser.getId(), JWTTokenExpiry.Ninety);
+
+    OpenMetadataClient asTarget = impersonationClient(oldToken, target.getName());
+    Exception denied =
+        assertThrows(
+            Exception.class,
+            () -> asTarget.users().getByName(target.getName()),
+            "A rotated bot token must not authenticate even with an impersonation header");
+    assertTrue(
+        denied.getMessage().contains("does not match the current bot's token"),
+        "Rotated bot token must be rejected by bot-token validation: " + denied.getMessage());
+  }
+
   private Bot putBot(
       OpenMetadataClient client, String botName, User botUser, Boolean allowImpersonation) {
     CreateBot request =

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BotImpersonationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BotImpersonationIT.java
@@ -242,6 +242,30 @@ public class BotImpersonationIT {
   }
 
   @Test
+  void test_nonAdminRole_deniesAdminTargetOnAdminOnlyEndpoint(TestNamespace ns) {
+    // GET /v1/system/settings is guarded only by authorizeAdmin, which short-circuits on the
+    // effective subject's isAdmin(). Without the impersonation check on that path a bot could
+    // borrow the impersonated admin's privileges while its own policy denies admin targets.
+    User botUser = createBotUser(ns, "adminguard");
+    createBot(ns.prefix("imp_adminguard_bot"), botUser, true);
+    swapImpersonationRole(botUser, BOT_NON_ADMIN_IMPERSONATION_ROLE);
+    String botToken = generateBotToken(botUser);
+
+    OpenMetadataClient asAdmin = impersonationClient(botToken, "admin");
+    Exception denied =
+        assertThrows(
+            Exception.class,
+            () ->
+                asAdmin
+                    .getHttpClient()
+                    .executeForString(HttpMethod.GET, "/v1/system/settings", null),
+            "Admin-only endpoints must enforce the bot's impersonation policy");
+    assertTrue(
+        denied.getMessage().contains("not authorized to impersonate"),
+        "Error should state the target is not allowed: " + denied.getMessage());
+  }
+
+  @Test
   void test_applicationBotRole_impersonatesIncludingAdmin(TestNamespace ns) {
     // Backward compatibility: existing application bots use ApplicationBotImpersonationRole
     // (ApplicationBotImpersonationPolicy = allow Impersonate on All, no deny rules). The new

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BotImpersonationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BotImpersonationIT.java
@@ -387,6 +387,29 @@ public class BotImpersonationIT {
   }
 
   @Test
+  void test_getPersonalAccessToken_whileImpersonating_rejected(TestNamespace ns) {
+    // Listing returns the raw jwtToken; an impersonating bot could otherwise exfiltrate the
+    // target's PAT and authenticate as them outside the impersonation flow.
+    User target = createRegularUser(ns, "listtarget");
+    User botUser = createBotUser(ns, "listpat");
+    createBot(ns.prefix("imp_listpat_bot"), botUser, true);
+    String botToken = generateBotToken(botUser);
+
+    OpenMetadataClient asTarget = impersonationClient(botToken, target.getName());
+    Exception denied =
+        assertThrows(
+            Exception.class,
+            () ->
+                asTarget
+                    .getHttpClient()
+                    .executeForString(HttpMethod.GET, "/v1/users/security/token", null),
+            "Listing personal access tokens while impersonating must be rejected");
+    assertTrue(
+        denied.getMessage().contains("while impersonated by"),
+        "List must be blocked by the impersonation guard: " + denied.getMessage());
+  }
+
+  @Test
   void test_revokePersonalAccessToken_whileImpersonating_rejected(TestNamespace ns) {
     // The create path already blocks minting a PAT under impersonation; revoke is the same
     // self-scoped operation and must be blocked too, even for a bot otherwise allowed to

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/UserResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/UserResourceIT.java
@@ -2320,6 +2320,41 @@ public class UserResourceIT extends BaseEntityIT<User, CreateUser> {
   }
 
   @Test
+  void test_updateUser_selfPartialRoleShedding_allowed(TestNamespace ns) throws Exception {
+    // Dropping one of several roles is a privilege reduction, not an elevation, so it must not
+    // require admin even though the resulting role set still differs from the current one.
+    // The name must equal the email local part: JwtFilter resolves the caller's username from the
+    // token's email claim, so a name that toValidEmail() would rewrite never authenticates.
+    String userName = "roleshedder" + ns.shortPrefix();
+    String dataStewardRoleId = getRoleId("DataSteward");
+    String dataConsumerRoleId = getRoleId("DataConsumer");
+    User user =
+        createEntity(
+            new CreateUser()
+                .withName(userName)
+                .withEmail(userName + "@test.com")
+                .withRoles(
+                    List.of(
+                        UUID.fromString(dataStewardRoleId), UUID.fromString(dataConsumerRoleId))));
+    OpenMetadataClient userClient =
+        SdkClients.createClient(user.getName(), user.getEmail(), new String[] {});
+
+    String shedBody =
+        "{\"name\":\""
+            + user.getName()
+            + "\",\"email\":\""
+            + user.getEmail()
+            + "\",\"roles\":[\""
+            + dataConsumerRoleId
+            + "\"]}";
+    userClient.getHttpClient().executeForString(HttpMethod.PUT, "/v1/users", shedBody);
+
+    List<EntityReference> roles = Users.get(user.getId().toString(), "roles").getRoles();
+    assertEquals(1, roles.size(), "Only the retained role should remain");
+    assertEquals(dataConsumerRoleId, roles.get(0).getId().toString());
+  }
+
+  @Test
   void test_createUser_adminOrBot_forbiddenForNonAdmin(TestNamespace ns) {
     String adminAttempt = ns.prefix("adminAttempt");
     String adminUserBody =

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/UserResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/UserResourceIT.java
@@ -21,6 +21,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.net.URI;
 import java.time.Duration;
 import java.util.List;
@@ -44,6 +48,9 @@ import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.ImageList;
 import org.openmetadata.schema.type.Profile;
 import org.openmetadata.schema.utils.ResultList;
+import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.sdk.config.OpenMetadataConfig;
+import org.openmetadata.sdk.exceptions.OpenMetadataException;
 import org.openmetadata.sdk.fluent.Personas;
 import org.openmetadata.sdk.fluent.Users;
 import org.openmetadata.sdk.models.ListParams;
@@ -2155,6 +2162,225 @@ public class UserResourceIT extends BaseEntityIT<User, CreateUser> {
                 .users()
                 .generateToken(regularUser.getId(), JWTTokenExpiry.Seven),
         "Admin should not be able to generate token for regular user");
+  }
+
+  // ===================================================================
+  // AUTHORIZATION HARDENING TESTS
+  // Root JSON Patch replacement and personal access token constraints
+  // ===================================================================
+
+  private static final ObjectMapper PATCH_MAPPER = new ObjectMapper();
+
+  @Test
+  void test_patchUser_rootReplacement_forbiddenForNonAdmin(TestNamespace ns) {
+    User testUser = getLoggedInUser(SdkClients.testUserClient());
+    ArrayNode rootPatch = rootReplacementOps(userJsonWithField(testUser, "isBot", true));
+
+    OpenMetadataException exception =
+        assertThrows(
+            OpenMetadataException.class,
+            () ->
+                SdkClients.testUserClient()
+                    .getHttpClient()
+                    .executeForString(
+                        HttpMethod.PATCH, "/v1/users/" + testUser.getId(), rootPatch));
+    assertEquals(403, exception.getStatusCode());
+
+    User afterPatch = Users.get(testUser.getId().toString(), "isBot");
+    assertFalse(
+        Boolean.TRUE.equals(afterPatch.getIsBot()),
+        "isBot must stay false when the root replacement patch is rejected");
+  }
+
+  @Test
+  void test_patchUser_rootReplacement_allowedForAdmin(TestNamespace ns) {
+    String userName = ns.prefix("rootPatchTarget");
+    User user = createEntity(new CreateUser().withName(userName).withEmail(toValidEmail(userName)));
+    String displayName = ns.prefix("rootPatchedDisplayName");
+    ArrayNode rootPatch = rootReplacementOps(userJsonWithField(user, "displayName", displayName));
+
+    String response =
+        SdkClients.adminClient()
+            .getHttpClient()
+            .executeForString(HttpMethod.PATCH, "/v1/users/" + user.getId(), rootPatch);
+
+    assertTrue(response.contains(displayName), "Admin root replacement patch should be applied");
+  }
+
+  @Test
+  void test_createPersonalAccessToken_impersonatedBot_forbidden(TestNamespace ns) {
+    // The bot's stored name must equal its email local-part: JwtFilter resolves the bot's
+    // username from the token's email claim, and BotTokenCache is keyed by that name.
+    String localPart = "patbot" + ns.shortPrefix();
+    AuthenticationMechanism authMechanism =
+        new AuthenticationMechanism()
+            .withAuthType(AuthenticationMechanism.AuthType.JWT)
+            .withConfig(new JWTAuthMechanism().withJWTTokenExpiry(JWTTokenExpiry.Unlimited));
+    User botUser =
+        createEntity(
+            new CreateUser()
+                .withName(localPart)
+                .withEmail(localPart + "@test.com")
+                .withIsBot(true)
+                .withAuthenticationMechanism(authMechanism));
+
+    JWTAuthMechanism botToken =
+        SdkClients.adminClient().users().generateToken(botUser.getId(), JWTTokenExpiry.Seven);
+    OpenMetadataClient botClient =
+        new OpenMetadataClient(
+            OpenMetadataConfig.builder()
+                .serverUrl(SdkClients.getServerUrl())
+                .accessToken(botToken.getJWTToken())
+                .build());
+    String tokenRequest =
+        "{\"tokenName\":\"" + ns.prefix("pat") + "\",\"JWTTokenExpiry\":\"OneHour\"}";
+
+    OpenMetadataException directException =
+        assertThrows(
+            OpenMetadataException.class,
+            () ->
+                botClient
+                    .getHttpClient()
+                    .executeForString(HttpMethod.PUT, "/v1/users/security/token", tokenRequest));
+    assertEquals(
+        400,
+        directException.getStatusCode(),
+        "Bots cannot own personal access tokens: " + directException.getMessage());
+
+    RequestOptions impersonateAdmin =
+        RequestOptions.builder().header("X-Impersonate-User", "admin").build();
+    OpenMetadataException impersonatedException =
+        assertThrows(
+            OpenMetadataException.class,
+            () ->
+                botClient
+                    .getHttpClient()
+                    .executeForString(
+                        HttpMethod.PUT,
+                        "/v1/users/security/token",
+                        tokenRequest,
+                        impersonateAdmin));
+    assertEquals(
+        403,
+        impersonatedException.getStatusCode(),
+        "Impersonated personal access token creation must be rejected: "
+            + impersonatedException.getMessage());
+  }
+
+  @Test
+  void test_createPersonalAccessToken_regularUser_ok(TestNamespace ns) {
+    String response =
+        SdkClients.testUserClient()
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.PUT,
+                "/v1/users/security/token",
+                "{\"tokenName\":\"" + ns.prefix("pat") + "\",\"JWTTokenExpiry\":\"OneHour\"}");
+
+    assertTrue(response.contains("jwtToken"), "Regular users can create their own personal tokens");
+  }
+
+  @Test
+  void test_updateUser_selfRoleElevation_forbidden(TestNamespace ns) throws Exception {
+    User testUser = getLoggedInUser(SdkClients.testUserClient());
+    String dataStewardRoleId = getRoleId("DataSteward");
+
+    String elevateBody =
+        "{\"name\":\""
+            + testUser.getName()
+            + "\",\"email\":\""
+            + testUser.getEmail()
+            + "\",\"roles\":[\""
+            + dataStewardRoleId
+            + "\"]}";
+    OpenMetadataException elevateException =
+        assertThrows(
+            OpenMetadataException.class,
+            () ->
+                SdkClients.testUserClient()
+                    .getHttpClient()
+                    .executeForString(HttpMethod.PUT, "/v1/users", elevateBody));
+    assertEquals(
+        403,
+        elevateException.getStatusCode(),
+        "Role elevation must be rejected: " + elevateException.getMessage());
+
+    // Self-updates that do not gain roles stay allowed
+    String selfUpdateBody =
+        "{\"name\":\""
+            + testUser.getName()
+            + "\",\"email\":\""
+            + testUser.getEmail()
+            + "\",\"description\":\"self update without role change\"}";
+    String response =
+        SdkClients.testUserClient()
+            .getHttpClient()
+            .executeForString(HttpMethod.PUT, "/v1/users", selfUpdateBody);
+    assertTrue(response.contains("self update without role change"));
+  }
+
+  @Test
+  void test_createUser_adminOrBot_forbiddenForNonAdmin(TestNamespace ns) {
+    String adminAttempt = ns.prefix("adminAttempt");
+    String adminUserBody =
+        "{\"name\":\""
+            + adminAttempt
+            + "\",\"email\":\""
+            + toValidEmail(adminAttempt)
+            + "\",\"isAdmin\":true}";
+    OpenMetadataException adminException =
+        assertThrows(
+            OpenMetadataException.class,
+            () ->
+                SdkClients.testUserClient()
+                    .getHttpClient()
+                    .executeForString(HttpMethod.POST, "/v1/users", adminUserBody));
+    assertEquals(403, adminException.getStatusCode());
+
+    String botAttempt = ns.prefix("botAttempt");
+    String botUserBody =
+        "{\"name\":\""
+            + botAttempt
+            + "\",\"email\":\""
+            + toValidEmail(botAttempt)
+            + "\",\"isBot\":true}";
+    OpenMetadataException botException =
+        assertThrows(
+            OpenMetadataException.class,
+            () ->
+                SdkClients.testUserClient()
+                    .getHttpClient()
+                    .executeForString(HttpMethod.POST, "/v1/users", botUserBody));
+    assertEquals(403, botException.getStatusCode());
+  }
+
+  private String getRoleId(String roleName) throws Exception {
+    String roleJson =
+        SdkClients.adminClient()
+            .getHttpClient()
+            .executeForString(HttpMethod.GET, "/v1/roles/name/" + roleName, null);
+    return PATCH_MAPPER.readTree(roleJson).get("id").asText();
+  }
+
+  private User getLoggedInUser(OpenMetadataClient client) {
+    return client
+        .getHttpClient()
+        .execute(HttpMethod.GET, "/v1/users/loggedInUser", null, User.class);
+  }
+
+  private ObjectNode userJsonWithField(User user, String field, Object value) {
+    ObjectNode userJson = PATCH_MAPPER.valueToTree(user);
+    userJson.set(field, PATCH_MAPPER.valueToTree(value));
+    return userJson;
+  }
+
+  private ArrayNode rootReplacementOps(JsonNode value) {
+    ArrayNode ops = PATCH_MAPPER.createArrayNode();
+    ObjectNode operation = ops.addObject();
+    operation.put("op", "replace");
+    operation.put("path", "");
+    operation.set("value", value);
+    return ops;
   }
 
   // ===================================================================

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/UserResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/UserResourceIT.java
@@ -2165,8 +2165,8 @@ public class UserResourceIT extends BaseEntityIT<User, CreateUser> {
   }
 
   // ===================================================================
-  // AUTHORIZATION HARDENING TESTS
-  // Root JSON Patch replacement and personal access token constraints
+  // AUTHORIZATION
+  // Root JSON Patch replacement, roles and personal access token constraints
   // ===================================================================
 
   private static final ObjectMapper PATCH_MAPPER = new ObjectMapper();
@@ -2305,7 +2305,7 @@ public class UserResourceIT extends BaseEntityIT<User, CreateUser> {
         elevateException.getStatusCode(),
         "Role elevation must be rejected: " + elevateException.getMessage());
 
-    // Self-updates that do not gain roles stay allowed
+    // Self-updates that leave the roles alone stay allowed
     String selfUpdateBody =
         "{\"name\":\""
             + testUser.getName()
@@ -2321,8 +2321,8 @@ public class UserResourceIT extends BaseEntityIT<User, CreateUser> {
 
   @Test
   void test_updateUser_selfPartialRoleShedding_allowed(TestNamespace ns) throws Exception {
-    // Dropping one of several roles is a privilege reduction, not an elevation, so it must not
-    // require admin even though the resulting role set still differs from the current one.
+    // Dropping one of several roles asks for no new role, so it must not require admin even though
+    // the resulting role set still differs from the current one.
     // The name must equal the email local part: JwtFilter resolves the caller's username from the
     // token's email claim, so a name that toValidEmail() would rewrite never authenticates.
     String userName = "roleshedder" + ns.shortPrefix();
@@ -2387,6 +2387,82 @@ public class UserResourceIT extends BaseEntityIT<User, CreateUser> {
                     .getHttpClient()
                     .executeForString(HttpMethod.POST, "/v1/users", botUserBody));
     assertEquals(403, botException.getStatusCode());
+  }
+
+  @Test
+  void test_createUser_withRoles_forbiddenForNonAdmin(TestNamespace ns) throws Exception {
+    String roleGrab = ns.prefix("roleGrab");
+    String createBody =
+        "{\"name\":\""
+            + roleGrab
+            + "\",\"email\":\""
+            + toValidEmail(roleGrab)
+            + "\",\"roles\":[\""
+            + getRoleId("DataSteward")
+            + "\"]}";
+
+    OpenMetadataException exception =
+        assertThrows(
+            OpenMetadataException.class,
+            () ->
+                SdkClients.testUserClient()
+                    .getHttpClient()
+                    .executeForString(HttpMethod.POST, "/v1/users", createBody));
+    assertEquals(
+        403,
+        exception.getStatusCode(),
+        "Setting roles at creation is admin only: " + exception.getMessage());
+  }
+
+  @Test
+  void test_createUser_selfSignUpWithRoles_forbidden(TestNamespace ns) throws Exception {
+    // A principal that authenticates but has no user row yet takes the self sign-up path, where the
+    // roles in the payload are decided before the entity exists.
+    // The name must equal the email local part for JwtFilter to resolve the caller.
+    String userName = "selfsignup" + ns.shortPrefix();
+    String email = userName + "@test.com";
+    OpenMetadataClient newcomerClient = SdkClients.createClient(userName, email, new String[] {});
+    String createBody =
+        "{\"name\":\""
+            + userName
+            + "\",\"email\":\""
+            + email
+            + "\",\"roles\":[\""
+            + getRoleId("DataSteward")
+            + "\"]}";
+
+    OpenMetadataException postException =
+        assertThrows(
+            OpenMetadataException.class,
+            () ->
+                newcomerClient
+                    .getHttpClient()
+                    .executeForString(HttpMethod.POST, "/v1/users", createBody));
+    assertEquals(
+        403,
+        postException.getStatusCode(),
+        "Self sign-up cannot set roles: " + postException.getMessage());
+
+    OpenMetadataException putException =
+        assertThrows(
+            OpenMetadataException.class,
+            () ->
+                newcomerClient
+                    .getHttpClient()
+                    .executeForString(HttpMethod.PUT, "/v1/users", createBody));
+    assertEquals(
+        403,
+        putException.getStatusCode(),
+        "Self creation through PUT cannot set roles: " + putException.getMessage());
+
+    OpenMetadataException notCreated =
+        assertThrows(
+            OpenMetadataException.class,
+            () ->
+                SdkClients.adminClient()
+                    .getHttpClient()
+                    .executeForString(HttpMethod.GET, "/v1/users/name/" + userName, null));
+    assertEquals(404, notCreated.getStatusCode(), "The rejected user should not exist");
   }
 
   private String getRoleId(String roleName) throws Exception {

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/UserResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/UserResourceIT.java
@@ -36,16 +36,22 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openmetadata.it.util.SdkClients;
 import org.openmetadata.it.util.TestNamespace;
 import org.openmetadata.schema.api.domains.CreateDomain;
+import org.openmetadata.schema.api.policies.CreatePolicy;
+import org.openmetadata.schema.api.teams.CreateRole;
 import org.openmetadata.schema.api.teams.CreateTeam;
 import org.openmetadata.schema.api.teams.CreateUser;
 import org.openmetadata.schema.auth.JWTAuthMechanism;
 import org.openmetadata.schema.auth.JWTTokenExpiry;
+import org.openmetadata.schema.entity.policies.Policy;
+import org.openmetadata.schema.entity.policies.accessControl.Rule;
 import org.openmetadata.schema.entity.teams.AuthenticationMechanism;
+import org.openmetadata.schema.entity.teams.Role;
 import org.openmetadata.schema.entity.teams.Team;
 import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.ImageList;
+import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.Profile;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.sdk.client.OpenMetadataClient;
@@ -2463,6 +2469,100 @@ public class UserResourceIT extends BaseEntityIT<User, CreateUser> {
                     .getHttpClient()
                     .executeForString(HttpMethod.GET, "/v1/users/name/" + userName, null));
     assertEquals(404, notCreated.getStatusCode(), "The rejected user should not exist");
+  }
+
+  @Test
+  void test_updateUser_crossUserRoleElevation_forbidden(TestNamespace ns) throws Exception {
+    // A principal holding EDIT on users may update somebody else, but granting them a role stays
+    // admin only - the same rule PATCH /v1/users/{id} enforces on the /roles path.
+    OpenMetadataClient admin = SdkClients.adminClient();
+    String prefix = ns.prefix("userEditor");
+    Policy policy =
+        admin
+            .policies()
+            .create(
+                new CreatePolicy()
+                    .withName(prefix + "_policy")
+                    .withDescription("Grants cross user edit for the role elevation IT")
+                    .withRules(
+                        List.of(
+                            userRule(prefix + "_view", MetadataOperation.VIEW_ALL),
+                            userRule(prefix + "_edit", MetadataOperation.EDIT_ALL))));
+    Role role =
+        admin
+            .roles()
+            .create(
+                new CreateRole()
+                    .withName(prefix + "_role")
+                    .withDescription("Cross user edit role for the role elevation IT")
+                    .withPolicies(List.of(policy.getFullyQualifiedName())));
+    CreateTeam createTeam = new CreateTeam();
+    createTeam.setName(prefix + "_team");
+    createTeam.setTeamType(CreateTeam.TeamType.GROUP);
+    createTeam.setDefaultRoles(List.of(role.getId()));
+    Team team = admin.teams().create(createTeam);
+
+    // The name must equal the email local part: JwtFilter resolves the caller's username from the
+    // token's email claim, so a name that toValidEmail() would rewrite never authenticates.
+    String editorName = "usereditor" + ns.shortPrefix();
+    User editor =
+        createEntity(
+            new CreateUser()
+                .withName(editorName)
+                .withEmail(editorName + "@test.com")
+                .withTeams(List.of(team.getId())));
+    OpenMetadataClient editorClient =
+        SdkClients.createClient(editor.getName(), editor.getEmail(), new String[] {});
+
+    String targetName = ns.prefix("elevationTarget");
+    User target =
+        createEntity(new CreateUser().withName(targetName).withEmail(toValidEmail(targetName)));
+    String elevateBody =
+        "{\"name\":\""
+            + target.getName()
+            + "\",\"email\":\""
+            + target.getEmail()
+            + "\",\"roles\":[\""
+            + getRoleId("DataSteward")
+            + "\"]}";
+
+    OpenMetadataException exception =
+        assertThrows(
+            OpenMetadataException.class,
+            () ->
+                editorClient
+                    .getHttpClient()
+                    .executeForString(HttpMethod.PUT, "/v1/users", elevateBody));
+    assertEquals(
+        403,
+        exception.getStatusCode(),
+        "Granting a role to another user is admin only: " + exception.getMessage());
+
+    List<EntityReference> roles = Users.get(target.getId().toString(), "roles").getRoles();
+    assertTrue(roles == null || roles.isEmpty(), "The rejected role must not have been assigned");
+
+    // The same principal can still update the target as long as no role is granted, which shows the
+    // rejection above comes from the role gate and not from a missing EDIT permission.
+    String description = "edited by a non admin holding user EDIT";
+    String updateBody =
+        "{\"name\":\""
+            + target.getName()
+            + "\",\"email\":\""
+            + target.getEmail()
+            + "\",\"description\":\""
+            + description
+            + "\"}";
+    String response =
+        editorClient.getHttpClient().executeForString(HttpMethod.PUT, "/v1/users", updateBody);
+    assertTrue(response.contains(description), "Cross user edit without roles must stay allowed");
+  }
+
+  private Rule userRule(String name, MetadataOperation operation) {
+    return new Rule()
+        .withName(name)
+        .withResources(List.of("user"))
+        .withOperations(List.of(operation))
+        .withEffect(Rule.Effect.ALLOW);
   }
 
   private String getRoleId(String roleName) throws Exception {

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/WorkflowTriggerPermissionsIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/WorkflowTriggerPermissionsIT.java
@@ -2,6 +2,7 @@ package org.openmetadata.it.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -20,8 +21,12 @@ import org.openmetadata.it.factories.UserTestFactory;
 import org.openmetadata.it.util.SdkClients;
 import org.openmetadata.it.util.TestNamespace;
 import org.openmetadata.it.util.TestNamespaceExtension;
+import org.openmetadata.schema.api.CreateBot;
 import org.openmetadata.schema.api.services.CreateDatabaseService;
 import org.openmetadata.schema.api.services.DatabaseConnection;
+import org.openmetadata.schema.api.teams.CreateUser;
+import org.openmetadata.schema.auth.JWTAuthMechanism;
+import org.openmetadata.schema.auth.JWTTokenExpiry;
 import org.openmetadata.schema.entity.automations.CreateWorkflow;
 import org.openmetadata.schema.entity.automations.QueryRunnerRequest;
 import org.openmetadata.schema.entity.automations.TestServiceConnectionRequest;
@@ -29,6 +34,8 @@ import org.openmetadata.schema.entity.automations.Workflow;
 import org.openmetadata.schema.entity.automations.WorkflowType;
 import org.openmetadata.schema.entity.services.DatabaseService;
 import org.openmetadata.schema.entity.services.ServiceType;
+import org.openmetadata.schema.entity.teams.AuthenticationMechanism;
+import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.services.connections.database.MysqlConnection;
 import org.openmetadata.schema.services.connections.database.common.basicAuth;
 import org.openmetadata.schema.type.EntityReference;
@@ -201,6 +208,72 @@ public class WorkflowTriggerPermissionsIT {
         response,
         "non-TEST_CONNECTION triggers are intentionally out of scope for the test-connection "
             + "authorizer (issue #26760) and must not be blocked by it");
+  }
+
+  @Test
+  void test_triggerTestConnection_impersonatingBotWithoutGrant_returns403(TestNamespace ns)
+      throws Exception {
+    // Advisory PoC: a bot without the impersonation grant attaches X-Impersonate-User to reach a
+    // gated trigger. authorizeWorkflowTrigger -> authorizeRequests must resolve the effective
+    // subject through impersonation validation and deny it, not trust the header.
+    OpenMetadataClient admin = SdkClients.adminClient();
+    DatabaseService service = createMysqlService(admin, ns.prefix("svc-impbot"), null);
+    Workflow workflow =
+        admin
+            .workflows()
+            .create(testConnectionRequest(ns.prefix("impbot-trig"), service.getName()));
+
+    String botToken = createImpersonationBotToken(ns, "nogrant", false);
+    HttpResponse<String> response = triggerWorkflow(workflow.getId(), botToken, "admin");
+
+    assertEquals(
+        403,
+        response.statusCode(),
+        "Impersonating bot without the grant must be denied on the trigger endpoint: "
+            + response.body());
+    assertTrue(
+        response.body().contains("impersonation"),
+        "Denial must come from impersonation validation: " + response.body());
+  }
+
+  private String createImpersonationBotToken(
+      TestNamespace ns, String suffix, boolean allowImpersonation) {
+    String localPart = "trigbot" + suffix + ns.shortPrefix();
+    OpenMetadataClient admin = SdkClients.adminClient();
+    AuthenticationMechanism authMechanism =
+        new AuthenticationMechanism()
+            .withAuthType(AuthenticationMechanism.AuthType.JWT)
+            .withConfig(new JWTAuthMechanism().withJWTTokenExpiry(JWTTokenExpiry.Unlimited));
+    User botUser =
+        admin
+            .users()
+            .create(
+                new CreateUser()
+                    .withName(localPart)
+                    .withEmail(localPart + "@test.com")
+                    .withIsBot(true)
+                    .withAuthenticationMechanism(authMechanism));
+    admin
+        .bots()
+        .create(
+            new CreateBot()
+                .withName(ns.prefix("trig_" + suffix + "_bot"))
+                .withBotUser(botUser.getName())
+                .withAllowImpersonation(allowImpersonation));
+    return admin.users().generateToken(botUser.getId(), JWTTokenExpiry.Seven).getJWTToken();
+  }
+
+  private HttpResponse<String> triggerWorkflow(
+      UUID workflowId, String token, String impersonateUser) throws Exception {
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(SdkClients.getServerUrl() + TRIGGER_PATH + workflowId))
+            .header("Authorization", "Bearer " + token)
+            .header("X-Impersonate-User", impersonateUser)
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.noBody())
+            .build();
+    return HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
   }
 
   private CreateWorkflow testConnectionRequest(String name, String serviceName) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
@@ -1785,6 +1785,7 @@ public class UserResource extends EntityResource<User, UserRepository> {
       @Parameter(description = "User Name of the User for which to get. (Default = `false`)")
           @QueryParam("username")
           String userName) {
+    rejectImpersonatedTokenOperation(securityContext, "list personal access tokens");
     limits.enforceLimits(
         securityContext,
         getResourceContext(),
@@ -1800,8 +1801,9 @@ public class UserResource extends EntityResource<User, UserRepository> {
     return Response.status(Response.Status.OK).entity(new ResultList<>(tokens)).build();
   }
 
-  // Impersonation must never create, revoke, or invalidate a target's tokens or sessions: the
-  // effective principal is the impersonated user, so these self-scoped operations would act on the
+  // Impersonation must never create, list, revoke, or invalidate a target's tokens or sessions:
+  // listing returns the raw jwtToken, so a read is itself credential exfiltration. The effective
+  // principal is the impersonated user, so these self-scoped operations would act on the
   // target rather than the caller. Reject them outright regardless of the bot's impersonation
   // grant.
   private void rejectImpersonatedTokenOperation(SecurityContext securityContext, String action) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
@@ -151,6 +151,7 @@ import org.openmetadata.service.security.AuthServeletHandlerRegistry;
 import org.openmetadata.service.security.AuthorizationException;
 import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.security.CatalogPrincipal;
+import org.openmetadata.service.security.ImpersonationContext;
 import org.openmetadata.service.security.auth.AuthenticatorHandler;
 import org.openmetadata.service.security.auth.BotTokenCache;
 import org.openmetadata.service.security.auth.CatalogSecurityContext;
@@ -679,6 +680,9 @@ public class UserResource extends EntityResource<User, UserRepository> {
       @Context SecurityContext securityContext,
       @Context ContainerRequestContext containerRequestContext,
       @Valid CreateUser create) {
+    if (Boolean.TRUE.equals(create.getIsAdmin()) || Boolean.TRUE.equals(create.getIsBot())) {
+      authorizer.authorizeAdmin(securityContext);
+    }
     User user = getUser(securityContext.getUserPrincipal().getName(), create);
     if (Boolean.TRUE.equals(user.getIsBot())) {
       addAuthMechanismToBot(user, create, uriInfo);
@@ -816,6 +820,10 @@ public class UserResource extends EntityResource<User, UserRepository> {
       OperationContext createOperationContext =
           new OperationContext(entityType, EntityUtil.createOrUpdateOperation(resourceContext));
       authorizer.authorize(securityContext, createOperationContext, resourceContext);
+    } else if (existingUser != null && hasRoleElevation(existingUser.getRoles(), user.getRoles())) {
+      // Self-updates skip generic authorization, so gaining roles needs an explicit admin check.
+      // Shedding roles stays allowed.
+      authorizer.authorizeAdmin(securityContext);
     }
     if (Boolean.TRUE.equals(create.getIsBot())) {
       return createOrUpdateBotUser(user, create, uriInfo, securityContext);
@@ -1081,12 +1089,15 @@ public class UserResource extends EntityResource<User, UserRepository> {
           JsonPatch patch) {
     for (JsonValue patchOp : patch.toJsonArray()) {
       JsonObject patchOpObject = patchOp.asJsonObject();
-      if (patchOpObject.containsKey("path") && patchOpObject.containsKey("value")) {
-        String path = patchOpObject.getString("path");
-        if (path.equals("/isAdmin") || path.equals("/isBot") || path.contains("/roles")) {
-          authorizer.authorizeAdmin(securityContext);
-          continue;
-        }
+      if (!patchOpObject.containsKey("path")) {
+        continue;
+      }
+      String path = patchOpObject.getString("path");
+      if (isPrivilegedUserPatchPath(path)) {
+        authorizer.authorizeAdmin(securityContext);
+        continue;
+      }
+      if (patchOpObject.containsKey("value")) {
         // Check if updating personaPreferences - users can only update their own
         if (path.startsWith("/personaPreferences")) {
           String authenticatedUserName = securityContext.getUserPrincipal().getName();
@@ -1117,6 +1128,32 @@ public class UserResource extends EntityResource<User, UserRepository> {
       }
     }
     return patchInternal(uriInfo, securityContext, id, patch);
+  }
+
+  private static final String IS_ADMIN_PATCH_PATH = "/isAdmin";
+  private static final String IS_BOT_PATCH_PATH = "/isBot";
+  private static final String ROLES_PATCH_PATH_SEGMENT = "/roles";
+
+  // A root-level operation (path "") replaces the whole user document, so it requires the
+  // same admin authorization as the privilege fields it can change.
+  private static boolean isPrivilegedUserPatchPath(String path) {
+    return path.isEmpty()
+        || path.equals(IS_ADMIN_PATCH_PATH)
+        || path.equals(IS_BOT_PATCH_PATH)
+        || path.contains(ROLES_PATCH_PATH_SEGMENT);
+  }
+
+  private static boolean hasRoleElevation(
+      List<EntityReference> currentRoles, List<EntityReference> updatedRoles) {
+    Set<UUID> updatedRoleIds = roleIds(updatedRoles);
+    return !updatedRoleIds.isEmpty() && !updatedRoleIds.equals(roleIds(currentRoles));
+  }
+
+  private static Set<UUID> roleIds(List<EntityReference> roles) {
+    if (nullOrEmpty(roles)) {
+      return Set.of();
+    }
+    return roles.stream().map(EntityReference::getId).collect(Collectors.toSet());
   }
 
   /** Preference {@code type} discriminator -> the concrete POJO it deserializes to. */
@@ -1795,6 +1832,14 @@ public class UserResource extends EntityResource<User, UserRepository> {
         getResourceContext(),
         new OperationContext(entityType, MetadataOperation.GENERATE_TOKEN));
     String userName = securityContext.getUserPrincipal().getName();
+    String impersonatedBy = ImpersonationContext.getImpersonatedBy();
+    if (!nullOrEmpty(impersonatedBy)) {
+      throw new AuthorizationException(
+          "Cannot create a personal access token for user "
+              + userName
+              + " while impersonated by "
+              + impersonatedBy);
+    }
     User user =
         repository.getByName(
             null, userName, getFields("roles,email,isBot"), Include.NON_DELETED, false);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
@@ -813,16 +813,16 @@ public class UserResource extends EntityResource<User, UserRepository> {
     ResourceContext<?> resourceContext = getResourceContextByName(user.getFullyQualifiedName());
     if (Boolean.TRUE.equals(create.getIsAdmin()) || Boolean.TRUE.equals(create.getIsBot())) {
       authorizer.authorizeAdmin(securityContext);
-    } else if (!securityContext.getUserPrincipal().getName().equals(user.getName())) {
+    } else if (!securityContext.getUserPrincipal().getName().equalsIgnoreCase(user.getName())) {
       // doing authorization check outside of authorizer here. We are checking if the logged-in user
       // is same as the user. We are trying to update. One option is to set users.owner as user,
-      // however that is not supported for User.
+      // however that is not supported for User. The principal name comes from the token unmodified
+      // while user.getName() is normalized to lower case, so this comparison ignores case.
       OperationContext createOperationContext =
           new OperationContext(entityType, EntityUtil.createOrUpdateOperation(resourceContext));
       authorizer.authorize(securityContext, createOperationContext, resourceContext);
-    } else if (existingUser != null && hasRoleElevation(existingUser.getRoles(), user.getRoles())) {
+    } else if (existingUser != null && hasRoleElevation(existingUser, user)) {
       // Self-updates skip generic authorization, so gaining roles needs an explicit admin check.
-      // Shedding roles stays allowed.
       authorizer.authorizeAdmin(securityContext);
     }
     if (Boolean.TRUE.equals(create.getIsBot())) {
@@ -1132,7 +1132,8 @@ public class UserResource extends EntityResource<User, UserRepository> {
 
   private static final String IS_ADMIN_PATCH_PATH = "/isAdmin";
   private static final String IS_BOT_PATCH_PATH = "/isBot";
-  private static final String ROLES_PATCH_PATH_SEGMENT = "/roles";
+  private static final String ROLES_FIELD = "roles";
+  private static final String ROLES_PATCH_PATH_SEGMENT = "/" + ROLES_FIELD;
 
   // A root-level operation (path "") replaces the whole user document, so it requires the
   // same admin authorization as the privilege fields it can change.
@@ -1143,10 +1144,18 @@ public class UserResource extends EntityResource<User, UserRepository> {
         || path.contains(ROLES_PATCH_PATH_SEGMENT);
   }
 
-  private static boolean hasRoleElevation(
-      List<EntityReference> currentRoles, List<EntityReference> updatedRoles) {
-    Set<UUID> updatedRoleIds = roleIds(updatedRoles);
-    return !updatedRoleIds.isEmpty() && !updatedRoleIds.equals(roleIds(currentRoles));
+  // Elevation is gaining a role the user does not already hold. Shedding roles - all of them or
+  // only some - is a privilege reduction and stays allowed without an admin check.
+  private boolean hasRoleElevation(User existingUser, User updatedUser) {
+    Set<UUID> updatedRoleIds = roleIds(updatedUser.getRoles());
+    if (updatedRoleIds.isEmpty()) {
+      return false;
+    }
+    // existingUser comes from findByNameOrNull(), which sets core fields only, so its roles are
+    // always null - they have to be loaded before they can be compared against.
+    List<EntityReference> currentRoles =
+        repository.get(null, existingUser.getId(), getFields(ROLES_FIELD), ALL, false).getRoles();
+    return !roleIds(currentRoles).containsAll(updatedRoleIds);
   }
 
   private static Set<UUID> roleIds(List<EntityReference> roles) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
@@ -680,8 +680,8 @@ public class UserResource extends EntityResource<User, UserRepository> {
       @Context SecurityContext securityContext,
       @Context ContainerRequestContext containerRequestContext,
       @Valid CreateUser create) {
-    if (Boolean.TRUE.equals(create.getIsAdmin()) || Boolean.TRUE.equals(create.getIsBot())) {
-      authorizer.authorizeAdmin(securityContext);
+    if (grantsPrivileges(create)) {
+      authorizeAdminForPrivilegedFields(securityContext);
     }
     User user = getUser(securityContext.getUserPrincipal().getName(), create);
     if (Boolean.TRUE.equals(user.getIsBot())) {
@@ -812,7 +812,7 @@ public class UserResource extends EntityResource<User, UserRepository> {
     }
     ResourceContext<?> resourceContext = getResourceContextByName(user.getFullyQualifiedName());
     if (Boolean.TRUE.equals(create.getIsAdmin()) || Boolean.TRUE.equals(create.getIsBot())) {
-      authorizer.authorizeAdmin(securityContext);
+      authorizeAdminForPrivilegedFields(securityContext);
     } else if (!securityContext.getUserPrincipal().getName().equalsIgnoreCase(user.getName())) {
       // doing authorization check outside of authorizer here. We are checking if the logged-in user
       // is same as the user. We are trying to update. One option is to set users.owner as user,
@@ -821,9 +821,8 @@ public class UserResource extends EntityResource<User, UserRepository> {
       OperationContext createOperationContext =
           new OperationContext(entityType, EntityUtil.createOrUpdateOperation(resourceContext));
       authorizer.authorize(securityContext, createOperationContext, resourceContext);
-    } else if (existingUser != null && hasRoleElevation(existingUser, user)) {
-      // Self-updates skip generic authorization, so gaining roles needs an explicit admin check.
-      authorizer.authorizeAdmin(securityContext);
+    } else if (hasRoleElevation(existingUser, user)) {
+      authorizeAdminForPrivilegedFields(securityContext);
     }
     if (Boolean.TRUE.equals(create.getIsBot())) {
       return createOrUpdateBotUser(user, create, uriInfo, securityContext);
@@ -1135,8 +1134,8 @@ public class UserResource extends EntityResource<User, UserRepository> {
   private static final String ROLES_FIELD = "roles";
   private static final String ROLES_PATCH_PATH_SEGMENT = "/" + ROLES_FIELD;
 
-  // A root-level operation (path "") replaces the whole user document, so it requires the
-  // same admin authorization as the privilege fields it can change.
+  // A root-level operation (path "") replaces the whole user document, so it covers the same
+  // fields as the explicit paths below.
   private static boolean isPrivilegedUserPatchPath(String path) {
     return path.isEmpty()
         || path.equals(IS_ADMIN_PATCH_PATH)
@@ -1144,18 +1143,46 @@ public class UserResource extends EntityResource<User, UserRepository> {
         || path.contains(ROLES_PATCH_PATH_SEGMENT);
   }
 
-  // Elevation is gaining a role the user does not already hold. Shedding roles - all of them or
-  // only some - is a privilege reduction and stays allowed without an admin check.
+  // True when the request asks for a role the user does not already hold. A null existingUser
+  // means the user is being created, so every requested role is a new one.
   private boolean hasRoleElevation(User existingUser, User updatedUser) {
     Set<UUID> updatedRoleIds = roleIds(updatedUser.getRoles());
     if (updatedRoleIds.isEmpty()) {
       return false;
+    }
+    if (existingUser == null) {
+      return true;
     }
     // existingUser comes from findByNameOrNull(), which sets core fields only, so its roles are
     // always null - they have to be loaded before they can be compared against.
     List<EntityReference> currentRoles =
         repository.get(null, existingUser.getId(), getFields(ROLES_FIELD), ALL, false).getRoles();
     return !roleIds(currentRoles).containsAll(updatedRoleIds);
+  }
+
+  // Fields on CreateUser that only an admin may set, whoever the user being created is.
+  private boolean grantsPrivileges(CreateUser create) {
+    return Boolean.TRUE.equals(create.getIsAdmin())
+        || Boolean.TRUE.equals(create.getIsBot())
+        || grantsRolesFromRequestBody(create);
+  }
+
+  // updateUserRolesIfRequired() discards the request body roles in favour of the ones in the
+  // authorization token when useRolesFromProvider is on, so there the body has no effect.
+  private boolean grantsRolesFromRequestBody(CreateUser create) {
+    return !nullOrEmpty(create.getRoles())
+        && !Boolean.TRUE.equals(authorizerConfiguration.getUseRolesFromProvider());
+  }
+
+  // The principal is not in the database yet during self sign-up, and authorizeAdmin() resolves the
+  // subject from it, so a plain call would surface the outcome as a 404 instead of a 403.
+  private void authorizeAdminForPrivilegedFields(SecurityContext securityContext) {
+    String principal = securityContext.getUserPrincipal().getName();
+    try {
+      authorizer.authorizeAdmin(securityContext);
+    } catch (EntityNotFoundException e) {
+      throw new AuthorizationException(CatalogExceptionMessage.notAdmin(principal));
+    }
   }
 
   private static Set<UUID> roleIds(List<EntityReference> roles) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
@@ -811,7 +811,12 @@ public class UserResource extends EntityResource<User, UserRepository> {
           new OperationContext(entityType, MetadataOperation.CREATE));
     }
     ResourceContext<?> resourceContext = getResourceContextByName(user.getFullyQualifiedName());
-    if (Boolean.TRUE.equals(create.getIsAdmin()) || Boolean.TRUE.equals(create.getIsBot())) {
+    // Privileged fields are admin only whoever the target is. This has to be checked before the
+    // ownership branch below, otherwise a principal holding EDIT on users would be able to grant
+    // roles to somebody else through PUT while PATCH refuses the same change.
+    if (Boolean.TRUE.equals(create.getIsAdmin())
+        || Boolean.TRUE.equals(create.getIsBot())
+        || hasRoleElevation(existingUser, user)) {
       authorizeAdminForPrivilegedFields(securityContext);
     } else if (!securityContext.getUserPrincipal().getName().equalsIgnoreCase(user.getName())) {
       // doing authorization check outside of authorizer here. We are checking if the logged-in user
@@ -821,8 +826,6 @@ public class UserResource extends EntityResource<User, UserRepository> {
       OperationContext createOperationContext =
           new OperationContext(entityType, EntityUtil.createOrUpdateOperation(resourceContext));
       authorizer.authorize(securityContext, createOperationContext, resourceContext);
-    } else if (hasRoleElevation(existingUser, user)) {
-      authorizeAdminForPrivilegedFields(securityContext);
     }
     if (Boolean.TRUE.equals(create.getIsBot())) {
       return createOrUpdateBotUser(user, create, uriInfo, securityContext);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
@@ -610,6 +610,7 @@ public class UserResource extends EntityResource<User, UserRepository> {
       @Context HttpServletRequest httpServletRequest,
       @Context HttpServletResponse httpServletResponse,
       @Valid LogoutRequest request) {
+    rejectImpersonatedTokenOperation(securityContext, "log out");
     Date logoutTime = Date.from(LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant());
     JwtTokenCacheManager.getInstance()
         .markLogoutEventForToken(
@@ -1799,6 +1800,23 @@ public class UserResource extends EntityResource<User, UserRepository> {
     return Response.status(Response.Status.OK).entity(new ResultList<>(tokens)).build();
   }
 
+  // Impersonation must never create, revoke, or invalidate a target's tokens or sessions: the
+  // effective principal is the impersonated user, so these self-scoped operations would act on the
+  // target rather than the caller. Reject them outright regardless of the bot's impersonation
+  // grant.
+  private void rejectImpersonatedTokenOperation(SecurityContext securityContext, String action) {
+    String impersonatedBy = ImpersonationContext.getImpersonatedBy();
+    if (!nullOrEmpty(impersonatedBy)) {
+      throw new AuthorizationException(
+          "Cannot "
+              + action
+              + " for user "
+              + securityContext.getUserPrincipal().getName()
+              + " while impersonated by "
+              + impersonatedBy);
+    }
+  }
+
   @PUT
   @Path("/security/token/revoke")
   @Operation(
@@ -1826,6 +1844,7 @@ public class UserResource extends EntityResource<User, UserRepository> {
           @DefaultValue("false")
           boolean removeAll,
       @Valid RevokePersonalTokenRequest request) {
+    rejectImpersonatedTokenOperation(securityContext, "revoke a personal access token");
     if (!CommonUtil.nullOrEmpty(userName)) {
       authorizer.authorizeAdmin(securityContext);
     } else {
@@ -1870,15 +1889,8 @@ public class UserResource extends EntityResource<User, UserRepository> {
         securityContext,
         getResourceContext(),
         new OperationContext(entityType, MetadataOperation.GENERATE_TOKEN));
+    rejectImpersonatedTokenOperation(securityContext, "create a personal access token");
     String userName = securityContext.getUserPrincipal().getName();
-    String impersonatedBy = ImpersonationContext.getImpersonatedBy();
-    if (!nullOrEmpty(impersonatedBy)) {
-      throw new AuthorizationException(
-          "Cannot create a personal access token for user "
-              + userName
-              + " while impersonated by "
-              + impersonatedBy);
-    }
     User user =
         repository.getByName(
             null, userName, getFields("roles,email,isBot"), Include.NON_DELETED, false);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/DefaultAuthorizer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/DefaultAuthorizer.java
@@ -139,7 +139,7 @@ public class DefaultAuthorizer implements Authorizer {
 
   @Override
   public void authorizeAdmin(String adminName) {
-    SubjectContext subjectContext = getSubjectContext(adminName);
+    SubjectContext subjectContext = subjectContextForUserName(adminName);
     if (subjectContext.isAdmin()) {
       return;
     }
@@ -183,8 +183,12 @@ public class DefaultAuthorizer implements Authorizer {
    * Resolves the effective subject from a username, for the call sites that only have the effective
    * user name rather than the {@link SecurityContext}. The impersonating bot is not carried by the
    * name, so it is read from the request's {@link ImpersonationContext}.
+   *
+   * <p>Deliberately not an overload of {@code getSubjectContext}: that name is statically imported
+   * and stubbed with untyped {@code any()} matchers across the codebase, where a second overload
+   * makes the call ambiguous.
    */
-  public static SubjectContext getSubjectContext(String userName) {
+  private static SubjectContext subjectContextForUserName(String userName) {
     String impersonatedBy = ImpersonationContext.getImpersonatedBy();
     if (impersonatedBy == null) {
       return SubjectContext.getSubjectContext(userName);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/DefaultAuthorizer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/DefaultAuthorizer.java
@@ -139,7 +139,7 @@ public class DefaultAuthorizer implements Authorizer {
 
   @Override
   public void authorizeAdmin(String adminName) {
-    SubjectContext subjectContext = SubjectContext.getSubjectContext(adminName);
+    SubjectContext subjectContext = getSubjectContext(adminName);
     if (subjectContext.isAdmin()) {
       return;
     }
@@ -170,17 +170,29 @@ public class DefaultAuthorizer implements Authorizer {
 
   /**
    * Resolves the effective subject for the request and, when the caller is a bot acting through
-   * impersonation, validates that impersonation before the subject is handed out.
+   * impersonation, checks that impersonation before the subject is handed out.
    *
-   * <p>The validation lives here rather than in the individual guards because every authorization
-   * entry point and every resource that filters on the effective subject funnels through this
-   * method. Guards such as {@link #authorizeAdmin(SecurityContext)} and {@link
-   * #authorizeAdminOrBot(SecurityContext)} short-circuit on {@code isAdmin()}, so a check placed
-   * only in {@link #authorize} would let a bot impersonating an admin reach admin-only endpoints
-   * without its {@code IMPERSONATE} policy ever being evaluated.
+   * <p>The check lives here rather than in the individual guards because every authorization entry
+   * point and every resource that filters on the effective subject funnels through this method.
    */
   public static SubjectContext getSubjectContext(SecurityContext securityContext) {
-    SubjectContext subjectContext = resolveSubjectContext(securityContext);
+    return validateImpersonation(resolveSubjectContext(securityContext));
+  }
+
+  /**
+   * Resolves the effective subject from a username, for the call sites that only have the effective
+   * user name rather than the {@link SecurityContext}. The impersonating bot is not carried by the
+   * name, so it is read from the request's {@link ImpersonationContext}.
+   */
+  public static SubjectContext getSubjectContext(String userName) {
+    String impersonatedBy = ImpersonationContext.getImpersonatedBy();
+    if (impersonatedBy == null) {
+      return SubjectContext.getSubjectContext(userName);
+    }
+    return validateImpersonation(SubjectContext.getSubjectContext(userName, impersonatedBy));
+  }
+
+  private static SubjectContext validateImpersonation(SubjectContext subjectContext) {
     if (subjectContext.impersonatedBy() != null) {
       checkImpersonationAuthorization(subjectContext);
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/DefaultAuthorizer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/DefaultAuthorizer.java
@@ -108,6 +108,10 @@ public class DefaultAuthorizer implements Authorizer {
       SecurityContext securityContext, List<AuthRequest> requests, AuthorizationLogic logic) {
     SubjectContext subjectContext = getSubjectContext(securityContext);
 
+    if (subjectContext.impersonatedBy() != null) {
+      checkImpersonationAuthorization(subjectContext);
+    }
+
     if (subjectContext.isAdmin()) {
       return;
     }
@@ -165,24 +169,6 @@ public class DefaultAuthorizer implements Authorizer {
   public boolean shouldMaskPasswords(SecurityContext securityContext) {
     SubjectContext subjectContext = getSubjectContext(securityContext);
     return !subjectContext.isBot();
-  }
-
-  public void authorizeImpersonation(SecurityContext securityContext, String targetUser) {
-    String botName = SecurityUtil.getUserName(securityContext);
-    SubjectContext botContext = SubjectContext.getSubjectContext(botName);
-
-    if (!botContext.isBot()) {
-      throw new AuthorizationException("Only bot users can impersonate");
-    }
-    if (!Boolean.TRUE.equals(botContext.user().getAllowImpersonation())) {
-      throw new AuthorizationException("Bot " + botName + " does not have impersonation enabled");
-    }
-
-    OperationContext operationContext =
-        new OperationContext(Entity.USER, MetadataOperation.IMPERSONATE);
-    ResourceContextInterface resourceContext = new ResourceContext<>(Entity.USER, null, targetUser);
-
-    PolicyEvaluator.hasPermission(botContext, resourceContext, operationContext);
   }
 
   /** In 1.2, evaluate policies here instead of just checking the subject */

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/DefaultAuthorizer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/DefaultAuthorizer.java
@@ -86,11 +86,6 @@ public class DefaultAuthorizer implements Authorizer {
     Timer.Sample authSample = RequestLatencyContext.startAuthOperation();
     try {
       SubjectContext subjectContext = getSubjectContext(securityContext);
-
-      if (subjectContext.impersonatedBy() != null) {
-        checkImpersonationAuthorization(subjectContext);
-      }
-
       if (subjectContext.isAdmin()) {
         return;
       }
@@ -107,11 +102,6 @@ public class DefaultAuthorizer implements Authorizer {
   public void authorizeRequests(
       SecurityContext securityContext, List<AuthRequest> requests, AuthorizationLogic logic) {
     SubjectContext subjectContext = getSubjectContext(securityContext);
-
-    if (subjectContext.impersonatedBy() != null) {
-      checkImpersonationAuthorization(subjectContext);
-    }
-
     if (subjectContext.isAdmin()) {
       return;
     }
@@ -178,7 +168,26 @@ public class DefaultAuthorizer implements Authorizer {
     return subjectContext.isAdmin() || subjectContext.isBot() || subjectContext.isOwner(owners);
   }
 
+  /**
+   * Resolves the effective subject for the request and, when the caller is a bot acting through
+   * impersonation, validates that impersonation before the subject is handed out.
+   *
+   * <p>The validation lives here rather than in the individual guards because every authorization
+   * entry point and every resource that filters on the effective subject funnels through this
+   * method. Guards such as {@link #authorizeAdmin(SecurityContext)} and {@link
+   * #authorizeAdminOrBot(SecurityContext)} short-circuit on {@code isAdmin()}, so a check placed
+   * only in {@link #authorize} would let a bot impersonating an admin reach admin-only endpoints
+   * without its {@code IMPERSONATE} policy ever being evaluated.
+   */
   public static SubjectContext getSubjectContext(SecurityContext securityContext) {
+    SubjectContext subjectContext = resolveSubjectContext(securityContext);
+    if (subjectContext.impersonatedBy() != null) {
+      checkImpersonationAuthorization(subjectContext);
+    }
+    return subjectContext;
+  }
+
+  private static SubjectContext resolveSubjectContext(SecurityContext securityContext) {
     if (securityContext == null || securityContext.getUserPrincipal() == null) {
       throw new AuthenticationException("No principal in security context");
     }
@@ -237,8 +246,13 @@ public class DefaultAuthorizer implements Authorizer {
                 e -> updatedBy.equals(e.getName()) || updatedBy.equals(e.getFullyQualifiedName()));
   }
 
-  private void checkImpersonationAuthorization(SubjectContext subjectContext) {
-    User bot = getImpersonatingBot(subjectContext.impersonatedBy());
+  private static void checkImpersonationAuthorization(SubjectContext subjectContext) {
+    String botName = subjectContext.impersonatedBy();
+    String targetUser = subjectContext.user().getName();
+    if (ImpersonationContext.isValidated(botName, targetUser)) {
+      return;
+    }
+    User bot = getImpersonatingBot(botName);
 
     if (!Boolean.TRUE.equals(bot.getIsBot()) || !Boolean.TRUE.equals(bot.getAllowImpersonation())) {
       LOG.warn(
@@ -248,9 +262,10 @@ public class DefaultAuthorizer implements Authorizer {
     }
 
     authorizeImpersonationTarget(bot.getName(), subjectContext.user());
+    ImpersonationContext.markValidated(botName, targetUser);
   }
 
-  private User getImpersonatingBot(String botName) {
+  private static User getImpersonatingBot(String botName) {
     User bot;
     try {
       bot = Entity.getEntityByName(Entity.USER, botName, "id,name,isBot,allowImpersonation", ALL);
@@ -270,7 +285,7 @@ public class DefaultAuthorizer implements Authorizer {
    * resource. Policies scope who can be impersonated - for example, a deny rule with the {@code
    * isAdminUser()} condition blocks impersonating admins.
    */
-  private void authorizeImpersonationTarget(String botName, User targetUser) {
+  private static void authorizeImpersonationTarget(String botName, User targetUser) {
     SubjectContext botSubjectContext = SubjectContext.getSubjectContext(botName);
     OperationContext operationContext =
         new OperationContext(Entity.USER, MetadataOperation.IMPERSONATE);
@@ -288,7 +303,7 @@ public class DefaultAuthorizer implements Authorizer {
   }
 
   @SuppressWarnings("unchecked")
-  private ResourceContextInterface targetUserResourceContext(User targetUser) {
+  private static ResourceContextInterface targetUserResourceContext(User targetUser) {
     EntityRepository<User> userRepository =
         (EntityRepository<User>) Entity.getEntityRepository(Entity.USER);
     return new ResourceContext<>(Entity.USER, targetUser, userRepository);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/ImpersonationContext.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/ImpersonationContext.java
@@ -8,7 +8,7 @@ public class ImpersonationContext {
   private static final ThreadLocal<String> impersonatedBy = new ThreadLocal<>();
 
   /**
-   * {@code "<bot>-><target>"} of an impersonation already cleared by {@link DefaultAuthorizer}.
+   * {@code "<bot>-><target>"} of an impersonation already checked by {@link DefaultAuthorizer}.
    * Subject resolution re-checks impersonation on every call and a single request resolves the
    * subject many times, so this keeps the bot lookup and policy evaluation to once per request.
    */

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/ImpersonationContext.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/ImpersonationContext.java
@@ -7,6 +7,13 @@ package org.openmetadata.service.security;
 public class ImpersonationContext {
   private static final ThreadLocal<String> impersonatedBy = new ThreadLocal<>();
 
+  /**
+   * {@code "<bot>-><target>"} of an impersonation already cleared by {@link DefaultAuthorizer}.
+   * Subject resolution re-checks impersonation on every call and a single request resolves the
+   * subject many times, so this keeps the bot lookup and policy evaluation to once per request.
+   */
+  private static final ThreadLocal<String> validatedImpersonation = new ThreadLocal<>();
+
   public static void setImpersonatedBy(String username) {
     impersonatedBy.set(username);
   }
@@ -15,7 +22,20 @@ public class ImpersonationContext {
     return impersonatedBy.get();
   }
 
+  public static boolean isValidated(String botName, String targetUser) {
+    return validationKey(botName, targetUser).equals(validatedImpersonation.get());
+  }
+
+  public static void markValidated(String botName, String targetUser) {
+    validatedImpersonation.set(validationKey(botName, targetUser));
+  }
+
+  private static String validationKey(String botName, String targetUser) {
+    return botName + "->" + targetUser;
+  }
+
   public static void clear() {
     impersonatedBy.remove();
+    validatedImpersonation.remove();
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/JwtFilter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/JwtFilter.java
@@ -284,10 +284,13 @@ public class JwtFilter implements ContainerRequestFilter {
           enforcePrincipalDomain);
     }
 
-    // Validate Bot token matches what was created in OM
-    // Skip validation for impersonation tokens - they are generated dynamically and not stored in
-    // cache
-    if (impersonatedBy == null && isBot(claims)) {
+    // Validate Bot token matches what was created in OM. Under impersonation the presented token
+    // belongs to the impersonating bot (impersonatedBy), while userName is the target, so validate
+    // the bot's own token against its cache entry instead of skipping - otherwise a rotated (i.e.
+    // revoked) bot token keeps working as long as an X-Impersonate-User header is attached.
+    if (impersonatedBy != null) {
+      validateBotToken(tokenFromHeader, impersonatedBy);
+    } else if (isBot(claims)) {
       validateBotToken(tokenFromHeader, userName);
     }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/DefaultAuthorizerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/DefaultAuthorizerTest.java
@@ -532,9 +532,8 @@ class DefaultAuthorizerTest {
 
   @Test
   void impersonationPolicyIsEnforcedOnEveryAuthorizerEntryPoint() {
-    // The bot is enabled for impersonation but its IMPERSONATE policy denies this target. Every
-    // entry point must reject it - including the admin-only guards, which short-circuit on
-    // isAdmin() and would otherwise inherit the impersonated admin's privileges.
+    // The bot is enabled for impersonation but its IMPERSONATE policy denies this target, so every
+    // entry point must reject it - including the admin-only guards.
     User adminTarget = new User().withName("admin").withIsAdmin(true);
     User bot = new User().withName("ingestion-bot").withIsBot(true).withAllowImpersonation(true);
     SecurityContext securityContext = impersonatedSecurityContext("admin", "ingestion-bot");
@@ -590,6 +589,56 @@ class DefaultAuthorizerTest {
       assertEquals(
           "Bot flagless-bot does not have impersonation enabled",
           denied(() -> authorizer.authorizeAdmin(securityContext)));
+    }
+  }
+
+  @Test
+  void impersonationPolicyIsEnforcedOnTheUserNameAdminGuard() {
+    // authorizeAdmin(String) only receives the effective user name, so the impersonating bot has to
+    // come from the request ThreadLocal.
+    User adminTarget = new User().withName("admin").withIsAdmin(true);
+    User bot = new User().withName("ingestion-bot").withIsBot(true).withAllowImpersonation(true);
+    ImpersonationContext.setImpersonatedBy(bot.getName());
+
+    try (MockedStatic<SubjectContext> mockedSubjectContext = mockStatic(SubjectContext.class);
+        MockedStatic<Entity> mockedEntity = mockStatic(Entity.class);
+        MockedStatic<PolicyEvaluator> mockedPolicyEvaluator = mockStatic(PolicyEvaluator.class)) {
+      stubImpersonation(mockedSubjectContext, mockedEntity, adminTarget, bot);
+      mockedPolicyEvaluator
+          .when(
+              () ->
+                  PolicyEvaluator.hasPermission(
+                      any(SubjectContext.class),
+                      any(ResourceContextInterface.class),
+                      any(OperationContext.class)))
+          .thenThrow(new AuthorizationException("denied by policy"));
+
+      assertEquals(
+          "Bot ingestion-bot is not authorized to impersonate user admin",
+          denied(() -> authorizer.authorizeAdmin("admin")));
+    }
+  }
+
+  @Test
+  void authorizedImpersonationPassesTheUserNameAdminGuard() {
+    User adminTarget = new User().withName("admin").withIsAdmin(true);
+    User bot = new User().withName("ingestion-bot").withIsBot(true).withAllowImpersonation(true);
+    ImpersonationContext.setImpersonatedBy(bot.getName());
+
+    try (MockedStatic<SubjectContext> mockedSubjectContext = mockStatic(SubjectContext.class);
+        MockedStatic<Entity> mockedEntity = mockStatic(Entity.class);
+        MockedStatic<PolicyEvaluator> mockedPolicyEvaluator = mockStatic(PolicyEvaluator.class)) {
+      stubImpersonation(mockedSubjectContext, mockedEntity, adminTarget, bot);
+      mockedPolicyEvaluator
+          .when(
+              () ->
+                  PolicyEvaluator.hasPermission(
+                      any(SubjectContext.class),
+                      any(ResourceContextInterface.class),
+                      any(OperationContext.class)))
+          .thenAnswer(invocation -> null);
+
+      assertDoesNotThrow(() -> authorizer.authorizeAdmin("admin"));
     }
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/DefaultAuthorizerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/DefaultAuthorizerTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -24,6 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.mockito.MockedStatic;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.entity.teams.User;
@@ -236,7 +236,7 @@ class DefaultAuthorizerTest {
 
   @Test
   void authorizeRejectsMissingOrMisconfiguredImpersonationBots() {
-    SecurityContext securityContext = securityContext("target-user");
+    SecurityContext missingBotContext = impersonatedSecurityContext("target-user", "missing-bot");
     SubjectContext impersonatedContext =
         new SubjectContext(new User().withName("target-user"), "missing-bot");
     ResourceContextInterface resourceContext = mock(ResourceContextInterface.class);
@@ -244,81 +244,65 @@ class DefaultAuthorizerTest {
     OperationContext operationContext =
         new OperationContext(Entity.TABLE, MetadataOperation.VIEW_ALL);
 
-    try (MockedStatic<DefaultAuthorizer> mockedAuthorizer = mockStatic(DefaultAuthorizer.class);
+    try (MockedStatic<SubjectContext> mockedSubjectContext = mockStatic(SubjectContext.class);
         MockedStatic<Entity> mockedEntity = mockStatic(Entity.class)) {
-      mockedAuthorizer
-          .when(() -> DefaultAuthorizer.getSubjectContext(securityContext))
+      mockedSubjectContext
+          .when(() -> SubjectContext.getSubjectContext("target-user", "missing-bot"))
           .thenReturn(impersonatedContext);
       mockedEntity
           .when(
-              () ->
-                  Entity.getEntityByName(
-                      Entity.USER,
-                      "missing-bot",
-                      "id,name,isBot,allowImpersonation",
-                      org.openmetadata.schema.type.Include.ALL))
+              () -> Entity.getEntityByName(eq(Entity.USER), eq("missing-bot"), anyString(), any()))
           .thenThrow(new IllegalArgumentException("missing"));
 
       AuthorizationException missingBot =
           assertThrows(
               AuthorizationException.class,
-              () -> authorizer.authorize(securityContext, operationContext, resourceContext));
+              () -> authorizer.authorize(missingBotContext, operationContext, resourceContext));
       assertTrue(missingBot.getMessage().contains("Bot user not found"));
     }
 
-    try (MockedStatic<DefaultAuthorizer> mockedAuthorizer = mockStatic(DefaultAuthorizer.class);
+    try (MockedStatic<SubjectContext> mockedSubjectContext = mockStatic(SubjectContext.class);
         MockedStatic<Entity> mockedEntity = mockStatic(Entity.class)) {
-      mockedAuthorizer
-          .when(() -> DefaultAuthorizer.getSubjectContext(securityContext))
+      mockedSubjectContext
+          .when(() -> SubjectContext.getSubjectContext("target-user", "missing-bot"))
           .thenReturn(impersonatedContext);
       mockedEntity
           .when(
-              () ->
-                  Entity.getEntityByName(
-                      Entity.USER,
-                      "missing-bot",
-                      "id,name,isBot,allowImpersonation",
-                      org.openmetadata.schema.type.Include.ALL))
+              () -> Entity.getEntityByName(eq(Entity.USER), eq("missing-bot"), anyString(), any()))
           .thenReturn(null);
 
       AuthorizationException nullBot =
           assertThrows(
               AuthorizationException.class,
-              () -> authorizer.authorize(securityContext, operationContext, resourceContext));
+              () -> authorizer.authorize(missingBotContext, operationContext, resourceContext));
       assertTrue(nullBot.getMessage().contains("Bot user not found"));
     }
 
+    SecurityContext flaggedBotContext = impersonatedSecurityContext("target-user", "bot-user");
     SubjectContext flaggedContext =
         new SubjectContext(new User().withName("target-user"), "bot-user");
-    User bot = new User().withName("bot-user").withIsBot(true);
-    bot.setAllowImpersonation(false);
+    User bot = new User().withName("bot-user").withIsBot(true).withAllowImpersonation(false);
 
-    try (MockedStatic<DefaultAuthorizer> mockedAuthorizer = mockStatic(DefaultAuthorizer.class);
+    try (MockedStatic<SubjectContext> mockedSubjectContext = mockStatic(SubjectContext.class);
         MockedStatic<Entity> mockedEntity = mockStatic(Entity.class)) {
-      mockedAuthorizer
-          .when(() -> DefaultAuthorizer.getSubjectContext(securityContext))
+      mockedSubjectContext
+          .when(() -> SubjectContext.getSubjectContext("target-user", "bot-user"))
           .thenReturn(flaggedContext);
       mockedEntity
-          .when(
-              () ->
-                  Entity.getEntityByName(
-                      Entity.USER,
-                      "bot-user",
-                      "id,name,isBot,allowImpersonation",
-                      org.openmetadata.schema.type.Include.ALL))
+          .when(() -> Entity.getEntityByName(eq(Entity.USER), eq("bot-user"), anyString(), any()))
           .thenReturn(bot);
 
       AuthorizationException disabledImpersonation =
           assertThrows(
               AuthorizationException.class,
-              () -> authorizer.authorize(securityContext, operationContext, resourceContext));
+              () -> authorizer.authorize(flaggedBotContext, operationContext, resourceContext));
       assertTrue(disabledImpersonation.getMessage().contains("impersonation enabled"));
     }
   }
 
   @Test
   void authorizeRejectsBotsNotAllowedToImpersonateTarget() {
-    SecurityContext securityContext = securityContext("target-user");
+    SecurityContext securityContext = impersonatedSecurityContext("target-user", "bot-user");
     SubjectContext impersonatedContext =
         new SubjectContext(new User().withName("target-user").withIsAdmin(true), "bot-user");
     ResourceContextInterface resourceContext = mock(ResourceContextInterface.class);
@@ -326,25 +310,17 @@ class DefaultAuthorizerTest {
     OperationContext operationContext =
         new OperationContext(Entity.TABLE, MetadataOperation.VIEW_ALL);
 
-    User bot = new User().withName("bot-user").withIsBot(true);
-    bot.setAllowImpersonation(true);
+    User bot = new User().withName("bot-user").withIsBot(true).withAllowImpersonation(true);
     SubjectContext botSubjectContext = subjectContext("bot-user", false, true, null);
 
-    try (MockedStatic<DefaultAuthorizer> mockedAuthorizer = mockStatic(DefaultAuthorizer.class);
-        MockedStatic<SubjectContext> mockedSubjectContext = mockStatic(SubjectContext.class);
+    try (MockedStatic<SubjectContext> mockedSubjectContext = mockStatic(SubjectContext.class);
         MockedStatic<Entity> mockedEntity = mockStatic(Entity.class);
         MockedStatic<PolicyEvaluator> mockedPolicyEvaluator = mockStatic(PolicyEvaluator.class)) {
-      mockedAuthorizer
-          .when(() -> DefaultAuthorizer.getSubjectContext(securityContext))
+      mockedSubjectContext
+          .when(() -> SubjectContext.getSubjectContext("target-user", "bot-user"))
           .thenReturn(impersonatedContext);
       mockedEntity
-          .when(
-              () ->
-                  Entity.getEntityByName(
-                      Entity.USER,
-                      "bot-user",
-                      "id,name,isBot,allowImpersonation",
-                      org.openmetadata.schema.type.Include.ALL))
+          .when(() -> Entity.getEntityByName(eq(Entity.USER), eq("bot-user"), anyString(), any()))
           .thenReturn(bot);
       mockedSubjectContext
           .when(() -> SubjectContext.getSubjectContext("bot-user"))
@@ -368,7 +344,7 @@ class DefaultAuthorizerTest {
 
   @Test
   void authorizeAllowsValidImpersonationBots() {
-    SecurityContext securityContext = securityContext("target-user");
+    SecurityContext securityContext = impersonatedSecurityContext("target-user", "bot-user");
     SubjectContext impersonatedContext =
         new SubjectContext(new User().withName("target-user"), "bot-user");
     ResourceContextInterface resourceContext = mock(ResourceContextInterface.class);
@@ -376,28 +352,20 @@ class DefaultAuthorizerTest {
     OperationContext operationContext =
         new OperationContext(Entity.TABLE, MetadataOperation.VIEW_ALL);
 
-    User bot = new User().withName("bot-user").withIsBot(true);
-    bot.setAllowImpersonation(true);
+    User bot = new User().withName("bot-user").withIsBot(true).withAllowImpersonation(true);
     SubjectContext botSubjectContext = subjectContext("bot-user", false, true, null);
     AtomicReference<ResourceContextInterface> impersonationResourceContext =
         new AtomicReference<>();
     AtomicReference<OperationContext> impersonationOperationContext = new AtomicReference<>();
 
-    try (MockedStatic<DefaultAuthorizer> mockedAuthorizer = mockStatic(DefaultAuthorizer.class);
-        MockedStatic<SubjectContext> mockedSubjectContext = mockStatic(SubjectContext.class);
+    try (MockedStatic<SubjectContext> mockedSubjectContext = mockStatic(SubjectContext.class);
         MockedStatic<Entity> mockedEntity = mockStatic(Entity.class);
         MockedStatic<PolicyEvaluator> mockedPolicyEvaluator = mockStatic(PolicyEvaluator.class)) {
-      mockedAuthorizer
-          .when(() -> DefaultAuthorizer.getSubjectContext(securityContext))
+      mockedSubjectContext
+          .when(() -> SubjectContext.getSubjectContext("target-user", "bot-user"))
           .thenReturn(impersonatedContext);
       mockedEntity
-          .when(
-              () ->
-                  Entity.getEntityByName(
-                      Entity.USER,
-                      "bot-user",
-                      "id,name,isBot,allowImpersonation",
-                      org.openmetadata.schema.type.Include.ALL))
+          .when(() -> Entity.getEntityByName(eq(Entity.USER), eq("bot-user"), anyString(), any()))
           .thenReturn(bot);
       mockedSubjectContext
           .when(() -> SubjectContext.getSubjectContext("bot-user"))
@@ -563,46 +531,81 @@ class DefaultAuthorizerTest {
   }
 
   @Test
-  void authorizeRequestsEnforcesImpersonationAuthorization() {
-    SecurityContext securityContext = securityContext("owner");
-    User ownerUser = new User().withName("owner").withIsAdmin(true);
-    User analystUser = new User().withName("analyst").withIsBot(false);
-    User botUser = new User().withName("ingestion-bot").withIsBot(true);
-    botUser.setAllowImpersonation(true);
-    User flaglessBotUser = new User().withName("flagless-bot").withIsBot(true);
-    SubjectContext botContext = new SubjectContext(botUser, null);
-    EntityRepository<?> repository = mock(EntityRepository.class);
-    List<AuthRequest> requests = List.of();
+  void impersonationPolicyIsEnforcedOnEveryAuthorizerEntryPoint() {
+    // The bot is enabled for impersonation but its IMPERSONATE policy denies this target. Every
+    // entry point must reject it - including the admin-only guards, which short-circuit on
+    // isAdmin() and would otherwise inherit the impersonated admin's privileges.
+    User adminTarget = new User().withName("admin").withIsAdmin(true);
+    User bot = new User().withName("ingestion-bot").withIsBot(true).withAllowImpersonation(true);
+    SecurityContext securityContext = impersonatedSecurityContext("admin", "ingestion-bot");
+
+    try (MockedStatic<SubjectContext> mockedSubjectContext = mockStatic(SubjectContext.class);
+        MockedStatic<Entity> mockedEntity = mockStatic(Entity.class);
+        MockedStatic<PolicyEvaluator> mockedPolicyEvaluator = mockStatic(PolicyEvaluator.class)) {
+      stubImpersonation(mockedSubjectContext, mockedEntity, adminTarget, bot);
+      mockedPolicyEvaluator
+          .when(
+              () ->
+                  PolicyEvaluator.hasPermission(
+                      any(SubjectContext.class),
+                      any(ResourceContextInterface.class),
+                      any(OperationContext.class)))
+          .thenThrow(new AuthorizationException("denied by policy"));
+
+      String expected = "Bot ingestion-bot is not authorized to impersonate user admin";
+      assertEquals(expected, denied(() -> authorizer.authorizeAdmin(securityContext)));
+      assertEquals(expected, denied(() -> authorizer.authorizeAdminOrBot(securityContext)));
+      assertEquals(expected, denied(() -> authorizer.authorizePII(securityContext, List.of())));
+      assertEquals(expected, denied(() -> authorizer.listPermissions(securityContext, null)));
+      assertEquals(
+          expected, denied(() -> authorizer.getPermission(securityContext, null, Entity.TABLE)));
+      assertEquals(expected, denied(() -> authorizer.shouldMaskPasswords(securityContext)));
+      assertEquals(
+          expected,
+          denied(
+              () ->
+                  authorizer.authorize(
+                      securityContext,
+                      new OperationContext(Entity.TABLE, MetadataOperation.VIEW_ALL),
+                      mock(ResourceContextInterface.class))));
+      assertEquals(
+          expected,
+          denied(
+              () ->
+                  authorizer.authorizeRequests(
+                      securityContext, List.of(), AuthorizationLogic.ANY)));
+    }
+  }
+
+  @Test
+  void impersonationRequiresBotWithImpersonationEnabled() {
+    User target = new User().withName("analyst");
+    User flaglessBot = new User().withName("flagless-bot").withIsBot(true);
+    SecurityContext securityContext = impersonatedSecurityContext("analyst", "flagless-bot");
+
+    try (MockedStatic<SubjectContext> mockedSubjectContext = mockStatic(SubjectContext.class);
+        MockedStatic<Entity> mockedEntity = mockStatic(Entity.class)) {
+      stubImpersonation(mockedSubjectContext, mockedEntity, target, flaglessBot);
+
+      assertEquals(
+          "Bot flagless-bot does not have impersonation enabled",
+          denied(() -> authorizer.authorizeAdmin(securityContext)));
+    }
+  }
+
+  @Test
+  void authorizedImpersonationEvaluatesImpersonateOperationOncePerRequest() {
+    User target = new User().withName("target-admin").withIsAdmin(true);
+    User bot = new User().withName("ingestion-bot").withIsBot(true).withAllowImpersonation(true);
+    SecurityContext securityContext = impersonatedSecurityContext("target-admin", "ingestion-bot");
+    AtomicInteger policyEvaluations = new AtomicInteger();
     AtomicReference<ResourceContextInterface> capturedResourceContext = new AtomicReference<>();
     AtomicReference<OperationContext> capturedOperationContext = new AtomicReference<>();
 
-    try (MockedStatic<DefaultAuthorizer> mockedAuthorizer = mockStatic(DefaultAuthorizer.class);
-        MockedStatic<SubjectContext> mockedSubjectContext = mockStatic(SubjectContext.class);
+    try (MockedStatic<SubjectContext> mockedSubjectContext = mockStatic(SubjectContext.class);
         MockedStatic<Entity> mockedEntity = mockStatic(Entity.class);
         MockedStatic<PolicyEvaluator> mockedPolicyEvaluator = mockStatic(PolicyEvaluator.class)) {
-      mockedAuthorizer
-          .when(() -> DefaultAuthorizer.getSubjectContext(securityContext))
-          .thenReturn(
-              new SubjectContext(ownerUser, null),
-              new SubjectContext(ownerUser, "analyst"),
-              new SubjectContext(ownerUser, "flagless-bot"),
-              new SubjectContext(ownerUser, "ingestion-bot"));
-      mockedSubjectContext
-          .when(() -> SubjectContext.getSubjectContext("ingestion-bot"))
-          .thenReturn(botContext);
-      mockedEntity
-          .when(() -> Entity.getEntityByName(eq(Entity.USER), eq("analyst"), anyString(), any()))
-          .thenReturn(analystUser);
-      mockedEntity
-          .when(
-              () -> Entity.getEntityByName(eq(Entity.USER), eq("flagless-bot"), anyString(), any()))
-          .thenReturn(flaglessBotUser);
-      mockedEntity
-          .when(
-              () ->
-                  Entity.getEntityByName(eq(Entity.USER), eq("ingestion-bot"), anyString(), any()))
-          .thenReturn(botUser);
-      mockedEntity.when(() -> Entity.getEntityRepository(Entity.USER)).thenReturn(repository);
+      stubImpersonation(mockedSubjectContext, mockedEntity, target, bot);
       mockedPolicyEvaluator
           .when(
               () ->
@@ -612,37 +615,40 @@ class DefaultAuthorizerTest {
                       any(OperationContext.class)))
           .thenAnswer(
               invocation -> {
+                policyEvaluations.incrementAndGet();
                 capturedResourceContext.set(invocation.getArgument(1));
                 capturedOperationContext.set(invocation.getArgument(2));
                 return null;
               });
 
-      assertDoesNotThrow(
-          () -> authorizer.authorizeRequests(securityContext, requests, AuthorizationLogic.ANY));
-      assertNull(capturedResourceContext.get(), "Non-impersonated requests skip authorization");
-
-      AuthorizationException nonBotException =
-          assertThrows(
-              AuthorizationException.class,
-              () ->
-                  authorizer.authorizeRequests(securityContext, requests, AuthorizationLogic.ANY));
-      assertTrue(nonBotException.getMessage().contains("does not have impersonation enabled"));
-
-      AuthorizationException flaglessException =
-          assertThrows(
-              AuthorizationException.class,
-              () ->
-                  authorizer.authorizeRequests(securityContext, requests, AuthorizationLogic.ANY));
-      assertTrue(flaglessException.getMessage().contains("does not have impersonation enabled"));
-
-      assertDoesNotThrow(
-          () -> authorizer.authorizeRequests(securityContext, requests, AuthorizationLogic.ANY));
-      assertNotNull(capturedResourceContext.get());
-      assertNotNull(capturedOperationContext.get());
+      assertDoesNotThrow(() -> authorizer.authorizeAdmin(securityContext));
       assertEquals(Entity.USER, capturedResourceContext.get().getResource());
       assertEquals(
           List.of(MetadataOperation.IMPERSONATE),
           capturedOperationContext.get().getOperations(capturedResourceContext.get()));
+
+      assertDoesNotThrow(() -> authorizer.authorizeAdminOrBot(securityContext));
+      assertDoesNotThrow(() -> authorizer.shouldMaskPasswords(securityContext));
+      assertEquals(
+          1,
+          policyEvaluations.get(),
+          "Impersonation is validated once per request, not once per subject resolution");
+    }
+  }
+
+  @Test
+  void nonImpersonatedRequestsSkipImpersonationChecks() {
+    SubjectContext adminContext = subjectContext("admin", true, false, null);
+    SecurityContext securityContext = securityContext("admin");
+
+    try (MockedStatic<SubjectContext> mockedSubjectContext = mockStatic(SubjectContext.class);
+        MockedStatic<Entity> mockedEntity = mockStatic(Entity.class)) {
+      mockedSubjectContext
+          .when(() -> SubjectContext.getSubjectContext("admin"))
+          .thenReturn(adminContext);
+
+      assertDoesNotThrow(() -> authorizer.authorizeAdmin(securityContext));
+      mockedEntity.verifyNoInteractions();
     }
   }
 
@@ -699,6 +705,41 @@ class DefaultAuthorizerTest {
     SecurityContext securityContext = mock(SecurityContext.class);
     when(securityContext.getUserPrincipal()).thenReturn(principal(userName));
     return securityContext;
+  }
+
+  /** A real bot-issued context whose effective subject is {@code userName}, as JwtFilter builds it. */
+  private static SecurityContext impersonatedSecurityContext(String userName, String botName) {
+    return new CatalogSecurityContext(
+        principal(userName),
+        "https",
+        CatalogSecurityContext.OPENID_AUTH,
+        Set.of(),
+        true,
+        botName,
+        null);
+  }
+
+  private static void stubImpersonation(
+      MockedStatic<SubjectContext> mockedSubjectContext,
+      MockedStatic<Entity> mockedEntity,
+      User targetUser,
+      User bot) {
+    mockedSubjectContext
+        .when(() -> SubjectContext.getSubjectContext(targetUser.getName(), bot.getName()))
+        .thenReturn(new SubjectContext(targetUser, bot.getName()));
+    mockedSubjectContext
+        .when(() -> SubjectContext.getSubjectContext(bot.getName()))
+        .thenReturn(new SubjectContext(bot, null));
+    mockedEntity
+        .when(() -> Entity.getEntityByName(eq(Entity.USER), eq(bot.getName()), anyString(), any()))
+        .thenReturn(bot);
+    mockedEntity
+        .when(() -> Entity.getEntityRepository(Entity.USER))
+        .thenReturn(mock(EntityRepository.class));
+  }
+
+  private static String denied(Executable action) {
+    return assertThrows(AuthorizationException.class, action).getMessage();
   }
 
   private static Principal principal(String userName) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/DefaultAuthorizerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/DefaultAuthorizerTest.java
@@ -4,10 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -561,31 +563,45 @@ class DefaultAuthorizerTest {
   }
 
   @Test
-  void authorizeImpersonationRequiresBotsAndUsesImpersonateOperation() {
-    SecurityContext userSecurityContext = securityContext("analyst");
-    SecurityContext botSecurityContext = securityContext("ingestion-bot");
-    SecurityContext flaglessBotSecurityContext = securityContext("flagless-bot");
-    SubjectContext userContext = subjectContext("analyst", false, false, null);
+  void authorizeRequestsEnforcesImpersonationAuthorization() {
+    SecurityContext securityContext = securityContext("owner");
+    User ownerUser = new User().withName("owner").withIsAdmin(true);
+    User analystUser = new User().withName("analyst").withIsBot(false);
     User botUser = new User().withName("ingestion-bot").withIsBot(true);
     botUser.setAllowImpersonation(true);
+    User flaglessBotUser = new User().withName("flagless-bot").withIsBot(true);
     SubjectContext botContext = new SubjectContext(botUser, null);
-    SubjectContext flaglessBotContext = subjectContext("flagless-bot", false, true, null);
     EntityRepository<?> repository = mock(EntityRepository.class);
+    List<AuthRequest> requests = List.of();
     AtomicReference<ResourceContextInterface> capturedResourceContext = new AtomicReference<>();
     AtomicReference<OperationContext> capturedOperationContext = new AtomicReference<>();
 
-    try (MockedStatic<SubjectContext> mockedSubjectContext = mockStatic(SubjectContext.class);
+    try (MockedStatic<DefaultAuthorizer> mockedAuthorizer = mockStatic(DefaultAuthorizer.class);
+        MockedStatic<SubjectContext> mockedSubjectContext = mockStatic(SubjectContext.class);
         MockedStatic<Entity> mockedEntity = mockStatic(Entity.class);
         MockedStatic<PolicyEvaluator> mockedPolicyEvaluator = mockStatic(PolicyEvaluator.class)) {
-      mockedSubjectContext
-          .when(() -> SubjectContext.getSubjectContext("analyst"))
-          .thenReturn(userContext);
+      mockedAuthorizer
+          .when(() -> DefaultAuthorizer.getSubjectContext(securityContext))
+          .thenReturn(
+              new SubjectContext(ownerUser, null),
+              new SubjectContext(ownerUser, "analyst"),
+              new SubjectContext(ownerUser, "flagless-bot"),
+              new SubjectContext(ownerUser, "ingestion-bot"));
       mockedSubjectContext
           .when(() -> SubjectContext.getSubjectContext("ingestion-bot"))
           .thenReturn(botContext);
-      mockedSubjectContext
-          .when(() -> SubjectContext.getSubjectContext("flagless-bot"))
-          .thenReturn(flaglessBotContext);
+      mockedEntity
+          .when(() -> Entity.getEntityByName(eq(Entity.USER), eq("analyst"), anyString(), any()))
+          .thenReturn(analystUser);
+      mockedEntity
+          .when(
+              () -> Entity.getEntityByName(eq(Entity.USER), eq("flagless-bot"), anyString(), any()))
+          .thenReturn(flaglessBotUser);
+      mockedEntity
+          .when(
+              () ->
+                  Entity.getEntityByName(eq(Entity.USER), eq("ingestion-bot"), anyString(), any()))
+          .thenReturn(botUser);
       mockedEntity.when(() -> Entity.getEntityRepository(Entity.USER)).thenReturn(repository);
       mockedPolicyEvaluator
           .when(
@@ -601,19 +617,26 @@ class DefaultAuthorizerTest {
                 return null;
               });
 
-      AuthorizationException exception =
+      assertDoesNotThrow(
+          () -> authorizer.authorizeRequests(securityContext, requests, AuthorizationLogic.ANY));
+      assertNull(capturedResourceContext.get(), "Non-impersonated requests skip authorization");
+
+      AuthorizationException nonBotException =
           assertThrows(
               AuthorizationException.class,
-              () -> authorizer.authorizeImpersonation(userSecurityContext, "owner"));
-      assertEquals("Only bot users can impersonate", exception.getMessage());
+              () ->
+                  authorizer.authorizeRequests(securityContext, requests, AuthorizationLogic.ANY));
+      assertTrue(nonBotException.getMessage().contains("does not have impersonation enabled"));
 
       AuthorizationException flaglessException =
           assertThrows(
               AuthorizationException.class,
-              () -> authorizer.authorizeImpersonation(flaglessBotSecurityContext, "owner"));
+              () ->
+                  authorizer.authorizeRequests(securityContext, requests, AuthorizationLogic.ANY));
       assertTrue(flaglessException.getMessage().contains("does not have impersonation enabled"));
 
-      assertDoesNotThrow(() -> authorizer.authorizeImpersonation(botSecurityContext, "owner"));
+      assertDoesNotThrow(
+          () -> authorizer.authorizeRequests(securityContext, requests, AuthorizationLogic.ANY));
       assertNotNull(capturedResourceContext.get());
       assertNotNull(capturedOperationContext.get());
       assertEquals(Entity.USER, capturedResourceContext.get().getResource());


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Security Hardening:**
    - Enforce admin authorization on privileged user patches and root-level JSON patch replacements in `UserResource.java`
    - Prevent impersonated users and bots from creating personal access tokens
- **Authorization & Tests:**
    - Add `hasRoleElevation` checks to prevent regular users from elevating their own roles during self-updates
    - Add comprehensive integration and unit tests for user patch, token, and impersonation permissions

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens user mutations and impersonation by protecting privileged user creation, role changes, root JSON Patch replacement, and personal-token creation. It also moves impersonation-policy checks into the main authorizer paths and adds integration and unit coverage.
- Requires administrator access when creating admin or bot users.
- Adds explicit checks for self-service role changes and privileged JSON Patch paths.
- Rejects personal access-token creation during impersonation.
- Enforces impersonation checks in `authorize` and `authorizeRequests`.
- Adds authorization-focused user integration tests and authorizer unit coverage.
</details>


<details open><summary><h3>Confidence Score: 2/5</h3></summary>

This PR should not merge until impersonation is checked across every authorizer entry point and legitimate role reductions are distinguished from role elevation.

Admin-only authorization can still rely on an impersonated administrator's privileges without checking the bot's target permission, and the new role comparison rejects self-service updates that only remove a subset of existing roles.

**Files Needing Attention:** openmetadata-service/src/main/java/org/openmetadata/service/security/DefaultAuthorizer.java; openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
</details>


<details open><summary><h3>Security Review</h3></summary>

The centralized impersonation enforcement does not cover `authorizeAdmin` or `authorizeAdminOrBot`. A bot impersonating an unauthorized administrator target can therefore reach endpoints guarded only by those methods without the bot's target-specific `IMPERSONATE` permission being evaluated.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java | Adds user privilege protections, but its role-elevation predicate incorrectly blocks nonempty role reductions. |
| openmetadata-service/src/main/java/org/openmetadata/service/security/DefaultAuthorizer.java | Adds centralized impersonation checks to two entry points while leaving admin-only authorization paths able to bypass target impersonation policy. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/UserResourceIT.java | Adds end-to-end coverage for root patches, token creation, role elevation, and privileged user creation. |
| openmetadata-service/src/test/java/org/openmetadata/service/security/DefaultAuthorizerTest.java | Covers the new impersonation sequence, but extensive internal static mocking weakens its regression value. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Bot request with X-Impersonate-User] --> B[JwtFilter]
  B --> C[Effective target-user SubjectContext]
  C --> D{Authorization entry point}
  D -->|authorize / authorizeRequests| E[Validate bot enablement and IMPERSONATE policy]
  E --> F[Evaluate requested resource operation]
  D -->|authorizeAdmin / authorizeAdminOrBot| G[Check effective target privileges only]
  G --> H[Privileged operation proceeds without target impersonation policy]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix user patch permissions"](https://github.com/open-metadata/openmetadata/commit/955ef7256b95b0a34b21b189ad8175bc25287b91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58892062)</sub>

> Greptile also left **3 inline comments** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))
- Knowledge Base — [Platform security and governance](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/platform-security-governance.md)
- Knowledge Base — [Metadata platform service](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/metadata-platform-service.md)
- Knowledge Base — [Service API resources](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/service-api-resources.md)
</details>


<!-- /greptile_comment -->