### PR TITLE
[ESLint] Clear sonarjs/no-nested-conditional + promote to error

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/eslint.config.mjs
+++ b/openmetadata-ui/src/main/resources/ui/eslint.config.mjs
@@ -348,7 +348,9 @@ export default [
       // extracting sub-expressions into named consts (short-circuit preserved);
       // backlog is zero and this ratchets it.
       'sonarjs/expression-complexity': 'error',
-      'sonarjs/no-nested-conditional': 'warn', // 16
+      // Promoted to error: all nested-ternary violations refactored to
+      // intermediate variables / if-else; backlog is zero and this ratchets it.
+      'sonarjs/no-nested-conditional': 'error',
       // Promoted to error: all 75 deeply-nested functions refactored by
       // hoisting the innermost callback to a shallower named scope; backlog is
       // zero and this ratchets it.

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/FeedCardBody/OwnerFeed/ActivityOwnersFeed.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/FeedCardBody/OwnerFeed/ActivityOwnersFeed.tsx
@@ -50,7 +50,11 @@ function ActivityOwnersFeed({
     try {
       if (activity.oldValue) {
         const parsed = JSON.parse(activity.oldValue);
-        oldOwners = Array.isArray(parsed) ? parsed : parsed ? [parsed] : [];
+        if (Array.isArray(parsed)) {
+          oldOwners = parsed;
+        } else if (parsed) {
+          oldOwners = [parsed];
+        }
       }
     } catch {
       oldOwners = [];
@@ -59,7 +63,11 @@ function ActivityOwnersFeed({
     try {
       if (activity.newValue) {
         const parsed = JSON.parse(activity.newValue);
-        newOwners = Array.isArray(parsed) ? parsed : parsed ? [parsed] : [];
+        if (Array.isArray(parsed)) {
+          newOwners = parsed;
+        } else if (parsed) {
+          newOwners = [parsed];
+        }
       }
     } catch {
       newOwners = [];

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityThreadPanel/ActivityThreadPanelBody.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityThreadPanel/ActivityThreadPanelBody.tsx
@@ -19,6 +19,7 @@ import {
   FC,
   Fragment,
   lazy,
+  ReactNode,
   RefObject,
   useCallback,
   useEffect,
@@ -209,8 +210,111 @@ const ActivityThreadPanelBody: FC<ActivityThreadPanelBodyProp> = ({
     paging,
   ]);
 
+  const isPanelLoading = isTaskType ? loading : isConversationLoading;
   const hasNoConversations =
     conversations.length === 0 && !isConversationLoading;
+
+  const backButton = (
+    <Button className="m-b-sm p-0" size="small" type="link" onClick={onBack}>
+      {t('label.back')}
+    </Button>
+  );
+
+  const taskListContent =
+    tasks.length === 0 && !loading ? (
+      <ErrorPlaceHolder className="mt-24" type={ERROR_PLACEHOLDER_TYPE.CUSTOM}>
+        <Typography.Paragraph>
+          {isTaskClosed
+            ? t('message.no-closed-task')
+            : t('message.no-open-task')}
+        </Typography.Paragraph>
+      </ErrorPlaceHolder>
+    ) : (
+      <div className={classNames(className, 'd-flex flex-col gap-3')}>
+        {tasks.map((task) => (
+          <TaskFeedCardFromTask
+            isOpenInDrawer
+            isActive={selectedTask?.id === task.id}
+            key={task.id}
+            task={task}
+            onAfterClose={() => getPanelData()}
+            onTaskClick={setActiveTask}
+          />
+        ))}
+      </div>
+    );
+
+  const listView = (
+    <Fragment>
+      {(showNewConversation || hasNoConversations) && isConversationType && (
+        <Space className="w-full" direction="vertical">
+          <Typography.Paragraph>
+            {t('message.new-conversation')}
+          </Typography.Paragraph>
+          <ActivityFeedEditor
+            placeHolder={t('message.enter-a-field', {
+              field: t('label.message-lowercase'),
+            })}
+            onSave={onPostConversation}
+          />
+        </Space>
+      )}
+
+      {isTaskType ? (
+        taskListContent
+      ) : (
+        <div className={classNames(className, 'd-flex flex-col gap-3')}>
+          {conversations.map((conversation) => (
+            <FeedPanelBodyV1New
+              isForFeedTab
+              feed={conversation}
+              isActive={false}
+              key={conversation.id}
+              onFeedClick={setActiveConversation}
+            />
+          ))}
+        </div>
+      )}
+
+      <div
+        data-testid="observer-element"
+        id="observer-element"
+        ref={elementRef as RefObject<HTMLDivElement>}>
+        {isPanelLoading ? <Loader /> : null}
+      </div>
+    </Fragment>
+  );
+
+  let panelContent: ReactNode;
+  if (isTaskType && !isUndefined(selectedTask)) {
+    panelContent = (
+      <Fragment>
+        {backButton}
+        <TaskTabNew
+          entityType={
+            (selectedTask.about?.type as EntityType) ?? EntityType.TABLE
+          }
+          hasGlossaryReviewer={false}
+          owners={[]}
+          task={selectedTask}
+        />
+      </Fragment>
+    );
+  } else if (!isUndefined(selectedConversation)) {
+    panelContent = (
+      <Fragment>
+        {backButton}
+        <ActivityFeedCardNew
+          isForFeedTab
+          isOpenInDrawer
+          showThread
+          feed={selectedConversation}
+        />
+      </Fragment>
+    );
+  } else {
+    panelContent = listView;
+  }
 
   return (
     <Fragment>
@@ -244,106 +348,7 @@ const ActivityThreadPanelBody: FC<ActivityThreadPanelBodyProp> = ({
           </Space>
         )}
 
-        {isTaskType && !isUndefined(selectedTask) ? (
-          <Fragment>
-            <Button
-              className="m-b-sm p-0"
-              size="small"
-              type="link"
-              onClick={onBack}>
-              {t('label.back')}
-            </Button>
-            <TaskTabNew
-              entityType={
-                (selectedTask.about?.type as EntityType) ?? EntityType.TABLE
-              }
-              hasGlossaryReviewer={false}
-              owners={[]}
-              task={selectedTask}
-            />
-          </Fragment>
-        ) : !isUndefined(selectedConversation) ? (
-          <Fragment>
-            <Button
-              className="m-b-sm p-0"
-              size="small"
-              type="link"
-              onClick={onBack}>
-              {t('label.back')}
-            </Button>
-            <ActivityFeedCardNew
-              isForFeedTab
-              isOpenInDrawer
-              showThread
-              feed={selectedConversation}
-            />
-          </Fragment>
-        ) : (
-          <Fragment>
-            {(showNewConversation || hasNoConversations) &&
-              isConversationType && (
-                <Space className="w-full" direction="vertical">
-                  <Typography.Paragraph>
-                    {t('message.new-conversation')}
-                  </Typography.Paragraph>
-                  <ActivityFeedEditor
-                    placeHolder={t('message.enter-a-field', {
-                      field: t('label.message-lowercase'),
-                    })}
-                    onSave={onPostConversation}
-                  />
-                </Space>
-              )}
-
-            {isTaskType ? (
-              tasks.length === 0 && !loading ? (
-                <ErrorPlaceHolder
-                  className="mt-24"
-                  type={ERROR_PLACEHOLDER_TYPE.CUSTOM}>
-                  <Typography.Paragraph>
-                    {isTaskClosed
-                      ? t('message.no-closed-task')
-                      : t('message.no-open-task')}
-                  </Typography.Paragraph>
-                </ErrorPlaceHolder>
-              ) : (
-                <div className={classNames(className, 'd-flex flex-col gap-3')}>
-                  {tasks.map((task) => (
-                    <TaskFeedCardFromTask
-                      isOpenInDrawer
-                      isActive={selectedTask?.id === task.id}
-                      key={task.id}
-                      task={task}
-                      onAfterClose={() => getPanelData()}
-                      onTaskClick={setActiveTask}
-                    />
-                  ))}
-                </div>
-              )
-            ) : (
-              <div className={classNames(className, 'd-flex flex-col gap-3')}>
-                {conversations.map((conversation) => (
-                  <FeedPanelBodyV1New
-                    isForFeedTab
-                    feed={conversation}
-                    isActive={false}
-                    key={conversation.id}
-                    onFeedClick={setActiveConversation}
-                  />
-                ))}
-              </div>
-            )}
-
-            <div
-              data-testid="observer-element"
-              id="observer-element"
-              ref={elementRef as RefObject<HTMLDivElement>}>
-              {(isTaskType ? loading : isConversationLoading) ? (
-                <Loader />
-              ) : null}
-            </div>
-          </Fragment>
-        )}
+        {panelContent}
       </div>
     </Fragment>
   );

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/TaskFeedCard/TaskFeedCardFromTask.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/TaskFeedCard/TaskFeedCardFromTask.component.tsx
@@ -281,6 +281,14 @@ const TaskFeedCardFromTask = ({
 
   const commentsCount = task.comments?.length ?? 0;
 
+  const nonPriorityRowGutter: [number, number] | undefined = isTaskDescription
+    ? undefined
+    : [0, 14];
+  const rowGutter: [number, number] | undefined =
+    isTaskTestCaseResult || isTaskApprovalRequest
+      ? [0, 6]
+      : nonPriorityRowGutter;
+
   return (
     <Button
       block
@@ -292,14 +300,7 @@ const TaskFeedCardFromTask = ({
           active: isActive,
         })}
         data-testid="task-feed-card">
-        <Row
-          gutter={
-            isTaskTestCaseResult || isTaskApprovalRequest
-              ? [0, 6]
-              : isTaskDescription
-              ? undefined
-              : [0, 14]
-          }>
+        <Row gutter={rowGutter}>
           <Col className="d-flex flex-col align-start">
             <Col>
               <Icon

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItem/TeamAndUserSelectItem/TeamAndUserSelectItem.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItem/TeamAndUserSelectItem/TeamAndUserSelectItem.tsx
@@ -19,7 +19,14 @@ import {
   Popover,
 } from '@openmetadata/ui-core-components';
 import { debounce, isEmpty } from 'lodash';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -132,6 +139,45 @@ function TeamAndUserSelectItem({
       );
   }, []);
 
+  let optionsContent: ReactNode;
+  if (isLoadingOptions) {
+    optionsContent = (
+      <div className="tw:space-y-1 tw:p-2">
+        {[1, 2, 3].map((i) => (
+          <div
+            className="tw:h-6 tw:animate-pulse tw:rounded tw:bg-secondary"
+            key={i}
+          />
+        ))}
+      </div>
+    );
+  } else if (isEmpty(options)) {
+    optionsContent = (
+      <p className="tw:p-2 tw:text-center tw:text-sm tw:text-tertiary">
+        {t('label.no-data-found')}
+      </p>
+    );
+  } else {
+    optionsContent = options.map(({ label, value }) => (
+      <button
+        className="tw:flex tw:w-full tw:cursor-pointer tw:items-center tw:gap-2 tw:rounded-md tw:px-2 tw:py-1.5 tw:text-left hover:tw:bg-secondary"
+        data-testid={value}
+        key={value}
+        type="button"
+        onClick={() => handleOptionClick(value)}>
+        <Checkbox
+          data-testid={`${label}-option-checkbox`}
+          isSelected={selectedOptions.includes(value)}
+        />
+        <span
+          className="tw:truncate tw:text-sm tw:text-primary"
+          data-testid={`${label}-option-label`}>
+          {label}
+        </span>
+      </button>
+    ));
+  }
+
   return (
     <div className="tw:relative tw:w-full">
       <div
@@ -209,39 +255,7 @@ function TeamAndUserSelectItem({
             onChange={(val) => setSearchText(val)}
           />
           <div className="tw:mt-2 tw:max-h-48 tw:overflow-y-auto">
-            {isLoadingOptions ? (
-              <div className="tw:space-y-1 tw:p-2">
-                {[1, 2, 3].map((i) => (
-                  <div
-                    className="tw:h-6 tw:animate-pulse tw:rounded tw:bg-secondary"
-                    key={i}
-                  />
-                ))}
-              </div>
-            ) : isEmpty(options) ? (
-              <p className="tw:p-2 tw:text-center tw:text-sm tw:text-tertiary">
-                {t('label.no-data-found')}
-              </p>
-            ) : (
-              options.map(({ label, value }) => (
-                <button
-                  className="tw:flex tw:w-full tw:cursor-pointer tw:items-center tw:gap-2 tw:rounded-md tw:px-2 tw:py-1.5 tw:text-left hover:tw:bg-secondary"
-                  data-testid={value}
-                  key={value}
-                  type="button"
-                  onClick={() => handleOptionClick(value)}>
-                  <Checkbox
-                    data-testid={`${label}-option-checkbox`}
-                    isSelected={selectedOptions.includes(value)}
-                  />
-                  <span
-                    className="tw:truncate tw:text-sm tw:text-primary"
-                    data-testid={`${label}-option-label`}>
-                    {label}
-                  </span>
-                </button>
-              ))
-            )}
+            {optionsContent}
           </div>
         </div>
       </Popover>

--- a/openmetadata-ui/src/main/resources/ui/src/components/BulkEditEntity/BulkEditEntity.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BulkEditEntity/BulkEditEntity.component.tsx
@@ -471,12 +471,12 @@ const BulkEditEntity = ({
               row[BULK_EDIT_OPERATION_KEY] ?? 'NO_CHANGE'
             ).toLowerCase()}`;
 
+            const highlightSuffix = isNewMetricRowMissingName(row)
+              ? ''
+              : ' bulk-edit-row-highlight';
+
             return row.id === highlightedRowId
-              ? `${operationClass}${
-                  isNewMetricRowMissingName(row)
-                    ? ''
-                    : ' bulk-edit-row-highlight'
-                }`
+              ? `${operationClass}${highlightSuffix}`
               : operationClass;
           }}
           rowHeight={52}
@@ -542,9 +542,14 @@ const BulkEditEntity = ({
     [dataSource]
   );
 
-  const shouldShowLoader =
-    (isExportHydrationRequired && isEmpty(csvExportData)) ||
-    isLoadingSourceData;
+  const showExportErrorState = Boolean(
+    isExportHydrationRequired && csvExportError
+  );
+  const showLoaderState =
+    !showExportErrorState &&
+    ((isExportHydrationRequired && isEmpty(csvExportData)) ||
+      isLoadingSourceData);
+  const showWorkflowContent = !showExportErrorState && !showLoaderState;
 
   return (
     <>
@@ -580,12 +585,12 @@ const BulkEditEntity = ({
         )}
       </div>
 
-      {isExportHydrationRequired && csvExportError ? (
+      {showExportErrorState && (
         <div className="csv-import-card bulk-edit-card">
           <Banner
             className="border-radius"
             isLoading={false}
-            message={csvExportError}
+            message={csvExportError ?? ''}
             type="error"
           />
           <div className="bulk-edit-retry">
@@ -594,9 +599,9 @@ const BulkEditEntity = ({
             </Button>
           </div>
         </div>
-      ) : shouldShowLoader ? (
-        <Loader />
-      ) : (
+      )}
+      {showLoaderState && <Loader />}
+      {showWorkflowContent && (
         <Fragment>
           <div>
             {activeStep === 1 && (

--- a/openmetadata-ui/src/main/resources/ui/src/components/Certification/Certification.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Certification/Certification.component.tsx
@@ -22,7 +22,7 @@ import {
   Typography,
 } from 'antd';
 import { AxiosError } from 'axios';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as CertificationIcon } from '../../assets/svg/ic-certification.svg';
 import { Tag } from '../../generated/entity/classification/tag';
@@ -169,6 +169,21 @@ const Certification = ({
               />
             ) : null;
 
+            let iconContent: ReactNode;
+            if (!renderedIcon) {
+              iconContent = (
+                <div className="certification-icon">
+                  <CertificationIcon height={28} width={28} />
+                </div>
+              );
+            } else if (isIcon) {
+              iconContent = (
+                <div className="certification-icon">{renderedIcon}</div>
+              );
+            } else {
+              iconContent = renderedIcon;
+            }
+
             return (
               <div
                 className="certification-card-item cursor-pointer"
@@ -184,17 +199,7 @@ const Certification = ({
                   value={fullyQualifiedName}
                 />
                 <div className="certification-card-content">
-                  {renderedIcon ? (
-                    isIcon ? (
-                      <div className="certification-icon">{renderedIcon}</div>
-                    ) : (
-                      renderedIcon
-                    )
-                  ) : (
-                    <div className="certification-icon">
-                      <CertificationIcon height={28} width={28} />
-                    </div>
-                  )}
+                  {iconContent}
                   <div>
                     <Typography.Paragraph className="m-b-0 font-regular text-xs text-grey-body">
                       {title}

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ContextSimplePillarCard/ContextSimplePillarCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ContextSimplePillarCard/ContextSimplePillarCard.component.tsx
@@ -18,7 +18,7 @@ import {
   Skeleton,
   Typography,
 } from '@openmetadata/ui-core-components';
-import { FC } from 'react';
+import { FC, ReactNode } from 'react';
 import { ContextSimplePillarCardProps } from './ContextSimplePillarCard.interface';
 
 const ContextSimplePillarCard: FC<ContextSimplePillarCardProps> = ({
@@ -31,6 +31,43 @@ const ContextSimplePillarCard: FC<ContextSimplePillarCardProps> = ({
   children,
   icon: Icon,
 }) => {
+  let pillarBody: ReactNode;
+  if (isLoading) {
+    pillarBody = (
+      <Box className="tw:px-4" direction="col" gap={2}>
+        <Skeleton height="14px" variant="rounded" width="80%" />
+        <Skeleton height="14px" variant="rounded" width="60%" />
+        <Skeleton height="14px" variant="rounded" width="70%" />
+      </Box>
+    );
+  } else if (isEmpty) {
+    pillarBody = (
+      <EmptyPlaceholder
+        actions={
+          emptyAction
+            ? [
+                {
+                  key: 'empty-action',
+                  label: emptyAction.label,
+                  color: 'link-color',
+                  iconLeading: emptyAction.icon,
+                  size: 'xs',
+                  onClick: emptyAction.onClick,
+                },
+              ]
+            : undefined
+        }
+        className="tw:justify-start tw:pt-6 tw:[&_:has(>[data-icon='true'])]:size-12.5 tw:**:data-[icon='true']:size-5 tw:[&>*:first-child]:gap-3"
+        description={emptyMessage}
+        icon={<Icon className="tw:text-fg-brand-primary" />}
+        variant="blank"
+        width={200}
+      />
+    );
+  } else {
+    pillarBody = children;
+  }
+
   return (
     <Card className="tw:h-full tw:flex tw:flex-col" data-testid={dataTestId}>
       <Box
@@ -56,37 +93,7 @@ const ContextSimplePillarCard: FC<ContextSimplePillarCardProps> = ({
       </Box>
 
       <div className="tw:relative tw:flex-1 tw:min-h-0 tw:overflow-y-auto">
-        {isLoading ? (
-          <Box className="tw:px-4" direction="col" gap={2}>
-            <Skeleton height="14px" variant="rounded" width="80%" />
-            <Skeleton height="14px" variant="rounded" width="60%" />
-            <Skeleton height="14px" variant="rounded" width="70%" />
-          </Box>
-        ) : isEmpty ? (
-          <EmptyPlaceholder
-            actions={
-              emptyAction
-                ? [
-                    {
-                      key: 'empty-action',
-                      label: emptyAction.label,
-                      color: 'link-color',
-                      iconLeading: emptyAction.icon,
-                      size: 'xs',
-                      onClick: emptyAction.onClick,
-                    },
-                  ]
-                : undefined
-            }
-            className="tw:justify-start tw:pt-6 tw:[&_:has(>[data-icon='true'])]:size-12.5 tw:**:data-[icon='true']:size-5 tw:[&>*:first-child]:gap-3"
-            description={emptyMessage}
-            icon={<Icon className="tw:text-fg-brand-primary" />}
-            variant="blank"
-            width={200}
-          />
-        ) : (
-          children
-        )}
+        {pillarBody}
       </div>
     </Card>
   );

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentsView.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentsView.component.tsx
@@ -637,6 +637,40 @@ const DocumentsView: FC<DocumentsViewProps> = ({
     }
   };
 
+  const emptyStateContent = selectedFolderName ? (
+    <div className="tw:relative tw:flex-1">
+      <EmptyPlaceholder
+        actions={
+          onUploadFile
+            ? [
+                {
+                  color: 'primary',
+                  key: 'upload-file',
+                  label: t('label.upload-file'),
+                  onClick: onUploadFile,
+                },
+              ]
+            : []
+        }
+        description={t('message.context-center-folder-empty-subtitle')}
+        icon={<UploadIcon className="tw:text-fg-brand-primary" />}
+        title={t('label.folder-name-is-empty', {
+          folderName: selectedFolderName,
+        })}
+        variant="blank"
+      />
+    </div>
+  ) : (
+    <div className="tw:relative tw:flex-1">
+      <EmptyPlaceholder
+        description={t('message.check-spelling-or-try-different-term')}
+        icon={<NoSearchResultIcon className="tw:text-quaternary" />}
+        title={t('label.no-matching-results')}
+        variant="blank"
+      />
+    </div>
+  );
+
   return (
     <Card
       className={classNames(
@@ -701,38 +735,8 @@ const DocumentsView: FC<DocumentsViewProps> = ({
             )}
           </Box>
         </Box>
-      ) : selectedFolderName ? (
-        <div className="tw:relative tw:flex-1">
-          <EmptyPlaceholder
-            actions={
-              onUploadFile
-                ? [
-                    {
-                      color: 'primary',
-                      key: 'upload-file',
-                      label: t('label.upload-file'),
-                      onClick: onUploadFile,
-                    },
-                  ]
-                : []
-            }
-            description={t('message.context-center-folder-empty-subtitle')}
-            icon={<UploadIcon className="tw:text-fg-brand-primary" />}
-            title={t('label.folder-name-is-empty', {
-              folderName: selectedFolderName,
-            })}
-            variant="blank"
-          />
-        </div>
       ) : (
-        <div className="tw:relative tw:flex-1">
-          <EmptyPlaceholder
-            description={t('message.check-spelling-or-try-different-term')}
-            icon={<NoSearchResultIcon className="tw:text-quaternary" />}
-            title={t('label.no-matching-results')}
-            variant="blank"
-          />
-        </div>
+        emptyStateContent
       )}
     </Card>
   );

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DomainLabelV2/DomainLabelV2.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DomainLabelV2/DomainLabelV2.test.tsx
@@ -67,12 +67,14 @@ jest.mock('../../../utils/DomainUtils', () => ({
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) =>
-      key === 'label.domain'
-        ? 'Domain'
-        : key === 'label.domain-plural'
-        ? 'Domains'
-        : key,
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'label.domain': 'Domain',
+        'label.domain-plural': 'Domains',
+      };
+
+      return translations[key] ?? key;
+    },
   }),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DomainLabelV2/DomainLabelV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DomainLabelV2/DomainLabelV2.tsx
@@ -89,13 +89,18 @@ export const DomainLabelV2 = <
       try {
         const entityDetailsResponse = await entityDetails;
         if (entityDetailsResponse) {
+          let domainsPayload: EntityReference[];
+          if (Array.isArray(selectedDomain)) {
+            domainsPayload = selectedDomain;
+          } else if (isEmpty(selectedDomain)) {
+            domainsPayload = [];
+          } else {
+            domainsPayload = [selectedDomain];
+          }
+
           const jsonPatch = compare(entityDetailsResponse, {
             ...entityDetailsResponse,
-            domains: Array.isArray(selectedDomain)
-              ? selectedDomain
-              : isEmpty(selectedDomain)
-              ? []
-              : [selectedDomain],
+            domains: domainsPayload,
           });
 
           const api = getAPIfromSource(entityType as AssetsUnion);

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ContractSecurityFormTab/ContractSecurityFormTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ContractSecurityFormTab/ContractSecurityFormTab.tsx
@@ -81,6 +81,55 @@ const ContractPolicyCard: React.FC<ContractPolicyCardProps> = ({
 }) => {
   const { t } = useTranslation();
 
+  const rowFilterContent = SUPPORTED_ROW_FILTER_ENTITIES.includes(
+    entityType
+  ) ? (
+    <Form.List name={[policyField.name, 'rowFilters']}>
+      {(rowFilterFields) => {
+        return (
+          <div className="contract-consumer-security-card-rule-container">
+            {rowFilterFields.map((rowFilterField, rowFilterIndex) => {
+              return (
+                <Row align="middle" gutter={[16, 16]} key={rowFilterField.key}>
+                  <Col span={11}>
+                    <Form.Item
+                      label={t('label.column-name')}
+                      name={[rowFilterField.name, 'columnName']}>
+                      <Input
+                        disabled
+                        data-testid={`columnName-input-${policyIndex}-${rowFilterIndex}`}
+                        placeholder={t('label.please-enter-entity-name', {
+                          entity: t('label.column'),
+                        })}
+                      />
+                    </Form.Item>
+                  </Col>
+
+                  <Col span={11}>
+                    <Form.Item
+                      label={t('label.value-plural')}
+                      name={[rowFilterField.name, 'values']}>
+                      <Select
+                        disabled
+                        data-testid={`values-${policyIndex}-${rowFilterIndex}`}
+                        id={`values-${policyIndex}-${rowFilterIndex}`}
+                        mode="tags"
+                        open={false}
+                        placeholder={t('label.please-enter-value', {
+                          name: t('label.column-plural'),
+                        })}
+                      />
+                    </Form.Item>
+                  </Col>
+                </Row>
+              );
+            })}
+          </div>
+        );
+      }}
+    </Form.List>
+  ) : null;
+
   return (
     <ExpandableCard
       cardProps={{
@@ -299,55 +348,9 @@ const ContractPolicyCard: React.FC<ContractPolicyCardProps> = ({
             )}
           </Col>
         </Row>
-      ) : SUPPORTED_ROW_FILTER_ENTITIES.includes(entityType) ? (
-        <Form.List name={[policyField.name, 'rowFilters']}>
-          {(rowFilterFields) => {
-            return (
-              <div className="contract-consumer-security-card-rule-container">
-                {rowFilterFields.map((rowFilterField, rowFilterIndex) => {
-                  return (
-                    <Row
-                      align="middle"
-                      gutter={[16, 16]}
-                      key={rowFilterField.key}>
-                      <Col span={11}>
-                        <Form.Item
-                          label={t('label.column-name')}
-                          name={[rowFilterField.name, 'columnName']}>
-                          <Input
-                            disabled
-                            data-testid={`columnName-input-${policyIndex}-${rowFilterIndex}`}
-                            placeholder={t('label.please-enter-entity-name', {
-                              entity: t('label.column'),
-                            })}
-                          />
-                        </Form.Item>
-                      </Col>
-
-                      <Col span={11}>
-                        <Form.Item
-                          label={t('label.value-plural')}
-                          name={[rowFilterField.name, 'values']}>
-                          <Select
-                            disabled
-                            data-testid={`values-${policyIndex}-${rowFilterIndex}`}
-                            id={`values-${policyIndex}-${rowFilterIndex}`}
-                            mode="tags"
-                            open={false}
-                            placeholder={t('label.please-enter-value', {
-                              name: t('label.column-plural'),
-                            })}
-                          />
-                        </Form.Item>
-                      </Col>
-                    </Row>
-                  );
-                })}
-              </div>
-            );
-          }}
-        </Form.List>
-      ) : null}
+      ) : (
+        rowFilterContent
+      )}
     </ExpandableCard>
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductDomainWidget/DataProductDomainWidget.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductDomainWidget/DataProductDomainWidget.tsx
@@ -66,11 +66,14 @@ export const DataProductDomainWidget = () => {
 
       setIsLoading(true);
       try {
-        const rawDomains = Array.isArray(selectedDomain)
-          ? selectedDomain
-          : isEmpty(selectedDomain)
-          ? []
-          : [selectedDomain];
+        let rawDomains: EntityReference[];
+        if (Array.isArray(selectedDomain)) {
+          rawDomains = selectedDomain;
+        } else if (isEmpty(selectedDomain)) {
+          rawDomains = [];
+        } else {
+          rawDomains = [selectedDomain];
+        }
 
         const domains: EntityReference[] = rawDomains.map((d) => ({
           id: d.id,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuitePipelineTab/TestSuitePipelineTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuitePipelineTab/TestSuitePipelineTab.component.tsx
@@ -541,11 +541,11 @@ const TestSuitePipelineTab = ({
                     </Table.Cell>
 
                     <Table.Cell className="tw:align-middle tw:w-60">
-                      {isFetchingStatus ? (
-                        <ButtonSkeleton size="default" />
-                      ) : isPlatformDisabled ? (
-                        NO_DATA_PLACEHOLDER
-                      ) : (
+                      {isFetchingStatus && <ButtonSkeleton size="default" />}
+                      {!isFetchingStatus &&
+                        isPlatformDisabled &&
+                        NO_DATA_PLACEHOLDER}
+                      {!isFetchingStatus && !isPlatformDisabled && (
                         <PipelineActions
                           deployIngestion={handleDeployIngestion}
                           handleDeleteSelection={(row) =>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ProfilerSettingsModal/ProfilerSettingsModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ProfilerSettingsModal/ProfilerSettingsModal.tsx
@@ -302,11 +302,11 @@ const ProfilerSettingsModal: React.FC<ProfilerSettingsModalProps> = ({
         sampleDataCount,
       } = data;
 
-      const profileSample = profileSampleType
-        ? profileSampleType === ProfileSampleType.Percentage
+      const sampleByType =
+        profileSampleType === ProfileSampleType.Percentage
           ? profileSamplePercentage
-          : profileSampleRows
-        : undefined;
+          : profileSampleRows;
+      const profileSample = profileSampleType ? sampleByType : undefined;
 
       const profileConfig: TableProfilerConfig = {
         excludeColumns: excludeCol.length > 0 ? excludeCol : undefined,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/RetentionPeriod/RetentionPeriod.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/RetentionPeriod/RetentionPeriod.component.tsx
@@ -35,6 +35,17 @@ import {
 import { showErrorToast } from '../../../utils/ToastUtils';
 import './retention-period.less';
 import { RetentionPeriodProps } from './RetentionPeriod.interface';
+// Format a single duration unit with correct pluralization, e.g. (2, 'year') -> '2 years'
+const formatDurationUnit = (value: number | undefined, unit: string) => {
+  if (!value) {
+    return '';
+  }
+
+  const suffix = value > 1 ? 's' : '';
+
+  return `${value} ${unit}${suffix}`;
+};
+
 // Helper function to detect and format ISO 8601 duration
 const formatRetentionPeriod = (retentionPeriod: string | undefined) => {
   if (!retentionPeriod) {
@@ -47,27 +58,13 @@ const formatRetentionPeriod = (retentionPeriod: string | undefined) => {
   if (isoDurationRegex.test(retentionPeriod)) {
     const duration = Duration.fromISO(retentionPeriod);
 
-    const years = duration.years
-      ? `${duration.years} year${duration.years > 1 ? 's' : ''}`
-      : '';
-    const months = duration.months
-      ? `${duration.months} month${duration.months > 1 ? 's' : ''}`
-      : '';
-    const weeks = duration.weeks
-      ? `${duration.weeks} week${duration.weeks > 1 ? 's' : ''}`
-      : '';
-    const days = duration.days
-      ? `${duration.days} day${duration.days > 1 ? 's' : ''}`
-      : '';
-    const hours = duration.hours
-      ? `${duration.hours} hour${duration.hours > 1 ? 's' : ''}`
-      : '';
-    const minutes = duration.minutes
-      ? `${duration.minutes} minute${duration.minutes > 1 ? 's' : ''}`
-      : '';
-    const seconds = duration.seconds
-      ? `${duration.seconds} second${duration.seconds > 1 ? 's' : ''}`
-      : '';
+    const years = formatDurationUnit(duration.years, 'year');
+    const months = formatDurationUnit(duration.months, 'month');
+    const weeks = formatDurationUnit(duration.weeks, 'week');
+    const days = formatDurationUnit(duration.days, 'day');
+    const hours = formatDurationUnit(duration.hours, 'hour');
+    const minutes = formatDurationUnit(duration.minutes, 'minute');
+    const seconds = formatDurationUnit(duration.seconds, 'second');
 
     const formattedDuration = [
       years,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.component.tsx
@@ -370,12 +370,12 @@ const AddDomainForm = ({
       return;
     }
     setCustomPropertiesLoaded(false);
-    const entityTypeApiName =
-      targetEntityType === TargetEntityType.DataProduct
-        ? 'dataProduct'
-        : targetEntityType === TargetEntityType.Domain
-        ? 'domain'
-        : 'glossaryTerm';
+    let entityTypeApiName = 'glossaryTerm';
+    if (targetEntityType === TargetEntityType.DataProduct) {
+      entityTypeApiName = 'dataProduct';
+    } else if (targetEntityType === TargetEntityType.Domain) {
+      entityTypeApiName = 'domain';
+    }
     getCustomPropertiesByEntityType(entityTypeApiName)
       .then((props) => {
         if (!cancelled) {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainFormExtensionFields.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainFormExtensionFields.tsx
@@ -125,6 +125,17 @@ interface DateParts {
 // CalendarDate class is nominally different from the DatePicker's DateValue.
 type DatePickerValue = ComponentProps<typeof DatePicker>['value'];
 
+const getNumberInputStringValue = (value: unknown): string => {
+  if (typeof value === 'number') {
+    return String(value);
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  return '';
+};
+
 const getReferenceIcon = (source: ReferenceSearchSource) => {
   const entityType = source.entityType ?? source.type;
   if (entityType === EntityType.TEAM) {
@@ -259,13 +270,7 @@ const NumberExtensionField = ({
                 : 1
             }
             type="number"
-            value={
-              typeof field.value === 'number'
-                ? String(field.value)
-                : typeof field.value === 'string'
-                ? field.value
-                : ''
-            }
+            value={getNumberInputStringValue(field.value)}
             onBlur={field.onBlur}
             onChange={(value) =>
               field.onChange(value === '' ? undefined : value)
@@ -609,13 +614,7 @@ const TimeIntervalExtensionField = ({
               label={inputLabel}
               step={1}
               type="number"
-              value={
-                typeof field.value === 'number'
-                  ? String(field.value)
-                  : typeof field.value === 'string'
-                  ? field.value
-                  : ''
-              }
+              value={getNumberInputStringValue(field.value)}
               onBlur={field.onBlur}
               onChange={(nextValue) =>
                 field.onChange(nextValue === '' ? undefined : nextValue)
@@ -894,6 +893,9 @@ const SimpleExtensionField = ({
   }
   const durationHint =
     kind === 'duration' ? t('message.duration-in-iso-format') : undefined;
+  const enumFieldType = enumConfig?.multiSelect
+    ? FieldTypes.MULTI_SELECT
+    : FieldTypes.SELECT;
   const field: FieldProp = {
     id: `root/${name.replace('.', '/')}`,
     label: labelNode,
@@ -915,12 +917,7 @@ const SimpleExtensionField = ({
     },
     required: isRequired,
     rules,
-    type:
-      kind === 'enum'
-        ? enumConfig?.multiSelect
-          ? FieldTypes.MULTI_SELECT
-          : FieldTypes.SELECT
-        : FieldTypes.TEXT,
+    type: kind === 'enum' ? enumFieldType : FieldTypes.TEXT,
   };
 
   return (

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityExportModalProvider/EntityExportModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityExportModalProvider/EntityExportModal.component.tsx
@@ -84,6 +84,13 @@ export const EntityExportModal: FC<EntityExportModalProps> = ({
   const isExportInProgress =
     csvExportJob?.status === 'IN_PROGRESS' && !csvExportJob.statusUnavailable;
 
+  let alertVariant: 'error' | 'brand' | 'success' = 'success';
+  if (csvExportJob?.error || csvExportJob?.statusUnavailable) {
+    alertVariant = 'error';
+  } else if (downloading) {
+    alertVariant = 'brand';
+  }
+
   return (
     <ModalOverlay isOpen>
       <Modal>
@@ -173,13 +180,7 @@ export const EntityExportModal: FC<EntityExportModalProps> = ({
                           })
                         : csvExportJob.error ?? csvExportJob.message ?? ''
                     }
-                    variant={
-                      csvExportJob.error || csvExportJob.statusUnavailable
-                        ? 'error'
-                        : downloading
-                        ? 'brand'
-                        : 'success'
-                    }
+                    variant={alertVariant}
                   />
                 )}
               </Fragment>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/Task/TaskTab/TaskTabNew.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/Task/TaskTab/TaskTabNew.component.tsx
@@ -500,11 +500,10 @@ export const TaskTabNew = ({
   const [taskAction, setTaskAction] = useState<TaskAction>(latestAction);
   const [isActionLoading, setIsActionLoading] = useState(false);
   const isTaskClosed = isTaskTerminalStatus(task.status);
-  const isTaskActionable = !isTaskClosed
-    ? isWorkflowDrivenTask
-      ? Boolean(task.availableTransitions?.length)
-      : task.status === TaskEntityStatus.Open
-    : false;
+  const openTaskActionable = isWorkflowDrivenTask
+    ? Boolean(task.availableTransitions?.length)
+    : task.status === TaskEntityStatus.Open;
+  const isTaskActionable = !isTaskClosed && openTaskActionable;
   const [showEditTaskModel, setShowEditTaskModel] = useState(false);
   const [comment, setComment] = useState('');
   const [isEditAssignee, setIsEditAssignee] = useState<boolean>(false);
@@ -811,12 +810,13 @@ export const TaskTabNew = ({
       status.toLowerCase() === 'approved'
         ? TaskResolutionType.Approved
         : TaskResolutionType.Rejected;
-    const newValue =
-      isApprovalWorkflowTask && status.toLowerCase() === 'approved'
+    const approvalWorkflowValue =
+      status.toLowerCase() === 'approved'
         ? taskHandler.approvedValue
-        : isApprovalWorkflowTask
-        ? taskHandler.rejectedValue
-        : suggestedValue;
+        : taskHandler.rejectedValue;
+    const newValue = isApprovalWorkflowTask
+      ? approvalWorkflowValue
+      : suggestedValue;
     updateTaskData({ newValue }, resolutionType);
   };
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/CommonEntitySummaryInfo/CommonEntitySummaryInfo.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/CommonEntitySummaryInfo/CommonEntitySummaryInfo.tsx
@@ -14,6 +14,7 @@
 import Icon from '@ant-design/icons/lib/components/Icon';
 import { Col, Row, Typography } from 'antd';
 import classNames from 'classnames';
+import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { ReactComponent as IconExternalLink } from '../../../../assets/svg/external-links.svg';
@@ -35,7 +36,47 @@ function CommonEntitySummaryInfo({
         const isDomain =
           isDomainVisible && info.name === t('label.domain-plural');
 
-        return info.visible?.includes(componentType) || isDomain ? (
+        if (!(info.visible?.includes(componentType) || isDomain)) {
+          return null;
+        }
+
+        let valueContent: ReactNode;
+        if (info.isLink && info.isExternal) {
+          valueContent = (
+            <a
+              className="summary-item-link"
+              data-testid={`${info.name}-value`}
+              href={info.url}
+              target="_blank">
+              {info.value}
+              <Icon
+                className="m-l-xs"
+                component={IconExternalLink}
+                data-testid="external-link-icon"
+                style={ICON_DIMENSION}
+              />
+            </a>
+          );
+        } else if (info.isLink) {
+          valueContent = (
+            <Link
+              className="summary-item-link"
+              data-testid={`${info.name}-value`}
+              to={info.linkProps ?? info.url ?? ''}>
+              {info.value}
+            </Link>
+          );
+        } else {
+          valueContent = (
+            <Typography.Text
+              className={classNames('summary-item-value text-grey-body')}
+              data-testid={`${info.name}-value`}>
+              {info.value}
+            </Typography.Text>
+          );
+        }
+
+        return (
           <Col key={info.name} span={24}>
             <Row gutter={[16, 32]}>
               <Col span={8}>
@@ -45,41 +86,10 @@ function CommonEntitySummaryInfo({
                   {info.name}
                 </Typography.Text>
               </Col>
-              <Col span={16}>
-                {info.isLink ? (
-                  info.isExternal ? (
-                    <a
-                      className="summary-item-link"
-                      data-testid={`${info.name}-value`}
-                      href={info.url}
-                      target="_blank">
-                      {info.value}
-                      <Icon
-                        className="m-l-xs"
-                        component={IconExternalLink}
-                        data-testid="external-link-icon"
-                        style={ICON_DIMENSION}
-                      />
-                    </a>
-                  ) : (
-                    <Link
-                      className="summary-item-link"
-                      data-testid={`${info.name}-value`}
-                      to={info.linkProps ?? info.url ?? ''}>
-                      {info.value}
-                    </Link>
-                  )
-                ) : (
-                  <Typography.Text
-                    className={classNames('summary-item-value text-grey-body')}
-                    data-testid={`${info.name}-value`}>
-                    {info.value}
-                  </Typography.Text>
-                )}
-              </Col>
+              <Col span={16}>{valueContent}</Col>
             </Row>
           </Col>
-        ) : null;
+        );
       })}
     </Row>
   );

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx
@@ -171,6 +171,38 @@ const QuickFilterDropdown: FC<QuickFilterDropdownProps> = ({
     setIsOpen(false);
   };
 
+  const optionListContent =
+    displayedOptions.length > 0 ? (
+      displayedOptions.map((option) => (
+        <div
+          className="tw:flex tw:items-center tw:justify-between tw:gap-2 tw:rounded-md tw:px-2 tw:py-1.5 tw:hover:bg-primary_hover"
+          key={option.key}>
+          <Checkbox
+            data-testid={`${option.label}-checkbox`}
+            isSelected={isOptionSelected(option)}
+            label={
+              option.icon ? (
+                <span className="tw:flex tw:items-center tw:gap-1.5">
+                  {option.icon}
+                  {option.label}
+                </span>
+              ) : (
+                option.label
+              )
+            }
+            onChange={() => handleOptionToggle(option)}
+          />
+          {!hideCounts && !isUndefined(option.count) && (
+            <span className="tw:text-xs tw:text-tertiary">{option.count}</span>
+          )}
+        </div>
+      ))
+    ) : (
+      <div className="tw:px-2 tw:py-3 tw:text-center tw:text-sm tw:text-tertiary">
+        {t('message.no-data-available')}
+      </div>
+    );
+
   return (
     <PopoverTrigger isOpen={isOpen} onOpenChange={handleOpenChange}>
       <Button
@@ -228,37 +260,8 @@ const QuickFilterDropdown: FC<QuickFilterDropdownProps> = ({
               <div className="tw:flex tw:justify-center tw:py-3">
                 <Loader size="small" />
               </div>
-            ) : displayedOptions.length > 0 ? (
-              displayedOptions.map((option) => (
-                <div
-                  className="tw:flex tw:items-center tw:justify-between tw:gap-2 tw:rounded-md tw:px-2 tw:py-1.5 tw:hover:bg-primary_hover"
-                  key={option.key}>
-                  <Checkbox
-                    data-testid={`${option.label}-checkbox`}
-                    isSelected={isOptionSelected(option)}
-                    label={
-                      option.icon ? (
-                        <span className="tw:flex tw:items-center tw:gap-1.5">
-                          {option.icon}
-                          {option.label}
-                        </span>
-                      ) : (
-                        option.label
-                      )
-                    }
-                    onChange={() => handleOptionToggle(option)}
-                  />
-                  {!hideCounts && !isUndefined(option.count) && (
-                    <span className="tw:text-xs tw:text-tertiary">
-                      {option.count}
-                    </span>
-                  )}
-                </div>
-              ))
             ) : (
-              <div className="tw:px-2 tw:py-3 tw:text-center tw:text-sm tw:text-tertiary">
-                {t('message.no-data-available')}
-              </div>
+              optionListContent
             )}
           </div>
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/AddGlossary/AddGlossary.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/AddGlossary/AddGlossary.component.tsx
@@ -14,7 +14,7 @@
 import { PlusOutlined } from '@ant-design/icons';
 import { Button, Form, Space, Typography } from 'antd';
 import { FormProps, useForm } from 'antd/lib/form/Form';
-import { isArray } from 'lodash';
+import { compact, isArray } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { NAME_FIELD_RULES } from '../../../constants/Form.constants';
 import { EntityType } from '../../../enums/entity.enum';
@@ -91,6 +91,10 @@ const AddGlossary = ({
             },
           ];
 
+    const selectedDomainList: EntityReference[] = isArray(selectedDomain)
+      ? selectedDomain
+      : compact([selectedDomain]);
+
     const data: CreateGlossary = {
       name: name.trim(),
       displayName: displayName?.trim(),
@@ -100,7 +104,7 @@ const AddGlossary = ({
       tags: tags || [],
       mutuallyExclusive: Boolean(mutuallyExclusive),
       domains: selectedDomain
-        ? ((isArray(selectedDomain) ? selectedDomain : [selectedDomain])
+        ? (selectedDomainList
             .map((d) => d.fullyQualifiedName)
             .filter(Boolean) as string[]) ?? []
         : undefined,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/GlossaryTermReferences.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/GlossaryTermReferences.tsx
@@ -164,16 +164,15 @@ const GlossaryTermReferences = () => {
         }}
         dataTestId="references-container"
         isExpandDisabled={isEmpty(references)}>
-        {isVersionView ? (
-          getVersionReferenceElements()
-        ) : !permissions.EditAll || !isEmpty(references) ? (
+        {isVersionView && getVersionReferenceElements()}
+        {!isVersionView && (!permissions.EditAll || !isEmpty(references)) && (
           <div className="d-flex flex-wrap">
             {references.map((ref) => renderReferenceElement(ref))}
             {!permissions.EditAll && references.length === 0 && (
               <div>{NO_DATA_PLACEHOLDER}</div>
             )}
           </div>
-        ) : null}
+        )}
       </ExpandableCard>
 
       <GlossaryTermReferencesModal

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/RelatedTerms.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/RelatedTerms.tsx
@@ -100,6 +100,12 @@ const RelatedTermTagButton: React.FC<RelatedTermTagButtonProps> = ({
   onRelatedTermClick,
 }) => {
   const descriptionText = getTextFromHtmlString(entity.description);
+  const removedDiffClassName = versionStatus?.removed
+    ? 'diff-removed'
+    : undefined;
+  const diffClassName = versionStatus?.added
+    ? 'diff-added'
+    : removedDiffClassName;
   const tooltipContent = (
     <div className="tw:p-2 tw:space-y-1">
       <Typography as="p" className="tw:text-white" weight="semibold">
@@ -121,13 +127,7 @@ const RelatedTermTagButton: React.FC<RelatedTermTagButtonProps> = ({
   return (
     <Tooltip arrow placement="bottom left" title={tooltipContent}>
       <TooltipTrigger
-        className={
-          versionStatus?.added
-            ? 'diff-added'
-            : versionStatus?.removed
-            ? 'diff-removed'
-            : undefined
-        }
+        className={diffClassName}
         data-testid={getEntityName(entity)}
         onPress={() => onRelatedTermClick(entity.fullyQualifiedName ?? '')}>
         <BadgeWithIcon

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryUpdateConfirmationModal/GlossaryUpdateConfirmationModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryUpdateConfirmationModal/GlossaryUpdateConfirmationModal.tsx
@@ -106,12 +106,13 @@ export const GlossaryUpdateConfirmationModal = ({
     ];
   }, []);
 
-  const progress =
-    updateState === UpdateState.VALIDATING
-      ? 10
-      : updateState === UpdateState.UPDATING
-      ? 60
-      : 100;
+  let progress = 100;
+
+  if (updateState === UpdateState.VALIDATING) {
+    progress = 10;
+  } else if (updateState === UpdateState.UPDATING) {
+    progress = 60;
+  }
 
   const data = useMemo(() => {
     const footer = (

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/rdfGraphAdapter.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/rdfGraphAdapter.ts
@@ -506,11 +506,12 @@ const collectSharedAssets = (
     // this correct for reverse-direction (concept->table) mappings.
     const source = idOf(link.source);
     const target = idOf(link.target);
-    const conceptId = expanded.has(source)
-      ? source
-      : expanded.has(target)
-      ? target
-      : undefined;
+    let conceptId: string | undefined;
+    if (expanded.has(source)) {
+      conceptId = source;
+    } else if (expanded.has(target)) {
+      conceptId = target;
+    }
     const assetId = conceptId === source ? target : source;
     const asset = conceptId ? byId.get(assetId) : undefined;
     if (asset?.type === 'table' && assetId !== selfId && !seen.has(assetId)) {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Learning/LearningDrawer/LearningDrawer.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Learning/LearningDrawer/LearningDrawer.component.tsx
@@ -97,6 +97,44 @@ export const LearningDrawer: React.FC<LearningDrawerProps> = ({
     return titleMap[pageId] || pageId;
   }, [pageId, title, t]);
 
+  let drawerContent: React.ReactNode;
+  if (isLoading) {
+    drawerContent = (
+      <div className="learning-drawer-loading">
+        <Spin
+          data-testid="loader"
+          indicator={<LoadingOutlined spin style={{ fontSize: 24 }} />}
+        />
+      </div>
+    );
+  } else if (hasError) {
+    drawerContent = (
+      <Empty
+        description={t('message.failed-to-load-learning-resources')}
+        image={Empty.PRESENTED_IMAGE_SIMPLE}
+      />
+    );
+  } else if (resources.length === 0) {
+    drawerContent = (
+      <Empty
+        description={t('message.no-learning-resources-available')}
+        image={Empty.PRESENTED_IMAGE_SIMPLE}
+      />
+    );
+  } else {
+    drawerContent = (
+      <div className="learning-drawer-cards">
+        {resources.map((resource) => (
+          <LearningResourceCard
+            key={resource.id}
+            resource={resource}
+            onClick={handleResourceClick}
+          />
+        ))}
+      </div>
+    );
+  }
+
   return (
     <>
       <Drawer
@@ -120,36 +158,7 @@ export const LearningDrawer: React.FC<LearningDrawerProps> = ({
         }
         width={576}
         onClose={onClose}>
-        <div className="learning-drawer-content">
-          {isLoading ? (
-            <div className="learning-drawer-loading">
-              <Spin
-                data-testid="loader"
-                indicator={<LoadingOutlined spin style={{ fontSize: 24 }} />}
-              />
-            </div>
-          ) : hasError ? (
-            <Empty
-              description={t('message.failed-to-load-learning-resources')}
-              image={Empty.PRESENTED_IMAGE_SIMPLE}
-            />
-          ) : resources.length === 0 ? (
-            <Empty
-              description={t('message.no-learning-resources-available')}
-              image={Empty.PRESENTED_IMAGE_SIMPLE}
-            />
-          ) : (
-            <div className="learning-drawer-cards">
-              {resources.map((resource) => (
-                <LearningResourceCard
-                  key={resource.id}
-                  resource={resource}
-                  onClick={handleResourceClick}
-                />
-              ))}
-            </div>
-          )}
-        </div>
+        <div className="learning-drawer-content">{drawerContent}</div>
       </Drawer>
 
       {selectedResource && (

--- a/openmetadata-ui/src/main/resources/ui/src/components/Learning/ResourcePlayer/ResourcePlayerModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Learning/ResourcePlayer/ResourcePlayerModal.component.tsx
@@ -68,12 +68,14 @@ export const ResourcePlayerModal: React.FC<ResourcePlayerModalProps> = ({
 
   const displayResource = fetchedResource ?? resource;
 
+  const durationUnitLabel =
+    displayResource.resourceType === 'Article'
+      ? t('label.min-read')
+      : t('label.min-watch');
   const formattedDuration = displayResource.estimatedDuration
-    ? `${Math.floor(displayResource.estimatedDuration / 60)} ${
-        displayResource.resourceType === 'Article'
-          ? t('label.min-read')
-          : t('label.min-watch')
-      }`
+    ? `${Math.floor(
+        displayResource.estimatedDuration / 60
+      )} ${durationUnitLabel}`
     : null;
 
   const formattedDate = displayResource.updatedAt

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/Persona/PersonaSelectableList/PersonaSelectableList.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/Persona/PersonaSelectableList/PersonaSelectableList.component.test.tsx
@@ -182,11 +182,11 @@ describe('PersonaSelectableList', () => {
   });
 
   it('retains a persona selected under a previous query when saving', async () => {
-    mockSearchPersonas.mockImplementation((query: string) =>
-      Promise.resolve(
-        query === 'ana' ? [PERSONAS[0]] : query === 'stew' ? [PERSONAS[1]] : []
-      )
-    );
+    mockSearchPersonas.mockImplementation((query: string) => {
+      const stewMatches = query === 'stew' ? [PERSONAS[1]] : [];
+
+      return Promise.resolve(query === 'ana' ? [PERSONAS[0]] : stewMatches);
+    });
     const onUpdate = jest.fn().mockResolvedValue(undefined);
 
     render(

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/DataProductsWidget/DataProductsWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/DataProductsWidget/DataProductsWidget.component.tsx
@@ -13,7 +13,7 @@
 import { Button, Typography } from 'antd';
 import classNames from 'classnames';
 import { isEmpty } from 'lodash';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { ReactComponent as DataProductNoDataPlaceholder } from '../../../../assets/svg/no-folder-data.svg';
@@ -272,25 +272,30 @@ const DataProductsWidget = ({
     ]
   );
 
+  let widgetContent: ReactNode;
+  if (error) {
+    widgetContent = (
+      <ErrorPlaceHolder
+        className="data-products-widget-error border-none"
+        type={ERROR_PLACEHOLDER_TYPE.CUSTOM}>
+        {error}
+      </ErrorPlaceHolder>
+    );
+  } else if (isEmpty(dataProducts)) {
+    widgetContent = (
+      <div data-testid="data-products-empty-state">{emptyState}</div>
+    );
+  } else {
+    widgetContent = dataProductsList;
+  }
+
   return (
     <WidgetWrapper
       dataTestId="KnowledgePanel.DataProducts"
       header={widgetHeader}
       loading={loading}>
       <div className="data-products-widget-container">
-        <div className="widget-content flex-1">
-          {error ? (
-            <ErrorPlaceHolder
-              className="data-products-widget-error border-none"
-              type={ERROR_PLACEHOLDER_TYPE.CUSTOM}>
-              {error}
-            </ErrorPlaceHolder>
-          ) : isEmpty(dataProducts) ? (
-            <div data-testid="data-products-empty-state">{emptyState}</div>
-          ) : (
-            dataProductsList
-          )}
-        </div>
+        <div className="widget-content flex-1">{widgetContent}</div>
         {!isEmpty(dataProducts) && footer}
       </div>
     </WidgetWrapper>

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/DomainsWidget/DomainsWidget.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/DomainsWidget/DomainsWidget.tsx
@@ -278,6 +278,8 @@ const DomainsWidget = ({
     ]
   );
 
+  const domainsContent = isEmpty(domains) ? emptyState : domainsList;
+
   return (
     <WidgetWrapper
       dataTestId="KnowledgePanel.Domains"
@@ -291,10 +293,8 @@ const DomainsWidget = ({
               type={ERROR_PLACEHOLDER_TYPE.CUSTOM}>
               {error}
             </ErrorPlaceHolder>
-          ) : isEmpty(domains) ? (
-            emptyState
           ) : (
-            domainsList
+            domainsContent
           )}
         </div>
         {!isEmpty(domains) && footer}

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/KPIWidget/KPILegend/KPILegend.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/KPIWidget/KPILegend/KPILegend.tsx
@@ -76,6 +76,20 @@ const KPILegend: React.FC<KPILegendProps> = ({
         const isTargetMet = targetResult.targetMet;
         const isTargetMissed = !targetResult.targetMet && daysLeft <= 0;
 
+        let centerContent: JSX.Element;
+        if (isTargetMet) {
+          centerContent = <GoalCompleted />;
+        } else if (isTargetMissed) {
+          centerContent = <GoalMissed />;
+        } else {
+          centerContent = (
+            <Typography.Text className="text-xss font-semibold kpi-legend-days-left text-center">
+              {daysLeft <= 0 ? 0 : daysLeft}{' '}
+              {t('label.days-left').toUpperCase()}
+            </Typography.Text>
+          );
+        }
+
         if (isFullSize) {
           return (
             <div className="kpi-full-legend" key={key}>
@@ -111,18 +125,7 @@ const KPILegend: React.FC<KPILegendProps> = ({
                     {suffix}
                   </Typography.Text>
                 </div>
-                <div className="kpi-legend-center-section">
-                  {isTargetMet ? (
-                    <GoalCompleted />
-                  ) : isTargetMissed ? (
-                    <GoalMissed />
-                  ) : (
-                    <Typography.Text className="text-xss font-semibold kpi-legend-days-left text-center">
-                      {daysLeft <= 0 ? 0 : daysLeft}{' '}
-                      {t('label.days-left').toUpperCase()}
-                    </Typography.Text>
-                  )}
-                </div>
+                <div className="kpi-legend-center-section">{centerContent}</div>
                 <div className="kpi-legend-value-section">
                   <Typography.Text className="text-xss kpi-legend-value">
                     {target.toFixed(0)}

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyConceptRealization.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyConceptRealization.component.tsx
@@ -306,24 +306,21 @@ export const OntologyConceptRealization: React.FC<
       ) : (
         realizations.map(renderRealization)
       )}
-      {canAuthor ? (
-        isAdding ? (
-          renderAddForm()
-        ) : (
-          <Button
-            noTextPadding
-            className={classNames(
-              'tw:flex tw:w-full tw:items-center tw:justify-center tw:gap-1 tw:rounded-lg tw:border tw:border-dashed',
-              'tw:border-primary tw:bg-primary tw:px-2.5 tw:py-2 tw:font-body tw:text-xs tw:font-semibold tw:text-secondary tw:*:data-icon:size-3'
-            )}
-            color="tertiary"
-            data-testid="add-realization"
-            iconLeading={Plus}
-            onClick={() => setIsAdding(true)}>
-            {t('label.add-entity', { entity: t('label.realized-in') })}
-          </Button>
-        )
-      ) : null}
+      {canAuthor && isAdding && renderAddForm()}
+      {canAuthor && !isAdding && (
+        <Button
+          noTextPadding
+          className={classNames(
+            'tw:flex tw:w-full tw:items-center tw:justify-center tw:gap-1 tw:rounded-lg tw:border tw:border-dashed',
+            'tw:border-primary tw:bg-primary tw:px-2.5 tw:py-2 tw:font-body tw:text-xs tw:font-semibold tw:text-secondary tw:*:data-icon:size-3'
+          )}
+          color="tertiary"
+          data-testid="add-realization"
+          iconLeading={Plus}
+          onClick={() => setIsAdding(true)}>
+          {t('label.add-entity', { entity: t('label.realized-in') })}
+        </Button>
+      )}
     </div>
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.tsx
@@ -29,6 +29,7 @@ import classNames from 'classnames';
 import React, {
   Fragment,
   Key,
+  ReactNode,
   useCallback,
   useEffect,
   useMemo,
@@ -913,6 +914,61 @@ const OntologyExplorer: React.FC<OntologyExplorerProps> = ({
   const showOnboardingEmptyState =
     hasEmptyConceptGraph && hasNoActiveOntologyFilters;
 
+  const nonGraphSurfaceContent =
+    surface === 'tree' ? (
+      <OntologyTreeView
+        groups={treeGroups}
+        selectedNodeId={selectedNode?.id}
+        onSelect={setSelectedNode}
+      />
+    ) : (
+      <OntologyTermEditor
+        edges={(filteredGraphData?.edges ?? []).filter(
+          (edge) => edge.relationType !== ASSET_RELATION_TYPE
+        )}
+        isEditable={isEditMode}
+        nodes={filteredGraphData?.nodes ?? []}
+        relationTypes={relationTypes}
+        selectedNode={selectedNode}
+        onCreateRelation={handleCreateRelation}
+        onDeleteTerm={() => {
+          setSelectedNode(null);
+          handleRefresh();
+        }}
+        onSelectNode={setSelectedNode}
+      />
+    );
+
+  let conceptInspectorContent: ReactNode = null;
+  if (showConceptInspector && selectedNode) {
+    conceptInspectorContent = selectedNode.isDraft ? (
+      <OntologyConceptDraftInspector
+        glossaries={glossaries}
+        isLeaseOwned={isEditMode}
+        key={selectedNode.id}
+        node={selectedNode}
+        onCancel={handleConceptDraftCancel}
+        onChange={handleConceptDraftChange}
+        onCreated={handleConceptCreated}
+      />
+    ) : (
+      <OntologyAuthoringInspector
+        edges={(filteredGraphData?.edges ?? []).filter(
+          (edge) => edge.relationType !== ASSET_RELATION_TYPE
+        )}
+        isEditable={isEditMode}
+        key={selectedNode.id}
+        node={selectedNode}
+        nodes={filteredGraphData?.nodes ?? []}
+        relationTypes={relationTypes}
+        onCreateRelation={handleCreateRelation}
+        onRequestEdit={isEditMode ? undefined : onRequestEdit}
+        onShowDataAssets={() => handleModeChange('data')}
+        onShowFullDetails={() => handleGraphNodeDoubleClick(selectedNode)}
+      />
+    );
+  }
+
   return (
     <div
       className={classNames(
@@ -1138,28 +1194,8 @@ const OntologyExplorer: React.FC<OntologyExplorerProps> = ({
                 {renderGraphContent()}
               </div>
             </>
-          ) : surface === 'tree' ? (
-            <OntologyTreeView
-              groups={treeGroups}
-              selectedNodeId={selectedNode?.id}
-              onSelect={setSelectedNode}
-            />
           ) : (
-            <OntologyTermEditor
-              edges={(filteredGraphData?.edges ?? []).filter(
-                (edge) => edge.relationType !== ASSET_RELATION_TYPE
-              )}
-              isEditable={isEditMode}
-              nodes={filteredGraphData?.nodes ?? []}
-              relationTypes={relationTypes}
-              selectedNode={selectedNode}
-              onCreateRelation={handleCreateRelation}
-              onDeleteTerm={() => {
-                setSelectedNode(null);
-                handleRefresh();
-              }}
-              onSelectNode={setSelectedNode}
-            />
+            nonGraphSurfaceContent
           )}
 
           {showEntityPanel && selectedNode ? (
@@ -1218,38 +1254,7 @@ const OntologyExplorer: React.FC<OntologyExplorerProps> = ({
             onUpdate={handleRelationUpdate}
           />
         ) : null}
-        {showConceptInspector && selectedNode ? (
-          selectedNode.isDraft ? (
-            <OntologyConceptDraftInspector
-              glossaries={glossaries}
-              isLeaseOwned={isEditMode}
-              key={selectedNode.id}
-              node={selectedNode}
-              onCancel={handleConceptDraftCancel}
-              onChange={handleConceptDraftChange}
-              onCreated={handleConceptCreated}
-            />
-          ) : (
-            <OntologyAuthoringInspector
-              edges={(filteredGraphData?.edges ?? []).filter(
-                (edge) => edge.relationType !== ASSET_RELATION_TYPE
-              )}
-              isEditable={isEditMode}
-              key={selectedNode.id}
-              node={selectedNode}
-              nodes={filteredGraphData?.nodes ?? []}
-              relationTypes={relationTypes}
-              onCreateRelation={handleCreateRelation}
-              onRequestEdit={isEditMode ? undefined : onRequestEdit}
-              onShowDataAssets={() => handleModeChange('data')}
-              onShowFullDetails={() => {
-                if (selectedNode) {
-                  handleGraphNodeDoubleClick(selectedNode);
-                }
-              }}
-            />
-          )
-        ) : null}
+        {conceptInspectorContent}
         {showHealth && !showConceptInspector && !selectedEdge ? (
           <OntologyHealthPanel
             health={healthSummary}

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyImportExportModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyImportExportModal.tsx
@@ -131,11 +131,12 @@ function highlightRdf(text: string): ReactNode[] {
     if (match.index > lastIndex) {
       nodes.push(text.slice(lastIndex, match.index));
     }
-    const color = match[1]
-      ? SYNTAX_COLOR.string
-      : match[2] || match[4]
-      ? SYNTAX_COLOR.keyword
-      : SYNTAX_COLOR.term;
+    let color = SYNTAX_COLOR.term;
+    if (match[1]) {
+      color = SYNTAX_COLOR.string;
+    } else if (match[2] || match[4]) {
+      color = SYNTAX_COLOR.keyword;
+    }
     nodes.push(
       <span key={key++} style={{ color }}>
         {match[0]}
@@ -439,6 +440,45 @@ const OntologyImportExportModal = ({
     }
   }, [importTarget, importFileContent, importFormat, onClose, t]);
 
+  let previewContent: ReactNode = '—';
+  if (isPreviewLoading) {
+    previewContent = t('label.loading');
+  } else if (isRdfFormat && preview) {
+    previewContent = highlightRdf(preview);
+  }
+
+  let shaclStatusContent: ReactNode = null;
+  if (shaclResult) {
+    shaclStatusContent = (
+      <div
+        className={classNames(
+          'tw:mt-3 tw:flex tw:items-center tw:gap-1.5 tw:text-[11px] tw:font-medium',
+          shaclResult.conforms
+            ? 'tw:text-success-primary'
+            : 'tw:text-error-primary'
+        )}
+        data-testid="ontology-shacl-status">
+        {shaclResult.conforms ? (
+          <CheckCircle className="tw:size-3.5" />
+        ) : (
+          <AlertCircle className="tw:size-3.5" />
+        )}
+        {t(
+          shaclResult.conforms
+            ? 'message.shacl-no-violations'
+            : 'message.shacl-violations-found'
+        )}
+      </div>
+    );
+  } else if (isPreviewReady) {
+    shaclStatusContent = (
+      <div className="tw:mt-3 tw:flex tw:items-center tw:gap-1.5 tw:text-[11px] tw:font-medium tw:text-success-primary">
+        <CheckCircle className="tw:size-3.5" />
+        {t('message.ontology-preview-ready')}
+      </div>
+    );
+  }
+
   return (
     <ModalOverlay
       isDismissable
@@ -586,39 +626,10 @@ const OntologyImportExportModal = ({
                       className="tw:max-h-[360px] tw:overflow-auto tw:font-mono tw:text-[11px] tw:leading-[1.7] tw:whitespace-pre-wrap"
                       data-testid="ontology-export-preview"
                       style={{ color: SYNTAX_COLOR.default }}>
-                      {isPreviewLoading
-                        ? t('label.loading')
-                        : isRdfFormat && preview
-                        ? highlightRdf(preview)
-                        : '—'}
+                      {previewContent}
                     </pre>
                   </div>
-                  {shaclResult ? (
-                    <div
-                      className={classNames(
-                        'tw:mt-3 tw:flex tw:items-center tw:gap-1.5 tw:text-[11px] tw:font-medium',
-                        shaclResult.conforms
-                          ? 'tw:text-success-primary'
-                          : 'tw:text-error-primary'
-                      )}
-                      data-testid="ontology-shacl-status">
-                      {shaclResult.conforms ? (
-                        <CheckCircle className="tw:size-3.5" />
-                      ) : (
-                        <AlertCircle className="tw:size-3.5" />
-                      )}
-                      {t(
-                        shaclResult.conforms
-                          ? 'message.shacl-no-violations'
-                          : 'message.shacl-violations-found'
-                      )}
-                    </div>
-                  ) : isPreviewReady ? (
-                    <div className="tw:mt-3 tw:flex tw:items-center tw:gap-1.5 tw:text-[11px] tw:font-medium tw:text-success-primary">
-                      <CheckCircle className="tw:size-3.5" />
-                      {t('message.ontology-preview-ready')}
-                    </div>
-                  ) : null}
+                  {shaclStatusContent}
                 </div>
               </div>
             ) : (

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyLibrary.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyLibrary.tsx
@@ -215,6 +215,66 @@ const OntologyLibrary = ({
     installations.map((installation) => installation.packId)
   ).size;
 
+  let libraryBody: JSX.Element;
+  if (isLoading) {
+    libraryBody = (
+      <Card data-testid="ontology-library-loading" size="lg">
+        <Card.Content>
+          <Typography as="p" className="tw:text-tertiary" size="text-sm">
+            {t('label.loading')}
+          </Typography>
+        </Card.Content>
+      </Card>
+    );
+  } else if (hasLoadError) {
+    libraryBody = (
+      <Alert
+        rightContent={
+          <Button
+            color="secondary"
+            iconLeading={RefreshCcw01}
+            size="sm"
+            onPress={() => void loadPacks()}>
+            {t('label.retry')}
+          </Button>
+        }
+        title={t('message.ontology-library-load-error')}
+        variant="error"
+      />
+    );
+  } else if (selectedPack) {
+    libraryBody = (
+      <OntologyLibraryDetail
+        activeAction={activeAction}
+        canInstall={canInstall}
+        installedResult={installedResult}
+        installedVersion={
+          installations.find(
+            (installation) => installation.packId === selectedPack.id
+          )?.version
+        }
+        pack={selectedPack}
+        previewResult={previewResult}
+        selectedModuleIds={selectedModuleIds}
+        targetGlossaryName={targetGlossaryName}
+        onBack={handleBack}
+        onInstall={() => void executeInstall(false)}
+        onModuleChange={handleModuleChange}
+        onOpenGlossary={handleOpenGlossary}
+        onPreview={() => void executeInstall(true)}
+        onTargetGlossaryChange={handleTargetGlossaryChange}
+      />
+    );
+  } else {
+    libraryBody = (
+      <OntologyLibraryCatalogue
+        installations={installations}
+        packs={packs}
+        onSelect={handleSelectPack}
+      />
+    );
+  }
+
   return createPortal(
     <div
       aria-labelledby="ontology-library-title"
@@ -259,58 +319,7 @@ const OntologyLibrary = ({
       </header>
 
       <div className="tw:min-h-0 tw:flex-1 tw:overflow-auto tw:p-6">
-        <div className="tw:mx-auto tw:max-w-[1040px]">
-          {isLoading ? (
-            <Card data-testid="ontology-library-loading" size="lg">
-              <Card.Content>
-                <Typography as="p" className="tw:text-tertiary" size="text-sm">
-                  {t('label.loading')}
-                </Typography>
-              </Card.Content>
-            </Card>
-          ) : hasLoadError ? (
-            <Alert
-              rightContent={
-                <Button
-                  color="secondary"
-                  iconLeading={RefreshCcw01}
-                  size="sm"
-                  onPress={() => void loadPacks()}>
-                  {t('label.retry')}
-                </Button>
-              }
-              title={t('message.ontology-library-load-error')}
-              variant="error"
-            />
-          ) : selectedPack ? (
-            <OntologyLibraryDetail
-              activeAction={activeAction}
-              canInstall={canInstall}
-              installedResult={installedResult}
-              installedVersion={
-                installations.find(
-                  (installation) => installation.packId === selectedPack.id
-                )?.version
-              }
-              pack={selectedPack}
-              previewResult={previewResult}
-              selectedModuleIds={selectedModuleIds}
-              targetGlossaryName={targetGlossaryName}
-              onBack={handleBack}
-              onInstall={() => void executeInstall(false)}
-              onModuleChange={handleModuleChange}
-              onOpenGlossary={handleOpenGlossary}
-              onPreview={() => void executeInstall(true)}
-              onTargetGlossaryChange={handleTargetGlossaryChange}
-            />
-          ) : (
-            <OntologyLibraryCatalogue
-              installations={installations}
-              packs={packs}
-              onSelect={handleSelectPack}
-            />
-          )}
-        </div>
+        <div className="tw:mx-auto tw:max-w-[1040px]">{libraryBody}</div>
       </div>
     </div>,
     document.body

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyLibraryCatalogue.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyLibraryCatalogue.tsx
@@ -113,6 +113,34 @@ const OntologyLibraryCatalogue = ({
             pack,
             pack.modules.map((module) => module.id)
           );
+          const uninstalledAction = pack.bundled ? (
+            <Button
+              className="tw:gap-1! tw:text-[11px]! tw:font-semibold!"
+              color="link-color"
+              data-testid={`ontology-pack-details-${pack.id}`}
+              iconTrailing={
+                <ArrowRight className="tw:size-3 tw:text-fg-brand-primary" />
+              }
+              size="xs"
+              onPress={() => onSelect(pack)}>
+              {t('label.install')}
+            </Button>
+          ) : (
+            <Button
+              className="tw:gap-1! tw:text-[11px]! tw:font-semibold!"
+              color="link-color"
+              data-testid={`ontology-pack-source-${pack.id}`}
+              href={pack.sourceUrl}
+              iconTrailing={
+                <ArrowUpRight className="tw:size-3 tw:text-fg-brand-primary" />
+              }
+              rel="noreferrer"
+              size="xs"
+              target="_blank">
+              {t('label.source')}
+            </Button>
+          );
+          const packActionButton = installation ? null : uninstalledAction;
 
           return (
             <Card
@@ -168,33 +196,7 @@ const OntologyLibraryCatalogue = ({
                   {t('label.relation-plural').toLocaleLowerCase()}
                 </span>
                 <span className="tw:flex-1" />
-                {!installation && pack.bundled ? (
-                  <Button
-                    className="tw:gap-1! tw:text-[11px]! tw:font-semibold!"
-                    color="link-color"
-                    data-testid={`ontology-pack-details-${pack.id}`}
-                    iconTrailing={
-                      <ArrowRight className="tw:size-3 tw:text-fg-brand-primary" />
-                    }
-                    size="xs"
-                    onPress={() => onSelect(pack)}>
-                    {t('label.install')}
-                  </Button>
-                ) : !installation ? (
-                  <Button
-                    className="tw:gap-1! tw:text-[11px]! tw:font-semibold!"
-                    color="link-color"
-                    data-testid={`ontology-pack-source-${pack.id}`}
-                    href={pack.sourceUrl}
-                    iconTrailing={
-                      <ArrowUpRight className="tw:size-3 tw:text-fg-brand-primary" />
-                    }
-                    rel="noreferrer"
-                    size="xs"
-                    target="_blank">
-                    {t('label.source')}
-                  </Button>
-                ) : null}
+                {packActionButton}
               </div>
             </Card>
           );

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyLibraryDetail.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyLibraryDetail.tsx
@@ -68,6 +68,27 @@ const OntologyLibraryDetail = ({
     selectedModuleIds.length > 0 &&
     targetGlossaryName.trim().length > 0;
 
+  const nonInstallPanel = pack.bundled ? (
+    <Alert title={t('message.no-permission-for-action')} variant="warning" />
+  ) : (
+    <Alert
+      rightContent={
+        <Button
+          color="secondary"
+          href={pack.sourceUrl}
+          iconTrailing={ArrowUpRight}
+          rel="noreferrer"
+          size="sm"
+          target="_blank">
+          {t('label.source')}
+        </Button>
+      }
+      title={t('message.ontology-pack-external-title')}
+      variant="warning">
+      {t('message.ontology-pack-external-description')}
+    </Alert>
+  );
+
   return (
     <div
       className="tw:flex tw:flex-col tw:gap-6"
@@ -304,28 +325,8 @@ const OntologyLibraryDetail = ({
                 </div>
               </Card.Content>
             </Card>
-          ) : pack.bundled ? (
-            <Alert
-              title={t('message.no-permission-for-action')}
-              variant="warning"
-            />
           ) : (
-            <Alert
-              rightContent={
-                <Button
-                  color="secondary"
-                  href={pack.sourceUrl}
-                  iconTrailing={ArrowUpRight}
-                  rel="noreferrer"
-                  size="sm"
-                  target="_blank">
-                  {t('label.source')}
-                </Button>
-              }
-              title={t('message.ontology-pack-external-title')}
-              variant="warning">
-              {t('message.ontology-pack-external-description')}
-            </Alert>
+            nonInstallPanel
           )}
         </div>
       </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyNodeRelationsContent.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyNodeRelationsContent.tsx
@@ -399,61 +399,60 @@ export const OntologyNodeRelationsContent: React.FC<
             </Typography>
           </Card>
         ))}
-        {isEditMode && isValidUUID(termId) ? (
-          isAddingMapping ? (
-            <Card className="tw:flex tw:flex-col tw:gap-3 tw:rounded-xl tw:border tw:border-dashed tw:border-utility-gray-blue-200 tw:p-3 tw:shadow-sm">
-              <Select
-                aria-label={t('label.mapping-type')}
-                items={Object.values(ConceptMappingType).map((type) => ({
-                  id: type,
-                  label: t(mappingLabelKeys[type]),
-                }))}
-                size="sm"
-                value={mappingType}
-                onChange={(key) =>
-                  setMappingType(String(key) as ConceptMappingType)
-                }>
-                {(item) => (
-                  <Select.Item id={item.id} key={item.id} label={item.label} />
-                )}
-              </Select>
-              <Input
-                data-testid="concept-mapping-iri"
-                placeholder={t('label.concept-iri')}
-                value={mappingIri}
-                onChange={setMappingIri}
-              />
-              <div className="tw:flex tw:justify-end tw:gap-2">
-                <Button
-                  color="tertiary"
-                  size="sm"
-                  onClick={() => {
-                    setMappingIri('');
-                    setIsAddingMapping(false);
-                  }}>
-                  {t('label.cancel')}
-                </Button>
-                <Button
-                  color="primary"
-                  data-testid="save-concept-mapping"
-                  isDisabled={isSavingMapping || !mappingIri.trim()}
-                  size="sm"
-                  onClick={handleAddMapping}>
-                  {t('label.add-mapping')}
-                </Button>
-              </div>
-            </Card>
-          ) : (
-            <Button
-              className="tw:w-full!"
-              color="secondary"
-              data-testid="add-concept-mapping"
+        {isEditMode && isValidUUID(termId) && isAddingMapping && (
+          <Card className="tw:flex tw:flex-col tw:gap-3 tw:rounded-xl tw:border tw:border-dashed tw:border-utility-gray-blue-200 tw:p-3 tw:shadow-sm">
+            <Select
+              aria-label={t('label.mapping-type')}
+              items={Object.values(ConceptMappingType).map((type) => ({
+                id: type,
+                label: t(mappingLabelKeys[type]),
+              }))}
               size="sm"
-              onClick={() => setIsAddingMapping(true)}>
-              {t('label.add-mapping')}
-            </Button>
-          )
-        ) : null}
+              value={mappingType}
+              onChange={(key) =>
+                setMappingType(String(key) as ConceptMappingType)
+              }>
+              {(item) => (
+                <Select.Item id={item.id} key={item.id} label={item.label} />
+              )}
+            </Select>
+            <Input
+              data-testid="concept-mapping-iri"
+              placeholder={t('label.concept-iri')}
+              value={mappingIri}
+              onChange={setMappingIri}
+            />
+            <div className="tw:flex tw:justify-end tw:gap-2">
+              <Button
+                color="tertiary"
+                size="sm"
+                onClick={() => {
+                  setMappingIri('');
+                  setIsAddingMapping(false);
+                }}>
+                {t('label.cancel')}
+              </Button>
+              <Button
+                color="primary"
+                data-testid="save-concept-mapping"
+                isDisabled={isSavingMapping || !mappingIri.trim()}
+                size="sm"
+                onClick={handleAddMapping}>
+                {t('label.add-mapping')}
+              </Button>
+            </div>
+          </Card>
+        )}
+        {isEditMode && isValidUUID(termId) && !isAddingMapping && (
+          <Button
+            className="tw:w-full!"
+            color="secondary"
+            data-testid="add-concept-mapping"
+            size="sm"
+            onClick={() => setIsAddingMapping(true)}>
+            {t('label.add-mapping')}
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyQueryResults.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyQueryResults.tsx
@@ -93,11 +93,16 @@ const OntologyQueryResults = ({
     return values;
   }, [resultTable]);
   const hasResultGraph = resultGraph.edges.length > 0;
-  const isGraphView = resultView === 'graph' && hasResultGraph;
 
   useEffect(() => {
     setResultView('table');
   }, [result]);
+
+  const showGraphView = resultView === 'graph' && hasResultGraph;
+  const showConceptChips = !showGraphView && Boolean(conceptResults);
+  const showResultTable =
+    !showGraphView && !showConceptChips && resultTable.variables.length > 0;
+  const showRawBody = !showGraphView && !showConceptChips && !showResultTable;
 
   return (
     <div data-testid="ontology-sparql-result">
@@ -127,7 +132,7 @@ const OntologyQueryResults = ({
         ) : null}
       </div>
 
-      {isGraphView ? (
+      {showGraphView && (
         <div
           className="tw:h-96 tw:overflow-hidden tw:rounded-lg tw:border tw:border-secondary tw:bg-primary"
           data-testid="ontology-sparql-result-graph">
@@ -147,7 +152,8 @@ const OntologyQueryResults = ({
             onPaneClick={NO_OP}
           />
         </div>
-      ) : conceptResults ? (
+      )}
+      {showConceptChips && conceptResults && (
         <div
           className="tw:flex tw:flex-wrap tw:gap-2"
           data-testid="ontology-sparql-chips">
@@ -159,7 +165,8 @@ const OntologyQueryResults = ({
             </span>
           ))}
         </div>
-      ) : resultTable.variables.length > 0 ? (
+      )}
+      {showResultTable && (
         <div className="tw:max-h-96 tw:overflow-auto tw:rounded-lg tw:border tw:border-secondary tw:bg-primary">
           <table className="tw:w-full tw:border-collapse tw:text-xs">
             <thead>
@@ -188,7 +195,8 @@ const OntologyQueryResults = ({
             </tbody>
           </table>
         </div>
-      ) : (
+      )}
+      {showRawBody && (
         <pre className="tw:m-0 tw:max-h-96 tw:overflow-auto tw:rounded-lg tw:border tw:border-secondary tw:bg-primary tw:p-3 tw:font-mono tw:text-xs tw:text-secondary">
           {result.body}
         </pre>

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyStudioQueryConsole.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyStudioQueryConsole.tsx
@@ -163,11 +163,15 @@ const OntologyStudioQueryConsole = ({
           : await runSparqlQuery(queryParams);
         setResult(nextResult);
       } catch (error) {
-        const message = isAxiosError(error)
-          ? typeof error.response?.data === 'string'
-            ? error.response.data
-            : error.message
-          : (error as Error).message;
+        let message: string;
+        if (isAxiosError(error)) {
+          message =
+            typeof error.response?.data === 'string'
+              ? error.response.data
+              : error.message;
+        } else {
+          message = (error as Error).message;
+        }
         setErrorMessage(message);
         showErrorToast(message);
       } finally {
@@ -303,6 +307,10 @@ const OntologyStudioQueryConsole = ({
     [deleteQueryTemplate]
   );
 
+  const templateSaveTitle = activeQueryId?.startsWith('template-')
+    ? t('label.update-sample-query')
+    : t('label.save-as-sample-query');
+
   return (
     <>
       <div
@@ -371,15 +379,17 @@ const OntologyStudioQueryConsole = ({
           <h3 className="tw:mb-2 tw:font-body tw:text-[10px] tw:leading-normal tw:font-semibold tw:tracking-[0.06em] tw:text-quaternary tw:uppercase">
             {t('label.installation-queries')}
           </h3>
-          {isLoading ? (
+          {isLoading && (
             <p className="tw:m-0 tw:px-1 tw:font-body tw:text-xs tw:text-quaternary">
               {t('label.loading')}
             </p>
-          ) : queryTemplates.length === 0 ? (
+          )}
+          {!isLoading && queryTemplates.length === 0 && (
             <p className="tw:m-0 tw:px-1 tw:font-body tw:text-xs tw:text-quaternary">
               {t('message.no-query-available')}
             </p>
-          ) : (
+          )}
+          {!isLoading && queryTemplates.length > 0 && (
             <div
               className="tw:flex tw:flex-col tw:gap-1"
               data-testid="ontology-query-template-list">
@@ -609,9 +619,7 @@ const OntologyStudioQueryConsole = ({
             data-testid="ontology-query-save-modal"
             title={
               saveTarget === 'template'
-                ? activeQueryId?.startsWith('template-')
-                  ? t('label.update-sample-query')
-                  : t('label.save-as-sample-query')
+                ? templateSaveTitle
                 : t('label.save-query')
             }
             width={480}

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyVisualQueryBuilder.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyVisualQueryBuilder.tsx
@@ -329,11 +329,15 @@ const OntologyVisualQueryBuilder = ({
         : await runSparqlQuery(queryParams);
       setMatchCount(result.parsed?.results?.bindings?.length ?? 0);
     } catch (error) {
-      const message = isAxiosError(error)
-        ? typeof error.response?.data === 'string'
-          ? error.response.data
-          : error.message
-        : (error as Error).message;
+      let message: string;
+      if (isAxiosError(error)) {
+        message =
+          typeof error.response?.data === 'string'
+            ? error.response.data
+            : error.message;
+      } else {
+        message = (error as Error).message;
+      }
       setErrorMessage(message);
       showErrorToast(message);
     } finally {

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/RelationshipTypePicker.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/RelationshipTypePicker.component.tsx
@@ -137,6 +137,45 @@ const RelationshipTypePicker: React.FC<RelationshipTypePickerProps> = ({
 
   const hasResults = systemTypes.length > 0 || customTypes.length > 0;
 
+  const renderRelationTypeList = () => {
+    if (isLoading) {
+      return (
+        <span className="tw:p-2 tw:font-body tw:text-xs tw:text-tertiary">
+          {t('label.loading')}
+        </span>
+      );
+    }
+
+    if (hasResults) {
+      return (
+        <>
+          {renderGroup(
+            t('label.core-owl-skos'),
+            'system-defined',
+            systemTypes,
+            onSelect,
+            t('label.inverse')
+          )}
+          {renderGroup(
+            t('label.custom-admin-defined'),
+            'custom',
+            customTypes,
+            onSelect,
+            t('label.inverse')
+          )}
+        </>
+      );
+    }
+
+    return (
+      <span
+        className="tw:p-2 tw:font-body tw:text-xs tw:text-tertiary"
+        data-testid="no-relation-types">
+        {t('message.no-data-available')}
+      </span>
+    );
+  };
+
   return (
     <div
       className={classNames(
@@ -183,34 +222,7 @@ const RelationshipTypePicker: React.FC<RelationshipTypePickerProps> = ({
       </div>
 
       <div className="tw:flex tw:max-h-64 tw:flex-col tw:overflow-auto tw:p-1.5">
-        {isLoading ? (
-          <span className="tw:p-2 tw:font-body tw:text-xs tw:text-tertiary">
-            {t('label.loading')}
-          </span>
-        ) : hasResults ? (
-          <>
-            {renderGroup(
-              t('label.core-owl-skos'),
-              'system-defined',
-              systemTypes,
-              onSelect,
-              t('label.inverse')
-            )}
-            {renderGroup(
-              t('label.custom-admin-defined'),
-              'custom',
-              customTypes,
-              onSelect,
-              t('label.inverse')
-            )}
-          </>
-        ) : (
-          <span
-            className="tw:p-2 tw:font-body tw:text-xs tw:text-tertiary"
-            data-testid="no-relation-types">
-            {t('message.no-data-available')}
-          </span>
-        )}
+        {renderRelationTypeList()}
       </div>
     </div>
   );

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/hooks/useGraphData.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/hooks/useGraphData.ts
@@ -538,25 +538,24 @@ export function useGraphDataBuilder({
       const shouldTruncateLabel =
         isInModelMode || (explorationMode === 'data' && !isDataAsset);
       const estimatedWidth = estimateNodeWidth(rawLabel);
-      const nodeWidth = studioMode
-        ? MODEL_NODE_MAX_WIDTH
-        : shouldTruncateLabel
+      const truncatedNodeWidth = shouldTruncateLabel
         ? Math.min(MODEL_NODE_MAX_WIDTH, estimatedWidth)
         : estimatedWidth;
+      const nodeWidth = studioMode ? MODEL_NODE_MAX_WIDTH : truncatedNodeWidth;
       const label = shouldTruncateLabel
         ? truncateNodeLabelByWidth(rawLabel, nodeWidth)
         : rawLabel;
       const studioAccentColor = studioMode
         ? getStudioNodeAccentColor(node)
         : undefined;
-      const pos =
-        explorationMode === 'hierarchy'
-          ? nodePositions?.[node.id]
-          : explorationMode === 'data'
-          ? isDataAsset
-            ? undefined
-            : dataModeTermPositions[node.id]
-          : undefined;
+      let pos: { x: number; y: number } | undefined;
+      if (explorationMode === 'hierarchy') {
+        pos = nodePositions?.[node.id];
+      } else if (explorationMode === 'data' && !isDataAsset) {
+        pos = dataModeTermPositions[node.id];
+      } else {
+        pos = undefined;
+      }
       const isSelected =
         explorationMode === 'hierarchy'
           ? node.termId === selectedNodeId || selectedNodeId === node.id
@@ -832,13 +831,12 @@ export function useGraphDataBuilder({
             isObservedLineage;
           const showLabel = settings.showEdgeLabels && isLabelableEdge;
 
-          const labelText = showLabel
-            ? singleEdge.inverseRelationType
-              ? `${formatRelationLabel(
-                  singleEdge.relationType
-                )} / ${formatRelationLabel(singleEdge.inverseRelationType)}`
-              : formatRelationLabel(singleEdge.relationType)
-            : undefined;
+          const relationLabelText = singleEdge.inverseRelationType
+            ? `${formatRelationLabel(
+                singleEdge.relationType
+              )} / ${formatRelationLabel(singleEdge.inverseRelationType)}`
+            : formatRelationLabel(singleEdge.relationType);
+          const labelText = showLabel ? relationLabelText : undefined;
           const displayLabel =
             studioMode && labelText ? labelText.toLocaleLowerCase() : labelText;
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/hooks/useOntologyExplorer.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/hooks/useOntologyExplorer.ts
@@ -497,11 +497,14 @@ export function useOntologyExplorer({
             .map((termNode) => termNode.glossaryId)
             .filter((id): id is string => Boolean(id))
         );
-        const requestedGlossaryIds = scopedGlossaryId
-          ? [scopedGlossaryId]
-          : glossaryFilterIds.length > 0
-          ? glossaryFilterIds.filter((id) => termGlossaryIds.has(id))
-          : [];
+        let requestedGlossaryIds: string[] = [];
+        if (scopedGlossaryId) {
+          requestedGlossaryIds = [scopedGlossaryId];
+        } else if (glossaryFilterIds.length > 0) {
+          requestedGlossaryIds = glossaryFilterIds.filter((id) =>
+            termGlossaryIds.has(id)
+          );
+        }
         const glossaryFqnsToFetch = requestedGlossaryIds
           .map(
             (id) =>

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/hooks/useOntologyGraph.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/hooks/useOntologyGraph.ts
@@ -942,11 +942,14 @@ export function useOntologyGraph({
               loadedAssetCount > 0 &&
               assetCount > DATA_MODE_ASSET_LOAD_PAGE_SIZE &&
               remaining > 0;
-            const badgeText = isLoadingAssets
-              ? '...'
-              : assetsExpanded
-              ? '\u2212'
-              : `+${assetCount}`;
+            let badgeText: string;
+            if (isLoadingAssets) {
+              badgeText = '...';
+            } else if (assetsExpanded) {
+              badgeText = '\u2212';
+            } else {
+              badgeText = `+${assetCount}`;
+            }
             const label = d?.label ?? datum.id;
             const badgeDiameterBase = isLoadingAssets
               ? DATA_MODE_TERM_ASSET_COUNT_BADGE_DIAMETER_WIDE

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/hooks/useOntologyGraphDerived.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/hooks/useOntologyGraphDerived.ts
@@ -434,14 +434,16 @@ export function useOntologyGraphDerived({
   const selectedGlossaryIds = withoutOntologyAutocompleteAll(
     filters.glossaryIds
   );
-  const exportableGlossaryId =
-    scope === 'glossary'
-      ? glossaryId
-      : scope === 'term'
-      ? termGlossaryId
-      : selectedGlossaryIds.length === 1
-      ? selectedGlossaryIds[0]
-      : undefined;
+  let exportableGlossaryId: string | undefined;
+  if (scope === 'glossary') {
+    exportableGlossaryId = glossaryId;
+  } else if (scope === 'term') {
+    exportableGlossaryId = termGlossaryId;
+  } else if (selectedGlossaryIds.length === 1) {
+    exportableGlossaryId = selectedGlossaryIds[0];
+  } else {
+    exportableGlossaryId = undefined;
+  }
 
   const exportableGlossaryName = exportableGlossaryId
     ? glossaries.find((g) => g.id === exportableGlossaryId)?.name ??

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/utils/graphStyles.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/utils/graphStyles.ts
@@ -557,27 +557,31 @@ export function getEdgeRelationLabelStyle(
     ? STUDIO_EDGE_BORDER_BY_COLOR[relationColor.toLowerCase()]
     : undefined;
 
+  const metaBackgroundFill = meta
+    ? getCanvasColor(meta.background, '#fafafa')
+    : getCanvasColor(EDGE_LABEL_BG_FILL, '#EFF1F8');
+  const metaBackgroundStroke = meta
+    ? 'none'
+    : getCanvasColor(EDGE_LABEL_BG_STROKE, '#FFF');
+  const metaBackgroundLineWidth = meta ? 0 : 1;
+  const metaBackgroundRadius = meta
+    ? EDGE_LABEL_BADGE_RADIUS
+    : EDGE_LABEL_BG_RADIUS;
+  const metaFontWeight = meta
+    ? EDGE_LABEL_BADGE_FONT_WEIGHT
+    : EDGE_LABEL_FONT_WEIGHT;
+
   return {
     labelText,
     labelPosition: 'center',
     labelBackground: true,
     labelBackgroundOpacity: 1,
-    labelBackgroundFill: studioMode
-      ? '#FFFFFF'
-      : meta
-      ? getCanvasColor(meta.background, '#fafafa')
-      : getCanvasColor(EDGE_LABEL_BG_FILL, '#EFF1F8'),
+    labelBackgroundFill: studioMode ? '#FFFFFF' : metaBackgroundFill,
     labelBackgroundStroke: studioMode
       ? studioBorderColor ?? '#E9EAEB'
-      : meta
-      ? 'none'
-      : getCanvasColor(EDGE_LABEL_BG_STROKE, '#FFF'),
-    labelBackgroundLineWidth: studioMode ? 1 : meta ? 0 : 1,
-    labelBackgroundRadius: studioMode
-      ? 9999
-      : meta
-      ? EDGE_LABEL_BADGE_RADIUS
-      : EDGE_LABEL_BG_RADIUS,
+      : metaBackgroundStroke,
+    labelBackgroundLineWidth: studioMode ? 1 : metaBackgroundLineWidth,
+    labelBackgroundRadius: studioMode ? 9999 : metaBackgroundRadius,
     labelPadding: edgeLabelPadding,
     labelBackgroundShadowColor: meta
       ? 'transparent'
@@ -589,11 +593,7 @@ export function getEdgeRelationLabelStyle(
       ? getCanvasColor(meta.color, '#717680')
       : getCanvasColor(EDGE_LABEL_FILL, '#8C93AE'),
     labelFontSize: EDGE_LABEL_FONT_SIZE,
-    labelFontWeight: studioMode
-      ? EDGE_LABEL_FONT_WEIGHT
-      : meta
-      ? EDGE_LABEL_BADGE_FONT_WEIGHT
-      : EDGE_LABEL_FONT_WEIGHT,
+    labelFontWeight: studioMode ? EDGE_LABEL_FONT_WEIGHT : metaFontWeight,
     labelFontFamily: EDGE_LABEL_FONT_FAMILY,
     labelLetterSpacing: EDGE_LABEL_LETTER_SPACING,
     labelAutoRotate: true,

--- a/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/SearchDropdown.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/SearchDropdown.tsx
@@ -345,108 +345,118 @@ const SearchDropdown: FC<SearchDropdownProps> = ({
   );
 
   const dropdownCardComponent = useCallback(
-    (menuNode: ReactNode) => (
-      <Card
-        bodyStyle={{ padding: 0 }}
-        className={classNames('custom-dropdown-render', dropdownClassName, {
-          'immediate-apply-dropdown': immediateApply,
-        })}
-        data-testid="drop-down-menu">
-        <Space className="w-full" direction="vertical" size={0}>
-          {!hideSearchBar && (
-            <div className="p-t-sm p-x-sm">
-              <Input
-                // eslint-disable-next-line jsx-a11y/no-autofocus -- focus the search box when the dropdown opens
-                autoFocus
-                data-testid="search-input"
-                placeholder={`${t('label.search-entity', {
-                  entity: label,
-                })}...`}
-                onChange={(e) => {
-                  const { value } = e.target;
-                  debouncedOnSearch(value);
-                }}
-              />
-            </div>
-          )}
-          {showClearAllBtn && (
-            <>
-              <Divider className="m-t-xs m-b-0" />
-              <Button
-                className="p-0 m-l-sm"
-                data-testid="clear-button"
-                type="link"
-                onClick={handleClear}>
-                {t('label.clear-entity', {
-                  entity: t('label.all'),
-                })}
-              </Button>
-            </>
-          )}
-          {!hideSearchBar && (
-            <Divider
-              className={classNames(showClearAllBtn ? 'm-y-0' : 'm-t-xs m-b-0')}
-            />
-          )}
+    (menuNode: ReactNode) => {
+      const helperTextContent = helperText ? (
+        <div
+          className="p-x-sm p-y-xss search-dropdown-helper-text"
+          data-testid="search-dropdown-helper-text">
+          <Typography.Text className="text-xs" type="secondary">
+            {helperText}
+          </Typography.Text>
+        </div>
+      ) : null;
 
-          {hasNullOption && (
-            <>
-              <div className="d-flex items-center m-x-sm m-y-xs gap-2">
-                {singleSelect ? (
-                  <Radio
-                    checked={nullOptionSelected}
-                    className="d-flex flex-1"
-                    data-testid="no-option-radio"
-                    onChange={(e) => handleNullOptionChange(e.target.checked)}>
-                    {nullLabelText}
-                  </Radio>
-                ) : (
-                  <Checkbox
-                    checked={nullOptionSelected}
-                    className="d-flex flex-1"
-                    data-testid="no-option-checkbox"
-                    onChange={(e) => handleNullOptionChange(e.target.checked)}>
-                    {nullLabelText}
-                  </Checkbox>
+      return (
+        <Card
+          bodyStyle={{ padding: 0 }}
+          className={classNames('custom-dropdown-render', dropdownClassName, {
+            'immediate-apply-dropdown': immediateApply,
+          })}
+          data-testid="drop-down-menu">
+          <Space className="w-full" direction="vertical" size={0}>
+            {!hideSearchBar && (
+              <div className="p-t-sm p-x-sm">
+                <Input
+                  // eslint-disable-next-line jsx-a11y/no-autofocus -- focus the search box when the dropdown opens
+                  autoFocus
+                  data-testid="search-input"
+                  placeholder={`${t('label.search-entity', {
+                    entity: label,
+                  })}...`}
+                  onChange={(e) => {
+                    const { value } = e.target;
+                    debouncedOnSearch(value);
+                  }}
+                />
+              </div>
+            )}
+            {showClearAllBtn && (
+              <>
+                <Divider className="m-t-xs m-b-0" />
+                <Button
+                  className="p-0 m-l-sm"
+                  data-testid="clear-button"
+                  type="link"
+                  onClick={handleClear}>
+                  {t('label.clear-entity', {
+                    entity: t('label.all'),
+                  })}
+                </Button>
+              </>
+            )}
+            {!hideSearchBar && (
+              <Divider
+                className={classNames(
+                  showClearAllBtn ? 'm-y-0' : 'm-t-xs m-b-0'
                 )}
-              </div>
+              />
+            )}
 
-              <Divider className="m-y-0" />
-            </>
-          )}
+            {hasNullOption && (
+              <>
+                <div className="d-flex items-center m-x-sm m-y-xs gap-2">
+                  {singleSelect ? (
+                    <Radio
+                      checked={nullOptionSelected}
+                      className="d-flex flex-1"
+                      data-testid="no-option-radio"
+                      onChange={(e) =>
+                        handleNullOptionChange(e.target.checked)
+                      }>
+                      {nullLabelText}
+                    </Radio>
+                  ) : (
+                    <Checkbox
+                      checked={nullOptionSelected}
+                      className="d-flex flex-1"
+                      data-testid="no-option-checkbox"
+                      onChange={(e) =>
+                        handleNullOptionChange(e.target.checked)
+                      }>
+                      {nullLabelText}
+                    </Checkbox>
+                  )}
+                </div>
 
-          {getDropdownBody(menuNode)}
-          {immediateApply ? (
-            helperText ? (
-              <div
-                className="p-x-sm p-y-xss search-dropdown-helper-text"
-                data-testid="search-dropdown-helper-text">
-                <Typography.Text className="text-xs" type="secondary">
-                  {helperText}
-                </Typography.Text>
-              </div>
-            ) : null
-          ) : (
-            <Space className="p-sm p-t-xss">
-              <Button
-                className="update-btn"
-                data-testid="update-btn"
-                size="small"
-                onClick={handleUpdate}>
-                {t('label.update')}
-              </Button>
-              <Button
-                data-testid="close-btn"
-                size="small"
-                type="link"
-                onClick={handleDropdownClose}>
-                {t('label.close')}
-              </Button>
-            </Space>
-          )}
-        </Space>
-      </Card>
-    ),
+                <Divider className="m-y-0" />
+              </>
+            )}
+
+            {getDropdownBody(menuNode)}
+            {immediateApply ? (
+              helperTextContent
+            ) : (
+              <Space className="p-sm p-t-xss">
+                <Button
+                  className="update-btn"
+                  data-testid="update-btn"
+                  size="small"
+                  onClick={handleUpdate}>
+                  {t('label.update')}
+                </Button>
+                <Button
+                  data-testid="close-btn"
+                  size="small"
+                  type="link"
+                  onClick={handleDropdownClose}>
+                  {t('label.close')}
+                </Button>
+              </Space>
+            )}
+          </Space>
+        </Card>
+      );
+    },
     [
       label,
       debouncedOnSearch,

--- a/openmetadata-ui/src/main/resources/ui/src/components/SearchSettings/EntitySeachSettings/EntitySearchSettings.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SearchSettings/EntitySeachSettings/EntitySearchSettings.tsx
@@ -374,13 +374,13 @@ const EntitySearchSettings = () => {
   ) => {
     updateRankingSettings((ranking) => ({
       ...ranking,
-      stages: (ranking.stages ?? []).map((stage, index) =>
-        index === stageIndex
-          ? weight === null
-            ? omit(stage, 'weight')
-            : { ...stage, weight }
-          : stage
-      ),
+      stages: (ranking.stages ?? []).map((stage, index) => {
+        if (index !== stageIndex) {
+          return stage;
+        }
+
+        return weight === null ? omit(stage, 'weight') : { ...stage, weight };
+      }),
     }));
   };
 
@@ -699,10 +699,11 @@ const EntitySearchSettings = () => {
     const stageTestId = stageName
       ? `ranking-stage-${stageName}`
       : `ranking-stage-unnamed-${stageIndex}`;
+    const minimumShouldMatchSuffix = stage.minimumShouldMatch
+      ? ` (${stage.minimumShouldMatch})`
+      : '';
     const matchType = stage.matchType
-      ? `${startCase(stage.matchType)}${
-          stage.minimumShouldMatch ? ` (${stage.minimumShouldMatch})` : ''
-        }`
+      ? `${startCase(stage.matchType)}${minimumShouldMatchSuffix}`
       : t('label.no-data');
 
     return (

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Bot/BotDetails/AuthMechanism.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Bot/BotDetails/AuthMechanism.tsx
@@ -64,6 +64,9 @@ const AuthMechanism: FC<Props> = ({
   }, [isBot, authenticationMechanism]);
 
   const { tokenExpiryDate, isTokenExpired } = getTokenExpiry(JWTTokenExpiresAt);
+  const tokenExpiryText = isTokenExpired
+    ? `Expired on ${tokenExpiryDate}.`
+    : `Expires on ${tokenExpiryDate}.`;
 
   return (
     <>
@@ -148,11 +151,7 @@ const AuthMechanism: FC<Props> = ({
           {!isSCIMBot && (
             <p className="text-grey-muted" data-testid="token-expiry">
               {JWTTokenExpiresAt ? (
-                isTokenExpired ? (
-                  `Expired on ${tokenExpiryDate}.`
-                ) : (
-                  `Expires on ${tokenExpiryDate}.`
-                )
+                tokenExpiryText
               ) : (
                 <>
                   <Icon

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Bot/BotListV1/BotListV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Bot/BotListV1/BotListV1.component.tsx
@@ -312,11 +312,12 @@ const BotListV1 = ({
         width: 90,
         render: (_, record) => {
           const isSystemBot = record.provider === ProviderType.System;
-          const title = isSystemBot
-            ? t('message.ingestion-bot-cant-be-deleted')
-            : isAdminUser
-            ? t('label.delete')
-            : t('message.admin-only-action');
+          let title = t('message.admin-only-action');
+          if (isSystemBot) {
+            title = t('message.ingestion-bot-cant-be-deleted');
+          } else if (isAdminUser) {
+            title = t('label.delete');
+          }
           const isDisabled = !isAdminUser || isSystemBot;
 
           return (

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/ContextRuleCard/ContextRuleCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/ContextRuleCard/ContextRuleCard.component.tsx
@@ -95,6 +95,59 @@ export const ContextRuleCard = ({
     onDelete();
   };
 
+  const conditionSummary =
+    conditionCount > 0 ? (
+      <Typography
+        as="span"
+        className="tw:rounded-md tw:bg-secondary tw:px-2 tw:py-0.5 tw:font-mono tw:text-secondary"
+        size="text-xs"
+        weight="medium">
+        {t('message.persona-context-condition-count', {
+          count: conditionCount,
+        })}
+      </Typography>
+    ) : (
+      <Typography
+        as="span"
+        className="tw:inline-flex tw:items-center tw:gap-1.5 tw:rounded-md tw:border tw:border-dashed tw:border-primary tw:px-2.5 tw:py-0.5 tw:text-tertiary"
+        size="text-xs"
+        weight="medium">
+        <FilterLines className="tw:size-3.5 tw:text-quaternary" />
+        {t('label.all-entity', {
+          entity: entityLabelPlural,
+        })}
+      </Typography>
+    );
+  const conditionContent = conditionParts ? (
+    <>
+      <Typography
+        as="span"
+        className="tw:rounded-md tw:bg-secondary tw:px-2 tw:py-0.5 tw:font-mono tw:text-secondary"
+        size="text-xs"
+        weight="medium">
+        {conditionParts.field}
+      </Typography>
+      <Typography
+        as="span"
+        className="tw:text-quaternary"
+        size="text-xs"
+        weight="semibold">
+        {conditionParts.operator}
+      </Typography>
+      {conditionParts.value && (
+        <Typography
+          as="span"
+          className="tw:rounded-md tw:border tw:border-brand tw:bg-brand-primary tw:px-2 tw:py-0.5 tw:font-mono tw:text-brand-secondary"
+          size="text-xs"
+          weight="medium">
+          {conditionParts.value}
+        </Typography>
+      )}
+    </>
+  ) : (
+    conditionSummary
+  );
+
   return (
     <Card
       className="tw:flex tw:gap-4 tw:rounded-[10px] tw:px-4.5 tw:py-4 tw:shadow-xs"
@@ -113,54 +166,7 @@ export const ContextRuleCard = ({
         </Box>
 
         <Box align="center" gap={2} wrap="wrap">
-          {conditionParts ? (
-            <>
-              <Typography
-                as="span"
-                className="tw:rounded-md tw:bg-secondary tw:px-2 tw:py-0.5 tw:font-mono tw:text-secondary"
-                size="text-xs"
-                weight="medium">
-                {conditionParts.field}
-              </Typography>
-              <Typography
-                as="span"
-                className="tw:text-quaternary"
-                size="text-xs"
-                weight="semibold">
-                {conditionParts.operator}
-              </Typography>
-              {conditionParts.value && (
-                <Typography
-                  as="span"
-                  className="tw:rounded-md tw:border tw:border-brand tw:bg-brand-primary tw:px-2 tw:py-0.5 tw:font-mono tw:text-brand-secondary"
-                  size="text-xs"
-                  weight="medium">
-                  {conditionParts.value}
-                </Typography>
-              )}
-            </>
-          ) : conditionCount > 0 ? (
-            <Typography
-              as="span"
-              className="tw:rounded-md tw:bg-secondary tw:px-2 tw:py-0.5 tw:font-mono tw:text-secondary"
-              size="text-xs"
-              weight="medium">
-              {t('message.persona-context-condition-count', {
-                count: conditionCount,
-              })}
-            </Typography>
-          ) : (
-            <Typography
-              as="span"
-              className="tw:inline-flex tw:items-center tw:gap-1.5 tw:rounded-md tw:border tw:border-dashed tw:border-primary tw:px-2.5 tw:py-0.5 tw:text-tertiary"
-              size="text-xs"
-              weight="medium">
-              <FilterLines className="tw:size-3.5 tw:text-quaternary" />
-              {t('label.all-entity', {
-                entity: entityLabelPlural,
-              })}
-            </Typography>
-          )}
+          {conditionContent}
         </Box>
 
         <Box align="center" className="tw:gap-1.5" wrap="wrap">

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/ContextRuleEditor/ContextRuleEditor.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/ContextRuleEditor/ContextRuleEditor.component.tsx
@@ -198,6 +198,14 @@ export const ContextRuleEditor = ({
 
   const sectionsDisabled = fullyRendered || isKnowledgeRule;
 
+  const nonKnowledgeFullyRenderedKey =
+    entityType === EntityType.DATA_PRODUCT
+      ? 'message.persona-context-data-product-fully-rendered-description'
+      : 'message.persona-context-fully-rendered-description';
+  const fullyRenderedDescriptionKey = isKnowledgeRule
+    ? 'message.persona-context-knowledge-fully-rendered'
+    : nonKnowledgeFullyRenderedKey;
+
   useEffect(() => {
     if (!open) {
       previewRequestRef.current++;
@@ -532,13 +540,7 @@ export const ContextRuleEditor = ({
                   {t('label.fully-rendered')}
                 </Typography>
                 <Typography className="tw:text-[12px] tw:text-quaternary">
-                  {t(
-                    isKnowledgeRule
-                      ? 'message.persona-context-knowledge-fully-rendered'
-                      : entityType === EntityType.DATA_PRODUCT
-                      ? 'message.persona-context-data-product-fully-rendered-description'
-                      : 'message.persona-context-fully-rendered-description'
-                  )}
+                  {t(fullyRenderedDescriptionKey)}
                 </Typography>
               </Box>
               <Toggle

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/AccessTokenCard/AccessTokenCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/AccessTokenCard/AccessTokenCard.component.tsx
@@ -307,13 +307,15 @@ const AccessTokenCard: FC<MockProps> = ({
     </Card>
   );
 
-  return isLoading ? (
-    <Loader />
-  ) : disabled ? (
-    <Tooltip title="Upgrade to use this feature">{tokenCard}</Tooltip>
-  ) : (
-    tokenCard
-  );
+  if (isLoading) {
+    return <Loader />;
+  }
+
+  if (disabled) {
+    return <Tooltip title="Upgrade to use this feature">{tokenCard}</Tooltip>;
+  }
+
+  return tokenCard;
 };
 
 export default AccessTokenCard;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/CreateUser/CreateUser.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/CreateUser/CreateUser.component.tsx
@@ -250,6 +250,27 @@ const CreateUser = ({
       allowImpersonation,
     } = values;
 
+    let authMechanismConfig: Partial<CreateUserFormData> = {};
+    if (forceBot) {
+      authMechanismConfig = {
+        authenticationMechanism: {
+          authType: AuthType.Jwt,
+          config: {
+            JWTTokenExpiry: tokenExpiry,
+          },
+        },
+        allowImpersonation,
+      };
+    } else if (isAuthProviderBasic) {
+      authMechanismConfig = {
+        password: isPasswordGenerated ? generatedPassword : password,
+        confirmPassword: isPasswordGenerated
+          ? generatedPassword
+          : confirmPassword,
+        createPasswordType: CreatePasswordType.AdminCreate,
+      };
+    }
+
     const userProfile: CreateUserFormData = {
       description,
       name: email.split('@')[0],
@@ -261,25 +282,7 @@ const CreateUser = ({
       isAdmin: isAdmin,
       domains: selectedDomain.map((domain) => domain.fullyQualifiedName ?? ''),
       isBot: isBot,
-      ...(forceBot
-        ? {
-            authenticationMechanism: {
-              authType: AuthType.Jwt,
-              config: {
-                JWTTokenExpiry: tokenExpiry,
-              },
-            },
-            allowImpersonation,
-          }
-        : isAuthProviderBasic
-        ? {
-            password: isPasswordGenerated ? generatedPassword : password,
-            confirmPassword: isPasswordGenerated
-              ? generatedPassword
-              : confirmPassword,
-            createPasswordType: CreatePasswordType.AdminCreate,
-          }
-        : {}),
+      ...authMechanismConfig,
     };
     onSave(userProfile);
   };

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UsersProfile/UserPermissions/UserPermissions.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UsersProfile/UserPermissions/UserPermissions.component.tsx
@@ -135,41 +135,38 @@ const UserPermissions: React.FC<UserPermissionsProps> = ({
     </div>
   );
 
-  const renderPolicy = (policy: PolicyInfo, index: number) => (
-    <Collapse ghost className="policy-collapse" key={index}>
-      <Panel
-        header={
-          <Space>
-            <Link
-              to={getEntityLink(
-                'policy',
-                policy.policy.fullyQualifiedName || ''
-              )}>
-              {getEntityName(policy.policy)}
-            </Link>
-            <Tag
-              color={
-                policy.effect === 'ALLOW'
-                  ? 'success'
-                  : policy.effect === 'DENY'
-                  ? 'error'
-                  : 'warning'
-              }>
-              {policy.effect}
-            </Tag>
-            <Text type="secondary">
-              <span>{policy.rules.length}</span>
-              {t('label.rule-lowercase-plural')}
-            </Text>
-          </Space>
-        }
-        key={index}>
-        <div className="rules-container">
-          {policy.rules.map((rule, ruleIndex) => renderRule(rule, ruleIndex))}
-        </div>
-      </Panel>
-    </Collapse>
-  );
+  const renderPolicy = (policy: PolicyInfo, index: number) => {
+    const nonAllowPolicyColor = policy.effect === 'DENY' ? 'error' : 'warning';
+    const policyTagColor =
+      policy.effect === 'ALLOW' ? 'success' : nonAllowPolicyColor;
+
+    return (
+      <Collapse ghost className="policy-collapse" key={index}>
+        <Panel
+          header={
+            <Space>
+              <Link
+                to={getEntityLink(
+                  'policy',
+                  policy.policy.fullyQualifiedName || ''
+                )}>
+                {getEntityName(policy.policy)}
+              </Link>
+              <Tag color={policyTagColor}>{policy.effect}</Tag>
+              <Text type="secondary">
+                <span>{policy.rules.length}</span>
+                {t('label.rule-lowercase-plural')}
+              </Text>
+            </Space>
+          }
+          key={index}>
+          <div className="rules-container">
+            {policy.rules.map((rule, ruleIndex) => renderRule(rule, ruleIndex))}
+          </div>
+        </Panel>
+      </Collapse>
+    );
+  };
 
   const renderDirectRoles = () => {
     if (isEmpty(permissionInfo?.directRoles)) {

--- a/openmetadata-ui/src/main/resources/ui/src/components/SettingsSso/SSOConfigurationForm/SsoConfigurationFormArrayFieldTemplate.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SettingsSso/SSOConfigurationForm/SsoConfigurationFormArrayFieldTemplate.tsx
@@ -174,11 +174,12 @@ const SsoConfigurationFormArrayFieldTemplate = (props: FieldProps) => {
   const handleChange = useCallback(
     (newValue: string[]) => {
       // Handle scope field conversion from array (UI) to string (backend)
-      const convertedValue = isScopeField
-        ? Array.isArray(newValue)
+      let convertedValue: string | string[] = newValue;
+      if (isScopeField) {
+        convertedValue = Array.isArray(newValue)
           ? newValue.join(' ')
-          : newValue
-        : newValue;
+          : newValue;
+      }
 
       props.onChange(convertedValue);
       // Clear field-specific error when value changes

--- a/openmetadata-ui/src/main/resources/ui/src/components/SettingsSso/SsoTestLogin/SsoTestLoginModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SettingsSso/SsoTestLogin/SsoTestLoginModal.tsx
@@ -96,13 +96,16 @@ const SsoTestLoginModal = ({
       );
     } else if (result) {
       const isSuccess = result.status === Status.Success;
-      const description = isSuccess
-        ? t('message.sso-test-login-success', {
-            email: result.resolvedEmail ?? '',
-          })
-        : !isEmpty(result.errors)
-        ? (result.errors ?? []).join(' ')
-        : t('message.sso-test-login-failed');
+      let description: string;
+      if (isSuccess) {
+        description = t('message.sso-test-login-success', {
+          email: result.resolvedEmail ?? '',
+        });
+      } else if (!isEmpty(result.errors)) {
+        description = (result.errors ?? []).join(' ');
+      } else {
+        description = t('message.sso-test-login-failed');
+      }
       content = (
         <Space className="w-full" direction="vertical" size={12}>
           <InlineAlert

--- a/openmetadata-ui/src/main/resources/ui/src/components/SparqlQueryConsole/SparqlQueryConsole.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SparqlQueryConsole/SparqlQueryConsole.component.tsx
@@ -175,11 +175,13 @@ const SparqlQueryConsole: React.FC<SparqlQueryConsoleProps> = ({
       const r = await runSparqlQuery({ query, format, inference });
       setResult(r);
     } catch (e) {
-      const message = isAxiosError(e)
-        ? typeof e.response?.data === 'string'
-          ? e.response.data
-          : e.message
-        : (e as Error).message;
+      let message: string;
+      if (isAxiosError(e)) {
+        message =
+          typeof e.response?.data === 'string' ? e.response.data : e.message;
+      } else {
+        message = (e as Error).message;
+      }
       setErrorMessage(message);
       showErrorToast(message);
     } finally {
@@ -310,6 +312,12 @@ const SparqlQueryConsole: React.FC<SparqlQueryConsoleProps> = ({
       value: (row[variable] as Binding | undefined)?.value ?? '',
     }));
   }, [tabularResult]);
+
+  const templateSaveTitle = activeTemplateId
+    ? t('label.update-sample-query')
+    : t('label.save-as-sample-query');
+  const modalTitle =
+    saveTarget === 'template' ? templateSaveTitle : t('label.save-query');
 
   return (
     <>
@@ -443,7 +451,7 @@ const SparqlQueryConsole: React.FC<SparqlQueryConsoleProps> = ({
                   {t('label.download')}
                 </Button>
               </div>
-              {conceptChips ? (
+              {conceptChips && (
                 <div
                   className="tw:flex tw:flex-wrap tw:gap-2"
                   data-testid="sparql-chips">
@@ -464,7 +472,8 @@ const SparqlQueryConsole: React.FC<SparqlQueryConsoleProps> = ({
                     ))
                   )}
                 </div>
-              ) : tabularResult ? (
+              )}
+              {!conceptChips && tabularResult && (
                 <div
                   className="tw:max-h-[420px] tw:overflow-auto tw:rounded-md tw:border tw:border-utility-gray-200"
                   data-testid="sparql-table">
@@ -504,7 +513,8 @@ const SparqlQueryConsole: React.FC<SparqlQueryConsoleProps> = ({
                     </div>
                   ) : null}
                 </div>
-              ) : (
+              )}
+              {!conceptChips && !tabularResult && (
                 <pre
                   className={classNames(
                     'tw:max-h-[420px] tw:overflow-auto tw:rounded-md tw:border tw:border-utility-gray-200 tw:bg-secondary tw:p-3 tw:text-xs'
@@ -525,15 +535,17 @@ const SparqlQueryConsole: React.FC<SparqlQueryConsoleProps> = ({
             weight="semibold">
             {t('label.installation-queries')}
           </Typography>
-          {isLoading ? (
+          {isLoading && (
             <Typography as="p" className="tw:text-tertiary" size="text-xs">
               {t('label.loading')}
             </Typography>
-          ) : queryTemplates.length === 0 ? (
+          )}
+          {!isLoading && queryTemplates.length === 0 && (
             <Typography as="p" className="tw:text-tertiary" size="text-xs">
               {t('message.no-query-available')}
             </Typography>
-          ) : (
+          )}
+          {!isLoading && queryTemplates.length !== 0 && (
             <ul className="tw:flex tw:flex-col tw:gap-1">
               {queryTemplates.map((queryTemplate) => (
                 <li
@@ -625,13 +637,7 @@ const SparqlQueryConsole: React.FC<SparqlQueryConsoleProps> = ({
           <Dialog
             showCloseButton
             data-testid="sparql-save-modal"
-            title={
-              saveTarget === 'template'
-                ? activeTemplateId
-                  ? t('label.update-sample-query')
-                  : t('label.save-as-sample-query')
-                : t('label.save-query')
-            }
+            title={modalTitle}
             width={480}
             onClose={() => setIsSaveModalOpen(false)}>
             <Dialog.Content>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Visualisations/Chart/CardinalityDistributionChart.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Visualisations/Chart/CardinalityDistributionChart.component.tsx
@@ -82,14 +82,19 @@ const CustomYAxisTick = ({
   const isSelected = selectedCategory === categoryName;
   const isHighlighted = selectedCategory && selectedCategory !== categoryName;
 
+  let tickFill = GRAY_600;
+  if (isSelected) {
+    tickFill = CHART_BLUE_1;
+  } else if (isHighlighted) {
+    tickFill = COLOR_GREY_400;
+  }
+
   return (
     <g transform={`translate(${x},${y})`}>
       <text
         cursor="pointer"
         dy={4}
-        fill={
-          isSelected ? CHART_BLUE_1 : isHighlighted ? COLOR_GREY_400 : GRAY_600
-        }
+        fill={tickFill}
         fontSize={12}
         fontWeight={isSelected ? 600 : 400}
         opacity={isHighlighted ? 0.5 : 1}
@@ -309,16 +314,15 @@ const CardinalityDistributionChart = ({
                                 selectedCategory &&
                                 selectedCategory !== entry.name;
 
+                              let cellFill = CHART_BLUE_1;
+                              if (!isSelected && isHighlighted) {
+                                cellFill = COLOR_GREY_300;
+                              }
+
                               return (
                                 <Cell
                                   cursor="pointer"
-                                  fill={
-                                    isSelected
-                                      ? CHART_BLUE_1
-                                      : isHighlighted
-                                      ? COLOR_GREY_300
-                                      : CHART_BLUE_1
-                                  }
+                                  fill={cellFill}
                                   key={`cell-${entry.name}`}
                                   opacity={isHighlighted ? 0.3 : 1}
                                   onClick={() =>

--- a/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/WorkflowCanvas.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/WorkflowCanvas.tsx
@@ -145,6 +145,8 @@ const WorkflowCanvasInternal: React.FC<WorkflowCanvasProps> = ({
             );
           }
 
+          const dimmedEdgeOpacity = isConnectionModalOpen ? 0.15 : 0.3;
+
           return {
             ...edge,
             type: edge.type || 'straight',
@@ -156,7 +158,7 @@ const WorkflowCanvasInternal: React.FC<WorkflowCanvasProps> = ({
             style: {
               strokeWidth: edge.style?.strokeWidth || 2,
               ...edge.style,
-              opacity: shouldDimEdge ? (isConnectionModalOpen ? 0.15 : 0.3) : 1,
+              opacity: shouldDimEdge ? dimmedEdgeOpacity : 1,
               transition: 'opacity 0.3s ease',
             },
             labelStyle: {
@@ -200,11 +202,13 @@ const WorkflowCanvasInternal: React.FC<WorkflowCanvasProps> = ({
             nodeCursor = 'pointer';
           }
 
+          const dimmedNodeOpacity = isConnectionModalOpen ? 0.15 : 0.3;
+
           return {
             ...node,
             style: {
               ...node.style,
-              opacity: shouldDimNode ? (isConnectionModalOpen ? 0.15 : 0.3) : 1,
+              opacity: shouldDimNode ? dimmedNodeOpacity : 1,
               transition: 'opacity 0.3s ease',
               cursor: nodeCursor,
             },

--- a/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/ConditionBuilder/ConditionBuilder.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/ConditionBuilder/ConditionBuilder.tsx
@@ -183,9 +183,11 @@ function ConditionBuilderValueControl(
   }
 
   const options = hasFetchOptions ? asyncOptions : staticOptions;
-  const items: SelectItemType[] = (
-    hasFetchOptions ? (loading ? [] : asyncOptions) : staticOptions
-  ).map((o) => ({ id: o.value, label: o.label }));
+  const itemsSource = hasFetchOptions && loading ? [] : options;
+  const items: SelectItemType[] = itemsSource.map((o) => ({
+    id: o.value,
+    label: o.label,
+  }));
 
   return (
     <Autocomplete

--- a/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/CronExpressionBuilder.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/CronExpressionBuilder.tsx
@@ -116,8 +116,12 @@ const generateDescription = (cronConfig: CronConfig): string => {
   const hourNum = parseInt(hour);
   const minuteNum = parseInt(minute);
   const ampm = hourNum >= 12 ? 'PM' : 'AM';
-  const displayHour =
-    hourNum === 0 ? 12 : hourNum > 12 ? hourNum - 12 : hourNum;
+  let displayHour = hourNum;
+  if (hourNum === 0) {
+    displayHour = 12;
+  } else if (hourNum > 12) {
+    displayHour = hourNum - 12;
+  }
   const timeStr = `${displayHour}:${minute} ${ampm}`;
 
   if (every === 'Hour') {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CertificationWidget/CertificationWidget.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CertificationWidget/CertificationWidget.tsx
@@ -58,21 +58,21 @@ const CertificationWidget = () => {
     }
   };
 
-  const headerExtra = canEdit ? (
-    entity.certification ? (
-      <WidgetEditButton
-        data-testid="edit-certification"
-        title={t('label.edit-entity', { entity: t('label.certification') })}
-        onClick={() => setIsEditing(true)}
-      />
-    ) : (
-      <WidgetPlusButton
-        data-testid="add-certification"
-        title={t('label.add-entity', { entity: t('label.certification') })}
-        onClick={() => setIsEditing(true)}
-      />
-    )
-  ) : null;
+  const certificationButton = entity.certification ? (
+    <WidgetEditButton
+      data-testid="edit-certification"
+      title={t('label.edit-entity', { entity: t('label.certification') })}
+      onClick={() => setIsEditing(true)}
+    />
+  ) : (
+    <WidgetPlusButton
+      data-testid="add-certification"
+      title={t('label.add-entity', { entity: t('label.certification') })}
+      onClick={() => setIsEditing(true)}
+    />
+  );
+
+  const headerExtra = canEdit ? certificationButton : null;
 
   const content = (
     <Certification

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DomainLabel/DomainLabel.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DomainLabel/DomainLabel.component.tsx
@@ -70,13 +70,17 @@ export const DomainLabel = ({
       try {
         const entityDetailsResponse = await entityDetails;
         if (entityDetailsResponse) {
+          let domains: EntityReference[];
+          if (Array.isArray(selectedDomain)) {
+            domains = selectedDomain;
+          } else if (isEmpty(selectedDomain)) {
+            domains = [];
+          } else {
+            domains = [selectedDomain];
+          }
           const jsonPatch = compare(entityDetailsResponse, {
             ...entityDetailsResponse,
-            domains: Array.isArray(selectedDomain)
-              ? selectedDomain
-              : isEmpty(selectedDomain)
-              ? []
-              : [selectedDomain],
+            domains,
           });
 
           const api = getAPIfromSource(entityType as AssetsUnion);

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DomainsSection/DomainsSection.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DomainsSection/DomainsSection.tsx
@@ -122,11 +122,14 @@ const DomainsSection: React.FC<DomainsSectionProps> = ({
           return;
         }
 
-        const domainsToSave = Array.isArray(selectedDomain)
-          ? selectedDomain
-          : isEmpty(selectedDomain)
-          ? []
-          : [selectedDomain];
+        let domainsToSave: EntityReference[];
+        if (Array.isArray(selectedDomain)) {
+          domainsToSave = selectedDomain;
+        } else if (isEmpty(selectedDomain)) {
+          domainsToSave = [];
+        } else {
+          domainsToSave = [selectedDomain];
+        }
 
         // Create JSON patch
         const jsonPatch = compare(entityDetailsResponse, {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityDescription/EntityAttachmentProvider/EntityAttachmentProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityDescription/EntityAttachmentProvider/EntityAttachmentProvider.tsx
@@ -207,16 +207,15 @@ export const EntityAttachmentProvider = ({
           view.dispatch(currentTr);
         }
 
-        showInlineAlert
-          ? setErrorMessage(
-              !isUndefined(errorMessage) && isString(errorMessage)
-                ? errorMessage
-                : t('label.failed-to-upload-file')
-            )
-          : showErrorToast(
-              error as AxiosError,
-              t('label.failed-to-upload-file')
-            );
+        if (showInlineAlert) {
+          const inlineErrorMessage =
+            !isUndefined(errorMessage) && isString(errorMessage)
+              ? errorMessage
+              : t('label.failed-to-upload-file');
+          setErrorMessage(inlineErrorMessage);
+        } else {
+          showErrorToast(error as AxiosError, t('label.failed-to-upload-file'));
+        }
       }
     },
     [onImageUpload, allowImageUpload, allowFileUpload, entityType, entityFqn, t]

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityDetailHeader/EntityDetailHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityDetailHeader/EntityDetailHeader.component.tsx
@@ -65,6 +65,16 @@ const EntityDetailHeader = ({
     onTabChange?.(String(key));
   };
 
+  const iconElement = icon ? (
+    <FeaturedIcon
+      color="brand"
+      icon={icon}
+      shape="square"
+      size="md"
+      theme="gradient"
+    />
+  ) : undefined;
+
   const resolvedLeading =
     leading ??
     (serviceLogoUrl ? (
@@ -78,15 +88,9 @@ const EntityDetailHeader = ({
           src={serviceLogoUrl}
         />
       </Box>
-    ) : icon ? (
-      <FeaturedIcon
-        color="brand"
-        icon={icon}
-        shape="square"
-        size="md"
-        theme="gradient"
-      />
-    ) : undefined);
+    ) : (
+      iconElement
+    ));
 
   const actions =
     primaryAction || secondaryActions ? (

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.tsx
@@ -513,6 +513,11 @@ export const CsvJobsTray = () => {
               const percent = getJobPercent(job);
               const variant = getStatusVariant(job.status);
               const KindIcon = getKindIcon(job.operation);
+              const nonRunningIcon = downloadedJobIds.has(job.jobId) ? (
+                <Check size={16} />
+              ) : (
+                <KindIcon size={16} />
+              );
 
               return (
                 <div
@@ -521,13 +526,9 @@ export const CsvJobsTray = () => {
                   key={job.jobId}>
                   <div className="csv-jobs-tray-item-row">
                     <span className="csv-jobs-tray-kind-icon">
-                      {variant === 'running' ? (
-                        renderStatusIcon(job)
-                      ) : downloadedJobIds.has(job.jobId) ? (
-                        <Check size={16} />
-                      ) : (
-                        <KindIcon size={16} />
-                      )}
+                      {variant === 'running'
+                        ? renderStatusIcon(job)
+                        : nonRunningIcon}
                     </span>
                     <div className="csv-jobs-tray-body">
                       <span className="tw:flex tw:min-w-0 tw:items-center tw:gap-1.5">

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntitySummaryDetails/EntitySummaryDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntitySummaryDetails/EntitySummaryDetails.tsx
@@ -17,7 +17,7 @@ import Tooltip from 'antd/lib/tooltip';
 import classNames from 'classnames';
 import { isEmpty, isString, isUndefined, lowerCase, toLower } from 'lodash';
 import { ExtraInfo } from 'Models';
-import { Fragment, useMemo } from 'react';
+import { ReactNode, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as IconExternalLink } from '../../../assets/svg/external-links.svg';
 import { ReactComponent as DomainIcon } from '../../../assets/svg/ic-domain.svg';
@@ -76,42 +76,42 @@ const EntitySummaryDetails = ({ data }: GetInfoElementsProps) => {
   switch (data.key) {
     case 'Owner':
       {
+        const ownerPrefix =
+          !isUndefined(userDetails) && isEntityDetails ? (
+            <>
+              <ProfilePicture
+                displayName={userDetails.ownerName}
+                name={userDetails.ownerName ?? ''}
+                width="24"
+              />
+              <span data-testid="owner-link">{userDetails.ownerName}</span>
+              <span className="m-r-xss d-inline-block text-grey-muted">
+                {t('label.pipe-symbol')}
+              </span>
+            </>
+          ) : null;
+        let ownerContent: ReactNode = <></>;
+        if (isString(displayVal)) {
+          const ownerAvatar = isTeamOwner ? (
+            <IconTeamsGrey className="align-middle" height={18} width={18} />
+          ) : (
+            <ProfilePicture
+              displayName={displayVal}
+              name={data.profileName ?? ''}
+              width={data.avatarWidth ?? '24'}
+            />
+          );
+          ownerContent = (
+            <>
+              {ownerPrefix}
+              {ownerAvatar}
+            </>
+          );
+        }
+
         retVal =
           displayVal && displayVal !== '--' ? (
-            isString(displayVal) ? (
-              <Fragment>
-                {!isUndefined(userDetails) && isEntityDetails && (
-                  <>
-                    <ProfilePicture
-                      displayName={userDetails.ownerName}
-                      name={userDetails.ownerName ?? ''}
-                      width="24"
-                    />
-                    <span data-testid="owner-link">
-                      {userDetails.ownerName}
-                    </span>
-                    <span className="m-r-xss d-inline-block text-grey-muted">
-                      {t('label.pipe-symbol')}
-                    </span>
-                  </>
-                )}
-                {isTeamOwner ? (
-                  <IconTeamsGrey
-                    className="align-middle"
-                    height={18}
-                    width={18}
-                  />
-                ) : (
-                  <ProfilePicture
-                    displayName={displayVal}
-                    name={data.profileName ?? ''}
-                    width={data.avatarWidth ?? '24'}
-                  />
-                )}
-              </Fragment>
-            ) : (
-              <></>
-            )
+            ownerContent
           ) : (
             <span
               className="d-flex gap-1 items-center"
@@ -162,26 +162,96 @@ const EntitySummaryDetails = ({ data }: GetInfoElementsProps) => {
       break;
     default:
       {
-        retVal = (
-          <>
-            {data.key
-              ? displayVal
-                ? data.showLabel
-                  ? `${t(`label.${toLower(data.key)}`)} - `
-                  : null
-                : `${t('label.no-entity', {
-                    entity: t(
-                      `label.${toLower(
-                        data.localizationKey ? data.localizationKey : data.key
-                      )}`
-                    ),
-                  })}`
-              : null}
-          </>
-        );
+        let defaultLabel: string | null = null;
+        if (data.key) {
+          if (displayVal) {
+            defaultLabel = data.showLabel
+              ? `${t(`label.${toLower(data.key)}`)} - `
+              : null;
+          } else {
+            defaultLabel = `${t('label.no-entity', {
+              entity: t(
+                `label.${toLower(
+                  data.localizationKey ? data.localizationKey : data.key
+                )}`
+              ),
+            })}`;
+          }
+        }
+
+        retVal = <>{defaultLabel}</>;
       }
 
       break;
+  }
+
+  let displayValueContent = <span>{displayVal}</span>;
+  if (data.isLink) {
+    displayValueContent = (
+      <>
+        <a
+          className={classNames(
+            'd-inline-block truncate link-text align-middle',
+            {
+              'w-52': (displayVal as string).length > 32,
+            }
+          )}
+          data-testid={`${lowerCase(data.key)}-link`}
+          href={data.value as string}
+          rel="noopener noreferrer"
+          target={data.openInNewTab ? '_blank' : '_self'}
+          onClick={(e) => {
+            e.stopPropagation();
+          }}>
+          {displayVal}
+          {data.openInNewTab && (
+            <>
+              &nbsp;
+              <Icon component={IconExternalLink} style={ICON_DIMENSION} />
+            </>
+          )}
+        </a>
+
+        {isEntityDetails && !isUndefined(userDetails) ? (
+          <InfoIcon
+            content={
+              displayVal
+                ? `${t('message.entity-owned-by-name', {
+                    entityOwner: displayVal ?? '',
+                  })}
+                        
+                        ${t('message.and-followed-owned-by-name', {
+                          userName: !isUndefined(userDetails)
+                            ? userDetails.ownerName
+                            : '',
+                        })}`
+                : ''
+            }
+          />
+        ) : null}
+      </>
+    );
+  } else if (isOwner) {
+    displayValueContent = (
+      <div className="d-flex" data-testid="owner-link">
+        {displayVal}
+      </div>
+    );
+  } else if (isTier) {
+    displayValueContent = (
+      <Space
+        className={classNames(
+          'd-inline-block truncate link-text align-middle',
+          {
+            'w-52': (displayVal as string).length > 32,
+          }
+        )}
+        data-testid="tier-name"
+        direction="horizontal"
+        title={displayVal as string}>
+        <span data-testid="Tier">{displayVal}</span>
+      </Space>
+    );
   }
 
   return (
@@ -190,73 +260,7 @@ const EntitySummaryDetails = ({ data }: GetInfoElementsProps) => {
       data-testid="entity-summary-details"
       direction="horizontal">
       {retVal}
-      {displayVal && (
-        <Fragment>
-          {data.isLink ? (
-            <Fragment>
-              <a
-                className={classNames(
-                  'd-inline-block truncate link-text align-middle',
-                  {
-                    'w-52': (displayVal as string).length > 32,
-                  }
-                )}
-                data-testid={`${lowerCase(data.key)}-link`}
-                href={data.value as string}
-                rel="noopener noreferrer"
-                target={data.openInNewTab ? '_blank' : '_self'}
-                onClick={(e) => {
-                  e.stopPropagation();
-                }}>
-                {displayVal}
-                {data.openInNewTab && (
-                  <>
-                    &nbsp;
-                    <Icon component={IconExternalLink} style={ICON_DIMENSION} />
-                  </>
-                )}
-              </a>
-
-              {isEntityDetails && !isUndefined(userDetails) ? (
-                <InfoIcon
-                  content={
-                    displayVal
-                      ? `${t('message.entity-owned-by-name', {
-                          entityOwner: displayVal ?? '',
-                        })}
-                        
-                        ${t('message.and-followed-owned-by-name', {
-                          userName: !isUndefined(userDetails)
-                            ? userDetails.ownerName
-                            : '',
-                        })}`
-                      : ''
-                  }
-                />
-              ) : null}
-            </Fragment>
-          ) : isOwner ? (
-            <div className="d-flex" data-testid="owner-link">
-              {displayVal}
-            </div>
-          ) : isTier ? (
-            <Space
-              className={classNames(
-                'd-inline-block truncate link-text align-middle',
-                {
-                  'w-52': (displayVal as string).length > 32,
-                }
-              )}
-              data-testid="tier-name"
-              direction="horizontal"
-              title={displayVal as string}>
-              <span data-testid="Tier">{displayVal}</span>
-            </Space>
-          ) : (
-            <span>{displayVal}</span>
-          )}
-        </Fragment>
-      )}
+      {displayVal && <>{displayValueContent}</>}
     </Space>
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/FilterButton/FilterButton.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/FilterButton/FilterButton.tsx
@@ -102,12 +102,12 @@ export const FilterButton: React.FC<FilterButtonProps> = (props) => {
   // trigger carries a tooltip naming them — otherwise "3 selected" is unreadable without
   // reopening the menu.
   const selectedLabels = selectedValues.map((value) => labelOf(value) ?? value);
-  const triggerLabel =
-    selectedValues.length === 1
-      ? selectedLabels[0]
-      : selectedValues.length === 0
+  const multiSelectionLabel =
+    selectedValues.length === 0
       ? label
       : t('label.n-selected', { count: selectedValues.length });
+  const triggerLabel =
+    selectedValues.length === 1 ? selectedLabels[0] : multiSelectionLabel;
   const triggerTitle =
     selectedLabels.length > 1 ? selectedLabels.join(', ') : undefined;
 
@@ -223,37 +223,41 @@ export const FilterButton: React.FC<FilterButtonProps> = (props) => {
                 }
                 id={opt.value}
                 key={opt.value}>
-                {(state) => (
-                  <div className="tw:flex tw:w-full tw:items-center tw:justify-between tw:gap-2">
-                    <div className="tw:flex tw:min-w-0 tw:flex-1 tw:items-center tw:gap-2">
-                      {renderItemIcon?.(opt.value)}
-                      <span
-                        className={[
-                          'tw:grow tw:truncate tw:text-sm',
-                          state.isDisabled
-                            ? 'tw:text-disabled'
-                            : state.isSelected
-                            ? 'tw:text-brand-700'
-                            : 'tw:text-secondary',
-                        ].join(' ')}>
-                        {opt.label}
-                      </span>
-                      {opt.supportingText && (
-                        <span className="tw:shrink-0 tw:text-xs tw:text-tertiary">
-                          {opt.supportingText}
+                {(state) => {
+                  const optionTextClass = state.isSelected
+                    ? 'tw:text-brand-700'
+                    : 'tw:text-secondary';
+
+                  return (
+                    <div className="tw:flex tw:w-full tw:items-center tw:justify-between tw:gap-2">
+                      <div className="tw:flex tw:min-w-0 tw:flex-1 tw:items-center tw:gap-2">
+                        {renderItemIcon?.(opt.value)}
+                        <span
+                          className={[
+                            'tw:grow tw:truncate tw:text-sm',
+                            state.isDisabled
+                              ? 'tw:text-disabled'
+                              : optionTextClass,
+                          ].join(' ')}>
+                          {opt.label}
                         </span>
+                        {opt.supportingText && (
+                          <span className="tw:shrink-0 tw:text-xs tw:text-tertiary">
+                            {opt.supportingText}
+                          </span>
+                        )}
+                      </div>
+                      {state.isSelected && (
+                        <Check
+                          aria-hidden="true"
+                          className="tw:size-4 tw:shrink-0 tw:text-brand-700"
+                          height={16}
+                          width={16}
+                        />
                       )}
                     </div>
-                    {state.isSelected && (
-                      <Check
-                        aria-hidden="true"
-                        className="tw:size-4 tw:shrink-0 tw:text-brand-700"
-                        height={16}
-                        width={16}
-                      />
-                    )}
-                  </div>
-                )}
+                  );
+                }}
               </Dropdown.Item>
             ))
           )}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilderV1/widgets/coreWidgetUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilderV1/widgets/coreWidgetUtils.ts
@@ -28,9 +28,9 @@ export const getWidgetLabel = ({
 }: Pick<WidgetProps, 'hideLabel' | 'label'>) => {
   const looksLikeRawKey = (s: string) => /^[a-z][a-zA-Z0-9]*$/.test(s); // camelCase id
 
-  return hideLabel
-    ? undefined
-    : looksLikeRawKey(label)
-    ? getFormDisplayLabel(label)
-    : label;
+  if (hideLabel) {
+    return undefined;
+  }
+
+  return looksLikeRawKey(label) ? getFormDisplayLabel(label) : label;
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.component.tsx
@@ -62,11 +62,9 @@ const HeaderShell = ({
 }: HeaderShellProps) => {
   // When the header renders a footer (the tab strip), the tabs sit flush at the
   // bottom edge of the card — drop the card's bottom padding but keep the top.
-  const paddingClass = footer
-    ? padding === 'comfortable'
-      ? 'tw:pt-4 tw:pb-0'
-      : 'tw:pt-3 tw:pb-0'
-    : PADDING_CLASS[padding];
+  const footerPaddingClass =
+    padding === 'comfortable' ? 'tw:pt-4 tw:pb-0' : 'tw:pt-3 tw:pb-0';
+  const paddingClass = footer ? footerPaddingClass : PADDING_CLASS[padding];
 
   return (
     <Card

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/LogViewerModal/LogViewerModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/LogViewerModal/LogViewerModal.component.tsx
@@ -198,6 +198,29 @@ const LogViewerModal: FunctionComponent<LogViewerModalProps> = (props) => {
 
   const isFullScreenClass = isFullScreen ? 'lvm-fullscreen' : '';
 
+  const logBodyContent = showEmptyState ? (
+    <div
+      className="lvm-empty tw:flex tw:h-full tw:items-center tw:justify-center"
+      data-testid="log-viewer-empty">
+      {t('label.no-result-found')}
+    </div>
+  ) : (
+    <LazyLog
+      caseInsensitive
+      enableLineNumbers
+      selectableLines
+      enableSearch={false}
+      extraLines={1}
+      follow={resolvedFollow}
+      formatPart={colorize ? formatLogPart : undefined}
+      ref={lazyLogRef}
+      rowHeight={25}
+      text={filteredLogs}
+      wrapLines={wrap}
+      onScroll={handleScroll}
+    />
+  );
+
   return (
     <ModalOverlay
       isDismissable
@@ -401,27 +424,8 @@ const LogViewerModal: FunctionComponent<LogViewerModalProps> = (props) => {
                 <div className="tw:flex tw:h-full tw:items-center tw:justify-center">
                   <Loader />
                 </div>
-              ) : showEmptyState ? (
-                <div
-                  className="lvm-empty tw:flex tw:h-full tw:items-center tw:justify-center"
-                  data-testid="log-viewer-empty">
-                  {t('label.no-result-found')}
-                </div>
               ) : (
-                <LazyLog
-                  caseInsensitive
-                  enableLineNumbers
-                  selectableLines
-                  enableSearch={false}
-                  extraLines={1}
-                  follow={resolvedFollow}
-                  formatPart={colorize ? formatLogPart : undefined}
-                  ref={lazyLogRef}
-                  rowHeight={25}
-                  text={filteredLogs}
-                  wrapLines={wrap}
-                  onScroll={handleScroll}
-                />
+                logBodyContent
               )}
             </div>
             {hasFooter && (

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/LogViewerModal/useLogStream.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/LogViewerModal/useLogStream.ts
@@ -68,12 +68,15 @@ const RESUMABLE_END_REASONS = new Set<LogStreamEndReason>([
  * carries query parameters, so an endpoint that takes its own does not lose them
  * — or silently drop the cursor — on reconnect.
  */
-export const withLogStreamCursor = (base: string, after?: string): string =>
-  after
-    ? `${base}${base.includes('?') ? '&' : '?'}after=${encodeURIComponent(
-        after
-      )}`
-    : base;
+export const withLogStreamCursor = (base: string, after?: string): string => {
+  if (!after) {
+    return base;
+  }
+
+  const separator = base.includes('?') ? '&' : '?';
+
+  return `${base}${separator}after=${encodeURIComponent(after)}`;
+};
 
 /**
  * Stream URL for one ingestion run's logs.

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
@@ -1027,6 +1027,13 @@ const TableV2 = <T extends object>(
         return;
       }
 
+      let sortOrder: SorterResult<T>['order'] = null;
+      if (newDirection === 'ascending') {
+        sortOrder = 'ascend';
+      } else if (newDirection === 'descending') {
+        sortOrder = 'descend';
+      }
+
       rest.onChange(
         {
           current: internalCurrentPage,
@@ -1038,12 +1045,7 @@ const TableV2 = <T extends object>(
           column: clickedColumn,
           columnKey: reportedKey,
           field: reportedKey,
-          order:
-            newDirection === 'ascending'
-              ? 'ascend'
-              : newDirection === 'descending'
-              ? 'descend'
-              : null,
+          order: sortOrder,
         } as SorterResult<T>,
         {
           currentDataSource: (rest.dataSource ?? []) as T[],
@@ -1172,6 +1174,79 @@ const TableV2 = <T extends object>(
           actualIndex
         ) as React.TdHTMLAttributes<HTMLTableCellElement>) ?? {};
 
+      let expandIndicator: React.ReactNode = null;
+      if (showExpandInCell) {
+        if (hasChildren && ExpandIcon) {
+          expandIndicator = (
+            <ExpandIcon
+              expandable={hasChildren}
+              expanded={isExpanded}
+              prefixCls=""
+              record={record}
+              onExpand={(rec, e) => {
+                e.stopPropagation();
+                handleExpandToggle(rec as T, rowKey);
+              }}
+            />
+          );
+        } else if (hasChildren) {
+          expandIndicator = (
+            <button
+              aria-expanded={isExpanded}
+              className="tw:p-0 tw:bg-transparent tw:border-0 tw:cursor-pointer tw:mr-1 tw:inline-flex"
+              data-testid="expand-icon"
+              onClick={(e) => {
+                e.stopPropagation();
+                handleExpandToggle(record, rowKey);
+              }}>
+              {isExpanded ? (
+                <ChevronDown className="tw:size-4" />
+              ) : (
+                <ChevronRight className="tw:size-4" />
+              )}
+            </button>
+          );
+        } else if (ExpandIcon) {
+          expandIndicator = (
+            <ExpandIcon
+              expandable={false}
+              expanded={false}
+              prefixCls=""
+              record={record}
+              onExpand={(_rec, _e) => {}}
+            />
+          );
+        } else {
+          expandIndicator = <span className="tw:inline-block tw:w-4 tw:mr-1" />;
+        }
+      }
+
+      let cellContent: React.ReactNode = resolveCellValue(
+        colType,
+        record,
+        actualIndex
+      );
+      if (colType.ellipsis) {
+        // `flex-1 min-w-0` only mean anything inside the flex row an expander
+        // creates; without one the wrapper is `display: contents` and this div
+        // is a block child of the cell, which already fills it. `truncate` is
+        // what does the work either way.
+        cellContent = (
+          <div
+            className={classNames('tw:truncate', {
+              'tw:flex-1 tw:min-w-0': showExpandInCell,
+            })}>
+            {cellContent}
+          </div>
+        );
+      } else if (showExpandInCell) {
+        // Same shrink permission without imposing `truncate`: a flex item's
+        // min-width is `auto`, so a nowrap value the call site ellipsizes
+        // itself (an AntD Typography link, say) could never shrink to the cell
+        // and painted across the neighbouring columns instead.
+        cellContent = <div className="tw:min-w-0 tw:flex-1">{cellContent}</div>;
+      }
+
       return (
         <UntitledTable.Cell
           {...cellHandlerProps}
@@ -1234,72 +1309,10 @@ const TableV2 = <T extends object>(
             })}>
             {showExpandInCell && (
               <div className="tw:flex tw:items-center tw:shrink-0">
-                {hasChildren ? (
-                  ExpandIcon ? (
-                    <ExpandIcon
-                      expandable={hasChildren}
-                      expanded={isExpanded}
-                      prefixCls=""
-                      record={record}
-                      onExpand={(rec, e) => {
-                        e.stopPropagation();
-                        handleExpandToggle(rec as T, rowKey);
-                      }}
-                    />
-                  ) : (
-                    <button
-                      aria-expanded={isExpanded}
-                      className="tw:p-0 tw:bg-transparent tw:border-0 tw:cursor-pointer tw:mr-1 tw:inline-flex"
-                      data-testid="expand-icon"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleExpandToggle(record, rowKey);
-                      }}>
-                      {isExpanded ? (
-                        <ChevronDown className="tw:size-4" />
-                      ) : (
-                        <ChevronRight className="tw:size-4" />
-                      )}
-                    </button>
-                  )
-                ) : ExpandIcon ? (
-                  <ExpandIcon
-                    expandable={false}
-                    expanded={false}
-                    prefixCls=""
-                    record={record}
-                    onExpand={(_rec, _e) => {}}
-                  />
-                ) : (
-                  <span className="tw:inline-block tw:w-4 tw:mr-1" />
-                )}
+                {expandIndicator}
               </div>
             )}
-            {colType.ellipsis ? (
-              // `flex-1 min-w-0` only mean anything inside the
-              // flex row an expander creates; without one the
-              // wrapper is `display: contents` and this div is
-              // a block child of the cell, which already fills
-              // it. `truncate` is what does the work either way.
-              <div
-                className={classNames('tw:truncate', {
-                  'tw:flex-1 tw:min-w-0': showExpandInCell,
-                })}>
-                {resolveCellValue(colType, record, actualIndex)}
-              </div>
-            ) : showExpandInCell ? (
-              // Same shrink permission without imposing
-              // `truncate`: a flex item's min-width is `auto`,
-              // so a nowrap value the call site ellipsizes
-              // itself (an AntD Typography link, say) could
-              // never shrink to the cell and painted across
-              // the neighbouring columns instead.
-              <div className="tw:min-w-0 tw:flex-1">
-                {resolveCellValue(colType, record, actualIndex)}
-              </div>
-            ) : (
-              resolveCellValue(colType, record, actualIndex)
-            )}
+            {cellContent}
           </div>
         </UntitledTable.Cell>
       );
@@ -1319,6 +1332,36 @@ const TableV2 = <T extends object>(
       (clientPagination.serverTotal ?? filteredDataSource.length) <=
         clientPagination.pageSize
     );
+
+  let paginationFooter: React.ReactNode = null;
+  if (showCustomPagination) {
+    paginationFooter = (
+      <div>
+        <NextPrevious {...customPaginationProps} />
+      </div>
+    );
+  } else if (showClientPagination) {
+    paginationFooter = (
+      <div>
+        {/*
+          The core pager rather than NextPrevious: it navigates by page
+          number instead of one step at a time, and it is react-aria rather
+          than AntD, which is the point of the migration. `total` here is a
+          page count, not a row count.
+        */}
+        <PaginationCardWithControls
+          page={currentPage}
+          pageSize={clientPagination.pageSize}
+          total={computeTotalPages(
+            clientPagination.pageSize,
+            clientPagination.serverTotal ?? filteredDataSource.length
+          )}
+          onPageChange={handlePageChange}
+          {...sizeChangerProps}
+        />
+      </div>
+    );
+  }
 
   return (
     <div
@@ -1722,30 +1765,7 @@ const TableV2 = <T extends object>(
         </div>
       )}
 
-      {showCustomPagination ? (
-        <div>
-          <NextPrevious {...customPaginationProps} />
-        </div>
-      ) : showClientPagination ? (
-        <div>
-          {/*
-            The core pager rather than NextPrevious: it navigates by page
-            number instead of one step at a time, and it is react-aria rather
-            than AntD, which is the point of the migration. `total` here is a
-            page count, not a row count.
-          */}
-          <PaginationCardWithControls
-            page={currentPage}
-            pageSize={clientPagination.pageSize}
-            total={computeTotalPages(
-              clientPagination.pageSize,
-              clientPagination.serverTotal ?? filteredDataSource.length
-            )}
-            onPageChange={handlePageChange}
-            {...sizeChangerProps}
-          />
-        </div>
-      ) : null}
+      {paginationFooter}
     </div>
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2Utils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2Utils.test.ts
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import type { ColumnType } from './Table.interface';
+import { resolveCellValue } from './TableV2Utils';
+
+type Row = Record<string, unknown>;
+
+const buildColumn = (partial: Partial<ColumnType<Row>>): ColumnType<Row> =>
+  partial as ColumnType<Row>;
+
+describe('resolveCellValue rawValue branch', () => {
+  it('walks a nested path when dataIndex is an array', () => {
+    const value = resolveCellValue(
+      buildColumn({ dataIndex: ['a', 'b'] }),
+      { a: { b: 'nested-value' } },
+      0
+    );
+
+    expect(value).toBe('nested-value');
+  });
+
+  it('reads a top-level key when dataIndex is a string', () => {
+    expect(
+      resolveCellValue(buildColumn({ dataIndex: 'name' }), { name: 'hello' }, 0)
+    ).toBe('hello');
+    expect(
+      resolveCellValue(buildColumn({ dataIndex: 'count' }), { count: 5 }, 0)
+    ).toBe('5');
+  });
+
+  it('returns null when dataIndex is undefined', () => {
+    expect(resolveCellValue(buildColumn({}), {}, 0)).toBeNull();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2Utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2Utils.ts
@@ -66,15 +66,17 @@ export function resolveCellValue<T>(
   index: number
 ): ReactNode {
   const { dataIndex, render } = col;
-  const rawValue = Array.isArray(dataIndex)
-    ? dataIndex.reduce(
-        (obj: unknown, key) =>
-          (obj as Record<string, unknown>)?.[key as string],
-        record as unknown
-      )
-    : typeof dataIndex === 'string'
-    ? (record as Record<string, unknown>)[dataIndex]
-    : undefined;
+  let rawValue: unknown;
+  if (Array.isArray(dataIndex)) {
+    rawValue = dataIndex.reduce(
+      (obj: unknown, key) => (obj as Record<string, unknown>)?.[key as string],
+      record as unknown
+    );
+  } else if (typeof dataIndex === 'string') {
+    rawValue = (record as Record<string, unknown>)[dataIndex];
+  } else {
+    rawValue = undefined;
+  }
 
   if (render) {
     const rendered = render(rawValue, record, index);

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/__tests__/TableV2.parity.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/__tests__/TableV2.parity.test.tsx
@@ -41,12 +41,16 @@ const coreAdapter: ParityAdapter = {
   clickNextPage: () => {
     fireEvent.click(screen.getByTestId('next'));
   },
-  getTextAlign: (el) =>
-    el.className.includes('tw:text-right')
-      ? 'right'
-      : el.className.includes('tw:text-center')
-      ? 'center'
-      : '',
+  getTextAlign: (el) => {
+    if (el.className.includes('tw:text-right')) {
+      return 'right';
+    }
+    if (el.className.includes('tw:text-center')) {
+      return 'center';
+    }
+
+    return '';
+  },
   isBordered: () =>
     (document.querySelector('table') as HTMLElement).className.includes(
       'border-secondary'

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TableDataCardV2/TableDataCardV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TableDataCardV2/TableDataCardV2.tsx
@@ -96,13 +96,12 @@ const TableDataCardV2: React.FC<TableDataCardPropsV2> = forwardRef<
         source.entityType !== EntityType.GLOSSARY_TERM &&
         source.entityType !== EntityType.TAG
       ) {
+        const tierName = isString(source.tier)
+          ? source.tier
+          : getEntityName(source.tier);
         _otherDetails.push({
           key: 'Tier',
-          value: source.tier
-            ? isString(source.tier)
-              ? source.tier
-              : getEntityName(source.tier)
-            : '',
+          value: source.tier ? tierName : '',
         });
       }
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TierWidget/TierWidget.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TierWidget/TierWidget.tsx
@@ -70,21 +70,21 @@ const TierWidget = () => {
     [permissions, isVersionView]
   );
 
-  const headerExtra = canEdit ? (
-    tier ? (
-      <WidgetEditButton
-        data-testid="edit-tier"
-        title={t('label.edit-entity', { entity: t('label.tier') })}
-        onClick={() => setIsEditing(true)}
-      />
-    ) : (
-      <WidgetPlusButton
-        data-testid="add-tier"
-        title={t('label.add-entity', { entity: t('label.tier') })}
-        onClick={() => setIsEditing(true)}
-      />
-    )
-  ) : null;
+  const tierEditControl = tier ? (
+    <WidgetEditButton
+      data-testid="edit-tier"
+      title={t('label.edit-entity', { entity: t('label.tier') })}
+      onClick={() => setIsEditing(true)}
+    />
+  ) : (
+    <WidgetPlusButton
+      data-testid="add-tier"
+      title={t('label.add-entity', { entity: t('label.tier') })}
+      onClick={() => setIsEditing(true)}
+    />
+  );
+
+  const headerExtra = canEdit ? tierEditControl : null;
 
   const tierDisplay = tier ? (
     <TagsV1

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/UserTeamSelectableList/UserTeamSelectableList.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/UserTeamSelectableList/UserTeamSelectableList.component.tsx
@@ -274,7 +274,12 @@ export const UserTeamSelectableList = ({
   };
 
   useEffect(() => {
-    const activeOwners = isArray(owner) ? owner : owner ? [owner] : [];
+    let activeOwners: EntityReference[] = [];
+    if (isArray(owner)) {
+      activeOwners = owner;
+    } else if (owner) {
+      activeOwners = [owner];
+    }
     setSelectedUsers(activeOwners);
   }, [owner]);
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/drawer/AiFormModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/drawer/AiFormModal.tsx
@@ -146,6 +146,15 @@ export const AiFormModal: FC<AiFormModalProps> = ({
   const { t } = useTranslation();
   const hasHintColumn = hintOpen !== undefined;
 
+  let modalWidth: number;
+  if (!hasHintColumn) {
+    modalWidth = WIDTH_NO_HINT_COLUMN;
+  } else if (hintOpen) {
+    modalWidth = WIDTH_WITH_HINT;
+  } else {
+    modalWidth = WIDTH_WITHOUT_HINT;
+  }
+
   // The submit handler surfaces failures via an inline alert in the form body
   // and resolves so the modal stays open; swallow the rejection here so React
   // does not log an unhandled promise rejection.
@@ -180,13 +189,7 @@ export const AiFormModal: FC<AiFormModalProps> = ({
           <Dialog
             showCloseButton
             panelClassName="tw:transition-[max-width] tw:duration-[240ms] tw:ease-in-out"
-            width={
-              hasHintColumn
-                ? hintOpen
-                  ? WIDTH_WITH_HINT
-                  : WIDTH_WITHOUT_HINT
-                : WIDTH_NO_HINT_COLUMN
-            }
+            width={modalWidth}
             onClose={onClose}>
             {/* The Request Data Access modal's header verbatim, that form being
                 the reference design named:

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/navigation/usePageHeader.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/navigation/usePageHeader.tsx
@@ -108,13 +108,7 @@ export const usePageHeader = (config: PageHeaderConfig) => {
       currentUser?.displayName || currentUser?.name || ''
     );
 
-    const leading = isGreeting ? (
-      <ProfilePicture
-        displayName={currentUser?.displayName}
-        name={currentUser?.name ?? ''}
-        width="48"
-      />
-    ) : config.icon ? (
+    const iconLeading = config.icon ? (
       <FeaturedIcon
         color={config.iconColor ?? 'brand'}
         icon={config.icon}
@@ -123,6 +117,16 @@ export const usePageHeader = (config: PageHeaderConfig) => {
         theme="gradient"
       />
     ) : undefined;
+
+    const leading = isGreeting ? (
+      <ProfilePicture
+        displayName={currentUser?.displayName}
+        name={currentUser?.name ?? ''}
+        width="48"
+      />
+    ) : (
+      iconLeading
+    );
 
     const title = isGreeting
       ? t(config.greetingNameKey ?? 'label.hey-comma-name', {

--- a/openmetadata-ui/src/main/resources/ui/src/components/discovery/explore/ExploreHeader/ExploreSearchCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/discovery/explore/ExploreHeader/ExploreSearchCard.tsx
@@ -141,11 +141,10 @@ export const ExploreSearchCard = () => {
   const handleQuickFilterClick = useCallback(
     (filter: QuickFilter) => {
       const ownerName = currentUser?.displayName || currentUser?.name;
-      const quickFilter = filter.quickFilterFn
-        ? ownerName
-          ? filter.quickFilterFn(ownerName)
-          : undefined
-        : filter.quickFilter;
+      let quickFilter: string | undefined = filter.quickFilter;
+      if (filter.quickFilterFn) {
+        quickFilter = ownerName ? filter.quickFilterFn(ownerName) : undefined;
+      }
 
       if (filter.quickFilterFn && !quickFilter) {
         return;

--- a/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/InboxIconButton/InboxIconButton.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/InboxIconButton/InboxIconButton.tsx
@@ -78,12 +78,14 @@ const InboxIconButton: React.FC = () => {
   const unreadActivityCount = useUnreadInboxActivity();
   const pendingCount = openTaskCount + unreadActivityCount;
 
-  const badgeLabel =
-    pendingCount > 99
-      ? '99+'
-      : pendingCount > 0
-      ? `${pendingCount}`
-      : undefined;
+  let badgeLabel: string | undefined;
+  if (pendingCount > 99) {
+    badgeLabel = '99+';
+  } else if (pendingCount > 0) {
+    badgeLabel = `${pendingCount}`;
+  } else {
+    badgeLabel = undefined;
+  }
 
   const isActive =
     pathname === PERSONAL_SPACE_ROUTES.INBOX ||

--- a/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/InboxPage/components/ActivityDetailDrawer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/InboxPage/components/ActivityDetailDrawer.tsx
@@ -349,11 +349,12 @@ const ActivityDetailDrawer: React.FC<ActivityDetailDrawerProps> = ({
   const canComment = Boolean(feed?.id);
   const feedDeleteAccess = useFeedDeleteAccess(open && canComment);
   // Guard: the drawer renders even when nothing is selected (both undefined).
-  const actionLabel = activity
-    ? getActivityEventLabel(activity, t)
-    : feed
-    ? t('label.posted-on')
-    : '';
+  let actionLabel = '';
+  if (activity) {
+    actionLabel = getActivityEventLabel(activity, t);
+  } else if (feed) {
+    actionLabel = t('label.posted-on');
+  }
   const entity = isActivity ? activity?.entity : feed?.entityRef;
   const entityName = entity?.displayName || entity?.name || entity?.type;
   const bodyMessage = isActivity

--- a/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/InboxPage/components/ActivityFeedItem.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/InboxPage/components/ActivityFeedItem.tsx
@@ -95,11 +95,12 @@ const ActivityFeedItem: React.FC<ActivityFeedItemProps> = ({
       ? activity?.actor?.displayName
       : feed?.createdBy?.displayName) ||
     actorName;
-  const actionLabel = activity
-    ? getActivityEventLabel(activity, t)
-    : feed
-    ? t('label.posted-on')
-    : '';
+  let actionLabel = '';
+  if (activity) {
+    actionLabel = getActivityEventLabel(activity, t);
+  } else if (feed) {
+    actionLabel = t('label.posted-on');
+  }
   const entity = isActivity ? activity?.entity : feed?.entityRef;
   const entityName = entity?.displayName || entity?.name || entity?.type;
   const timestamp = isActivity

--- a/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/InboxPage/components/TaskDetailPanel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/InboxPage/components/TaskDetailPanel.tsx
@@ -617,11 +617,12 @@ const TaskDetailPanel: React.FC<TaskDetailPanelProps> = ({
   // getTaskDetailPathFromTask maps the about entity to its Activity Feed → Tasks
   // tab, honouring per-type routes (glossaryTerm → /glossary, testCase, user, …).
   // Incidents fall back to the derived test case's Issues tab.
-  const aboutPath = aboutRef?.fullyQualifiedName
-    ? getTaskDetailPathFromTask(task)
-    : incidentTestCaseFqn.includes('.')
+  const incidentPath = incidentTestCaseFqn.includes('.')
     ? getTestCaseDetailPagePath(incidentTestCaseFqn, TestCasePageTabs.ISSUES)
     : '';
+  const aboutPath = aboutRef?.fullyQualifiedName
+    ? getTaskDetailPathFromTask(task)
+    : incidentPath;
   // Highlight the title token (display name, raw name, or last FQN segment)
   // that carries the asset, so both "…dim_address_clean" and
   // "…dim_address_clean_changed" colour the whole trailing identifier.
@@ -641,6 +642,18 @@ const TaskDetailPanel: React.FC<TaskDetailPanelProps> = ({
     : null;
   const assetIndex = assetMatch?.index ?? -1;
   const assetEnd = assetMatch ? assetMatch.index + assetMatch.length : -1;
+  // No asset token in the title — keep the whole title in normal colour
+  // (still clickable), so the header never turns fully blue.
+  const plainTitleNode = aboutPath ? (
+    <Link
+      className="tw:text-inherit tw:no-underline! tw:hover:underline!"
+      data-testid="task-about-link"
+      to={aboutPath}>
+      {titleText}
+    </Link>
+  ) : (
+    titleText
+  );
   const titleNode =
     assetIndex >= 0 ? (
       <>
@@ -653,17 +666,8 @@ const TaskDetailPanel: React.FC<TaskDetailPanelProps> = ({
         </Link>
         {titleText.slice(assetEnd)}
       </>
-    ) : aboutPath ? (
-      // No asset token in the title — keep the whole title in normal colour
-      // (still clickable), so the header never turns fully blue.
-      <Link
-        className="tw:text-inherit tw:no-underline! tw:hover:underline!"
-        data-testid="task-about-link"
-        to={aboutPath}>
-        {titleText}
-      </Link>
     ) : (
-      titleText
+      plainTitleNode
     );
   // Not using Typography's `ellipsis` here: it wraps content in a pressable and
   // stringifies children, which would drop the asset Link. A plain line-clamp
@@ -737,29 +741,29 @@ const TaskDetailPanel: React.FC<TaskDetailPanelProps> = ({
               );
             }
 
+            const nonRejectColor =
+              approve || action.id === 'resolve' ? 'primary' : 'secondary';
+            const buttonColor = reject
+              ? 'secondary-destructive'
+              : nonRejectColor;
+            const nonApproveTestId = reject
+              ? 'task-reject'
+              : `task-transition-${action.id}`;
+            const buttonTestId = approve ? 'task-approve' : nonApproveTestId;
+            const nonApproveIcon = reject ? (
+              <XCircle height={16} width={16} />
+            ) : undefined;
+            const buttonIcon = approve ? (
+              <CheckCircle height={16} width={16} />
+            ) : (
+              nonApproveIcon
+            );
+
             return (
               <Button
-                color={
-                  reject
-                    ? 'secondary-destructive'
-                    : approve || action.id === 'resolve'
-                    ? 'primary'
-                    : 'secondary'
-                }
-                data-testid={
-                  approve
-                    ? 'task-approve'
-                    : reject
-                    ? 'task-reject'
-                    : `task-transition-${action.id}`
-                }
-                iconLeading={
-                  approve ? (
-                    <CheckCircle height={16} width={16} />
-                  ) : reject ? (
-                    <XCircle height={16} width={16} />
-                  ) : undefined
-                }
+                color={buttonColor}
+                data-testid={buttonTestId}
+                iconLeading={buttonIcon}
                 isDisabled={isDisabled}
                 isLoading={isBusy}
                 key={action.id}

--- a/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/InboxPage/tabs/ActivityTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/InboxPage/tabs/ActivityTab.tsx
@@ -69,57 +69,62 @@ const ActivityTab: React.FC<ActivityTabProps> = ({
 
   const selectedId = selected?.activity?.id ?? selected?.feed?.id;
 
+  const emptyPlaceholder = isFiltered ? (
+    <EmptyPlaceholder
+      data-testid="inbox-activity-no-results"
+      description={t('message.activity-feed-no-results-description')}
+      icon={
+        <FilterFunnel01 className="tw:size-7 tw:text-utility-gray-blue-600" />
+      }
+      title={t('label.no-activity-in-period')}
+      variant="blank"
+    />
+  ) : (
+    <EmptyPlaceholder
+      data-testid="inbox-activity-empty"
+      description={t('message.activity-feed-empty-description')}
+      icon={<Hourglass01 className="tw:size-7 tw:text-utility-brand-600" />}
+      title={t('label.activity-feed-starts-here')}
+      variant="blank"
+    />
+  );
+
+  let activityContent: React.ReactNode;
+  if (isLoading) {
+    activityContent = <ActivitySkeleton />;
+  } else if (items.length === 0) {
+    activityContent = emptyPlaceholder;
+  } else {
+    activityContent = (
+      <Box
+        className="inbox-activity-timeline tw:relative"
+        direction="col"
+        gap={2}>
+        <span className="tw:pointer-events-none tw:absolute tw:-top-5 tw:bottom-2 tw:left-[23px] tw:z-[2] tw:w-px tw:bg-utility-gray-blue-100" />
+        {items.map((item) => {
+          const itemId = item.activity?.id ?? item.feed?.id;
+
+          return (
+            <ActivityFeedItem
+              activity={item.activity}
+              feed={item.feed}
+              isActive={isDrawerOpen && selectedId === itemId}
+              key={itemId}
+              onClick={handleSelect}
+            />
+          );
+        })}
+      </Box>
+    );
+  }
+
   return (
     <>
       <Box className="tw:flex tw:h-full tw:min-h-0" direction="col">
         <div
           className="tw:relative tw:min-h-0 tw:flex-1 tw:overflow-y-auto tw:pt-4 tw:pr-1"
           data-testid="inbox-activity-tab">
-          {isLoading ? (
-            <ActivitySkeleton />
-          ) : items.length === 0 ? (
-            isFiltered ? (
-              <EmptyPlaceholder
-                data-testid="inbox-activity-no-results"
-                description={t('message.activity-feed-no-results-description')}
-                icon={
-                  <FilterFunnel01 className="tw:size-7 tw:text-utility-gray-blue-600" />
-                }
-                title={t('label.no-activity-in-period')}
-                variant="blank"
-              />
-            ) : (
-              <EmptyPlaceholder
-                data-testid="inbox-activity-empty"
-                description={t('message.activity-feed-empty-description')}
-                icon={
-                  <Hourglass01 className="tw:size-7 tw:text-utility-brand-600" />
-                }
-                title={t('label.activity-feed-starts-here')}
-                variant="blank"
-              />
-            )
-          ) : (
-            <Box
-              className="inbox-activity-timeline tw:relative"
-              direction="col"
-              gap={2}>
-              <span className="tw:pointer-events-none tw:absolute tw:-top-5 tw:bottom-2 tw:left-[23px] tw:z-[2] tw:w-px tw:bg-utility-gray-blue-100" />
-              {items.map((item) => {
-                const itemId = item.activity?.id ?? item.feed?.id;
-
-                return (
-                  <ActivityFeedItem
-                    activity={item.activity}
-                    feed={item.feed}
-                    isActive={isDrawerOpen && selectedId === itemId}
-                    key={itemId}
-                    onClick={handleSelect}
-                  />
-                );
-              })}
-            </Box>
-          )}
+          {activityContent}
         </div>
       </Box>
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/InboxPage/tabs/TasksTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/InboxPage/tabs/TasksTab.tsx
@@ -190,12 +190,14 @@ const TasksTab: React.FC<TasksTabProps> = ({
       // filter. A Data Access Request that was just Approved stays Open (it is
       // awaiting grant), so removing it optimistically would make it vanish and
       // then reappear on refresh — update it in place instead.
-      const stillVisible =
-        status === 'all'
-          ? true
-          : status === 'open'
-          ? isTaskOpen(resolved)
-          : !isTaskOpen(resolved);
+      let stillVisible: boolean;
+      if (status === 'all') {
+        stillVisible = true;
+      } else if (status === 'open') {
+        stillVisible = isTaskOpen(resolved);
+      } else {
+        stillVisible = !isTaskOpen(resolved);
+      }
 
       if (stillVisible) {
         setItems((prev) =>
@@ -305,6 +307,30 @@ const TasksTab: React.FC<TasksTabProps> = ({
   };
   const emptyState = emptyStateByStatus[status];
 
+  let taskDetailContent: ReactNode;
+  if (isLoading) {
+    taskDetailContent = <TaskDetailSkeleton />;
+  } else if (selectedTaskId) {
+    taskDetailContent = (
+      <TaskDetailPanel
+        fallbackTask={tasks.find((task) => task.id === selectedTaskId)}
+        key={selectedTaskId}
+        taskId={selectedTaskId}
+        onCommentsChanged={handleCommentsChanged}
+        onResolved={handleResolved}
+        onTaskUpdated={handleTaskUpdated}
+      />
+    );
+  } else {
+    taskDetailContent = (
+      <Box align="center" className="tw:w-full tw:justify-center tw:py-16">
+        <Typography className="tw:text-secondary">
+          {t('label.no-tasks-right-now')}
+        </Typography>
+      </Box>
+    );
+  }
+
   return (
     <Box
       className={classNames(
@@ -355,26 +381,7 @@ const TasksTab: React.FC<TasksTabProps> = ({
           <Box
             className="tw:h-full tw:w-full tw:overflow-y-auto tw:p-5"
             direction="col">
-            {isLoading ? (
-              <TaskDetailSkeleton />
-            ) : selectedTaskId ? (
-              <TaskDetailPanel
-                fallbackTask={tasks.find((task) => task.id === selectedTaskId)}
-                key={selectedTaskId}
-                taskId={selectedTaskId}
-                onCommentsChanged={handleCommentsChanged}
-                onResolved={handleResolved}
-                onTaskUpdated={handleTaskUpdated}
-              />
-            ) : (
-              <Box
-                align="center"
-                className="tw:w-full tw:justify-center tw:py-16">
-                <Typography className="tw:text-secondary">
-                  {t('label.no-tasks-right-now')}
-                </Typography>
-              </Box>
-            )}
+            {taskDetailContent}
           </Box>
         </Box>
       )}

--- a/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/Profile/ProfilePage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/Profile/ProfilePage.tsx
@@ -104,12 +104,14 @@ const ProfilePage: React.FC = () => {
         if (!response) {
           return;
         }
+        const nonTeamKeyData =
+          key === 'roles'
+            ? { roles: response.roles, isAdmin: response.isAdmin }
+            : { [key]: response[key] };
         const updatedKeyData =
           key === 'teams'
             ? { teams: response.teams, domains: response.domains }
-            : key === 'roles'
-            ? { roles: response.roles, isAdmin: response.isAdmin }
-            : { [key]: response[key] };
+            : nonTeamKeyData;
         const newUserData = omitBy(
           { ...userData, ...updatedKeyData },
           isUndefined

--- a/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/Profile/components/InlineEditCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/Profile/components/InlineEditCard.tsx
@@ -87,13 +87,14 @@ const InlineEditCard: React.FC<InlineEditCardProps> = ({
   const showLock = !isEditing && !canEdit && Boolean(lockedLabel);
   // Reserve space on the right so the value never sits under the pencil
   // (narrow) or the "Admin-managed" lock (wider).
-  const rightPadding = isEditing
-    ? 'tw:w-full'
-    : canEdit
-    ? 'tw:w-full tw:pr-8'
-    : showLock
-    ? 'tw:w-full tw:pr-32'
-    : 'tw:w-full';
+  let rightPadding = 'tw:w-full';
+  if (!isEditing) {
+    if (canEdit) {
+      rightPadding = 'tw:w-full tw:pr-8';
+    } else if (showLock) {
+      rightPadding = 'tw:w-full tw:pr-32';
+    }
+  }
 
   return (
     <Box

--- a/openmetadata-ui/src/main/resources/ui/src/components/observability/Alerts/AlertAiDestinationConfigFields.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/observability/Alerts/AlertAiDestinationConfigFields.component.tsx
@@ -248,6 +248,36 @@ const TeamUserSelectInput = ({
     return () => document.removeEventListener('click', handleOutsideClick);
   }, []);
 
+  const optionsContent = isEmpty(options) ? (
+    <Typography
+      as="p"
+      className={ALERT_AI_FORM_CLASS_NAMES.teamUserSelectEmptyText}
+      size="text-sm">
+      {t('label.no-teams-or-users')}
+    </Typography>
+  ) : (
+    options.map(({ label, value }) => (
+      <Button
+        noTextPadding
+        className={ALERT_AI_FORM_CLASS_NAMES.teamUserSelectOptionButton}
+        color="tertiary"
+        data-testid={`team-user-option-${value}`}
+        key={value}
+        onPress={() => handleOptionClick(value)}>
+        <Checkbox
+          data-testid={`${label}-option-checkbox`}
+          isSelected={selectedOptions.includes(value)}
+        />
+        <Typography
+          as="span"
+          className={ALERT_AI_FORM_CLASS_NAMES.teamUserSelectOptionLabel}
+          data-testid={`${label}-option-label`}>
+          {label}
+        </Typography>
+      </Button>
+    ))
+  );
+
   return (
     <div className={ALERT_AI_FORM_CLASS_NAMES.teamUserSelectRoot}>
       <div
@@ -316,38 +346,8 @@ const TeamUserSelectInput = ({
                 <Skeleton height={24} variant="rounded" />
                 <Skeleton height={24} variant="rounded" />
               </div>
-            ) : isEmpty(options) ? (
-              <Typography
-                as="p"
-                className={ALERT_AI_FORM_CLASS_NAMES.teamUserSelectEmptyText}
-                size="text-sm">
-                {t('label.no-teams-or-users')}
-              </Typography>
             ) : (
-              options.map(({ label, value }) => (
-                <Button
-                  noTextPadding
-                  className={
-                    ALERT_AI_FORM_CLASS_NAMES.teamUserSelectOptionButton
-                  }
-                  color="tertiary"
-                  data-testid={`team-user-option-${value}`}
-                  key={value}
-                  onPress={() => handleOptionClick(value)}>
-                  <Checkbox
-                    data-testid={`${label}-option-checkbox`}
-                    isSelected={selectedOptions.includes(value)}
-                  />
-                  <Typography
-                    as="span"
-                    className={
-                      ALERT_AI_FORM_CLASS_NAMES.teamUserSelectOptionLabel
-                    }
-                    data-testid={`${label}-option-label`}>
-                    {label}
-                  </Typography>
-                </Button>
-              ))
+              optionsContent
             )}
           </div>
         </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/observability/Alerts/AlertAiFormFields.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/observability/Alerts/AlertAiFormFields.component.test.tsx
@@ -511,13 +511,13 @@ jest.mock('@untitledui/icons', () => ({
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string, params?: Record<string, string>) => {
-      const value =
+      const suffix =
         params?.entity ||
         params?.fieldName ||
         params?.field ||
         params?.fieldText;
 
-      return value ? `${key}:${value}` : key;
+      return suffix ? `${key}:${suffix}` : key;
     },
   }),
 }));

--- a/openmetadata-ui/src/main/resources/ui/src/components/observability/Alerts/AlertAiFormFieldsPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/observability/Alerts/AlertAiFormFieldsPureUtils.ts
@@ -57,8 +57,13 @@ export const isWebhookDestination = (
   destinationType === SubscriptionType.Webhook;
 
 /** Normalizes API string/string-array values into arrays for multi-value inputs. */
-export const getStringArrayValue = (value?: string | string[]) =>
-  Array.isArray(value) ? value : value ? [value] : [];
+export const getStringArrayValue = (value?: string | string[]) => {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  return value ? [value] : [];
+};
 
 /** Splits comma-separated text input into the string-array payload expected by alert rules. */
 export const getCommaSeparatedStringArray = (value: string) =>
@@ -85,7 +90,7 @@ export const getCommaSeparatedValues = (value?: string | string[]) =>
 
 /** Normalizes scalar or array values for Core UI multi-select selected item state. */
 export const getListValue = (value?: string | string[]) =>
-  Array.isArray(value) ? value : value ? [value] : [];
+  getStringArrayValue(value);
 
 /** Reads the selected alert source from create/edit form values or existing alert details. */
 export const getAlertAiResources = (

--- a/openmetadata-ui/src/main/resources/ui/src/components/observability/Alerts/AlertAiNotificationTemplateUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/observability/Alerts/AlertAiNotificationTemplateUtils.ts
@@ -43,12 +43,15 @@ interface CustomTemplateFieldLabels {
 
 export const getSelectedTemplateKey = (
   notificationTemplate: ModifiedCreateEventSubscription['notificationTemplate']
-) =>
-  typeof notificationTemplate === 'string'
-    ? notificationTemplate
-    : notificationTemplate
+) => {
+  if (typeof notificationTemplate === 'string') {
+    return notificationTemplate;
+  }
+
+  return notificationTemplate
     ? JSON.stringify(notificationTemplate)
     : undefined;
+};
 
 export const getSelectedSavedTemplate = (
   selectedTemplate: string | undefined,
@@ -198,10 +201,12 @@ export const getCustomTemplateFieldData = ({
   customTemplateData?: ModifiedCreateEventSubscription['customNotificationTemplateData'];
   isCustomTemplate: boolean;
   selectedSavedTemplate?: NotificationTemplate;
-}) =>
-  isCustomTemplate
-    ? customTemplateData
-    : selectedSavedTemplate
+}) => {
+  if (isCustomTemplate) {
+    return customTemplateData;
+  }
+
+  return selectedSavedTemplate
     ? {
         displayName:
           selectedSavedTemplate.displayName ?? selectedSavedTemplate.name,
@@ -209,3 +214,4 @@ export const getCustomTemplateFieldData = ({
         templateSubject: selectedSavedTemplate.templateSubject,
       }
     : undefined;
+};

--- a/openmetadata-ui/src/main/resources/ui/src/components/observability/Alerts/ObservabilityAlertsAiTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/observability/Alerts/ObservabilityAlertsAiTable.component.tsx
@@ -275,14 +275,14 @@ function ObservabilityAlertsAiTable({
     </Box>
   );
 
+  const alertsEmptyPlaceholder = hasResourcePermissionError
+    ? errorStatePlaceholder
+    : emptyStatePlaceholder;
+
   return (
     <TableCard.Root className="tw:rounded-xl tw:border tw:border-secondary tw:shadow-none tw:outline-0">
       {isAlertsEmpty ? (
-        hasResourcePermissionError ? (
-          errorStatePlaceholder
-        ) : (
-          emptyStatePlaceholder
-        )
+        alertsEmptyPlaceholder
       ) : (
         <>
           <div className="tw:border-b tw:border-secondary">

--- a/openmetadata-ui/src/main/resources/ui/src/components/observability/common/FilterChip/FilterChip.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/observability/common/FilterChip/FilterChip.tsx
@@ -405,8 +405,12 @@ const UserChip = ({
   };
   const { label, key, value, selectedOwners, onOwnerChange } = descriptor;
   const selected = selectedOwners?.[0];
-  const selectedText = selected?.displayName ?? selected?.name ?? '';
-  const displayText = selected ? selectedText : isString(value) ? value : '';
+  let displayText = '';
+  if (selected) {
+    displayText = selected.displayName ?? selected.name ?? '';
+  } else if (isString(value)) {
+    displayText = value;
+  }
   const hasSelection = Boolean(displayText);
 
   const trigger =

--- a/openmetadata-ui/src/main/resources/ui/src/components/platform/ai-shell/context/useRouteActivation.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/platform/ai-shell/context/useRouteActivation.test.tsx
@@ -1,0 +1,95 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { act, renderHook } from '@testing-library/react';
+import { PropsWithChildren } from 'react';
+import {
+  createRouteActivationStore,
+  RouteActivationProvider,
+  RouteActivationStore,
+} from './RouteActivationContext';
+import {
+  RouteActivationReason,
+  useRouteActivation,
+} from './useRouteActivation';
+
+const PATH = '/home';
+
+const renderRouteActivation = (
+  store: RouteActivationStore,
+  onActivate: (reason: RouteActivationReason) => void,
+  maxAgeMs?: number
+) => {
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <RouteActivationProvider store={store}>{children}</RouteActivationProvider>
+  );
+
+  return renderHook(
+    () => useRouteActivation(onActivate, { path: PATH, maxAgeMs }),
+    { wrapper }
+  );
+};
+
+describe('useRouteActivation reason branch', () => {
+  it('fires the activation reason on a plain re-activation', () => {
+    const store = createRouteActivationStore();
+    const onActivate = jest.fn();
+    renderRouteActivation(store, onActivate);
+
+    expect(onActivate).not.toHaveBeenCalled();
+
+    act(() => {
+      store.bumpEpoch(PATH);
+    });
+
+    expect(onActivate).toHaveBeenCalledTimes(1);
+    expect(onActivate).toHaveBeenCalledWith('activation');
+  });
+
+  it('upgrades the reason to dirty when a dirty signal is pending on re-activation', () => {
+    const store = createRouteActivationStore();
+    const onActivate = jest.fn();
+    renderRouteActivation(store, onActivate);
+
+    // Marked dirty while the page is not the active route: no immediate fire.
+    act(() => {
+      store.markRouteDirty(PATH);
+    });
+
+    expect(onActivate).not.toHaveBeenCalled();
+
+    act(() => {
+      store.bumpEpoch(PATH);
+    });
+
+    expect(onActivate).toHaveBeenCalledTimes(1);
+    expect(onActivate).toHaveBeenCalledWith('dirty');
+  });
+
+  it('upgrades the reason to maxAge when the page has aged past maxAgeMs', () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1000);
+    const store = createRouteActivationStore();
+    const onActivate = jest.fn();
+    renderRouteActivation(store, onActivate, 500);
+
+    nowSpy.mockReturnValue(2000);
+
+    act(() => {
+      store.bumpEpoch(PATH);
+    });
+
+    expect(onActivate).toHaveBeenCalledTimes(1);
+    expect(onActivate).toHaveBeenCalledWith('maxAge');
+
+    nowSpy.mockRestore();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/platform/ai-shell/context/useRouteActivation.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/platform/ai-shell/context/useRouteActivation.ts
@@ -96,9 +96,13 @@ export const useRouteActivation = (
         lastEpoch = epoch;
         lastFocus = focus; // a focus that coincides with activation shouldn't double-fire
         lastDirty = dirty;
-        onActivateRef.current(
-          becameDirty ? 'dirty' : isAged() ? 'maxAge' : 'activation'
-        );
+        let reason: RouteActivationReason = 'activation';
+        if (becameDirty) {
+          reason = 'dirty';
+        } else if (isAged()) {
+          reason = 'maxAge';
+        }
+        onActivateRef.current(reason);
 
         return;
       }

--- a/openmetadata-ui/src/main/resources/ui/src/context/LineageProvider/LineageProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/LineageProvider/LineageProvider.tsx
@@ -331,11 +331,12 @@ const LineageProvider = ({ children }: LineageProviderProps) => {
     };
 
     const existingMust = quickFilterQuery?.query?.bool?.must;
-    const mustArray = Array.isArray(existingMust)
-      ? [...existingMust]
-      : existingMust
-      ? [existingMust]
-      : [];
+    let mustArray: QueryFieldInterface[] = [];
+    if (Array.isArray(existingMust)) {
+      mustArray = [...existingMust];
+    } else if (existingMust) {
+      mustArray = [existingMust];
+    }
 
     const scopedQuery: QueryFilterInterface = {
       query: {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/EntityImport/BulkEntityImportPage/BulkEntityImportPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/EntityImport/BulkEntityImportPage/BulkEntityImportPage.tsx
@@ -1388,22 +1388,25 @@ const BulkEntityImportPage = () => {
     key: string;
     label: string;
     state: CsvProcessingStage;
-  }) => (
-    <div
-      className={`csv-processing-stage csv-processing-stage-${state}`}
-      key={key}>
-      <span className="csv-processing-stage-icon">
-        {state === 'done' ? (
-          <CheckCircle size={16} />
-        ) : state === 'active' ? (
-          <RefreshCw01 className="csv-import-spin" size={16} />
-        ) : (
-          <span className="csv-processing-stage-dot" />
-        )}
-      </span>
-      <span>{label}</span>
-    </div>
-  );
+  }) => {
+    const inProgressStageIcon =
+      state === 'active' ? (
+        <RefreshCw01 className="csv-import-spin" size={16} />
+      ) : (
+        <span className="csv-processing-stage-dot" />
+      );
+
+    return (
+      <div
+        className={`csv-processing-stage csv-processing-stage-${state}`}
+        key={key}>
+        <span className="csv-processing-stage-icon">
+          {state === 'done' ? <CheckCircle size={16} /> : inProgressStageIcon}
+        </span>
+        <span>{label}</span>
+      </div>
+    );
+  };
 
   const renderSelectedCsvFile = () => {
     if (!selectedCsvFile) {
@@ -1694,6 +1697,54 @@ const BulkEntityImportPage = () => {
     [entityPluralDisplayName, t, translatedSteps]
   );
 
+  const getAsyncImportBannerType = (
+    job: CSVImportJobType
+  ): 'error' | 'info' | 'success' => {
+    if (job.error) {
+      return 'error';
+    }
+
+    if (job.status === 'IN_PROGRESS') {
+      return 'info';
+    }
+
+    return 'success';
+  };
+
+  const renderUploadStepContent = () => {
+    if (isCsvPreviewProcessing) {
+      return renderProcessingCsvPreview();
+    }
+
+    if (validationData?.abortReason) {
+      return (
+        <div className="csv-import-card m-t-lg">
+          <div className="csv-import-abort-state">
+            <p className="text-center" data-testid="abort-reason">
+              <strong className="d-block">{t('label.aborted')}</strong>{' '}
+              {validationData.abortReason}
+            </p>
+            <Button
+              color="secondary"
+              data-testid="cancel-button"
+              onPress={handleRetryCsvUpload}>
+              {t('label.back')}
+            </Button>
+          </div>
+        </div>
+      );
+    }
+
+    return renderUploadStep();
+  };
+
+  let primaryActionLabel = t('label.next');
+  if (activeStep === VALIDATION_STEP.EDIT_VALIDATE && isRichGridImport) {
+    primaryActionLabel = `${t('label.start')} ${t('label.import')}`;
+  } else if (activeStep === VALIDATION_STEP.UPDATE) {
+    primaryActionLabel = t('label.update');
+  }
+
   return (
     <PageLayoutV1
       pageTitle={t('label.import-entity', {
@@ -1770,13 +1821,7 @@ const BulkEntityImportPage = () => {
                         activeAsyncImportJob.message ??
                         ''
                       }
-                      type={
-                        activeAsyncImportJob.error
-                          ? 'error'
-                          : activeAsyncImportJob.status === 'IN_PROGRESS'
-                          ? 'info'
-                          : 'success'
-                      }
+                      type={getAsyncImportBannerType(activeAsyncImportJob)}
                     />
                     {activeAsyncImportJob.status === 'IN_PROGRESS' &&
                       activeAsyncImportJob.total !== undefined &&
@@ -1797,32 +1842,7 @@ const BulkEntityImportPage = () => {
                 )}
             </div>
             <div>
-              {activeStep === 0 && (
-                <>
-                  {isCsvPreviewProcessing ? (
-                    renderProcessingCsvPreview()
-                  ) : validationData?.abortReason ? (
-                    <div className="csv-import-card m-t-lg">
-                      <div className="csv-import-abort-state">
-                        <p className="text-center" data-testid="abort-reason">
-                          <strong className="d-block">
-                            {t('label.aborted')}
-                          </strong>{' '}
-                          {validationData.abortReason}
-                        </p>
-                        <Button
-                          color="secondary"
-                          data-testid="cancel-button"
-                          onPress={handleRetryCsvUpload}>
-                          {t('label.back')}
-                        </Button>
-                      </div>
-                    </div>
-                  ) : (
-                    renderUploadStep()
-                  )}
-                </>
-              )}
+              {activeStep === 0 && <>{renderUploadStepContent()}</>}
               {activeStep === 1 && (
                 <div className="csv-import-card">
                   <div className="csv-import-stack">
@@ -1941,12 +1961,7 @@ const BulkEntityImportPage = () => {
                       color="primary"
                       isDisabled={isValidating}
                       onPress={handleValidate}>
-                      {activeStep === VALIDATION_STEP.EDIT_VALIDATE &&
-                      isRichGridImport
-                        ? `${t('label.start')} ${t('label.import')}`
-                        : activeStep === VALIDATION_STEP.UPDATE
-                        ? t('label.update')
-                        : t('label.next')}
+                      {primaryActionLabel}
                     </Button>
                   </div>
                 </div>

--- a/openmetadata-ui/src/main/resources/ui/src/pages/IncidentManager/IncidentManagerDetailPage/IncidentManagerDetailPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/IncidentManager/IncidentManagerDetailPage/IncidentManagerDetailPage.tsx
@@ -174,42 +174,45 @@ const IncidentManagerDetailPage = ({
     const fqnParts = tableFqn ? Fqn.split(tableFqn) : [];
     const [service, database, schema, table] = fqnParts;
 
-    const data: TitleBreadcrumbProps['titleLinks'] = originBreadcrumb?.length
-      ? originBreadcrumb
-      : fqnParts.length === 4
-      ? [
-          {
-            name: service,
-            url: getServiceDetailsPath(
-              service,
-              ServiceCategory.DATABASE_SERVICES
-            ),
-          },
-          {
-            name: database,
-            url: getEntityDetailsPath(
-              EntityType.DATABASE,
-              `${service}.${database}`
-            ),
-          },
-          {
-            name: schema,
-            url: getEntityDetailsPath(
-              EntityType.DATABASE_SCHEMA,
-              `${service}.${database}.${schema}`
-            ),
-          },
-          {
-            name: table,
-            url: getEntityDetailsPath(EntityType.TABLE, tableFqn),
-          },
-        ]
-      : [
-          {
-            name: t('label.incident-manager'),
-            url: observabilityRouterClassBase.getIncidentManagerPath(),
-          },
-        ];
+    let data: TitleBreadcrumbProps['titleLinks'];
+    if (originBreadcrumb?.length) {
+      data = originBreadcrumb;
+    } else if (fqnParts.length === 4) {
+      data = [
+        {
+          name: service,
+          url: getServiceDetailsPath(
+            service,
+            ServiceCategory.DATABASE_SERVICES
+          ),
+        },
+        {
+          name: database,
+          url: getEntityDetailsPath(
+            EntityType.DATABASE,
+            `${service}.${database}`
+          ),
+        },
+        {
+          name: schema,
+          url: getEntityDetailsPath(
+            EntityType.DATABASE_SCHEMA,
+            `${service}.${database}.${schema}`
+          ),
+        },
+        {
+          name: table,
+          url: getEntityDetailsPath(EntityType.TABLE, tableFqn),
+        },
+      ];
+    } else {
+      data = [
+        {
+          name: t('label.incident-manager'),
+          url: observabilityRouterClassBase.getIncidentManagerPath(),
+        },
+      ];
+    }
 
     if (isDimensionPage) {
       return [

--- a/openmetadata-ui/src/main/resources/ui/src/pages/LearningResourcesPage/LearningResourceForm.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/LearningResourcesPage/LearningResourceForm.component.tsx
@@ -38,6 +38,14 @@ import { LearningResourceFormProps } from './LearningResourceForm.interface';
 
 const { TextArea } = Input;
 
+const normalizeToArray = (val: unknown): unknown[] => {
+  if (Array.isArray(val)) {
+    return val;
+  }
+
+  return val != null ? [val] : [];
+};
+
 export const LearningResourceForm: React.FC<LearningResourceFormProps> = ({
   open,
   resource,
@@ -258,9 +266,7 @@ export const LearningResourceForm: React.FC<LearningResourceFormProps> = ({
           data-testid="categories-form-item"
           label={t('label.category-plural')}
           name="categories"
-          normalize={(val) =>
-            Array.isArray(val) ? val : val != null ? [val] : []
-          }
+          normalize={normalizeToArray}
           rules={[
             {
               message: t('label.field-required', {
@@ -282,9 +288,7 @@ export const LearningResourceForm: React.FC<LearningResourceFormProps> = ({
           data-testid="contexts-form-item"
           label={t('label.context')}
           name="contexts"
-          normalize={(val) =>
-            Array.isArray(val) ? val : val != null ? [val] : []
-          }
+          normalize={normalizeToArray}
           rules={[
             {
               message: t('label.field-required', {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ObservabilityAlertsPage/components/ObservabilityAlertsTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ObservabilityAlertsPage/components/ObservabilityAlertsTable.tsx
@@ -210,14 +210,14 @@ function ObservabilityAlertsTable({
     </Box>
   );
 
+  const emptyOrErrorPlaceholder = hasResourcePermissionError
+    ? errorStatePlaceholder
+    : emptyStatePlaceholder;
+
   return (
     <TableCard.Root className="tw:rounded-xl tw:border tw:border-secondary tw:shadow-none tw:outline-0">
       {isAlertsEmpty ? (
-        hasResourcePermissionError ? (
-          errorStatePlaceholder
-        ) : (
-          emptyStatePlaceholder
-        )
+        emptyOrErrorPlaceholder
       ) : (
         <>
           <div className="tw:border-b tw:border-secondary">

--- a/openmetadata-ui/src/main/resources/ui/src/pages/OntologyExplorerPage/OntologyExplorerPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/OntologyExplorerPage/OntologyExplorerPage.tsx
@@ -352,49 +352,96 @@ const OntologyExplorerPage: React.FC = () => {
     }
   };
 
-  const showAiAssistant = mode === 'ai' && isOntologyAiEnabled;
-  const showRdfDisabledNotice =
-    mode === 'query' && !isRdfEnabled && !isCapabilityLoading;
-  const showQuerySurface = mode === 'query';
-  const showModelingWorkbench = mode === 'edit' && editSurface === 'model';
+  const renderMainContent = () => {
+    if (mode === 'ai' && isOntologyAiEnabled) {
+      return (
+        <OntologyAiAssistant
+          canCreateDraft={canEditOntology}
+          glossary={selectedGlossary}
+          graphData={graphData}
+          relationshipTypes={relationTypes}
+          onOpenQuery={(query) => {
+            setGeneratedQuery(query);
+            setQuerySurface('console');
+            setMode('query');
+          }}
+        />
+      );
+    }
 
-  const defaultModeContent = showModelingWorkbench ? (
-    <OntologyModelingWorkbench
-      glossaries={glossaries}
-      graphData={graphData}
-      selectedGlossary={selectedGlossary}
-    />
-  ) : (
-    <OntologyExplorer
-      className="tw:min-h-0 tw:flex-1"
-      conceptDraftId={conceptDraft?.id}
-      defaultConceptGlossaryId={conceptDraft?.defaultGlossaryId}
-      globalGlossaryIds={selectedGlossaryIds}
-      height="100%"
-      isAuthoringMode={mode === 'edit'}
-      isEditMode={mode === 'edit' && isLeaseOwned}
-      key={explorerRevision}
-      scope="global"
-      showHealth={mode === 'view'}
-      surface={explorerSurface}
-      onConceptCreated={(concept) => {
-        setConceptDraft(undefined);
-        if (concept.glossary?.id) {
-          setSelectedGlossaryId(concept.glossary.id);
+    if (mode === 'query' && !isRdfEnabled && !isCapabilityLoading) {
+      return <RdfDisabledNotice />;
+    }
+
+    if (mode === 'query') {
+      return (
+        <div className="tw:min-h-0 tw:min-w-0 tw:flex-1 tw:overflow-auto">
+          {querySurface === 'console' ? (
+            <OntologyStudioQueryConsole
+              graphData={graphData}
+              initialQuery={generatedQuery}
+              relationTypes={relationTypes}
+              selectedGlossaryIds={selectedGlossaryIds}
+            />
+          ) : (
+            <OntologyVisualQueryBuilder
+              graphData={graphData}
+              relationTypes={relationTypes}
+              selectedGlossaryIds={selectedGlossaryIds}
+              onEditAsSparql={(query) => {
+                setGeneratedQuery(query);
+                setQuerySurface('console');
+              }}
+            />
+          )}
+        </div>
+      );
+    }
+
+    if (mode === 'edit' && editSurface === 'model') {
+      return (
+        <OntologyModelingWorkbench
+          glossaries={glossaries}
+          graphData={graphData}
+          selectedGlossary={selectedGlossary}
+        />
+      );
+    }
+
+    return (
+      <OntologyExplorer
+        className="tw:min-h-0 tw:flex-1"
+        conceptDraftId={conceptDraft?.id}
+        defaultConceptGlossaryId={conceptDraft?.defaultGlossaryId}
+        globalGlossaryIds={selectedGlossaryIds}
+        height="100%"
+        isAuthoringMode={mode === 'edit'}
+        isEditMode={mode === 'edit' && isLeaseOwned}
+        key={explorerRevision}
+        scope="global"
+        showHealth={mode === 'view'}
+        surface={explorerSurface}
+        onConceptCreated={(concept) => {
+          setConceptDraft(undefined);
+          if (concept.glossary?.id) {
+            setSelectedGlossaryId(concept.glossary.id);
+          }
+        }}
+        onConceptDraftClose={() => setConceptDraft(undefined)}
+        onGlossariesChange={handleGlossariesChange}
+        onGraphDataChange={handleGraphDataChange}
+        onRelationTypesChange={handleRelationTypesChange}
+        onRequestEdit={() => {
+          setEditSurface('graph');
+          setMode('edit');
+        }}
+        onSelectedNodeChange={(node) =>
+          setAuthoringGlossaryId(node?.glossaryId)
         }
-      }}
-      onConceptDraftClose={() => setConceptDraft(undefined)}
-      onGlossariesChange={handleGlossariesChange}
-      onGraphDataChange={handleGraphDataChange}
-      onRelationTypesChange={handleRelationTypesChange}
-      onRequestEdit={() => {
-        setEditSurface('graph');
-        setMode('edit');
-      }}
-      onSelectedNodeChange={(node) => setAuthoringGlossaryId(node?.glossaryId)}
-      onStatsChange={handleStatsChange}
-    />
-  );
+        onStatsChange={handleStatsChange}
+      />
+    );
+  };
 
   return (
     <PageLayoutV1
@@ -632,44 +679,7 @@ const OntologyExplorerPage: React.FC = () => {
               ? 'tw:bg-secondary'
               : 'tw:bg-primary'
           )}>
-          {showAiAssistant ? (
-            <OntologyAiAssistant
-              canCreateDraft={canEditOntology}
-              glossary={selectedGlossary}
-              graphData={graphData}
-              relationshipTypes={relationTypes}
-              onOpenQuery={(query) => {
-                setGeneratedQuery(query);
-                setQuerySurface('console');
-                setMode('query');
-              }}
-            />
-          ) : showRdfDisabledNotice ? (
-            <RdfDisabledNotice />
-          ) : showQuerySurface ? (
-            <div className="tw:min-h-0 tw:min-w-0 tw:flex-1 tw:overflow-auto">
-              {querySurface === 'console' ? (
-                <OntologyStudioQueryConsole
-                  graphData={graphData}
-                  initialQuery={generatedQuery}
-                  relationTypes={relationTypes}
-                  selectedGlossaryIds={selectedGlossaryIds}
-                />
-              ) : (
-                <OntologyVisualQueryBuilder
-                  graphData={graphData}
-                  relationTypes={relationTypes}
-                  selectedGlossaryIds={selectedGlossaryIds}
-                  onEditAsSparql={(query) => {
-                    setGeneratedQuery(query);
-                    setQuerySurface('console');
-                  }}
-                />
-              )}
-            </div>
-          ) : (
-            defaultModeContent
-          )}
+          {renderMainContent()}
         </section>
 
         {isLibraryOpen ? (

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableConstraints/TableConstraints.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableConstraints/TableConstraints.tsx
@@ -12,7 +12,7 @@
  */
 import { Space, Tooltip, Typography } from 'antd';
 import { isEmpty, map } from 'lodash';
-import { useCallback, useMemo, useState } from 'react';
+import { ReactNode, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import {
@@ -64,19 +64,24 @@ const TableConstraints = ({
   const showAddConstraint = hasPermission && isEmpty(data?.tableConstraints);
   const showEditConstraint = hasPermission && !isEmpty(data?.tableConstraints);
 
-  const headerExtra = showAddConstraint ? (
-    <WidgetPlusButton
-      data-testid="table-constraints-add-button"
-      title={t('label.add-entity', { entity: t('label.table-constraints') })}
-      onClick={handleOpenEditConstraintModal}
-    />
-  ) : showEditConstraint ? (
-    <WidgetEditButton
-      data-testid="edit-table-constraint-button"
-      title={t('label.edit-entity', { entity: t('label.table-constraints') })}
-      onClick={handleOpenEditConstraintModal}
-    />
-  ) : null;
+  let headerExtra: ReactNode = null;
+  if (showAddConstraint) {
+    headerExtra = (
+      <WidgetPlusButton
+        data-testid="table-constraints-add-button"
+        title={t('label.add-entity', { entity: t('label.table-constraints') })}
+        onClick={handleOpenEditConstraintModal}
+      />
+    );
+  } else if (showEditConstraint) {
+    headerExtra = (
+      <WidgetEditButton
+        data-testid="edit-table-constraint-button"
+        title={t('label.edit-entity', { entity: t('label.table-constraints') })}
+        onClick={handleOpenEditConstraintModal}
+      />
+    );
+  }
 
   const content = isEmpty(data?.tableConstraints) ? null : (
     <Space className="w-full new-header-border-card" direction="vertical">

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TagPage/TagPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TagPage/TagPage.tsx
@@ -296,12 +296,12 @@ const TagPage = () => {
   // embeds the DQ dashboard, route the tag's FQN through the dashboard's
   // matching filter key — otherwise the dashboard queries `tags.tagFQN`,
   // which never matches assets carrying these system tags.
-  const dqFilterKey: 'tier' | 'certification' | 'tags' =
-    classificationName === 'Tier'
-      ? 'tier'
-      : classificationName === 'Certification'
-      ? 'certification'
-      : 'tags';
+  let dqFilterKey: 'tier' | 'certification' | 'tags' = 'tags';
+  if (classificationName === 'Tier') {
+    dqFilterKey = 'tier';
+  } else if (classificationName === 'Certification') {
+    dqFilterKey = 'certification';
+  }
 
   const showDisableOption = useMemo(
     () => tagPermissions.EditAll && !tagItem?.deleted,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/Assignees.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/Assignees.tsx
@@ -51,15 +51,20 @@ const Assignees: FC<Props> = ({
     _values: Option[],
     newOptions?: DefaultOptionType | DefaultOptionType[]
   ) => {
-    const newValues = isUndefined(newOptions)
-      ? newOptions
-      : (isArray(newOptions) ? newOptions : [newOptions]).map((option) => ({
-          label: option['data-label'],
-          value: option.value,
-          type: option.type,
-          name: option.name,
-          displayName: option.displayName,
-        }));
+    if (isUndefined(newOptions)) {
+      onChange(newOptions as unknown as Option[]);
+
+      return;
+    }
+
+    const normalizedOptions = isArray(newOptions) ? newOptions : [newOptions];
+    const newValues = normalizedOptions.map((option) => ({
+      label: option['data-label'],
+      value: option.value,
+      type: option.type,
+      name: option.name,
+      displayName: option.displayName,
+    }));
 
     onChange(newValues as Option[]);
   };

--- a/openmetadata-ui/src/main/resources/ui/src/pages/WorkflowDefinitions/WorkflowBuilder/WorkflowBuilder.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/WorkflowDefinitions/WorkflowBuilder/WorkflowBuilder.tsx
@@ -458,6 +458,13 @@ const WorkflowBuilderInternal: React.FC<WorkflowBuilderInternalProps> = ({
     }
   );
 
+  const viewModeNodeDragEnabled = canDragNodesInViewMode
+    ? () => true
+    : () => false;
+  const canvasNodeDragEnabled = canDragNodes
+    ? isNodeDragEnabledWrapper
+    : viewModeNodeDragEnabled;
+
   return (
     <PageLayoutV1
       fullHeight
@@ -525,13 +532,7 @@ const WorkflowBuilderInternal: React.FC<WorkflowBuilderInternalProps> = ({
                 focusedConnection={focusedConnection}
                 isConnectionModalOpen={isConnectionModalOpen}
                 isDragging={isDragging}
-                isNodeDragEnabled={
-                  canDragNodes
-                    ? isNodeDragEnabledWrapper
-                    : canDragNodesInViewMode
-                    ? () => true
-                    : () => false
-                }
+                isNodeDragEnabled={canvasNodeDragEnabled}
                 nodes={nodes}
                 pendingConnection={pendingConnection}
                 onConnect={onConnect}

--- a/openmetadata-ui/src/main/resources/ui/src/rest/searchAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/searchAPI.ts
@@ -96,25 +96,28 @@ export const formatSearchQueryResponse = <
     hits: {
       ..._data.hits,
       hits: isArray(_data.hits.hits)
-        ? _data.hits.hits.map((hit) =>
-            '_source' in hit
-              ? 'entityType' in hit._source
-                ? {
-                    ...hit,
-                    _source: {
-                      ...(hit._source as SearchIndexSearchSourceMapping[SI extends Array<SearchIndex>
-                        ? SI[number]
-                        : SI]),
-                      type: (
-                        hit._source as SearchIndexSearchSourceMapping[SI extends Array<SearchIndex>
-                          ? SI[number]
-                          : SI]
-                      ).entityType,
-                    },
-                  }
-                : hit
-              : hit
-          )
+        ? _data.hits.hits.map((hit) => {
+            if (!('_source' in hit)) {
+              return hit;
+            }
+            if (!('entityType' in hit._source)) {
+              return hit;
+            }
+
+            return {
+              ...hit,
+              _source: {
+                ...(hit._source as SearchIndexSearchSourceMapping[SI extends Array<SearchIndex>
+                  ? SI[number]
+                  : SI]),
+                type: (
+                  hit._source as SearchIndexSearchSourceMapping[SI extends Array<SearchIndex>
+                    ? SI[number]
+                    : SI]
+                ).entityType,
+              },
+            };
+          })
         : [],
     },
   };
@@ -178,12 +181,8 @@ export const rawSearchQuery = <
   const includeDeletedParam =
     'includeDeleted' in req ? req.includeDeleted : false;
 
-  const apiQuery =
-    query && query !== '**'
-      ? filters
-        ? `${queryWithSlash} AND `
-        : queryWithSlash
-      : '';
+  const filteredQuery = filters ? `${queryWithSlash} AND ` : queryWithSlash;
+  const apiQuery = query && query !== '**' ? filteredQuery : '';
 
   const apiUrl = `/search/query?q=${apiQuery}${filters ?? ''}`;
 

--- a/openmetadata-ui/src/main/resources/ui/src/rest/suggestionsAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/suggestionsAPI.ts
@@ -191,12 +191,13 @@ export const updateSuggestionStatus = async (
       ? TaskResolutionType.Approved
       : TaskResolutionType.Rejected;
 
+  const tagLabelsValue = data.tagLabels
+    ? JSON.stringify(data.tagLabels)
+    : undefined;
   const newValue =
     data.type === SuggestionType.SuggestDescription
       ? data.description
-      : data.tagLabels
-      ? JSON.stringify(data.tagLabels)
-      : undefined;
+      : tagLabelsValue;
 
   const result = await resolveTask(data.id, {
     resolutionType,
@@ -238,12 +239,13 @@ export const approveRejectAllSuggestions = async (
   // Resolve sequentially to avoid optimistic-lock version conflicts on the entity.
   for (const task of filteredTasks) {
     const suggestion = taskToSuggestion(task);
+    const tagLabelsValue = suggestion.tagLabels
+      ? JSON.stringify(suggestion.tagLabels)
+      : undefined;
     const newValue =
       suggestion.type === SuggestionType.SuggestDescription
         ? suggestion.description
-        : suggestion.tagLabels
-        ? JSON.stringify(suggestion.tagLabels)
-        : undefined;
+        : tagLabelsValue;
 
     // Mirror Promise.allSettled behavior: one failure must not block remaining tasks.
     await resolveTask(task.id, { resolutionType, newValue }).catch(

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CSV/CSVPureUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CSV/CSVPureUtils.test.ts
@@ -1,0 +1,79 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import type { Column } from 'react-data-grid';
+import { getCsvGridRowHeight } from './CSVPureUtils';
+
+type GridColumn = Column<Record<string, string>>;
+
+// Five short chip labels: each estimates to a 29px chip (2 chars * 6.5 + 16),
+// packed greedily with a 6px gap into (columnWidth - 36) available px.
+const FIVE_CHIP_VALUE = 'aa;bb;cc;dd;ee';
+
+const buildColumn = (partial: Partial<GridColumn>): GridColumn =>
+  ({ key: 'tags', name: 'Tags', ...partial } as GridColumn);
+
+describe('getCsvGridRowHeight columnWidth branch', () => {
+  it('uses column.width when it is a number (wide width fits all chips on one line)', () => {
+    const columns = [buildColumn({ width: 1000 })];
+
+    expect(getCsvGridRowHeight({ tags: FIVE_CHIP_VALUE }, columns)).toBe(44);
+  });
+
+  it('uses column.width when it is a number (narrow width wraps every chip)', () => {
+    const columns = [buildColumn({ width: 40 })];
+
+    // available = max(1, 40 - 36) = 4 -> each of the 5 chips wraps -> 5 lines
+    expect(getCsvGridRowHeight({ tags: FIVE_CHIP_VALUE }, columns)).toBe(
+      44 + 4 * 26
+    );
+  });
+
+  it('falls back to column.minWidth when width is not a number', () => {
+    const narrow = [buildColumn({ minWidth: 40 })];
+    const wide = [buildColumn({ minWidth: 1000 })];
+
+    // minWidth 40 -> 5 lines; minWidth 1000 -> single line (proves minWidth,
+    // not the 200px default, was used)
+    expect(getCsvGridRowHeight({ tags: FIVE_CHIP_VALUE }, narrow)).toBe(
+      44 + 4 * 26
+    );
+    expect(getCsvGridRowHeight({ tags: FIVE_CHIP_VALUE }, wide)).toBe(44);
+  });
+
+  it('falls back to the default chip column width when neither width nor minWidth is set', () => {
+    const columns = [buildColumn({})];
+
+    // default 200 -> available 164 -> four chips fit, fifth wraps -> 2 lines
+    expect(getCsvGridRowHeight({ tags: FIVE_CHIP_VALUE }, columns)).toBe(
+      44 + 26
+    );
+  });
+
+  it('returns the base height for non-chip columns and single-chip rows', () => {
+    const nonChip = [buildColumn({ key: 'description', width: 40 })];
+    const singleChip = [buildColumn({ width: 40 })];
+
+    expect(getCsvGridRowHeight({ description: FIVE_CHIP_VALUE }, nonChip)).toBe(
+      44
+    );
+    expect(getCsvGridRowHeight({ tags: 'only-one' }, singleChip)).toBe(44);
+  });
+
+  it('honours a custom base row height', () => {
+    const columns = [buildColumn({ width: 1000 })];
+
+    expect(getCsvGridRowHeight({ tags: FIVE_CHIP_VALUE }, columns, 60)).toBe(
+      60
+    );
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CSV/CSVPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CSV/CSVPureUtils.ts
@@ -145,12 +145,14 @@ export const getCsvGridRowHeight = (
       return currentMax;
     }
 
-    const columnWidth =
-      typeof column.width === 'number'
-        ? column.width
-        : typeof column.minWidth === 'number'
-        ? column.minWidth
-        : CSV_DEFAULT_CHIP_COLUMN_WIDTH;
+    let columnWidth: number;
+    if (typeof column.width === 'number') {
+      columnWidth = column.width;
+    } else if (typeof column.minWidth === 'number') {
+      columnWidth = column.minWidth;
+    } else {
+      columnWidth = CSV_DEFAULT_CHIP_COLUMN_WIDTH;
+    }
 
     return Math.max(currentMax, estimateChipRowLines(items, columnWidth));
   }, 1);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CSV/CSVUtilsClassBase.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CSV/CSVUtilsClassBase.tsx
@@ -419,11 +419,12 @@ const getEntityReferenceOption = (
 const getEntityReferenceInitialOptions = (
   value: ExtensionDataTypes | undefined
 ) => {
-  const references = Array.isArray(value)
-    ? value.filter(isEntityReferenceValue)
-    : isEntityReferenceValue(value)
-    ? [value]
-    : [];
+  let references: EntityReference[] = [];
+  if (Array.isArray(value)) {
+    references = value.filter(isEntityReferenceValue);
+  } else if (isEntityReferenceValue(value)) {
+    references = [value];
+  }
 
   return references.map(getEntityReferenceOption);
 };
@@ -1134,6 +1135,81 @@ const InlineBulkEditReferencePickerEditor = ({
     onComplete(serializeBulkEditPickerValues(columnKey, draft));
   const handleClearAll = () => setDraft([]);
 
+  let pickerContent: React.ReactNode;
+  if (isLoading) {
+    pickerContent = (
+      <span className="bulk-edit-picker-loading">{t('label.loading')}</span>
+    );
+  } else if (hasOptions) {
+    pickerContent = (
+      <div className="bulk-edit-picker-option-list">
+        {options.map((option) => {
+          const isSelected = selectedSet.has(option.value);
+
+          return (
+            <button
+              className={`bulk-edit-picker-option${
+                isSelected ? ' selected' : ''
+              }`}
+              key={option.value}
+              type="button"
+              onClick={() => handleToggleOption(option)}>
+              {renderBulkEditPickerOptionMarker(option)}
+              <span className="bulk-edit-picker-option-meta">
+                <span className="bulk-edit-picker-option-label">
+                  {option.label}
+                </span>
+                {option.description && (
+                  <span className="bulk-edit-picker-option-value">
+                    {option.description}
+                  </span>
+                )}
+              </span>
+              {isSelected && <Check size={18} />}
+            </button>
+          );
+        })}
+      </div>
+    );
+  } else {
+    pickerContent = (
+      <div className="bulk-edit-picker-empty-state">
+        <div className={`bulk-edit-picker-empty-icon ${config.actionStyle}`}>
+          {config.emptyIcon}
+        </div>
+        <div className="bulk-edit-picker-empty-title">{config.emptyTitle}</div>
+        <div className="bulk-edit-picker-empty-description">
+          {config.description}
+        </div>
+        <button
+          className={`bulk-edit-picker-empty-action ${config.actionStyle}`}
+          type="button"
+          onClick={() => openBulkEditPickerPath(config.actionPath)}>
+          {config.actionStyle === 'primary' ? (
+            <Plus size={14} />
+          ) : (
+            <ArrowUpRight size={14} />
+          )}
+          <span>{config.primaryActionLabel}</span>
+        </button>
+        {config.secondaryActionLabel && config.secondaryActionPath && (
+          <button
+            className="bulk-edit-picker-empty-secondary-action"
+            type="button"
+            onClick={() =>
+              openBulkEditPickerPath(config.secondaryActionPath ?? '')
+            }>
+            <span>{config.secondaryActionLabel}</span>
+            <ArrowUpRight size={14} />
+          </button>
+        )}
+        {config.hint && (
+          <span className="bulk-edit-picker-empty-hint">{config.hint}</span>
+        )}
+      </div>
+    );
+  }
+
   const editor = (
     <KeyDownStopPropagationWrapper>
       <div
@@ -1156,82 +1232,7 @@ const InlineBulkEditReferencePickerEditor = ({
               onChange={(event) => setSearchText(event.target.value)}
             />
           </div>
-          <div className="bulk-edit-picker-content">
-            {isLoading ? (
-              <span className="bulk-edit-picker-loading">
-                {t('label.loading')}
-              </span>
-            ) : hasOptions ? (
-              <div className="bulk-edit-picker-option-list">
-                {options.map((option) => {
-                  const isSelected = selectedSet.has(option.value);
-
-                  return (
-                    <button
-                      className={`bulk-edit-picker-option${
-                        isSelected ? ' selected' : ''
-                      }`}
-                      key={option.value}
-                      type="button"
-                      onClick={() => handleToggleOption(option)}>
-                      {renderBulkEditPickerOptionMarker(option)}
-                      <span className="bulk-edit-picker-option-meta">
-                        <span className="bulk-edit-picker-option-label">
-                          {option.label}
-                        </span>
-                        {option.description && (
-                          <span className="bulk-edit-picker-option-value">
-                            {option.description}
-                          </span>
-                        )}
-                      </span>
-                      {isSelected && <Check size={18} />}
-                    </button>
-                  );
-                })}
-              </div>
-            ) : (
-              <div className="bulk-edit-picker-empty-state">
-                <div
-                  className={`bulk-edit-picker-empty-icon ${config.actionStyle}`}>
-                  {config.emptyIcon}
-                </div>
-                <div className="bulk-edit-picker-empty-title">
-                  {config.emptyTitle}
-                </div>
-                <div className="bulk-edit-picker-empty-description">
-                  {config.description}
-                </div>
-                <button
-                  className={`bulk-edit-picker-empty-action ${config.actionStyle}`}
-                  type="button"
-                  onClick={() => openBulkEditPickerPath(config.actionPath)}>
-                  {config.actionStyle === 'primary' ? (
-                    <Plus size={14} />
-                  ) : (
-                    <ArrowUpRight size={14} />
-                  )}
-                  <span>{config.primaryActionLabel}</span>
-                </button>
-                {config.secondaryActionLabel && config.secondaryActionPath && (
-                  <button
-                    className="bulk-edit-picker-empty-secondary-action"
-                    type="button"
-                    onClick={() =>
-                      openBulkEditPickerPath(config.secondaryActionPath ?? '')
-                    }>
-                    <span>{config.secondaryActionLabel}</span>
-                    <ArrowUpRight size={14} />
-                  </button>
-                )}
-                {config.hint && (
-                  <span className="bulk-edit-picker-empty-hint">
-                    {config.hint}
-                  </span>
-                )}
-              </div>
-            )}
-          </div>
+          <div className="bulk-edit-picker-content">{pickerContent}</div>
           {hasOptions && (
             <div className="bulk-edit-picker-footer">
               <button
@@ -1463,14 +1464,13 @@ const InlineCustomPropertiesEditor = ({
       }));
 
       const handleEnumChange = (selectedValue?: string | string[]) => {
-        handleUpdateDraft(
-          customProperty.name,
-          Array.isArray(selectedValue)
-            ? selectedValue
-            : selectedValue
-            ? [selectedValue]
-            : []
-        );
+        let normalizedValue: string[] = [];
+        if (Array.isArray(selectedValue)) {
+          normalizedValue = selectedValue;
+        } else if (selectedValue) {
+          normalizedValue = [selectedValue];
+        }
+        handleUpdateDraft(customProperty.name, normalizedValue);
       };
 
       return (

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ContextCenterPureUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ContextCenterPureUtils.test.ts
@@ -1,0 +1,95 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { PageType } from '../interface/knowledge-center.interface';
+import { knowledgePageToArticleItem } from './ContextCenterPureUtils';
+
+jest.mock('./ContextCenterClassBase', () => ({
+  __esModule: true,
+  default: {
+    getArticlePath: jest.fn((fqn: string) => `/article/${fqn}`),
+  },
+}));
+
+const UNTITLED = 'Untitled';
+
+describe('knowledgePageToArticleItem href branch', () => {
+  it('uses the quick link url when the page type is QUICK_LINK', () => {
+    const result = knowledgePageToArticleItem(
+      {
+        id: '1',
+        updatedAt: 100,
+        pageType: PageType.QUICK_LINK,
+        page: { url: 'https://example.com' },
+        fullyQualifiedName: 'ignored.fqn',
+      },
+      UNTITLED
+    );
+
+    expect(result.href).toBe('https://example.com');
+  });
+
+  it('returns undefined href for a QUICK_LINK page with no url', () => {
+    const result = knowledgePageToArticleItem(
+      {
+        id: '1',
+        updatedAt: 100,
+        pageType: PageType.QUICK_LINK,
+        page: undefined,
+      },
+      UNTITLED
+    );
+
+    expect(result.href).toBeUndefined();
+  });
+
+  it('derives the article path from the fqn for a non quick-link page', () => {
+    const result = knowledgePageToArticleItem(
+      {
+        id: '1',
+        updatedAt: 100,
+        pageType: PageType.ARTICLE,
+        fullyQualifiedName: 'ctx.page.one',
+      },
+      UNTITLED
+    );
+
+    expect(result.href).toBe('/article/ctx.page.one');
+  });
+
+  it('returns undefined href for a non quick-link page without a fqn', () => {
+    const result = knowledgePageToArticleItem(
+      {
+        id: '1',
+        updatedAt: 100,
+        pageType: PageType.ARTICLE,
+      },
+      UNTITLED
+    );
+
+    expect(result.href).toBeUndefined();
+  });
+
+  it('maps tags to their last fqn segment and falls back to the untitled label', () => {
+    const result = knowledgePageToArticleItem(
+      {
+        id: '1',
+        updatedAt: 100,
+        tags: [{ tagFQN: 'PII.Sensitive' }, { tagFQN: 'flat' }],
+      },
+      UNTITLED
+    );
+
+    expect(result.tags).toEqual([{ label: 'Sensitive' }, { label: 'flat' }]);
+    expect(result.title).toBe(UNTITLED);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ContextCenterPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ContextCenterPureUtils.ts
@@ -78,21 +78,25 @@ export const knowledgePageToArticleItem = (
     page?: QuickLink | unknown;
   },
   untitledLabel: string
-): KnowledgePageArticleItem => ({
-  description: data.description ?? '',
-  href:
-    data.pageType === PageType.QUICK_LINK
-      ? (data.page as QuickLink)?.url
-      : data.fullyQualifiedName
-      ? contextCenterClassBase.getArticlePath(data.fullyQualifiedName)
-      : undefined,
-  id: data.id,
-  lastEditedAt: data.updatedAt,
-  tags: (data.tags ?? []).map((tag) => ({
-    label: tag.tagFQN.split('.').pop() ?? tag.tagFQN,
-  })),
-  title: getEntityName(data) || untitledLabel,
-});
+): KnowledgePageArticleItem => {
+  let href: string | undefined;
+  if (data.pageType === PageType.QUICK_LINK) {
+    href = (data.page as QuickLink)?.url;
+  } else if (data.fullyQualifiedName) {
+    href = contextCenterClassBase.getArticlePath(data.fullyQualifiedName);
+  }
+
+  return {
+    description: data.description ?? '',
+    href,
+    id: data.id,
+    lastEditedAt: data.updatedAt,
+    tags: (data.tags ?? []).map((tag) => ({
+      label: tag.tagFQN.split('.').pop() ?? tag.tagFQN,
+    })),
+    title: getEntityName(data) || untitledLabel,
+  };
+};
 
 export const fetchContextCenterDocuments = async (
   params?: ListParams

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityPureUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityPureUtils.test.ts
@@ -1,0 +1,73 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import type { Operation } from 'fast-json-patch';
+import type { TestCaseFormType } from '../../components/DataQuality/AddDataQualityTest/AddDataQualityTest.interface';
+import type { TestCase } from '../../generated/tests/testCase';
+import { createUpdatedTestCasePatch } from './DataQualityPureUtils';
+
+const baseTestCase = {
+  name: 'tc',
+  description: 'old',
+  displayName: 'Old Display',
+} as TestCase;
+
+const buildValue = (description: string | undefined): TestCaseFormType =>
+  ({
+    description,
+    displayName: 'Old Display',
+  } as TestCaseFormType);
+
+const findDescriptionOp = (ops: Operation[]): Operation | undefined =>
+  ops.find((op) => op.path === '/description');
+
+describe('createUpdatedTestCasePatch description branch', () => {
+  it('keeps the existing description untouched when showOnlyParameter is true', () => {
+    const ops = createUpdatedTestCasePatch({
+      testCase: baseTestCase,
+      value: buildValue('new'),
+      createTestCaseObject: {},
+      showOnlyParameter: true,
+      isComputeRowCountFieldVisible: false,
+    });
+
+    expect(findDescriptionOp(ops)).toBeUndefined();
+  });
+
+  it('applies the form description when it is not empty', () => {
+    const ops = createUpdatedTestCasePatch({
+      testCase: baseTestCase,
+      value: buildValue('new'),
+      createTestCaseObject: {},
+      showOnlyParameter: false,
+      isComputeRowCountFieldVisible: false,
+    });
+
+    expect(findDescriptionOp(ops)).toEqual({
+      op: 'replace',
+      path: '/description',
+      value: 'new',
+    });
+  });
+
+  it('removes the description when the form value is empty', () => {
+    const ops = createUpdatedTestCasePatch({
+      testCase: baseTestCase,
+      value: buildValue(''),
+      createTestCaseObject: {},
+      showOnlyParameter: false,
+      isComputeRowCountFieldVisible: false,
+    });
+
+    expect(findDescriptionOp(ops)?.op).toBe('remove');
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityPureUtils.ts
@@ -140,14 +140,13 @@ export const createUpdatedTestCasePatch = ({
     ...(value.tags ?? []),
     ...(value.glossaryTerms ?? []),
   ];
+  const nonEmptyDescription = isEmpty(value.description)
+    ? undefined
+    : value.description;
   const updatedTestCase = {
     ...testCase,
     ...createTestCaseObject,
-    description: showOnlyParameter
-      ? testCase.description
-      : isEmpty(value.description)
-      ? undefined
-      : value.description,
+    description: showOnlyParameter ? testCase.description : nonEmptyDescription,
     displayName: showOnlyParameter ? testCase?.displayName : value.displayName,
     computePassedFailedRowCount: isComputeRowCountFieldVisible
       ? value.computePassedFailedRowCount

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityDisplayPureUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityDisplayPureUtils.test.tsx
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import type { ReactElement } from 'react';
+import { getCountBadge } from './EntityDisplayPureUtils';
+
+const getBadgeClassName = (badge: ReactElement): string =>
+  (badge as ReactElement<{ className: string }>).props.className;
+
+describe('getCountBadge active class branch', () => {
+  it('renders the active classes when isActive is true', () => {
+    const className = getBadgeClassName(getCountBadge(1, '', true));
+
+    expect(className).toContain('bg-primary text-white no-border');
+    expect(className).not.toContain('ant-tag');
+  });
+
+  it('renders the ant-tag class when isActive is false', () => {
+    const className = getBadgeClassName(getCountBadge(1, '', false));
+
+    expect(className).toContain('ant-tag');
+    expect(className).not.toContain('bg-primary');
+  });
+
+  it('renders neither active nor ant-tag class when isActive is undefined', () => {
+    const className = getBadgeClassName(getCountBadge(1));
+
+    expect(className).not.toContain('ant-tag');
+    expect(className).not.toContain('bg-primary');
+    expect(className).toContain('global-border');
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityDisplayPureUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityDisplayPureUtils.tsx
@@ -26,11 +26,8 @@ export const getCountBadge = (
   className = '',
   isActive?: boolean
 ) => {
-  const clsBG = isUndefined(isActive)
-    ? ''
-    : isActive
-    ? 'bg-primary text-white no-border'
-    : 'ant-tag';
+  const activeCls = isActive ? 'bg-primary text-white no-border' : 'ant-tag';
+  const clsBG = isUndefined(isActive) ? '' : activeCls;
 
   return (
     <span

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageNodeUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageNodeUtils.ts
@@ -491,14 +491,17 @@ export const createNodes = (
     const hasOutgoing = outgoingMap.has(node.id);
     const isOutputNode = hasIncoming && !hasOutgoing;
     const isInputNode = !hasIncoming && hasOutgoing;
-    const type =
-      node.type === EntityLineageNodeType.LOAD_MORE
-        ? node.type
-        : isOutputNode
-        ? EntityLineageNodeType.OUTPUT
-        : isInputNode
-        ? EntityLineageNodeType.INPUT
-        : EntityLineageNodeType.DEFAULT;
+
+    let type: EntityLineageNodeType | string;
+    if (node.type === EntityLineageNodeType.LOAD_MORE) {
+      type = node.type;
+    } else if (isOutputNode) {
+      type = EntityLineageNodeType.OUTPUT;
+    } else if (isInputNode) {
+      type = EntityLineageNodeType.INPUT;
+    } else {
+      type = EntityLineageNodeType.DEFAULT;
+    }
 
     const nodeHeight = isExpanded ? 550 : NODE_HEIGHT;
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtilsV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtilsV1.tsx
@@ -959,13 +959,14 @@ const APIEndpointSchemaV1: React.FC<{
           : [];
 
         if (nameMatch || filteredChildren.length > 0) {
+          let matchedChildren = field.children;
+          if (!nameMatch && filteredChildren.length > 0) {
+            matchedChildren = filteredChildren;
+          }
+
           acc.push({
             ...field,
-            children: nameMatch
-              ? field.children
-              : filteredChildren.length > 0
-              ? filteredChildren
-              : field.children,
+            children: matchedChildren,
           });
         }
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ExplorePureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ExplorePureUtils.ts
@@ -539,11 +539,15 @@ export const getQueryFilterMust = (
 ): QueryFieldInterface[] => {
   const parsedMust = get(queryFilter, 'query.bool.must');
 
-  return Array.isArray(parsedMust)
-    ? parsedMust
-    : parsedMust
-    ? [parsedMust]
-    : [];
+  if (Array.isArray(parsedMust)) {
+    return parsedMust;
+  }
+
+  if (parsedMust) {
+    return [parsedMust];
+  }
+
+  return [];
 };
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/utils/NodeUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/NodeUtils.test.ts
@@ -1,0 +1,81 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import type { Node } from 'reactflow';
+import { NodeType } from '../generated/governance/workflows/elements/nodeType';
+import { ScheduleTimeline } from '../generated/governance/workflows/elements/triggers/periodicBatchEntityTrigger';
+import {
+  Type,
+  WorkflowDefinition,
+} from '../generated/governance/workflows/workflowDefinition';
+import { getInitialNodeConfig } from './NodeUtils';
+
+const startNode = {
+  id: 'n1',
+  type: NodeType.StartEvent,
+  data: {},
+  position: { x: 0, y: 0 },
+} as Node;
+
+const buildWorkflowDefinition = (
+  schedule?: Record<string, unknown>
+): WorkflowDefinition =>
+  ({
+    displayName: 'WF',
+    description: 'desc',
+    trigger: {
+      type: Type.PeriodicBatchEntity,
+      config: {
+        entityTypes: [],
+        ...(schedule ? { schedule } : {}),
+      },
+    },
+  } as unknown as WorkflowDefinition);
+
+describe('getInitialNodeConfig scheduleType branch', () => {
+  it('sets scheduleType to OnDemand when the timeline is None', () => {
+    const config = getInitialNodeConfig(
+      startNode,
+      buildWorkflowDefinition({ scheduleTimeline: ScheduleTimeline.None })
+    );
+
+    expect(config.scheduleType).toBe('OnDemand');
+  });
+
+  it('sets scheduleType to Scheduled for a Custom timeline with a cron expression', () => {
+    const config = getInitialNodeConfig(
+      startNode,
+      buildWorkflowDefinition({
+        scheduleTimeline: ScheduleTimeline.Custom,
+        cronExpression: '0 0 * * *',
+      })
+    );
+
+    expect(config.scheduleType).toBe('Scheduled');
+    expect(config.cronExpression).toBe('0 0 * * *');
+  });
+
+  it('leaves scheduleType empty for a Custom timeline without a cron expression', () => {
+    const config = getInitialNodeConfig(
+      startNode,
+      buildWorkflowDefinition({ scheduleTimeline: ScheduleTimeline.Custom })
+    );
+
+    expect(config.scheduleType).toBe('');
+  });
+
+  it('leaves scheduleType empty when there is no schedule config', () => {
+    const config = getInitialNodeConfig(startNode, buildWorkflowDefinition());
+
+    expect(config.scheduleType).toBe('');
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/NodeUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/NodeUtils.ts
@@ -246,6 +246,16 @@ export const getInitialNodeConfig = (
       );
     }
 
+    let scheduleType = '';
+    if (config.schedule?.scheduleTimeline === ScheduleTimeline.None) {
+      scheduleType = 'OnDemand';
+    } else if (
+      config.schedule?.scheduleTimeline === ScheduleTimeline.Custom &&
+      config.schedule?.cronExpression
+    ) {
+      scheduleType = 'Scheduled';
+    }
+
     return {
       name:
         workflowMetadata?.displayName || workflowDefinition.displayName || '',
@@ -262,13 +272,7 @@ export const getInitialNodeConfig = (
       excludeFields:
         config.exclude && Array.isArray(config.exclude) ? config.exclude : [],
       include: Array.isArray(config.include) ? config.include : [],
-      scheduleType:
-        config.schedule?.scheduleTimeline === ScheduleTimeline.None
-          ? 'OnDemand'
-          : config.schedule?.scheduleTimeline === ScheduleTimeline.Custom &&
-            config.schedule?.cronExpression
-          ? 'Scheduled'
-          : '',
+      scheduleType,
       cronExpression: config.schedule?.cronExpression || '',
       batchSize: config.batchSize || 500,
       dataAssetFilters,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.js
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.js
@@ -22,6 +22,33 @@ import { Utils as extendConfigUtils } from '@react-awesome-query-builder/core';
 export const ES_7_SYNTAX = 'ES_7_SYNTAX';
 export const ES_6_SYNTAX = 'ES_6_SYNTAX';
 
+const EXACT_MATCH_OPERATORS = [
+  'equal',
+  'not_equal',
+  'select_equals',
+  'select_not_equals',
+  'multiselect_equals',
+  'multiselect_not_equals',
+];
+
+const NEGATED_OPERATORS = [
+  'not_equal',
+  'not_between',
+  'not_like',
+  'select_not_equals',
+  'multiselect_not_equals',
+  'multiselect_not_contains',
+];
+
+const RANGEABLE_OM_TYPES = [
+  'integer',
+  'number',
+  'timestamp',
+  'date-cp',
+  'dateTime-cp',
+  'time-cp',
+];
+
 /**
  * Converts a string representation of top_left and bottom_right cords to
  * a ES geo_point required for query
@@ -645,14 +672,7 @@ function buildExtensionQuery(
         minimum_should_match: 1,
       },
     };
-  } else if (
-    operator === 'equal' ||
-    operator === 'not_equal' ||
-    operator === 'select_equals' ||
-    operator === 'select_not_equals' ||
-    operator === 'multiselect_equals' ||
-    operator === 'multiselect_not_equals'
-  ) {
+  } else if (EXACT_MATCH_OPERATORS.includes(operator)) {
     // Exact match: pick the right typed field.
     // 1) If we know the OM property type, route directly: numeric types ->
     //    longValue/doubleValue, all others -> stringValue. This avoids the bug
@@ -717,15 +737,7 @@ function buildExtensionQuery(
   }
 
   // Wrap in must_not if negated
-  if (
-    not ||
-    operator === 'not_equal' ||
-    operator === 'not_between' ||
-    operator === 'not_like' ||
-    operator === 'select_not_equals' ||
-    operator === 'multiselect_not_equals' ||
-    operator === 'multiselect_not_contains'
-  ) {
+  if (not || NEGATED_OPERATORS.includes(operator)) {
     mainQuery = {
       bool: {
         must_not: mainQuery.nested ? mainQuery : [mainQuery],
@@ -777,13 +789,14 @@ function buildEsRule(fieldName, value, operator, config, valueSrc) {
     return undefined;
   }
 
-  if (
-    (operator === 'between' || operator === 'not_between') &&
-    (!Array.isArray(value) ||
-      value.length < 2 ||
-      value[0] === undefined ||
-      value[1] === undefined)
-  ) {
+  const isBetweenOperator =
+    operator === 'between' || operator === 'not_between';
+  const hasIncompleteRangeBounds =
+    !Array.isArray(value) ||
+    value.length < 2 ||
+    value[0] === undefined ||
+    value[1] === undefined;
+  if (isBetweenOperator && hasIncompleteRangeBounds) {
     return undefined;
   }
 
@@ -837,18 +850,11 @@ function buildEsRule(fieldName, value, operator, config, valueSrc) {
     // zero-padded formats (e.g. yyyy-MM-dd HH:mm:ss). Other types collapse to
     // value[0] since only a single bound is meaningful.
     const isBetweenOp = op === 'between';
-    const isRangeableOmType =
-      omPropertyType === 'integer' ||
-      omPropertyType === 'number' ||
-      omPropertyType === 'timestamp' ||
-      omPropertyType === 'date-cp' ||
-      omPropertyType === 'dateTime-cp' ||
-      omPropertyType === 'time-cp';
-    const extensionValue = hasValue
-      ? isBetweenOp && isRangeableOmType
-        ? value
-        : value[0]
-      : null;
+    const isRangeableOmType = RANGEABLE_OM_TYPES.includes(omPropertyType);
+    let extensionValue = null;
+    if (hasValue) {
+      extensionValue = isBetweenOp && isRangeableOmType ? value : value[0];
+    }
 
     return buildExtensionQuery(
       extensionPropertyName,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderPureUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderPureUtils.test.ts
@@ -1,0 +1,68 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { getSelectEqualsNotEqualsProperties } from './QueryBuilderPureUtils';
+
+type RuleProperties = {
+  valueType: string[];
+  asyncListValues?: { key: string; value: string; children: string }[];
+};
+
+const getRuleProperties = (
+  value: unknown,
+  operator: string
+): RuleProperties => {
+  const result = getSelectEqualsNotEqualsProperties(
+    [],
+    'field',
+    value as string,
+    operator
+  );
+
+  return (Object.values(result)[0] as { properties: RuleProperties })
+    .properties;
+};
+
+describe('getSelectEqualsNotEqualsProperties valueType and asyncListValues branch', () => {
+  it('uses the boolean value type for an equality op on a boolean value', () => {
+    const properties = getRuleProperties(true, 'equal');
+
+    expect(properties.valueType).toEqual(['boolean']);
+    expect(properties.asyncListValues).toBeUndefined();
+  });
+
+  it('uses the text value type for an equality op on a non-boolean value', () => {
+    const properties = getRuleProperties('abc', 'not_equal');
+
+    expect(properties.valueType).toEqual(['text']);
+    expect(properties.asyncListValues).toBeUndefined();
+  });
+
+  it('uses multiselect and maps array items for a membership op on an array value', () => {
+    const properties = getRuleProperties(['a', 'b'], 'select_equals');
+
+    expect(properties.valueType).toEqual(['multiselect']);
+    expect(properties.asyncListValues).toEqual([
+      { key: 'a', value: 'a', children: 'a' },
+      { key: 'b', value: 'b', children: 'b' },
+    ]);
+  });
+
+  it('uses select and a single async value for a membership op on a scalar value', () => {
+    const properties = getRuleProperties('x', 'select_not_equals');
+
+    expect(properties.valueType).toEqual(['select']);
+    expect(properties.asyncListValues).toEqual([
+      { key: 'x', value: 'x', children: 'x' },
+    ]);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderPureUtils.ts
@@ -88,13 +88,14 @@ export const getSelectEqualsNotEqualsProperties = (
 ) => {
   const id = generateUUID();
   const isEqualNotEqualOp = ['equal', 'not_equal'].includes(operator);
-  const valueType = isEqualNotEqualOp
-    ? isBoolean(value)
-      ? ['boolean']
-      : ['text']
-    : Array.isArray(value)
+  const equalityValueType = isBoolean(value) ? ['boolean'] : ['text'];
+  const membershipValueType = Array.isArray(value)
     ? ['multiselect']
     : ['select'];
+  const valueType = isEqualNotEqualOp ? equalityValueType : membershipValueType;
+  const listValues = Array.isArray(value)
+    ? value.map((item) => ({ key: item, value: item, children: item }))
+    : [{ key: value, value, children: value }];
 
   return {
     [id]: {
@@ -106,11 +107,7 @@ export const getSelectEqualsNotEqualsProperties = (
         valueSrc: ['value'],
         operatorOptions: null,
         valueType: valueType,
-        asyncListValues: isEqualNotEqualOp
-          ? undefined
-          : Array.isArray(value)
-          ? value.map((item) => ({ key: item, value: item, children: item }))
-          : [{ key: value, value, children: value }],
+        asyncListValues: isEqualNotEqualOp ? undefined : listValues,
       },
       id,
       path: [...parentPath, id],

--- a/openmetadata-ui/src/main/resources/ui/src/utils/RecentActivityUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/RecentActivityUtils.test.ts
@@ -1,0 +1,48 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { arraySorterByKey } from './RecentActivityUtils';
+
+type Item = { timestamp: number };
+
+describe('arraySorterByKey comparison branch', () => {
+  it('returns -1, 1 and 0 for less-than, greater-than and equal in ascending order', () => {
+    const sorter = arraySorterByKey<Item>('timestamp');
+
+    expect(sorter({ timestamp: 1 }, { timestamp: 2 })).toBe(-1);
+    expect(sorter({ timestamp: 2 }, { timestamp: 1 })).toBe(1);
+    expect(sorter({ timestamp: 1 }, { timestamp: 1 })).toBe(0);
+  });
+
+  it('flips the comparison sign in descending order', () => {
+    const sorter = arraySorterByKey<Item>('timestamp', true);
+
+    expect(sorter({ timestamp: 1 }, { timestamp: 2 })).toBe(1);
+    expect(sorter({ timestamp: 2 }, { timestamp: 1 })).toBe(-1);
+    // Equal keys yield 0 * -1 === -0; assert numeric equality with 0.
+    expect(sorter({ timestamp: 1 }, { timestamp: 1 })).toBeCloseTo(0);
+  });
+
+  it('orders an array descending by the given key', () => {
+    const items: Item[] = [
+      { timestamp: 2 },
+      { timestamp: 1 },
+      { timestamp: 3 },
+    ];
+
+    expect([...items].sort(arraySorterByKey<Item>('timestamp', true))).toEqual([
+      { timestamp: 3 },
+      { timestamp: 2 },
+      { timestamp: 1 },
+    ]);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/RecentActivityUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/RecentActivityUtils.ts
@@ -27,13 +27,14 @@ export const arraySorterByKey = <T extends object>(
   const sortOrder = sortDescending ? -1 : 1;
 
   return (elementOne: T, elementTwo: T) => {
-    return (
-      (elementOne[key] < elementTwo[key]
-        ? -1
-        : elementOne[key] > elementTwo[key]
-        ? 1
-        : 0) * sortOrder
-    );
+    let comparison = 0;
+    if (elementOne[key] < elementTwo[key]) {
+      comparison = -1;
+    } else if (elementOne[key] > elementTwo[key]) {
+      comparison = 1;
+    }
+
+    return comparison * sortOrder;
   };
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TaskPayloadUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TaskPayloadUtils.test.ts
@@ -1,0 +1,51 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { TaskEntityType, type Task as TaskEntity } from '../rest/tasksAPI';
+import { getNormalizedTaskPayload } from './TaskPayloadUtils';
+
+const buildTask = (
+  type: TaskEntityType,
+  payload: Record<string, unknown>
+): TaskEntity => ({ type, payload } as unknown as TaskEntity);
+
+describe('getNormalizedTaskPayload suggestedValue branch', () => {
+  it('serializes the suggested tags for a tag task with tags', () => {
+    const suggestedTags = [{ tagFQN: 'PII.Sensitive' }];
+    const result = getNormalizedTaskPayload(
+      buildTask(TaskEntityType.TagUpdate, { tagsToAdd: suggestedTags })
+    );
+
+    expect(result.suggestedValue).toBe(JSON.stringify(suggestedTags));
+    expect(result.isSuggestionEmpty).toBe(false);
+  });
+
+  it('returns an undefined suggested value for a tag task with no tags', () => {
+    const result = getNormalizedTaskPayload(
+      buildTask(TaskEntityType.TagUpdate, {})
+    );
+
+    expect(result.suggestedValue).toBeUndefined();
+    expect(result.isSuggestionEmpty).toBe(true);
+  });
+
+  it('uses the new description for a non-tag task', () => {
+    const result = getNormalizedTaskPayload(
+      buildTask(TaskEntityType.DescriptionUpdate, {
+        newDescription: 'updated description',
+      })
+    );
+
+    expect(result.suggestedValue).toBe('updated description');
+    expect(result.isSuggestionEmpty).toBe(false);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TaskPayloadUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TaskPayloadUtils.ts
@@ -77,11 +77,9 @@ export const getNormalizedTaskPayload = (
         ]
       : suggestedTagsFromLegacyPayload;
 
-  const suggestedValue = isTagTask
-    ? suggestedTags.length > 0
-      ? JSON.stringify(suggestedTags)
-      : undefined
-    : newDescription;
+  const tagSuggestedValue =
+    suggestedTags.length > 0 ? JSON.stringify(suggestedTags) : undefined;
+  const suggestedValue = isTagTask ? tagSuggestedValue : newDescription;
 
   const isSuggestionEmpty = isTagTask
     ? suggestedTags.length === 0


### PR DESCRIPTION
## Summary

Part of **rule 9** of the ESLint-cleanup epic (#30977, sub-issue #30984 — the *sonarjs complexity* family). This PR takes the **`sonarjs/no-nested-conditional`** sub-rule to **0 violations** and **promotes it `warn` → `error`** so nested ternaries can't drift back in. The remaining complexity rules in #30984 (`cyclomatic-complexity`, `no-nested-functions`, `cognitive-complexity`) stay at `warn` for their own follow-up PRs — this keeps the change small and reviewable, consistent with the one-rule-per-PR ratchet. (`expression-complexity` was already promoted to `error` on `main` by #32381; this PR leaves that line untouched — it shows up as unchanged context in the `eslint.config.mjs` diff.)

## Approach — real refactors, behavior-preserving

Every nested ternary was **refactored**, not suppressed: the inner ternary is lifted into an intermediate `const`/`let` (or an `if/else` chain for value selection) so the render/return logic reads top-to-bottom. No `eslint-disable`, no logic change.

- **~194 violations across 122 files → 0.**
- Extraction can drop TypeScript control-flow narrowing; five files needed the type restored **without** reintroducing a nested ternary (typed `let`, `lodash/compact`, an explicit non-null guard in the render path, a typed `if/else`, an `unknown` bridge). See commit `preserve type narrowing after no-nested-conditional extraction`.

## Verification

- **ESLint:** `eslint --quiet 'src/**/*.{ts,tsx}'` with the rule at **error** → **0 errors tree-wide, 0 `no-nested-conditional` occurrences.**
- **Types — no regressions:** full `tsc --noEmit` diff vs `origin/main`, line/path-normalized → **0 net-new error signatures** (branch has 587 total vs main 591; net direction is *fewer* errors, none introduced).
- **Existing behavior:** the **86 co-located test suites** covering the changed files pass (**1111 tests green**; the lone `TaskTabNew` failure was CPU-contention flake under parallel workers — passes 30/30 in isolation).
- **New coverage:** added **focused co-located unit tests for the 10 pure-logic files** whose refactor touched exported branch logic and that had no co-located test (9 `utils` + the `useRouteActivation` hook) — **37 cases**, each exercising every arm of the refactored conditional.
- `yarn ui-checkstyle:changed` → 0 errors.

## Ratchet

```diff
- 'sonarjs/no-nested-conditional': 'warn', // 16
+ 'sonarjs/no-nested-conditional': 'error',
```

Per the epic's merge-time lesson, a full-lint over the whole tree (not just changed files) was run right before promotion to confirm zero violations anywhere.

---

> **Tracker:** this PR does _not_ close #30984 — it clears only the `no-nested-conditional` sub-rule of the sonarjs complexity family, leaving #30984 open for the remaining complexity rules. The PR-metadata gate is intentionally bypassed via the `skip-pr-checks` label for this reason.
