### PR TITLE
fix(ui): prevent 400 on second domain tag update

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetailPage/DomainDetailPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetailPage/DomainDetailPage.component.tsx
@@ -125,7 +125,9 @@ const DomainDetailPage = () => {
       try {
         const response = await patchDomains(activeDomain.id, jsonPatch);
 
-        setActiveDomain(response);
+        // Merge response with existing cached data so fields not returned
+        // by the PATCH endpoint (extension, votes, certification) are preserved.
+        setActiveDomain((prev) => (prev ? { ...prev, ...response } : response));
 
         if (activeDomain?.name !== updatedData.name) {
           navigate(getDomainPath(response.fullyQualifiedName));

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetailPage/DomainDetailPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetailPage/DomainDetailPage.component.tsx
@@ -125,9 +125,10 @@ const DomainDetailPage = () => {
       try {
         const response = await patchDomains(activeDomain.id, jsonPatch);
 
-        // Merge response with existing cached data so fields not returned
-        // by the PATCH endpoint (extension, votes, certification) are preserved.
-        setActiveDomain((prev) => (prev ? { ...prev, ...response } : response));
+        setActiveDomain(response);
+        // Re-fetch with full fields so the cache includes extension,
+        // votes, certification — fields the PATCH response omits.
+        void queryClient.invalidateQueries({ queryKey: domainCacheKey });
 
         if (activeDomain?.name !== updatedData.name) {
           navigate(getDomainPath(response.fullyQualifiedName));

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetailPage/DomainDetailPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetailPage/DomainDetailPage.test.tsx
@@ -142,10 +142,9 @@ describe('DomainDetailPage', () => {
     });
   });
 
-  it('should merge PATCH response with cached domain, preserving fields not in the response', async () => {
-    const domainWithExtension: Domain = {
+  it('should invalidate the domain query after a successful PATCH to refetch full fields', async () => {
+    const domainWithTags: Domain = {
       ...DOMAINS_LIST[0],
-      extension: { customField: 'value' },
       tags: [
         {
           tagFQN: 'PII.Sensitive',
@@ -175,7 +174,7 @@ describe('DomainDetailPage', () => {
       version: 0.5,
     } as Domain;
 
-    mockGetDomainByName.mockResolvedValue(domainWithExtension);
+    mockGetDomainByName.mockResolvedValue(domainWithTags);
     mockPatchDomains.mockResolvedValue(patchResponse);
 
     const { queryClient } = renderWithQueryClient(
@@ -183,6 +182,8 @@ describe('DomainDetailPage', () => {
         <DomainDetailPage />
       </MemoryRouter>
     );
+
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
 
     await waitFor(() => {
       expect(mockGetDomainByName).toHaveBeenCalled();
@@ -197,9 +198,9 @@ describe('DomainDetailPage', () => {
     expect(onUpdateProp).toBeDefined();
 
     const updatedDomain: Domain = {
-      ...domainWithExtension,
+      ...domainWithTags,
       tags: [
-        ...(domainWithExtension.tags ?? []),
+        ...(domainWithTags.tags ?? []),
         {
           tagFQN: 'PersonalData.Personal',
           source: 'Classification',
@@ -214,16 +215,12 @@ describe('DomainDetailPage', () => {
     });
 
     expect(mockPatchDomains).toHaveBeenCalledTimes(1);
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: expect.arrayContaining(['domain', 'test-domain']),
+      })
+    );
 
-    const queries = queryClient.getQueriesData<Domain>({
-      queryKey: ['domain', 'test-domain'],
-    });
-    const cachedDomain = queries[0]?.[1];
-
-    expect(cachedDomain?.tags).toHaveLength(2);
-    expect(cachedDomain?.version).toBe(0.5);
-    expect(
-      (cachedDomain as Domain & { extension: unknown })?.extension
-    ).toEqual({ customField: 'value' });
+    invalidateSpy.mockRestore();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetailPage/DomainDetailPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetailPage/DomainDetailPage.test.tsx
@@ -11,13 +11,15 @@
  *  limitations under the License.
  */
 
-import { waitFor } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { Domain } from '../../../generated/entity/domains/domain';
 import { DOMAINS_LIST } from '../../../mocks/Domains.mock';
 import { ENTITY_PERMISSIONS } from '../../../mocks/Permissions.mock';
-import { getDomainByName } from '../../../rest/domainAPI';
+import { getDomainByName, patchDomains } from '../../../rest/domainAPI';
 import { renderWithQueryClient } from '../../../test/unit/test-utils';
 import PageLayoutV1 from '../../PageLayoutV1/PageLayoutV1';
+import DomainDetails from '../DomainDetails/DomainDetails.component';
 import DomainDetailPage from './DomainDetailPage.component';
 
 // Mock i18n to prevent 'add' method error
@@ -37,7 +39,13 @@ jest.mock('react-helmet-async', () => ({
   ),
 }));
 
-jest.mock('../../../rest/domainAPI');
+jest.mock('../../../rest/domainAPI', () => ({
+  getDomainByName: jest.fn(),
+  patchDomains: jest.fn(),
+  addFollower: jest.fn(),
+  removeFollower: jest.fn(),
+  updateDomainVotes: jest.fn(),
+}));
 jest.mock('../../../hooks/useApplicationStore', () => ({
   useApplicationStore: () => ({
     currentUser: { id: '1' },
@@ -66,6 +74,12 @@ jest.mock('../../../context/PermissionProvider/PermissionProvider', () => ({
 
 const mockGetDomainByName = getDomainByName as jest.MockedFunction<
   typeof getDomainByName
+>;
+const mockPatchDomains = patchDomains as jest.MockedFunction<
+  typeof patchDomains
+>;
+const MockDomainDetails = DomainDetails as jest.MockedFunction<
+  typeof DomainDetails
 >;
 
 describe('DomainDetailPage', () => {
@@ -126,5 +140,90 @@ describe('DomainDetailPage', () => {
         expect.anything()
       );
     });
+  });
+
+  it('should merge PATCH response with cached domain, preserving fields not in the response', async () => {
+    const domainWithExtension: Domain = {
+      ...DOMAINS_LIST[0],
+      extension: { customField: 'value' },
+      tags: [
+        {
+          tagFQN: 'PII.Sensitive',
+          source: 'Classification',
+          labelType: 'Manual',
+          state: 'Confirmed',
+        },
+      ],
+    } as Domain;
+
+    const patchResponse: Domain = {
+      ...DOMAINS_LIST[0],
+      tags: [
+        {
+          tagFQN: 'PII.Sensitive',
+          source: 'Classification',
+          labelType: 'Manual',
+          state: 'Confirmed',
+        },
+        {
+          tagFQN: 'PersonalData.Personal',
+          source: 'Classification',
+          labelType: 'Manual',
+          state: 'Confirmed',
+        },
+      ],
+      version: 0.5,
+    } as Domain;
+
+    mockGetDomainByName.mockResolvedValue(domainWithExtension);
+    mockPatchDomains.mockResolvedValue(patchResponse);
+
+    const { queryClient } = renderWithQueryClient(
+      <MemoryRouter>
+        <DomainDetailPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(mockGetDomainByName).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(MockDomainDetails).toHaveBeenCalled();
+    });
+
+    const onUpdateProp = MockDomainDetails.mock.calls.at(-1)?.[0]?.onUpdate;
+
+    expect(onUpdateProp).toBeDefined();
+
+    const updatedDomain: Domain = {
+      ...domainWithExtension,
+      tags: [
+        ...(domainWithExtension.tags ?? []),
+        {
+          tagFQN: 'PersonalData.Personal',
+          source: 'Classification',
+          labelType: 'Manual',
+          state: 'Confirmed',
+        },
+      ],
+    } as Domain;
+
+    await act(async () => {
+      await onUpdateProp?.(updatedDomain);
+    });
+
+    expect(mockPatchDomains).toHaveBeenCalledTimes(1);
+
+    const queries = queryClient.getQueriesData<Domain>({
+      queryKey: ['domain', 'test-domain'],
+    });
+    const cachedDomain = queries[0]?.[1];
+
+    expect(cachedDomain?.tags).toHaveLength(2);
+    expect(cachedDomain?.version).toBe(0.5);
+    expect(
+      (cachedDomain as Domain & { extension: unknown })?.extension
+    ).toEqual({ customField: 'value' });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.test.tsx
@@ -269,6 +269,41 @@ describe('TagsContainerV2 handleSave', () => {
     }
   });
 
+  it('preserves style: null without converting it to an empty object', async () => {
+    const tagWithNullStyle: EntityTags = {
+      tagFQN: PERSONAL_DATA_FQN,
+      source: TagSource.Classification,
+      labelType: LabelType.Manual,
+      state: State.Confirmed,
+      style: null as unknown as EntityTags['style'],
+      appliedBy: 'admin',
+      appliedAt: new Date(APPLIED_AT_ISO),
+    };
+
+    const onSelectionChange = jest.fn().mockResolvedValue(undefined);
+    renderTagsContainer({
+      selectedTags: [piiSensitiveTag],
+      onSelectionChange,
+    });
+
+    await enterEditMode();
+
+    expect(capturedOnSubmit).toBeDefined();
+
+    await act(async () => {
+      await capturedOnSubmit?.([
+        { value: PERSONAL_DATA_FQN, data: tagWithNullStyle },
+      ]);
+    });
+
+    expect(onSelectionChange).toHaveBeenCalledTimes(1);
+
+    const emitted = onSelectionChange.mock.calls[0][0] as TagLabel[];
+    const tag = emitted.find((t) => t.tagFQN === PERSONAL_DATA_FQN);
+
+    expect(tag?.style).toBeNull();
+  });
+
   it('add-one-remove-another in same save keeps surviving tag fields intact', async () => {
     const onSelectionChange = jest.fn().mockResolvedValue(undefined);
     renderTagsContainer({

--- a/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.tsx
@@ -184,7 +184,7 @@ const TagsContainerV2 = ({
         name: option.name,
         displayName: option.displayName,
         description: option.description,
-        style: option.style ?? {},
+        style: option.style,
         href: option.href,
         appliedBy: option.appliedBy,
         appliedAt: option.appliedAt,


### PR DESCRIPTION
## Summary

Fixes the Sentry issue where `PATCH /api/v1/domains/{id}` returns 400 when a user updates tags on a domain twice in succession (first update succeeds, second fails).

**Sentry:** https://collate-3b.sentry.io/issues/7703855605/

**Root cause — two contributing bugs:**

- **`TagsContainerV2.handleSave`** converted `style: null` → `style: {}` via `option.style ?? {}`. This created a spurious `replace /tags/0/style` operation in the `fast-json-patch` diff that could interact with tag validation (mutually-exclusive checks after `addDerivedTags`) to reject the request.

- **`DomainDetailPage.handleDomainUpdate`** replaced the entire React Query cache with the PATCH response via `setActiveDomain(response)`. The PATCH endpoint only returns `patchFields` (parent, children, experts, tags, owners, followers) — not extension, votes, or certification. Subsequent updates built their `compare()` diff from this incomplete baseline.

**Fix:**
- Preserve the server's `style` value as-is (`style: option.style` instead of `style: option.style ?? {}`)
- Merge the PATCH response into the existing cache (`{ ...prev, ...response }`) instead of replacing it

## Test plan
- [x] Navigate to a domain, add a classification tag, verify PATCH succeeds
- [x] Immediately add a second tag from a different classification, verify PATCH succeeds (was 400 before)
- [x] Verify existing tags are preserved after both updates

