### PR TITLE
Fixes #28142: probe only the in-scope databases in the MongoDB test connection

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/mongodb/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/mongodb/connection.py
@@ -29,9 +29,16 @@ from metadata.generated.schema.entity.services.connections.testConnectionResult 
 )
 from metadata.ingestion.connections.builders import get_connection_url_common
 from metadata.ingestion.connections.connection import BaseConnection
-from metadata.ingestion.connections.test_connections import test_connection_steps
+from metadata.ingestion.connections.test_connections import (
+    SourceConnectionException,
+    test_connection_steps,
+)
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.constants import THREE_MIN
+from metadata.utils.filters import filter_by_schema
+from metadata.utils.logger import ingestion_logger
+
+logger = ingestion_logger()
 
 
 class MongoDBConnection(BaseConnection[MongoDBConnectionConfig, MongoClient]):
@@ -49,6 +56,21 @@ class MongoDBConnection(BaseConnection[MongoDBConnectionConfig, MongoClient]):
         self._on_close(client.close)
         return client
 
+    def _get_databases_in_scope(self, client: MongoClient) -> list[str]:
+        """Databases the ingestion would actually read.
+
+        MongoDB databases are ingested as OpenMetadata schemas, so `databaseSchema`
+        and `schemaFilterPattern` are what narrow them down.
+        """
+        connection = self.service_connection
+        if connection.databaseSchema:
+            return [connection.databaseSchema]
+        return [
+            database
+            for database in client.list_database_names()
+            if not filter_by_schema(connection.schemaFilterPattern, database)
+        ]
+
     def test_connection(
         self,
         metadata: OpenMetadata,
@@ -62,27 +84,47 @@ class MongoDBConnection(BaseConnection[MongoDBConnectionConfig, MongoClient]):
         client = self.client
         service_connection = self.service_connection
 
-        class SchemaHolder(BaseModel):
-            database: str | None = None
+        class DatabaseHolder(BaseModel):
+            """Databases resolved by GetDatabases for GetCollections to probe"""
 
-        holder = SchemaHolder()
+            databases: list[str] = []
+            listed: bool = False
 
-        def test_get_databases(client_: MongoClient, holder_: SchemaHolder, database_name: str | None = None):
-            # If database name is provided, use it directly instead of listing all databases
-            if database_name:
-                holder_.database = database_name
-            else:
-                for database in client_.list_database_names():
-                    holder_.database = database
-                    break
+        holder = DatabaseHolder()
 
-        def test_get_collections(client_: MongoClient, holder_: SchemaHolder):
-            database = client_.get_database(holder_.database)
-            database.list_collection_names()
+        def test_get_databases(client_: MongoClient, holder_: DatabaseHolder):
+            holder_.databases = self._get_databases_in_scope(client_)
+            holder_.listed = True
+            if not holder_.databases:
+                logger.warning("No database is in scope: check `Database Schema` and `Schema Filter Pattern`.")
+
+        def test_get_collections(client_: MongoClient, holder_: DatabaseHolder):
+            """Probe `listCollections` on the databases in scope, passing on the first success.
+
+            Restricted users often hold `listCollections` only on the databases they
+            ingest, so probing one arbitrary database fails the whole test connection
+            for a configuration that would ingest fine.
+            """
+            if not holder_.listed:
+                raise SourceConnectionException(
+                    "The databases to probe could not be listed, see the GetDatabases step."
+                )
+
+            error: Exception | None = None
+            for database in holder_.databases:
+                try:
+                    client_.get_database(database).list_collection_names()
+                except Exception as exc:
+                    error = exc
+                    logger.debug("Failed to list collections of database [%s]: %s", database, exc)
+                else:
+                    return
+            if error is not None:
+                raise error
 
         test_fn = {
             "CheckAccess": client.server_info,
-            "GetDatabases": partial(test_get_databases, client, holder, service_connection.databaseSchema),
+            "GetDatabases": partial(test_get_databases, client, holder),
             "GetCollections": partial(test_get_collections, client, holder),
         }
 

--- a/ingestion/tests/unit/source/database/mongodb/test_connection.py
+++ b/ingestion/tests/unit/source/database/mongodb/test_connection.py
@@ -15,7 +15,10 @@ rather than a SQLAlchemy ``Engine``, so ``BaseConnection``'s client type is
 ``MongoClient`` and ``test_connection`` drives pymongo calls directly.
 """
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pymongo.errors import OperationFailure
 
 from metadata.generated.schema.entity.services.connections.database.mongoDBConnection import (
     MongoDBConnection as MongoDBConnectionConfig,
@@ -24,6 +27,7 @@ from metadata.generated.schema.entity.services.connections.database.mongoDBConne
     MongoDBScheme,
 )
 from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.connections.test_connections import SourceConnectionException
 from metadata.ingestion.source.database.mongodb.connection import MongoDBConnection
 
 CONNECTION_MODULE = "metadata.ingestion.source.database.mongodb.connection"
@@ -66,3 +70,116 @@ def test_close_releases_the_mongo_client_pool():
         _ = connection.client
         connection.close()
     mock_mongo.return_value.close.assert_called_once_with()
+
+
+def _fake_client(databases: list[str], authorized: list[str]) -> MagicMock:
+    """A client that only lets `authorized` databases list their collections"""
+    client = MagicMock()
+    client.list_database_names.return_value = databases
+
+    def get_database(name: str) -> MagicMock:
+        database = MagicMock()
+        if name in authorized:
+            database.list_collection_names.return_value = ["collection"]
+        else:
+            database.list_collection_names.side_effect = OperationFailure(f"not authorized on {name}")
+        return database
+
+    client.get_database.side_effect = get_database
+    return client
+
+
+def _test_steps(config: MongoDBConnectionConfig, client: MagicMock) -> dict:
+    """Build the test connection steps against `client` and hand them back to be run"""
+    with (
+        patch(f"{CONNECTION_MODULE}.MongoClient", return_value=client),
+        patch(f"{CONNECTION_MODULE}.test_connection_steps") as mock_steps,
+    ):
+        MongoDBConnection(config).test_connection(metadata=MagicMock())
+    return mock_steps.call_args.kwargs["test_fn"]
+
+
+def _probed_databases(client: MagicMock) -> list[str]:
+    return [call.args[0] for call in client.get_database.call_args_list]
+
+
+def test_get_collections_skips_the_databases_filtered_out():
+    """The probe must not touch a database the ingestion is configured to skip"""
+    config = _config(schemaFilterPattern={"excludes": ["__mongo_connector", "admin", "local"]})
+    client = _fake_client(["__mongo_connector", "admin", "local", "testdb"], authorized=["testdb"])
+
+    steps = _test_steps(config, client)
+    steps["GetDatabases"]()
+    steps["GetCollections"]()
+
+    assert _probed_databases(client) == ["testdb"]
+
+
+def test_get_collections_only_probes_the_included_databases():
+    config = _config(schemaFilterPattern={"includes": ["testdb"]})
+    client = _fake_client(["admin", "testdb"], authorized=["testdb"])
+
+    steps = _test_steps(config, client)
+    steps["GetDatabases"]()
+    steps["GetCollections"]()
+
+    assert _probed_databases(client) == ["testdb"]
+
+
+def test_get_collections_passes_when_one_database_can_be_read():
+    """Without filters the probe keeps going until a database lets us in"""
+    client = _fake_client(["admin", "local", "testdb"], authorized=["testdb"])
+
+    steps = _test_steps(_config(), client)
+    steps["GetDatabases"]()
+    steps["GetCollections"]()
+
+    assert _probed_databases(client) == ["admin", "local", "testdb"]
+
+
+def test_get_collections_fails_when_no_database_can_be_read():
+    client = _fake_client(["admin", "testdb"], authorized=[])
+
+    steps = _test_steps(_config(), client)
+    steps["GetDatabases"]()
+
+    with pytest.raises(OperationFailure):
+        steps["GetCollections"]()
+
+
+def test_database_schema_is_the_only_database_probed():
+    """`databaseSchema` restricts the ingestion to one database, so it needs no listing"""
+    config = _config(databaseSchema="testdb")
+    client = _fake_client(["admin", "testdb"], authorized=["testdb"])
+
+    steps = _test_steps(config, client)
+    steps["GetDatabases"]()
+    steps["GetCollections"]()
+
+    client.list_database_names.assert_not_called()
+    assert _probed_databases(client) == ["testdb"]
+
+
+def test_get_collections_passes_when_no_database_is_in_scope():
+    """Nothing to read collections from is not a connection failure"""
+    config = _config(schemaFilterPattern={"excludes": [".*"]})
+    client = _fake_client(["admin", "testdb"], authorized=["testdb"])
+
+    steps = _test_steps(config, client)
+    steps["GetDatabases"]()
+    steps["GetCollections"]()
+
+    client.get_database.assert_not_called()
+
+
+def test_get_collections_fails_when_the_databases_could_not_be_listed():
+    """A failed GetDatabases must not leave GetCollections reporting success"""
+    client = _fake_client([], authorized=[])
+    client.list_database_names.side_effect = OperationFailure("not authorized on admin")
+
+    steps = _test_steps(_config(), client)
+    with pytest.raises(OperationFailure):
+        steps["GetDatabases"]()
+
+    with pytest.raises(SourceConnectionException):
+        steps["GetCollections"]()

--- a/openmetadata-service/src/main/resources/json/data/testConnections/database/mongodb.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/database/mongodb.json
@@ -19,8 +19,8 @@
       },
       {
         "name": "GetCollections",
-        "description": "List all the collection available within a randomly chosen database available to the user.",
-        "errorMessage": "Failed to fetch collection, please validate if the user has `listCollection` privilege on available databases",
+        "description": "List the collections of the databases in scope, as narrowed by `Database Schema` and `Schema Filter Pattern`. Passes as soon as the collections of one of them can be listed.",
+        "errorMessage": "Failed to fetch collection, please validate if the user has `listCollection` privilege on the databases in scope",
         "mandatory": true
       }
     ]


### PR DESCRIPTION
### Describe your changes:

Fixes #28142

`GetCollections` listed the collections of an arbitrary database — whichever one `list_database_names()` returned first — so a MongoDB user holding `listCollections` only on the databases it ingests failed a mandatory test-connection step for a configuration that would have ingested fine. The step description said as much: *"a randomly chosen database"*.

- `GetDatabases` now resolves the databases the ingestion would actually read: `databaseSchema` when set, otherwise the listed databases minus the ones `schemaFilterPattern` filters out (MongoDB databases are ingested as OpenMetadata schemas). Same idea as the Snowflake test connection, which already picks its probe database through `databaseFilterPattern`.
- `GetCollections` probes those databases and passes on the first success instead of betting the whole test on one of them. Nothing in scope is no longer a failure either — an empty instance, or filters that exclude everything, is not a connection problem.
- Updated the step description / error message, which described the old behaviour.
- `GetCollections` also fails explicitly when `GetDatabases` could not list at all, so a failed listing cannot leave it reporting success.

The couchbase connector has the same one-arbitrary-database probe shape; not touched here.

The pipeline-level `sourceConfig` filters are not reachable from `test_connection` (it only receives the service connection), so the connection-level `Database Schema` / `Schema Filter Pattern` fields are what the probe can honour.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- A user with `listCollections` on only one database passes the test connection when the other databases are excluded by `Schema Filter Pattern`, or included by it, or when no filter is set at all.
- The test connection still fails when no database in scope can be read.
- `Database Schema` remains the single probed database and skips listing entirely.

#### Unit tests
- [x] Added, in `ingestion/tests/unit/source/database/mongodb/test_connection.py`. Four of them fail on `main`.

#### Backend integration tests
- [x] Not applicable (no API changes).

#### Ingestion integration tests
- [x] Not applicable — covered by unit tests plus the manual run below.

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Against a `mongo:6.0` container with authentication on, holding `testdb`, `__mongo_connector`, `admin`, `local`, and a user with `read` on `testdb` plus cluster `listDatabases` — the reporter's setup. Ran the real test-connection steps through pymongo: `GetCollections` fails on `main` in every filter combination and passes here, while a user that can read no database at all still fails.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added a test that covers the exact scenario we are fixing.
