### PR TITLE
Backport #31958 to 1.13: fix(glue): stop a custom databaseName dropping every schema

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/glue/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/glue/metadata.py
@@ -91,6 +91,7 @@ class GlueSource(ExternalTableLineageMixin, DatabaseServiceSource):
 
         self.connection_obj = self.glue
         self.schema_description_map = {}
+        self.schema_catalog_id_map = {}
         self.external_location_map = {}
         self.test_connection()
 
@@ -115,7 +116,13 @@ class GlueSource(ExternalTableLineageMixin, DatabaseServiceSource):
     def _get_glue_tables(self):
         schema_name = self.context.get().database_schema
         paginator = self.glue.get_paginator("get_tables")
-        paginator_response = paginator.paginate(DatabaseName=schema_name)
+        # Name the schema's own catalog. Defaulting to the caller's catalog reads the
+        # wrong tables, or none, for a schema that came from another one.
+        paginate_args = {"DatabaseName": schema_name}
+        catalog_id = self.schema_catalog_id_map.get(schema_name)
+        if catalog_id:
+            paginate_args["CatalogId"] = catalog_id
+        paginator_response = paginator.paginate(**paginate_args)
         for page in paginator_response:
             yield TablePage(**page)
 
@@ -185,12 +192,19 @@ class GlueSource(ExternalTableLineageMixin, DatabaseServiceSource):
     def get_database_schema_names(self) -> Iterable[str]:
         """
         return schema names
+
+        Without databaseName the OpenMetadata database is the Glue Catalog ID, so a
+        schema from another catalog belongs to a different database. databaseName only
+        labels the single database we create, so every visible Glue database is one of
+        its schemas.
         """
         database_name = self.context.get().database
+        custom_database_name = self.service_connection.databaseName
+        catalog_ids_seen = set()
         for page in self._get_glue_database_and_schemas() or []:
             for schema in page.DatabaseList:
                 try:
-                    if schema.CatalogId != database_name:
+                    if not custom_database_name and schema.CatalogId != database_name:
                         continue
                     schema_fqn = fqn.build(
                         self.metadata,
@@ -208,9 +222,10 @@ class GlueSource(ExternalTableLineageMixin, DatabaseServiceSource):
                         self.status.filter(schema_fqn, "Schema Filtered Out")
                         continue
                     if schema.Description:
-                        self.schema_description_map[schema.Name] = Markdown(
-                            schema.Description
-                        )
+                        self.schema_description_map[schema.Name] = Markdown(schema.Description)
+                    if schema.CatalogId:
+                        self.schema_catalog_id_map[schema.Name] = schema.CatalogId
+                        catalog_ids_seen.add(schema.CatalogId)
                     yield schema.Name
                 except Exception as exc:
                     self.status.failed(
@@ -220,6 +235,15 @@ class GlueSource(ExternalTableLineageMixin, DatabaseServiceSource):
                             stackTrace=traceback.format_exc(),
                         )
                     )
