### PR TITLE
Fixes 32365: stop catalog.log duplicating every rotated openmetadata.log line

### DIFF
--- a/bin/openmetadata-server-start.sh
+++ b/bin/openmetadata-server-start.sh
@@ -122,6 +122,10 @@ APP_CLASS="org.openmetadata.service.OpenMetadataApplication"
 
 # Launch mode
 if [ "x$DAEMON_MODE" = "xtrue" ]; then
+    # $CONSOLE_OUTPUT_FILE has no rotation, and the console appender in conf/openmetadata.yaml
+    # emits what logback already writes to the rotated logs/openmetadata.log. Silence the console
+    # so this file only collects JVM and pre-logback output. CONSOLE_LOG_LEVEL=TRACE restores it.
+    export CONSOLE_LOG_LEVEL="${CONSOLE_LOG_LEVEL:-OFF}"
     nohup $JAVA $OPENMETADATA_HEAP_OPTS $OPENMETADATA_JVM_PERFORMANCE_OPTS $OPENMETADATA_GC_LOG_OPTS -cp $CLASSPATH $OPENMETADATA_OPTS "$APP_CLASS" "server" "$@" > "$CONSOLE_OUTPUT_FILE" 2>&1 < /dev/null &
 else
     exec $JAVA $OPENMETADATA_HEAP_OPTS $OPENMETADATA_JVM_PERFORMANCE_OPTS $OPENMETADATA_GC_LOG_OPTS -cp $CLASSPATH $OPENMETADATA_OPTS "$APP_CLASS" "server" "$@"

--- a/bin/openmetadata.sh
+++ b/bin/openmetadata.sh
@@ -13,8 +13,6 @@
 # Home Dir
 base_dir=$(dirname $0)/..
 
-CATALOG_HOME=$base_dirbase_dir=$(dirname $0)/..
-
 CATALOG_HOME=$base_dir
 PID_DIR=$base_dir/logs
 LOG_DIR=$base_dir/logs
