### PR TITLE
Fixes #32377: cap pygtrie below 2.6 so `import airflow` works on Python 3.10

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -45,6 +45,12 @@ VERSIONS = {
     "pydantic": "pydantic>=2.12.5,<3",
     "pydantic-settings": "pydantic-settings~=2.0,>=2.14.2",  # GHSA-4xgf-cpjx-pc3j secrets_dir symlink escape
     "pydomo": "pydomo~=0.3",
+    # 2.6.0 annotates with typing.Self (3.11+) but declares no requires-python floor, so
+    # pip/uv installs it on 3.10 and `import pygtrie` raises AttributeError. Airflow pulls
+    # it in unpinned (apache-airflow-core/task-sdk require pygtrie>=2.5.0) and imports it
+    # from airflow._shared.logging.structlog, which breaks `import airflow` on our main CI
+    # interpreter. Drop the cap once pygtrie declares its floor or 3.10 support is dropped.
+    "pygtrie": "pygtrie<2.6",
     "pymysql": "pymysql~=1.0",
     "pyodbc": "pyodbc~=5.3.0",
     "numpy": "numpy>=2,<3",
@@ -206,6 +212,7 @@ plugins: Dict[str, Set[str]] = {  # noqa: UP006
         "opentelemetry-exporter-otlp==1.37.0",
         "attrs",
         VERSIONS["airflow"],
+        VERSIONS["pygtrie"],
         # Transitive floor pins for Airflow 3.x stack — Dependabot CVEs.
         "apache-airflow-providers-http>=6.0.0",  # CVE-2025-69219 unsafe pickle RCE
         "apache-airflow-providers-opensearch>=1.9.1",  # CVE-2026-43826 credential leak
@@ -490,6 +497,7 @@ test = {
     # Install Airflow as it's not part of `all` plugin
     "opentelemetry-exporter-otlp==1.37.0",
     VERSIONS["airflow"],
+    VERSIONS["pygtrie"],
     "boto3-stubs",
     "mypy-boto3-glue",
     "coverage",


### PR DESCRIPTION
### Describe your changes:

Fixes #32377

`py-tests` has been red on the Python 3.10 lane since **2026-09-01T11:06Z**, taking `py-tests-status` with it and evicting every PR that touches `ingestion/` from the merge queue:

```
ImportError: cannot import name 'Connection' from 'airflow.models'
```

No code change caused it. `pygtrie 2.6.0` was published at 11:06:08Z; it annotates with `typing.Self` (PEP 673, 3.11+) but declares **no `requires-python` floor**, so pip and uv install it on 3.10, where it is unimportable:

```
$ python3.10 -c "import pygtrie"
AttributeError: module 'typing' has no attribute 'Self'   # pygtrie.py:83, `def __copy__(self) -> _t.Self`
$ python3.13 -c "import pygtrie"   # fine
```

`apache-airflow-core` and `apache-airflow-task-sdk` both require `pygtrie>=2.5.0` with no ceiling, and `airflow._shared.logging.structlog` imports it at module level — reached from `airflow/__init__.py` via `configuration.initialize_secrets_backends()`, which is why the `AttributeError` surfaces as a missing `Connection`. 3.11 and 3.12 are unaffected because they have `typing.Self`; 3.10 is `MAIN_PYTHON_VERSION`. Full chain and the package-diff evidence are in the issue.

This caps `pygtrie<2.6` in `VERSIONS` and applies it in two places:

- the **`airflow` plugin** extra, alongside the existing transitive pins — covers the Airflow image;
- the **`test`** extra, which is where CI actually pulls Airflow in (`uv pip install "ingestion[all]"` then `"ingestion[test]"`; `all-dev-env` and `all` both exclude the airflow plugin).

`ingestion/airflow-constraints-3.3.1.txt:583` already pins `pygtrie==2.5.0`, but the unit-test install path does not apply that constraints file — which is exactly why it did not protect CI.

The cap is temporary. It can be dropped once pygtrie declares `requires-python>=3.11` (or switches to `typing_extensions.Self`), or Airflow caps the dependency, or 3.10 support is dropped. The comment in `VERSIONS` says so.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — one-line dependency cap.

#
### Tests:

#### Use cases covered
- `ingestion[test]` resolves on Python 3.10 with a `pygtrie` that is actually importable
- `import airflow` works again, so the Airflow connector unit tests and integration shard-3 collect

#### Unit tests
- [x] Not applicable — this is a dependency constraint; the verification is the resolver and CI itself (see below).

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion code changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed

Full resolver dry-run of the affected extra on Python 3.10 — 421 packages, no conflict:

```
$ python3.10 -m pip install --dry-run --ignore-installed "./ingestion[test]"
  pygtrie: 2.5.0
  apache-airflow: 3.3.1
  apache-airflow-core: 3.3.1
  apache-airflow-task-sdk: 1.3.1
```

Before the cap the same resolution selects `pygtrie 2.6.0`, which is the failure. Also confirmed directly that 2.5.0 imports on 3.10 and 2.6.0 does not, and that 2.6.0 imports fine on 3.13.

This PR's own `py-tests` run on 3.10 is the real regression test.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
