### PR TITLE
fix: mask PubSub credentials in backend (#32102) [2.0]

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/ClassConverterFactory.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/ClassConverterFactory.java
@@ -50,6 +50,7 @@ import org.openmetadata.schema.services.connections.database.UnityCatalogConnect
 import org.openmetadata.schema.services.connections.database.datalake.GCSConfig;
 import org.openmetadata.schema.services.connections.database.deltalake.StorageConfig;
 import org.openmetadata.schema.services.connections.drive.GoogleDriveConnection;
+import org.openmetadata.schema.services.connections.messaging.PubSubConnection;
 import org.openmetadata.schema.services.connections.mlmodel.VertexAIConnection;
 import org.openmetadata.schema.services.connections.pipeline.AirbyteConnection;
 import org.openmetadata.schema.services.connections.pipeline.AirflowConnection;
@@ -91,6 +92,7 @@ public final class ClassConverterFactory {
             Map.entry(GCPCredentials.class, new GcpCredentialsClassConverter()),
             Map.entry(GCSConnection.class, new GcpConnectionClassConverter()),
             Map.entry(GoogleDriveConnection.class, new GoogleDriveConnectionClassConverter()),
+            Map.entry(PubSubConnection.class, new PubSubConnectionClassConverter()),
             Map.entry(HiveConnection.class, new HiveConnectionClassConverter()),
             Map.entry(LookerConnection.class, new LookerConnectionClassConverter()),
             Map.entry(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/PubSubConnectionClassConverter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/PubSubConnectionClassConverter.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.secrets.converter;
+
+import java.util.List;
+import org.openmetadata.schema.security.credentials.GCPCredentials;
+import org.openmetadata.schema.services.connections.messaging.PubSubConnection;
+import org.openmetadata.schema.utils.JsonUtils;
+
+/** Converter class to get a {@code PubSubConnection} object. */
+public class PubSubConnectionClassConverter extends ClassConverter {
+
+  public PubSubConnectionClassConverter() {
+    super(PubSubConnection.class);
+  }
+
+  @Override
+  public Object convert(Object object) {
+    PubSubConnection pubSubConnection =
+        (PubSubConnection) JsonUtils.convertValue(object, this.clazz);
+
+    tryToConvertOrFail(pubSubConnection.getGcpConfig(), List.of(GCPCredentials.class))
+        .ifPresent(obj -> pubSubConnection.setGcpConfig((GCPCredentials) obj));
+
+    return pubSubConnection;
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/secrets/converter/ClassConverterFactoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/secrets/converter/ClassConverterFactoryTest.java
@@ -22,6 +22,7 @@ import org.openmetadata.schema.services.connections.database.PostgresConnection;
 import org.openmetadata.schema.services.connections.database.SalesforceConnection;
 import org.openmetadata.schema.services.connections.database.TrinoConnection;
 import org.openmetadata.schema.services.connections.database.datalake.GCSConfig;
+import org.openmetadata.schema.services.connections.messaging.PubSubConnection;
 import org.openmetadata.schema.services.connections.pipeline.AirflowConnection;
 import org.openmetadata.schema.services.connections.pipeline.MatillionConnection;
 import org.openmetadata.schema.services.connections.pipeline.OpenLineageConnection;
@@ -54,6 +55,7 @@ public class ClassConverterFactoryTest {
         SalesforceConnection.class,
         MatillionConnection.class,
         OpenLineageConnection.class,
+        PubSubConnection.class,
       })
   void testClassConverterIsSet(Class<?> clazz) {
     assertFalse(

--- a/openmetadata-service/src/test/java/org/openmetadata/service/secrets/masker/TestEntityMasker.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/secrets/masker/TestEntityMasker.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.Map;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.api.services.DatabaseConnection;
@@ -28,6 +29,7 @@ import org.openmetadata.schema.services.connections.database.DatalakeConnection;
 import org.openmetadata.schema.services.connections.database.MysqlConnection;
 import org.openmetadata.schema.services.connections.database.common.basicAuth;
 import org.openmetadata.schema.services.connections.database.datalake.GCSConfig;
+import org.openmetadata.schema.services.connections.messaging.PubSubConnection;
 import org.openmetadata.schema.services.connections.messaging.SaslMechanismType;
 import org.openmetadata.schema.services.connections.metadata.OpenMetadataConnection;
 import org.openmetadata.schema.services.connections.pipeline.AirflowConnection;
@@ -90,6 +92,24 @@ abstract class TestEntityMasker {
                 .unmaskServiceConnectionConfig(
                     masked, bigQueryConnection, "BigQuery", ServiceType.DATABASE);
     assertEquals(PASSWORD, getPrivateKeyFromGcsConfig(unmasked.getCredentials()));
+  }
+
+  @Test
+  void testPubSubConnectionMasker() {
+    Map<String, Object> connectionConfig =
+        JsonUtils.getMap(new PubSubConnection().withGcpConfig(buildGcpCredentials()));
+    PubSubConnection masked =
+        (PubSubConnection)
+            EntityMaskerFactory.createEntityMasker()
+                .maskServiceConnectionConfig(connectionConfig, "PubSub", ServiceType.MESSAGING);
+    assertNotNull(masked);
+    assertEquals(getPrivateKeyFromGcsConfig(masked.getGcpConfig()), getMaskedPassword());
+    PubSubConnection unmasked =
+        (PubSubConnection)
+            EntityMaskerFactory.createEntityMasker()
+                .unmaskServiceConnectionConfig(
+                    masked, connectionConfig, "PubSub", ServiceType.MESSAGING);
+    assertEquals(PASSWORD, getPrivateKeyFromGcsConfig(unmasked.getGcpConfig()));
   }
 
   @Test


### PR DESCRIPTION
Backports #32135 to the `2.0` release branch.

Fixes #32102

Converts persisted Pub/Sub GCP credentials to generated schema classes before secret masking and unmasking, matching the main-branch fix.