@@ -31,6 +29,12 @@ function catalogStart {
        rm -f ${PID_FILE}
        echo "Starting OpenMetadata"
        APP_CLASS="org.openmetadata.service.OpenMetadataApplication"
+       # ${OUT_FILE} is an append-mode redirect with no rotation. The console appender in
+       # conf/openmetadata.yaml emits the same lines that logback already writes to the rotated
+       # logs/openmetadata.log, so leaving it on makes catalog.log an unbounded duplicate.
+       # Silence it here; catalog.log then only collects JVM and pre-logback output.
+       # Export CONSOLE_LOG_LEVEL=TRACE before starting to get the old behaviour back.
+       export CONSOLE_LOG_LEVEL="${CONSOLE_LOG_LEVEL:-OFF}"
        cd ${CATALOG_HOME}
        nohup ${JAVA} ${CATALOG_HEAP_OPTS} ${CATALOG_JVM_PERF_OPTS} ${CATALOG_DEBUG_OPTS} ${CATALOG_GC_LOG_OPTS} ${CATALOG_JMX_OPTS} -cp ${CLASSPATH} "${APP_CLASS}" "server" "$@" 2>>"${ERR_FILE}" 1>>"${OUT_FILE}" &
        cd - &> /dev/null

--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -289,8 +289,12 @@ logging:
       # logs/audit.log. Pin the level so audit capture does not depend on the global LOG_LEVEL.
       level: INFO
   appenders:
+    # Containers keep this on — stdout is how `docker logs` / `kubectl logs` see the server.
+    # `bin/openmetadata.sh start` exports CONSOLE_LOG_LEVEL=OFF instead, because it redirects
+    # stdout into logs/catalog.log, which has no rotation: leaving the console on there duplicates
+    # every rotated logs/openmetadata.log line into a file that grows for the life of the install.
     - type: console
-      threshold: TRACE
+      threshold: ${CONSOLE_LOG_LEVEL:-TRACE}
       timeZone: UTC
       layout:
         type: om-event-layout

--- a/openmetadata-service/src/test/java/org/openmetadata/service/config/LoggingConfigurationYamlTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/config/LoggingConfigurationYamlTest.java
@@ -14,6 +14,9 @@
 package org.openmetadata.service.config;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
@@ -21,10 +24,13 @@ import io.dropwizard.configuration.FileConfigurationSourceProvider;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
+import io.dropwizard.logging.common.ConsoleAppenderFactory;
+import io.dropwizard.logging.common.DefaultLoggingFactory;
 import jakarta.validation.Validation;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.events.AuditExcludeFilterFactory;
@@ -33,9 +39,12 @@ import org.openmetadata.service.logging.SwitchableAccessLayoutFactory;
 import org.openmetadata.service.logging.SwitchableEventLayoutFactory;
 
 class LoggingConfigurationYamlTest {
+  private static final String SHIPPED_CONFIG = "../conf/openmetadata.yaml";
+  private static final String LOG_FORMAT_PLACEHOLDER = "${LOG_FORMAT:-text}";
+  private static final String CONSOLE_LEVEL_PLACEHOLDER = "${CONSOLE_LOG_LEVEL:-TRACE}";
   private static final List<String> CONFIG_PATHS =
       List.of(
-          "../conf/openmetadata.yaml",
+          SHIPPED_CONFIG,
           "../docker/development/distributed-test/local/server1.yaml",
           "../docker/development/distributed-test/local/server2.yaml",
           "../docker/development/distributed-test/local/server3.yaml",
@@ -55,11 +64,51 @@ class LoggingConfigurationYamlTest {
     }
   }
 
+  /**
+   * On bare metal {@code bin/openmetadata.sh start} appends stdout to {@code logs/catalog.log},
+   * which nothing rotates. The console appender emits the same lines logback already writes to the
+   * rotated {@code logs/openmetadata.log}, so leaving the console on makes that file an unbounded
+   * duplicate — one reported install reached 20M lines going back two years.
+   *
+   * <p>The fix is a pair: the yaml reads its console threshold from {@code CONSOLE_LOG_LEVEL} and
+   * the start script exports it. Either half alone is a silent no-op, so assert both. {@code
+   * DefaultLoggingFactory.toLevel} degrades an unrecognised value to INFO without complaint, which
+   * is why the parsed level is asserted rather than the yaml text.
+   */
+  @Test
+  void bareMetalStartScriptSilencesTheConsoleAppender() throws Exception {
+    assumeTrue(
+        System.getenv("CONSOLE_LOG_LEVEL") == null,
+        "CONSOLE_LOG_LEVEL overrides the shipped value");
+
+    assertEquals("TRACE", consoleThreshold(parse(SHIPPED_CONFIG)));
+    assertEquals("OFF", consoleThreshold(parse(SHIPPED_CONFIG, CONSOLE_LEVEL_PLACEHOLDER, "OFF")));
+    assertTrue(
+        Pattern.compile("export\\s+CONSOLE_LOG_LEVEL=.*:-OFF")
+            .matcher(Files.readString(Path.of("../bin/openmetadata.sh")))
+            .find(),
+        "bin/openmetadata.sh must silence the console appender it redirects into catalog.log");
+  }
+
+  private String consoleThreshold(OpenMetadataApplicationConfig config) {
+    return ((DefaultLoggingFactory) config.getLoggingFactory())
+        .getAppenders().stream()
+            .filter(ConsoleAppenderFactory.class::isInstance)
+            .map(appender -> ((ConsoleAppenderFactory<?>) appender).getThreshold())
+            .findFirst()
+            .orElseThrow();
+  }
+
   private OpenMetadataApplicationConfig parse(String path) throws Exception {
-    return parse(path, null);
+    return parse(path, LOG_FORMAT_PLACEHOLDER, null);
   }
 
   private OpenMetadataApplicationConfig parse(String path, String formatOverride) throws Exception {
+    return parse(path, LOG_FORMAT_PLACEHOLDER, formatOverride);
+  }
+
+  private OpenMetadataApplicationConfig parse(String path, String placeholder, String replacement)
+      throws Exception {
     ObjectMapper objectMapper = Jackson.newObjectMapper();
     objectMapper.registerSubtypes(
         AuditExcludeFilterFactory.class,
@@ -73,7 +122,7 @@ class LoggingConfigurationYamlTest {
             objectMapper,
             "dw");
 
-    if (formatOverride == null) {
+    if (replacement == null) {
       return factory.build(
           new SubstitutingSourceProvider(
               new FileConfigurationSourceProvider(),
@@ -84,7 +133,7 @@ class LoggingConfigurationYamlTest {
     Path tempFile = Files.createTempFile("logging-config-", ".yaml");
     try {
       Files.writeString(
-          tempFile, Files.readString(Path.of(path)).replace("${LOG_FORMAT:-text}", formatOverride));
+          tempFile, Files.readString(Path.of(path)).replace(placeholder, replacement));
       return factory.build(
           new SubstitutingSourceProvider(
               new FileConfigurationSourceProvider(),


### PR DESCRIPTION
### Describe your changes:

Fixes #32365

`catalog.log` is not a *separate* log — it is a byte-for-byte **duplicate** of `logs/openmetadata.log`.

The root console appender in `conf/openmetadata.yaml` is `threshold: TRACE`, so every line logback writes to the rotated `logs/openmetadata.log` also goes to stdout; `bin/openmetadata.sh start` appends stdout to `logs/catalog.log` (`1>>"${OUT_FILE}"`). Same content, two files, only one of them rotated — so `catalog.log` grows for the life of the deployment. A reported production install reached 20M+ lines with entries going back to 2024.

The two-logs problem and the unbounded-growth problem are therefore the same bug, and the fix is one decision: **keep the console on where stdout *is* the log destination, turn it off where it gets teed into a file nothing rotates.**

| Path | Console | Why |
|---|---|---|
| `openmetadata-server-start.sh` (no flags → `exec`) — what the Docker image uses | **on** | stdout is how `docker logs` / `kubectl logs` see the server |
| `openmetadata.sh start` → `nohup ... 1>>logs/catalog.log` | **off** | already captured, rotated, in `openmetadata.log` |
| `openmetadata-server-start.sh -daemon` → `> logs/OpenMetadataServer.out` | **off** | same |

After this, `catalog.log` holds only what genuinely cannot go through logback — JVM output (fatal errors, OOM), pre-logback stderr, and the `OpenMetadataSetup` startup/migration banner (that logger keeps its own console appender, deliberately untouched, and `LoggerConfiguration` is additive by default). Kilobytes per start, not gigabytes. `openmetadata.log` is unchanged and remains the complete log.

**Changes**

- `conf/openmetadata.yaml` — root console appender `threshold: TRACE` → `threshold: ${CONSOLE_LOG_LEVEL:-TRACE}`
- `bin/openmetadata.sh` — `export CONSOLE_LOG_LEVEL="${CONSOLE_LOG_LEVEL:-OFF}"` in `catalogStart`
- `bin/openmetadata-server-start.sh` — same export, **in the `-daemon` branch only**
- `bin/openmetadata.sh` — dropped the corrupted `CATALOG_HOME=$base_dirbase_dir=$(dirname $0)/..` line (a bad merge; bash parsed it as `CATALOG_HOME="=./bin/.."` before the next line overwrote it)

`CONSOLE_LOG_LEVEL=TRACE` restores the old behaviour for anyone who wants it. Operators who have customized `conf/openmetadata.yaml` need to take the new `threshold:` line for this to reach them.

**Rejected alternative:** redirecting stdout to `/dev/null` in the start script is a one-character diff, but it discards JVM crash output — `Error occurred during initialization of VM`, OOM messages, hs_err pointers — which is exactly what support needs when a server won't start.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Operator starts a bare-metal server with `bin/openmetadata.sh start`: `logs/catalog.log` no longer accumulates a duplicate of `logs/openmetadata.log`
- Operator runs the Docker image: container logs are unchanged (non-daemon `exec` path, console stays `TRACE`)
- Operator sets `CONSOLE_LOG_LEVEL=TRACE` before `bin/openmetadata.sh start`: previous behaviour restored

#### Unit tests
- [x] Added `LoggingConfigurationYamlTest.bareMetalStartScriptSilencesTheConsoleAppender`.

The yaml knob and the script export are a **pair** — either half alone is a silent no-op — so the test asserts both: the shipped yaml resolves to `TRACE` by default and `OFF` when `CONSOLE_LOG_LEVEL` is set, *and* `bin/openmetadata.sh` actually exports it. Asserting the parsed level rather than the yaml text matters because `DefaultLoggingFactory.toLevel` degrades an unrecognised value to `INFO` without complaining, so a typo would otherwise ship silently.

```
mvn -pl openmetadata-service -Dtest=LoggingConfigurationYamlTest test
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed

1. `bash -n` on both modified scripts — clean.
2. Ran `bin/openmetadata.sh start` against a stub `java` that echoes its environment:

```
--- default start ---
child sees CONSOLE_LOG_LEVEL=[OFF]
--- CONSOLE_LOG_LEVEL=TRACE start ---
child sees CONSOLE_LOG_LEVEL=[TRACE]
```

3. Confirmed `Level.OFF` is reached rather than silently degraded: `DefaultLoggingFactory.toLevel("OFF")` → `Level.toLevel("OFF", INFO)` → `Level.OFF`, and `ThresholdFilter` denies every event at `OFF` (`ERROR`=40000 < `Integer.MAX_VALUE`).

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. — no schema changes.
- [x] For UI changes: I attached a screen recording and/or screenshots above. — no UI changes.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

- [x] I have added a test that covers the exact scenario we are fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
