### PR TITLE
fix(security): move Reactor to the 2026.0 train (reactor-core/netty CVE-2026-47857/47874) [2.0]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,10 +233,28 @@
         <artifactId>logging-interceptor</artifactId>
         <version>4.12.0</version>
       </dependency>
+      <!-- CVE-2026-47857: reactor-core < 3.8.7 (reached transitively via reactor-netty and the
+           azure/spring stacks). Pin the whole Reactor 2026.0 train together: reactor-core 3.8.7
+           and reactor-netty 1.3.7 are the aligned release, so mixing lines is avoided. -->
+      <dependency>
+        <groupId>io.projectreactor</groupId>
+        <artifactId>reactor-core</artifactId>
+        <version>3.8.7</version>
+      </dependency>
+      <!-- CVE-2026-47874: reactor-netty-http < 1.3.7. The fix ships only on the 1.3.x line (1.2.18
+           is the last 1.2.x GA, no backport), and reactor-netty 1.3.x requires Netty 4.2.x — see
+           the netty-bom pin below, raised to 4.2.x in lockstep so 1.3.x's Netty 4.2 APIs resolve.
+           Pin -core alongside -http so a path that reaches -core directly cannot drag the 1.2 line
+           back in. This mirrors ai-platform's ADR-0018, which moves the same three together. -->
+      <dependency>
+        <groupId>io.projectreactor.netty</groupId>
+        <artifactId>reactor-netty-core</artifactId>
+        <version>1.3.7</version>
+      </dependency>
       <dependency>
         <groupId>io.projectreactor.netty</groupId>
         <artifactId>reactor-netty-http</artifactId>
-        <version>1.2.18</version>
+        <version>1.3.7</version>
       </dependency>
       <!-- CVE-2026-45292: opentelemetry-api 1.37.0 (transitive of
            co.elastic.clients:elasticsearch-java, shaded into elasticsearch-deps)
@@ -742,12 +760,14 @@
         <version>1.15.2</version>
       </dependency>
       <!-- Pin all transitive io.netty:* to one patched line via the BOM (netty-codec-http et al.
-           arrive transitively through reactor-netty-http and others). 4.1.137.Final clears the
-           CorsHandler Vary-header cache-poisoning / info-disclosure issue, CVE-2026-59903. -->
+           arrive transitively through reactor-netty-http and others). Held on the 4.2.x line
+           because reactor-netty 1.3.x (pinned above) is built against Netty 4.2; 4.2.17.Final is
+           newer than the 4.1.137.Final we previously held, so it still clears the CorsHandler
+           Vary-header cache-poisoning / info-disclosure issue, CVE-2026-59903. -->
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.1.137.Final</version>
+        <version>4.2.17.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Backport of #32170 to the **2.0** release branch.

Moves the Reactor stack to the aligned 2026.0 train to clear two CVEs that reach OpenMetadata transitively (Azure / Spring / reactor-netty):

- **CVE-2026-47857** — `reactor-core < 3.8.7` (unbounded allocation). Pins `reactor-core` to `3.8.7`.
- **CVE-2026-47874** — `reactor-netty-http < 1.3.7`. The fix ships only on the 1.3.x line, which requires Netty 4.2.x, so `netty-bom` moves `4.1.137.Final → 4.2.17.Final` in lockstep. `reactor-netty-core` is pinned to `1.3.7` alongside `-http` so a path reaching `-core` directly can't drag the 1.2 line back in.

Collate equivalent already backported: open-metadata/openmetadata-collate#6280.

### Cherry-pick
Clean cherry-pick of `21b6de2` (squash of #32170) — `pom.xml` auto-merged with no conflicts.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
