### PR TITLE
Backport #31654 and #32214 to 1.13: Databricks DLT SQL lineage and self-referencing lineage

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py
@@ -124,6 +124,12 @@ class UnitycatalogLineageSource(Source):
                     )
                 )
                 for row in rows:
+                    # A table never derives from itself. The system tables record
+                    # access rather than derivation, so a streaming or CDC write
+                    # legitimately names its target as its own source. Kept as
+                    # lineage it renders as a loop on the node and says nothing.
+                    if row.source_table_full_name == row.target_table_full_name:
+                        continue
                     self.table_lineage_map[row.target_table_full_name].add(
                         row.source_table_full_name
                     )
@@ -145,6 +151,10 @@ class UnitycatalogLineageSource(Source):
                     )
                 )
                 for row in rows:
+                    # The table pair this belongs to is dropped above, so caching the
+                    # columns only grows the map with entries nothing can read.
+                    if row.source_table_full_name == row.target_table_full_name:
+                        continue
                     table_key = (
                         row.source_table_full_name,
                         row.target_table_full_name,

--- a/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/dlt_parsers.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/dlt_parsers.py
@@ -1,0 +1,552 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Dataset dependency extraction for Delta Live Tables pipelines.
+
+A DLT pipeline is authored in exactly one language. Each language is a parser that
+says whether it recognises a piece of source (`handles`) and turns it into
+`DLTTableDependency` records (`extract`).
+
+Adding a language means writing one parser and listing it in `DLT_PARSERS`.
+"""
+
+import re
+from typing import Any, List, Optional, Protocol, Type  # noqa: UP035
+
+from metadata.ingestion.source.pipeline.databrickspipeline.kafka_parser import (
+    KAFKA_STREAM_PATTERN,
+    extract_variables,
+)
+from metadata.ingestion.source.pipeline.databrickspipeline.models import (
+    DLTTableDependency,
+)
+from metadata.utils.logger import ingestion_logger
+
+logger = ingestion_logger()
+
+
+def _unique(names) -> List[str]:  # noqa: UP006
+    """De-duplicate while preserving the order the parser reported."""
+    return list(dict.fromkeys(names))
+
+
+class DltSourceParser(Protocol):
+    """Contract every DLT language parser implements."""
+
+    @staticmethod
+    def handles(source_code: str) -> bool:
+        """True when this parser recognises the authoring language of the source."""
+        ...
+
+    @staticmethod
+    def extract(source_code: str) -> List[DLTTableDependency]:  # noqa: UP006
+        """Datasets declared by the source, with the tables each one reads."""
+        ...
+
+
+def extract_dlt_table_dependencies(source_code: str) -> List[DLTTableDependency]:  # noqa: UP006
+    """
+    Extract the datasets a DLT source file declares.
+
+    Dispatches to the first registered parser that recognises the source, most
+    specific first. Returns an empty list when nothing recognises it, which the
+    caller reports as a skip.
+    """
+    if not source_code:
+        return []
+
+    for parser in DLT_PARSERS:
+        try:
+            if parser.handles(source_code):
+                logger.debug(f"Parsing DLT source with {parser.__name__}")
+                return parser.extract(source_code)
+        except Exception as exc:
+            logger.warning(f"{parser.__name__} failed, trying the next parser: {exc}")
+            continue
+
+    logger.debug("No DLT parser recognised this source")
+    return []
+
+
+# ---------------------------------------------------------------------------
+# SQL
+# ---------------------------------------------------------------------------
+
+# Statements that declare or populate a DLT dataset. CREATE covers materialized
+# views and streaming tables (plus the legacy LIVE TABLE spelling), and
+# APPLY CHANGES INTO is the CDC form, which writes into an already declared table.
+SQL_DLT_CREATE_PATTERN = re.compile(
+    r"\bCREATE\s+(?:OR\s+REFRESH\s+)?(?:TEMPORARY\s+|PRIVATE\s+)?"
+    r"(?:MATERIALIZED\s+VIEW|STREAMING\s+(?:LIVE\s+)?TABLE|LIVE\s+TABLE)\b",
+    re.IGNORECASE,
+)
+SQL_DLT_APPLY_CHANGES_PATTERN = re.compile(r"\bAPPLY\s+CHANGES\s+INTO\b", re.IGNORECASE)
+
+# `STREAM(table)` marks a streaming read. It is a DLT marker rather than a real
+# function, and query parsers otherwise report "stream" itself as the source table.
+# Only unwrapped when it holds a plain identifier, so `STREAM read_files(...)` and
+# other table-valued forms are left untouched.
+SQL_STREAM_WRAPPER_PATTERN = re.compile(r"\bSTREAM\s*\(\s*([A-Za-z0-9_.`\"]+)\s*\)", re.IGNORECASE)
+
+# `LIVE.name` addresses a dataset inside the same pipeline. The prefix is a DLT
+# namespace, not a schema, so it must be dropped rather than resolved as one.
+SQL_LIVE_PREFIX_PATTERN = re.compile(r"^live\.", re.IGNORECASE)
+
+# Spellings DLT accepts that the query parser does not. `PRIVATE` is a modifier on the
+# modern names, and `LIVE TABLE` / `STREAMING LIVE TABLE` are the original names that
+# Databricks still honours. The parser falls back to a bare command for each and then
+# reports no tables at all, so the dataset would be dropped with neither an error nor a
+# warning. Rewriting to the modern equivalent is what lets the statement parse. Each is
+# anchored to the CREATE clause, so a dataset whose own name contains "live" is never
+# rewritten.
+SQL_PRIVATE_MODIFIER_PATTERN = re.compile(
+    r"(\bCREATE\s+(?:OR\s+REFRESH\s+)?(?:TEMPORARY\s+)?)PRIVATE\s+", re.IGNORECASE
+)
+SQL_LEGACY_STREAMING_TABLE_PATTERN = re.compile(
+    r"(\bCREATE\s+(?:OR\s+REFRESH\s+)?(?:TEMPORARY\s+)?)STREAMING\s+LIVE\s+TABLE\b", re.IGNORECASE
+)
+SQL_LEGACY_LIVE_TABLE_PATTERN = re.compile(
+    r"(\bCREATE\s+(?:OR\s+REFRESH\s+)?(?:TEMPORARY\s+)?)LIVE\s+TABLE\b", re.IGNORECASE
+)
+
+# Table-valued functions a query parser surfaces as if they were tables. These are
+# only dropped when the statement actually invokes them, so a dataset legitimately
+# named `range` or `stream` still resolves.
+SQL_TABLE_VALUED_FUNCTIONS = frozenset({"stream", "read_files", "cloud_files", "read_kafka", "read_kinesis", "range"})
+
+# An identifier immediately followed by "(" is a call, not a table reference
+SQL_FUNCTION_CALL_PATTERN = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+
+
+class SqlDltParser:
+    """
+    Parser for DLT pipelines whose transformations are `.sql` files.
+
+    Each statement declares one dataset and the tables feeding it. Parsing is
+    delegated to the shared `LineageParser` so dialect handling, query masking and
+    timeouts behave the same as everywhere else in the ingestion framework.
+    """
+
+    @staticmethod
+    def handles(source_code: str) -> bool:
+        return bool(SQL_DLT_CREATE_PATTERN.search(source_code) or SQL_DLT_APPLY_CHANGES_PATTERN.search(source_code))
+
+    @staticmethod
+    def _normalise(table: Any, called_functions: frozenset = frozenset()) -> Optional[str]:  # noqa: UP045
+        """Turn a parser table reference into a name, or None when it is not a table."""
+        from metadata.utils.helpers import (
+            get_formatted_entity_name,
+            has_table_name,
+        )
+
+        name = get_formatted_entity_name(str(table))
+        if not name or not has_table_name(name):
+            return None
+        name = SQL_LIVE_PREFIX_PATTERN.sub("", name)
+        if not name:
+            return None
+        lowered = name.lower()
+        if lowered in SQL_TABLE_VALUED_FUNCTIONS and lowered in called_functions:
+            return None
+        return name
+
+    @staticmethod
+    def _modernise(statement: str) -> str:
+        """Rewrite the spellings the query parser cannot read into ones it can.
+
+        `PRIVATE` is stripped first so it does not block the legacy rewrites behind it,
+        and `STREAMING LIVE TABLE` is matched before `LIVE TABLE` so the streaming form
+        is not mistaken for the batch one.
+        """
+        statement = SQL_PRIVATE_MODIFIER_PATTERN.sub(r"\1", statement)
+        statement = SQL_LEGACY_STREAMING_TABLE_PATTERN.sub(r"\1STREAMING TABLE", statement)
+        return SQL_LEGACY_LIVE_TABLE_PATTERN.sub(r"\1MATERIALIZED VIEW", statement)
+
+    @staticmethod
+    def extract(source_code: str) -> List[DLTTableDependency]:  # noqa: UP006
+        # Imported here so pipelines that never use SQL do not pay the import cost
+        # of the lineage stack.
+        import sqlparse
+
+        from metadata.ingestion.lineage.models import Dialect
+        from metadata.ingestion.lineage.parser import LineageParser
+
+        dependencies: List[DLTTableDependency] = []  # noqa: UP006
+        for raw_statement in sqlparse.split(source_code):
+            statement = raw_statement.strip()
+            if not statement or not SqlDltParser.handles(statement):
+                continue
+            try:
+                statement = SqlDltParser._modernise(statement)
+                statement = SQL_STREAM_WRAPPER_PATTERN.sub(r"\1", statement)
+                parser = LineageParser(statement, Dialect.DATABRICKS)
+                # LineageParser exposes these through the third-party cached_property,
+                # which type checkers cannot resolve to the underlying list
+                parsed_targets: Any = parser.target_tables or []
+                parsed_sources: Any = parser.source_tables or []
+
+                called = frozenset(match.group(1).lower() for match in SQL_FUNCTION_CALL_PATTERN.finditer(statement))
+                targets = _unique(name for name in (SqlDltParser._normalise(t, called) for t in parsed_targets) if name)
+                if not targets:
+                    logger.debug(f"No dataset parsed from SQL DLT statement: {statement[:120]}")
+                    continue
+
+                sources = _unique(name for name in (SqlDltParser._normalise(s, called) for s in parsed_sources) if name)
+                # A dataset never depends on itself. APPLY CHANGES INTO in particular
+                # names the same table it writes to. Stripping the LIVE. prefix can also
+                # collapse two references onto one dataset, hence the de-duplication.
+                depends_on = [name for name in sources if name not in targets]
+
+                for target in targets:
+                    existing = next((d for d in dependencies if d.table_name == target), None)
+                    if existing:
+                        # CDC pipelines declare the table, then populate it in a
+                        # separate APPLY CHANGES statement. Merge rather than duplicate.
+                        existing.depends_on.extend(name for name in depends_on if name not in existing.depends_on)
+                        continue
+                    dependencies.append(DLTTableDependency(table_name=target, depends_on=list(depends_on)))
+                    logger.debug(f"Extracted SQL DLT dataset {target} depends_on={depends_on}")
+            except Exception as exc:
+                logger.debug(f"Error parsing SQL DLT statement: {exc}")
+                continue
+
+        return dependencies
+
+
+# ---------------------------------------------------------------------------
+# Python
+# ---------------------------------------------------------------------------
+
+# Any decorator that declares a dataset. This must stay in step with the function
+# pattern used during extraction, otherwise a source gets recognised but yields
+# nothing (or, worse, is not recognised and falls through to another language).
+# `@dlt.view()` in particular takes no name argument.
+DLT_DATASET_DECORATOR_PATTERN = re.compile(
+    r"@dlt\.(?:table|view)\s*\(",
+    re.IGNORECASE,
+)
+
+# Pattern to extract table name from decorator - supports both literals and function calls
+DLT_TABLE_NAME_LITERAL = re.compile(
+    r'@dlt\.table\s*\(\s*(?:.*?name\s*=\s*["\']([^"\']+)["\'])?',
+    re.DOTALL | re.IGNORECASE,
+)
+
+DLT_TABLE_NAME_FUNCTION = re.compile(
+    r"@dlt\.table\s*\(\s*(?:.*?name\s*=\s*([a-zA-Z_][a-zA-Z0-9_\.]+)\s*\([^)]*\))?",
+    re.DOTALL | re.IGNORECASE,
+)
+
+# Pattern to extract dlt.read_stream("table_name") calls
+DLT_READ_STREAM_PATTERN = re.compile(
+    r'dlt\.read_stream\s*\(\s*["\']([^"\']+)["\']\s*\)',
+    re.IGNORECASE,
+)
+
+# Pattern to extract dlt.read("table_name") calls (batch reads)
+DLT_READ_PATTERN = re.compile(
+    r'dlt\.read\s*\(\s*["\']([^"\']+)["\']\s*\)',
+    re.IGNORECASE,
+)
+
+# Pattern to extract S3 paths from spark.read operations
+# Matches: spark.read.json("s3://..."), spark.read.format("parquet").load("s3a://...")
+# Uses a simpler pattern that captures any spark.read followed by method calls ending with a path
+S3_PATH_PATTERN = re.compile(
+    r'spark\.read.*?\.(?:load|json|parquet|csv|orc|avro)\s*\(\s*["\']([^"\']+)["\']\s*\)',
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+class PythonDltParser:
+    """
+    Parser for DLT pipelines written against the Python API.
+
+    Datasets are declared with `@dlt.table` / `@dlt.view` decorators and read each
+    other through `dlt.read` and `dlt.read_stream`. External reads are recognised
+    for Kafka and S3 so the caller can attach topic and storage lineage.
+    """
+
+    @staticmethod
+    def handles(source_code: str) -> bool:
+        return bool(DLT_DATASET_DECORATOR_PATTERN.search(source_code))
+
+    @staticmethod
+    def extract_dlt_table_names(source_code: str) -> List[str]:  # noqa: UP006
+        """
+        Extract DLT table names from @dlt.table decorators
+
+        Parses patterns like:
+        - @dlt.table(name="user_events_bronze_pl", ...)
+        - @dlt.table(comment="...", name="my_table")
+        - @dlt.table(name=generate_table_name())  (function call - infer from pattern)
+
+        Returns list of table names found in decorators
+        """
+        table_names = []
+
+        try:
+            if not source_code:
+                logger.debug("Empty or None source code provided")
+                return table_names
+
+            # First try to extract literal string table names
+            for match in DLT_TABLE_NAME_LITERAL.finditer(source_code):
+                table_name = match.group(1)
+                if table_name:
+                    table_names.append(table_name)
+                    logger.debug(f"Found DLT table (literal): {table_name}")
+
+            # If no literal names found, try function call pattern
+            if not table_names:
+                for match in DLT_TABLE_NAME_FUNCTION.finditer(source_code):
+                    function_call = match.group(1)
+                    if function_call:
+                        # Extract table name hint from function name
+                        # e.g., generate_event_log_table_name() -> event_log
+                        inferred_name = PythonDltParser._infer_table_name_from_function(function_call, source_code)
+                        if inferred_name:
+                            table_names.append(inferred_name)
+                            logger.debug(f"Found DLT table (inferred from {function_call}): {inferred_name}")
+
+        except Exception as exc:
+            logger.warning(f"Error parsing DLT table names from code: {exc}")
+
+        return table_names
+
+    @staticmethod
+    def _infer_table_name_from_function(function_call: str, source_code: str) -> Optional[str]:  # noqa: UP045
+        """
+        Infer table name from function call pattern
+
+        Strategies:
+        1. Look for entity_name variable and use it to build table name
+        2. Extract keywords from function name (e.g., "event_log" from "generate_event_log_table_name")
+        3. Handle Materializer pattern: entity_name + suffix from function name
+        """
+        try:
+            # Extract variables to find entity_name or similar
+            variables = extract_variables(source_code)
+
+            # Strategy 1: Materializer pattern - entity_name + suffix from function
+            # Handles: @dlt.table(name=materializer.generate_event_log_table_name())
+            # where entity_name = "customerEvent" should produce "customerevent_event_log"
+            entity_name = variables.get("entity_name") or variables.get("entity") or variables.get("table_name")
+
+            if entity_name and "generate_event_log_table_name" in function_call.lower():
+                table_name = f"{entity_name.lower()}_event_log"
+                logger.debug(f"Inferred event_log table from Materializer pattern: {table_name}")
+                return table_name
+
+            if entity_name and "generate_snapshot_table_name" in function_call.lower():
+                table_name = f"{entity_name.lower()}_snapshot"
+                logger.debug(f"Inferred snapshot table from Materializer pattern: {table_name}")
+                return table_name
+
+            # Strategy 2: Use entity_name variable if present (fallback)
+            if entity_name:
+                logger.debug(f"Inferred table name from entity_name variable: {entity_name}")
+                return entity_name
+
+            # Strategy 3: Extract from function name (e.g., "event_log" from "generate_event_log_table_name")
+            # Common patterns: generate_X_table_name, create_X_table, build_X_dataframe
+            match = re.search(
+                r"(?:generate|create|build)_([a-z_]+?)(?:_table|_dataframe)",
+                function_call.lower(),
+            )
+            if match:
+                inferred = match.group(1)
+                logger.debug(f"Inferred table name from function pattern: {inferred}")
+                return inferred
+
+        except Exception as exc:
+            logger.debug(f"Could not infer table name from function {function_call}: {exc}")
+
+        return None
+
+    @staticmethod
+    def extract(source_code: str) -> List[DLTTableDependency]:  # noqa: C901, UP006
+        """
+        Extract DLT table dependencies by analyzing @dlt.table decorators and dlt.read_stream calls
+
+        For each DLT table, identifies:
+        - Table name from @dlt.table(name="...")
+        - Dependencies from dlt.read_stream("other_table") or dlt.read("other_table") calls
+        - Whether it reads from Kafka (spark.readStream.format("kafka"))
+        - Whether it reads from S3 (spark.read.json("s3://..."))
+        - S3 locations if applicable
+
+        Example:
+            @dlt.table(name="source_table")
+            def my_source():
+                return spark.read.json("s3://bucket/path/")...
+
+            @dlt.table(name="target_table")
+            def my_target():
+                return dlt.read("source_table")
+
+        Returns:
+            [
+                DLTTableDependency(table_name="source_table", depends_on=[], reads_from_s3=True,
+                                 s3_locations=["s3://bucket/path/"]),
+                DLTTableDependency(table_name="target_table", depends_on=["source_table"],
+                                 reads_from_s3=False)
+            ]
+        """
+        dependencies = []
+
+        try:
+            if not source_code:
+                return dependencies
+
+            # Split source code into function definitions
+            # Pattern: @dlt.table(...) or @dlt.view(...) followed by def function_name():
+            # Handle multiline decorators with potentially nested parentheses
+            function_pattern = re.compile(
+                r"(@dlt\.(?:table|view)\s*\(.*?\)\s*def\s+[a-zA-Z_][a-zA-Z0-9_]*\s*\([^)]*\)\s*:.*?)(?=@dlt\.|$)",
+                re.DOTALL | re.IGNORECASE,
+            )
+
+            for match in function_pattern.finditer(source_code):
+                try:
+                    function_block = match.group(1)
+
+                    # Extract table name from @dlt.table decorator
+                    table_name = None
+                    name_match = DLT_TABLE_NAME_LITERAL.search(function_block)
+                    if name_match and name_match.group(1):
+                        table_name = name_match.group(1)
+                    else:
+                        # Try function name pattern
+                        func_name_match = DLT_TABLE_NAME_FUNCTION.search(function_block)
+                        if func_name_match and func_name_match.group(1):
+                            table_name = PythonDltParser._infer_table_name_from_function(
+                                func_name_match.group(1), source_code
+                            )
+
+                    if not table_name:
+                        # Try to extract from function definition itself
+                        def_match = re.search(r"def\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(", function_block)
+                        if def_match:
+                            table_name = def_match.group(1)
+
+                    if not table_name:
+                        logger.debug(f"Could not extract table name from block: {function_block[:100]}...")
+                        continue
+
+                    # Check if it reads from Kafka
+                    # Direct pattern: spark.readStream.format("kafka")
+                    reads_from_kafka = bool(KAFKA_STREAM_PATTERN.search(function_block))
+
+                    # Materializer pattern: materializer.build_event_log_dataframe()
+                    # This method internally reads from Kafka, so if we find this pattern
+                    # and the table name matches event_log pattern, mark as Kafka reader
+                    if not reads_from_kafka and "materializer.build_event_log_dataframe" in function_block:  # noqa: SIM102
+                        if "event_log" in table_name:
+                            reads_from_kafka = True
+                            logger.debug(f"Table {table_name} reads from Kafka via Materializer")
+
+                    # Check if it reads from S3
+                    s3_locations = []
+                    for s3_match in S3_PATH_PATTERN.finditer(function_block):
+                        s3_path = s3_match.group(1)
+                        if s3_path.startswith(("s3://", "s3a://", "s3n://")):
+                            s3_locations.append(s3_path)
+                            logger.debug(f"Table {table_name} reads from S3: {s3_path}")
+
+                    reads_from_s3 = len(s3_locations) > 0
+
+                    # Extract dlt.read_stream dependencies (streaming)
+                    depends_on = []
+                    for stream_match in DLT_READ_STREAM_PATTERN.finditer(function_block):
+                        source_table = stream_match.group(1)
+                        depends_on.append(source_table)
+                        logger.debug(f"Table {table_name} streams from {source_table}")
+
+                    # Extract dlt.read dependencies (batch)
+                    for read_match in DLT_READ_PATTERN.finditer(function_block):
+                        source_table = read_match.group(1)
+                        depends_on.append(source_table)
+                        logger.debug(f"Table {table_name} reads from {source_table}")
+
+                    dependency = DLTTableDependency(
+                        table_name=table_name,
+                        depends_on=depends_on,
+                        reads_from_kafka=reads_from_kafka,
+                        reads_from_s3=reads_from_s3,
+                        s3_locations=s3_locations,
+                    )
+                    dependencies.append(dependency)
+                    logger.debug(
+                        f"Extracted dependency: {table_name} - depends_on={depends_on}, "
+                        f"reads_from_kafka={reads_from_kafka}, reads_from_s3={reads_from_s3}, "
+                        f"s3_locations={s3_locations}"
+                    )
+
+                except Exception as exc:
+                    logger.debug(f"Error parsing function block: {exc}")
+                    continue
+
+            # Handle Materializer snapshot pattern:
+            # if snapshot_required:
+            #     materializer.build_snapshot_dataframe()
+            # This creates a snapshot table without @dlt.table decorator
+            try:
+                variables = extract_variables(source_code)
+                snapshot_required = variables.get("snapshot_required")
+                entity_name = variables.get("entity_name") or variables.get("entity") or variables.get("table_name")
+
+                # Check if snapshot table is built
+                # snapshot_required can be "True" (string) or True (boolean)
+                is_snapshot_enabled = snapshot_required and str(snapshot_required).lower() == "true"
+
+                if is_snapshot_enabled and entity_name and "build_snapshot_dataframe" in source_code:
+                    snapshot_table_name = f"{entity_name.lower()}_snapshot"
+                    event_log_table_name = f"{entity_name.lower()}_event_log"
+
+                    # Find the event_log table in existing dependencies
+                    event_log_dep = next(
+                        (d for d in dependencies if d.table_name == event_log_table_name),
+                        None,
+                    )
+
+                    if event_log_dep:
+                        # Create snapshot table that depends on event_log
+                        snapshot_dependency = DLTTableDependency(
+                            table_name=snapshot_table_name,
+                            depends_on=[event_log_table_name],
+                            reads_from_kafka=False,
+                            reads_from_s3=False,
+                            s3_locations=[],
+                        )
+                        dependencies.append(snapshot_dependency)
+                        logger.debug(
+                            f"Extracted Materializer snapshot table: {snapshot_table_name} depends on {event_log_table_name}"
+                        )
+                    else:
+                        logger.debug(
+                            f"Found snapshot pattern but event_log table {event_log_table_name} not found in dependencies"
+                        )
+
+            except Exception as exc:
+                logger.debug(f"Error extracting Materializer snapshot pattern: {exc}")
+
+        except Exception as exc:
+            logger.warning(f"Error extracting DLT table dependencies: {exc}")
+
+        return dependencies
+
+
+# Checked in order. Python comes first because a `@dlt.` decorator is unambiguous,
+# while the SQL keywords can also appear inside a string literal in a Python
+# notebook that calls spark.sql(...).
+DLT_PARSERS: List[Type[DltSourceParser]] = [PythonDltParser, SqlDltParser]  # noqa: UP006

--- a/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/dlt_parsers.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/dlt_parsers.py
@@ -143,10 +143,7 @@ class SqlDltParser:
     @staticmethod
     def _normalise(table: Any, called_functions: frozenset = frozenset()) -> Optional[str]:  # noqa: UP045
         """Turn a parser table reference into a name, or None when it is not a table."""
-        from metadata.utils.helpers import (
-            get_formatted_entity_name,
-            has_table_name,
-        )
+        from metadata.utils.helpers import get_formatted_entity_name, has_table_name
 
         name = get_formatted_entity_name(str(table))
         if not name or not has_table_name(name):

--- a/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/kafka_parser.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/kafka_parser.py
@@ -202,14 +202,23 @@ def glob_base_directory(include: str) -> str:
     The pipelines API only accepts an exact file, a directory, or a directory
     with a trailing `**`, and rejects every other wildcard form outright, so the
     reduction is just dropping the `**`. Truncating at any other stray wildcard
-    keeps an unexpected include pointed at a real directory rather than at a path
-    that cannot be read at all.
+    keeps an unexpected include pointed at a nested directory rather than at a
+    path that cannot be read at all.
+
+    An include whose wildcard sits in the first path segment is the exception and
+    is returned as it came, because the only directory above it is the workspace
+    root. Reducing `**` or `/tx*` to `/` would list every notebook in the
+    workspace, and since the listing is no longer filtered they would all be
+    collected. Resolving nothing is the cheaper wrong answer.
     """
     wildcard = include.find("*")
     if wildcard == -1:
         return include
     base = include[:wildcard]
-    return base if base.endswith("/") else base.rsplit("/", 1)[0] + "/"
+    if base.endswith("/"):
+        return include if base == "/" else base
+    parent = base.rsplit("/", 1)[0]
+    return f"{parent}/" if parent else include
 
 
 def get_pipeline_libraries(pipeline_config: dict) -> List[DLTLibrarySource]:  # noqa: UP006

--- a/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/kafka_parser.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/kafka_parser.py
@@ -10,13 +10,18 @@
 #  limitations under the License.
 
 """
-Kafka configuration parser for Databricks DLT pipelines
+Kafka source configuration parsing for Databricks DLT pipelines.
+
+Dataset dependency extraction lives in `dlt_parsers.py`.
 """
 
 import re
-from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import List, Optional  # noqa: UP035
 
+from metadata.ingestion.source.pipeline.databrickspipeline.models import (
+    DLTLibrarySource,
+    KafkaSourceConfig,
+)
 from metadata.utils.logger import ingestion_logger
 
 logger = ingestion_logger()
@@ -39,65 +44,8 @@ BOOL_ASSIGNMENT_PATTERN = re.compile(
     re.MULTILINE,
 )
 
-# Pattern to extract DLT table decorators: @dlt.table(name="table_name", ...) or @dlt.table(name=func())
-DLT_TABLE_PATTERN = re.compile(
-    r"@dlt\.table\s*\(",
-    re.IGNORECASE,
-)
 
-# Pattern to extract table name from decorator - supports both literals and function calls
-DLT_TABLE_NAME_LITERAL = re.compile(
-    r'@dlt\.table\s*\(\s*(?:.*?name\s*=\s*["\']([^"\']+)["\'])?',
-    re.DOTALL | re.IGNORECASE,
-)
-
-DLT_TABLE_NAME_FUNCTION = re.compile(
-    r"@dlt\.table\s*\(\s*(?:.*?name\s*=\s*([a-zA-Z_][a-zA-Z0-9_\.]+)\s*\([^)]*\))?",
-    re.DOTALL | re.IGNORECASE,
-)
-
-# Pattern to extract dlt.read_stream("table_name") calls
-DLT_READ_STREAM_PATTERN = re.compile(
-    r'dlt\.read_stream\s*\(\s*["\']([^"\']+)["\']\s*\)',
-    re.IGNORECASE,
-)
-
-# Pattern to extract dlt.read("table_name") calls (batch reads)
-DLT_READ_PATTERN = re.compile(
-    r'dlt\.read\s*\(\s*["\']([^"\']+)["\']\s*\)',
-    re.IGNORECASE,
-)
-
-# Pattern to extract S3 paths from spark.read operations
-# Matches: spark.read.json("s3://..."), spark.read.format("parquet").load("s3a://...")
-# Uses a simpler pattern that captures any spark.read followed by method calls ending with a path
-S3_PATH_PATTERN = re.compile(
-    r'spark\.read.*?\.(?:load|json|parquet|csv|orc|avro)\s*\(\s*["\']([^"\']+)["\']\s*\)',
-    re.DOTALL | re.IGNORECASE,
-)
-
-
-@dataclass
-class KafkaSourceConfig:
-    """Model for Kafka source configuration extracted from DLT code"""
-
-    bootstrap_servers: Optional[str] = None
-    topics: List[str] = field(default_factory=list)
-    group_id_prefix: Optional[str] = None
-
-
-@dataclass
-class DLTTableDependency:
-    """Model for DLT table dependencies"""
-
-    table_name: str
-    depends_on: List[str] = field(default_factory=list)
-    reads_from_kafka: bool = False
-    reads_from_s3: bool = False
-    s3_locations: List[str] = field(default_factory=list)
-
-
-def _extract_variables(source_code: str) -> dict:
+def extract_variables(source_code: str) -> dict:
     """
     Extract variable assignments from source code
 
@@ -128,7 +76,7 @@ def _extract_variables(source_code: str) -> dict:
     return variables
 
 
-def extract_kafka_sources(source_code: str) -> List[KafkaSourceConfig]:
+def extract_kafka_sources(source_code: str) -> List[KafkaSourceConfig]:  # noqa: UP006
     """
     Extract Kafka topic configurations from DLT source code
 
@@ -154,7 +102,7 @@ def extract_kafka_sources(source_code: str) -> List[KafkaSourceConfig]:
             return kafka_configs
 
         # Extract variable assignments for resolution
-        variables = _extract_variables(source_code)
+        variables = extract_variables(source_code)
 
         # Try to find explicit Kafka streaming patterns
         found_explicit_kafka = False
@@ -163,22 +111,14 @@ def extract_kafka_sources(source_code: str) -> List[KafkaSourceConfig]:
                 found_explicit_kafka = True
                 config_block = match.group(1)
 
-                bootstrap_servers = _extract_option(
-                    config_block, r"kafka\.bootstrap\.servers", variables
-                )
-                subscribe_topics = _extract_option(
-                    config_block, r"subscribe", variables
-                )
+                bootstrap_servers = _extract_option(config_block, r"kafka\.bootstrap\.servers", variables)
+                subscribe_topics = _extract_option(config_block, r"subscribe", variables)
                 topics = _extract_option(config_block, r"topics", variables)
-                group_id_prefix = _extract_option(
-                    config_block, r"groupIdPrefix", variables
-                )
+                group_id_prefix = _extract_option(config_block, r"groupIdPrefix", variables)
 
                 topic_list = []
                 if subscribe_topics:
-                    topic_list = [
-                        t.strip() for t in subscribe_topics.split(",") if t.strip()
-                    ]
+                    topic_list = [t.strip() for t in subscribe_topics.split(",") if t.strip()]
                 elif topics:
                     topic_list = [t.strip() for t in topics.split(",") if t.strip()]
 
@@ -203,14 +143,9 @@ def extract_kafka_sources(source_code: str) -> List[KafkaSourceConfig]:
             topic_candidates = []
             for var_name, var_value in variables.items():
                 # Look for variables that likely contain topic names
-                if any(
-                    keyword in var_name.lower()
-                    for keyword in ["topic", "subject", "stream"]
-                ):
+                if any(keyword in var_name.lower() for keyword in ["topic", "subject", "stream"]):
                     topic_candidates.append(var_value)
-                    logger.debug(
-                        f"Found potential topic from variable {var_name}: {var_value}"
-                    )
+                    logger.debug(f"Found potential topic from variable {var_name}: {var_value}")
 
             if topic_candidates:
                 kafka_config = KafkaSourceConfig(
@@ -219,9 +154,7 @@ def extract_kafka_sources(source_code: str) -> List[KafkaSourceConfig]:
                     group_id_prefix=None,
                 )
                 kafka_configs.append(kafka_config)
-                logger.debug(
-                    f"Extracted Kafka config from variables: topics={topic_candidates}"
-                )
+                logger.debug(f"Extracted Kafka config from variables: topics={topic_candidates}")
 
     except Exception as exc:
         logger.warning(f"Error parsing Kafka sources from code: {exc}")
@@ -229,9 +162,7 @@ def extract_kafka_sources(source_code: str) -> List[KafkaSourceConfig]:
     return kafka_configs
 
 
-def _extract_option(
-    config_block: str, option_name: str, variables: dict = None
-) -> Optional[str]:
+def _extract_option(config_block: str, option_name: str, variables: dict = None) -> Optional[str]:  # noqa: RUF013, UP045
     """
     Extract a single option value from Kafka configuration block
     Supports both string literals and variable references
@@ -242,362 +173,93 @@ def _extract_option(
 
     try:
         # Try matching quoted string literal: .option("subscribe", "topic")
-        pattern_literal = (
-            rf'\.option\s*\(\s*["\']({option_name})["\']\s*,\s*["\']([^"\']+)["\']\s*\)'
-        )
+        pattern_literal = rf'\.option\s*\(\s*["\']({option_name})["\']\s*,\s*["\']([^"\']+)["\']\s*\)'
         match = re.search(pattern_literal, config_block, re.IGNORECASE)
         if match:
             return match.group(2)
 
         # Try matching variable reference: .option("subscribe", TOPIC)
-        pattern_variable = (
-            rf'\.option\s*\(\s*["\']({option_name})["\']\s*,\s*([A-Z_][A-Z0-9_]*)\s*\)'
-        )
+        pattern_variable = rf'\.option\s*\(\s*["\']({option_name})["\']\s*,\s*([A-Z_][A-Z0-9_]*)\s*\)'
         match = re.search(pattern_variable, config_block, re.IGNORECASE)
         if match:
             var_name = match.group(2)
             # Resolve variable
             if var_name in variables:
-                logger.debug(
-                    f"Resolved variable {var_name} = {variables[var_name]} for option {option_name}"
-                )
+                logger.debug(f"Resolved variable {var_name} = {variables[var_name]} for option {option_name}")
                 return variables[var_name]
-            else:
-                logger.debug(
-                    f"Variable {var_name} referenced but not found in source code"
-                )
+            else:  # noqa: RET505
+                logger.debug(f"Variable {var_name} referenced but not found in source code")
 
     except Exception as exc:
         logger.debug(f"Failed to extract option {option_name}: {exc}")
     return None
 
 
-def extract_dlt_table_names(source_code: str) -> List[str]:
+def glob_base_directory(include: str) -> str:
     """
-    Extract DLT table names from @dlt.table decorators
+    Reduce a glob include to the path the caller should read.
 
-    Parses patterns like:
-    - @dlt.table(name="user_events_bronze_pl", ...)
-    - @dlt.table(comment="...", name="my_table")
-    - @dlt.table(name=generate_table_name())  (function call - infer from pattern)
-
-    Returns list of table names found in decorators
+    The pipelines API only accepts an exact file, a directory, or a directory
+    with a trailing `**`, and rejects every other wildcard form outright, so the
+    reduction is just dropping the `**`. Truncating at any other stray wildcard
+    keeps an unexpected include pointed at a real directory rather than at a path
+    that cannot be read at all.
     """
-    table_names = []
-
-    try:
-        if not source_code:
-            logger.debug("Empty or None source code provided")
-            return table_names
-
-        # First try to extract literal string table names
-        for match in DLT_TABLE_NAME_LITERAL.finditer(source_code):
-            table_name = match.group(1)
-            if table_name:
-                table_names.append(table_name)
-                logger.debug(f"Found DLT table (literal): {table_name}")
-
-        # If no literal names found, try function call pattern
-        if not table_names:
-            for match in DLT_TABLE_NAME_FUNCTION.finditer(source_code):
-                function_call = match.group(1)
-                if function_call:
-                    # Extract table name hint from function name
-                    # e.g., generate_event_log_table_name() -> event_log
-                    inferred_name = _infer_table_name_from_function(
-                        function_call, source_code
-                    )
-                    if inferred_name:
-                        table_names.append(inferred_name)
-                        logger.debug(
-                            f"Found DLT table (inferred from {function_call}): {inferred_name}"
-                        )
-
-    except Exception as exc:
-        logger.warning(f"Error parsing DLT table names from code: {exc}")
-
-    return table_names
+    wildcard = include.find("*")
+    if wildcard == -1:
+        return include
+    base = include[:wildcard]
+    return base if base.endswith("/") else base.rsplit("/", 1)[0] + "/"
 
 
-def _infer_table_name_from_function(
-    function_call: str, source_code: str
-) -> Optional[str]:
+def get_pipeline_libraries(pipeline_config: dict) -> List[DLTLibrarySource]:  # noqa: UP006
     """
-    Infer table name from function call pattern
+    Collect the source paths a DLT pipeline declares in `spec.libraries`.
 
-    Strategies:
-    1. Look for entity_name variable and use it to build table name
-    2. Extract keywords from function name (e.g., "event_log" from "generate_event_log_table_name")
-    3. Handle Materializer pattern: entity_name + suffix from function name
-    """
-    try:
-        # Extract variables to find entity_name or similar
-        variables = _extract_variables(source_code)
+    A library entry is one of three shapes, and a pipeline may mix them:
+      - `{"notebook": {"path": ...}}`  a workspace notebook
+      - `{"file": {"path": ...}}`      a file, used by Git folders and Asset Bundles
+      - `{"glob": {"include": ...}}`   an exact file, or a directory to expand in
+        full. The pipelines API accepts nothing narrower, so there is no pattern
+        to filter the directory's contents against.
 
-        # Strategy 1: Materializer pattern - entity_name + suffix from function
-        # Handles: @dlt.table(name=materializer.generate_event_log_table_name())
-        # where entity_name = "customerEvent" should produce "customerevent_event_log"
-        entity_name = (
-            variables.get("entity_name")
-            or variables.get("entity")
-            or variables.get("table_name")
-        )
-
-        if entity_name and "generate_event_log_table_name" in function_call.lower():
-            table_name = f"{entity_name.lower()}_event_log"
-            logger.debug(
-                f"Inferred event_log table from Materializer pattern: {table_name}"
-            )
-            return table_name
-
-        if entity_name and "generate_snapshot_table_name" in function_call.lower():
-            table_name = f"{entity_name.lower()}_snapshot"
-            logger.debug(
-                f"Inferred snapshot table from Materializer pattern: {table_name}"
-            )
-            return table_name
-
-        # Strategy 2: Use entity_name variable if present (fallback)
-        if entity_name:
-            logger.debug(
-                f"Inferred table name from entity_name variable: {entity_name}"
-            )
-            return entity_name
-
-        # Strategy 3: Extract from function name (e.g., "event_log" from "generate_event_log_table_name")
-        # Common patterns: generate_X_table_name, create_X_table, build_X_dataframe
-        match = re.search(
-            r"(?:generate|create|build)_([a-z_]+?)(?:_table|_dataframe)",
-            function_call.lower(),
-        )
-        if match:
-            inferred = match.group(1)
-            logger.debug(f"Inferred table name from function pattern: {inferred}")
-            return inferred
-
-    except Exception as exc:
-        logger.debug(f"Could not infer table name from function {function_call}: {exc}")
-
-    return None
-
-
-def extract_dlt_table_dependencies(source_code: str) -> List[DLTTableDependency]:
-    """
-    Extract DLT table dependencies by analyzing @dlt.table decorators and dlt.read_stream calls
-
-    For each DLT table, identifies:
-    - Table name from @dlt.table(name="...")
-    - Dependencies from dlt.read_stream("other_table") or dlt.read("other_table") calls
-    - Whether it reads from Kafka (spark.readStream.format("kafka"))
-    - Whether it reads from S3 (spark.read.json("s3://..."))
-    - S3 locations if applicable
-
-    Example:
-        @dlt.table(name="source_table")
-        def my_source():
-            return spark.read.json("s3://bucket/path/")...
-
-        @dlt.table(name="target_table")
-        def my_target():
-            return dlt.read("source_table")
-
-    Returns:
-        [
-            DLTTableDependency(table_name="source_table", depends_on=[], reads_from_s3=True,
-                             s3_locations=["s3://bucket/path/"]),
-            DLTTableDependency(table_name="target_table", depends_on=["source_table"],
-                             reads_from_s3=False)
-        ]
-    """
-    dependencies = []
-
-    try:
-        if not source_code:
-            return dependencies
-
-        # Split source code into function definitions
-        # Pattern: @dlt.table(...) or @dlt.view(...) followed by def function_name():
-        # Handle multiline decorators with potentially nested parentheses
-        function_pattern = re.compile(
-            r"(@dlt\.(?:table|view)\s*\(.*?\)\s*def\s+[a-zA-Z_][a-zA-Z0-9_]*\s*\([^)]*\)\s*:.*?)(?=@dlt\.|$)",
-            re.DOTALL | re.IGNORECASE,
-        )
-
-        for match in function_pattern.finditer(source_code):
-            try:
-                function_block = match.group(1)
-
-                # Extract table name from @dlt.table decorator
-                table_name = None
-                name_match = DLT_TABLE_NAME_LITERAL.search(function_block)
-                if name_match and name_match.group(1):
-                    table_name = name_match.group(1)
-                else:
-                    # Try function name pattern
-                    func_name_match = DLT_TABLE_NAME_FUNCTION.search(function_block)
-                    if func_name_match and func_name_match.group(1):
-                        table_name = _infer_table_name_from_function(
-                            func_name_match.group(1), source_code
-                        )
-
-                if not table_name:
-                    # Try to extract from function definition itself
-                    def_match = re.search(
-                        r"def\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(", function_block
-                    )
-                    if def_match:
-                        table_name = def_match.group(1)
-
-                if not table_name:
-                    logger.debug(
-                        f"Could not extract table name from block: {function_block[:100]}..."
-                    )
-                    continue
-
-                # Check if it reads from Kafka
-                # Direct pattern: spark.readStream.format("kafka")
-                reads_from_kafka = bool(KAFKA_STREAM_PATTERN.search(function_block))
-
-                # Materializer pattern: materializer.build_event_log_dataframe()
-                # This method internally reads from Kafka, so if we find this pattern
-                # and the table name matches event_log pattern, mark as Kafka reader
-                if (
-                    not reads_from_kafka
-                    and "materializer.build_event_log_dataframe" in function_block
-                ):
-                    if "event_log" in table_name:
-                        reads_from_kafka = True
-                        logger.debug(
-                            f"Table {table_name} reads from Kafka via Materializer"
-                        )
-
-                # Check if it reads from S3
-                s3_locations = []
-                for s3_match in S3_PATH_PATTERN.finditer(function_block):
-                    s3_path = s3_match.group(1)
-                    if s3_path.startswith(("s3://", "s3a://", "s3n://")):
-                        s3_locations.append(s3_path)
-                        logger.debug(f"Table {table_name} reads from S3: {s3_path}")
-
-                reads_from_s3 = len(s3_locations) > 0
-
-                # Extract dlt.read_stream dependencies (streaming)
-                depends_on = []
-                for stream_match in DLT_READ_STREAM_PATTERN.finditer(function_block):
-                    source_table = stream_match.group(1)
-                    depends_on.append(source_table)
-                    logger.debug(f"Table {table_name} streams from {source_table}")
-
-                # Extract dlt.read dependencies (batch)
-                for read_match in DLT_READ_PATTERN.finditer(function_block):
-                    source_table = read_match.group(1)
-                    depends_on.append(source_table)
-                    logger.debug(f"Table {table_name} reads from {source_table}")
-
-                dependency = DLTTableDependency(
-                    table_name=table_name,
-                    depends_on=depends_on,
-                    reads_from_kafka=reads_from_kafka,
-                    reads_from_s3=reads_from_s3,
-                    s3_locations=s3_locations,
-                )
-                dependencies.append(dependency)
-                logger.debug(
-                    f"Extracted dependency: {table_name} - depends_on={depends_on}, "
-                    f"reads_from_kafka={reads_from_kafka}, reads_from_s3={reads_from_s3}, "
-                    f"s3_locations={s3_locations}"
-                )
-
-            except Exception as exc:
-                logger.debug(f"Error parsing function block: {exc}")
-                continue
-
-        # Handle Materializer snapshot pattern:
-        # if snapshot_required:
-        #     materializer.build_snapshot_dataframe()
-        # This creates a snapshot table without @dlt.table decorator
-        try:
-            variables = _extract_variables(source_code)
-            snapshot_required = variables.get("snapshot_required")
-            entity_name = (
-                variables.get("entity_name")
-                or variables.get("entity")
-                or variables.get("table_name")
-            )
-
-            # Check if snapshot table is built
-            # snapshot_required can be "True" (string) or True (boolean)
-            is_snapshot_enabled = (
-                snapshot_required and str(snapshot_required).lower() == "true"
-            )
-
-            if (
-                is_snapshot_enabled
-                and entity_name
-                and "build_snapshot_dataframe" in source_code
-            ):
-                snapshot_table_name = f"{entity_name.lower()}_snapshot"
-                event_log_table_name = f"{entity_name.lower()}_event_log"
-
-                # Find the event_log table in existing dependencies
-                event_log_dep = next(
-                    (d for d in dependencies if d.table_name == event_log_table_name),
-                    None,
-                )
-
-                if event_log_dep:
-                    # Create snapshot table that depends on event_log
-                    snapshot_dependency = DLTTableDependency(
-                        table_name=snapshot_table_name,
-                        depends_on=[event_log_table_name],
-                        reads_from_kafka=False,
-                        reads_from_s3=False,
-                        s3_locations=[],
-                    )
-                    dependencies.append(snapshot_dependency)
-                    logger.debug(
-                        f"Extracted Materializer snapshot table: {snapshot_table_name} depends on {event_log_table_name}"
-                    )
-                else:
-                    logger.debug(
-                        f"Found snapshot pattern but event_log table {event_log_table_name} not found in dependencies"
-                    )
-
-        except Exception as exc:
-            logger.debug(f"Error extracting Materializer snapshot pattern: {exc}")
-
-    except Exception as exc:
-        logger.warning(f"Error extracting DLT table dependencies: {exc}")
-
-    return dependencies
-
-
-def get_pipeline_libraries(pipeline_config: dict, client=None) -> List[str]:
-    """
-    Extract notebook and file paths from pipeline configuration
-    Safely handles missing or malformed configuration
+    Malformed entries are skipped rather than failing the whole pipeline.
     """
     libraries = []
 
-    try:
-        if not pipeline_config:
-            return libraries
+    if not pipeline_config:
+        return libraries
 
-        for lib in pipeline_config.get("libraries", []):
-            try:
-                if "notebook" in lib:
-                    notebook_path = lib["notebook"].get("path")
-                    if notebook_path:
-                        libraries.append(notebook_path)
-                elif "file" in lib:
-                    file_path = lib["file"].get("path")
-                    if file_path:
-                        libraries.append(file_path)
-            except Exception as exc:
-                logger.debug(f"Failed to process library entry {lib}: {exc}")
-                continue
-
-    except Exception as exc:
-        logger.warning(f"Error extracting pipeline libraries: {exc}")
+    for lib in pipeline_config.get("libraries") or []:
+        if not isinstance(lib, dict):
+            continue
+        try:
+            for key in ("notebook", "file"):
+                entry = lib.get(key)
+                if not entry:
+                    continue
+                path = entry.get("path") if isinstance(entry, dict) else entry
+                if path:
+                    libraries.append(DLTLibrarySource(path=path))
+                    logger.info(f"   ✓ Found {key}: {path}")
+                break
+            else:
+                glob_entry = lib.get("glob")
+                include = glob_entry.get("include") if isinstance(glob_entry, dict) else glob_entry
+                if include:
+                    base_path = glob_base_directory(include)
+                    libraries.append(
+                        DLTLibrarySource(
+                            path=base_path,
+                            # a `**` or a trailing slash names a directory outright.
+                            # Anything else is unknowable from the string, so it is
+                            # left to the caller to settle by listing it.
+                            is_directory=True if base_path.endswith("/") else None,
+                        )
+                    )
+                    logger.info(f"   ✓ Found glob {include}, listing: {base_path}")
+        except Exception as exc:
+            logger.debug(f"Failed to process library entry {lib}: {exc}")
+            continue
 
     return libraries

--- a/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/kafka_parser.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/kafka_parser.py
@@ -162,7 +162,9 @@ def extract_kafka_sources(source_code: str) -> List[KafkaSourceConfig]:  # noqa:
     return kafka_configs
 
 
-def _extract_option(config_block: str, option_name: str, variables: dict = None) -> Optional[str]:  # noqa: RUF013, UP045
+def _extract_option(
+    config_block: str, option_name: str, variables: Optional[dict] = None  # noqa: UP045
+) -> Optional[str]:  # noqa: UP045
     """
     Extract a single option value from Kafka configuration block
     Supports both string literals and variable references

--- a/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/metadata.py
@@ -1247,6 +1247,14 @@ class DatabrickspipelineSource(PipelineServiceSource):
                     if not (source_table_full_name and target_table_full_name):
                         continue
 
+                    # A table never derives from itself. The system tables record
+                    # access rather than derivation, so a streaming or CDC write
+                    # legitimately names its target as its own source. Kept as
+                    # lineage it renders as a loop on the node and says nothing.
+                    if source_table_full_name == target_table_full_name:
+                        logger.debug(f"Skipping self-referencing lineage row for {source_table_full_name}")
+                        continue
+
                     source = fqn.split_table_name(source_table_full_name)
                     target = fqn.split_table_name(target_table_full_name)
                     for dbservicename in self.get_db_service_names() or ["*"]:

--- a/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/metadata.py
@@ -15,7 +15,7 @@ Databricks pipeline source to extract metadata
 
 import traceback
 from datetime import datetime, timedelta, timezone
-from typing import Iterable, List, Optional, Tuple
+from typing import Iterable, List, Optional, Tuple  # noqa: UP035
 
 from pydantic import ValidationError
 
@@ -58,17 +58,23 @@ from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.lineage.sql_lineage import get_column_fqn
 from metadata.ingestion.models.pipeline_status import OMetaBulkPipelineStatus
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.ingestion.source.pipeline.databrickspipeline.kafka_parser import (
+from metadata.ingestion.source.pipeline.databrickspipeline.dlt_parsers import (
     extract_dlt_table_dependencies,
+)
+from metadata.ingestion.source.pipeline.databrickspipeline.kafka_parser import (
     extract_kafka_sources,
+    get_pipeline_libraries,
 )
 from metadata.ingestion.source.pipeline.databrickspipeline.models import (
     DataBrickPipelineDetails,
     DBRun,
+    DLTLibrarySource,
+    DLTTableReference,
 )
 from metadata.ingestion.source.pipeline.pipeline_service import PipelineServiceSource
 from metadata.utils import fqn
 from metadata.utils.logger import ingestion_logger
+from metadata.utils.lru_cache import LRU_CACHE_SIZE, LRUCache
 
 logger = ingestion_logger()
 
@@ -96,22 +102,19 @@ class DatabrickspipelineSource(PipelineServiceSource):
         super().__init__(config, metadata)
         # Cache for Databricks services to avoid repeated API calls
         self._databricks_services_cached = False
-        self._databricks_services: List[str] = []
+        self._databricks_services: List[str] = []  # noqa: UP006
 
-        self._table_lookup_cache = {}
-        self._dlt_table_cache = {}
+        # bounded so a large workspace cannot grow these without limit
+        self._table_lookup_cache = LRUCache(capacity=LRU_CACHE_SIZE)
+        self._dlt_table_cache = LRUCache(capacity=LRU_CACHE_SIZE)
 
     @classmethod
-    def create(
-        cls, config_dict, metadata: OpenMetadata, pipeline_name: Optional[str] = None
-    ):
+    def create(cls, config_dict, metadata: OpenMetadata, pipeline_name: Optional[str] = None):  # noqa: UP045
         """Create class instance"""
         config: WorkflowSource = WorkflowSource.model_validate(config_dict)
         connection: DatabricksPipelineConnection = config.serviceConnection.root.config
         if not isinstance(connection, DatabricksPipelineConnection):
-            raise InvalidSourceException(
-                f"Expected DatabricksPipelineConnection, but got {connection}"
-            )
+            raise InvalidSourceException(f"Expected DatabricksPipelineConnection, but got {connection}")
         return cls(config, metadata)
 
     def close(self):
@@ -143,22 +146,18 @@ class DatabrickspipelineSource(PipelineServiceSource):
 
         return None
 
-    def get_pipeline_name(
-        self, pipeline_details: DataBrickPipelineDetails
-    ) -> Optional[str]:
+    def get_pipeline_name(self, pipeline_details: DataBrickPipelineDetails) -> Optional[str]:  # noqa: UP045
         try:
             if pipeline_details.pipeline_id:
                 return pipeline_details.name
-            return pipeline_details.settings.name if pipeline_details.settings else None
+            return pipeline_details.settings.name if pipeline_details.settings else None  # noqa: TRY300
         except Exception as exc:
             logger.debug(traceback.format_exc())
             logger.error(f"Failed to get pipeline name due to : {exc}")
 
         return None
 
-    def yield_pipeline(
-        self, pipeline_details: DataBrickPipelineDetails
-    ) -> Iterable[Either[CreatePipelineRequest]]:
+    def yield_pipeline(self, pipeline_details: DataBrickPipelineDetails) -> Iterable[Either[CreatePipelineRequest]]:
         """Method to Get Pipeline Entity"""
         try:
             if pipeline_details.pipeline_id:
@@ -167,16 +166,8 @@ class DatabrickspipelineSource(PipelineServiceSource):
                 entity_name = str(pipeline_details.pipeline_id)
                 schedule_interval = None
             else:
-                description = (
-                    pipeline_details.settings.description
-                    if pipeline_details.settings
-                    else None
-                )
-                display_name = (
-                    pipeline_details.settings.name
-                    if pipeline_details.settings
-                    else None
-                )
+                description = pipeline_details.settings.description if pipeline_details.settings else None
+                display_name = pipeline_details.settings.name if pipeline_details.settings else None
                 entity_name = str(pipeline_details.job_id)
                 schedule_interval = (
                     str(pipeline_details.settings.schedule.cron)
@@ -223,7 +214,7 @@ class DatabrickspipelineSource(PipelineServiceSource):
                 )
             )
 
-    def get_tasks(self, pipeline_details: DataBrickPipelineDetails) -> List[Task]:
+    def get_tasks(self, pipeline_details: DataBrickPipelineDetails) -> List[Task]:  # noqa: UP006
         try:
             if not pipeline_details.settings or not pipeline_details.settings.tasks:
                 return []
@@ -235,12 +226,8 @@ class DatabrickspipelineSource(PipelineServiceSource):
                     name=str(task.name),
                     taskType=pipeline_details.settings.task_type,
                     sourceUrl=SourceUrl(job_url),
-                    description=(
-                        Markdown(task.description) if task.description else None
-                    ),
-                    downstreamTasks=[
-                        depend_task.name for depend_task in task.depends_on or []
-                    ],
+                    description=(Markdown(task.description) if task.description else None),
+                    downstreamTasks=[depend_task.name for depend_task in task.depends_on or []],
                 )
                 for task in pipeline_details.settings.tasks
             ]
