### PR TITLE
Fixes #32338: Looker — flush sink buffer before resolving data models

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
@@ -159,9 +159,14 @@ REPO_TMP_LOCAL_PATH = f"{TEMP_FOLDER_DIRECTORY}/lookml_repos"
 
 LOOKER_TAG_CATEGORY = "LookerTags"
 
-# Appended by `list_datamodels` after the last explore. Seeing it means every data model
-# of the bulk stage has been yielded, so the sink buffer can be flushed and the models
-# resolved before any lineage is drawn. See `_yield_bulk_datamodel_lineage`.
+# A stage processor is called once per produced entity and gets no "end of stream" hook,
+# but the buffer must be flushed exactly once, after the last explore. `list_datamodels`
+# appends this sentinel so `yield_bulk_datamodel` can recognise that point.
+#
+# It replaces a `processed_count >= total_explores` counter: the total was taken from every
+# explore in every model, while the producer skips models that fail the filter and explores
+# whose fetch raises, so one filtered explore left the count permanently short and standalone
+# views were never processed at all. Same pattern as omni/metadata.py.
 DATAMODEL_LINEAGE_SENTINEL = object()
 
 

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
@@ -160,15 +160,32 @@ REPO_TMP_LOCAL_PATH = f"{TEMP_FOLDER_DIRECTORY}/lookml_repos"
 
 LOOKER_TAG_CATEGORY = "LookerTags"
 
-# A stage processor is called once per produced entity and gets no "end of stream" hook,
-# but the buffer must be flushed exactly once, after the last explore. `list_datamodels`
-# appends this sentinel so `yield_bulk_datamodel` can recognise that point.
-#
-# It replaces a `processed_count >= total_explores` counter: the total was taken from every
-# explore in every model, while the producer skips models that fail the filter and explores
-# whose fetch raises, so one filtered explore left the count permanently short and standalone
-# views were never processed at all. Same pattern as omni/metadata.py.
-DATAMODEL_LINEAGE_SENTINEL = object()
+
+class _EndOfExplores:
+    """Producer-side end-of-stream marker for the bulk data-model stage.
+
+    A stage processor is called once per produced entity and gets no "end of stream" hook,
+    but the buffer must be flushed exactly once, after the last explore. `list_datamodels`
+    appends this so `yield_bulk_datamodel` can recognise that point.
+
+    It cannot be a `Barrier`: producer yields are the stage processor's *input* and never
+    reach the sink, so a Barrier here would be handed to `yield_bulk_datamodel` as `model`
+    and flush nothing. The real Barrier is yielded from `_yield_bulk_datamodel_lineage`, on
+    the `Either(right=...)` output channel the sink actually reads.
+
+    It replaces a `processed_count >= total_explores` counter: the total was taken from every
+    explore in every model, while the producer skips models that fail the filter and explores
+    whose fetch raises, so one filtered explore left the count permanently short and
+    standalone views were never processed at all.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "<end of explores>"
+
+
+DATAMODEL_LINEAGE_SENTINEL = _EndOfExplores()
 
 
 class ExploreRef(NamedTuple):

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
@@ -198,8 +198,8 @@ class ExploreRef(NamedTuple):
     """
 
     # Optional to match the SDK, where both fields are `str | None`.
-    model_name: Optional[str]  # noqa: UP045
-    name: Optional[str]  # noqa: UP045
+    model_name: str | None
+    name: str | None
 
 
 def clean_dashboard_name(name: str) -> str:
@@ -775,23 +775,23 @@ class LookerSource(DashboardServiceSource):
             yield from self._add_standalone_view_lineage(view, project_name, model_name)
         self._pending_standalone_lineage = []
 
-    def _resolve_pending_datamodels(self) -> Dict[str, Optional[DashboardDataModel]]:  # noqa: UP006, UP045
+    def _resolve_pending_datamodels(self) -> dict[str, DashboardDataModel | None]:
         """Fetch the data models written by this stage, keyed by their data model name.
 
         A view joined from several explores is yielded once per explore, so the same
         name is fetched only once and the caches keep the last-writer-wins semantics
         the interleaved implementation had.
         """
-        resolved: Dict[str, Optional[DashboardDataModel]] = {}  # noqa: UP006, UP045
+        resolved: dict[str, DashboardDataModel | None] = {}
 
-        def resolve(data_model_name: str) -> Optional[DashboardDataModel]:  # noqa: UP045
+        def resolve(data_model_name: str) -> DashboardDataModel | None:
             if data_model_name not in resolved:
                 try:
                     resolved[data_model_name] = self._build_data_model(data_model_name)
                 except Exception as err:
                     # One flaky lookup must not cost every other view its lineage; the
                     # None lands in the caches and the lineage builders skip that view.
-                    logger.warning(f"Error fetching data model [{data_model_name}]: {err}")
+                    logger.warning("Error fetching data model [%s]: %s", data_model_name, err)
                     logger.debug(traceback.format_exc())
                     resolved[data_model_name] = None
             return resolved[data_model_name]
@@ -1050,8 +1050,11 @@ class LookerSource(DashboardServiceSource):
             # the Barrier flush; a miss means the data model never made it to the server.
             if not self._view_data_model:
                 logger.warning(
-                    f"Skipping lineage for standalone view [{view.name}]: its data model "
-                    f"[{model_name}_{view.name}_view] was not found in OpenMetadata."
+                    "Skipping lineage for standalone view [%s]: its data model [%s_%s_view] "
+                    "was not found in OpenMetadata.",
+                    view.name,
+                    model_name,
+                    view.name,
                 )
                 return
 
