### PR TITLE
fix(ui): stop treating scroll x: true as a table width

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/table/table.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/table/table.tsx
@@ -424,12 +424,17 @@ const TableRow = <T extends object>({
       {...props}
       className={(state) =>
         cx(
-          'tw:relative tw:outline-focus-ring tw:transition-colors tw:after:pointer-events-none tw:hover:bg-secondary tw:focus-visible:outline-2 tw:focus-visible:-outline-offset-2',
+          // No `after:` utilities on the row itself: the variant injects
+          // `content: ''`, and a content box inside a table-row is wrapped in
+          // an anonymous table cell — a phantom column that Chrome 151's
+          // fixed-layout algorithm counts when splitting leftover width, so
+          // every table came up one column-share short of its own right edge.
+          'tw:relative tw:outline-focus-ring tw:transition-colors tw:hover:bg-secondary tw:focus-visible:outline-2 tw:focus-visible:-outline-offset-2',
           TABLE_SIZES[size].rowHeight,
           highlightSelectedRow && 'tw:selected:bg-secondary',
 
           // Row border—using an "after" pseudo-element to avoid the border taking up space.
-          'tw:[&>td]:after:absolute tw:[&>td]:after:inset-x-0 tw:[&>td]:after:bottom-0 tw:[&>td]:after:h-px tw:[&>td]:after:w-full tw:[&>td]:after:bg-border-secondary tw:last:[&>td]:after:hidden tw:[&>td]:focus-visible:after:opacity-0 tw:focus-visible:[&>td]:after:opacity-0',
+          'tw:[&>td]:after:pointer-events-none tw:[&>td]:after:absolute tw:[&>td]:after:inset-x-0 tw:[&>td]:after:bottom-0 tw:[&>td]:after:h-px tw:[&>td]:after:w-full tw:[&>td]:after:bg-border-secondary tw:last:[&>td]:after:hidden tw:[&>td]:focus-visible:after:opacity-0 tw:focus-visible:[&>td]:after:opacity-0',
 
           typeof className === 'function' ? className(state) : className
         )

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
@@ -502,6 +502,18 @@ const TableV2 = <T extends object>(
     [rest.staticVisibleColumns, defaultVisibleColumns]
   );
 
+  /**
+   * `scroll.x` only counts as a width when it is one. AntD accepts
+   * `scroll={{ x: true }}` to mean "allow sideways scroll, size by content" —
+   * treating that `true` as a width set `width: true` on the table (dropped by
+   * React) and, worse, switched on the pixel min-width floors, pinning every
+   * sized column on a table that was never going to overflow.
+   */
+  const scrollWidth =
+    typeof scroll?.x === 'number' || typeof scroll?.x === 'string'
+      ? scroll.x
+      : undefined;
+
   const scrollStyle = useMemo((): React.CSSProperties => {
     if (!scroll) {
       return {};
@@ -557,7 +569,7 @@ const TableV2 = <T extends object>(
    * keep their relative proportions either way.
    */
   const pixelWidthTotal = useMemo((): number | null => {
-    if (scroll?.x || rest.resizableColumns) {
+    if (scrollWidth !== undefined || rest.resizableColumns) {
       return null;
     }
     const widths = propsColumns.map((col) => (col as ColumnType<T>).width);
@@ -574,7 +586,7 @@ const TableV2 = <T extends object>(
     // 259. Reserving the checkbox's width out of the total instead makes it
     // absorb the leftover and balloon to ~195px.
     return total > 0 ? total : null;
-  }, [propsColumns, scroll?.x, rest.resizableColumns]);
+  }, [propsColumns, scrollWidth, rest.resizableColumns]);
 
   const toColumnWidth = useCallback(
     (width: number | string | undefined) =>
@@ -1273,9 +1285,9 @@ const TableV2 = <T extends object>(
                 // wrapper scroll: `width: <x>; min-width: 100%`. Without it the
                 // table is squeezed into its container instead, and columns
                 // that cannot wrap spill over their neighbours.
-                scroll?.x
+                scrollWidth !== undefined
                   ? {
-                      width: scroll.x as string | number,
+                      width: scrollWidth,
                       minWidth: '100%',
                     }
                   : undefined
@@ -1331,7 +1343,8 @@ const TableV2 = <T extends object>(
                               // percentage floor is worse still: rounded up per
                               // column it totals over 100% and raises a
                               // scrollbar on a table that fits.
-                              ...(scroll?.x && typeof colWidth === 'number'
+                              ...(scrollWidth !== undefined &&
+                              typeof colWidth === 'number'
                                 ? { minWidth: colWidth }
                                 : {}),
                             }
@@ -1404,8 +1417,8 @@ const TableV2 = <T extends object>(
                       </div>
                       {rest.resizableColumns && (
                         <ColumnResizer
-                          className="tw:absolute tw:right-0 tw:top-1/4 tw:h-1/2 tw:w-2 tw:cursor-col-resize 
-                        tw:touch-none tw:after:absolute tw:after:left-1/2 tw:after:h-full tw:after:w-px tw:after:-translate-x-1/2 tw:after:content-[''] 
+                          className="tw:absolute tw:right-0 tw:top-1/4 tw:h-1/2 tw:w-2 tw:cursor-col-resize
+                        tw:touch-none tw:after:absolute tw:after:left-1/2 tw:after:h-full tw:after:w-px tw:after:-translate-x-1/2 tw:after:content-['']
                         tw:after:bg-border-secondary tw:data-[resizing]:after:w-0.5 tw:data-[resizing]:after:bg-border-brand"
                         />
                       )}
@@ -1528,7 +1541,7 @@ const TableV2 = <T extends object>(
                                     ),
                                     // Scrollable pixel columns only — see the
                                     // header cell.
-                                    ...(scroll?.x &&
+                                    ...(scrollWidth !== undefined &&
                                     typeof colType.width === 'number'
                                       ? { minWidth: colType.width }
                                       : {}),
@@ -1658,7 +1671,7 @@ const TableV2 = <T extends object>(
           (clientPagination.serverTotal ?? filteredDataSource.length) <=
             clientPagination.pageSize
         ) ? (
-        <div className="tw:px-4 tw:pb-4">
+        <div>
           {/*
             The core pager rather than NextPrevious: it navigates by page
             number instead of one step at a time, and it is react-aria rather

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
@@ -1626,6 +1626,20 @@ const TableV2 = <T extends object>(
                                     actualIndex
                                   )}
                                 </div>
+                              ) : showExpandInCell ? (
+                                // Same shrink permission without imposing
+                                // `truncate`: a flex item's min-width is `auto`,
+                                // so a nowrap value the call site ellipsizes
+                                // itself (an AntD Typography link, say) could
+                                // never shrink to the cell and painted across
+                                // the neighbouring columns instead.
+                                <div className="tw:min-w-0 tw:flex-1">
+                                  {resolveCellValue(
+                                    colType,
+                                    record,
+                                    actualIndex
+                                  )}
+                                </div>
                               ) : (
                                 resolveCellValue(colType, record, actualIndex)
                               )}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/__tests__/TableV2.parity.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/__tests__/TableV2.parity.test.tsx
@@ -858,6 +858,49 @@ describe('TableV2 — size drives cell padding', () => {
 });
 
 /**
+ * TableV2-only: the expander turns the first cell into a flex row, and a flex
+ * item's min-width defaults to `auto` — a nowrap value the call site ellipsizes
+ * itself (an AntD Typography link) could then never shrink to the cell and
+ * painted across the neighbouring columns. The value slot must carry `min-w-0`
+ * whether or not the column also asks TableV2 to truncate.
+ */
+describe('TableV2 — expander cells let their value shrink', () => {
+  const firstCellDiv = (ellipsis?: boolean) => {
+    const { unmount } = render(
+      <TableV2
+        columns={[{ dataIndex: 'a', ellipsis, key: 'a', title: 'A' }]}
+        dataSource={[{ a: 'x'.repeat(400), children: [] }]}
+        expandable={{ rowExpandable: () => true }}
+        pagination={false}
+        rowKey="a"
+      />
+    );
+    const cell = document.querySelector('tbody td') as HTMLElement;
+    // jsdom's `:scope` parser trips over React Aria's `:`-laden ids, so walk.
+    const wrapper = cell.firstElementChild as HTMLElement;
+    const value = wrapper.lastElementChild as HTMLElement;
+    const cls = value.className;
+    unmount();
+
+    return cls;
+  };
+
+  it('without column ellipsis, the slot may shrink but not truncate', () => {
+    const cls = firstCellDiv();
+
+    expect(cls).toContain('tw:min-w-0');
+    expect(cls).not.toContain('tw:truncate');
+  });
+
+  it('with column ellipsis, it shrinks and truncates', () => {
+    const cls = firstCellDiv(true);
+
+    expect(cls).toContain('tw:min-w-0');
+    expect(cls).toContain('tw:truncate');
+  });
+});
+
+/**
  * TableV2-only: the app's own stylesheet sets
  * `.ant-table-cell { vertical-align: top }`, so every legacy table tops its
  * cells — stock AntD sets none, which is what made the browser default look

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/__tests__/TableV2.parity.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/__tests__/TableV2.parity.test.tsx
@@ -715,6 +715,12 @@ describe('TableV2 — pixel columns stretch to fill', () => {
     ]);
   });
 
+  it('treats scroll x: true as no width at all', () => {
+    // AntD's `x: true` means "allow sideways scroll, size by content" — it is
+    // not a width, so it must not pin the columns or stop them stretching.
+    expect(widthsFor({ scroll: { x: true } }).header).toEqual(['75%', '25%']);
+  });
+
   it('keeps pixels while columns are resizable', () => {
     // A resizable table measures its own columns, so the values come from the
     // resize state rather than the props — what matters is the unit: a drag


### PR DESCRIPTION
## Describe your changes

Stacked on #31953 (do not merge before it). Two Chrome-151 layout fixes the migration surfaced:

**1. `scroll={{ x: true }}` treated as a width.** AntD accepts `x: true` to mean "allow sideways scroll, size by content" — it is not a width. TableV2 took any truthy `scroll.x` as one: `width: true` (dropped by React, leaving a stray `min-width: 100%`), pixel min-width floors re-pinned, proportional stretch disabled. Now only a `number | string` counts as a width; a bare `true` keeps just the overflow container. Parity spec: `treats scroll x: true as no width at all`.

**2. Row `::after` registering as a phantom column.** The core `Table.Row` carried `tw:after:pointer-events-none` on the `<tr>` itself; Tailwind's `after:` variant injects `content: ''`, and a content box inside a table-row wraps in an anonymous table cell. Chrome 151's fixed-layout algorithm counts it as a column when splitting leftover width, so every table stopped one column-share short of its right edge (7 pixel columns split 1088px eight ways; two unsized columns took a third of the leftover each). Chromium ≤143 ignores the anonymous cell — this never reproduced headless. The border is drawn on `td::after`, so the pointer-events guard moves there: `tw:[&>td]:after:pointer-events-none`.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have added tests that prove my fix is effective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)