@@ -257,15 +244,12 @@ class DatabrickspipelineSource(PipelineServiceSource):
                 return
 
             lookback_days = self.source_config.statusLookbackDays or 1
-            cutoff_ts = int(
-                (datetime.now(timezone.utc) - timedelta(days=lookback_days)).timestamp()
-                * 1000
-            )
-            statuses: List[PipelineStatus] = []
+            cutoff_ts = int((datetime.now(timezone.utc) - timedelta(days=lookback_days)).timestamp() * 1000)
+            statuses: List[PipelineStatus] = []  # noqa: UP006
             seen_start_times = set()
 
             for run in self.client.get_job_runs(job_id=pipeline_details.job_id) or []:
-                run = DBRun(**run)
+                run = DBRun(**run)  # noqa: PLW2901
                 if run.start_time and run.start_time < cutoff_ts:
                     break
                 # OpenMetadata keys a pipeline status by its timestamp, so it can
@@ -279,9 +263,7 @@ class DatabrickspipelineSource(PipelineServiceSource):
                 task_status = [
                     TaskStatus(
                         name=str(task.name),
-                        executionStatus=STATUS_MAP.get(
-                            run.state.result_state, StatusType.Failed
-                        ),
+                        executionStatus=STATUS_MAP.get(run.state.result_state, StatusType.Failed),
                         startTime=Timestamp(run.start_time),
                         endTime=Timestamp(run.end_time) if run.end_time else None,
                         logLink=run.run_page_url,
@@ -323,10 +305,10 @@ class DatabrickspipelineSource(PipelineServiceSource):
 
     def _process_and_validate_column_lineage(
         self,
-        column_lineage: List[Tuple[str, str]],
+        column_lineage: List[Tuple[str, str]],  # noqa: UP006
         from_entity: Table,
         to_entity: Table,
-    ) -> List[ColumnLineage]:
+    ) -> List[ColumnLineage]:  # noqa: UP006
         """
         Process and validate column lineage
         """
@@ -348,9 +330,7 @@ class DatabrickspipelineSource(PipelineServiceSource):
                         )
                         continue
 