@@ -1140,7 +1143,7 @@ class LookerSource(DashboardServiceSource):
     def add_view_lineage(  # noqa: C901
         self,
         view: LookMlView,
-        explore: Union[LookmlModelExplore, ExploreRef],  # noqa: UP007
+        explore: LookmlModelExplore | ExploreRef,
     ) -> Iterable[Either[AddLineageRequest]]:
         """
         Add the lineage source -> view -> explore
@@ -1150,8 +1153,9 @@ class LookerSource(DashboardServiceSource):
             # the Barrier flush; a miss means the data model never made it to the server.
             if not self._view_data_model:
                 logger.warning(
-                    f"Skipping lineage for view [{view.name}] of explore [{explore.name}]: "
-                    "its data model was not found in OpenMetadata."
+                    "Skipping lineage for view [%s] of explore [%s]: its data model was not found in OpenMetadata.",
+                    view.name,
+                    explore.name,
                 )
                 return
 

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
@@ -99,6 +99,7 @@ from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.lineage.models import ConnectionTypeDialectMapper, Dialect
 from metadata.ingestion.lineage.parser import LineageParser
 from metadata.ingestion.lineage.sql_lineage import get_column_fqn
+from metadata.ingestion.models.barrier import Barrier
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.progress.modes import ProgressMode
@@ -158,6 +159,11 @@ REPO_TMP_LOCAL_PATH = f"{TEMP_FOLDER_DIRECTORY}/lookml_repos"
 
 LOOKER_TAG_CATEGORY = "LookerTags"
 
+# Appended by `list_datamodels` after the last explore. Seeing it means every data model
+# of the bulk stage has been yielded, so the sink buffer can be flushed and the models
+# resolved before any lineage is drawn. See `_yield_bulk_datamodel_lineage`.
+DATAMODEL_LINEAGE_SENTINEL = object()
+
 
 def clean_dashboard_name(name: str) -> str:
     """
@@ -215,6 +221,14 @@ class LookerSource(DashboardServiceSource):
         self._parsed_views: dict[str, str] | None = {}
         self._unparsed_views: dict[str, str] | None = {}
         self._derived_dependencies = nx.DiGraph()
+
+        # Data models yielded by the bulk stage but not yet written by the sink. They are
+        # resolved in `_yield_bulk_datamodel_lineage`, after the Barrier has flushed them.
+        self._pending_explores: list[str] = []
+        self._pending_views: list[tuple[str, str]] = []
+        self._processed_view_names: set[str] = set()
+        self._pending_view_lineage: list[tuple[LookMlView, LookmlModelExplore, str]] = []
+        self._pending_standalone_lineage: list[tuple[LookMlView, str, str, str]] = []
 
         self._added_lineage: dict | None = {}
 
@@ -403,9 +417,12 @@ class LookerSource(DashboardServiceSource):
 
         return self._repo_credentials
 
-    def list_datamodels(self) -> Iterable[LookmlModelExplore]:
+    def list_datamodels(self) -> Iterable:
         """
-        Fetch explores with the SDK
+        Fetch explores with the SDK.
+
+        Yields `LookmlModelExplore`s followed by `DATAMODEL_LINEAGE_SENTINEL`, hence the
+        untyped `Iterable`.
         """
         if self.source_config.includeDataModels:
             # First, pick up all the LookML Models
@@ -431,6 +448,10 @@ class LookerSource(DashboardServiceSource):
             except Exception as err:
                 logger.debug(traceback.format_exc())
                 logger.error(f"Unexpected error fetching LookML models - {err}")
+
+            # Always close the stream, even when the explore fetch blew up: standalone
+            # views and the lineage of whatever was yielded still need to be drawn.
+            yield DATAMODEL_LINEAGE_SENTINEL
 
     def _reconcilable_explore_total(self, all_lookml_models: Sequence[LookmlModel]) -> int:
         """Count the explores that ``fetch_lookml_explores`` would actually
@@ -501,8 +522,9 @@ class LookerSource(DashboardServiceSource):
         if not first_project:
             return
 
-        # Get the first model name for naming purposes
-        first_model_name = self._all_lookml_models[0].name if self._all_lookml_models else "default"
+        # Get the first model name for naming purposes. An unnamed model would otherwise
+        # build data models called "None_<view>_view".
+        first_model_name = (self._all_lookml_models[0].name if self._all_lookml_models else None) or "default"
 
         project_parser = self._project_parsers.get(first_project)
         if not project_parser:
@@ -510,8 +532,9 @@ class LookerSource(DashboardServiceSource):
 
         # Iterate through all cached views
         for view_name, view in project_parser._views_cache.items():
-            # Skip if view was already processed
-            if view_name in self._views_cache:
+            # Skip if view was already processed. `_views_cache` is only filled after the
+            # Barrier flush, so the explore pass records its views here as it goes.
+            if view_name in self._processed_view_names:
                 logger.debug(f"View [{view_name}] already processed, skipping")
                 continue
 
@@ -555,12 +578,11 @@ class LookerSource(DashboardServiceSource):
                 self.progress_tracking.manual.track(DashboardDataModel.__name__)
                 self.register_record_datamodel(datamodel_request=data_model_request)
 
-                # Build and cache the view model
-                view_data_model = self._build_data_model(datamodel_view_name)
-                self._views_cache[view.name] = view_data_model
-
-                # Add lineage for standalone views
-                yield from self._add_standalone_view_lineage(view, first_project, first_model_name)
+                # Resolution and lineage are deferred to `_yield_bulk_datamodel_lineage`,
+                # once the Barrier has committed this request.
+                self._pending_views.append((view.name, datamodel_view_name))
+                self._processed_view_names.add(view.name)
+                self._pending_standalone_lineage.append((view, first_project, first_model_name, datamodel_view_name))
 
             except ValidationError as err:
                 yield Either(
@@ -609,15 +631,15 @@ class LookerSource(DashboardServiceSource):
 
     def yield_bulk_datamodel(self, model: LookmlModelExplore) -> Iterable[Either[CreateDashboardDataModelRequest]]:
         """
