### PR TITLE
fix(governance): validate workflow edge conditions and node references (2.0)

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/WorkflowExpressionValidator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/WorkflowExpressionValidator.java
@@ -1,0 +1,31 @@
+package org.openmetadata.service.governance.workflows;
+
+import java.util.regex.Pattern;
+
+/**
+ * Restricts the governance-workflow edge values that get interpolated into Flowable JUEL
+ * sequence-flow expressions ({@code ${from_result == 'condition'}}) to a well-formed character set,
+ * so only valid comparison values and variable references reach the generated expression.
+ */
+public final class WorkflowExpressionValidator {
+  // Edge conditions are embedded inside a quoted JUEL string literal (${var == 'condition'}) as an
+  // inert comparison value. Require at least one alphanumeric character (a value of only spaces or
+  // punctuation is a meaningless condition) and allow the separators legitimate conditions use
+  // (e.g. "Tier.Gold").
+  private static final Pattern SAFE_EDGE_CONDITION =
+      Pattern.compile("^(?=.*[A-Za-z0-9])[A-Za-z0-9 ._-]+$");
+
+  // A conditional edge's source ('from') lands in code position as the JUEL variable-name prefix
+  // (${from_result == ...}); a valid variable reference is limited to identifier characters.
+  private static final Pattern SAFE_NODE_REFERENCE = Pattern.compile("^[A-Za-z0-9_]+$");
+
+  private WorkflowExpressionValidator() {}
+
+  public static boolean isSafeCondition(String condition) {
+    return condition != null && SAFE_EDGE_CONDITION.matcher(condition).matches();
+  }
+
+  public static boolean isSafeNodeReference(String reference) {
+    return reference != null && SAFE_NODE_REFERENCE.matcher(reference).matches();
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/Edge.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/Edge.java
@@ -8,6 +8,7 @@ import org.flowable.bpmn.model.BpmnModel;
 import org.flowable.bpmn.model.Process;
 import org.flowable.bpmn.model.SequenceFlow;
 import org.openmetadata.common.utils.CommonUtil;
+import org.openmetadata.service.governance.workflows.WorkflowExpressionValidator;
 
 @Slf4j
 public class Edge {
@@ -35,6 +36,14 @@ public class Edge {
   }
 
   private String getFlowableCondition(String from, String condition) {
+    if (!WorkflowExpressionValidator.isSafeNodeReference(from)) {
+      throw new IllegalArgumentException(
+          String.format("[WorkflowEdge] Unsafe edge source node reference: '%s'", from));
+    }
+    if (!WorkflowExpressionValidator.isSafeCondition(condition)) {
+      throw new IllegalArgumentException(
+          String.format("[WorkflowEdge] Unsafe edge condition: '%s'", condition));
+    }
     String variableName = getNamespacedVariableName(from, RESULT_VARIABLE);
     String expression = String.format("${%s == '%s'}", variableName, condition);
     LOG.debug(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/WorkflowDefinitionRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/WorkflowDefinitionRepository.java
@@ -1,5 +1,7 @@
 package org.openmetadata.service.jdbi3;
 
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -19,6 +21,7 @@ import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.BadRequestException;
 import org.openmetadata.service.governance.workflows.Workflow;
+import org.openmetadata.service.governance.workflows.WorkflowExpressionValidator;
 import org.openmetadata.service.governance.workflows.WorkflowHandler;
 import org.openmetadata.service.resources.governance.WorkflowDefinitionResource;
 import org.openmetadata.service.util.EntityUtil;
@@ -186,6 +189,45 @@ public class WorkflowDefinitionRepository extends EntityRepository<WorkflowDefin
     validateNodeInputOutputMapping(workflowDefinition);
     // 5. Conditional task validations
     validateConditionalTasks(workflowDefinition);
+    // 6. Restrict the values interpolated into conditional-edge JUEL expressions
+    validateEdgeConditions(workflowDefinition);
+  }
+
+  private void validateEdgeConditions(WorkflowDefinition workflowDefinition) {
+    if (workflowDefinition.getEdges() == null) {
+      return;
+    }
+    String workflowName = workflowDefinition.getName();
+    for (EdgeDefinition edge : workflowDefinition.getEdges()) {
+      checkEdgeExpressionSafety(workflowName, edge);
+    }
+  }
+
+  /**
+   * A conditional edge builds the Flowable expression {@code ${from_result == 'condition'}}, so both
+   * the condition value and the source node ('from') are interpolated into it. Restrict them to a
+   * well-formed character set. Unconditional edges (null/empty condition) are left untouched, so node
+   * names keep the broader entityName contract.
+   */
+  static void checkEdgeExpressionSafety(String workflowName, EdgeDefinition edge) {
+    String condition = edge.getCondition();
+    if (nullOrEmpty(condition)) {
+      return;
+    }
+    if (!WorkflowExpressionValidator.isSafeCondition(condition)) {
+      throw BadRequestException.of(
+          String.format(
+              "Workflow '%s' edge '%s' -> '%s' has an invalid condition '%s'; it must contain at "
+                  + "least one letter or digit and only letters, digits, space, '.', '_', '-'",
+              workflowName, edge.getFrom(), edge.getTo(), condition));
+    }
+    if (!WorkflowExpressionValidator.isSafeNodeReference(edge.getFrom())) {
+      throw BadRequestException.of(
+          String.format(
+              "Workflow '%s' conditional edge '%s' -> '%s' has an invalid source node reference; "
+                  + "allowed characters: letters, digits, '_'",
+              workflowName, edge.getFrom(), edge.getTo()));
+    }
   }
 
   /**

--- a/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/WorkflowExpressionValidatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/WorkflowExpressionValidatorTest.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright 2024 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.governance.workflows;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class WorkflowExpressionValidatorTest {
+
+  @ParameterizedTest
+  @ValueSource(strings = {"approve", "reject", "true", "false", "ack", "assign", "resolve", "new"})
+  void acceptsLegitimateConditions(String condition) {
+    assertTrue(WorkflowExpressionValidator.isSafeCondition(condition));
+  }
+
+  @Test
+  void acceptsDottedAndHyphenatedConditionValues() {
+    assertTrue(WorkflowExpressionValidator.isSafeCondition("Tier.Gold"));
+    assertTrue(WorkflowExpressionValidator.isSafeCondition("start-progress"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"a' b", "x'=='x", "${x}", "a\\b", "\"quoted\"", "a(b)", "a=b"})
+  void rejectsConditionsWithDisallowedCharacters(String condition) {
+    assertFalse(WorkflowExpressionValidator.isSafeCondition(condition));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {" ", "   ", "...", "-.-"})
+  void rejectsConditionsWithoutAlphanumeric(String condition) {
+    assertFalse(WorkflowExpressionValidator.isSafeCondition(condition));
+  }
+
+  @Test
+  void rejectsNullCondition() {
+    assertFalse(WorkflowExpressionValidator.isSafeCondition(null));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"GlossaryTermCreated", "CheckIfGlossaryTermIsNew", "node_1"})
+  void acceptsLegitimateNodeReferences(String reference) {
+    assertTrue(WorkflowExpressionValidator.isSafeNodeReference(reference));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"a' b", "foo.bar", "node-1", "has space", "${x}"})
+  void rejectsNodeReferencesWithDisallowedCharacters(String reference) {
+    assertFalse(WorkflowExpressionValidator.isSafeNodeReference(reference));
+  }
+
+  @Test
+  void rejectsNullNodeReference() {
+    assertFalse(WorkflowExpressionValidator.isSafeNodeReference(null));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/elements/EdgeTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/elements/EdgeTest.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright 2024 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.governance.workflows.elements;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.flowable.bpmn.model.BpmnModel;
+import org.flowable.bpmn.model.Process;
+import org.flowable.bpmn.model.SequenceFlow;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.governance.workflows.elements.EdgeDefinition;
+
+class EdgeTest {
+
+  private static String buildConditionExpression(String from, String to, String condition) {
+    EdgeDefinition definition =
+        new EdgeDefinition().withFrom(from).withTo(to).withCondition(condition);
+    Process process = new Process();
+    new Edge(definition).addToWorkflow(new BpmnModel(), process);
+    SequenceFlow flow = (SequenceFlow) process.getFlowElements().iterator().next();
+    return flow.getConditionExpression();
+  }
+
+  @Test
+  void buildsExpectedExpressionForLegitimateCondition() {
+    String expression = buildConditionExpression("CheckApproval", "Approved", "approve");
+    assertEquals("${CheckApproval_result == 'approve'}", expression);
+  }
+
+  @Test
+  void emptyConditionProducesUnconditionalEdge() {
+    assertNull(buildConditionExpression("CheckApproval", "Approved", ""));
+  }
+
+  @Test
+  void rejectsConditionWithDisallowedCharacters() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> buildConditionExpression("CheckApproval", "Owned", "a' b"));
+  }
+
+  @Test
+  void rejectsConditionWithExpressionCharacters() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> buildConditionExpression("CheckApproval", "Owned", "true ${x}"));
+  }
+
+  @Test
+  void rejectsSourceNodeWithDisallowedCharacters() {
+    assertThrows(
+        IllegalArgumentException.class, () -> buildConditionExpression("a' b", "Owned", "approve"));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/WorkflowDefinitionRepositoryEdgeSafetyTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/WorkflowDefinitionRepositoryEdgeSafetyTest.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright 2024 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.governance.workflows.elements.EdgeDefinition;
+import org.openmetadata.service.exception.BadRequestException;
+
+class WorkflowDefinitionRepositoryEdgeSafetyTest {
+
+  private static EdgeDefinition edge(String from, String to, String condition) {
+    return new EdgeDefinition().withFrom(from).withTo(to).withCondition(condition);
+  }
+
+  @Test
+  void acceptsLegitimateConditionalEdge() {
+    assertDoesNotThrow(
+        () ->
+            WorkflowDefinitionRepository.checkEdgeExpressionSafety(
+                "wf", edge("Check", "Ok", "approve")));
+  }
+
+  @Test
+  void skipsUnconditionalEdgeWithNullCondition() {
+    // A null condition is an unconditional edge; the source node keeps the broader entityName
+    // charset.
+    assertDoesNotThrow(
+        () ->
+            WorkflowDefinitionRepository.checkEdgeExpressionSafety(
+                "wf", edge("My Node-1", "Ok", null)));
+  }
+
+  @Test
+  void skipsUnconditionalEdgeWithEmptyCondition() {
+    // Empty condition is treated the same as null (unconditional) — must not be rejected.
+    assertDoesNotThrow(
+        () ->
+            WorkflowDefinitionRepository.checkEdgeExpressionSafety(
+                "wf", edge("My Node-1", "Ok", "")));
+  }
+
+  @Test
+  void rejectsConditionWithDisallowedCharacters() {
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            WorkflowDefinitionRepository.checkEdgeExpressionSafety(
+                "wf", edge("Check", "Ok", "a' b")));
+  }
+
+  @Test
+  void rejectsSourceNodeWithDisallowedCharactersOnConditionalEdge() {
+    // The 'from' is only interpolated into the expression when the edge is conditional, so it must
+    // be validated whenever a (safe) condition is present.
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            WorkflowDefinitionRepository.checkEdgeExpressionSafety(
+                "wf", edge("a' b", "Ok", "approve")));
+  }
+}

--- a/openmetadata-spec/src/main/resources/json/schema/governance/workflows/elements/edge.json
+++ b/openmetadata-spec/src/main/resources/json/schema/governance/workflows/elements/edge.json
@@ -8,15 +8,21 @@
   "properties": {
     "from": {
       "description": "Element from which the edge will start.",
-      "type": "string"
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
     },
     "to": {
       "description": "Element on which the edge will end.",
-      "type": "string"
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
     },
     "condition": {
       "description": "Defines if the edge will follow a path depending on the source node result.",
-      "type": "string"
+      "type": "string",
+      "maxLength": 256,
+      "pattern": "^(?=$|.*[A-Za-z0-9])[A-Za-z0-9 ._-]*$"
     }
   },
   "required": ["to", "from"],


### PR DESCRIPTION
Backport of #32326 to `2.0`.

## Describe your changes

Governance workflow edge `condition` values and node references are interpolated into the Flowable sequence-flow expressions that drive conditional transitions (`${from_result == 'condition'}`). This PR restricts those values so only well-formed input is accepted.

- Add `WorkflowExpressionValidator` with the allowed patterns (a condition must be empty — unconditional — or contain at least one alphanumeric plus `space . _ -`; a conditional edge's source must be an identifier).
- Validate the condition and source node of **conditional** edges at the create/update boundary in `WorkflowDefinitionRepository` (rejected with a clear `400`). Unconditional edges are untouched, so node names keep the broader `entityName` contract.
- Guard expression construction in `Edge` as a defense-in-depth check.
- In `edge.json`: `pattern`/`maxLength` on `condition` (aligned with the server-side validator) and `minLength`/`maxLength` on `from`/`to`.

No change to the generated BPMN for valid workflows (the expression string is identical), so no redeploy/migration is required.

## Type of change

- [x] Bug fix

## Tests

- Unit: `WorkflowExpressionValidatorTest`, `EdgeTest`, `WorkflowDefinitionRepositoryEdgeSafetyTest`.

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My PR includes tests for the changes made.