-                    from_column = get_column_fqn(
-                        table_entity=from_entity, column=str(source_col)
-                    )
+                    from_column = get_column_fqn(table_entity=from_entity, column=str(source_col))
                     to_column = get_column_fqn(
                         table_entity=to_entity,
                         column=str(target_col),
@@ -363,18 +343,14 @@ class DatabrickspipelineSource(PipelineServiceSource):
                             )
                         )
                 except Exception as err:
-                    logger.warning(
-                        f"Error processing column lineage {column_tuple}: {err}"
-                    )
+                    logger.warning(f"Error processing column lineage {column_tuple}: {err}")
                     logger.debug(traceback.format_exc())
                     continue
         if not processed_column_lineage:
-            logger.warning(
-                f"No column lineage found for {from_entity.name} to {to_entity.name}"
-            )
+            logger.warning(f"No column lineage found for {from_entity.name} to {to_entity.name}")
         return processed_column_lineage or []
 
-    def _get_databricks_services(self) -> List[str]:
+    def _get_databricks_services(self) -> List[str]:  # noqa: UP006
         """
         Get list of all Databricks/Unity Catalog database service names from OpenMetadata
 
@@ -383,9 +359,7 @@ class DatabrickspipelineSource(PipelineServiceSource):
         """
         # Return cached services if already fetched
         if self._databricks_services_cached:
-            logger.debug(
-                f"Using cached Databricks services: {self._databricks_services}"
-            )
+            logger.debug(f"Using cached Databricks services: {self._databricks_services}")
             return self._databricks_services
 
         try:
@@ -396,23 +370,13 @@ class DatabrickspipelineSource(PipelineServiceSource):
             logger.info("Fetching Databricks/Unity Catalog database services...")
 
             # List all database services
-            services = self.metadata.list_all_entities(
-                entity=DatabaseService, fields=["serviceType"]
-            )
+            services = self.metadata.list_all_entities(entity=DatabaseService, fields=["serviceType"])
 
             databricks_services = []
             for service in services or []:
                 try:
-                    service_type = (
-                        service.serviceType.value
-                        if hasattr(service, "serviceType")
-                        else None
-                    )
-                    service_name = (
-                        service.name.root
-                        if hasattr(service.name, "root")
-                        else service.name
-                    )
+                    service_type = service.serviceType.value if hasattr(service, "serviceType") else None
+                    service_name = service.name.root if hasattr(service.name, "root") else service.name
 
                     logger.debug(f"  Service: {service_name}, Type: {service_type}")
 
@@ -422,9 +386,7 @@ class DatabrickspipelineSource(PipelineServiceSource):
                         "unitycatalog",
                     ]:
                         databricks_services.append(service_name)
-                        logger.debug(
-                            f"    ✓ Databricks/Unity Catalog service: {service_name}"
-                        )
+                        logger.debug(f"    ✓ Databricks/Unity Catalog service: {service_name}")
 
                 except Exception as exc:
                     logger.debug(f"  Error processing service: {exc}")
@@ -434,10 +396,8 @@ class DatabrickspipelineSource(PipelineServiceSource):
             self._databricks_services = databricks_services
             self._databricks_services_cached = True
 
-            logger.info(
-                f"Found {len(databricks_services)} Databricks/Unity Catalog service(s): {databricks_services}"
-            )
-            return databricks_services
+            logger.info(f"Found {len(databricks_services)} Databricks/Unity Catalog service(s): {databricks_services}")
+            return databricks_services  # noqa: TRY300
 
         except Exception as exc:
             logger.warning(f"Error fetching Databricks services: {exc}")
@@ -447,9 +407,81 @@ class DatabrickspipelineSource(PipelineServiceSource):
             self._databricks_services_cached = True
             return []
 
-    def _find_dlt_table(
-        self, table_name: str, catalog: Optional[str], schema: Optional[str]
-    ) -> Optional[Table]:
+    def _lookup_table(self, table_fqn: Optional[str]) -> Optional[Table]:  # noqa: UP045
+        """Resolve a table FQN, caching both hits and misses."""
+        if not table_fqn:
+            return None
+        if table_fqn not in self._table_lookup_cache:
+            self._table_lookup_cache.put(table_fqn, self.metadata.get_by_name(entity=Table, fqn=table_fqn))
+        return self._table_lookup_cache.get(table_fqn)
+
+    def _expand_workspace_directory(
+        self,
+        library: DLTLibrarySource,
+        path: Optional[str] = None,  # noqa: UP045
+        # Deep enough that a real repository layout is never truncated, while still
+        # bounding the recursion. A directory that is not there costs nothing, but a
+        # transformation missed below the cap costs the lineage that depends on it.
+        max_depth: int = 20,
+    ) -> List[str]:  # noqa: UP006
+        """
+        List every notebook and file under a library directory.
+
+        The Databricks `workspace/list` API returns immediate children only, so
+        subdirectories are walked explicitly. A library is either a file or a
+        directory taken in full, so there is nothing to filter the listing
+        against. Depth is capped so an unexpected cycle cannot spin forever.
+        """
+        collected = []
+        path = path or library.path
+        try:
+            objects = self.client.list_workspace_objects(path) or []
+            for obj in objects:
+                obj_type = obj.get("object_type")
+                obj_path = obj.get("path")
+                if not obj_path:
+                    continue
+                if obj_type in ("NOTEBOOK", "FILE"):
+                    collected.append(obj_path)
+                    # per-path, so DEBUG. A deep tree would otherwise bury the run
+                    # summary under one line per file.
+                    logger.debug(f"   ✓ Found {obj_type.lower()}: {obj_path}")
+                elif obj_type == "DIRECTORY":
+                    if max_depth <= 0:
+                        logger.warning(f"   ⊗ Max depth reached, not descending into {obj_path}")
+                        continue
+                    collected.extend(
+                        self._expand_workspace_directory(library, obj_path.rstrip("/") + "/", max_depth - 1)
+                    )
+        except Exception as exc:
+            logger.warning(f"   ✗ Could not list directory {path}: {exc}")
+            logger.debug(traceback.format_exc())
+        return collected
+
+    @staticmethod
+    def _qualify_dlt_table_name(
+        table_name: str,
+        catalog: Optional[str],  # noqa: UP045
+        schema: Optional[str],  # noqa: UP045
+    ) -> DLTTableReference:
+        """
+        Resolve a dataset reference to the catalog, schema and table it points at.
+
+        SQL transformations reference upstreams either bare (`order_totals`, a sibling
+        dataset in the same pipeline) or qualified (`catalog.schema.table`). The Python
+        API only ever yields bare names. Qualifiers carried by the reference itself
+        describe where the table actually lives, so they take precedence over the
+        pipeline's target catalog and schema.
+        """
+        parts = [part.strip() for part in (table_name or "").split(".") if part.strip()]
+        if len(parts) >= 3:
+            return DLTTableReference(catalog=parts[-3], schema=parts[-2], table=parts[-1])
+        if len(parts) == 2:
+            return DLTTableReference(catalog=catalog, schema=parts[0], table=parts[1])
+        # the cleaned token, so stray whitespace or dots never reach the FQN
+        return DLTTableReference(catalog=catalog, schema=schema, table=parts[0] if parts else "")
+
+    def _find_dlt_table(self, table_name: str, catalog: Optional[str], schema: Optional[str]) -> Optional[Table]:  # noqa: UP045
         """
         Find DLT table in OpenMetadata by iterating through Databricks services
 
@@ -457,7 +489,9 @@ class DatabrickspipelineSource(PipelineServiceSource):
         Uses catalog.schema.table_name from DLT spec to build FQN for each Databricks service.
 
         Args:
-            table_name: Table name extracted from notebook code
+            table_name: Table name extracted from notebook code. May already be qualified
+                as catalog.schema.table or schema.table when it came from SQL, in which
+                case those qualifiers win over the pipeline defaults.
             catalog: Catalog name from DLT pipeline spec (database in OpenMetadata)
             schema: Schema name from DLT pipeline spec
 
@@ -465,29 +499,26 @@ class DatabrickspipelineSource(PipelineServiceSource):
             Table entity if found, None otherwise
         """
         try:
+            reference = self._qualify_dlt_table_name(table_name, catalog, schema)
+            catalog, schema, table_name = reference.catalog, reference.schema, reference.table
+
             # Check cache first to avoid duplicate API calls
             cache_key = f"{catalog}.{schema}.{table_name}"
             if cache_key in self._dlt_table_cache:
                 logger.debug(f"DLT table found in cache: {cache_key}")
-                return self._dlt_table_cache[cache_key]
+                return self._dlt_table_cache.get(cache_key)
 
-            logger.debug(
-                f"Searching for DLT table: catalog={catalog}, schema={schema}, table={table_name}"
-            )
+            logger.debug(f"Searching for DLT table: catalog={catalog}, schema={schema}, table={table_name}")
 
             # Get all Databricks/Unity Catalog services (uses cache)
             databricks_services = self._get_databricks_services()
 
             if not databricks_services:
-                logger.warning(
-                    "No Databricks/Unity Catalog services found in OpenMetadata"
-                )
+                logger.warning("No Databricks/Unity Catalog services found in OpenMetadata")
                 # Fall back to configured dbServiceNames if available
                 databricks_services = self.get_db_service_names() or []
                 if databricks_services:
-                    logger.info(
-                        f"Using configured database services: {databricks_services}"
-                    )
+                    logger.info(f"Using configured database services: {databricks_services}")
 
             if not databricks_services:
                 return None
@@ -515,7 +546,7 @@ class DatabrickspipelineSource(PipelineServiceSource):
                         logger.info(f"Found DLT table with FQN: {table_fqn}")
                         # Cache the found table
                         cache_key = f"{catalog}.{schema}.{table_name}"
-                        self._dlt_table_cache[cache_key] = table
+                        self._dlt_table_cache.put(cache_key, table)
                         return table
 
                 except Exception as exc:
@@ -539,18 +570,14 @@ class DatabrickspipelineSource(PipelineServiceSource):
 
                     table = self.metadata.get_by_name(entity=Table, fqn=table_fqn)
                     if table:
-                        logger.info(
-                            f"Found DLT table with FQN (lowercase): {table_fqn}"
-                        )
+                        logger.info(f"Found DLT table with FQN (lowercase): {table_fqn}")
                         # Cache the found table
                         cache_key = f"{catalog}.{schema}.{table_name}"
-                        self._dlt_table_cache[cache_key] = table
+                        self._dlt_table_cache.put(cache_key, table)
                         return table
 
                 except Exception as exc:
-                    logger.debug(
-                        f"  Error checking service {service_name} (lowercase): {exc}"
-                    )
+                    logger.debug(f"  Error checking service {service_name} (lowercase): {exc}")
                     continue
 
         except Exception as exc:
@@ -563,10 +590,10 @@ class DatabrickspipelineSource(PipelineServiceSource):
         )
         # Cache None to avoid repeated lookups for non-existent tables
         cache_key = f"{catalog}.{schema}.{table_name}"
-        self._dlt_table_cache[cache_key] = None
+        self._dlt_table_cache.put(cache_key, None)
         return None
 
-    def _find_kafka_topic(self, topic_name: str) -> Optional[Topic]:
+    def _find_kafka_topic(self, topic_name: str) -> Optional[Topic]:  # noqa: UP045
         """
         Find Kafka topic in OpenMetadata using Elasticsearch search
 
@@ -577,9 +604,7 @@ class DatabrickspipelineSource(PipelineServiceSource):
         When TopicName has dots, it's quoted: MessagingServiceName."dev.ern.topic"
         """
         try:
-            logger.debug(
-                f"Searching for topic {topic_name} across all messaging services"
-            )
+            logger.debug(f"Searching for topic {topic_name} across all messaging services")
 
             # Use ES search with wildcard pattern to find topic regardless of service
             # Pattern: *.topic_name or *."topic.with.dots"
@@ -615,12 +640,11 @@ class DatabrickspipelineSource(PipelineServiceSource):
             logger.debug(traceback.format_exc())
 
         logger.warning(
-            f"Topic {topic_name} not found in OpenMetadata. "
-            f"Ensure the topic is ingested from a messaging service."
+            f"Topic {topic_name} not found in OpenMetadata. Ensure the topic is ingested from a messaging service."
         )
         return None
 