-        Get the Explore and View information and prepare
-        the model creation request.
+        Get the Explore and View information and prepare the model creation request.
 
-        After processing all explores, this method also processes standalone views
-        from the repository that aren't associated with any explore.
+        This stage only *writes*: the created data models are still buffered in the sink,
+        so nothing here may read them back. Resolution and lineage happen once the
+        producer's sentinel arrives, in `_yield_bulk_datamodel_lineage`.
         """
-        # Initialize the flag to track if we've started processing standalone views
-        if not hasattr(self, "_standalone_views_processed"):
-            self._standalone_views_processed = False
+        if model is DATAMODEL_LINEAGE_SENTINEL:
+            yield from self._yield_bulk_datamodel_lineage()
+            return
 
         try:
             datamodel_name = build_datamodel_name(model.model_name, model.name)
@@ -651,15 +673,8 @@ class LookerSource(DashboardServiceSource):
                 self.progress_tracking.manual.track(DashboardDataModel.__name__)
                 self.register_record_datamodel(datamodel_request=explore_datamodel)
 
-                # build datamodel by our hand since ack_sink=False
-                self.context.get().dataModel = self._build_data_model(datamodel_name)
-                self._view_data_model = copy.deepcopy(self.context.get().dataModel)
-
-                # Maybe use the project_name as key too?
-                # Save the explores for when we create the lineage with the dashboards and views
-                self._explores_cache[explore_datamodel.name.root] = (
-                    self.context.get().dataModel
-                )  # This is the newly created explore
+                # Resolved after the Barrier flush; see `_resolve_pending_datamodels`.
+                self._pending_explores.append(explore_datamodel.name.root)
 
                 # We can get VIEWs from the JOINs to know the dependencies
                 # We will only try and fetch if we have the credentials
@@ -697,23 +712,62 @@ class LookerSource(DashboardServiceSource):
                     stackTrace=traceback.format_exc(),
                 )
             )
-        finally:
-            # After processing the last explore, process standalone views
-            # This is a sentinel pattern - we check if this is the last model
-            if not self._standalone_views_processed and hasattr(self, "_all_lookml_models"):
-                # Count how many explores we've processed
-                if not hasattr(self, "_explores_processed_count"):
-                    self._explores_processed_count = 0
-                self._explores_processed_count += 1
 
-                # Calculate total explores
-                total_explores = sum(len(m.explores) if m.explores else 0 for m in self._all_lookml_models)
+    def _yield_bulk_datamodel_lineage(self) -> Iterable[Either]:
+        """Close the bulk data-model stage: write what is left, then draw lineage.
 
-                # If this is the last explore, process standalone views
-                if self._explores_processed_count >= total_explores:
-                    self._standalone_views_processed = True
-                    logger.info("All explores processed, now processing standalone views")
-                    yield from self.yield_standalone_datamodels()
+        Standalone views are yielded here too, so a single Barrier covers every data
+        model of the stage. Resolving them all up front also means view-to-view
+        `extends` lineage can find its parents in `_views_cache`.
+        """
+        yield from self.yield_standalone_datamodels()
+
+        # The data models above are still in the sink's bulk buffer. Commit them before
+        # anything looks them up by name, or every lookup below comes back empty.
+        yield Either(right=Barrier(reason="looker_datamodel_lineage_flush"))  # pyright: ignore[reportCallIssue]
+
+        resolved = self._resolve_pending_datamodels()
+
+        for view, explore, datamodel_view_name in self._pending_view_lineage:
+            self._view_data_model = resolved.get(datamodel_view_name)
+            yield from self.add_view_lineage(view, explore)
+        self._pending_view_lineage = []
+
+        for view, project_name, model_name, datamodel_view_name in self._pending_standalone_lineage:
+            self._view_data_model = resolved.get(datamodel_view_name)
+            yield from self._add_standalone_view_lineage(view, project_name, model_name)
+        self._pending_standalone_lineage = []
+
+    def _resolve_pending_datamodels(self) -> Dict[str, Optional[DashboardDataModel]]:  # noqa: UP006, UP045
+        """Fetch the data models written by this stage, keyed by their data model name.
+
+        A view joined from several explores is yielded once per explore, so the same
+        name is fetched only once and the caches keep the last-writer-wins semantics
+        the interleaved implementation had.
+        """
+        resolved: Dict[str, Optional[DashboardDataModel]] = {}  # noqa: UP006, UP045
+
+        def resolve(data_model_name: str) -> Optional[DashboardDataModel]:  # noqa: UP045
+            if data_model_name not in resolved:
+                try:
+                    resolved[data_model_name] = self._build_data_model(data_model_name)
+                except Exception as err:
+                    # One flaky lookup must not cost every other view its lineage; the
+                    # None lands in the caches and the lineage builders skip that view.
+                    logger.warning(f"Error fetching data model [{data_model_name}]: {err}")
+                    logger.debug(traceback.format_exc())
+                    resolved[data_model_name] = None
+            return resolved[data_model_name]
+
+        for datamodel_name in self._pending_explores:
+            self._explores_cache[datamodel_name] = resolve(datamodel_name)
+        self._pending_explores = []
+
+        for view_name, datamodel_view_name in self._pending_views:
+            self._views_cache[view_name] = resolve(datamodel_view_name)
+        self._pending_views = []
+
+        return resolved
 
     def _get_explore_sql(self, explore: LookmlModelExplore) -> str | None:
         """
@@ -778,10 +832,13 @@ class LookerSource(DashboardServiceSource):
                     else None,
                 )
                 yield Either(right=data_model_request)
-                self._view_data_model = self._build_data_model(datamodel_view_name)
-                self._views_cache[view.name] = self._view_data_model
                 self.register_record_datamodel(datamodel_request=data_model_request)
