### PR TITLE
feat(ui): use the Ontology Studio glyph in both nav surfaces

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/governance/govern/govern.module.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/governance/govern/govern.module.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { LayersThree01 } from '@untitledui/icons';
 import { ReactComponent as ClassificationActiveIcon } from '../../../assets/svg/ask-collate-nav-bar/classification-active.svg';
 import { ReactComponent as ClassificationIcon } from '../../../assets/svg/ask-collate-nav-bar/classification-default.svg';
 import { ReactComponent as GlossaryActiveIcon } from '../../../assets/svg/ask-collate-nav-bar/glossary-active.svg';
@@ -23,6 +22,7 @@ import { ReactComponent as MetricsIcon } from '../../../assets/svg/ask-collate-n
 import { ReactComponent as WorkflowsActiveIcon } from '../../../assets/svg/ask-collate-nav-bar/workflows-active.svg';
 import { ReactComponent as WorkflowsIcon } from '../../../assets/svg/ask-collate-nav-bar/workflows-default.svg';
 import { ROUTES } from '../../../constants/constants';
+import { OntologyStudioIcon } from '../../../utils/IconUtils';
 import { AppModule } from '../../platform/ai-shell/AppModule.types';
 
 /**
@@ -63,7 +63,7 @@ export const governModule: AppModule = {
           },
           {
             key: 'ontology-explorer',
-            icon: LayersThree01,
+            icon: OntologyStudioIcon,
             labelKey: 'label.ontology-studio',
             path: ROUTES.ONTOLOGY_EXPLORER,
           },

--- a/openmetadata-ui/src/main/resources/ui/src/components/governance/govern/govern.module.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/governance/govern/govern.module.tsx
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 
+import { LayersThree01 } from '@untitledui/icons';
 import { ReactComponent as ClassificationActiveIcon } from '../../../assets/svg/ask-collate-nav-bar/classification-active.svg';
 import { ReactComponent as ClassificationIcon } from '../../../assets/svg/ask-collate-nav-bar/classification-default.svg';
 import { ReactComponent as GlossaryActiveIcon } from '../../../assets/svg/ask-collate-nav-bar/glossary-active.svg';
@@ -19,8 +20,6 @@ import { ReactComponent as GovernIcon } from '../../../assets/svg/ask-collate-na
 import { ReactComponent as GovernActiveIcon } from '../../../assets/svg/ask-collate-nav-bar/governance-active.svg';
 import { ReactComponent as MetricsActiveIcon } from '../../../assets/svg/ask-collate-nav-bar/metrics-active.svg';
 import { ReactComponent as MetricsIcon } from '../../../assets/svg/ask-collate-nav-bar/metrics-default.svg';
-import { ReactComponent as OntologyActiveIcon } from '../../../assets/svg/ask-collate-nav-bar/ontology-active.svg';
-import { ReactComponent as OntologyIcon } from '../../../assets/svg/ask-collate-nav-bar/ontology-default.svg';
 import { ReactComponent as WorkflowsActiveIcon } from '../../../assets/svg/ask-collate-nav-bar/workflows-active.svg';
 import { ReactComponent as WorkflowsIcon } from '../../../assets/svg/ask-collate-nav-bar/workflows-default.svg';
 import { ROUTES } from '../../../constants/constants';
@@ -28,7 +27,7 @@ import { AppModule } from '../../platform/ai-shell/AppModule.types';
 
 /**
  * Govern module — mirrors the classic "Govern" left-sidebar section (Glossary,
- * Ontology Explorer, Classifications, Metrics, Workflows). Owns no routes of
+ * Ontology Studio, Classifications, Metrics, Workflows). Owns no routes of
  * its own: every target is a canonical OM path served by the shell's page-table
  * fallback (`applicationRoutesClass.getRouteElements()`). This module provides
  * the sidebar entry and the sub-nav panel only.
@@ -64,9 +63,8 @@ export const governModule: AppModule = {
           },
           {
             key: 'ontology-explorer',
-            icon: OntologyIcon,
-            activeIcon: OntologyActiveIcon,
-            labelKey: 'label.ontology-explorer',
+            icon: LayersThree01,
+            labelKey: 'label.ontology-studio',
             path: ROUTES.ONTOLOGY_EXPLORER,
           },
           {

--- a/openmetadata-ui/src/main/resources/ui/src/constants/LeftSidebar.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/LeftSidebar.constants.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { Cube01 } from '@untitledui/icons';
+import { Cube01, LayersThree01 } from '@untitledui/icons';
 import { ReactComponent as GovernIcon } from '../assets/svg/bank.svg';
 import { ReactComponent as ClassificationIcon } from '../assets/svg/classification.svg';
 import { ReactComponent as MemoriesIcon } from '../assets/svg/common/memories.svg';
@@ -26,7 +26,6 @@ import { ReactComponent as MarketplaceIcon } from '../assets/svg/ic-data-marketp
 import { ReactComponent as DomainsIcon } from '../assets/svg/ic-domain.svg';
 import { ReactComponent as HomeIcon } from '../assets/svg/ic-home.svg';
 import { ReactComponent as IncidentMangerIcon } from '../assets/svg/ic-incident-manager.svg';
-import { ReactComponent as LineageIcon } from '../assets/svg/ic-lineage.svg';
 import { ReactComponent as ObservabilityIcon } from '../assets/svg/ic-observability.svg';
 import { ReactComponent as OverviewIcon } from '../assets/svg/ic-overview.svg';
 import { ReactComponent as PlatformLineageIcon } from '../assets/svg/ic-platform-lineage.svg';
@@ -52,6 +51,13 @@ type UntitledIconType = React.ComponentType<{
 }>;
 
 const DataProductIcon = createIconWithStroke(Cube01 as UntitledIconType, 1.2);
+
+// Same glyph the Ontology Studio page header uses, restroked to 1.2 to match
+// the sidebar's other icons.
+const OntologyStudioIcon = createIconWithStroke(
+  LayersThree01 as UntitledIconType,
+  1.2
+);
 
 export const SIDEBAR_NESTED_KEYS = {
   [ROUTES.OBSERVABILITY_ALERTS]: ROUTES.OBSERVABILITY_ALERTS,
@@ -186,7 +192,7 @@ export const SIDEBAR_LIST: Array<LeftSidebarItem> = [
         key: ROUTES.ONTOLOGY_EXPLORER,
         title: 'label.ontology-studio',
         redirect_url: ROUTES.ONTOLOGY_EXPLORER,
-        icon: LineageIcon,
+        icon: OntologyStudioIcon,
         dataTestId: `app-bar-item-${SidebarItem.ONTOLOGY_EXPLORER}`,
       },
       {

--- a/openmetadata-ui/src/main/resources/ui/src/constants/LeftSidebar.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/LeftSidebar.constants.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { Cube01, LayersThree01 } from '@untitledui/icons';
+import { Cube01 } from '@untitledui/icons';
 import { ReactComponent as GovernIcon } from '../assets/svg/bank.svg';
 import { ReactComponent as ClassificationIcon } from '../assets/svg/classification.svg';
 import { ReactComponent as MemoriesIcon } from '../assets/svg/common/memories.svg';
@@ -41,7 +41,7 @@ import { ReactComponent as DocumentsIcon } from '../assets/svg/sidebar-icons/doc
 import { LeftSidebarItem } from '../components/MyData/LeftSidebar/LeftSidebar.interface';
 import { SidebarItem } from '../enums/sidebar.enum';
 import { DataInsightTabs } from '../interface/data-insight.interface';
-import { createIconWithStroke } from '../utils/IconUtils';
+import { createIconWithStroke, OntologyStudioIcon } from '../utils/IconUtils';
 import { ENTITY_PATH, PLACEHOLDER_ROUTE_TAB, ROUTES } from './constants';
 
 type UntitledIconType = React.ComponentType<{
@@ -51,13 +51,6 @@ type UntitledIconType = React.ComponentType<{
 }>;
 
 const DataProductIcon = createIconWithStroke(Cube01 as UntitledIconType, 1.2);
-
-// Same glyph the Ontology Studio page header uses, restroked to 1.2 to match
-// the sidebar's other icons.
-const OntologyStudioIcon = createIconWithStroke(
-  LayersThree01 as UntitledIconType,
-  1.2
-);
 
 export const SIDEBAR_NESTED_KEYS = {
   [ROUTES.OBSERVABILITY_ALERTS]: ROUTES.OBSERVABILITY_ALERTS,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/IconUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/IconUtils.tsx
@@ -137,23 +137,42 @@ export const ICON_MAP: Record<
 };
 
 /**
+ * An icon whose stroke weight can be overridden — the shape `@untitledui`
+ * icons expose (their own props type is wider, so they need a cast).
+ */
+export type StrokableIcon = ComponentType<{
+  size?: number;
+  strokeWidth?: number;
+  style?: React.CSSProperties;
+}>;
+
+/**
  * Creates an icon component with custom stroke width
  * @param IconComponent - The icon component from @untitledui/icons
  * @param strokeWidth - Custom stroke width (default icons use 2)
  * @returns Wrapped icon component with custom stroke width
  */
 export const createIconWithStroke = (
-  IconComponent: ComponentType<{
-    size?: number;
-    strokeWidth?: number;
-    style?: React.CSSProperties;
-  }>,
+  IconComponent: StrokableIcon,
   strokeWidth: number
 ) => {
   return (props: { size?: number; style?: React.CSSProperties }) => (
     <IconComponent {...props} strokeWidth={strokeWidth} />
   );
 };