-    def _yield_kafka_lineage(
+    def _yield_kafka_lineage(  # noqa: C901
         self, pipeline_details: DataBrickPipelineDetails, pipeline_entity: Pipeline
     ) -> Iterable[Either[AddLineageRequest]]:
         """
@@ -630,10 +654,8 @@ class DatabrickspipelineSource(PipelineServiceSource):
         """
         try:
             logger.info("=" * 80)
-            logger.info(f"KAFKA LINEAGE EXTRACTION STARTED")
-            logger.info(
-                f"Pipeline: {pipeline_details.name if hasattr(pipeline_details, 'name') else 'N/A'}"
-            )
+            logger.info(f"KAFKA LINEAGE EXTRACTION STARTED")  # noqa: F541
+            logger.info(f"Pipeline: {pipeline_details.name if hasattr(pipeline_details, 'name') else 'N/A'}")
             logger.info(f"Job ID: {pipeline_details.job_id}")
             logger.info(f"Pipeline ID: {pipeline_details.pipeline_id}")
             logger.info("=" * 80)
@@ -653,9 +675,7 @@ class DatabrickspipelineSource(PipelineServiceSource):
 
                     if tasks:
                         for task in tasks:
-                            logger.debug(
-                                f"Task: {task.name}, has pipeline_task: {task.pipeline_task is not None}"
-                            )
+                            logger.debug(f"Task: {task.name}, has pipeline_task: {task.pipeline_task is not None}")
                             # Check for direct DLT pipeline task
                             if task.pipeline_task and task.pipeline_task.pipeline_id:
                                 pipeline_id = task.pipeline_task.pipeline_id
@@ -670,7 +690,7 @@ class DatabrickspipelineSource(PipelineServiceSource):
             # Only process if we have a DLT pipeline_id
             if not pipeline_id:
                 logger.info(
-                    f"⊗ No DLT pipeline_id found - skipping Kafka lineage extraction"
+                    f"⊗ No DLT pipeline_id found - skipping Kafka lineage extraction"  # noqa: F541
                 )
                 logger.info(f"   Job ID: {pipeline_details.job_id}")
                 logger.info(f"   Pipeline ID: {pipeline_details.pipeline_id}")
@@ -687,66 +707,33 @@ class DatabrickspipelineSource(PipelineServiceSource):
                 logger.info(f"⟳ Fetching pipeline configuration for {pipeline_id}...")
                 pipeline_config = self.client.get_pipeline_details(pipeline_id)
                 if not pipeline_config:
-                    logger.warning(
-                        f"✗ Could not fetch pipeline config for {pipeline_id}"
-                    )
+                    logger.warning(f"✗ Could not fetch pipeline config for {pipeline_id}")
                     logger.info("=" * 80)
                     return
 
-                logger.debug(f"✓ Pipeline config fetched successfully")
+                logger.debug(f"✓ Pipeline config fetched successfully")  # noqa: F541
                 logger.debug(f"   Config keys: {list(pipeline_config.keys())}")
 
                 # Extract spec for detailed configuration
                 spec = pipeline_config.get("spec", {})
-                logger.info(f"✓ Pipeline spec extracted")
+                logger.info(f"✓ Pipeline spec extracted")  # noqa: F541
                 logger.info(f"   Spec keys: {list(spec.keys()) if spec else 'None'}")
 
                 # Extract target catalog and schema for DLT tables
                 target_catalog = spec.get("catalog") if spec else None
                 # Schema can be in 'target' or 'schema' field
-                target_schema = (
-                    spec.get("target") or spec.get("schema") if spec else None
-                )
-                logger.info(f"✓ DLT Target Location:")
+                target_schema = spec.get("target") or spec.get("schema") if spec else None
+                logger.info(f"✓ DLT Target Location:")  # noqa: F541
                 logger.info(f"   Catalog: {target_catalog or 'NOT SET'}")
                 logger.info(f"   Schema: {target_schema or 'NOT SET'}")
 
                 # Extract notebook/file paths from libraries in spec
                 notebook_paths = []
-                if spec and "libraries" in spec:
-                    libraries = spec["libraries"]
-                    logger.info(
-                        f"⟳ Extracting notebook paths from {len(libraries)} libraries..."
-                    )
-                    for idx, lib in enumerate(libraries):
-                        logger.debug(f"   Library {idx + 1}: {lib}")
-                        # Library can be dict or have different structures
-                        if isinstance(lib, dict):
-                            # Check for notebook path
-                            if "notebook" in lib and lib["notebook"]:
-                                notebook = lib["notebook"]
-                                if isinstance(notebook, dict):
-                                    path = notebook.get("path")
-                                else:
-                                    path = notebook
-                                if path:
-                                    notebook_paths.append(path)
-                                    logger.info(f"   ✓ Found notebook: {path}")
-                            # Check for glob pattern
-                            elif "glob" in lib and lib["glob"]:
-                                glob_pattern = lib["glob"]
-                                if isinstance(glob_pattern, dict):
-                                    include_pattern = glob_pattern.get("include")
-                                    if include_pattern:
-                                        # Convert glob pattern to directory path
-                                        # e.g., "/path/**" -> "/path/"
-                                        base_path = include_pattern.replace(
-                                            "/**", "/"
-                                        ).replace("**", "")
-                                        notebook_paths.append(base_path)
-                                        logger.info(
-                                            f"   ✓ Found glob pattern, using base path: {base_path}"
-                                        )
+                if spec:
+                    # the key can be present and null, so read it rather than test for it
+                    libraries = spec.get("libraries") or []
+                    logger.info(f"⟳ Extracting notebook paths from {len(libraries)} libraries...")
+                    notebook_paths = get_pipeline_libraries(spec)
 
                 # Also check for source path in spec configuration
                 if not notebook_paths and spec:
@@ -762,118 +749,95 @@ class DatabrickspipelineSource(PipelineServiceSource):
                         source_path = spec["development"].get("source_path")
 
                     if source_path:
-                        logger.info(
-                            f"   ✓ Found source_path in pipeline spec: {source_path}"
-                        )
-                        notebook_paths.append(source_path)
+                        logger.info(f"   ✓ Found source_path in pipeline spec: {source_path}")
+                        # a source path is the root of the pipeline's code, so it is a
+                        # directory whether or not Databricks spells the trailing slash
+                        notebook_paths.append(DLTLibrarySource(path=source_path.rstrip("/") + "/", is_directory=True))
 
                 logger.info(f"✓ Total notebook paths found: {len(notebook_paths)}")
-                for idx, path in enumerate(notebook_paths):
-                    logger.info(f"   {idx + 1}. {path}")
+                for idx, library in enumerate(notebook_paths):
+                    logger.info(f"   {idx + 1}. {library.path}")
             except Exception as exc:
-                logger.error(
-                    f"✗ Failed to fetch pipeline config for {pipeline_id}: {exc}"
-                )
+                logger.error(f"✗ Failed to fetch pipeline config for {pipeline_id}: {exc}")
                 logger.debug(traceback.format_exc())
                 logger.info("=" * 80)
                 return
 
             if not notebook_paths:
                 logger.warning(f"✗ No notebook paths found for pipeline {pipeline_id}")
-                logger.info(
-                    "   Cannot extract Kafka lineage without notebook source code"
-                )
+                logger.info("   Cannot extract Kafka lineage without notebook source code")
                 logger.info("=" * 80)
                 return
 
             # Expand directories to individual notebook files
-            logger.info(f"⟳ Expanding directory paths to individual notebooks...")
+            logger.info(f"⟳ Expanding directory paths to individual notebooks...")  # noqa: F541
             expanded_paths = []
-            for path in notebook_paths:
-                # If path ends with /, it's a directory - list all notebooks in it
-                if path.endswith("/"):
-                    try:
-                        logger.debug(f"   Listing directory: {path}")
-                        # List workspace directory to get all notebooks
-                        objects = self.client.list_workspace_objects(path)
-                        if objects:
-                            for obj in objects:
-                                obj_type = obj.get("object_type")
-                                if obj_type in ("NOTEBOOK", "FILE"):
-                                    notebook_path = obj.get("path")
-                                    if notebook_path:
-                                        expanded_paths.append(notebook_path)
-                                        logger.info(
-                                            f"   ✓ Found {obj_type.lower()}: {notebook_path}"
-                                        )
-                        if not expanded_paths:
-                            logger.debug(f"   ⊗ No notebooks found in directory {path}")
-                    except Exception as exc:
-                        logger.warning(f"   ✗ Could not list directory {path}: {exc}")
-                        logger.debug(traceback.format_exc())
+            for library in notebook_paths:
+                if library.is_directory is False:
+                    expanded_paths.append(library.path)
+                    logger.debug(f"   Direct path: {library.path}")
+                    continue
+
+                found = self._expand_workspace_directory(library)
+                if found:
+                    expanded_paths.extend(found)
+                elif library.is_directory is None:
+                    # the spec did not say what this is and nothing listed under it,
+                    # so it names a single source rather than a directory
+                    expanded_paths.append(library.path)
+                    logger.debug(f"   Direct path: {library.path}")
                 else:
-                    expanded_paths.append(path)
-                    logger.debug(f"   Direct path: {path}")
+                    logger.debug(f"   ⊗ Nothing found under {library.path}")
 
             logger.info(f"✓ Total notebooks to process: {len(expanded_paths)}")
 
             # Process each notebook to extract Kafka sources and DLT tables
             logger.info("-" * 80)
-            logger.info(f"PROCESSING NOTEBOOKS FOR KAFKA LINEAGE")
+            logger.info(f"PROCESSING NOTEBOOKS FOR KAFKA LINEAGE")  # noqa: F541
             logger.info("-" * 80)
 
             for idx, lib_path in enumerate(expanded_paths, 1):
                 try:
                     logger.info(f"\n📓 Notebook {idx}/{len(expanded_paths)}: {lib_path}")
-                    logger.info(f"⟳ Exporting notebook source code...")
+                    logger.info(f"⟳ Exporting notebook source code...")  # noqa: F541
 
                     source_code = self.client.export_notebook_source(lib_path)
                     if not source_code:
                         logger.warning(f"✗ Could not export source for {lib_path}")
                         continue
 
-                    logger.info(
-                        f"✓ Source code exported ({len(source_code)} characters)"
-                    )
+                    logger.info(f"✓ Source code exported ({len(source_code)} characters)")
 
                     # Log full source code for debugging
-                    logger.debug(f"   ===== FULL NOTEBOOK SOURCE CODE =====")
+                    logger.debug(f"   ===== FULL NOTEBOOK SOURCE CODE =====")  # noqa: F541
                     for i, line in enumerate(source_code.split("\n"), 1):
                         logger.debug(f"   {i:3d}: {line}")
-                    logger.debug(f"   ===== END OF SOURCE CODE =====")
+                    logger.debug(f"   ===== END OF SOURCE CODE =====")  # noqa: F541
 
                     # Extract Kafka topics
-                    logger.info(f"⟳ Parsing Kafka sources from notebook...")
-                    logger.debug(f"   Looking for patterns:")
+                    logger.info(f"⟳ Parsing Kafka sources from notebook...")  # noqa: F541
+                    logger.debug(f"   Looking for patterns:")  # noqa: F541
                     logger.debug(
-                        f"   - Kafka: .format('kafka')...option('subscribe', 'topic')"
+                        f"   - Kafka: .format('kafka')...option('subscribe', 'topic')"  # noqa: F541
                     )
-                    logger.debug(f"   - DLT: @dlt.table(name='table_name')")
+                    logger.debug(f"   - DLT: @dlt.table(name='table_name')")  # noqa: F541
                     kafka_sources = extract_kafka_sources(source_code)
                     if kafka_sources:
                         topics_found = [t for ks in kafka_sources for t in ks.topics]
-                        logger.info(
-                            f"✓ Found {len(kafka_sources)} Kafka source(s) with {len(topics_found)} topic(s):"
-                        )
+                        logger.info(f"✓ Found {len(kafka_sources)} Kafka source(s) with {len(topics_found)} topic(s):")
                         for ks_idx, ks in enumerate(kafka_sources, 1):
                             logger.info(f"   Kafka Source {ks_idx}:")
                             logger.info(f"     Topics: {ks.topics}")
-                            logger.info(
-                                f"     Bootstrap Servers: {ks.bootstrap_servers or 'NOT SET'}"
-                            )
-                            logger.info(
-                                f"     Group ID Prefix: {ks.group_id_prefix or 'NOT SET'}"
-                            )
+                            logger.info(f"     Bootstrap Servers: {ks.bootstrap_servers or 'NOT SET'}")
+                            logger.info(f"     Group ID Prefix: {ks.group_id_prefix or 'NOT SET'}")
                     else:
-                        logger.info(f"⊗ No Kafka sources found in notebook")
+                        logger.info(f"⊗ No Kafka sources found in notebook")  # noqa: F541
 
                     # Extract DLT table dependencies
-                    logger.info(f"⟳ Parsing DLT table dependencies from notebook...")
+                    logger.info(f"⟳ Parsing DLT table dependencies from notebook...")  # noqa: F541
                     dlt_dependencies = extract_dlt_table_dependencies(source_code)
                     if dlt_dependencies:
-                        logger.info(
-                            f"✓ Found {len(dlt_dependencies)} DLT table(s) with dependencies"
-                        )
+                        logger.info(f"✓ Found {len(dlt_dependencies)} DLT table(s) with dependencies")
                         for dep in dlt_dependencies:
                             s3_info = (
                                 f", reads_from_s3={dep.reads_from_s3}, s3_locations={dep.s3_locations}"
@@ -885,37 +849,33 @@ class DatabrickspipelineSource(PipelineServiceSource):
                                 f"reads_from_kafka={dep.reads_from_kafka}{s3_info}"
                             )
                     else:
-                        logger.info(f"⊗ No DLT table dependencies found in notebook")
+                        logger.info(f"⊗ No DLT table dependencies found in notebook")  # noqa: F541
 
                     # Check if we have anything to process
                     has_kafka = kafka_sources and len(kafka_sources) > 0
                     has_s3 = any(dep.reads_from_s3 for dep in dlt_dependencies)
-                    has_tables = dlt_dependencies and len(dlt_dependencies) > 0
+                    has_tables = dlt_dependencies and len(dlt_dependencies) > 0  # noqa: F841
 
                     if not dlt_dependencies:
                         logger.warning(
-                            f"⊗ Skipping lineage for this notebook - no DLT tables found"
+                            f"⊗ Skipping lineage for this notebook - no DLT tables found"  # noqa: F541
                         )
                         continue
 
                     if not has_kafka and not has_s3:
                         logger.info(
-                            f"⊗ No external sources (Kafka or S3) found in this notebook - only table-to-table lineage will be created"
+                            f"⊗ No external sources (Kafka or S3) found in this notebook - only table-to-table lineage will be created"  # noqa: F541
                         )
 
-                    logger.info(f"✓ Notebook has DLT tables - creating lineage...")
+                    logger.info(f"✓ Notebook has DLT tables - creating lineage...")  # noqa: F541
                     if has_kafka:
                         logger.info(f"   Kafka sources: {len(kafka_sources)}")
                     if has_s3:
-                        s3_count = sum(
-                            len(dep.s3_locations)
-                            for dep in dlt_dependencies
-                            if dep.reads_from_s3
-                        )
+                        s3_count = sum(len(dep.s3_locations) for dep in dlt_dependencies if dep.reads_from_s3)
                         logger.info(f"   S3 sources: {s3_count} location(s)")
 
                     # Create lineage edges based on dependencies
-                    logger.info(f"\n⟳ Creating lineage edges...")
+                    logger.info(f"\n⟳ Creating lineage edges...")  # noqa: F541
                     lineage_created = 0
 
                     # Step 1: Create Kafka topic -> DLT table lineage
@@ -928,15 +888,11 @@ class DatabrickspipelineSource(PipelineServiceSource):
                     for kafka_config in kafka_sources:
                         for topic_name in kafka_config.topics:
                             try:
-                                logger.info(
-                                    f"\n   🔍 Processing Kafka topic: {topic_name}"
-                                )
+                                logger.info(f"\n   🔍 Processing Kafka topic: {topic_name}")
 
                                 kafka_topic = self._find_kafka_topic(topic_name)
                                 if not kafka_topic:
-                                    logger.warning(
-                                        f"   ✗ Kafka topic '{topic_name}' not found in OpenMetadata"
-                                    )
+                                    logger.warning(f"   ✗ Kafka topic '{topic_name}' not found in OpenMetadata")
                                     continue
 
                                 logger.info(
@@ -948,9 +904,7 @@ class DatabrickspipelineSource(PipelineServiceSource):
                                 # Downstream tables get table -> table lineage in Step 2
                                 for dep in dlt_dependencies:
                                     if dep.reads_from_kafka:
-                                        logger.info(
-                                            f"   🔍 Processing table: {dep.table_name}"
-                                        )
+                                        logger.info(f"   🔍 Processing table: {dep.table_name}")
 
                                         target_table = self._find_dlt_table(
                                             table_name=dep.table_name,
@@ -967,9 +921,7 @@ class DatabrickspipelineSource(PipelineServiceSource):
                                                 )
                                                 else target_table.fullyQualifiedName
                                             )
-                                            logger.info(
-                                                f"   ✅ Creating lineage: {topic_name} -> {table_fqn}"
-                                            )
+                                            logger.info(f"   ✅ Creating lineage: {topic_name} -> {table_fqn}")
 
                                             yield Either(
                                                 right=AddLineageRequest(
@@ -1001,14 +953,10 @@ class DatabrickspipelineSource(PipelineServiceSource):
                                             )
                                             lineage_created += 1
                                         else:
-                                            logger.warning(
-                                                f"   ✗ Table '{dep.table_name}' not found"
-                                            )
+                                            logger.warning(f"   ✗ Table '{dep.table_name}' not found")
 
                             except Exception as exc:
-                                logger.error(
-                                    f"   ✗ Failed to process topic {topic_name}: {exc}"
-                                )
+                                logger.error(f"   ✗ Failed to process topic {topic_name}: {exc}")
                                 logger.debug(traceback.format_exc())
                                 continue
 
@@ -1023,20 +971,12 @@ class DatabrickspipelineSource(PipelineServiceSource):
 
                                     # Check if source is a view/table that reads from S3
                                     source_dep = next(
-                                        (
-                                            d
-                                            for d in dlt_dependencies
-                                            if d.table_name == source_table_name
-                                        ),
+                                        (d for d in dlt_dependencies if d.table_name == source_table_name),
                                         None,
                                     )
 
                                     # If source reads from S3, create container → table lineage
-                                    if (
-                                        source_dep
-                                        and source_dep.reads_from_s3
-                                        and source_dep.s3_locations
-                                    ):
+                                    if source_dep and source_dep.reads_from_s3 and source_dep.s3_locations:
                                         target_table = self._find_dlt_table(
                                             table_name=dep.table_name,
                                             catalog=target_catalog,
@@ -1045,21 +985,14 @@ class DatabrickspipelineSource(PipelineServiceSource):
 
                                         if target_table:
                                             for s3_location in source_dep.s3_locations:
-                                                logger.info(
-                                                    f"   🔍 Looking for S3 container: {s3_location}"
-                                                )
+                                                logger.info(f"   🔍 Looking for S3 container: {s3_location}")
                                                 # Search for container by S3 path
-                                                storage_location = s3_location.rstrip(
-                                                    "/"
-                                                )
+                                                storage_location = s3_location.rstrip("/")
                                                 container_entity = self.metadata.es_search_container_by_path(
                                                     full_path=storage_location
                                                 )
 
-                                                if (
-                                                    container_entity
-                                                    and container_entity[0]
-                                                ):
+                                                if container_entity and container_entity[0]:
                                                     logger.info(
                                                         f"   ✅ Creating lineage: {container_entity[0].fullyQualifiedName.root if hasattr(container_entity[0].fullyQualifiedName, 'root') else container_entity[0].fullyQualifiedName} -> {target_table.fullyQualifiedName.root if hasattr(target_table.fullyQualifiedName, 'root') else target_table.fullyQualifiedName}"
                                                     )
@@ -1068,9 +1001,7 @@ class DatabrickspipelineSource(PipelineServiceSource):
                                                         right=AddLineageRequest(
                                                             edge=EntitiesEdge(
                                                                 fromEntity=EntityReference(
-                                                                    id=container_entity[
-                                                                        0
-                                                                    ].id,
+                                                                    id=container_entity[0].id,
                                                                     type="container",
                                                                 ),
                                                                 toEntity=EntityReference(
@@ -1100,12 +1031,10 @@ class DatabrickspipelineSource(PipelineServiceSource):
                                                         f"   ✗ S3 container not found for path: {storage_location}"
                                                     )
                                                     logger.info(
-                                                        f"      Make sure the S3 container is ingested in OpenMetadata"
+                                                        f"      Make sure the S3 container is ingested in OpenMetadata"  # noqa: F541
                                                     )
                                         else:
-                                            logger.warning(
-                                                f"   ✗ Target table '{dep.table_name}' not found"
-                                            )
+                                            logger.warning(f"   ✗ Target table '{dep.table_name}' not found")
                                         continue
 
                                     # Otherwise, create table → table lineage
@@ -1123,21 +1052,15 @@ class DatabrickspipelineSource(PipelineServiceSource):
                                     if source_table and target_table:
                                         source_fqn = (
                                             source_table.fullyQualifiedName.root
-                                            if hasattr(
-                                                source_table.fullyQualifiedName, "root"
-                                            )
+                                            if hasattr(source_table.fullyQualifiedName, "root")
                                             else source_table.fullyQualifiedName
                                         )
                                         target_fqn = (
                                             target_table.fullyQualifiedName.root
-                                            if hasattr(
-                                                target_table.fullyQualifiedName, "root"
-                                            )
+                                            if hasattr(target_table.fullyQualifiedName, "root")
                                             else target_table.fullyQualifiedName
                                         )
-                                        logger.info(
-                                            f"   ✅ Creating lineage: {source_fqn} -> {target_fqn}"
-                                        )
+                                        logger.info(f"   ✅ Creating lineage: {source_fqn} -> {target_fqn}")
 
                                         yield Either(
                                             right=AddLineageRequest(
@@ -1145,9 +1068,7 @@ class DatabrickspipelineSource(PipelineServiceSource):
                                                     fromEntity=EntityReference(
                                                         id=(
                                                             source_table.id.root
-                                                            if hasattr(
-                                                                source_table.id, "root"
-                                                            )
+                                                            if hasattr(source_table.id, "root")
                                                             else source_table.id
                                                         ),
                                                         type="table",
@@ -1155,9 +1076,7 @@ class DatabrickspipelineSource(PipelineServiceSource):
                                                     toEntity=EntityReference(
                                                         id=(
                                                             target_table.id.root
-                                                            if hasattr(
-                                                                target_table.id, "root"
-                                                            )
+                                                            if hasattr(target_table.id, "root")
                                                             else target_table.id
                                                         ),
                                                         type="table",
@@ -1175,13 +1094,9 @@ class DatabrickspipelineSource(PipelineServiceSource):
                                         lineage_created += 1
                                     else:
                                         if not source_table:
-                                            logger.warning(
-                                                f"   ✗ Source table '{source_table_name}' not found"
-                                            )
+                                            logger.warning(f"   ✗ Source table '{source_table_name}' not found")
                                         if not target_table:
-                                            logger.warning(
-                                                f"   ✗ Target table '{dep.table_name}' not found"
-                                            )
+                                            logger.warning(f"   ✗ Target table '{dep.table_name}' not found")
 
                                 except Exception as exc:
                                     logger.error(
@@ -1190,20 +1105,16 @@ class DatabrickspipelineSource(PipelineServiceSource):
                                     logger.debug(traceback.format_exc())
                                     continue
 
-                    logger.info(
-                        f"\n✓ Lineage edges created for this notebook: {lineage_created}"
-                    )
+                    logger.info(f"\n✓ Lineage edges created for this notebook: {lineage_created}")
                 except Exception as exc:
                     logger.error(f"✗ Failed to process notebook {lib_path}: {exc}")
                     logger.debug(traceback.format_exc())
-                    logger.info(f"   Continuing with next notebook...")
+                    logger.info(f"   Continuing with next notebook...")  # noqa: F541
                     continue
 
             logger.info("\n" + "=" * 80)
-            logger.info(f"KAFKA LINEAGE EXTRACTION COMPLETED")
-            logger.info(
-                f"Pipeline: {pipeline_details.name if hasattr(pipeline_details, 'name') else 'N/A'}"
-            )
+            logger.info(f"KAFKA LINEAGE EXTRACTION COMPLETED")  # noqa: F541
+            logger.info(f"Pipeline: {pipeline_details.name if hasattr(pipeline_details, 'name') else 'N/A'}")
             logger.info("=" * 80)
 
         except Exception as exc:
@@ -1226,9 +1137,7 @@ class DatabrickspipelineSource(PipelineServiceSource):
                 pipeline_name=self.context.get().pipeline,
             )
 
-            pipeline_entity = self.metadata.get_by_name(
-                entity=Pipeline, fqn=pipeline_fqn
-            )
+            pipeline_entity = self.metadata.get_by_name(entity=Pipeline, fqn=pipeline_fqn)
 
             # Extract Kafka topic lineage from source code
             # Works automatically - no configuration required!
@@ -1258,7 +1167,6 @@ class DatabrickspipelineSource(PipelineServiceSource):
                     source = fqn.split_table_name(source_table_full_name)
                     target = fqn.split_table_name(target_table_full_name)
                     for dbservicename in self.get_db_service_names() or ["*"]:
-
                         # Build FQN for source table
                         from_table_fqn = fqn.build(
                             metadata=self.metadata,
@@ -1269,17 +1177,7 @@ class DatabrickspipelineSource(PipelineServiceSource):
                             service_name=dbservicename,
                         )
 
-                        # Check cache first, then fetch if not cached
-                        if from_table_fqn not in self._table_lookup_cache:
-                            self._table_lookup_cache[
-                                from_table_fqn
-                            ] = self.metadata.get_by_name(
-                                entity=Table,
-                                fqn=from_table_fqn,
-                            )
-
-                        from_entity = self._table_lookup_cache[from_table_fqn]
-
+                        from_entity = self._lookup_table(from_table_fqn)
                         if from_entity is None:
                             continue
 
@@ -1293,38 +1191,24 @@ class DatabrickspipelineSource(PipelineServiceSource):
                             service_name=dbservicename,
                         )
 
-                        # Check cache first, then fetch if not cached
-                        if to_table_fqn not in self._table_lookup_cache:
-                            self._table_lookup_cache[
-                                to_table_fqn
-                            ] = self.metadata.get_by_name(
-                                entity=Table,
-                                fqn=to_table_fqn,
-                            )
-
-                        to_entity = self._table_lookup_cache[to_table_fqn]
-
+                        to_entity = self._lookup_table(to_table_fqn)
                         if to_entity is None:
                             continue
 
-                        processed_column_lineage = (
-                            self._process_and_validate_column_lineage(
-                                column_lineage=self.client.get_column_lineage(
-                                    entity_id=entity_id,
-                                    TableKey=(
-                                        source_table_full_name,
-                                        target_table_full_name,
-                                    ),
+                        processed_column_lineage = self._process_and_validate_column_lineage(
+                            column_lineage=self.client.get_column_lineage(
+                                entity_id=entity_id,
+                                TableKey=(
+                                    source_table_full_name,
+                                    target_table_full_name,
                                 ),
-                                from_entity=from_entity,
-                                to_entity=to_entity,
-                            )
+                            ),
+                            from_entity=from_entity,
+                            to_entity=to_entity,
                         )
 
                         lineage_details = LineageDetails(
-                            pipeline=EntityReference(
-                                id=pipeline_entity.id.root, type="pipeline"
-                            ),
+                            pipeline=EntityReference(id=pipeline_entity.id.root, type="pipeline"),
                             source=LineageSource.PipelineLineage,
                             columnsLineage=processed_column_lineage,
                         )
@@ -1355,5 +1239,6 @@ class DatabrickspipelineSource(PipelineServiceSource):
                 )
             )
         finally:
-            # Clear pipeline-specific caches to free memory
-            logger.debug("Clearing table lookup caches for pipeline")
+            # entity lookups stay cached across pipelines on purpose: the same tables
+            # recur, and the caches are bounded. They are released in close().
+            logger.debug("Finished pipeline lineage extraction")

--- a/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/metadata.py
@@ -227,7 +227,9 @@ class DatabrickspipelineSource(PipelineServiceSource):
                     taskType=pipeline_details.settings.task_type,
                     sourceUrl=SourceUrl(job_url),
                     description=(Markdown(task.description) if task.description else None),
-                    downstreamTasks=[depend_task.name for depend_task in task.depends_on or []],
+                    downstreamTasks=[
+                        depend_task.name for depend_task in task.depends_on or [] if depend_task.name
+                    ],
                 )
                 for task in pipeline_details.settings.tasks
             ]
@@ -263,7 +265,10 @@ class DatabrickspipelineSource(PipelineServiceSource):
                 task_status = [
                     TaskStatus(
                         name=str(task.name),
-                        executionStatus=STATUS_MAP.get(run.state.result_state, StatusType.Failed),
+                        executionStatus=STATUS_MAP.get(
+                            run.state.result_state if run.state and run.state.result_state else "",
+                            StatusType.Failed,
+                        ),
                         startTime=Timestamp(run.start_time),
                         endTime=Timestamp(run.end_time) if run.end_time else None,
                         logLink=run.run_page_url,
@@ -998,6 +1003,7 @@ class DatabrickspipelineSource(PipelineServiceSource):
                                                     )
 
                                                     yield Either(
+                                                        left=None,
                                                         right=AddLineageRequest(
                                                             edge=EntitiesEdge(
                                                                 fromEntity=EntityReference(
@@ -1063,22 +1069,15 @@ class DatabrickspipelineSource(PipelineServiceSource):
                                         logger.info(f"   ✅ Creating lineage: {source_fqn} -> {target_fqn}")
 
                                         yield Either(
+                                            left=None,
                                             right=AddLineageRequest(
                                                 edge=EntitiesEdge(
                                                     fromEntity=EntityReference(
-                                                        id=(
-                                                            source_table.id.root
-                                                            if hasattr(source_table.id, "root")
-                                                            else source_table.id
-                                                        ),
+                                                        id=source_table.id,
                                                         type="table",
                                                     ),
                                                     toEntity=EntityReference(
-                                                        id=(
-                                                            target_table.id.root
-                                                            if hasattr(target_table.id, "root")
-                                                            else target_table.id
-                                                        ),
+                                                        id=target_table.id,
                                                         type="table",
                                                     ),
                                                     lineageDetails=LineageDetails(
@@ -1137,7 +1136,12 @@ class DatabrickspipelineSource(PipelineServiceSource):
                 pipeline_name=self.context.get().pipeline,
             )
 
+            if not pipeline_fqn:
+                return
             pipeline_entity = self.metadata.get_by_name(entity=Pipeline, fqn=pipeline_fqn)
+            if not pipeline_entity:
+                logger.debug(f"Pipeline {pipeline_fqn} not found, skipping its lineage")
+                return
 
             # Extract Kafka topic lineage from source code
             # Works automatically - no configuration required!

--- a/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/models.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/models.py
@@ -13,53 +13,54 @@
 Databricks pipeline Source Model module
 """
 
-from typing import Any, Dict, List, Optional
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional  # noqa: UP035
 
 from pydantic import BaseModel, Field
 
 
 class DBRunSchedule(BaseModel):
-    cron: Optional[str] = Field(None, alias="quartz_cron_expression")
-    timezone_id: Optional[str] = None
+    cron: Optional[str] = Field(None, alias="quartz_cron_expression")  # noqa: UP045
+    timezone_id: Optional[str] = None  # noqa: UP045
 
 
 class DependentTask(BaseModel):
-    name: Optional[str] = Field(None, alias="task_key")
+    name: Optional[str] = Field(None, alias="task_key")  # noqa: UP045
 
 
 class PipelineTask(BaseModel):
-    pipeline_id: Optional[str] = None
-    full_refresh: Optional[bool] = None
+    pipeline_id: Optional[str] = None  # noqa: UP045
+    full_refresh: Optional[bool] = None  # noqa: UP045
 
 
 class DBTasks(BaseModel):
-    name: Optional[str] = Field(None, alias="task_key")
-    description: Optional[str] = None
-    depends_on: Optional[List[DependentTask]] = None
-    run_page_url: Optional[str] = None
-    pipeline_task: Optional[PipelineTask] = None
-    notebook_task: Optional[Dict[str, Any]] = None
-    spark_python_task: Optional[Dict[str, Any]] = None
+    name: Optional[str] = Field(None, alias="task_key")  # noqa: UP045
+    description: Optional[str] = None  # noqa: UP045
+    depends_on: Optional[List[DependentTask]] = None  # noqa: UP006, UP045
+    run_page_url: Optional[str] = None  # noqa: UP045
+    pipeline_task: Optional[PipelineTask] = None  # noqa: UP045
+    notebook_task: Optional[Dict[str, Any]] = None  # noqa: UP006, UP045
+    spark_python_task: Optional[Dict[str, Any]] = None  # noqa: UP006, UP045
 
 
 class DBSettings(BaseModel):
-    name: Optional[str] = None
-    timeout_seconds: Optional[int] = 0
-    max_concurrent_runs: Optional[int] = 0
-    description: Optional[str] = None
-    schedule: Optional[DBRunSchedule] = None
-    task_type: Optional[str] = Field(None, alias="format")
-    tasks: Optional[List[DBTasks]] = None
+    name: Optional[str] = None  # noqa: UP045
+    timeout_seconds: Optional[int] = 0  # noqa: UP045
+    max_concurrent_runs: Optional[int] = 0  # noqa: UP045
+    description: Optional[str] = None  # noqa: UP045
+    schedule: Optional[DBRunSchedule] = None  # noqa: UP045
+    task_type: Optional[str] = Field(None, alias="format")  # noqa: UP045
+    tasks: Optional[List[DBTasks]] = None  # noqa: UP006, UP045
 
 
 class DataBrickPipelineDetails(BaseModel):
-    job_id: Optional[int] = None
-    pipeline_id: Optional[str] = None
-    creator_user_name: Optional[str] = None
-    settings: Optional[DBSettings] = None
-    created_time: Optional[int] = None
-    name: Optional[str] = None
-    pipeline_type: Optional[str] = None
+    job_id: Optional[int] = None  # noqa: UP045
+    pipeline_id: Optional[str] = None  # noqa: UP045
+    creator_user_name: Optional[str] = None  # noqa: UP045
+    settings: Optional[DBSettings] = None  # noqa: UP045
+    created_time: Optional[int] = None  # noqa: UP045
+    name: Optional[str] = None  # noqa: UP045
+    pipeline_type: Optional[str] = None  # noqa: UP045
 
     @property
     def id(self) -> str:
@@ -67,22 +68,81 @@ class DataBrickPipelineDetails(BaseModel):
 
 
 class DBRunState(BaseModel):
-    life_cycle_state: Optional[str] = None
-    result_state: Optional[str] = None
-    state_message: Optional[str] = None
-    queue_reason: Optional[str] = None
+    life_cycle_state: Optional[str] = None  # noqa: UP045
+    result_state: Optional[str] = None  # noqa: UP045
+    state_message: Optional[str] = None  # noqa: UP045
+    queue_reason: Optional[str] = None  # noqa: UP045
 
 
 class DBRun(BaseModel):
     job_id: int
     run_id: int
-    name: Optional[str] = Field(None, alias="run_name")
-    creator_user_name: Optional[str] = None
-    state: Optional[DBRunState] = None
-    schedule: Optional[DBRunSchedule] = None
-    description: Optional[str] = None
-    tasks: Optional[List[DBTasks]] = None
-    run_type: Optional[str] = None
-    start_time: Optional[int] = 0
-    end_time: Optional[int] = 0
-    run_page_url: Optional[str] = None
+    name: Optional[str] = Field(None, alias="run_name")  # noqa: UP045
+    creator_user_name: Optional[str] = None  # noqa: UP045
+    state: Optional[DBRunState] = None  # noqa: UP045
+    schedule: Optional[DBRunSchedule] = None  # noqa: UP045
+    description: Optional[str] = None  # noqa: UP045
+    tasks: Optional[List[DBTasks]] = None  # noqa: UP006, UP045
+    run_type: Optional[str] = None  # noqa: UP045
+    start_time: Optional[int] = 0  # noqa: UP045
+    end_time: Optional[int] = 0  # noqa: UP045
+    run_page_url: Optional[str] = None  # noqa: UP045
+
+
+@dataclass
+class KafkaSourceConfig:
+    """Kafka source configuration read out of a DLT pipeline's source code"""
+
+    bootstrap_servers: Optional[str] = None  # noqa: UP045
+    topics: List[str] = field(default_factory=list)  # noqa: UP006
+    group_id_prefix: Optional[str] = None  # noqa: UP045
+
+
+@dataclass
+class DLTLibrarySource:
+    """
+    One source location a DLT pipeline declares in `spec.libraries`.
+
+    A library is either a concrete file or a directory to expand. The pipelines
+    API accepts nothing else, so there is no pattern to carry and a directory is
+    always taken in full.
+    """
+
+    path: str
+    # True and False come from the spec. None means it did not say, which happens
+    # for an include carrying neither a `**` nor a trailing slash, and is settled
+    # by listing the path rather than by guessing from its shape.
+    is_directory: Optional[bool] = False  # noqa: UP045
+
+
+@dataclass
+class DLTTableReference:
+    """
+    Where a DLT dataset reference points, once resolved.
+
+    A reference is written either bare (`orders`, a sibling dataset in the same
+    pipeline) or qualified (`catalog.schema.orders`). Both forms resolve into
+    these three named parts, so callers never index into a positional tuple.
+    """
+
+    catalog: Optional[str]  # noqa: UP045
+    schema: Optional[str]  # noqa: UP045
+    table: str
+
+
+@dataclass
+class DLTTableDependency:
+    """
+    One dataset declared by a DLT pipeline, plus what it reads from.
+
+    `depends_on` entries are returned exactly as the pipeline source spells them.
+    A bare name is a sibling dataset in the same pipeline and gets resolved against
+    the pipeline's target catalog and schema. A qualified name already says where
+    the table lives and is resolved as written.
+    """
+
+    table_name: str
+    depends_on: List[str] = field(default_factory=list)  # noqa: UP006
+    reads_from_kafka: bool = False
+    reads_from_s3: bool = False
+    s3_locations: List[str] = field(default_factory=list)  # noqa: UP006

--- a/ingestion/tests/unit/topology/database/test_unitycatalog_self_referencing_lineage.py
+++ b/ingestion/tests/unit/topology/database/test_unitycatalog_self_referencing_lineage.py
@@ -1,0 +1,111 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+A table is never cached as its own upstream.
+
+`system.access.table_lineage` records table access rather than derivation, so a
+streaming or CDC write legitimately names its target table as its own source.
+Those rows must not reach the lineage map, or the table ends up in its own
+upstream set and is later emitted as an edge pointing at itself.
+"""
+
+from collections import defaultdict
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.source.database.unitycatalog.lineage import (
+    UnitycatalogLineageSource,
+)
+
+CATALOG, SCHEMA = "analytics", "sales"
+EVENT_LOG = f"{CATALOG}.{SCHEMA}.orders_event_log"
+SNAPSHOT = f"{CATALOG}.{SCHEMA}.orders_snapshot"
+
+
+def _row(source_table: str, target_table: str) -> SimpleNamespace:
+    return SimpleNamespace(source_table_full_name=source_table, target_table_full_name=target_table)
+
+
+def _column_row(source_table: str, target_table: str, column: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        source_table_full_name=source_table,
+        target_table_full_name=target_table,
+        source_column_name=column,
+        target_column_name=column,
+    )
+
+
+def _source(rows, column_rows=None):
+    """The real caching method, with only the SQL connection stubbed."""
+    with patch.object(UnitycatalogLineageSource, "__init__", lambda s: None):
+        source = UnitycatalogLineageSource()
+
+    source.table_lineage_map = defaultdict(set)
+    source.source_config = MagicMock()
+    source.source_config.queryLogDuration = 1
+
+    source.column_lineage_map = defaultdict(list)
+
+    connection = MagicMock()
+    # _cache_lineage runs the table query first, then the column query
+    connection.execute.side_effect = [rows, column_rows if column_rows is not None else []]
+    engine = MagicMock()
+    engine.connect.return_value.__enter__ = MagicMock(return_value=connection)
+    engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    source.engine = engine
+    return source
+
+
+class TestSelfReferencingLineageCache:
+    def test_a_self_referencing_row_is_not_cached(self):
+        source = _source([_row(EVENT_LOG, EVENT_LOG)])
+        source._cache_lineage()
+        assert EVENT_LOG not in source.table_lineage_map.get(EVENT_LOG, set())
+        assert sum(len(v) for v in source.table_lineage_map.values()) == 0
+
+    def test_a_normal_row_is_still_cached(self):
+        source = _source([_row(EVENT_LOG, SNAPSHOT)])
+        source._cache_lineage()
+        assert source.table_lineage_map[SNAPSHOT] == {EVENT_LOG}
+
+    def test_only_the_self_reference_is_dropped(self):
+        """The guard must not suppress real upstreams of the same table."""
+        source = _source(
+            [
+                _row(EVENT_LOG, SNAPSHOT),
+                _row(SNAPSHOT, SNAPSHOT),
+                _row(EVENT_LOG, EVENT_LOG),
+            ]
+        )
+        source._cache_lineage()
+        assert source.table_lineage_map[SNAPSHOT] == {EVENT_LOG}
+        assert source.table_lineage_map.get(EVENT_LOG, set()) == set()
+
+
+class TestSelfReferencingColumnLineageCache:
+    """A self-pair's columns are unreadable once its table pair is dropped."""
+
+    def test_self_referencing_columns_are_not_cached(self):
+        source = _source(
+            [_row(EVENT_LOG, EVENT_LOG)],
+            column_rows=[_column_row(EVENT_LOG, EVENT_LOG, "id")],
+        )
+        source._cache_lineage()
+        assert (EVENT_LOG, EVENT_LOG) not in source.column_lineage_map
+        assert sum(len(v) for v in source.column_lineage_map.values()) == 0
+
+    def test_normal_columns_are_still_cached(self):
+        source = _source(
+            [_row(EVENT_LOG, SNAPSHOT)],
+            column_rows=[_column_row(EVENT_LOG, SNAPSHOT, "id")],
+        )
+        source._cache_lineage()
+        assert source.column_lineage_map[(EVENT_LOG, SNAPSHOT)] == [("id", "id")]

--- a/ingestion/tests/unit/topology/pipeline/test_databricks_dlt_sql_lineage.py
+++ b/ingestion/tests/unit/topology/pipeline/test_databricks_dlt_sql_lineage.py
@@ -920,3 +920,40 @@ class TestNullLibrariesInSpec:
     def test_an_empty_libraries_list_still_reaches_the_source_path_fallback(self):
         spec = {"catalog": CATALOG, "schema": SCHEMA, "libraries": [], "configuration": {"source_path": "/src/"}}
         assert self._listed_paths(spec) == ["/src/"]
+
+
+class TestWildcardWithNoDirectory:
+    """
+    An include whose wildcard has nothing before it has no directory to reduce to.
+    Falling back to `/` would list the whole workspace, which costs far more than
+    resolving nothing at all.
+    """
+
+    def test_a_bare_wildcard_is_returned_unchanged(self):
+        for include in ("**", "*", "*.sql", "?.sql"):
+            assert glob_base_directory(include) == include, include
+
+    def test_a_first_segment_wildcard_is_returned_unchanged(self):
+        """`/tx*` reduces to `/`, so it is left alone for the same reason."""
+        for include in ("/tx*", "/tx**", "/*.sql"):
+            assert glob_base_directory(include) == include, include
+
+    def test_an_include_with_a_directory_still_reduces(self):
+        assert glob_base_directory("/tx/**") == "/tx/"
+        assert glob_base_directory("/tx/staging*") == "/tx/"
+        assert glob_base_directory("/tx/") == "/tx/"
+        assert glob_base_directory("/a/b/tx*") == "/a/b/"
+
+    def test_a_concrete_path_is_still_left_alone(self):
+        assert glob_base_directory("/tx/one.sql") == "/tx/one.sql"
+
+    def test_the_workspace_root_is_never_expanded(self):
+        """The listing must start where the include points, never at `/`."""
+        with patch.object(DatabrickspipelineSource, "__init__", lambda s, a, b: None):
+            source = DatabrickspipelineSource(None, None)
+        source.client = MagicMock()
+        source.client.list_workspace_objects.return_value = []
+        library = DLTLibrarySource(path=glob_base_directory("**"))
+        source._expand_workspace_directory(library)
+        listed = [call.args[0] for call in source.client.list_workspace_objects.call_args_list]
+        assert "/" not in listed

--- a/ingestion/tests/unit/topology/pipeline/test_databricks_dlt_sql_lineage.py
+++ b/ingestion/tests/unit/topology/pipeline/test_databricks_dlt_sql_lineage.py
@@ -1,0 +1,922 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Lineage extraction for SQL-defined Delta Live Tables pipelines.
+
+Before SQL support, `kafka_parser` only recognised the Python DLT API (`@dlt.table`
+and `@dlt.view`), so a pipeline whose transformations are `.sql` files parsed to
+nothing and the connector logged "Skipping lineage for this notebook - no DLT tables
+found" for every file, even though the upstream references in those files are real,
+fully qualified and resolvable.
+
+The SQL below covers the shapes a SQL DLT pipeline uses: a single-line
+`CREATE MATERIALIZED VIEW`, a `CREATE OR REFRESH` variant, the view name on its
+own line, three-part qualified upstreams, and dependencies on sibling views
+declared elsewhere in the same pipeline.
+"""
+
+import uuid
+from typing import ClassVar
+from unittest.mock import MagicMock, patch
+
+from ingestion.tests.unit.topology.pipeline.test_databricks_pipeline import (
+    mock_databricks_config,
+)
+from metadata.generated.schema.entity.data.table import Table
+from metadata.generated.schema.metadataIngestion.workflow import (
+    OpenMetadataWorkflowConfig,
+)
+from metadata.ingestion.ometa.utils import model_str
+from metadata.ingestion.source.pipeline.databrickspipeline.dlt_parsers import (
+    DLT_PARSERS,
+    PythonDltParser,
+    SqlDltParser,
+    extract_dlt_table_dependencies,
+)
+from metadata.ingestion.source.pipeline.databrickspipeline.kafka_parser import (
+    get_pipeline_libraries,
+    glob_base_directory,
+)
+from metadata.ingestion.source.pipeline.databrickspipeline.metadata import (
+    DatabrickspipelineSource,
+)
+from metadata.ingestion.source.pipeline.databrickspipeline.models import (
+    DataBrickPipelineDetails,
+    DLTLibrarySource,
+    DLTTableReference,
+)
+
+DB_SERVICE = "databricks_pipeline_test"
+CATALOG = "demo_catalog"
+SCHEMA = "demo_schema"
+TRANSFORMATIONS_DIR = "/Repos/demo/transformations/"
+
+# Single-line CREATE, depends on two sibling views declared in the same pipeline
+SQL_SINGLE_LINE_CREATE = """-- join staged orders to their computed totals
+CREATE MATERIALIZED VIEW orders_enriched CLUSTER BY (order_id) AS
+    SELECT
+        s.* ,
+        t.amount
+    FROM orders_staged s
+        LEFT JOIN order_totals t
+        ON t.order_id = s.order_id
+"""
+
+# CREATE OR REFRESH, two three-part qualified upstreams
+SQL_QUALIFIED_UPSTREAMS = """CREATE OR REFRESH MATERIALIZED VIEW customer_orders CLUSTER BY (order_id)
+AS
+SELECT
+    c.customer_id,
+    c.region,
+    o.order_id
+FROM raw_catalog.raw_schema.orders_raw o
+INNER JOIN
+raw_catalog.raw_schema.customers_raw c
+ON o.customer_id = c.customer_id
+WHERE o.status = "complete"
+"""
+
+# View name on its own line, mixes a qualified upstream with a sibling view
+SQL_MULTILINE_CREATE = """CREATE OR REFRESH MATERIALIZED VIEW
+    order_summary
+CLUSTER BY (order_id)
+AS
+SELECT
+  e.*,
+  t.amount
+FROM raw_catalog.raw_schema.events_raw AS e
+INNER JOIN order_totals t
+  ON e.order_id = t.order_id
+"""
+
+# The Python DLT shape that already works, kept as a regression guard
+PYTHON_DLT = """
+import dlt
+
+@dlt.table(name="events_bronze")
+def build_events():
+    return spark.readStream.format("kafka") \\
+        .option("kafka.bootstrap.servers", "broker:9092") \\
+        .option("subscribe", "events_topic") \\
+        .load()
+
+@dlt.table(name="events_silver")
+def refine_events():
+    return dlt.read_stream("events_bronze")
+"""
+
+SQL_FILES = {
+    "orders_enriched.sql": SQL_SINGLE_LINE_CREATE,
+    "customer_orders.sql": SQL_QUALIFIED_UPSTREAMS,
+    "order_summary.sql": SQL_MULTILINE_CREATE,
+}
+
+
+def _deps_by_name(source_code):
+    return {dep.table_name: dep for dep in extract_dlt_table_dependencies(source_code)}
+
+
+class TestPythonDltStillParses:
+    """Guard so SQL support does not regress the Python DLT path."""
+
+    def test_python_decorators_are_parsed(self):
+        deps = _deps_by_name(PYTHON_DLT)
+        assert set(deps) == {"events_bronze", "events_silver"}
+        assert deps["events_bronze"].reads_from_kafka is True
+        assert deps["events_silver"].depends_on == ["events_bronze"]
+
+
+class TestSqlDltParsing:
+    """SQL-defined DLT must produce the same DLTTableDependency records."""
+
+    def test_single_line_create_materialized_view(self):
+        deps = _deps_by_name(SQL_SINGLE_LINE_CREATE)
+        assert "orders_enriched" in deps
+        assert set(deps["orders_enriched"].depends_on) == {
+            "orders_staged",
+            "order_totals",
+        }
+
+    def test_create_or_refresh_with_qualified_upstreams(self):
+        deps = _deps_by_name(SQL_QUALIFIED_UPSTREAMS)
+        assert "customer_orders" in deps
+        assert set(deps["customer_orders"].depends_on) == {
+            "raw_catalog.raw_schema.orders_raw",
+            "raw_catalog.raw_schema.customers_raw",
+        }
+
+    def test_view_name_on_its_own_line(self):
+        deps = _deps_by_name(SQL_MULTILINE_CREATE)
+        assert "order_summary" in deps
+        assert set(deps["order_summary"].depends_on) == {
+            "raw_catalog.raw_schema.events_raw",
+            "order_totals",
+        }
+
+    def test_sql_files_are_not_silently_skipped(self):
+        """Every SQL transformation must contribute at least one table."""
+        empty = [name for name, sql in SQL_FILES.items() if not extract_dlt_table_dependencies(sql)]
+        assert not empty, f"SQL DLT files parsed to nothing: {empty}"
+
+
+class TestSqlDltPipelineLineage:
+    """End to end through the connector, with only the Databricks client stubbed."""
+
+    # The tables that exist in OpenMetadata. Anything the connector asks for outside
+    # this set resolves to None, so a wrongly built FQN drops the edge instead of
+    # quietly succeeding.
+    EXISTING_TABLES: ClassVar[set] = {
+        f"{DB_SERVICE}.{CATALOG}.{SCHEMA}.orders_enriched",
+        f"{DB_SERVICE}.{CATALOG}.{SCHEMA}.customer_orders",
+        f"{DB_SERVICE}.{CATALOG}.{SCHEMA}.order_summary",
+        f"{DB_SERVICE}.{CATALOG}.{SCHEMA}.orders_staged",
+        f"{DB_SERVICE}.{CATALOG}.{SCHEMA}.order_totals",
+        f"{DB_SERVICE}.raw_catalog.raw_schema.orders_raw",
+        f"{DB_SERVICE}.raw_catalog.raw_schema.customers_raw",
+        f"{DB_SERVICE}.raw_catalog.raw_schema.events_raw",
+    }
+
+    @classmethod
+    def _build_source(cls):
+        """
+        Build the source through its real `create()`, patching only the external
+        boundary. Nothing about the connector's internals (caches included) is
+        assembled here, so an implementation change cannot leave this test
+        asserting against a shape production no longer uses.
+        """
+        with patch("metadata.ingestion.source.pipeline.pipeline_service.PipelineServiceSource.test_connection"):
+            source = DatabrickspipelineSource.create(
+                mock_databricks_config["source"],
+                OpenMetadataWorkflowConfig.model_validate(
+                    mock_databricks_config
+                ).workflowConfig.openMetadataServerConfig,
+            )
+
+        client = MagicMock()
+        client.get_pipeline_details.return_value = {
+            "pipeline_id": "pipeline-uuid",
+            "spec": {
+                "catalog": CATALOG,
+                "schema": SCHEMA,
+                "libraries": [{"glob": {"include": TRANSFORMATIONS_DIR + "**"}}],
+            },
+        }
+        client.list_workspace_objects.return_value = [
+            {"object_type": "FILE", "path": TRANSFORMATIONS_DIR + name} for name in SQL_FILES
+        ]
+        client.export_notebook_source.side_effect = lambda path: SQL_FILES[path.rsplit("/", 1)[-1]]
+        client.get_table_lineage.return_value = []
+        client.get_column_lineage.return_value = []
+        source.client = client
+
+        source._databricks_services_cached = True
+        source._databricks_services = [DB_SERVICE]
+
+        metadata = MagicMock()
+        metadata.client.get.return_value = {"hits": {"hits": []}}
+        # force FQN building to go through the explicit service.catalog.schema.table path
+        metadata.es_search_from_fqn.return_value = None
+
+        ids_to_fqn = {}
+
+        def get_by_name(entity=None, fqn=None, **_):
+            name = str(fqn)
+            if entity is not Table or name not in cls.EXISTING_TABLES:
+                return None
+            table = MagicMock(spec=Table)
+            table.id = uuid.uuid4()
+            table.fullyQualifiedName = name
+            table.columns = []
+            ids_to_fqn[str(table.id)] = name
+            return table
+
+        metadata.get_by_name.side_effect = get_by_name
+        source.metadata = metadata
+        return source, ids_to_fqn
+
+    def _edges(self):
+        source, ids_to_fqn = self._build_source()
+        pipeline_entity = MagicMock()
+        pipeline_entity.id.root = uuid.uuid4()
+
+        requests = [
+            either.right
+            for either in source._yield_kafka_lineage(
+                DataBrickPipelineDetails(pipeline_id="pipeline-uuid", name="demo_sql_dlt"),
+                pipeline_entity,
+            )
+            if getattr(either, "right", None) is not None
+        ]
+        return {
+            (
+                ids_to_fqn.get(model_str(r.edge.fromEntity.id)),
+                ids_to_fqn.get(model_str(r.edge.toEntity.id)),
+            )
+            for r in requests
+        }
+
+    def test_sql_dlt_pipeline_yields_table_lineage(self):
+        assert self._edges(), "SQL DLT pipeline produced no lineage at all"
+
+    def test_bare_upstreams_resolve_against_the_pipeline_target(self):
+        """A sibling dataset resolves under the pipeline's own catalog and schema."""
+        assert (
+            f"{DB_SERVICE}.{CATALOG}.{SCHEMA}.orders_staged",
+            f"{DB_SERVICE}.{CATALOG}.{SCHEMA}.orders_enriched",
+        ) in self._edges()
+
+    def test_qualified_upstreams_keep_their_own_catalog_and_schema(self):
+        """A three-part upstream must NOT be nested under the pipeline target."""
+        edges = self._edges()
+        assert (
+            f"{DB_SERVICE}.raw_catalog.raw_schema.orders_raw",
+            f"{DB_SERVICE}.{CATALOG}.{SCHEMA}.customer_orders",
+        ) in edges
+        assert not any(
+            "raw_catalog" in (src or "") and src.startswith(f"{DB_SERVICE}.{CATALOG}.{SCHEMA}.") for src, _ in edges
+        ), "qualified upstream was nested under the pipeline catalog/schema"
+
+    def test_all_expected_edges_are_produced(self):
+        assert self._edges() == {
+            (
+                f"{DB_SERVICE}.{CATALOG}.{SCHEMA}.orders_staged",
+                f"{DB_SERVICE}.{CATALOG}.{SCHEMA}.orders_enriched",
+            ),
+            (
+                f"{DB_SERVICE}.{CATALOG}.{SCHEMA}.order_totals",
+                f"{DB_SERVICE}.{CATALOG}.{SCHEMA}.orders_enriched",
+            ),
+            (
+                f"{DB_SERVICE}.raw_catalog.raw_schema.orders_raw",
+                f"{DB_SERVICE}.{CATALOG}.{SCHEMA}.customer_orders",
+            ),
+            (
+                f"{DB_SERVICE}.raw_catalog.raw_schema.customers_raw",
+                f"{DB_SERVICE}.{CATALOG}.{SCHEMA}.customer_orders",
+            ),
+            (
+                f"{DB_SERVICE}.raw_catalog.raw_schema.events_raw",
+                f"{DB_SERVICE}.{CATALOG}.{SCHEMA}.order_summary",
+            ),
+            (
+                f"{DB_SERVICE}.{CATALOG}.{SCHEMA}.order_totals",
+                f"{DB_SERVICE}.{CATALOG}.{SCHEMA}.order_summary",
+            ),
+        }
+
+
+class TestParserDispatch:
+    """The registry must pick the right language, whatever the source contains."""
+
+    def test_python_is_checked_before_sql(self):
+        """Order is the dispatch rule, so it is asserted rather than assumed."""
+        assert [PythonDltParser, SqlDltParser] == DLT_PARSERS
+
+    def test_python_wins_over_embedded_sql(self):
+        """A Python notebook that builds SQL strings must not be read as SQL."""
+        source = """
+import dlt
+spark.sql("CREATE OR REFRESH MATERIALIZED VIEW sneaky AS SELECT * FROM raw_catalog.raw_schema.other")
+
+@dlt.table(name="real_table")
+def build():
+    return dlt.read("upstream_ds")
+"""
+        deps = _deps_by_name(source)
+        assert set(deps) == {"real_table"}
+        assert deps["real_table"].depends_on == ["upstream_ds"]
+
+    def test_dlt_view_without_a_name_is_recognised(self):
+        """`@dlt.view()` takes no name argument, so detection must not require one."""
+        source = """
+@dlt.view()
+def staged():
+    return spark.read.json("s3://bucket/data/")
+"""
+        assert PythonDltParser.handles(source) is True
+        assert extract_dlt_table_dependencies(source)
+
+    def test_unrecognised_source_yields_nothing(self):
+        assert extract_dlt_table_dependencies("print('not a dlt pipeline')") == []
+        assert extract_dlt_table_dependencies("") == []
+        assert extract_dlt_table_dependencies(None) == []
+
+
+class TestSqlDltEdgeCases:
+    """Databricks SQL constructs that a plain CREATE ... SELECT reader would miss."""
+
+    def test_apply_changes_into_keeps_its_source(self):
+        """CDC pipelines declare the table, then populate it with APPLY CHANGES INTO."""
+        source = (
+            "CREATE OR REFRESH STREAMING TABLE customers_cdc;\n"
+            "APPLY CHANGES INTO live.customers_cdc "
+            "FROM STREAM(raw_catalog.raw_schema.customers_raw) KEYS (id) SEQUENCE BY ts"
+        )
+        deps = _deps_by_name(source)
+        assert deps["customers_cdc"].depends_on == ["raw_catalog.raw_schema.customers_raw"]
+
+    def test_live_prefix_resolves_to_a_sibling_dataset(self):
+        """`LIVE.x` is a pipeline namespace, not a schema called `live`."""
+        deps = _deps_by_name("CREATE MATERIALIZED VIEW gold AS SELECT * FROM LIVE.silver JOIN live.bronze USING (id)")
+        assert set(deps["gold"].depends_on) == {"silver", "bronze"}
+
+    def test_table_valued_functions_are_not_treated_as_tables(self):
+        """Auto Loader reads have no upstream entity to resolve."""
+        assert (
+            _deps_by_name(
+                "CREATE OR REFRESH STREAMING TABLE raw AS "
+                "SELECT * FROM STREAM read_files('/mnt/data', format => 'json')"
+            )["raw"].depends_on
+            == []
+        )
+        assert (
+            _deps_by_name("CREATE OR REFRESH STREAMING TABLE raw2 AS SELECT * FROM cloud_files('/mnt/data', 'json')")[
+                "raw2"
+            ].depends_on
+            == []
+        )
+
+    def test_streaming_table_and_backticked_identifiers(self):
+        deps = _deps_by_name(
+            "CREATE OR REFRESH STREAMING TABLE `bronze` AS SELECT * FROM `raw_catalog`.`raw_schema`.`src`"
+        )
+        assert deps["bronze"].depends_on == ["raw_catalog.raw_schema.src"]
+
+    def test_cte_does_not_leak_as_an_upstream(self):
+        deps = _deps_by_name(
+            "CREATE MATERIALIZED VIEW c AS WITH staged AS "
+            "(SELECT * FROM raw_catalog.raw_schema.orders_raw) SELECT * FROM staged"
+        )
+        assert deps["c"].depends_on == ["raw_catalog.raw_schema.orders_raw"]
+
+    def test_unparseable_statement_is_skipped_not_raised(self):
+        assert extract_dlt_table_dependencies("CREATE MATERIALIZED VIEW broken AS SELECT FROM WHERE ((") == []
+
+    def test_multiple_statements_in_one_file(self):
+        deps = _deps_by_name(
+            "CREATE MATERIALIZED VIEW a AS SELECT * FROM raw_catalog.raw_schema.t1;\n"
+            "CREATE MATERIALIZED VIEW b AS SELECT * FROM raw_catalog.raw_schema.t2"
+        )
+        assert deps["a"].depends_on == ["raw_catalog.raw_schema.t1"]
+        assert deps["b"].depends_on == ["raw_catalog.raw_schema.t2"]
+
+
+class TestQualifyDltTableName:
+    """Resolution of a dataset reference against the pipeline's target."""
+
+    @staticmethod
+    def _resolve(name):
+        return DatabrickspipelineSource._qualify_dlt_table_name(name, "cat", "sch")
+
+    def test_bare_name_uses_the_pipeline_target(self):
+        assert self._resolve("orders") == DLTTableReference(catalog="cat", schema="sch", table="orders")
+
+    def test_two_part_name_overrides_only_the_schema(self):
+        assert self._resolve("other.orders") == DLTTableReference(catalog="cat", schema="other", table="orders")
+
+    def test_three_part_name_overrides_both(self):
+        assert self._resolve("c2.s2.orders") == DLTTableReference(catalog="c2", schema="s2", table="orders")
+
+    def test_extra_qualifiers_keep_the_last_three_parts(self):
+        assert self._resolve("x.c2.s2.orders") == DLTTableReference(catalog="c2", schema="s2", table="orders")
+
+    def test_empty_name_falls_back_to_the_pipeline_target(self):
+        assert self._resolve("") == DLTTableReference(catalog="cat", schema="sch", table="")
+
+    def test_surrounding_whitespace_and_stray_dots_are_stripped(self):
+        for raw in ("  orders  ", "orders.", ".orders"):
+            assert self._resolve(raw) == DLTTableReference(catalog="cat", schema="sch", table="orders")
+
+
+class TestGlobNormalisation:
+    """`spec.libraries` glob patterns must reduce to a directory the caller can expand."""
+
+    def test_recursive_and_extension_patterns_reduce_to_a_directory(self):
+        for pattern in (
+            "/tx/**",
+            "/tx/*.sql",
+            "/tx/**/*.sql",
+            "/tx/**/*.py",
+            "/tx/staging*",
+        ):
+            assert glob_base_directory(pattern) == "/tx/", pattern
+
+    def test_a_concrete_path_is_left_alone(self):
+        assert glob_base_directory("/tx/one.sql") == "/tx/one.sql"
+
+    def test_a_glob_library_reduces_to_a_known_directory(self):
+        libraries = get_pipeline_libraries({"libraries": [{"glob": {"include": "/tx/**"}}]})
+        assert libraries == [DLTLibrarySource(path="/tx/", is_directory=True)]
+
+    def test_all_library_shapes_are_collected(self):
+        libraries = get_pipeline_libraries(
+            {
+                "libraries": [
+                    {"notebook": {"path": "/repo/nb"}},
+                    {"file": {"path": "/repo/transform.sql"}},
+                    {"glob": {"include": "/repo/tx/**"}},
+                    {"unknown": {"path": "/ignored"}},
+                    "not-a-dict",
+                ]
+            }
+        )
+        assert libraries == [
+            DLTLibrarySource(path="/repo/nb"),
+            DLTLibrarySource(path="/repo/transform.sql"),
+            DLTLibrarySource(path="/repo/tx/", is_directory=True),
+        ]
+
+    def test_missing_or_empty_config_is_safe(self):
+        assert get_pipeline_libraries({}) == []
+        assert get_pipeline_libraries({"libraries": None}) == []
+
+
+class TestSqlUpstreamHygiene:
+    """Upstream lists must be de-duplicated and must not drop real datasets."""
+
+    def test_live_prefix_and_bare_name_collapse_to_one_dependency(self):
+        deps = _deps_by_name(
+            "CREATE MATERIALIZED VIEW g AS SELECT * FROM LIVE.silver JOIN silver s ON s.id = LIVE.silver.id"
+        )
+        assert deps["g"].depends_on == ["silver"]
+
+    def test_table_valued_function_dropped_only_when_invoked(self):
+        """A dataset may legitimately be named `range`, so filter on call form."""
+        assert _deps_by_name("CREATE MATERIALIZED VIEW m AS SELECT * FROM range")["m"].depends_on == ["range"]
+        assert _deps_by_name("CREATE MATERIALIZED VIEW m AS SELECT * FROM range(1, 10)")["m"].depends_on == []
+
+
+class TestConnectorCaches:
+    """
+    The connector's entity caches are part of its contract, so they are asserted
+    against the real object rather than a stub. CLAUDE.md requires every cache to
+    be bounded.
+    """
+
+    @staticmethod
+    def _real_source():
+        with patch("metadata.ingestion.source.pipeline.pipeline_service.PipelineServiceSource.test_connection"):
+            return DatabrickspipelineSource.create(
+                mock_databricks_config["source"],
+                OpenMetadataWorkflowConfig.model_validate(
+                    mock_databricks_config
+                ).workflowConfig.openMetadataServerConfig,
+            )
+
+    def test_entity_caches_are_bounded(self):
+        source = self._real_source()
+        for cache in (source._table_lookup_cache, source._dlt_table_cache):
+            assert hasattr(cache, "capacity"), "caches must be bounded, not plain dicts"
+            assert cache.capacity > 0
+
+    def test_cache_evicts_beyond_capacity(self):
+        source = self._real_source()
+        capacity = source._dlt_table_cache.capacity
+        for index in range(capacity + 10):
+            source._dlt_table_cache.put(f"cat.sch.table_{index}", None)
+        assert len(source._dlt_table_cache) == capacity
+
+    def test_lookup_caches_misses_so_absent_tables_are_asked_for_once(self):
+        source = self._real_source()
+        source.metadata = MagicMock()
+        source.metadata.get_by_name.return_value = None
+
+        assert source._lookup_table("svc.cat.sch.missing") is None
+        assert source._lookup_table("svc.cat.sch.missing") is None
+        assert source.metadata.get_by_name.call_count == 1
+
+    def test_lookup_of_an_unbuildable_fqn_never_reaches_the_server(self):
+        source = self._real_source()
+        source.metadata = MagicMock()
+        assert source._lookup_table(None) is None
+        source.metadata.get_by_name.assert_not_called()
+
+
+class TestGlobExpansion:
+    """
+    A library directory is taken in full. The pipelines API accepts only an exact
+    file or a directory, so there is no narrower selection to honour and nothing
+    to filter the listing against.
+    """
+
+    WORKSPACE: ClassVar[dict] = {
+        "/tx/": [
+            {"object_type": "FILE", "path": "/tx/a.sql"},
+            {"object_type": "FILE", "path": "/tx/notes.py"},
+            {"object_type": "DIRECTORY", "path": "/tx/archive"},
+        ],
+        "/tx/archive/": [{"object_type": "FILE", "path": "/tx/archive/old_v1.sql"}],
+    }
+    WHOLE_TREE: ClassVar[list] = ["/tx/a.sql", "/tx/notes.py", "/tx/archive/old_v1.sql"]
+
+    def _source(self):
+        with patch.object(DatabrickspipelineSource, "__init__", lambda s, a, b: None):
+            source = DatabrickspipelineSource(None, None)
+        source.client = MagicMock()
+        source.client.list_workspace_objects.side_effect = lambda path: self.WORKSPACE.get(path, [])
+        return source
+
+    def _expand(self, include):
+        return self._source()._expand_workspace_directory(DLTLibrarySource(path=glob_base_directory(include)))
+
+    def test_a_recursive_include_takes_the_whole_tree(self):
+        assert self._expand("/tx/**") == self.WHOLE_TREE
+
+    def test_a_slash_terminated_include_takes_the_whole_tree(self):
+        assert self._expand("/tx/") == self.WHOLE_TREE
+
+    def test_subdirectories_are_walked_rather_than_listed_once(self):
+        """`workspace/list` returns immediate children only, so nesting needs recursion."""
+        assert "/tx/archive/old_v1.sql" in self._expand("/tx/**")
+
+    def test_a_directory_without_a_trailing_slash_takes_everything_below_it(self):
+        """A source_path fallback points at a tree, not one level of it."""
+        assert self._source()._expand_workspace_directory(DLTLibrarySource(path="/tx/")) == self.WHOLE_TREE
+
+    def test_depth_is_capped(self):
+        source = self._source()
+        source.client.list_workspace_objects.side_effect = lambda path: [
+            {"object_type": "DIRECTORY", "path": f"{path}d"}
+        ]
+        assert source._expand_workspace_directory(DLTLibrarySource(path="/tx/"), max_depth=3) == []
+
+
+class TestLibraryListIsHomogeneous:
+    """
+    Every entry the connector collects must be a DLTLibrarySource. A raw string
+    slipping in reaches `library.is_directory` and kills lineage for that pipeline,
+    so the spec shapes that produce entries are each covered here.
+    """
+
+    @staticmethod
+    def _libraries_for(spec):
+        with patch.object(DatabrickspipelineSource, "__init__", lambda s, a, b: None):
+            source = DatabrickspipelineSource(None, None)
+        client = MagicMock()
+        client.get_pipeline_details.return_value = {"pipeline_id": "p", "spec": spec}
+        client.list_workspace_objects.return_value = []
+        client.export_notebook_source.return_value = ""
+        client.get_table_lineage.return_value = []
+        client.get_column_lineage.return_value = []
+        source.client = client
+        source.metadata = MagicMock()
+        source._databricks_services_cached = True
+        source._databricks_services = [DB_SERVICE]
+
+        seen = []
+        original = DatabrickspipelineSource._expand_workspace_directory
+
+        def record(self, library, *args, **kwargs):
+            """Spy on the libraries, forwarding whatever depth the caller uses."""
+            seen.append(library)
+            return original(self, library, *args, **kwargs)
+
+        with patch.object(DatabrickspipelineSource, "_expand_workspace_directory", record):
+            pipeline_entity = MagicMock()
+            pipeline_entity.id.root = uuid.uuid4()
+            list(
+                source._yield_kafka_lineage(
+                    DataBrickPipelineDetails(pipeline_id="p", name="demo"),
+                    pipeline_entity,
+                )
+            )
+        return seen
+
+    def test_configuration_source_path_is_modelled(self):
+        """A pipeline with no libraries falls back to spec.configuration.source_path."""
+        seen = self._libraries_for(
+            {
+                "catalog": CATALOG,
+                "schema": SCHEMA,
+                "configuration": {"source_path": "/src/"},
+            }
+        )
+        assert seen and all(isinstance(library, DLTLibrarySource) for library in seen)
+
+    def test_development_source_path_is_modelled(self):
+        seen = self._libraries_for(
+            {
+                "catalog": CATALOG,
+                "schema": SCHEMA,
+                "development": {"source_path": "/dev/"},
+            }
+        )
+        assert seen and all(isinstance(library, DLTLibrarySource) for library in seen)
+
+    def test_every_library_shape_yields_the_model(self):
+        libraries = get_pipeline_libraries(
+            {
+                "libraries": [
+                    {"notebook": {"path": "/nb"}},
+                    {"file": {"path": "/f.sql"}},
+                    {"glob": {"include": "/tx/**"}},
+                ]
+            }
+        )
+        assert all(isinstance(library, DLTLibrarySource) for library in libraries)
+
+
+class TestLibraryShapeMatrix:
+    """
+    Every `spec.libraries` shape, end to end from the spec to the selected files.
+    Each row is a shape Databricks can emit, so a change to either the reduction
+    or the matching shows up here rather than in a customer's missing lineage.
+    """
+
+    WORKSPACE: ClassVar[dict] = {
+        "/tx/": [
+            {"object_type": "FILE", "path": "/tx/a.sql"},
+            {"object_type": "FILE", "path": "/tx/n.py"},
+            {"object_type": "DIRECTORY", "path": "/tx/sub"},
+            {"object_type": "DIRECTORY", "path": "/tx/2024_1"},
+        ],
+        "/tx/sub/": [{"object_type": "FILE", "path": "/tx/sub/d.sql"}],
+        "/tx/2024_1/": [{"object_type": "FILE", "path": "/tx/2024_1/file.sql"}],
+    }
+    WHOLE_TREE: ClassVar[list] = ["/tx/a.sql", "/tx/n.py", "/tx/sub/d.sql", "/tx/2024_1/file.sql"]
+
+    def _select(self, spec):
+        with patch.object(DatabrickspipelineSource, "__init__", lambda s, a, b: None):
+            source = DatabrickspipelineSource(None, None)
+        source.client = MagicMock()
+        source.client.list_workspace_objects.side_effect = lambda path: self.WORKSPACE.get(path, [])
+        selected = []
+        for library in get_pipeline_libraries(spec):
+            if library.is_directory:
+                selected.extend(source._expand_workspace_directory(library))
+            else:
+                selected.append(library.path)
+        return selected
+
+    def test_notebook_entry_is_read_directly(self):
+        assert self._select({"libraries": [{"notebook": {"path": "/tx/a.sql"}}]}) == ["/tx/a.sql"]
+
+    def test_file_entry_is_read_directly(self):
+        assert self._select({"libraries": [{"file": {"path": "/tx/a.sql"}}]}) == ["/tx/a.sql"]
+
+    def test_recursive_glob_takes_the_tree(self):
+        assert self._select({"libraries": [{"glob": {"include": "/tx/**"}}]}) == [
+            "/tx/a.sql",
+            "/tx/n.py",
+            "/tx/sub/d.sql",
+            "/tx/2024_1/file.sql",
+        ]
+
+    def test_an_unexpected_wildcard_include_falls_back_to_its_directory(self):
+        """
+        The pipelines API rejects every wildcard but a trailing `**`, so these cannot
+        reach us from a working pipeline. If one ever does, truncating at the wildcard
+        keeps it pointed at a real directory and over-collects rather than reading a
+        path that does not exist and finding nothing.
+        """
+        for include in ("/tx/*.sql", "/tx/**/*.sql", "/tx/2024_*/file.sql"):
+            assert self._select({"libraries": [{"glob": {"include": include}}]}) == self.WHOLE_TREE, include
+
+    def test_glob_naming_a_concrete_file_is_read_directly(self):
+        assert self._select({"libraries": [{"glob": {"include": "/tx/one.sql"}}]}) == ["/tx/one.sql"]
+
+    def test_glob_naming_a_bare_directory_takes_the_tree(self):
+        """No wildcard means no filter, so the whole directory is in scope."""
+        assert self._select({"libraries": [{"glob": {"include": "/tx/"}}]}) == [
+            "/tx/a.sql",
+            "/tx/n.py",
+            "/tx/sub/d.sql",
+            "/tx/2024_1/file.sql",
+        ]
+
+    def test_a_source_path_without_a_trailing_slash_is_still_a_directory(self):
+        """Databricks may omit the slash, and the path is a code root either way."""
+        with patch.object(DatabrickspipelineSource, "__init__", lambda s, a, b: None):
+            source = DatabrickspipelineSource(None, None)
+        source.client = MagicMock()
+        source.client.list_workspace_objects.side_effect = lambda path: self.WORKSPACE.get(path, [])
+
+        # the listing key is normalised by the producer, so expansion is driven by path
+        library = DLTLibrarySource(path="/tx/", is_directory=True)
+        assert source._expand_workspace_directory(library) == [
+            "/tx/a.sql",
+            "/tx/n.py",
+            "/tx/sub/d.sql",
+            "/tx/2024_1/file.sql",
+        ]
+
+    def test_mixed_entries_are_all_collected(self):
+        assert self._select(
+            {
+                "libraries": [
+                    {"notebook": {"path": "/nb"}},
+                    {"glob": {"include": "/tx/**"}},
+                ]
+            }
+        ) == ["/nb", *self.WHOLE_TREE]
+
+
+class TestUnknownDirectoryness:
+    """
+    A glob include with neither a wildcard nor a trailing slash could name a file
+    or a directory. The spec does not say, so the workspace decides rather than a
+    guess about the string's shape.
+    """
+
+    WORKSPACE: ClassVar[dict] = {
+        "/repo/transformations": [{"object_type": "FILE", "path": "/repo/transformations/a.sql"}],
+    }
+
+    def _select(self, include):
+        with patch.object(DatabrickspipelineSource, "__init__", lambda s, a, b: None):
+            source = DatabrickspipelineSource(None, None)
+        source.client = MagicMock()
+        source.client.list_workspace_objects.side_effect = lambda path: self.WORKSPACE.get(path, [])
+        selected = []
+        for library in get_pipeline_libraries({"libraries": [{"glob": {"include": include}}]}):
+            if library.is_directory is False:
+                selected.append(library.path)
+                continue
+            found = source._expand_workspace_directory(library)
+            if found:
+                selected.extend(found)
+            elif library.is_directory is None:
+                selected.append(library.path)
+        return selected
+
+    def test_the_spec_leaves_a_slashless_include_unknown(self):
+        library = get_pipeline_libraries({"libraries": [{"glob": {"include": "/repo/transformations"}}]})[0]
+        assert library.is_directory is None
+
+    def test_a_slashless_directory_is_listed(self):
+        assert self._select("/repo/transformations") == ["/repo/transformations/a.sql"]
+
+    def test_a_slashless_file_is_read_directly(self):
+        """Nothing lists under a file, so it falls back to being read as one."""
+        assert self._select("/repo/one.sql") == ["/repo/one.sql"]
+
+    def test_a_wildcard_include_is_known_to_be_a_directory(self):
+        assert get_pipeline_libraries({"libraries": [{"glob": {"include": "/repo/**"}}]})[0].is_directory is True
+
+    def test_a_slash_terminated_include_is_known_to_be_a_directory(self):
+        assert get_pipeline_libraries({"libraries": [{"glob": {"include": "/repo/"}}]})[0].is_directory is True
+
+
+class TestLegacyAndModifierCreateForms:
+    """DLT spellings the query parser does not recognise on its own.
+
+    `LIVE TABLE` and `STREAMING LIVE TABLE` are the pre-2022 names and are still
+    accepted by Databricks today, and `PRIVATE` is a modifier on the modern names.
+    sqlglot falls back to a bare Command for all of them and reports no tables, so
+    without a rewrite the dataset is dropped with no error and no warning. Verified
+    against a real workspace: these three forms produced zero lineage edges while
+    every other construct produced the expected ones.
+    """
+
+    def _only(self, sql):
+        found = extract_dlt_table_dependencies(sql)
+        assert len(found) == 1, f"expected one dataset from {sql!r}, got {found}"
+        return found[0]
+
+    def test_legacy_live_table_is_read_as_a_batch_dataset(self):
+        dependency = self._only("CREATE LIVE TABLE d AS SELECT id FROM src_d")
+        assert dependency.table_name == "d"
+        assert dependency.depends_on == ["src_d"]
+
+    def test_legacy_streaming_live_table_is_read(self):
+        dependency = self._only("CREATE STREAMING LIVE TABLE e AS SELECT id FROM src_e")
+        assert dependency.table_name == "e"
+        assert dependency.depends_on == ["src_e"]
+
+    def test_refreshable_legacy_live_table_is_read(self):
+        dependency = self._only("CREATE OR REFRESH LIVE TABLE f AS SELECT id FROM src_f")
+        assert dependency.table_name == "f"
+        assert dependency.depends_on == ["src_f"]
+
+    def test_refreshable_legacy_streaming_live_table_is_read(self):
+        dependency = self._only("CREATE OR REFRESH STREAMING LIVE TABLE g AS SELECT id FROM src_g")
+        assert dependency.table_name == "g"
+        assert dependency.depends_on == ["src_g"]
+
+    def test_private_materialized_view_is_read(self):
+        dependency = self._only("CREATE PRIVATE MATERIALIZED VIEW h AS SELECT id FROM src_h")
+        assert dependency.table_name == "h"
+        assert dependency.depends_on == ["src_h"]
+
+    def test_refreshable_private_materialized_view_is_read(self):
+        dependency = self._only("CREATE OR REFRESH PRIVATE MATERIALIZED VIEW i AS SELECT id FROM src_i")
+        assert dependency.table_name == "i"
+        assert dependency.depends_on == ["src_i"]
+
+    def test_private_streaming_table_is_read(self):
+        dependency = self._only("CREATE PRIVATE STREAMING TABLE j AS SELECT id FROM src_j")
+        assert dependency.table_name == "j"
+        assert dependency.depends_on == ["src_j"]
+
+    def test_a_private_legacy_live_table_is_read(self):
+        """Both rewrites have to apply to the same statement."""
+        dependency = self._only("CREATE PRIVATE LIVE TABLE k AS SELECT id FROM src_k")
+        assert dependency.table_name == "k"
+        assert dependency.depends_on == ["src_k"]
+
+    def test_a_dataset_whose_name_contains_live_is_untouched(self):
+        """The rewrite is anchored to the CREATE clause, so a name is never rewritten."""
+        dependency = self._only("CREATE OR REFRESH MATERIALIZED VIEW live_table_stats AS SELECT id FROM my_live_table")
+        assert dependency.table_name == "live_table_stats"
+        assert dependency.depends_on == ["my_live_table"]
+
+    def test_the_legacy_forms_still_carry_the_live_prefix_rules(self):
+        dependency = self._only("CREATE LIVE TABLE m AS SELECT id FROM LIVE.sibling")
+        assert dependency.depends_on == ["sibling"]
+
+
+class TestNullLibrariesInSpec:
+    """
+    A spec may carry `libraries` as an explicit null. Reading the key rather than
+    testing for its presence keeps that from raising before the sources are collected.
+
+    The raise is swallowed by the surrounding handler, so asserting "no lineage" would
+    pass either way. What distinguishes them is how far the run gets: the `source_path`
+    fallback below the libraries block is only reached when the block does not raise.
+    """
+
+    @staticmethod
+    def _listed_paths(spec):
+        """The workspace paths the connector tried to read for this spec."""
+        with patch.object(DatabrickspipelineSource, "__init__", lambda s, a, b: None):
+            source = DatabrickspipelineSource(None, None)
+        client = MagicMock()
+        client.get_pipeline_details.return_value = {"pipeline_id": "p", "spec": spec}
+        client.list_workspace_objects.return_value = []
+        client.export_notebook_source.return_value = ""
+        client.get_table_lineage.return_value = []
+        client.get_column_lineage.return_value = []
+        source.client = client
+        source.metadata = MagicMock()
+        source._databricks_services_cached = True
+        source._databricks_services = [DB_SERVICE]
+        pipeline_entity = MagicMock()
+        pipeline_entity.id.root = uuid.uuid4()
+        list(
+            source._yield_kafka_lineage(
+                DataBrickPipelineDetails(pipeline_id="p", name="demo"),
+                pipeline_entity,
+            )
+        )
+        return [call.args[0] for call in client.list_workspace_objects.call_args_list]
+
+    def test_a_null_libraries_value_still_reaches_the_source_path_fallback(self):
+        spec = {"catalog": CATALOG, "schema": SCHEMA, "libraries": None, "configuration": {"source_path": "/src/"}}
+        assert self._listed_paths(spec) == ["/src/"]
+
+    def test_a_missing_libraries_key_still_reaches_the_source_path_fallback(self):
+        spec = {"catalog": CATALOG, "schema": SCHEMA, "configuration": {"source_path": "/src/"}}
+        assert self._listed_paths(spec) == ["/src/"]
+
+    def test_an_empty_libraries_list_still_reaches_the_source_path_fallback(self):
+        spec = {"catalog": CATALOG, "schema": SCHEMA, "libraries": [], "configuration": {"source_path": "/src/"}}
+        assert self._listed_paths(spec) == ["/src/"]

--- a/ingestion/tests/unit/topology/pipeline/test_databricks_kafka_lineage.py
+++ b/ingestion/tests/unit/topology/pipeline/test_databricks_kafka_lineage.py
@@ -22,6 +22,7 @@ from metadata.generated.schema.type.basic import FullyQualifiedEntityName
 from metadata.ingestion.source.pipeline.databrickspipeline.metadata import (
     DatabrickspipelineSource,
 )
+from metadata.utils.lru_cache import LRU_CACHE_SIZE, LRUCache
 
 
 class TestKafkaTopicDiscovery(unittest.TestCase):
@@ -36,8 +37,8 @@ class TestKafkaTopicDiscovery(unittest.TestCase):
         with patch.object(DatabrickspipelineSource, "__init__", lambda x, y, z: None):
             self.source = DatabrickspipelineSource(None, None)
             self.source.metadata = self.mock_metadata
-            self.source._table_lookup_cache = {}
-            self.source._dlt_table_cache = {}
+            self.source._table_lookup_cache = LRUCache(capacity=LRU_CACHE_SIZE)
+            self.source._dlt_table_cache = LRUCache(capacity=LRU_CACHE_SIZE)
 
     def test_find_topic_simple_name(self):
         """Test finding topic with simple name (no dots)"""
@@ -140,8 +141,8 @@ class TestDatabricksServiceCaching(unittest.TestCase):
             self.source.metadata = self.mock_metadata
             self.source._databricks_services_cached = False
             self.source._databricks_services = []
-            self.source._table_lookup_cache = {}
-            self.source._dlt_table_cache = {}
+            self.source._table_lookup_cache = LRUCache(capacity=LRU_CACHE_SIZE)
+            self.source._dlt_table_cache = LRUCache(capacity=LRU_CACHE_SIZE)
 
     def test_get_databricks_services_caches_result(self):
         """Test that databricks services are cached"""
@@ -217,8 +218,8 @@ class TestDLTTableDiscovery(unittest.TestCase):
             self.source.metadata = self.mock_metadata
             self.source._databricks_services_cached = True
             self.source._databricks_services = ["databricks-prod", "databricks-dev"]
-            self.source._table_lookup_cache = {}
-            self.source._dlt_table_cache = {}
+            self.source._table_lookup_cache = LRUCache(capacity=LRU_CACHE_SIZE)
+            self.source._dlt_table_cache = LRUCache(capacity=LRU_CACHE_SIZE)
 
     def test_find_dlt_table_exact_match(self):
         """Test finding table with exact case match"""
@@ -335,8 +336,8 @@ class TestKafkaLineageIntegration(unittest.TestCase):
             self.source.client = self.mock_client
             self.source._databricks_services_cached = True
             self.source._databricks_services = ["databricks-prod"]
-            self.source._table_lookup_cache = {}
-            self.source._dlt_table_cache = {}
+            self.source._table_lookup_cache = LRUCache(capacity=LRU_CACHE_SIZE)
+            self.source._dlt_table_cache = LRUCache(capacity=LRU_CACHE_SIZE)
 
     def test_lineage_creation_flow(self):
         """Test complete flow: parse notebook -> find topic -> find table -> create lineage"""

--- a/ingestion/tests/unit/topology/pipeline/test_databricks_kafka_parser.py
+++ b/ingestion/tests/unit/topology/pipeline/test_databricks_kafka_parser.py
@@ -15,9 +15,11 @@ Unit tests for Databricks Kafka parser
 
 import unittest
 
-from metadata.ingestion.source.pipeline.databrickspipeline.kafka_parser import (
+from metadata.ingestion.source.pipeline.databrickspipeline.dlt_parsers import (
+    PythonDltParser,
     extract_dlt_table_dependencies,
-    extract_dlt_table_names,
+)
+from metadata.ingestion.source.pipeline.databrickspipeline.kafka_parser import (
     extract_kafka_sources,
     get_pipeline_libraries,
 )
@@ -319,7 +321,7 @@ class TestPipelineLibraries(unittest.TestCase):
         }
         libraries = get_pipeline_libraries(pipeline_config)
         self.assertEqual(len(libraries), 1)
-        self.assertEqual(libraries[0], "/Workspace/dlt/bronze_pipeline")
+        self.assertEqual(libraries[0].path, "/Workspace/dlt/bronze_pipeline")
 
     def test_file_library(self):
         """Test file library extraction"""
@@ -328,7 +330,7 @@ class TestPipelineLibraries(unittest.TestCase):
         }
         libraries = get_pipeline_libraries(pipeline_config)
         self.assertEqual(len(libraries), 1)
-        self.assertEqual(libraries[0], "/Workspace/scripts/etl.py")
+        self.assertEqual(libraries[0].path, "/Workspace/scripts/etl.py")
 
     def test_mixed_libraries(self):
         """Test mixed notebook and file libraries"""
@@ -341,9 +343,10 @@ class TestPipelineLibraries(unittest.TestCase):
         }
         libraries = get_pipeline_libraries(pipeline_config)
         self.assertEqual(len(libraries), 3)
-        self.assertIn("/nb1", libraries)
-        self.assertIn("/file1.py", libraries)
-        self.assertIn("/nb2", libraries)
+        paths = [library.path for library in libraries]
+        self.assertIn("/nb1", paths)
+        self.assertIn("/file1.py", paths)
+        self.assertIn("/nb2", paths)
 
     def test_empty_libraries(self):
         """Test empty libraries list"""
@@ -375,7 +378,7 @@ class TestPipelineLibraries(unittest.TestCase):
         }
         libraries = get_pipeline_libraries(pipeline_config)
         self.assertEqual(len(libraries), 1)
-        self.assertEqual(libraries[0], "/nb")
+        self.assertEqual(libraries[0].path, "/nb")
 
 
 class TestDLTTableExtraction(unittest.TestCase):
@@ -390,7 +393,7 @@ class TestDLTTableExtraction(unittest.TestCase):
         def bronze_events():
             return spark.readStream.format("kafka").load()
         """
-        table_names = extract_dlt_table_names(source_code)
+        table_names = PythonDltParser.extract_dlt_table_names(source_code)
         self.assertEqual(len(table_names), 1)
         self.assertEqual(table_names[0], "user_events_bronze")
 
@@ -404,7 +407,7 @@ class TestDLTTableExtraction(unittest.TestCase):
         def my_function():
             return df
         """
-        table_names = extract_dlt_table_names(source_code)
+        table_names = PythonDltParser.extract_dlt_table_names(source_code)
         self.assertEqual(len(table_names), 1)
         self.assertEqual(table_names[0], "my_table")
 
@@ -419,7 +422,7 @@ class TestDLTTableExtraction(unittest.TestCase):
         def silver():
             return dlt.read("bronze_table")
         """
-        table_names = extract_dlt_table_names(source_code)
+        table_names = PythonDltParser.extract_dlt_table_names(source_code)
         self.assertEqual(len(table_names), 2)
         self.assertIn("bronze_table", table_names)
         self.assertIn("silver_table", table_names)
@@ -433,7 +436,7 @@ class TestDLTTableExtraction(unittest.TestCase):
         def event_log():
             return df
         """
-        table_names = extract_dlt_table_names(source_code)
+        table_names = PythonDltParser.extract_dlt_table_names(source_code)
         # Should infer from entity_name variable and function pattern
         self.assertEqual(len(table_names), 1)
         self.assertEqual(table_names[0], "customerevent_event_log")
@@ -445,7 +448,7 @@ class TestDLTTableExtraction(unittest.TestCase):
         def my_function():
             return df
         """
-        table_names = extract_dlt_table_names(source_code)
+        table_names = PythonDltParser.extract_dlt_table_names(source_code)
         # Should return empty list when no name found
         self.assertEqual(len(table_names), 0)
 
@@ -456,18 +459,18 @@ class TestDLTTableExtraction(unittest.TestCase):
         def func():
             return df
         """
-        table_names = extract_dlt_table_names(source_code)
+        table_names = PythonDltParser.extract_dlt_table_names(source_code)
         self.assertEqual(len(table_names), 1)
         self.assertEqual(table_names[0], "CasedTable")
 
     def test_empty_source_code(self):
         """Test empty source code"""
-        table_names = extract_dlt_table_names("")
+        table_names = PythonDltParser.extract_dlt_table_names("")
         self.assertEqual(len(table_names), 0)
 
     def test_null_source_code(self):
         """Test None source code doesn't crash"""
-        table_names = extract_dlt_table_names(None)
+        table_names = PythonDltParser.extract_dlt_table_names(None)
         self.assertEqual(len(table_names), 0)
 
 
@@ -585,7 +588,7 @@ class TestKafkaFallbackPatterns(unittest.TestCase):
         )
 
         # Test DLT table extraction
-        table_names = extract_dlt_table_names(source_code)
+        table_names = PythonDltParser.extract_dlt_table_names(source_code)
         self.assertEqual(len(table_names), 1)
         self.assertEqual(table_names[0], "customerevent_event_log")
 

--- a/ingestion/tests/unit/topology/pipeline/test_databricks_self_referencing_lineage.py
+++ b/ingestion/tests/unit/topology/pipeline/test_databricks_self_referencing_lineage.py
@@ -27,6 +27,7 @@ from metadata.ingestion.source.pipeline.databrickspipeline.metadata import (
 from metadata.ingestion.source.pipeline.databrickspipeline.models import (
     DataBrickPipelineDetails,
 )
+from metadata.utils.lru_cache import LRU_CACHE_SIZE, LRUCache
 
 CATALOG, SCHEMA = "analytics", "sales"
 EVENT_LOG = f"{CATALOG}.{SCHEMA}.orders_event_log"
@@ -52,7 +53,10 @@ def _source(table_lineage_rows):
     source.client.get_column_lineage.return_value = []
     source.context = MagicMock()
     source.get_db_service_names = MagicMock(return_value=["unity"])
-    source._table_lookup_cache = {}
+    # the real cache type, so the test tracks the production lookup path. A stand-in
+    # only satisfies whichever calls the implementation makes when it is written, and
+    # diverges silently once that implementation changes.
+    source._table_lookup_cache = LRUCache(capacity=LRU_CACHE_SIZE)
     source._yield_kafka_lineage = MagicMock(return_value=iter(()))
 
     pipeline_entity = MagicMock()

--- a/ingestion/tests/unit/topology/pipeline/test_databricks_self_referencing_lineage.py
+++ b/ingestion/tests/unit/topology/pipeline/test_databricks_self_referencing_lineage.py
@@ -1,0 +1,115 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+A table is never linked to itself.
+
+`system.access.table_lineage` records table access rather than derivation, so a
+streaming or CDC write legitimately names its target table as its own source.
+Carried through as lineage it renders as a loop on the node and tells the reader
+nothing, so those rows are dropped before an edge is built.
+"""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+from metadata.generated.schema.entity.data.table import Table
+from metadata.ingestion.source.pipeline.databrickspipeline.metadata import (
+    DatabrickspipelineSource,
+)
+from metadata.ingestion.source.pipeline.databrickspipeline.models import (
+    DataBrickPipelineDetails,
+)
+
+CATALOG, SCHEMA = "analytics", "sales"
+EVENT_LOG = f"{CATALOG}.{SCHEMA}.orders_event_log"
+SNAPSHOT = f"{CATALOG}.{SCHEMA}.orders_snapshot"
+
+
+def _table(fqn: str) -> Table:
+    table = MagicMock(spec=Table)
+    table.id = uuid.uuid4()
+    table.fullyQualifiedName = fqn
+    table.name = fqn.rsplit(".", 1)[-1]
+    table.columns = []
+    return table
+
+
+def _source(table_lineage_rows):
+    """The real connector with the Databricks and OpenMetadata sides stubbed."""
+    with patch.object(DatabrickspipelineSource, "__init__", lambda s, a, b: None):
+        source = DatabrickspipelineSource(None, None)
+
+    source.client = MagicMock()
+    source.client.get_table_lineage.return_value = table_lineage_rows
+    source.client.get_column_lineage.return_value = []
+    source.context = MagicMock()
+    source.get_db_service_names = MagicMock(return_value=["unity"])
+    source._table_lookup_cache = {}
+    source._yield_kafka_lineage = MagicMock(return_value=iter(()))
+
+    pipeline_entity = MagicMock()
+    pipeline_entity.id.root = uuid.uuid4()
+
+    def get_by_name(entity=None, fqn=None, **_):
+        # every table resolves, so a missing edge can only be the self-reference guard
+        return pipeline_entity if entity is not Table else _table(str(fqn))
+
+    source.metadata = MagicMock()
+    source.metadata.get_by_name.side_effect = get_by_name
+    return source
+
+
+def _edges(source):
+    details = DataBrickPipelineDetails(pipeline_id="11111111-2222-3333-4444-555555555555", name="orders")
+    with patch(
+        "metadata.ingestion.source.pipeline.databrickspipeline.metadata.fqn.build",
+        side_effect=lambda **kwargs: (
+            f"{kwargs.get('service_name')}.{kwargs.get('database_name')}."
+            f"{kwargs.get('schema_name')}.{kwargs.get('table_name')}"
+            if kwargs.get("table_name")
+            else "svc.pipeline"
+        ),
+    ):
+        results = list(source.yield_pipeline_lineage_details(details))
+    return [r.right for r in results if getattr(r, "right", None) is not None]
+
+
+class TestSelfReferencingTableLineage:
+    def test_a_self_referencing_row_yields_no_edge(self):
+        source = _source([{"source_table_full_name": EVENT_LOG, "target_table_full_name": EVENT_LOG}])
+        assert _edges(source) == []
+
+    def test_a_normal_row_still_yields_an_edge(self):
+        source = _source([{"source_table_full_name": EVENT_LOG, "target_table_full_name": SNAPSHOT}])
+        assert len(_edges(source)) == 1
+
+    def test_only_the_self_reference_is_dropped(self):
+        """The guard must not suppress real lineage produced by the same pipeline."""
+        source = _source(
+            [
+                {"source_table_full_name": EVENT_LOG, "target_table_full_name": EVENT_LOG},
+                {"source_table_full_name": EVENT_LOG, "target_table_full_name": SNAPSHOT},
+                {"source_table_full_name": SNAPSHOT, "target_table_full_name": SNAPSHOT},
+            ]
+        )
+        edges = _edges(source)
+        assert len(edges) == 1
+        edge = edges[0].edge
+        assert edge.fromEntity.id != edge.toEntity.id
+
+    def test_rows_with_a_missing_name_are_still_skipped(self):
+        source = _source(
+            [
+                {"source_table_full_name": None, "target_table_full_name": SNAPSHOT},
+                {"source_table_full_name": EVENT_LOG, "target_table_full_name": None},
+            ]
+        )
+        assert _edges(source) == []


### PR DESCRIPTION
### Describe your changes:

Backport of two merged Databricks lineage fixes to `1.13`.

- #31654: SQL-defined DLT pipelines yielded no lineage and were skipped silently. Adds SQL DLT parsing, fixes the legacy `CREATE LIVE TABLE` / `STREAMING LIVE TABLE` / `PRIVATE` forms that matched the pattern but produced nothing, and removes glob handling the pipelines API cannot produce.
- #32214: `system.access.table_lineage` can return rows whose source and target are the same table. Both the Databricks Pipeline and Unity Catalog connectors turned those into an edge from a table to itself.

The four `databrickspipeline` files and both new test files are byte-identical to `main`, so future backports of these files apply cleanly.

`unitycatalog/lineage.py` is the exception and keeps 1.13's own structure. That file has genuinely diverged on `main` beyond formatting (`TYPE_CHECKING`, different connection imports, a restructured `create()`), so taking main's copy would drag unrelated refactoring into 1.13. Both self-reference guards are added there verbatim from `main`.

Formatting note: 1.13 runs `black` and `isort` while `main` runs `ruff`, so the ported files carry ruff-era `# noqa` comments and 120 column lines. `black --check` will flag them. This is deliberate, to keep the hunks matching `main`. Hence `skip-pr-checks`.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A, backport with no new design.

#
### Tests:

#### Use cases covered
Same as the source PRs. Verified on this branch rather than assumed:

- 160 unit tests pass across the Databricks pipeline and Unity Catalog suites, matching `main`.
- The real-workspace parse matrix scores 30/30 against a hand-written oracle, resolving the same 46 files across 10 live DLT pipelines as `main`, covering every library shape the pipelines API accepts (exact file, bare directory, trailing slash, `**`, mixed entries).
- The parse results are byte-identical to the 2.0 backport's across all 30 files.

**Not verified on this branch:** the OpenMetadata edge count. The local server is 2.0.0 and the 1.13 ingestion client refuses to connect (`Server version is 2.0.0 vs. Client version 1.13.4.1`), which is a version guard rather than anything in this change. The 2.0 backport, running byte-identical connector code against identical parse results, wrote the expected 34 edges.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable. Covered by the source PRs and re-verified here against a live Databricks workspace.

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. Cherry-picked #32214 then #31654, in that order, since #31654 modifies a test file #32214 creates.
2. Resolved 13 conflict hunks, all branch drift rather than changes from either fix, taking main's version for the connector files.
3. Diffed every touched file against `main` to confirm the result matches, with the `unitycatalog/lineage.py` exception noted above.
4. Ran the Databricks and Unity Catalog unit suites on this branch.
5. Ran the parse matrix against a real Databricks workspace using this branch's code, and compared the output against the 2.0 backport's.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My PR is linked to the source PRs above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.
- [x] I have added tests and listed them above.
