### PR TITLE
fix(ui): full-width ER diagram drawer and column panel double-close

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
@@ -1179,10 +1179,25 @@ export const openColumnDetailPanel = async ({
   return panelContainer;
 };
 
-export const closeColumnDetailPanel = async (page: Page) => {
+export const closeColumnDetailPanel = async (
+  page: Page,
+  entityUrl?: string
+) => {
+  // Snapshot the column URL. If the panel reopens (bug), it navigates back to this URL.
+  const columnUrl = page.url();
   const panelContainer = page.locator('.column-detail-panel');
   await panelContainer.getByTestId('close-button').click();
 
+  // 1. Immediate visibility check.
+  await expect(page.locator('.column-detail-panel')).not.toBeVisible();
+  // 2. Positive URL check: assert the URL has settled at the entity path, not bounced back.
+  //    Callers should pass entityUrl (the FQN-less entity path) for the strongest guard.
+  if (entityUrl) {
+    await expect(page).toHaveURL(entityUrl);
+  } else {
+    await expect(page).not.toHaveURL(columnUrl);
+  }
+  // 3. After URL has settled, verify the panel is still not visible.
   await expect(page.locator('.column-detail-panel')).not.toBeVisible();
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.tsx
@@ -268,8 +268,9 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
     (column: ColumnOrTask) => {
       const columnFqn = column.fullyQualifiedName;
 
-      // If the column is already selected, don't do anything to avoid loops
-      if (selectedColumn?.fullyQualifiedName === columnFqn) {
+      // Use ref so the callback is not recreated on every selection change,
+      // which would cause useFqnDeepLink to re-run and reopen the panel on close.
+      if (selectedColumnRef.current?.fullyQualifiedName === columnFqn) {
         return;
       }
 
@@ -299,7 +300,6 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
       routeTab,
       navigate,
       location.pathname,
-      selectedColumn?.fullyQualifiedName,
       extractedColumns,
     ]
   );

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/entity-summary-panel.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/entity-summary-panel.less
@@ -17,6 +17,7 @@
 .entity-summary-panel-container,
 .column-detail-panel-container {
   height: 100%;
+  width: 100%;
   background: var(--tw-color-bg-primary);
 
   &.explore {


### PR DESCRIPTION
Backport of #32305 to the `2.0` branch.

### Describe your changes:

Two UI drawer bugs ported from main → 2.0:

1. **ER Diagram drawer not full-width** — `entity-summary-panel-container` had `height: 100%` but no `width`, so the panel didn't fill the Ant Design Drawer body when opened from the ER Diagram tab. Fixed by adding `width: 100%` to the shared container rule in `entity-summary-panel.less`.

2. **Column detail panel double-close** — `openColumnDetailPanel` had `selectedColumn?.fullyQualifiedName` in its `useCallback` deps, causing it to be recreated when `closeColumnDetailPanel` cleared the selection. This triggered `useFqnDeepLink` to re-run and reopen the panel before the URL update propagated. Fixed by switching the guard to use `selectedColumnRef.current` (already kept in sync) and removing the dep.

3. **Playwright regression guard** — Strengthened `closeColumnDetailPanel` helper with a URL bounce-back check and a second visibility assertion.

### Type of change:
- [x] Bug fix

### Tests:

#### Playwright (UI) tests
- [x] Strengthened existing `closeColumnDetailPanel` helper in `playwright/utils/entity.ts` — all tests that call it now assert the panel stays closed and the URL doesn't bounce back.

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.