### PR TITLE
feat(login): drive login video gradient from LoginClassBase (backport #32311 to 2.0)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Layout/CarouselLayout/CarouselLayout.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Layout/CarouselLayout/CarouselLayout.tsx
@@ -28,8 +28,7 @@ const LOGIN_SPLIT_LAYOUT_CLASSES =
 
 const LOGIN_VIDEO_PANEL_CLASSES =
   'tw:relative tw:flex tw:flex-[1_1_52%] tw:min-w-0 tw:items-center ' +
-  'tw:justify-center tw:overflow-hidden tw:max-[1000px]:hidden ' +
-  'tw:bg-[linear-gradient(165deg,#f8f7fc_0%,#f3effc_55%,#ece5fb_100%)]';
+  'tw:justify-center tw:overflow-hidden tw:max-[1000px]:hidden';
 
 const LOGIN_VIDEO_INSET_CLASSES =
   'tw:flex tw:box-border tw:h-full tw:w-full tw:items-center tw:justify-center ' +
@@ -38,8 +37,6 @@ const LOGIN_VIDEO_INSET_CLASSES =
 const LOGIN_VIDEO_CARD_CLASSES =
   'tw:relative tw:aspect-[2024/2160] tw:max-h-full tw:max-w-full ' +
   'tw:w-[min(100cqw,93.7cqh)] tw:overflow-hidden tw:rounded-[max(22px,4.8%)] ' +
-  'tw:bg-[linear-gradient(180deg,#f2f1f5_0%,#e3d9f8_55%,#8a5cf0_100%)] ' +
-  'tw:shadow-[0_32px_80px_-28px_rgba(86,54,205,0.38),0_6px_20px_-6px_rgba(38,24,90,0.12)] ' +
   'tw:[transform:translateZ(0)]';
 
 const LOGIN_FORM_PANEL_CLASSES =
@@ -67,9 +64,17 @@ export const CarouselLayout = ({
         <Content
           className={classNames(LOGIN_SPLIT_LAYOUT_CLASSES, carouselClassName)}
           data-testid="signin-page">
-          <div className={LOGIN_VIDEO_PANEL_CLASSES}>
+          <div
+            className={classNames(
+              LOGIN_VIDEO_PANEL_CLASSES,
+              loginClassBase.getLoginVideoPanelClassName()
+            )}>
             <div className={LOGIN_VIDEO_INSET_CLASSES}>
-              <div className={LOGIN_VIDEO_CARD_CLASSES}>
+              <div
+                className={classNames(
+                  LOGIN_VIDEO_CARD_CLASSES,
+                  loginClassBase.getLoginVideoCardClassName()
+                )}>
                 <LoginCarousel />
               </div>
             </div>

--- a/openmetadata-ui/src/main/resources/ui/src/constants/LoginClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/LoginClassBase.ts
@@ -49,6 +49,22 @@ class LoginClassBase {
   public getLoginVideo(): string | undefined {
     return loginVideo;
   }
+
+  // Gradient behind the login video panel. Returned from here (not inlined in
+  // CarouselLayout) so Collate can override the login palette via
+  // LoginClassCollate without forking the layout. Fixed brand illustration
+  // colours — no semantic-token equivalent.
+  public getLoginVideoPanelClassName(): string {
+    return 'tw:bg-[linear-gradient(165deg,#f8f7fc_0%,#f3effc_55%,#ece5fb_100%)]';
+  }
+
+  // Gradient + shadow of the inset video card, shown until the video paints.
+  public getLoginVideoCardClassName(): string {
+    return (
+      'tw:bg-[linear-gradient(180deg,#f2f1f5_0%,#e3d9f8_55%,#8a5cf0_100%)] ' +
+      'tw:shadow-[0_32px_80px_-28px_rgba(86,54,205,0.38),0_6px_20px_-6px_rgba(38,24,90,0.12)]'
+    );
+  }
 }
 
 const loginClassBase = new LoginClassBase();


### PR DESCRIPTION
Backport of #32311 to `2.0`. Clean cherry-pick of 24470b411238cfab4eb2d1bd7b57d879458d8e2f — no conflicts, no adaptation.

The login video panel and inset-card gradients were inlined in `CarouselLayout`. This moves them behind `getLoginVideoPanelClassName()` and `getLoginVideoCardClassName()` on `LoginClassBase` so downstream builds can override the login palette without forking the layout. **The OSS default palette is unchanged** — the same purple values now come from the base class instead of module constants, so there is no visual change on OSS.

Needed on `2.0` because openmetadata-collate `2.0` tracks this branch as its submodule, and the Collate-side override (open-metadata/openmetadata-collate#6301, backported in open-metadata/openmetadata-collate#6332) has no effect until these base methods exist here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
