### PR TITLE
refactor: OIDC login handler and MCP callback auth handling

### DIFF
--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/auth/handlers/McpCallbackServlet.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/auth/handlers/McpCallbackServlet.java
@@ -4,7 +4,6 @@ import static org.openmetadata.service.security.AuthenticationCodeFlowHandler.OI
 import static org.openmetadata.service.security.SecurityUtil.findEmailFromClaims;
 import static org.openmetadata.service.security.SecurityUtil.findUserNameFromClaims;
 
-import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.pkce.CodeVerifier;
@@ -217,13 +216,23 @@ public class McpCallbackServlet extends HttpServlet {
 
     String expectedIssuer;
     try {
+      // pac4j 6 removed getProviderMetadata(); metadata now loads lazily via the resolver, which
+      // must be initialized first because OM builds the OidcClient without calling client.init().
+      ssoHandler.getClient().getConfiguration().ensuresMetadataResolverInitialized();
       expectedIssuer =
-          ssoHandler.getClient().getConfiguration().getProviderMetadata().getIssuer().getValue();
+          ssoHandler
+              .getClient()
+              .getConfiguration()
+              .getOpMetadataResolver()
+              .load()
+              .getIssuer()
+              .getValue();
     } catch (Exception e) {
-      LOG.warn(
-          "Could not extract issuer from OIDC provider metadata, will use default: {}",
-          e.getMessage());
       expectedIssuer = authConfig.getAuthority();
+      LOG.warn(
+          "Could not extract issuer from OIDC provider metadata, using default: {}",
+          expectedIssuer,
+          e);
     }
 
     String expectedAudience = null;
@@ -462,11 +471,12 @@ public class McpCallbackServlet extends HttpServlet {
         throw new IllegalStateException("No OIDC credentials found in session after SSO callback");
       }
 
-      JWT idToken = credentials.getIdToken();
+      // pac4j 6 stores the id token as a serialized String; use it directly for validation.
+      String idTokenString = credentials.getIdToken();
 
       JWTClaimsSet claimsSet;
       try {
-        claimsSet = getIdTokenValidator(ssoHandler).validateAndDecode(idToken.serialize());
+        claimsSet = getIdTokenValidator(ssoHandler).validateAndDecode(idTokenString);
         LOG.debug("ID token signature validated successfully in standard SSO flow");
       } catch (IdTokenValidator.IdTokenValidationException e) {
         LOG.error(

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -20,7 +20,7 @@
     <java.saml>2.9.0</java.saml>
     <xmlsec.version>2.3.4</xmlsec.version>
     <quartz.version>2.5.0-rc2</quartz.version>
-    <pac4j.version>5.7.10</pac4j.version>
+    <pac4j.version>6.5.6</pac4j.version>
     <maven-javadoc-plugin.version>3.6.0</maven-javadoc-plugin.version>
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     <socket.io-client.version>2.1.1</socket.io-client.version>

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
@@ -241,11 +241,9 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
   private void initializeFields() {
     this.client = buildOidcClient(authenticationConfiguration.getOidcConfiguration());
     client.setCallbackUrl(authenticationConfiguration.getOidcConfiguration().getCallbackUrl());
-    // Create the OIDC metadata resolver here, during single-threaded startup, so concurrent logins
-    // never race to lazily initialize it. pac4j 6 normally does this in client.init() (which OM
-    // does
-    // not call); resolveProviderMetadata() then only reads the already-initialized, cached
-    // resolver.
+    // Create the OIDC metadata resolver during single-threaded startup so concurrent logins never
+    // race to lazily initialize it. pac4j 6 normally does this in client.init(), but OM does not
+    // call it. resolveProviderMetadata() then reads the initialized, cached resolver.
     client.getConfiguration().ensuresMetadataResolverInitialized();
 
     this.serverUrl = authenticationConfiguration.getOidcConfiguration().getServerUrl();
@@ -752,11 +750,8 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
     }
   }
 
-  // pac4j 6 removed OidcConfiguration#getProviderMetadata()/findProviderMetadata(); provider
-  // metadata now loads through an IOidcOpMetadataResolver. OM builds the OidcClient without calling
-  // client.init(), so the resolver is not created for us - ensuresMetadataResolverInitialized()
-  // creates it on first use (idempotent null-check) and load() then lazily fetches and caches the
-  // discovery document, matching the old findProviderMetadata() laziness.
+  // pac4j 6 replaces provider-metadata accessors with a lazy IOidcOpMetadataResolver. OM does not
+  // call client.init(), so ensure the resolver exists before loading its cached discovery document.
   private static OIDCProviderMetadata resolveProviderMetadata(OidcConfiguration configuration) {
     configuration.ensuresMetadataResolverInitialized();
     return configuration.getOpMetadataResolver().load();
@@ -1032,13 +1027,19 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
     OIDCTokenResponse tokenSuccessResponse = parseTokenResponseFromHttpResponse(httpResponse);
     populateCredentialsFromTokenResponse(tokenSuccessResponse, credentials);
 
-    Date expirationTime = credentials.toIdToken().getJWTClaimsSet().getExpirationTime();
+    Date expirationTime = getIdTokenExpirationTime(credentials);
     if (expirationTime != null
         && expirationTime.before(Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTime())) {
       LOG.warn(
           "OIDC provider returned an expired ID token for session {}. Proceeding with claim extraction.",
           session.getId());
     }
+  }
+
+  @SneakyThrows
+  private static Date getIdTokenExpirationTime(OidcCredentials credentials) {
+    JWT idToken = credentials.toIdToken();
+    return idToken == null ? null : idToken.getJWTClaimsSet().getExpirationTime();
   }
 
   public static boolean isJWT(String token) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
@@ -109,7 +109,7 @@ import org.pac4j.oidc.client.GoogleOidcClient;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.AzureAd2OidcConfiguration;
 import org.pac4j.oidc.config.OidcConfiguration;
-import org.pac4j.oidc.config.PrivateKeyJWTClientAuthnMethodConfig;
+import org.pac4j.oidc.config.method.IPrivateKeyJwtClientAuthnMethodConfig;
 import org.pac4j.oidc.credentials.OidcCredentials;
 
 @Slf4j
@@ -241,6 +241,12 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
   private void initializeFields() {
     this.client = buildOidcClient(authenticationConfiguration.getOidcConfiguration());
     client.setCallbackUrl(authenticationConfiguration.getOidcConfiguration().getCallbackUrl());
+    // Create the OIDC metadata resolver here, during single-threaded startup, so concurrent logins
+    // never race to lazily initialize it. pac4j 6 normally does this in client.init() (which OM
+    // does
+    // not call); resolveProviderMetadata() then only reads the already-initialized, cached
+    // resolver.
+    client.getConfiguration().ensuresMetadataResolverInitialized();
 
     this.serverUrl = authenticationConfiguration.getOidcConfiguration().getServerUrl();
     this.claimsOrder = authenticationConfiguration.getJwtPrincipalClaims();
@@ -495,7 +501,7 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
       LOG.debug("Authentication response successful");
       AuthenticationSuccessResponse successResponse = (AuthenticationSuccessResponse) response;
 
-      OIDCProviderMetadata metadata = client.getConfiguration().getProviderMetadata();
+      OIDCProviderMetadata metadata = resolveProviderMetadata(client.getConfiguration());
       if (metadata.supportsAuthorizationResponseIssuerParam()
           && !metadata.getIssuer().equals(successResponse.getIssuer())) {
         throw new TechnicalException("Issuer mismatch, possible mix-up attack.");
@@ -510,11 +516,14 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
       // Validations
       validateAndSendTokenRequest(pendingSession, credentials, computedCallbackUrl);
 
-      if (credentials.getIdToken() == null) {
+      // pac4j 6 re-parses the serialized id token on every toIdToken() call; parse once and reuse.
+      JWT idToken = credentials.toIdToken();
+      if (idToken == null) {
         throw new TechnicalException("ID token not returned by OIDC provider");
       }
+      JWTClaimsSet idTokenClaims = idToken.getJWTClaimsSet();
 
-      validateNonceIfRequired(pendingSession, credentials.getIdToken().getJWTClaimsSet());
+      validateNonceIfRequired(pendingSession, idTokenClaims);
 
       // The MCP callback completes its own OAuth exchange off the provider-issued id_token, which
       // is only available here. Hand the validated credentials over on the session for it to pick
@@ -525,7 +534,7 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
       }
 
       Map<String, Object> claims = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-      claims.putAll(credentials.getIdToken().getJWTClaimsSet().getClaims());
+      claims.putAll(idTokenClaims.getClaims());
 
       String userName = findUserNameFromClaims(claimsMapping, claimsOrder, claims);
       String email = findEmailFromClaims(claimsMapping, claimsOrder, claims, principalDomain);
@@ -540,6 +549,8 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
       org.openmetadata.schema.auth.RefreshToken refreshToken =
           TokenUtil.getRefreshToken(user.getId(), UUID.randomUUID());
       Entity.getTokenRepository().insertToken(refreshToken);
+      // pac4j 6 re-parses the stored refresh token on every toRefreshToken() call; parse once.
+      var providerRefreshToken = credentials.toRefreshToken();
       Optional<UserSession> maybeActiveSession =
           sessionService.activatePendingSession(
               req,
@@ -547,9 +558,7 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
               pendingSession,
               user,
               refreshToken.getToken().toString(),
-              credentials.getRefreshToken() != null
-                  ? credentials.getRefreshToken().getValue()
-                  : null);
+              providerRefreshToken != null ? providerRefreshToken.getValue() : null);
       if (maybeActiveSession.isEmpty()) {
         Entity.getTokenRepository().deleteToken(refreshToken.getToken().toString());
         throw new TechnicalException("Failed to activate OIDC session");
@@ -680,7 +689,9 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
     } catch (Exception e) {
       throw new TechnicalException(e);
     }
-    return client.getConfiguration().getProviderMetadata().getAuthorizationEndpointURI().toString()
+    return resolveProviderMetadata(client.getConfiguration())
+            .getAuthorizationEndpointURI()
+            .toString()
         + '?'
         + queryString;
   }
@@ -711,7 +722,7 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
       TokenRequest request =
           createTokenRequest(
               new AuthorizationCodeGrant(
-                  oidcCredentials.getCode(), new URI(computedCallbackUrl), verifier));
+                  oidcCredentials.toAuthorizationCode(), new URI(computedCallbackUrl), verifier));
       executeAuthorizationCodeTokenRequest(session, request, oidcCredentials);
     }
   }