+        if len(catalog_ids_seen) > 1:
+            self.status.warning(
+                database_name,
+                "AWS returned Glue databases from more than one catalog "
+                f"({', '.join(sorted(catalog_ids_seen))}), and all of them were "
+                f"ingested into '{database_name}' because the 'Database Name' field is set on this service. "
+                "If two of those Glue databases share a name, one overwrites the other and its tables go missing. "
+                "Clear the 'Database Name' field to get one OpenMetadata database per AWS catalog instead.",
+            )
 
     def yield_database_schema(
         self, schema_name: str
@@ -418,10 +442,12 @@ class GlueSource(ExternalTableLineageMixin, DatabaseServiceSource):
                 schema_name = self.context.get().database_schema
                 table_name = table.Name
 
-                # Get full table metadata from Glue API
-                response = self.glue.get_table(
-                    DatabaseName=schema_name, Name=table_name
-                )
+                # Get full table metadata from Glue API, from the schema's own catalog
+                get_table_args = {"DatabaseName": schema_name, "Name": table_name}
+                catalog_id = self.schema_catalog_id_map.get(schema_name)
+                if catalog_id:
+                    get_table_args["CatalogId"] = catalog_id
+                response = self.glue.get_table(**get_table_args)
 
                 table_info = response["Table"]
 

--- a/ingestion/tests/unit/topology/database/test_glue.py
+++ b/ingestion/tests/unit/topology/database/test_glue.py
@@ -334,6 +334,132 @@ class GlueUnitTest(TestCase):
         self.assertFalse(is_iceberg_2)
         self.assertFalse(is_iceberg_3)
 
+    def _custom_db_name_source(self, pages):
+        """A source configured with a custom databaseName, reading the given catalog pages."""
+        with patch(
+            "metadata.ingestion.source.database.glue.metadata.GlueSource.test_connection",
+            return_value=False,
+        ):
+            source = GlueSource.create(
+                mock_glue_config_db_test["source"],
+                self.config.workflowConfig.openMetadataServerConfig,
+            )
+        source.context.get().__dict__["database_service"] = MOCK_DATABASE_SERVICE.name.root
+        source.context.get().__dict__["database"] = MOCK_CUSTOM_DB_NAME
+        source._get_glue_database_and_schemas = lambda: pages
+        return source
+
+    def test_custom_db_name_still_discovers_schemas(self):
+        """databaseName names the OpenMetadata database, it does not select a Glue catalog.
+
+        The catalog check compares against a Glue CatalogId, so a custom name matched
+        nothing and every schema was dropped while the run still reported Success.
+        """
+        source = self._custom_db_name_source([DatabasePage(**mock_data.get("mock_database_paginator"))])
+
+        assert EXPECTED_DATABASE_SCHEMA_NAMES == list(source.get_database_schema_names())  # noqa: SIM300
+        assert source.status.failures == []
+        assert source.status.warnings == []
+
+    def test_custom_db_name_merges_catalogs_and_warns(self):
+        """One name means one database, so catalogs merge. Say so, rather than dropping them."""
+        source = self._custom_db_name_source(
+            [
+                DatabasePage(
+                    DatabaseList=[
+                        GlueSchema(
+                            CatalogId=MOCK_DATABASE.name.root,
+                            Name="default",
+                            Description="current catalog schema",
+                        ),
+                        GlueSchema(
+                            CatalogId="different-catalog",
+                            Name="foreign_schema",
+                            Description="other catalog schema",
+                        ),
+                    ]
+                )
+            ]
+        )
+
+        assert ["default", "foreign_schema"] == list(source.get_database_schema_names())  # noqa: SIM300
+        assert len(source.status.warnings) == 1
+        assert "more than one catalog" in source.status.warnings[0][MOCK_CUSTOM_DB_NAME]
+
+    def test_schema_without_catalog_id_is_not_counted_as_another_catalog(self):
+        """A missing CatalogId is not a second catalog, so it must not warn about merging."""
+        source = self._custom_db_name_source(
+            [
+                DatabasePage(
+                    DatabaseList=[
+                        GlueSchema(CatalogId=MOCK_DATABASE.name.root, Name="default"),
+                        GlueSchema(Name="schema_without_catalog"),
+                    ]
+                )
+            ]
+        )
+
+        assert ["default", "schema_without_catalog"] == list(source.get_database_schema_names())  # noqa: SIM300
+        assert source.status.warnings == []
+
+    def test_tables_are_read_from_the_schema_own_catalog(self):
+        """A schema from another catalog must not have its tables read from the caller's."""
+        source = self._custom_db_name_source(
+            [
+                DatabasePage(
+                    DatabaseList=[
+                        GlueSchema(CatalogId="different-catalog", Name="foreign_schema"),
+                    ]
+                )
+            ]
+        )
+        assert ["foreign_schema"] == list(source.get_database_schema_names())  # noqa: SIM300
+
+        paginator = Mock()
+        paginator.paginate.return_value = [mock_data.get("mock_table_paginator")]
+        source.glue = Mock()
+        source.glue.get_paginator.return_value = paginator
+        source.context.get().__dict__["database_schema"] = "foreign_schema"
+
+        list(source._get_glue_tables())
+
+        paginator.paginate.assert_called_once_with(DatabaseName="foreign_schema", CatalogId="different-catalog")
+
+    def test_iceberg_columns_are_read_from_the_schema_own_catalog(self):
+        """The Iceberg detail lookup must name the same catalog the schema came from.
+
+        Reading it from the caller's catalog raises, and the broad fallback then serves
+        the unfiltered storage-descriptor columns, so dropped columns come back as live.
+        """
+        source = self._custom_db_name_source(
+            [
+                DatabasePage(
+                    DatabaseList=[
+                        GlueSchema(CatalogId="different-catalog", Name="foreign_schema"),
+                    ]
+                )
+            ]
+        )
+        assert ["foreign_schema"] == list(source.get_database_schema_names())  # noqa: SIM300
+
+        iceberg_table = Mock()
+        iceberg_table.Name = "iceberg_table"
+        iceberg_table.Parameters.table_type = "ICEBERG"
+        source.context.get().__dict__["database_schema"] = "foreign_schema"
+        # The topology context is shared, so a stray table_data leaks into later tests.
+        source.context.get().__dict__["table_data"] = iceberg_table
+        self.addCleanup(source.context.get().__dict__.pop, "table_data", None)
+        source.glue = Mock()
+        source.glue.get_table.return_value = {"Table": {"StorageDescriptor": {"Columns": []}}}
+
+        list(source.get_columns(Mock()))
+
+        source.glue.get_table.assert_called_once_with(
+            DatabaseName="foreign_schema",
+            Name="iceberg_table",
+            CatalogId="different-catalog",
+        )
+
 
 class TestGlueColumnDeduplication:
     """Glue may return a partition key in StorageDescriptor.Columns as well as in PartitionKeys.

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/glueConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/glueConnection.json
@@ -26,7 +26,7 @@
     },
     "databaseName": {
       "title": "Database Name",
-      "description": "Optional name to give to the database in OpenMetadata. If left blank, we will use default as the database name.",
+      "description": "Optional name to give to the database in OpenMetadata. If left blank, the Glue Catalog ID (your AWS account ID) is used. This only names the database in OpenMetadata, it does not select which Glue database to ingest.",
       "type": "string"
     },
     "connectionOptions": {

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/automations/createWorkflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/automations/createWorkflow.ts
@@ -802,6 +802,10 @@ export interface ConfigObject {
      * Optional name to give to the database in OpenMetadata. If left blank, we will use default
      * as the database name.
      *
+     * Optional name to give to the database in OpenMetadata. If left blank, the Glue Catalog ID
+     * (your AWS account ID) is used. This only names the database in OpenMetadata, it does not
+     * select which Glue database to ingest.
+     *
      * Optional name to give to the database in OpenMetadata. If left blank, we will use 'epic'
      * as the database name.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createDatabaseService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createDatabaseService.ts
@@ -361,6 +361,10 @@ export interface Connection {
      * Optional name to give to the database in OpenMetadata. If left blank, we will use default
      * as the database name.
      *
+     * Optional name to give to the database in OpenMetadata. If left blank, the Glue Catalog ID
+     * (your AWS account ID) is used. This only names the database in OpenMetadata, it does not
+     * select which Glue database to ingest.
+     *
      * Optional name to give to the database in OpenMetadata. If left blank, we will use 'epic'
      * as the database name.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
@@ -4148,6 +4148,10 @@ export interface ConfigObject {
      * Optional name to give to the database in OpenMetadata. If left blank, we will use default
      * as the database name.
      *
+     * Optional name to give to the database in OpenMetadata. If left blank, the Glue Catalog ID
+     * (your AWS account ID) is used. This only names the database in OpenMetadata, it does not
+     * select which Glue database to ingest.
+     *
      * Optional name to give to the database in OpenMetadata. If left blank, we will use 'epic'
      * as the database name.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/testServiceConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/testServiceConnection.ts
@@ -684,6 +684,10 @@ export interface ConfigObject {
      * Optional name to give to the database in OpenMetadata. If left blank, we will use default
      * as the database name.
      *
+     * Optional name to give to the database in OpenMetadata. If left blank, the Glue Catalog ID
+     * (your AWS account ID) is used. This only names the database in OpenMetadata, it does not
+     * select which Glue database to ingest.
+     *
      * Optional name to give to the database in OpenMetadata. If left blank, we will use 'epic'
      * as the database name.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/workflow.ts
@@ -1346,6 +1346,10 @@ export interface ConfigObject {
      * Optional name to give to the database in OpenMetadata. If left blank, we will use default
      * as the database name.
      *
+     * Optional name to give to the database in OpenMetadata. If left blank, the Glue Catalog ID
+     * (your AWS account ID) is used. This only names the database in OpenMetadata, it does not
+     * select which Glue database to ingest.
+     *
      * Optional name to give to the database in OpenMetadata. If left blank, we will use 'epic'
      * as the database name.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/glueConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/glueConnection.ts
@@ -22,8 +22,9 @@ export interface GlueConnection {
      */
     databaseFilterPattern?: FilterPattern;
     /**
-     * Optional name to give to the database in OpenMetadata. If left blank, we will use default
-     * as the database name.
+     * Optional name to give to the database in OpenMetadata. If left blank, the Glue Catalog ID
+     * (your AWS account ID) is used. This only names the database in OpenMetadata, it does not
+     * select which Glue database to ingest.
      */
     databaseName?: string;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
@@ -1200,6 +1200,10 @@ export interface ConfigObject {
      * Optional name to give to the database in OpenMetadata. If left blank, we will use default
      * as the database name.
      *
+     * Optional name to give to the database in OpenMetadata. If left blank, the Glue Catalog ID
+     * (your AWS account ID) is used. This only names the database in OpenMetadata, it does not
+     * select which Glue database to ingest.
+     *
      * Optional name to give to the database in OpenMetadata. If left blank, we will use 'epic'
      * as the database name.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/databaseService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/databaseService.ts
@@ -492,6 +492,10 @@ export interface Connection {
      * Optional name to give to the database in OpenMetadata. If left blank, we will use default
      * as the database name.
      *
+     * Optional name to give to the database in OpenMetadata. If left blank, the Glue Catalog ID
+     * (your AWS account ID) is used. This only names the database in OpenMetadata, it does not
+     * select which Glue database to ingest.
+     *
      * Optional name to give to the database in OpenMetadata. If left blank, we will use 'epic'
      * as the database name.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
@@ -4738,6 +4738,10 @@ export interface ConfigObject {
      * Optional name to give to the database in OpenMetadata. If left blank, we will use default
      * as the database name.
      *
+     * Optional name to give to the database in OpenMetadata. If left blank, the Glue Catalog ID
+     * (your AWS account ID) is used. This only names the database in OpenMetadata, it does not
+     * select which Glue database to ingest.
+     *
      * Optional name to give to the database in OpenMetadata. If left blank, we will use 'epic'
      * as the database name.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
@@ -1298,6 +1298,10 @@ export interface ConfigObject {
      * Optional name to give to the database in OpenMetadata. If left blank, we will use default
      * as the database name.
      *
+     * Optional name to give to the database in OpenMetadata. If left blank, the Glue Catalog ID
+     * (your AWS account ID) is used. This only names the database in OpenMetadata, it does not
+     * select which Glue database to ingest.
+     *
      * Optional name to give to the database in OpenMetadata. If left blank, we will use 'epic'
      * as the database name.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
@@ -1289,6 +1289,10 @@ export interface ConfigObject {
      * Optional name to give to the database in OpenMetadata. If left blank, we will use default
      * as the database name.
      *
+     * Optional name to give to the database in OpenMetadata. If left blank, the Glue Catalog ID
+     * (your AWS account ID) is used. This only names the database in OpenMetadata, it does not
+     * select which Glue database to ingest.
+     *
      * Optional name to give to the database in OpenMetadata. If left blank, we will use 'epic'
      * as the database name.
      */


### PR DESCRIPTION
Backport of #31958 to 1.13.

Setting the Glue `databaseName` produced a successful ingestion with zero schemas and zero tables. `get_database_schema_names` compared that label against the Glue Catalog ID (the AWS account ID), so nothing ever matched, every schema was skipped, and the run still reported Success with no failures and no warnings.

Cherry-picked from `311b17d0f2f`. Original issue: open-metadata/openmetadata-collate#5942.
Two adjustments were needed, neither changes behaviour:

- `serviceProgressEvent.ts` does not exist on 1.13, so that generated file is not part of this backport.
- 1.13 had `Markdown(schema.Description)` wrapped across three lines from before the ruff migration. It is now on one line, matching main, so future Glue backports keep applying cleanly. No other line was reformatted, and 1.13's copy of this file was already not black-clean before this change (the #31978 backport in #32106 landed main-formatted lines the same way).

Resulting code in the changed region is byte-identical to main.