+
+/**
+ * The Ontology Studio glyph, as every nav entry leading there renders it —
+ * classic sidebar and app-mode sub-nav — so the two surfaces cannot drift
+ * apart. Restroked to 1.2, the weight the hand-drawn nav SVGs beside it use:
+ * `@untitledui` icons ship at stroke 2, which at nav size reads noticeably
+ * heavier than the items around it. The page header draws the same glyph
+ * unrestroked, because there it sits reversed-out on a brand-solid badge.
+ */
+export const OntologyStudioIcon = createIconWithStroke(
+  LayersThree01 as StrokableIcon,
+  1.2
+);
 
 /**
  * Get the default icon for an entity type


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

The Ontology Studio page header renders LayersThree01 in a brand-solid square, but the two nav entries that lead there used unrelated icons and, in the app-mode sidebar, the pre-rename "Ontology Explorer" label.

<img width="1511" height="747" alt="Screenshot 2026-08-31 at 11 34 03 PM" src="https://github.com/user-attachments/assets/08a3a783-9039-443c-8764-c6676578afad" />


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR aligns the Ontology Studio label and glyph across the classic sidebar and application-mode governance navigation.
- Adds a shared, restroked `OntologyStudioIcon` based on `LayersThree01`.
- Replaces the classic sidebar’s lineage icon with the shared glyph.
- Updates the application-mode entry from “Ontology Explorer” to “Ontology Studio” and uses the same glyph.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/governance/govern/govern.module.tsx | Updates the application-mode Ontology navigation entry to use the shared glyph and current label. |
| openmetadata-ui/src/main/resources/ui/src/constants/LeftSidebar.constants.ts | Replaces the classic sidebar’s Ontology Studio icon with the shared glyph. |
| openmetadata-ui/src/main/resources/ui/src/utils/IconUtils.tsx | Introduces a reusable strokable icon type and shared Ontology Studio icon wrapper. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): restroke the Ontology Studio na..."](https://github.com/open-metadata/openmetadata/commit/03add95a8ff2f1fb36950e358f99ac3dd6633106) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58906443)</sub>

<!-- /greptile_comment -->