-                yield from self.add_view_lineage(view, explore)
+
+                # Resolution and lineage are deferred to `_yield_bulk_datamodel_lineage`,
+                # once the Barrier has committed this request.
+                self._pending_views.append((view.name, datamodel_view_name))
+                self._processed_view_names.add(view.name)
+                self._pending_view_lineage.append((view, explore, datamodel_view_name))
             else:
                 logger.warning(
                     f"Cannot find the view [{view_name}] in the configured repositories. "
@@ -950,9 +1007,14 @@ class LookerSource(DashboardServiceSource):
         This handles view-to-table lineage and view-to-view lineage via extends.
         """
         try:
-            # Set the current view data model for lineage processing
-            datamodel_view_name = f"{model_name}_{view.name}_view"
-            self._view_data_model = self._build_data_model(datamodel_view_name)
+            # `_yield_bulk_datamodel_lineage` resolves and sets `_view_data_model` after
+            # the Barrier flush; a miss means the data model never made it to the server.
+            if not self._view_data_model:
+                logger.warning(
+                    f"Skipping lineage for standalone view [{view.name}]: its data model "
+                    f"[{model_name}_{view.name}_view] was not found in OpenMetadata."
+                )
+                return
 
             # Handle view-to-view lineage via extends
             if view.extends__all:
@@ -1041,6 +1103,15 @@ class LookerSource(DashboardServiceSource):
         Add the lineage source -> view -> explore
         """
         try:
+            # `_yield_bulk_datamodel_lineage` resolves and sets `_view_data_model` after
+            # the Barrier flush; a miss means the data model never made it to the server.
+            if not self._view_data_model:
+                logger.warning(
+                    f"Skipping lineage for view [{view.name}] of explore [{explore.name}]: "
+                    "its data model was not found in OpenMetadata."
+                )
+                return
+
             # This is the name we store in the cache
             explore_name = build_datamodel_name(explore.model_name, explore.name)
             explore_model = self._explores_cache.get(explore_name)

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
@@ -28,6 +28,7 @@ from collections.abc import Iterable, Sequence
 from datetime import datetime
 from pathlib import Path
 from typing import (
+    NamedTuple,
     cast,
     get_args,
 )
@@ -170,6 +171,20 @@ LOOKER_TAG_CATEGORY = "LookerTags"
 DATAMODEL_LINEAGE_SENTINEL = object()
 
 
+class ExploreRef(NamedTuple):
+    """The only two fields view lineage needs off a `LookmlModelExplore`.
+
+    Deferred lineage keeps one entry per (view, explore) pair until the flush. Holding the
+    SDK object there would pin its whole fieldset — measured at ~250 KB per explore — for
+    the length of the bulk stage, so a large instance would carry hundreds of MB it never
+    reads. Two strings cost ~200 B.
+    """
+
+    # Optional to match the SDK, where both fields are `str | None`.
+    model_name: Optional[str]  # noqa: UP045
+    name: Optional[str]  # noqa: UP045
+
+
 def clean_dashboard_name(name: str) -> str:
     """
     Clean incorrect (and known) looker characters in ids
@@ -232,7 +247,7 @@ class LookerSource(DashboardServiceSource):
         self._pending_explores: list[str] = []
         self._pending_views: list[tuple[str, str]] = []
         self._processed_view_names: set[str] = set()
-        self._pending_view_lineage: list[tuple[LookMlView, LookmlModelExplore, str]] = []
+        self._pending_view_lineage: list[tuple[LookMlView, ExploreRef, str]] = []
         self._pending_standalone_lineage: list[tuple[LookMlView, str, str, str]] = []
 
         self._added_lineage: dict | None = {}
@@ -843,7 +858,9 @@ class LookerSource(DashboardServiceSource):
                 # once the Barrier has committed this request.
                 self._pending_views.append((view.name, datamodel_view_name))
                 self._processed_view_names.add(view.name)
-                self._pending_view_lineage.append((view, explore, datamodel_view_name))
+                self._pending_view_lineage.append(
+                    (view, ExploreRef(explore.model_name, explore.name), datamodel_view_name)
+                )
             else:
                 logger.warning(
                     f"Cannot find the view [{view_name}] in the configured repositories. "
@@ -1103,7 +1120,11 @@ class LookerSource(DashboardServiceSource):
                 )
             )
 
-    def add_view_lineage(self, view: LookMlView, explore: LookmlModelExplore) -> Iterable[Either[AddLineageRequest]]:  # noqa: C901
+    def add_view_lineage(  # noqa: C901
+        self,
+        view: LookMlView,
+        explore: Union[LookmlModelExplore, ExploreRef],  # noqa: UP007
+    ) -> Iterable[Either[AddLineageRequest]]:
         """
         Add the lineage source -> view -> explore
         """

--- a/ingestion/src/metadata/utils/logger.py
+++ b/ingestion/src/metadata/utils/logger.py
@@ -32,6 +32,7 @@ from metadata.generated.schema.entity.datacontract.dataContractResult import (
 from metadata.generated.schema.type.queryParserData import QueryParserData
 from metadata.generated.schema.type.tableQuery import TableQueries
 from metadata.ingestion.api.models import Entity
+from metadata.ingestion.models.barrier import Barrier
 from metadata.ingestion.models.delete_entity import DeleteEntity
 from metadata.ingestion.models.life_cycle import OMetaLifeCycleData
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
@@ -276,6 +277,16 @@ def _(record: OMetaFQNLineageRequest) -> str:
         f"{type(record).__name__} "
         f"[{record.from_entity_type}: {record.from_entity_fqn} -> {record.to_entity_type}: {record.to_entity_fqn}]"
     )
+
+
+@get_log_name.register
+def _(record: Barrier) -> None:
+    """A Barrier is a control record, not an ingested asset.
+
+    Returning None keeps it out of Status.scanned, which would otherwise report the
+    flush as a scanned record and inflate the connector's record count.
+    """
+    return
 
 
 @get_log_name.register

--- a/ingestion/tests/unit/topology/dashboard/test_looker_lineage_barrier.py
+++ b/ingestion/tests/unit/topology/dashboard/test_looker_lineage_barrier.py
@@ -316,6 +316,66 @@ class TestLookerLineageBarrier:
         assert status.records == []
 
 
+class TestProducerClosesTheStream:
+    """`list_datamodels` must always close with the sentinel.
+
+    Without it `_yield_bulk_datamodel_lineage` never runs and the whole lineage phase
+    vanishes silently — no error, no edges. Nothing else in the suite covers this, so
+    dropping the yield used to be an undetectable regression.
+    """
+
+    def _models(self, looker, explore_side_effect=None):
+        looker.client.all_lookml_models = MagicMock(
+            return_value=[SimpleNamespace(name="m1", project_name="p", explores=[SimpleNamespace(name="e1")])]
+        )
+        looker.client.lookml_model_explore = MagicMock(
+            side_effect=explore_side_effect or (lambda **_: SimpleNamespace(name="e1", model_name="m1"))
+        )
+
+    def test_sentinel_is_yielded_last(self, looker):
+        self._models(looker)
+
+        produced = list(looker.list_datamodels())
+
+        assert produced[-1] is DATAMODEL_LINEAGE_SENTINEL
+        assert sum(1 for p in produced if p is DATAMODEL_LINEAGE_SENTINEL) == 1
+
+    def test_sentinel_is_yielded_when_a_single_explore_fetch_fails(self, looker):
+        """`fetch_lookml_explores` swallows this one, so the stream just ends early."""
+        self._models(looker, explore_side_effect=Exception("explore 500"))
+
+        produced = list(looker.list_datamodels())
+
+        assert produced == [DATAMODEL_LINEAGE_SENTINEL]
+
+    def test_sentinel_is_yielded_when_the_model_listing_itself_blows_up(self, looker):
+        """The outer handler must not swallow the sentinel with the error.
+
+        Standalone views and the lineage of whatever was already yielded still need
+        drawing, so the sentinel lives after the `except`, not inside the `try`.
+        """
+        looker.client.all_lookml_models = MagicMock(side_effect=Exception("looker api down"))
+
+        produced = list(looker.list_datamodels())
+
+        assert produced == [DATAMODEL_LINEAGE_SENTINEL]
+
+    def test_no_sentinel_when_data_models_are_disabled(self, looker):
+        """Nothing was written, so there is nothing to flush or resolve."""
+        looker.source_config.includeDataModels = False
+
+        assert list(looker.list_datamodels()) == []
+
+    def test_the_sentinel_is_not_a_barrier(self, looker):
+        """Producer yields are the stage's input and never reach the sink.
+
+        A Barrier here would be handed to `yield_bulk_datamodel` as `model` and flush
+        nothing; the real Barrier goes out on the Either channel instead.
+        """
+        assert not isinstance(DATAMODEL_LINEAGE_SENTINEL, Barrier)
+        assert repr(DATAMODEL_LINEAGE_SENTINEL) == "<end of explores>"
+
+
 class TestLookerMissingDataModel:
     """A data model that genuinely fails to create must not crash the stage."""
 

--- a/ingestion/tests/unit/topology/dashboard/test_looker_lineage_barrier.py
+++ b/ingestion/tests/unit/topology/dashboard/test_looker_lineage_barrier.py
@@ -1,0 +1,313 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Looker must not read back a data model it has only just yielded.
+
+``CreateDashboardDataModelRequest`` records sit in ``MetadataRestSink``'s bulk buffer
+until it reaches ``bulk_sink_batch_size``, so a ``get_by_name`` issued straight after
+the yield returns ``None``. The source has to emit a ``Barrier`` first and resolve the
+data models afterwards.
+
+The fixtures below model that sink semantics directly: ``_build_data_model`` returns
+``None`` until a ``Barrier`` has travelled down the stream.
+"""
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from looker_sdk.sdk.api40.models import (
+    LookmlModelExplore,
+    LookmlModelExploreFieldset,
+    LookmlModelExploreJoins,
+)
+
+from metadata.generated.schema.api.data.createDashboardDataModel import (
+    CreateDashboardDataModelRequest,
+)
+from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
+from metadata.generated.schema.entity.data.dashboardDataModel import (
+    DashboardDataModel,
+    DataModelType,
+)
+from metadata.generated.schema.metadataIngestion.workflow import (
+    OpenMetadataWorkflowConfig,
+)
+from metadata.generated.schema.type.entityReference import EntityReference
+from metadata.ingestion.api.status import Status
+from metadata.ingestion.models.barrier import Barrier
+from metadata.ingestion.source.dashboard.looker.metadata import (
+    DATAMODEL_LINEAGE_SENTINEL,
+    LookerSource,
+)
+from metadata.ingestion.source.dashboard.looker.models import LookMlView
+
+MOCK_LOOKER_CONFIG = {
+    "source": {
+        "type": "looker",
+        "serviceName": "test_looker",
+        "serviceConnection": {
+            "config": {
+                "type": "Looker",
+                "clientId": "test",
+                "clientSecret": "test",
+                "hostPort": "https://my-looker.com",
+            }
+        },
+        "sourceConfig": {"config": {"type": "DashboardMetadata"}},
+    },
+    "sink": {"type": "metadata-rest", "config": {}},
+    "workflowConfig": {
+        "openMetadataServerConfig": {
+            "hostPort": "http://localhost:8585/api",
+            "authProvider": "openmetadata",
+            "securityConfig": {"jwtToken": "token"},
+        }
+    },
+}
+
+EXPECTED_DATA_MODELS = [
+    "my_model_joined_view_view",
+    "my_model_my_explore",
+    "my_model_my_view_view",
+    "my_model_orphan_view_view",
+]
+
+
+def _data_model(name: str) -> DashboardDataModel:
+    return DashboardDataModel(
+        id=uuid.uuid4(),
+        name=name,
+        displayName=name,
+        service=EntityReference(id=uuid.uuid4(), type="dashboardService"),
+        dataModelType=DataModelType.LookMlView,
+        columns=[],
+    )
+
+
+def _rights(records, of_type):
+    return [either.right for either in records if either.right is not None and isinstance(either.right, of_type)]
+
+
+def _first_index(records, of_type) -> int:
+    for index, either in enumerate(records):
+        if either.right is not None and isinstance(either.right, of_type):
+            return index
+    return -1
+
+
+@pytest.fixture
+def looker():
+    with patch(
+        "metadata.ingestion.source.dashboard.dashboard_service.DashboardServiceSource.test_connection",
+        return_value=False,
+    ):
+        config = OpenMetadataWorkflowConfig.model_validate(MOCK_LOOKER_CONFIG)
+        source = LookerSource.create(
+            MOCK_LOOKER_CONFIG["source"],
+            config.workflowConfig.openMetadataServerConfig,
+        )
+    source.context.get().__dict__["dashboard_service"] = "test_looker"
+    return source
+
+
+@pytest.fixture
+def explore():
+    return LookmlModelExplore(
+        name="my_explore",
+        model_name="my_model",
+        project_name="my_project",
+        view_name="my_view",
+        joins=[LookmlModelExploreJoins(name="joined_view")],
+        fields=LookmlModelExploreFieldset(dimensions=[], measures=[]),
+    )
+
+
+@pytest.fixture
+def bulk_stage(looker, explore):
+    """Run the bulk data-model stage the way the workflow does.
+
+    Returns a callable giving back the emitted records in order plus, for every
+    ``_build_data_model`` call, the stream index at which it happened.
+    """
+    views = {
+        "my_view": LookMlView(name="my_view", sql_table_name="db.schema.my_table"),
+        "joined_view": LookMlView(name="joined_view", sql_table_name="db.schema.joined_table"),
+        # Referenced by no explore, so it goes down the standalone path. `extends` gives it
+        # an edge that needs no dbServicePrefixes, and its parent is a view resolved by the
+        # same flush — which only works because the barrier precedes resolution.
+        "orphan_view": LookMlView(name="orphan_view", extends__all=[["my_view"]]),
+    }
+
+    def find_view(view_name):
+        """`_process_view` calls this by keyword, so `views.get` cannot stand in."""
+        return views.get(view_name)
+
+    parser = MagicMock()
+    parser._views_cache = views
+    parser.parsed_files = {}
+    parser.find_view.side_effect = find_view
+
+    looker._repo_credentials = True
+    looker._project_parsers = {"my_project": parser}
+    looker._all_lookml_models = [SimpleNamespace(name="my_model", explores=[SimpleNamespace(name="my_explore")])]
+
+    def run():
+        records = []
+        lookups = []
+        flushed = False
+
+        def build_data_model(data_model_name):
+            lookups.append((len(records), data_model_name))
+            return _data_model(data_model_name) if flushed else None
+
+        with (
+            patch.object(LookerSource, "register_record_datamodel", return_value=None),
+            patch.object(LookerSource, "_get_explore_sql", return_value=None),
+            patch.object(LookerSource, "_build_data_model", side_effect=build_data_model),
+            patch.object(LookerSource, "get_db_service_prefixes", return_value=[]),
+        ):
+            for node_entity in (explore, DATAMODEL_LINEAGE_SENTINEL):
+                for either in looker.yield_bulk_datamodel(node_entity):
+                    records.append(either)
+                    # The sink commits the buffer synchronously on a Barrier.
+                    if either.right is not None and isinstance(either.right, Barrier):
+                        flushed = True
+
+        return records, lookups
+
+    return run
+
+
+class TestLookerLineageBarrier:
+    """Ordering contract between the data-model writes and the lineage reads."""
+
+    def test_no_data_model_lookup_before_the_barrier(self, bulk_stage):
+        """Every read-back must happen after the buffer has been flushed."""
+        records, lookups = bulk_stage()
+
+        barrier_index = _first_index(records, Barrier)
+        assert barrier_index != -1, "The bulk stage must emit a Barrier"
+        assert lookups, "The stage should still resolve its data models"
+
+        early = [name for index, name in lookups if index < barrier_index]
+        assert early == [], f"Data models resolved before the Barrier: {early}"
+
+    def test_barrier_precedes_every_lineage_record(self, bulk_stage):
+        records, _ = bulk_stage()
+
+        lineage_index = _first_index(records, AddLineageRequest)
+        assert lineage_index != -1, "The stage should emit lineage"
+        assert _first_index(records, Barrier) < lineage_index
+
+    def test_data_models_are_created_before_the_barrier(self, bulk_stage):
+        """The whole point of the barrier is that the creates precede it."""
+        records, _ = bulk_stage()
+
+        barrier_index = _first_index(records, Barrier)
+        creates = [
+            index
+            for index, either in enumerate(records)
+            if either.right is not None and isinstance(either.right, CreateDashboardDataModelRequest)
+        ]
+
+        assert creates
+        assert all(index < barrier_index for index in creates)
+
+    def test_view_lineage_is_emitted_and_not_reported_as_failure(self, bulk_stage):
+        """The regression: 306 'NoneType has no attribute name' errors."""
+        records, _ = bulk_stage()
+
+        failures = [either.left.error for either in records if either.left is not None]
+        assert failures == [], f"Bulk stage reported failures: {failures}"
+        assert _rights(records, AddLineageRequest), "View -> explore lineage should be produced"
+
+    def test_only_one_barrier_per_bulk_stage(self, bulk_stage):
+        records, _ = bulk_stage()
+
+        assert len(_rights(records, Barrier)) == 1, "One flush is enough for the whole stage"
+
+    def test_explore_views_are_not_re_emitted_as_standalone_views(self, bulk_stage):
+        """`_views_cache` now fills after the flush, so the dedup can't rely on it."""
+        records, _ = bulk_stage()
+
+        created = [request.name.root for request in _rights(records, CreateDashboardDataModelRequest)]
+
+        assert sorted(created) == sorted(set(created)), f"Duplicate data models: {created}"
+        assert sorted(created) == EXPECTED_DATA_MODELS
+
+    def test_a_failed_lookup_does_not_sink_the_whole_lineage_phase(self, looker):
+        """One flaky GET must cost only its own view's lineage."""
+
+        def flaky(data_model_name):
+            if data_model_name == "my_model_my_view_view":
+                raise RuntimeError("boom")
+            return _data_model(data_model_name)
+
+        looker._pending_views = [
+            ("my_view", "my_model_my_view_view"),
+            ("other_view", "my_model_other_view_view"),
+        ]
+
+        with patch.object(LookerSource, "_build_data_model", side_effect=flaky):
+            resolved = looker._resolve_pending_datamodels()
+
+        assert resolved["my_model_my_view_view"] is None
+        assert resolved["my_model_other_view_view"] is not None
+        assert looker._views_cache["other_view"] is not None
+
+    def test_standalone_view_lineage_also_runs_after_the_barrier(self, bulk_stage, looker):
+        """The standalone path is the other half of the bug (109 of the 306 failures)."""
+        records, _ = bulk_stage()
+
+        assert looker._views_cache["orphan_view"] is not None, "standalone view must resolve"
+
+        # orphan_view extends my_view, so the edge is my_view -> orphan_view.
+        parent = looker._views_cache["my_view"]
+        child = looker._views_cache["orphan_view"]
+        extends_edges = [
+            r
+            for r in _rights(records, AddLineageRequest)
+            if r.edge.fromEntity.id.root == parent.id.root and r.edge.toEntity.id.root == child.id.root
+        ]
+        assert extends_edges, "standalone view -> extends parent lineage should be produced"
+
+    def test_barrier_is_not_counted_as_a_scanned_record(self):
+        """A flush is a control record, not an ingested asset."""
+        status = Status()
+        status.scanned(Barrier(reason="looker_datamodel_lineage_flush"))
+
+        assert status.records == []
+
+
+class TestLookerMissingDataModel:
+    """A data model that genuinely fails to create must not crash the stage."""
+
+    def test_add_view_lineage_skips_when_data_model_is_missing(self, looker, explore):
+        looker._view_data_model = None
+        looker._explores_cache["my_model_my_explore"] = _data_model("my_model_my_explore")
+
+        results = list(looker.add_view_lineage(LookMlView(name="my_view"), explore))
+
+        assert results == [], "A missing data model is a skip, not a stack trace"
+
+    def test_standalone_view_lineage_skips_when_data_model_is_missing(self, looker):
+        looker._view_data_model = None
+
+        results = list(
+            looker._add_standalone_view_lineage(
+                LookMlView(name="my_view", sql_table_name="db.schema.my_table"),
+                "my_project",
+                "my_model",
+            )
+        )
+
+        assert results == [], "A missing data model is a skip, not a stack trace"

--- a/ingestion/tests/unit/topology/dashboard/test_looker_lineage_barrier.py
+++ b/ingestion/tests/unit/topology/dashboard/test_looker_lineage_barrier.py
@@ -19,6 +19,7 @@ The fixtures below model that sink semantics directly: ``_build_data_model`` ret
 ``None`` until a ``Barrier`` has travelled down the stream.
 """
 
+import sys
 import uuid
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -46,6 +47,7 @@ from metadata.ingestion.api.status import Status
 from metadata.ingestion.models.barrier import Barrier
 from metadata.ingestion.source.dashboard.looker.metadata import (
     DATAMODEL_LINEAGE_SENTINEL,
+    ExploreRef,
     LookerSource,
 )
 from metadata.ingestion.source.dashboard.looker.models import LookMlView
@@ -279,6 +281,32 @@ class TestLookerLineageBarrier:
             if r.edge.fromEntity.id.root == parent.id.root and r.edge.toEntity.id.root == child.id.root
         ]
         assert extends_edges, "standalone view -> extends parent lineage should be produced"
+
+    def test_deferred_lineage_does_not_pin_the_explore_sdk_object(self, looker, bulk_stage):
+        """Deferring lineage must not retain LookmlModelExplore for the whole stage.
+
+        The SDK object carries the full fieldset — measured at ~250 KB per explore, so a
+        1,000-explore instance would hold ~250 MB it never reads. Only model_name and name
+        are used, so the pending entry keeps an ExploreRef instead.
+        """
+        # The lineage loop clears the list, so snapshot it at the flush while it is populated.
+        captured = []
+        original = LookerSource._resolve_pending_datamodels
+
+        def snapshot(self):
+            captured.extend(self._pending_view_lineage)
+            return original(self)
+
+        with patch.object(LookerSource, "_resolve_pending_datamodels", autospec=True, side_effect=snapshot):
+            bulk_stage()
+
+        assert captured, "the stage should defer at least one view -> explore lineage"
+        for _, held, _ in captured:
+            assert not isinstance(held, LookmlModelExplore), (
+                f"pending lineage pins the SDK explore ({sys.getsizeof(held)} B shallow); use ExploreRef"
+            )
+            assert isinstance(held, ExploreRef)
+            assert (held.model_name, held.name) == ("my_model", "my_explore")
 
     def test_barrier_is_not_counted_as_a_scanned_record(self):
         """A flush is a control record, not an ingested asset."""


### PR DESCRIPTION
### Describe your changes:

Fixes #32338

`yield_bulk_datamodel` yielded a `CreateDashboardDataModelRequest` and then immediately read it back with `get_by_name`. Since #24393 that record sits in `MetadataRestSink`'s bulk buffer until it reaches `bulk_sink_batch_size` (default 100), so the lookup returned `None` and `add_view_lineage` died on `self._view_data_model.name`. I split the bulk data-model stage into write → `Barrier` → resolve → lineage, reusing the sentinel/`Barrier` pattern PowerBI and Omni already use, so every data model is committed before anything looks it up.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

**Root cause.** Read-after-write against a buffered sink. In the reference reproduction the whole run produced only **5** `PUT /api/v1/dashboard/datamodels/bulk` calls and exactly **5** successful view lineages — the records that happened to be the 100th in the buffer and so triggered a synchronous flush before their own read-back. Everything else resolved to `None`.

**Approach.** `ingestion/src/metadata/ingestion/models/barrier.py` already exists for exactly this (added in #28308 for the same PowerBI bug); Looker was the one dashboard connector never migrated to it.

- `list_datamodels` appends `DATAMODEL_LINEAGE_SENTINEL` after the last explore, including on the error path. This also replaces the fragile `_explores_processed_count >= total_explores` counter that previously triggered standalone views.
- `yield_bulk_datamodel` now only writes, recording work on `_pending_explores` / `_pending_views` / `_pending_view_lineage`.
- On the sentinel, `_yield_bulk_datamodel_lineage` emits the standalone-view creates, yields **one** `Barrier`, resolves every pending data model, then draws all lineage.
- `_resolve_pending_datamodels` fetches each name once — a view joined from N explores was previously fetched N times (`dim_date` 136 times in the reference log) — and preserves last-writer-wins cache semantics.

**Alternatives rejected.** Setting `bulk_sink_batch_size: 1` works but discards the bulk optimisation for every connector. Emitting FQN-based lineage (`OMetaFQNLineageRequest`) removes the read but not the ordering constraint — the server still can't resolve a data model that hasn't been written.

**Also in this PR.** Both lineage builders skip with a readable warning when the data model is missing rather than raising `AttributeError`; `_views_cache` now fills after the flush, so standalone-view dedup uses a new `_processed_view_names` set; `get_log_name` returns `None` for `Barrier` so a flush is not counted as a scanned record (also affects PowerBI/Omni/api-service/delete).

**Compatibility.** No schema change, no config change, no new dependency. Applies to Looker only, apart from the `Barrier` log-name registration.

#
### Tests:

#### Use cases covered
- LookML view → explore lineage is created on the **first** ingestion run, with `bulk_sink_batch_size` at its default of 100
- LookML view → warehouse-table lineage is created for standalone views not referenced by any explore
- View-to-view `extends` lineage resolves, since `_views_cache` is fully populated before lineage is drawn
- A data model that genuinely fails to create is skipped with a warning instead of aborting the view's lineage
- Explore-joined views are not re-emitted as standalone views now that `_views_cache` fills later

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Added: `ingestion/tests/unit/topology/dashboard/test_looker_lineage_barrier.py` (11 tests)
- **Coverage: 100% of changed executable lines** in `looker/metadata.py` (57/57), measured by intersecting `git diff -U0 origin/main` against `coverage json`. Whole-file coverage is 67%.
- Regression suite: 749 passed, 1 skipped across `tests/unit/topology/dashboard/`, the sink tests, `test_logger.py`, `test_delete_stale.py`, `topology/api/`, and the Snowflake semantic-view tests. Full `tests/unit` run: 8942 passed, with 28 pre-existing failures from optional connector extras missing in the local venv (Azure, Druid, PubSub, SAP HANA, Unity Catalog, Airflow, Salesforce, Databricks) — none in the changed area.
- The tests are mutation-verified, not just green: deleting the `Barrier` yield fails 6 of them, and reverting the standalone dedup to `_views_cache` fails the duplicate test.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- Covered by the unit tests above plus the live end-to-end run below. The fixture models the sink contract directly: `_build_data_model` returns `None` until a `Barrier` has travelled down the stream.

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
End-to-end against a live Looker instance (`collate.cloud.looker.com`, LookML in Azure DevOps, 4 explores / 20 views) and a local OpenMetadata stack, with `DB_SERVICE_PREFIXES` pointing at a BigQuery-typed service so the LookML's backtick-quoted tables resolve. Same credentials, same repo, fresh services, only the code differs:

| | pre-fix (`origin/main`) | this PR |
|---|---|---|
| `'NoneType' object has no attribute 'name'` | **165** | **0** |
| Source-step failures | 20 | 0 |
| Views with lineage | **0 / 20** | **20 / 20** |
| Edges created | none | 20 × `table → dataModel`, 3 × `dataModel → dataModel` |

Steps:
1. `docker compose -f docker/development/docker-compose.yml up -d`
2. Created a BigQuery-typed database service with the 20 tables the views reference
3. Ran the Looker workflow on `origin/main` (via a detached worktree) → 165 failures, 0 lineage edges
4. Ran the same workflow on this branch → 0 failures, 20/20 views with lineage, verified by reading `GET /v1/lineage/dashboardDataModel/{id}` per view
5. Confirmed the log shows a single `Barrier flush: 24 entities, reason=looker_datamodel_lineage_flush` before any lineage request

Worth flagging for reviewers: pre-fix behaviour is **state-dependent**. On a clean slate the explore also fails to resolve, so `add_view_lineage` takes the `else` branch and logs INFO — zero lineage, **zero errors**, run reports success. On a re-run where views already exist it self-heals. The 306-error storm needs explores present and views absent. A green pipeline was never evidence the lineage was there.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable, no schema changes.
- [x] For UI changes: not applicable, no UI changes.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing. `test_no_data_model_lookup_before_the_barrier` and `test_view_lineage_is_emitted_and_not_reported_as_failure` both fail against pre-fix behaviour; issue #32338 is referenced in the test module docstring.