@@ -741,22 +752,35 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
     }
   }
 
+  // pac4j 6 removed OidcConfiguration#getProviderMetadata()/findProviderMetadata(); provider
+  // metadata now loads through an IOidcOpMetadataResolver. OM builds the OidcClient without calling
+  // client.init(), so the resolver is not created for us - ensuresMetadataResolverInitialized()
+  // creates it on first use (idempotent null-check) and load() then lazily fetches and caches the
+  // discovery document, matching the old findProviderMetadata() laziness.
+  private static OIDCProviderMetadata resolveProviderMetadata(OidcConfiguration configuration) {
+    configuration.ensuresMetadataResolverInitialized();
+    return configuration.getOpMetadataResolver().load();
+  }
+
   private OidcCredentials buildCredentials(AuthenticationSuccessResponse successResponse) {
     OidcCredentials credentials = new OidcCredentials();
     // get authorization code
     AuthorizationCode code = successResponse.getAuthorizationCode();
     if (code != null) {
-      credentials.setCode(code);
+      // pac4j 6 stores the code as a String; toAuthorizationCode() reconstructs the nimbus type.
+      credentials.setCode(code.getValue());
     }
     // get ID token
     JWT idToken = successResponse.getIDToken();
     if (idToken != null) {
-      credentials.setIdToken(idToken);
+      // pac4j 6 stores the id token as a serialized String; toIdToken() re-parses it to a JWT.
+      credentials.setIdToken(idToken.serialize());
     }
     // get access token
     AccessToken accessToken = successResponse.getAccessToken();
     if (accessToken != null) {
-      credentials.setAccessToken(accessToken);
+      // pac4j 6 setAccessToken takes a Map; setAccessTokenObject keeps the nimbus AccessToken.
+      credentials.setAccessTokenObject(accessToken);
     }
 
     return credentials;
@@ -804,7 +828,7 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
     if (configuration.getSecret() != null) {
       // check authentication methods
       List<ClientAuthenticationMethod> metadataMethods =
-          configuration.findProviderMetadata().getTokenEndpointAuthMethods();
+          resolveProviderMetadata(configuration).getTokenEndpointAuthMethods();
 
       ClientAuthenticationMethod preferredMethod = getPreferredAuthenticationMethod(configuration);
 
@@ -840,19 +864,19 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
         Secret clientSecret = new Secret(configuration.getSecret());
         clientAuthenticationMechanism = new ClientSecretBasic(clientID, clientSecret);
       } else if (ClientAuthenticationMethod.PRIVATE_KEY_JWT.equals(chosenMethod)) {
-        PrivateKeyJWTClientAuthnMethodConfig privateKetJwtConfig =
+        IPrivateKeyJwtClientAuthnMethodConfig privateKeyJwtConfig =
             configuration.getPrivateKeyJWTClientAuthnMethodConfig();
-        assertNotNull("privateKetJwtConfig", privateKetJwtConfig);
-        JWSAlgorithm jwsAlgo = privateKetJwtConfig.getJwsAlgorithm();
-        assertNotNull("privateKetJwtConfig.getJwsAlgorithm()", jwsAlgo);
-        PrivateKey privateKey = privateKetJwtConfig.getPrivateKey();
-        assertNotNull("privateKetJwtConfig.getPrivateKey()", privateKey);
-        String keyID = privateKetJwtConfig.getKeyID();
+        assertNotNull("privateKeyJwtConfig", privateKeyJwtConfig);
+        JWSAlgorithm jwsAlgo = privateKeyJwtConfig.getJwsAlgorithm();
+        assertNotNull("privateKeyJwtConfig.getJwsAlgorithm()", jwsAlgo);
+        PrivateKey privateKey = privateKeyJwtConfig.getPrivateKey();
+        assertNotNull("privateKeyJwtConfig.getPrivateKey()", privateKey);
+        String keyID = privateKeyJwtConfig.getKeyID();
         try {
           clientAuthenticationMechanism =
               new PrivateKeyJWT(
                   clientID,
-                  configuration.findProviderMetadata().getTokenEndpointURI(),
+                  resolveProviderMetadata(configuration).getTokenEndpointURI(),
                   jwsAlgo,
                   privateKey,
                   keyID,
@@ -1008,7 +1032,7 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
     OIDCTokenResponse tokenSuccessResponse = parseTokenResponseFromHttpResponse(httpResponse);
     populateCredentialsFromTokenResponse(tokenSuccessResponse, credentials);
 
-    Date expirationTime = credentials.getIdToken().getJWTClaimsSet().getExpirationTime();
+    Date expirationTime = credentials.toIdToken().getJWTClaimsSet().getExpirationTime();
     if (expirationTime != null
         && expirationTime.before(Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTime())) {
       LOG.warn(
@@ -1039,12 +1063,12 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
   private TokenRequest createTokenRequest(final AuthorizationGrant grant) {
     if (clientAuthentication != null) {
       return new TokenRequest(
-          client.getConfiguration().findProviderMetadata().getTokenEndpointURI(),
+          resolveProviderMetadata(client.getConfiguration()).getTokenEndpointURI(),
           this.clientAuthentication,
           grant);
     } else {
       return new TokenRequest(
-          client.getConfiguration().findProviderMetadata().getTokenEndpointURI(),
+          resolveProviderMetadata(client.getConfiguration()).getTokenEndpointURI(),
           new ClientID(client.getConfiguration().getClientId()),
           grant);
     }
@@ -1083,12 +1107,14 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
   private void populateCredentialsFromTokenResponse(
       OIDCTokenResponse tokenSuccessResponse, OidcCredentials credentials) {
     OIDCTokens oidcTokens = tokenSuccessResponse.getOIDCTokens();
-    credentials.setAccessToken(oidcTokens.getAccessToken());
+    // pac4j 6 exposes Map-based setters plus set*Object() overloads that retain the nimbus types;
+    // the id token is stored as a serialized String and re-parsed via toIdToken().
+    credentials.setAccessTokenObject(oidcTokens.getAccessToken());
     if (oidcTokens.getRefreshToken() != null) {
-      credentials.setRefreshToken(oidcTokens.getRefreshToken());
+      credentials.setRefreshTokenObject(oidcTokens.getRefreshToken());
     }
     if (oidcTokens.getIDToken() != null) {
-      credentials.setIdToken(oidcTokens.getIDToken());
+      credentials.setIdToken(oidcTokens.getIDToken().serialize());
     }
   }
 
@@ -1233,7 +1259,7 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
       }
 
       OIDCProviderMetadata providerMetadata =
-          validationClient.getConfiguration().findProviderMetadata();
+          resolveProviderMetadata(validationClient.getConfiguration());
       if (providerMetadata == null) {
         throw new IllegalArgumentException("Failed to retrieve provider metadata from server URL");
       }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
@@ -520,6 +520,13 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
         throw new TechnicalException("ID token not returned by OIDC provider");
       }
       JWTClaimsSet idTokenClaims = idToken.getJWTClaimsSet();
+      Date expirationTime = idTokenClaims.getExpirationTime();
+      if (expirationTime != null
+          && expirationTime.before(Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTime())) {
+        LOG.warn(
+            "OIDC provider returned an expired ID token for session {}. Proceeding with claim extraction.",
+            pendingSession.getId());
+      }
 
       validateNonceIfRequired(pendingSession, idTokenClaims);
 
@@ -1026,20 +1033,6 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
     HTTPResponse httpResponse = executeTokenHttpRequest(request);
     OIDCTokenResponse tokenSuccessResponse = parseTokenResponseFromHttpResponse(httpResponse);
     populateCredentialsFromTokenResponse(tokenSuccessResponse, credentials);
-
-    Date expirationTime = getIdTokenExpirationTime(credentials);
-    if (expirationTime != null
-        && expirationTime.before(Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTime())) {
-      LOG.warn(
-          "OIDC provider returned an expired ID token for session {}. Proceeding with claim extraction.",
-          session.getId());
-    }
-  }
-
-  @SneakyThrows
-  private static Date getIdTokenExpirationTime(OidcCredentials credentials) {
-    JWT idToken = credentials.toIdToken();
-    return idToken == null ? null : idToken.getJWTClaimsSet().getExpirationTime();
   }
 
   public static boolean isJWT(String token) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/AuthenticationCodeFlowHandlerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/AuthenticationCodeFlowHandlerTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -59,7 +58,6 @@ import org.openmetadata.service.util.RestUtil.PutResponse;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
-import org.pac4j.oidc.credentials.OidcCredentials;
 import org.pac4j.oidc.metadata.IOidcOpMetadataResolver;
 
 @ExtendWith(MockitoExtension.class)
@@ -711,16 +709,6 @@ class AuthenticationCodeFlowHandlerTest {
     assertEquals(metadata, result);
     verify(oidcConfiguration).ensuresMetadataResolverInitialized();
     verify(resolver).load();
-  }
-
-  @Test
-  void getIdTokenExpirationTime_returnsNullWhenIdTokenIsMissing() throws Exception {
-    Method method =
-        AuthenticationCodeFlowHandler.class.getDeclaredMethod(
-            "getIdTokenExpirationTime", OidcCredentials.class);
-    method.setAccessible(true);
-
-    assertNull(method.invoke(null, new OidcCredentials()));
   }
 
   private void stubOidcConfigForLogin() {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/AuthenticationCodeFlowHandlerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/AuthenticationCodeFlowHandlerTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -57,6 +58,7 @@ import org.openmetadata.service.util.RestUtil.PutResponse;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
+import org.pac4j.oidc.metadata.IOidcOpMetadataResolver;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -687,6 +689,26 @@ class AuthenticationCodeFlowHandlerTest {
     assertFalse((Boolean) method.invoke(handler, TEST_SERVER_URL + "/auth/callback"));
     assertFalse((Boolean) method.invoke(handler, "https://evil.example.com" + MCP_CALLBACK));
     assertFalse((Boolean) method.invoke(handler, (Object) null));
+  }
+
+  @Test
+  void resolveProviderMetadata_initializesResolverAndReturnsLoadedMetadata() throws Exception {
+    IOidcOpMetadataResolver resolver = mock(IOidcOpMetadataResolver.class);
+    OIDCProviderMetadata metadata = mock(OIDCProviderMetadata.class);
+    when(oidcConfiguration.getOpMetadataResolver()).thenReturn(resolver);
+    when(resolver.load()).thenReturn(metadata);
+
+    Method method =
+        AuthenticationCodeFlowHandler.class.getDeclaredMethod(
+            "resolveProviderMetadata", OidcConfiguration.class);
+    method.setAccessible(true);
+
+    Object result = method.invoke(null, oidcConfiguration);
+
+    // pac4j 6 removed getProviderMetadata(); the helper must initialize the resolver, then load().
+    assertEquals(metadata, result);
+    verify(oidcConfiguration).ensuresMetadataResolverInitialized();
+    verify(resolver).load();
   }
 
   private void stubOidcConfigForLogin() {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/AuthenticationCodeFlowHandlerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/AuthenticationCodeFlowHandlerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -58,6 +59,7 @@ import org.openmetadata.service.util.RestUtil.PutResponse;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
+import org.pac4j.oidc.credentials.OidcCredentials;
 import org.pac4j.oidc.metadata.IOidcOpMetadataResolver;
 
 @ExtendWith(MockitoExtension.class)
@@ -709,6 +711,16 @@ class AuthenticationCodeFlowHandlerTest {
     assertEquals(metadata, result);
     verify(oidcConfiguration).ensuresMetadataResolverInitialized();
     verify(resolver).load();
+  }
+
+  @Test
+  void getIdTokenExpirationTime_returnsNullWhenIdTokenIsMissing() throws Exception {
+    Method method =
+        AuthenticationCodeFlowHandler.class.getDeclaredMethod(
+            "getIdTokenExpirationTime", OidcCredentials.class);
+    method.setAccessible(true);
+
+    assertNull(method.invoke(null, new OidcCredentials()));
   }
 
   private void stubOidcConfigForLogin() {


### PR DESCRIPTION
## What

Upgrade `pac4j` from 5.7.10 to 6.5.6 and adapt the code to its API changes.

## Why

Routine dependency maintenance — the 5.x line is EOL, so this moves to the current stable 6.x release.

## Migration (pac4j 5 → 6 is API-breaking)

`AuthenticationCodeFlowHandler` and `openmetadata-mcp`'s `McpCallbackServlet` are the only pac4j consumers. Changes:

- **`OidcCredentials`** — field types changed: `getCode()`/`getIdToken()`/`getAccessToken()`/`getRefreshToken()` now return `String`/`Map` instead of the nimbus types. Switched to the new `to*()` converters (`toAuthorizationCode()`, `toIdToken()`, `toRefreshToken()`) where nimbus types are needed, and to `setAccessTokenObject()`/`setRefreshTokenObject()` + `JWT.serialize()` when populating. Each token is now parsed once per request.
- **Provider metadata** — `OidcConfiguration.getProviderMetadata()`/`findProviderMetadata()` were replaced by a lazy `IOidcOpMetadataResolver`. Added a `resolveProviderMetadata()` helper used at all call sites; the resolver is initialized during single-threaded startup (`initializeFields()`) so concurrent logins never race to create it (pac4j 6 normally does this in `client.init()`, which OM does not call).
- **PrivateKeyJWT** — `getPrivateKeyJWTClientAuthnMethodConfig()` now returns the interface `IPrivateKeyJwtClientAuthnMethodConfig`.

## Tests

- New unit test for `resolveProviderMetadata` (stubs the resolver, asserts init + load).
- `AuthenticationCodeFlowHandlerTest` — 34 tests green.

## Verification

- `mvn install -pl openmetadata-service,openmetadata-mcp -am` → BUILD SUCCESS
- postgresql Playwright e2e suite → all shards pass

## Additional local verification

- Ran the existing `openmetadata-service` JAR against isolated dependencies: service `9595` (admin `9596`), MySQL `13306`, Elasticsearch `19200`, and a mock OIDC provider on `19090`.
- The service healthcheck passed. A full authorization-code login completed; the callback returned the OpenMetadata JWT, and that JWT successfully authenticated `GET /api/v1/users/loggedInUser` as `admin`.
- All temporary containers and processes were stopped and removed after verification.
