### PR TITLE
perf(ui): cache user profile pics in localStorage for 24h

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.test.tsx
@@ -137,6 +137,7 @@ jest.mock('../../../hooks/useApplicationStore', () => ({
     setJwtPrincipalClaimsMapping: jest.fn(),
     isApplicationLoading: false,
     setApplicationLoading: jest.fn(),
+    resetUserProfilePics: jest.fn(),
     initializeAuthState: jest.fn(),
     isAuthenticating: false,
     authConfig: {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
@@ -284,6 +284,7 @@ export const AuthProvider = ({
     isApplicationLoading,
     setApplicationLoading,
     isAuthenticating,
+    resetUserProfilePics,
   } = useApplicationStore();
   const tokenService = useRef<TokenService>(TokenService.getInstance());
 
@@ -373,6 +374,11 @@ export const AuthProvider = ({
     useExploreCache.getState().clearCache();
     clearEtagCache();
     queryClient.clear();
+
+    // Drop the persisted (localStorage) + in-memory user profile cache so the
+    // next principal on this browser cannot see the previous user's cached
+    // names/emails/avatars.
+    resetUserProfilePics();
 
     // Drop the tab-scoped app-mode session so the next user boots into
     // their own persona/preference-resolved mode rather than inheriting

--- a/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
@@ -75,6 +75,7 @@ export const TEST_CASE_FEED_GRAPH_HEIGHT = 250;
 export const ONE_MINUTE_IN_MILLISECOND = 60000;
 export const TWO_MINUTE_IN_MILLISECOND = 120000;
 export const ONE_HOUR_MS = 3600000; // 1 hour in milliseconds
+export const TWENTY_FOUR_HOUR_MS = 86400000; // 24 hours in milliseconds
 export const SCROLL_TRIGGER_THRESHOLD = 200;
 export const INITIAL_PAGING_STATE = {
   offset: 0,
@@ -82,6 +83,8 @@ export const INITIAL_PAGING_STATE = {
   total: 0,
 };
 
+export const USER_PROFILE_CACHE_KEY = 'userProfileCache';
+export const USER_PROFILE_CACHE_MAX_SIZE = 500;
 export const LAST_VERSION_FETCH_TIME_KEY = 'versionFetchTime';
 export const LOCALSTORAGE_RECENTLY_VIEWED = `recentlyViewedData`;
 export const LOCALSTORAGE_RECENTLY_SEARCHED = `recentlySearchedData`;

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useApplicationStore.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useApplicationStore.ts
@@ -30,6 +30,7 @@ import { getOidcToken } from '../utils/SwTokenStorageUtils';
 import { getThemeConfig } from '../utils/ThemeUtils';
 import { useDomainStore } from './useDomainStore';
 import {
+  clearUserProfileCache,
   getPersistedUserProfiles,
   persistUserProfile,
 } from './user-profile/userProfileCache.utils';
@@ -234,6 +235,10 @@ export const useApplicationStore = create<ApplicationStore>()((set, get) => ({
     set({
       userProfilePics: { ...get()?.userProfilePics, [id]: user },
     });
+  },
+  resetUserProfilePics: () => {
+    clearUserProfileCache();
+    set({ userProfilePics: {} });
   },
   updateCachedEntityData: ({
     id,

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useApplicationStore.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useApplicationStore.ts
@@ -29,6 +29,10 @@ import {
 import { getOidcToken } from '../utils/SwTokenStorageUtils';
 import { getThemeConfig } from '../utils/ThemeUtils';
 import { useDomainStore } from './useDomainStore';
+import {
+  getPersistedUserProfiles,
+  persistUserProfile,
+} from './user-profile/userProfileCache.utils';
 
 const resolvePersonaFromSession = (user: User): EntityReference | undefined => {
   const storedId = readPersonaSession();
@@ -95,7 +99,7 @@ export const useApplicationStore = create<ApplicationStore>()((set, get) => ({
   isSigningUp: false,
   jwtPrincipalClaims: [],
   jwtPrincipalClaimsMapping: [],
-  userProfilePics: {},
+  userProfilePics: getPersistedUserProfiles(),
   cachedEntityData: {},
   selectedPersona: undefined,
   searchCriteria: '',
@@ -226,6 +230,7 @@ export const useApplicationStore = create<ApplicationStore>()((set, get) => ({
     syncDomainStoreForUser(user);
   },
   updateUserProfilePics: ({ id, user }: { id: string; user: User }) => {
+    persistUserProfile(id, user);
     set({
       userProfilePics: { ...get()?.userProfilePics, [id]: user },
     });

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/user-profile/userProfileCache.utils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/user-profile/userProfileCache.utils.test.ts
@@ -1,0 +1,90 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import {
+  TWENTY_FOUR_HOUR_MS,
+  USER_PROFILE_CACHE_KEY,
+  USER_PROFILE_CACHE_MAX_SIZE,
+} from '../../constants/constants';
+import { User } from '../../generated/entity/teams/user';
+import {
+  getPersistedUserProfiles,
+  persistUserProfile,
+} from './userProfileCache.utils';
+
+const buildUser = (name: string): User =>
+  ({
+    id: name,
+    name,
+    email: `${name}@example.com`,
+    profile: { images: { image512: `${name}-512` } },
+  } as User);
+
+describe('userProfileCache.utils', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  it('persists and reads back a profile', () => {
+    persistUserProfile('john', buildUser('john'));
+
+    expect(getPersistedUserProfiles().john.email).toBe('john@example.com');
+  });
+
+  it('drops entries older than 24 hours and rewrites the pruned cache', () => {
+    const fresh = buildUser('fresh');
+    const stale = buildUser('stale');
+    const now = Date.now();
+    localStorage.setItem(
+      USER_PROFILE_CACHE_KEY,
+      JSON.stringify({
+        fresh: { user: fresh, timestamp: now },
+        stale: { user: stale, timestamp: now - TWENTY_FOUR_HOUR_MS - 1 },
+      })
+    );
+
+    const result = getPersistedUserProfiles();
+
+    expect(result.fresh).toBeDefined();
+    expect(result.stale).toBeUndefined();
+    expect(
+      JSON.parse(localStorage.getItem(USER_PROFILE_CACHE_KEY) ?? '{}')
+    ).not.toHaveProperty('stale');
+  });
+
+  it('does not persist error placeholders (no profile, empty email)', () => {
+    persistUserProfile('ghost', { id: 'ghost', name: 'ghost', email: '' });
+
+    expect(getPersistedUserProfiles()).toEqual({});
+  });
+
+  it('evicts the oldest entries once the size cap is exceeded', () => {
+    const nowSpy = jest.spyOn(Date, 'now');
+    for (let i = 0; i <= USER_PROFILE_CACHE_MAX_SIZE; i++) {
+      nowSpy.mockReturnValue(i);
+      persistUserProfile(`user-${i}`, buildUser(`user-${i}`));
+    }
+
+    const result = getPersistedUserProfiles();
+
+    expect(Object.keys(result)).toHaveLength(USER_PROFILE_CACHE_MAX_SIZE);
+    expect(result['user-0']).toBeUndefined();
+    expect(result[`user-${USER_PROFILE_CACHE_MAX_SIZE}`]).toBeDefined();
+  });
+
+  it('returns an empty map when storage is corrupt', () => {
+    localStorage.setItem(USER_PROFILE_CACHE_KEY, 'not-json');
+
+    expect(getPersistedUserProfiles()).toEqual({});
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/user-profile/userProfileCache.utils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/user-profile/userProfileCache.utils.test.ts
@@ -16,10 +16,8 @@ import {
   USER_PROFILE_CACHE_MAX_SIZE,
 } from '../../constants/constants';
 import { User } from '../../generated/entity/teams/user';
-import {
-  getPersistedUserProfiles,
-  persistUserProfile,
-} from './userProfileCache.utils';
+
+type CacheModule = typeof import('./userProfileCache.utils');
 
 const buildUser = (name: string): User =>
   ({
@@ -29,16 +27,46 @@ const buildUser = (name: string): User =>
     profile: { images: { image512: `${name}-512` } },
   } as User);
 
+const readStorage = () =>
+  JSON.parse(localStorage.getItem(USER_PROFILE_CACHE_KEY) ?? 'null');
+
 describe('userProfileCache.utils', () => {
+  let getPersistedUserProfiles: CacheModule['getPersistedUserProfiles'];
+  let persistUserProfile: CacheModule['persistUserProfile'];
+  let clearUserProfileCache: CacheModule['clearUserProfileCache'];
+
   beforeEach(() => {
+    // Reset module-level in-memory cache so each test hydrates from a clean slate.
+    jest.resetModules();
+    jest.useFakeTimers();
+    jest.setSystemTime(1_000_000);
     localStorage.clear();
-    jest.restoreAllMocks();
+    ({
+      getPersistedUserProfiles,
+      persistUserProfile,
+      clearUserProfileCache,
+    } = require('./userProfileCache.utils'));
   });
 
-  it('persists and reads back a profile', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('persists and reads back a profile from the in-memory mirror', () => {
     persistUserProfile('john', buildUser('john'));
 
     expect(getPersistedUserProfiles().john.email).toBe('john@example.com');
+  });
+
+  it('coalesces writes into a single storage flush on the next tick', () => {
+    persistUserProfile('a', buildUser('a'));
+    persistUserProfile('b', buildUser('b'));
+
+    expect(readStorage()).toBeNull();
+
+    jest.runAllTimers();
+
+    expect(Object.keys(readStorage().profiles)).toEqual(['a', 'b']);
   });
 
   it('drops the whole cache once it is older than 24 hours', () => {
@@ -55,29 +83,24 @@ describe('userProfileCache.utils', () => {
   });
 
   it('keeps a fixed window across writes (does not slide on new writes)', () => {
-    const nowSpy = jest.spyOn(Date, 'now');
-
-    nowSpy.mockReturnValue(1000);
+    jest.setSystemTime(1000);
     persistUserProfile('a', buildUser('a'));
 
-    nowSpy.mockReturnValue(1000 + TWENTY_FOUR_HOUR_MS - 1);
+    jest.setSystemTime(1000 + TWENTY_FOUR_HOUR_MS - 1);
     persistUserProfile('b', buildUser('b'));
+    jest.runAllTimers();
 
-    const raw = JSON.parse(
-      localStorage.getItem(USER_PROFILE_CACHE_KEY) ?? '{}'
-    );
+    const raw = readStorage();
 
     expect(raw.timestamp).toBe(1000);
     expect(Object.keys(raw.profiles)).toEqual(['a', 'b']);
   });
 
   it('starts a fresh window when writing into an expired cache', () => {
-    const nowSpy = jest.spyOn(Date, 'now');
-
-    nowSpy.mockReturnValue(1000);
+    jest.setSystemTime(1000);
     persistUserProfile('old', buildUser('old'));
 
-    nowSpy.mockReturnValue(1000 + TWENTY_FOUR_HOUR_MS + 5);
+    jest.setSystemTime(1000 + TWENTY_FOUR_HOUR_MS + 5);
     persistUserProfile('new', buildUser('new'));
 
     const result = getPersistedUserProfiles();
@@ -88,8 +111,10 @@ describe('userProfileCache.utils', () => {
 
   it('does not persist error placeholders (no profile, empty email)', () => {
     persistUserProfile('ghost', { id: 'ghost', name: 'ghost', email: '' });
+    jest.runAllTimers();
 
     expect(getPersistedUserProfiles()).toEqual({});
+    expect(readStorage()).toBeNull();
   });
 
   it('evicts the oldest entries once the size cap is exceeded', () => {
@@ -104,9 +129,32 @@ describe('userProfileCache.utils', () => {
     expect(result[`user-${USER_PROFILE_CACHE_MAX_SIZE}`]).toBeDefined();
   });
 
-  it('returns an empty map when storage is corrupt', () => {
+  it('returns an empty map when storage is corrupt (invalid JSON)', () => {
     localStorage.setItem(USER_PROFILE_CACHE_KEY, 'not-json');
 
     expect(getPersistedUserProfiles()).toEqual({});
+  });
+
+  it('falls back to empty for a valid-JSON blob of the wrong shape', () => {
+    // e.g. the pre-refactor Record<string, {user, timestamp}> format, or null.
+    localStorage.setItem(
+      USER_PROFILE_CACHE_KEY,
+      JSON.stringify({ someUser: { user: buildUser('x'), timestamp: 1 } })
+    );
+
+    expect(getPersistedUserProfiles()).toEqual({});
+    expect(() => persistUserProfile('y', buildUser('y'))).not.toThrow();
+  });
+
+  it('clearUserProfileCache wipes memory and storage', () => {
+    persistUserProfile('john', buildUser('john'));
+    jest.runAllTimers();
+
+    expect(readStorage()).not.toBeNull();
+
+    clearUserProfileCache();
+
+    expect(getPersistedUserProfiles()).toEqual({});
+    expect(localStorage.getItem(USER_PROFILE_CACHE_KEY)).toBeNull();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/user-profile/userProfileCache.utils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/user-profile/userProfileCache.utils.test.ts
@@ -41,25 +41,49 @@ describe('userProfileCache.utils', () => {
     expect(getPersistedUserProfiles().john.email).toBe('john@example.com');
   });
 
-  it('drops entries older than 24 hours and rewrites the pruned cache', () => {
-    const fresh = buildUser('fresh');
-    const stale = buildUser('stale');
-    const now = Date.now();
+  it('drops the whole cache once it is older than 24 hours', () => {
     localStorage.setItem(
       USER_PROFILE_CACHE_KEY,
       JSON.stringify({
-        fresh: { user: fresh, timestamp: now },
-        stale: { user: stale, timestamp: now - TWENTY_FOUR_HOUR_MS - 1 },
+        timestamp: Date.now() - TWENTY_FOUR_HOUR_MS - 1,
+        profiles: { fresh: buildUser('fresh'), stale: buildUser('stale') },
       })
     );
 
+    expect(getPersistedUserProfiles()).toEqual({});
+    expect(localStorage.getItem(USER_PROFILE_CACHE_KEY)).toBeNull();
+  });
+
+  it('keeps a fixed window across writes (does not slide on new writes)', () => {
+    const nowSpy = jest.spyOn(Date, 'now');
+
+    nowSpy.mockReturnValue(1000);
+    persistUserProfile('a', buildUser('a'));
+
+    nowSpy.mockReturnValue(1000 + TWENTY_FOUR_HOUR_MS - 1);
+    persistUserProfile('b', buildUser('b'));
+
+    const raw = JSON.parse(
+      localStorage.getItem(USER_PROFILE_CACHE_KEY) ?? '{}'
+    );
+
+    expect(raw.timestamp).toBe(1000);
+    expect(Object.keys(raw.profiles)).toEqual(['a', 'b']);
+  });
+
+  it('starts a fresh window when writing into an expired cache', () => {
+    const nowSpy = jest.spyOn(Date, 'now');
+
+    nowSpy.mockReturnValue(1000);
+    persistUserProfile('old', buildUser('old'));
+
+    nowSpy.mockReturnValue(1000 + TWENTY_FOUR_HOUR_MS + 5);
+    persistUserProfile('new', buildUser('new'));
+
     const result = getPersistedUserProfiles();
 
-    expect(result.fresh).toBeDefined();
-    expect(result.stale).toBeUndefined();
-    expect(
-      JSON.parse(localStorage.getItem(USER_PROFILE_CACHE_KEY) ?? '{}')
-    ).not.toHaveProperty('stale');
+    expect(result.old).toBeUndefined();
+    expect(result.new).toBeDefined();
   });
 
   it('does not persist error placeholders (no profile, empty email)', () => {
@@ -69,9 +93,7 @@ describe('userProfileCache.utils', () => {
   });
 
   it('evicts the oldest entries once the size cap is exceeded', () => {
-    const nowSpy = jest.spyOn(Date, 'now');
     for (let i = 0; i <= USER_PROFILE_CACHE_MAX_SIZE; i++) {
-      nowSpy.mockReturnValue(i);
       persistUserProfile(`user-${i}`, buildUser(`user-${i}`));
     }
 

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/user-profile/userProfileCache.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/user-profile/userProfileCache.utils.ts
@@ -1,0 +1,100 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import {
+  TWENTY_FOUR_HOUR_MS,
+  USER_PROFILE_CACHE_KEY,
+  USER_PROFILE_CACHE_MAX_SIZE,
+} from '../../constants/constants';
+import { User } from '../../generated/entity/teams/user';
+
+interface CachedUserProfile {
+  user: User;
+  timestamp: number;
+}
+
+type UserProfileCache = Record<string, CachedUserProfile>;
+
+const readRawCache = (): UserProfileCache => {
+  try {
+    const raw = localStorage.getItem(USER_PROFILE_CACHE_KEY);
+
+    return raw ? (JSON.parse(raw) as UserProfileCache) : {};
+  } catch {
+    // Corrupt/inaccessible storage falls back to an empty cache; the profiles
+    // simply get re-fetched instead of breaking the app.
+    return {};
+  }
+};
+
+const writeRawCache = (cache: UserProfileCache): void => {
+  try {
+    localStorage.setItem(USER_PROFILE_CACHE_KEY, JSON.stringify(cache));
+  } catch {
+    // Storage full/unavailable — persistence is best-effort, so ignore.
+  }
+};
+
+/**
+ * An error-path placeholder (see useUserProfile) has an empty email and no
+ * profile. We never persist those so a transient 4xx/5xx does not suppress a
+ * user's avatar for a full 24 hours.
+ */
+const isPlaceholderProfile = (user: User): boolean =>
+  !user.profile && (user.email ?? '') === '';
+
+/**
+ * Returns the non-expired persisted profiles keyed by name and rewrites the
+ * pruned map back to storage. Used to hydrate the in-memory store on load.
+ */
+export const getPersistedUserProfiles = (): Record<string, User> => {
+  const cache = readRawCache();
+  const now = Date.now();
+  const valid: Record<string, User> = {};
+  const pruned: UserProfileCache = {};
+
+  Object.entries(cache).forEach(([id, entry]) => {
+    if (entry && now - entry.timestamp < TWENTY_FOUR_HOUR_MS) {
+      valid[id] = entry.user;
+      pruned[id] = entry;
+    }
+  });
+
+  if (Object.keys(pruned).length !== Object.keys(cache).length) {
+    writeRawCache(pruned);
+  }
+
+  return valid;
+};
+
+/**
+ * Write-through a single profile with a fresh 24h timestamp. Skips error
+ * placeholders and evicts the oldest entries once the cache exceeds its cap.
+ */
+export const persistUserProfile = (id: string, user: User): void => {
+  if (isPlaceholderProfile(user)) {
+    return;
+  }
+
+  const cache = readRawCache();
+  cache[id] = { user, timestamp: Date.now() };
+
+  const ids = Object.keys(cache);
+  if (ids.length > USER_PROFILE_CACHE_MAX_SIZE) {
+    ids
+      .sort((a, b) => cache[a].timestamp - cache[b].timestamp)
+      .slice(0, ids.length - USER_PROFILE_CACHE_MAX_SIZE)
+      .forEach((staleId) => delete cache[staleId]);
+  }
+
+  writeRawCache(cache);
+};

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/user-profile/userProfileCache.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/user-profile/userProfileCache.utils.ts
@@ -17,22 +17,20 @@ import {
 } from '../../constants/constants';
 import { User } from '../../generated/entity/teams/user';
 
-interface CachedUserProfile {
-  user: User;
+interface UserProfileCache {
   timestamp: number;
+  profiles: Record<string, User>;
 }
 
-type UserProfileCache = Record<string, CachedUserProfile>;
-
-const readRawCache = (): UserProfileCache => {
+const readRawCache = (): UserProfileCache | null => {
   try {
     const raw = localStorage.getItem(USER_PROFILE_CACHE_KEY);
 
-    return raw ? (JSON.parse(raw) as UserProfileCache) : {};
+    return raw ? (JSON.parse(raw) as UserProfileCache) : null;
   } catch {
-    // Corrupt/inaccessible storage falls back to an empty cache; the profiles
-    // simply get re-fetched instead of breaking the app.
-    return {};
+    // Corrupt/inaccessible storage falls back to no cache; the profiles simply
+    // get re-fetched instead of breaking the app.
+    return null;
   }
 };
 
@@ -44,56 +42,62 @@ const writeRawCache = (cache: UserProfileCache): void => {
   }
 };
 
+const isExpired = (cache: UserProfileCache): boolean =>
+  Date.now() - cache.timestamp >= TWENTY_FOUR_HOUR_MS;
+
 /**
  * An error-path placeholder (see useUserProfile) has an empty email and no
  * profile. We never persist those so a transient 4xx/5xx does not suppress a
- * user's avatar for a full 24 hours.
+ * user's avatar for the lifetime of the cache.
  */
 const isPlaceholderProfile = (user: User): boolean =>
   !user.profile && (user.email ?? '') === '';
 
 /**
- * Returns the non-expired persisted profiles keyed by name and rewrites the
- * pruned map back to storage. Used to hydrate the in-memory store on load.
+ * Returns the persisted profiles keyed by name, or an empty map when the whole
+ * cache has aged past its 24h window (in which case the stale blob is cleared).
+ * The window is fixed from first write — it does not slide on reads.
  */
 export const getPersistedUserProfiles = (): Record<string, User> => {
   const cache = readRawCache();
-  const now = Date.now();
-  const valid: Record<string, User> = {};
-  const pruned: UserProfileCache = {};
 
-  Object.entries(cache).forEach(([id, entry]) => {
-    if (entry && now - entry.timestamp < TWENTY_FOUR_HOUR_MS) {
-      valid[id] = entry.user;
-      pruned[id] = entry;
-    }
-  });
-
-  if (Object.keys(pruned).length !== Object.keys(cache).length) {
-    writeRawCache(pruned);
+  if (!cache) {
+    return {};
   }
 
-  return valid;
+  if (isExpired(cache)) {
+    localStorage.removeItem(USER_PROFILE_CACHE_KEY);
+
+    return {};
+  }
+
+  return cache.profiles;
 };
 
 /**
- * Write-through a single profile with a fresh 24h timestamp. Skips error
- * placeholders and evicts the oldest entries once the cache exceeds its cap.
+ * Write-through a single profile into the shared cache. The 24h window is
+ * stamped once when the cache is (re)created and preserved across subsequent
+ * writes; an expired cache is discarded and a new window started. Skips error
+ * placeholders and evicts the oldest entries once the cap is exceeded.
  */
 export const persistUserProfile = (id: string, user: User): void => {
   if (isPlaceholderProfile(user)) {
     return;
   }
 
-  const cache = readRawCache();
-  cache[id] = { user, timestamp: Date.now() };
+  const existing = readRawCache();
+  const cache: UserProfileCache =
+    existing && !isExpired(existing)
+      ? existing
+      : { timestamp: Date.now(), profiles: {} };
 
-  const ids = Object.keys(cache);
+  cache.profiles[id] = user;
+
+  const ids = Object.keys(cache.profiles);
   if (ids.length > USER_PROFILE_CACHE_MAX_SIZE) {
     ids
-      .sort((a, b) => cache[a].timestamp - cache[b].timestamp)
       .slice(0, ids.length - USER_PROFILE_CACHE_MAX_SIZE)
-      .forEach((staleId) => delete cache[staleId]);
+      .forEach((staleId) => delete cache.profiles[staleId]);
   }
 
   writeRawCache(cache);

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/user-profile/userProfileCache.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/user-profile/userProfileCache.utils.ts
@@ -22,28 +22,82 @@ interface UserProfileCache {
   profiles: Record<string, User>;
 }
 
-const readRawCache = (): UserProfileCache | null => {
+/**
+ * In-memory source of truth for the current tab. localStorage is only read once
+ * (lazily, on first access) and thereafter written from this mirror, so a burst
+ * of avatar misses does not re-parse/re-serialize the whole blob per entry.
+ */
+let memoryCache: UserProfileCache | null = null;
+let hydrated = false;
+let flushScheduled = false;
+
+const isValidShape = (value: unknown): value is UserProfileCache => {
+  const cache = value as UserProfileCache | null;
+
+  return (
+    typeof cache === 'object' &&
+    cache !== null &&
+    typeof cache.timestamp === 'number' &&
+    typeof cache.profiles === 'object' &&
+    cache.profiles !== null
+  );
+};
+
+const isExpired = (cache: UserProfileCache): boolean =>
+  Date.now() - cache.timestamp >= TWENTY_FOUR_HOUR_MS;
+
+/**
+ * Loads the persisted cache into memory exactly once per tab. A malformed blob
+ * (invalid JSON, wrong shape, or an older cache format) or an expired window is
+ * discarded so callers fall back to re-fetching instead of crashing.
+ */
+const ensureHydrated = (): void => {
+  if (hydrated) {
+    return;
+  }
+  hydrated = true;
+
   try {
     const raw = localStorage.getItem(USER_PROFILE_CACHE_KEY);
+    const parsed = raw ? (JSON.parse(raw) as unknown) : null;
 
-    return raw ? (JSON.parse(raw) as UserProfileCache) : null;
+    if (isValidShape(parsed) && !isExpired(parsed)) {
+      memoryCache = parsed;
+    } else {
+      memoryCache = null;
+      if (raw) {
+        localStorage.removeItem(USER_PROFILE_CACHE_KEY);
+      }
+    }
   } catch {
-    // Corrupt/inaccessible storage falls back to no cache; the profiles simply
-    // get re-fetched instead of breaking the app.
-    return null;
+    memoryCache = null;
   }
 };
 
-const writeRawCache = (cache: UserProfileCache): void => {
+const flush = (): void => {
+  flushScheduled = false;
   try {
-    localStorage.setItem(USER_PROFILE_CACHE_KEY, JSON.stringify(cache));
+    if (memoryCache) {
+      localStorage.setItem(USER_PROFILE_CACHE_KEY, JSON.stringify(memoryCache));
+    } else {
+      localStorage.removeItem(USER_PROFILE_CACHE_KEY);
+    }
   } catch {
     // Storage full/unavailable — persistence is best-effort, so ignore.
   }
 };
 
-const isExpired = (cache: UserProfileCache): boolean =>
-  Date.now() - cache.timestamp >= TWENTY_FOUR_HOUR_MS;
+/**
+ * Coalesces a burst of writes into a single serialize+persist on the next tick,
+ * keeping the render hot path free of repeated full-cache JSON.stringify calls.
+ */
+const scheduleFlush = (): void => {
+  if (flushScheduled) {
+    return;
+  }
+  flushScheduled = true;
+  setTimeout(flush, 0);
+};
 
 /**
  * An error-path placeholder (see useUserProfile) has an empty email and no
@@ -55,23 +109,13 @@ const isPlaceholderProfile = (user: User): boolean =>
 
 /**
  * Returns the persisted profiles keyed by name, or an empty map when the whole
- * cache has aged past its 24h window (in which case the stale blob is cleared).
- * The window is fixed from first write — it does not slide on reads.
+ * cache has aged past its 24h window. The window is fixed from first write — it
+ * does not slide on reads.
  */
 export const getPersistedUserProfiles = (): Record<string, User> => {
-  const cache = readRawCache();
+  ensureHydrated();
 
-  if (!cache) {
-    return {};
-  }
-
-  if (isExpired(cache)) {
-    localStorage.removeItem(USER_PROFILE_CACHE_KEY);
-
-    return {};
-  }
-
-  return cache.profiles;
+  return memoryCache?.profiles ?? {};
 };
 
 /**
@@ -85,20 +129,35 @@ export const persistUserProfile = (id: string, user: User): void => {
     return;
   }
 
-  const existing = readRawCache();
-  const cache: UserProfileCache =
-    existing && !isExpired(existing)
-      ? existing
-      : { timestamp: Date.now(), profiles: {} };
+  ensureHydrated();
 
-  cache.profiles[id] = user;
+  if (!memoryCache || isExpired(memoryCache)) {
+    memoryCache = { timestamp: Date.now(), profiles: {} };
+  }
 
-  const ids = Object.keys(cache.profiles);
+  memoryCache.profiles[id] = user;
+
+  const ids = Object.keys(memoryCache.profiles);
   if (ids.length > USER_PROFILE_CACHE_MAX_SIZE) {
     ids
       .slice(0, ids.length - USER_PROFILE_CACHE_MAX_SIZE)
-      .forEach((staleId) => delete cache.profiles[staleId]);
+      .forEach((staleId) => delete memoryCache?.profiles[staleId]);
   }
 
-  writeRawCache(cache);
+  scheduleFlush();
+};
+
+/**
+ * Drops the cache from memory and storage. Called on logout so one user's
+ * cached profiles cannot leak into the next session on a shared browser.
+ */
+export const clearUserProfileCache = (): void => {
+  memoryCache = null;
+  hydrated = true;
+  flushScheduled = false;
+  try {
+    localStorage.removeItem(USER_PROFILE_CACHE_KEY);
+  } catch {
+    // best-effort
+  }
 };

--- a/openmetadata-ui/src/main/resources/ui/src/interface/store.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/interface/store.interface.ts
@@ -76,6 +76,7 @@ export interface ApplicationStore
     claimsMapping: AuthenticationConfiguration['jwtPrincipalClaimsMapping']
   ) => void;
   updateUserProfilePics: (data: { id: string; user: User }) => void;
+  resetUserProfilePics: () => void;
   updateCachedEntityData: (data: {
     id: string;
     entityDetails: EntityUnion;


### PR DESCRIPTION
## Describe your changes

User profile pictures were stored only in the in-memory zustand `userProfilePics` cache, so a page refresh discarded them and every avatar was re-fetched from the server on each load. This backs the cache with `localStorage` using a per-entry 24-hour TTL, so refreshes reuse cached profiles and reduce server load.

- New `userProfileCache.utils.ts`:
  - `getPersistedUserProfiles()` — reads the cache, prunes entries older than 24h on read, and rewrites the pruned map.
  - `persistUserProfile(id, user)` — write-through with a fresh timestamp, LRU-by-timestamp eviction at a 500-entry cap (bounded cache).
- `useApplicationStore` hydrates `userProfilePics` from the cache at store creation and write-throughs on `updateUserProfilePics`.
- Error placeholders (empty email + no profile) are **not** persisted, so a transient 4xx/5xx does not suppress an avatar for 24 hours.

The store shape stays `Record<string, User>`, so all existing consumers (FeedEditor, UserTeams, UserRoles, popover) are untouched.

## Type of change

- [x] Improvement (a change that improves performance without adding new functionality)

## Tests

- New unit tests `userProfileCache.utils.test.ts` cover persist/read, 24h TTL pruning, placeholder skipping, size-cap eviction, and corrupt-storage fallback.
- Existing `useUserProfile.test.ts` still passes.
- `tsc --noEmit` clean; UI checkstyle passes with 0 errors / 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR persists the UI user-profile cache in localStorage with a fixed 24-hour window, bounded eviction, malformed-storage handling, and logout cleanup. The latest changes address the earlier malformed-cache crash and add principal-transition cleanup, but some authentication and multi-tab transitions still retain prior-session data.
- Hydrates Zustand profile state from a persistent cache.
- Coalesces profile writes and caps the cache at 500 entries.
- Rejects malformed or expired storage and skips error placeholders.
- Adds explicit-logout cleanup for persisted and in-memory profile state.
</details>


<details open><summary><h3>Confidence Score: 1/5</h3></summary>

The PR is not safe to merge until profile-cache isolation covers every principal-ending authentication path and all tabs sharing the session.

Non-explicit authentication resets leave the persisted and Zustand caches intact, while another open tab can retain and rewrite prior-session profile data after explicit logout.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx, openmetadata-ui/src/main/resources/ui/src/hooks/user-profile/userProfileCache.utils.ts, openmetadata-ui/src/main/resources/ui/src/hooks/useApplicationStore.ts
</details>


<details open><summary><h3>Security Review</h3></summary>

Principal-scoped User records can still cross authentication sessions because non-explicit session termination bypasses cache cleanup and other tabs retain independent in-memory mirrors that can restore cleared storage.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx | Adds profile-cache cleanup to explicit logout, but direct authentication-reset paths still reach sign-in without invoking it. |
| openmetadata-ui/src/main/resources/ui/src/hooks/useApplicationStore.ts | Hydrates profile state from localStorage and exposes coordinated persistent/in-memory cleanup, making complete lifecycle coverage essential. |
| openmetadata-ui/src/main/resources/ui/src/hooks/user-profile/userProfileCache.utils.ts | Validates and bounds the persistent cache, but its tab-local memory mirror is not invalidated across browser tabs. |
| openmetadata-ui/src/main/resources/ui/src/hooks/user-profile/userProfileCache.utils.test.ts | Covers storage shape, expiry, batching, eviction, placeholders, and same-tab clearing, but not alternate auth transitions or cross-tab invalidation. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[User profile response] --> B[Zustand userProfilePics]
  B --> C[Tab-local memoryCache]
  C --> D[Shared localStorage]
  D --> E[Store hydration]
  F[Explicit logout] --> G[resetUserProfilePics]
  G --> B
  G --> C
  G --> D
  H[Session expiry or auth reset] --> I[resetUserDetails]
  I --> J[Sign-in]
  I -. cache remains .-> B
  K[Other open tab] -. retained memory and flush .-> D
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ui): harden profile cache — validate..."](https://github.com/open-metadata/openmetadata/commit/5527e24c10ce4f2787d81a7e9368692c64a7944d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58632383)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Metadata web application](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/metadata-web-application.md)

<!-- /greptile_comment -->
