### PR TITLE
Cherry-pick #32190 to 1.13: improve casing on quick filters for glossary terms and tags

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreQuickFilters.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreQuickFilters.spec.ts
@@ -17,6 +17,7 @@ import { Domain } from '../../support/domain/Domain';
 import { MetricClass } from '../../support/entity/MetricClass';
 import { TableClass } from '../../support/entity/TableClass';
 import { TagClass } from '../../support/tag/TagClass';
+import { UserClass } from '../../support/user/UserClass';
 import {
   clickOutside,
   createNewPage,
@@ -44,6 +45,7 @@ const tier = new TagClass({
 const tierWithoutAsset = new TagClass({
   classification: 'Tier',
 });
+let user: UserClass;
 
 // Adding an asset to a data product updates the asset's search document
 // asynchronously, and the Data Products dropdown reads its options from that
@@ -86,6 +88,8 @@ test.beforeAll('Setup pre-requests', async ({ browser }) => {
   await tier.create(apiContext);
   // Create second tier but do NOT assign it to any asset
   await tierWithoutAsset.create(apiContext);
+  user = new UserClass();
+  await user.create(apiContext);
 
   await table.patch({
     apiContext,
@@ -114,6 +118,11 @@ test.beforeAll('Setup pre-requests', async ({ browser }) => {
           displayName: domain.responseData.displayName,
         },
       },
+      {
+        op: 'add',
+        path: '/owners/0',
+        value: { id: user.responseData.id, type: 'user' },
+      },
     ],
   });
 
@@ -135,6 +144,12 @@ test.beforeAll('Setup pre-requests', async ({ browser }) => {
 test.afterAll('Cleanup', async ({ browser }) => {
   const { apiContext, afterAction } = await createNewPage(browser);
   await dataProduct.delete(apiContext);
+  await afterAction();
+});
+
+test.afterAll('Cleanup', async ({ browser }) => {
+  const { apiContext, afterAction } = await createNewPage(browser);
+  await user.delete(apiContext);
   await afterAction();
 });
 
@@ -414,6 +429,155 @@ test.describe('Tier filter - aggregation-based options', () => {
         )
       ).toBeVisible();
     });
+  });
+});
+
+test.describe('Quick filter options - proper casing from top_hits', () => {
+  test('domain filter option label uses original casing from _source', async ({
+    page,
+  }) => {
+    const domainName = domain.responseData.displayName as string;
+
+    await test.step('Open Domains filter and wait for aggregate response', async () => {
+      const aggRes = page.waitForResponse(
+        '/api/v1/search/aggregate?index=dataAsset&field=domains.displayName.keyword*'
+      );
+      await page.click('[data-testid="search-dropdown-Domains"]');
+      await aggRes;
+      await waitForAllLoadersToDisappear(page);
+    });
+
+    await test.step('Option label matches original casing, not lowercased bucket key', async () => {
+      const searchRes = page.waitForResponse(
+        '/api/v1/search/aggregate?index=dataAsset&field=domains.displayName.keyword*'
+      );
+      await page.fill('[data-testid="search-input"]', domainName);
+      await searchRes;
+
+      // The rendered option text must match the original-cased displayName
+      const optionEl = page.getByTestId(domainName.toLowerCase());
+
+      await expect(optionEl).toBeVisible();
+      await expect(optionEl).toContainText(domainName);
+    });
+
+    await clickOutside(page);
+  });
+
+  test('tier filter option label uses original casing from _source', async ({
+    page,
+  }) => {
+    const tierFqn = tier.responseData.fullyQualifiedName as string;
+
+    await test.step('Open Tier filter and wait for aggregate response', async () => {
+      const aggRes = page.waitForResponse(
+        '/api/v1/search/aggregate?index=dataAsset&field=tier.tagFQN*'
+      );
+      await page.click('[data-testid="search-dropdown-Tier"]');
+      await aggRes;
+      await waitForAllLoadersToDisappear(page);
+    });
+
+    await test.step('Option label matches original FQN casing', async () => {
+      const searchRes = page.waitForResponse(
+        '/api/v1/search/aggregate?index=dataAsset&field=tier.tagFQN*'
+      );
+      await page.fill('[data-testid="search-input"]', tierFqn);
+      await searchRes;
+
+      const optionEl = page.getByTestId(tierFqn.toLowerCase());
+
+      await expect(optionEl).toBeVisible();
+      await expect(optionEl).toContainText(tierFqn);
+    });
+
+    await clickOutside(page);
+  });
+
+  test('tag filter option label uses original casing from _source', async ({
+    page,
+  }) => {
+    const tagFqn = 'PersonalData.Personal';
+
+    await test.step('Open Tag filter and search for the tag', async () => {
+      await page.click('[data-testid="search-dropdown-Tag"]');
+      const searchRes = page.waitForResponse(
+        '/api/v1/search/aggregate?index=dataAsset&field=tags.tagFQN*'
+      );
+      await page.fill('[data-testid="search-input"]', tagFqn);
+      await searchRes;
+    });
+
+    await test.step('Option label matches original FQN casing', async () => {
+      const optionEl = page.getByTestId(tagFqn.toLowerCase());
+
+      await expect(optionEl).toBeVisible();
+      await expect(optionEl).toContainText(tagFqn);
+    });
+
+    await clickOutside(page);
+  });
+
+  test('owner filter option label uses original casing from _source', async ({
+    page,
+  }) => {
+    const ownerName = (user.responseData.displayName ??
+      user.responseData.name) as string;
+
+    await test.step('Open Owners filter and wait for aggregate response', async () => {
+      const aggRes = page.waitForResponse(
+        '/api/v1/search/aggregate?index=dataAsset&field=ownerDisplayName*'
+      );
+      await page.click('[data-testid="search-dropdown-Owners"]');
+      await aggRes;
+      await waitForAllLoadersToDisappear(page);
+    });
+
+    await test.step('Option label matches original casing, not lowercased bucket key', async () => {
+      const searchRes = page.waitForResponse(
+        '/api/v1/search/aggregate?index=dataAsset&field=ownerDisplayName*'
+      );
+      await page.fill('[data-testid="search-input"]', ownerName);
+      await searchRes;
+
+      const optionEl = page.getByTestId(ownerName.toLowerCase());
+
+      await expect(optionEl).toBeVisible();
+      await expect(optionEl).toContainText(ownerName);
+    });
+
+    await clickOutside(page);
+  });
+
+  test('service filter option label uses original casing from _source', async ({
+    page,
+  }) => {
+    const serviceName = (table.serviceResponseData.displayName ??
+      table.serviceResponseData.name) as string;
+
+    await test.step('Open Service filter and wait for aggregate response', async () => {
+      const aggRes = page.waitForResponse(
+        '/api/v1/search/aggregate?index=dataAsset&field=service.displayName.keyword*'
+      );
+      await page.click('[data-testid="search-dropdown-Service"]');
+      await aggRes;
+      await waitForAllLoadersToDisappear(page);
+    });
+
+    await test.step('Option label matches original casing', async () => {
+      const searchRes = page.waitForResponse(
+        '/api/v1/search/aggregate?index=dataAsset&field=service.displayName.keyword*'
+      );
+      await page.fill('[data-testid="search-input"]', serviceName);
+      await searchRes;
+
+      const optionEl = page.getByTestId(serviceName.toLowerCase());
+
+      await expect(optionEl).toBeVisible();
+      await expect(optionEl).toContainText(serviceName);
+    });
+
+    await clickOutside(page);
   });
 });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataProductCertificationFilter.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataProductCertificationFilter.spec.ts
@@ -15,22 +15,58 @@ import { Operation } from 'fast-json-patch';
 import { SidebarItem } from '../../constant/sidebar';
 import { DataProduct } from '../../support/domain/DataProduct';
 import { Domain } from '../../support/domain/Domain';
+import { Glossary } from '../../support/glossary/Glossary';
+import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import { TagClass } from '../../support/tag/TagClass';
-import { createNewPage, redirectToHomePage } from '../../utils/common';
+import { createNewPage, redirectToHomePage, uuid } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import { clickUpdateButtonIfVisible } from '../../utils/explore';
+import { waitForAggregation } from '../../utils/searchAggregation';
 import { sidebarClick } from '../../utils/sidebar';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 
-const CERTIFICATION_FILTER_LABEL = 'Certification';
-const CERTIFICATION_FIELD = 'certification.tagLabel.tagFQN';
+type QuickFilter = {
+  /** Rendered dropdown label, which is also part of its test id. */
+  label: string;
+  /** Aggregated field, which is also the URL parameter for the filter. */
+  field: string;
+};
+
+const CERTIFICATION_FILTER: QuickFilter = {
+  label: 'Certification',
+  field: 'certification.tagLabel.tagFQN',
+};
+const GLOSSARY_FILTER: QuickFilter = {
+  label: 'Glossary Terms',
+  field: 'glossaryTags',
+};
+const TAG_FILTER: QuickFilter = {
+  label: 'Tags',
+  field: 'classificationTags',
+};
 
 const domain = new Domain();
 const goldCertification = new TagClass({ classification: 'Certification' });
 const silverCertification = new TagClass({ classification: 'Certification' });
 const goldDataProduct = new DataProduct([domain]);
 const silverDataProduct = new DataProduct([domain]);
+
+// `glossaryTags` and `classificationTags` are indexed through
+// `lowercase_normalizer`, so their aggregation buckets come back lowercased
+// while `_source` keeps the original casing. Mixed-case names make the
+// difference between the two observable.
+const casingId = uuid();
+const glossary = new Glossary(`PW Enterprise Business Glossary ${casingId}`);
+const glossaryTerm = new GlossaryTerm(
+  glossary,
+  undefined,
+  `PW Advanced Shipment Notification ${casingId}`
+);
+const classificationTag = new TagClass({
+  classification: 'PersonalData',
+  name: `PW Data Protection Classification ${casingId}`,
+});
 
 const certificationPatch = (tagFQN: string): Operation[] => [
   {
@@ -47,23 +83,49 @@ const certificationPatch = (tagFQN: string): Operation[] => [
   },
 ];
 
-const assignCertification = async (
+const tagLabel = (tagFQN: string, source: string) => ({
+  tagFQN,
+  source,
+  labelType: 'Manual',
+  state: 'Confirmed',
+});
+
+const patchDataProduct = async (
   apiContext: APIRequestContext,
   dataProduct: DataProduct,
-  certification: TagClass
+  data: Operation[]
 ) => {
   const response = await apiContext.patch(
     `/api/v1/dataProducts/${dataProduct.responseData.id}`,
     {
-      data: certificationPatch(certification.responseData.fullyQualifiedName),
+      data,
       headers: { 'Content-Type': 'application/json-patch+json' },
     }
   );
+
   expect(response.status()).toBe(200);
 };
 
-const resolveCertificationOptionKey = async (
+const assignCertification = (
+  apiContext: APIRequestContext,
+  dataProduct: DataProduct,
+  certification: TagClass
+) =>
+  patchDataProduct(
+    apiContext,
+    dataProduct,
+    certificationPatch(certification.responseData.fullyQualifiedName)
+  );
+
+/**
+ * Types the value into the filter dropdown until the aggregation returns a
+ * matching bucket, then returns that bucket key — which is also the option's
+ * test id. The data product has to be indexed first, so this is retried rather
+ * than asserted once.
+ */
+const resolveFilterOptionKey = async (
   page: Page,
+  filter: QuickFilter,
   searchText: string
 ): Promise<string> => {
   const menu = page.getByTestId('drop-down-menu');
@@ -72,28 +134,28 @@ const resolveCertificationOptionKey = async (
   await expect(async () => {
     const isMenuOpen = await menu.isVisible().catch(() => false);
     if (!isMenuOpen) {
-      await page
-        .getByTestId(`search-dropdown-${CERTIFICATION_FILTER_LABEL}`)
-        .click();
+      await page.getByTestId(`search-dropdown-${filter.label}`).click();
       await menu.waitFor({ state: 'visible' });
     }
 
-    const aggregateResponse = page.waitForResponse(
-      (response) =>
-        response.url().includes('/api/v1/search/aggregate') &&
-        response.url().includes(CERTIFICATION_FIELD)
-    );
+    const aggregateResponse = waitForAggregation(page, {
+      field: filter.field,
+      value: searchText,
+    });
     await menu.getByTestId('search-input').fill(searchText);
     const body = await (await aggregateResponse).json();
     const buckets: Array<{ key: string }> =
-      body?.aggregations?.[`sterms#${CERTIFICATION_FIELD}`]?.buckets ?? [];
+      body?.aggregations?.[`sterms#${filter.field}`]?.buckets ?? [];
+    // Buckets are lowercased by the index normalizer, so the match has to be.
     const match = buckets.find((bucket) =>
-      bucket.key.toLowerCase().includes(searchText.toLowerCase())
+      bucket.key.includes(searchText.toLowerCase())
     );
 
     if (!match) {
       throw new Error(
-        `No certification bucket matched "${searchText}". Server returned keys: ${JSON.stringify(
+        `No ${
+          filter.field
+        } bucket matched "${searchText}". Server returned keys: ${JSON.stringify(
           buckets.map((bucket) => bucket.key)
         )}`
       );
@@ -106,7 +168,7 @@ const resolveCertificationOptionKey = async (
   return resolvedKey;
 };
 
-const applyCertificationFilter = async (page: Page, optionKey: string) => {
+const applyFilter = async (page: Page, optionKey: string) => {
   const option = page.getByTestId('drop-down-menu').getByTestId(optionKey);
 
   const queryResponse = page.waitForResponse((response) => {
@@ -129,33 +191,43 @@ const navigateToDataProducts = async (page: Page) => {
   await waitForAllLoadersToDisappear(page);
 };
 
-test.describe(
-  'Data Products - Certification filter',
-  { tag: '@Governance' },
-  () => {
-    test.beforeAll('Setup certified data products', async ({ browser }) => {
-      const { apiContext, afterAction } = await createNewPage(browser);
+test.describe('Data Products - quick filters', { tag: '@Governance' }, () => {
+  test.beforeAll('Setup data products', async ({ browser }) => {
+    const { apiContext, afterAction } = await createNewPage(browser);
 
-      await domain.create(apiContext);
-      await goldCertification.create(apiContext);
-      await silverCertification.create(apiContext);
-      await goldDataProduct.create(apiContext);
-      await silverDataProduct.create(apiContext);
+    await domain.create(apiContext);
+    await goldCertification.create(apiContext);
+    await silverCertification.create(apiContext);
+    await goldDataProduct.create(apiContext);
+    await silverDataProduct.create(apiContext);
 
-      await assignCertification(apiContext, goldDataProduct, goldCertification);
-      await assignCertification(
-        apiContext,
-        silverDataProduct,
-        silverCertification
-      );
+    await assignCertification(apiContext, goldDataProduct, goldCertification);
+    await assignCertification(
+      apiContext,
+      silverDataProduct,
+      silverCertification
+    );
 
-      await afterAction();
-    });
+    await afterAction();
+  });
 
-    test.beforeEach('Visit home page', async ({ page }) => {
-      await redirectToHomePage(page);
-    });
+  test.afterAll('Cleanup data products', async ({ browser }) => {
+    const { apiContext, afterAction } = await createNewPage(browser);
 
+    await goldDataProduct.delete(apiContext);
+    await silverDataProduct.delete(apiContext);
+    await goldCertification.delete(apiContext);
+    await silverCertification.delete(apiContext);
+    await domain.delete(apiContext);
+
+    await afterAction();
+  });
+
+  test.beforeEach('Visit home page', async ({ page }) => {
+    await redirectToHomePage(page);
+  });
+
+  test.describe('Certification filter', () => {
     test('lists only certifications assigned to data products', async ({
       page,
     }) => {
@@ -165,17 +237,19 @@ test.describe(
 
       await test.step('Certification quick filter is available', async () => {
         await expect(
-          page.getByTestId(`search-dropdown-${CERTIFICATION_FILTER_LABEL}`)
+          page.getByTestId(`search-dropdown-${CERTIFICATION_FILTER.label}`)
         ).toBeVisible();
       });
 
       await test.step('Assigned certifications are searchable', async () => {
-        await resolveCertificationOptionKey(
+        await resolveFilterOptionKey(
           page,
+          CERTIFICATION_FILTER,
           goldCertification.responseData.name
         );
-        await resolveCertificationOptionKey(
+        await resolveFilterOptionKey(
           page,
+          CERTIFICATION_FILTER,
           silverCertification.responseData.name
         );
         await page.keyboard.press('Escape');
@@ -190,11 +264,12 @@ test.describe(
       });
 
       await test.step('Apply the gold certification filter', async () => {
-        const goldOptionKey = await resolveCertificationOptionKey(
+        const goldOptionKey = await resolveFilterOptionKey(
           page,
+          CERTIFICATION_FILTER,
           goldCertification.responseData.name
         );
-        await applyCertificationFilter(page, goldOptionKey);
+        await applyFilter(page, goldOptionKey);
       });
 
       await test.step('Only the gold-certified data product remains', async () => {
@@ -206,5 +281,118 @@ test.describe(
         ).toBeHidden();
       });
     });
-  }
-);
+  });
+
+  test.describe('Option casing', () => {
+    test.beforeAll('Tag a data product', async ({ browser }) => {
+      const { apiContext, afterAction } = await createNewPage(browser);
+
+      await glossary.create(apiContext);
+      await glossaryTerm.create(apiContext);
+      await classificationTag.create(apiContext);
+
+      await patchDataProduct(apiContext, goldDataProduct, [
+        {
+          op: 'add',
+          path: '/tags',
+          value: [
+            tagLabel(glossaryTerm.responseData.fullyQualifiedName, 'Glossary'),
+            tagLabel(
+              classificationTag.responseData.fullyQualifiedName,
+              'Classification'
+            ),
+          ],
+        },
+      ]);
+
+      await afterAction();
+    });
+
+    test.afterAll('Cleanup tags', async ({ browser }) => {
+      const { apiContext, afterAction } = await createNewPage(browser);
+
+      await glossaryTerm.delete(apiContext);
+      await glossary.delete(apiContext);
+      await classificationTag.delete(apiContext);
+
+      await afterAction();
+    });
+
+    test('glossary term option keeps its original casing while the filter value stays lowercased', async ({
+      page,
+    }) => {
+      test.slow();
+
+      const termFQN = glossaryTerm.responseData.fullyQualifiedName;
+
+      await navigateToDataProducts(page);
+
+      const optionKey =
+        await test.step('The dropdown option reads in the original casing', async () => {
+          const resolvedKey = await resolveFilterOptionKey(
+            page,
+            GLOSSARY_FILTER,
+            glossaryTerm.responseData.name
+          );
+
+          // The option is keyed by the lowercased bucket key — what the
+          // `top_hits` sub-aggregation adds is the label read from `_source`.
+          expect(resolvedKey).toBe(termFQN.toLowerCase());
+          await expect(
+            page.getByTestId('drop-down-menu').getByTestId(resolvedKey)
+          ).toContainText(termFQN);
+
+          return resolvedKey;
+        });
+
+      await test.step('Applying the filter keeps the original casing on the chip', async () => {
+        await applyFilter(page, optionKey);
+
+        await expect(
+          page.getByTestId(`filter-chip-${GLOSSARY_FILTER.field}`)
+        ).toContainText(termFQN);
+        await expect(
+          page.getByText(goldDataProduct.responseData.displayName)
+        ).toBeVisible();
+      });
+
+      await test.step('The URL carries the lowercased key, not the label', async () => {
+        expect(
+          new URL(page.url()).searchParams.get(GLOSSARY_FILTER.field)
+        ).toBe(optionKey);
+      });
+
+      await test.step('The casing survives a reload of the filtered URL', async () => {
+        await page.reload();
+        await waitForAllLoadersToDisappear(page);
+
+        await expect(
+          page.getByTestId(`filter-chip-${GLOSSARY_FILTER.field}`)
+        ).toContainText(termFQN);
+      });
+    });
+
+    test('tag option keeps its original casing', async ({ page }) => {
+      const tagFQN = classificationTag.responseData.fullyQualifiedName;
+
+      await navigateToDataProducts(page);
+
+      const optionKey = await resolveFilterOptionKey(
+        page,
+        TAG_FILTER,
+        classificationTag.responseData.name
+      );
+
+      expect(optionKey).toBe(tagFQN.toLowerCase());
+      await expect(
+        page.getByTestId('drop-down-menu').getByTestId(optionKey)
+      ).toContainText(tagFQN);
+
+      await applyFilter(page, optionKey);
+
+      await expect(
+        page.getByTestId(`filter-chip-${TAG_FILTER.field}`)
+      ).toContainText(tagFQN);
+    });
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
@@ -966,12 +966,23 @@ const testFilterWithSpecificOption = async (
   filterWrapper: Locator,
   filterName: string,
   optionTestId: string,
-  expectedQueryFilterValue: string
+  expectedQueryFilterValue: string,
+  searchText?: string
 ) => {
   const filter = filterWrapper.getByTestId(`search-dropdown-${filterName}`);
   await filter.click();
 
   await page.getByTestId('drop-down-menu').waitFor();
+
+  if (searchText) {
+    const aggregateResponse = page.waitForResponse(
+      '/api/v1/search/aggregate?*'
+    );
+    await page
+      .getByRole('textbox', { name: 'Search Service Type...' })
+      .fill(searchText);
+    await aggregateResponse;
+  }
 
   await page.locator(`[data-testid="${optionTestId}"]`).click();
 
@@ -1012,6 +1023,7 @@ const testFilterWithFirstOption = async (
   const noDataPlaceholder = page.getByText(/No data available/i);
   if (await noDataPlaceholder.isVisible()) {
     await page.getByTestId('close-btn').click();
+    await page.getByTestId('close-btn').waitFor({ state: 'detached' });
   } else {
     const optionCount = await firstOption.count();
     if (optionCount > 0) {
@@ -1092,8 +1104,9 @@ export const verifyAssetModalFilters = async (
     page,
     filterWrapper,
     'Service Type',
+    'Mysql',
     'mysql',
-    'mysql'
+    'Mysql'
   );
 
   await testFilterWithFirstOption(page, filterWrapper, 'Tag');

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
@@ -966,12 +966,25 @@ const testFilterWithSpecificOption = async (
   filterWrapper: Locator,
   filterName: string,
   optionTestId: string,
-  expectedQueryFilterValue: string
+  expectedQueryFilterValue: string,
+  searchText?: string
 ) => {
   const filter = filterWrapper.getByTestId(`search-dropdown-${filterName}`);
   await filter.click();
 
-  await page.getByTestId('drop-down-menu').waitFor();
+  const menu = page.getByTestId('drop-down-menu');
+  await menu.waitFor();
+
+  // A filter backed by sourceFields fetches a size-capped, alphabetically
+  // ordered aggregation, so the wanted option may not be on the first page —
+  // narrow the aggregation by searching before clicking.
+  if (searchText) {
+    const aggregateResponse = page.waitForResponse(
+      '/api/v1/search/aggregate?*'
+    );
+    await menu.getByTestId('search-input').fill(searchText);
+    await aggregateResponse;
+  }
 
   await page.locator(`[data-testid="${optionTestId}"]`).click();
 
@@ -1093,6 +1106,7 @@ export const verifyAssetModalFilters = async (
     page,
     filterWrapper,
     'Service Type',
+    'mysql',
     'mysql',
     'mysql'
   );

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
@@ -966,23 +966,12 @@ const testFilterWithSpecificOption = async (
   filterWrapper: Locator,
   filterName: string,
   optionTestId: string,
-  expectedQueryFilterValue: string,
-  searchText?: string
+  expectedQueryFilterValue: string
 ) => {
   const filter = filterWrapper.getByTestId(`search-dropdown-${filterName}`);
   await filter.click();
 
   await page.getByTestId('drop-down-menu').waitFor();
-
-  if (searchText) {
-    const aggregateResponse = page.waitForResponse(
-      '/api/v1/search/aggregate?*'
-    );
-    await page
-      .getByRole('textbox', { name: 'Search Service Type...' })
-      .fill(searchText);
-    await aggregateResponse;
-  }
 
   await page.locator(`[data-testid="${optionTestId}"]`).click();
 
@@ -1104,9 +1093,8 @@ export const verifyAssetModalFilters = async (
     page,
     filterWrapper,
     'Service Type',
-    'Mysql',
     'mysql',
-    'Mysql'
+    'mysql'
   );
 
   await testFilterWithFirstOption(page, filterWrapper, 'Tag');

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/searchAggregation.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/searchAggregation.ts
@@ -1,0 +1,87 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { Page, Response } from '@playwright/test';
+
+const AGGREGATE_PATH = '/api/v1/search/aggregate';
+
+/**
+ * A dropdown aggregates the same field twice — once on open, once per typed
+ * search — so `value` is what tells the two apart and is therefore required.
+ */
+export type AggregationWait = {
+  /** Aggregated field, e.g. `domains.displayName.keyword`. Omit to match any. */
+  field?: string;
+  /** Typed search text; `null` or `''` for the request fired on open. */
+  value: string | null;
+  /** Match only when the request carries this `deleted` flag. */
+  deleted?: boolean;
+};
+
+const KEYWORD_SUFFIX = /\.keyword$/;
+const WRAPPED_SEARCH_TEXT = /^\.\*(.*)\.\*$/;
+
+// The API escapes ES reserved characters, so `service-name` arrives as
+// `service\-name`. Unescaping (rather than stripping backslashes from both
+// sides) keeps `foo\bar` distinguishable from `foobar`.
+const unescapeReserved = (text: string): string =>
+  text.replace(/\\(.)/g, '$1').toLowerCase();
+
+// Specs name a field either way — `entityType` in one, the `entityType.keyword`
+// sub-field the request carries in another — and both mean the same field, so
+// the suffix is not a discriminator.
+const isSameField = (requested: string | null, expected: string): boolean =>
+  requested?.replace(KEYWORD_SUFFIX, '') ===
+  expected.replace(KEYWORD_SUFFIX, '');
+
+const matches = (response: Response, wait: AggregationWait): boolean => {
+  const url = new URL(response.url());
+
+  if (!url.pathname.endsWith(AGGREGATE_PATH)) {
+    return false;
+  }
+
+  const params = url.searchParams;
+
+  if (wait.field && !isSameField(params.get('field'), wait.field)) {
+    return false;
+  }
+
+  if (
+    wait.deleted !== undefined &&
+    params.get('deleted') !== String(wait.deleted)
+  ) {
+    return false;
+  }
+
+  const value = params.get('value');
+
+  // The API sends `.*` when there is no search text, which is the open request.
+  if (!wait.value) {
+    return value === null || value === '.*';
+  }
+
+  const searchText = value?.match(WRAPPED_SEARCH_TEXT)?.[1];
+
+  // Exact, not substring: a wait for `service` must not resolve on an in-flight
+  // response for `service-name`.
+  if (searchText !== undefined) {
+    return unescapeReserved(searchText) === wait.value.toLowerCase();
+  }
+
+  // Unwrapped value: outside the documented shape, so stay permissive.
+  return unescapeReserved(value ?? '').includes(wait.value.toLowerCase());
+};
+
+/** Arm before the action that triggers the request, as with `waitForResponse`. */
+export const waitForAggregation = (page: Page, wait: AggregationWait) =>
+  page.waitForResponse((response) => matches(response, wait));

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExplorePage.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExplorePage.interface.ts
@@ -127,6 +127,7 @@ export interface ExploreQuickFilterField {
   searchKey?: string;
   dropdownClassName?: string;
   singleSelect?: boolean;
+  sourceFields?: string;
 }
 
 // Type for all the explore tab entities

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.test.tsx
@@ -487,7 +487,88 @@ describe('ExploreQuickFilters component', () => {
           undefined,
           false,
           '',
-          undefined
+          'tier.tagFQN'
+        );
+      });
+    });
+
+    it('should derive sourceFields from the shared map for a field that omits it', async () => {
+      mockGetAggregationOptions.mockResolvedValue(
+        mockAdvancedFieldDefaultOptions
+      );
+
+      const glossaryFields: ExploreQuickFilterField[] = [
+        { label: 'Glossary Term', key: 'glossaryTags', value: undefined },
+      ];
+
+      render(
+        <ExploreQuickFilters
+          {...mockProps}
+          aggregations={undefined}
+          fields={glossaryFields}
+        />
+      );
+
+      await act(async () => {
+        userEvent.click(screen.getByTestId('onGetInitialOptions-glossaryTags'));
+      });
+
+      await waitFor(() => {
+        expect(getAggregationOptions).toHaveBeenCalledWith(
+          SearchIndex.TABLE,
+          'glossaryTags',
+          '',
+          expect.any(String),
+          false,
+          false,
+          undefined,
+          false,
+          '',
+          'glossaryTags'
+        );
+      });
+    });
+
+    it('should prefer the sourceFields pinned on the field over the shared map', async () => {
+      mockGetAggregationOptions.mockResolvedValue(
+        mockAdvancedFieldDefaultOptions
+      );
+
+      const pinnedFields: ExploreQuickFilterField[] = [
+        {
+          label: 'Owner',
+          key: 'ownerDisplayName',
+          sourceFields: 'owners.displayName',
+          value: undefined,
+        },
+      ];
+
+      render(
+        <ExploreQuickFilters
+          {...mockProps}
+          aggregations={undefined}
+          fields={pinnedFields}
+        />
+      );
+
+      await act(async () => {
+        userEvent.click(
+          screen.getByTestId('onGetInitialOptions-ownerDisplayName')
+        );
+      });
+
+      await waitFor(() => {
+        expect(getAggregationOptions).toHaveBeenCalledWith(
+          SearchIndex.TABLE,
+          'ownerDisplayName',
+          '',
+          expect.any(String),
+          false,
+          false,
+          undefined,
+          false,
+          '',
+          'owners.displayName'
         );
       });
     });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.test.tsx
@@ -322,7 +322,8 @@ describe('ExploreQuickFilters component', () => {
           false,
           undefined,
           false,
-          'pets'
+          'pets',
+          undefined
         );
       });
     });
@@ -347,7 +348,8 @@ describe('ExploreQuickFilters component', () => {
           false,
           undefined,
           false,
-          ''
+          '',
+          undefined
         );
       });
     });
@@ -377,7 +379,8 @@ describe('ExploreQuickFilters component', () => {
           false,
           undefined,
           false,
-          ''
+          '',
+          undefined
         );
       });
     });
@@ -413,7 +416,8 @@ describe('ExploreQuickFilters component', () => {
           false,
           50,
           false,
-          ''
+          '',
+          undefined
         );
       });
     });
@@ -443,7 +447,8 @@ describe('ExploreQuickFilters component', () => {
           false,
           undefined,
           false,
-          ''
+          '',
+          undefined
         );
       });
     });
@@ -481,7 +486,8 @@ describe('ExploreQuickFilters component', () => {
           false,
           undefined,
           false,
-          ''
+          '',
+          undefined
         );
       });
     });
@@ -529,7 +535,8 @@ describe('ExploreQuickFilters component', () => {
           false,
           undefined,
           false,
-          ''
+          '',
+          undefined
         );
       });
     });
@@ -558,7 +565,8 @@ describe('ExploreQuickFilters component', () => {
           false,
           undefined,
           true,
-          ''
+          '',
+          undefined
         );
       });
     });
@@ -685,7 +693,8 @@ describe('ExploreQuickFilters component', () => {
           expect.anything(),
           undefined,
           expect.anything(),
-          expect.any(String)
+          expect.any(String),
+          undefined
         );
       });
     });
@@ -720,7 +729,8 @@ describe('ExploreQuickFilters component', () => {
           false,
           undefined,
           false,
-          ''
+          '',
+          undefined
         );
       });
     });
@@ -844,7 +854,8 @@ describe('ExploreQuickFilters component', () => {
           false,
           undefined,
           false,
-          ''
+          '',
+          undefined
         );
       });
     });
@@ -874,7 +885,8 @@ describe('ExploreQuickFilters component', () => {
           false,
           undefined,
           false,
-          ''
+          '',
+          undefined
         );
       });
     });
@@ -905,7 +917,8 @@ describe('ExploreQuickFilters component', () => {
           true,
           undefined,
           false,
-          ''
+          '',
+          undefined
         );
       });
     });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
@@ -94,7 +94,8 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
     index: SearchIndex | SearchIndex[],
     key: string,
     fieldSearchIndex?: SearchIndex,
-    fieldSearchKey?: string
+    fieldSearchKey?: string,
+    sourceFields?: string
   ) => {
     const staticOptions = getStaticOptions(key);
     if (staticOptions) {
@@ -108,7 +109,10 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
     // Use field-specific searchKey if provided, otherwise use the key
     const searchKeyToUse = fieldSearchKey ?? key;
 
-    let buckets = aggregations?.[key]?.buckets;
+    // Page aggregations carry only bucket keys (lowercased by the index
+    // normalizer), so fields needing original casing must fetch per-facet
+    // aggregations that include top_hits source data.
+    let buckets = sourceFields ? undefined : aggregations?.[key]?.buckets;
     if (!buckets) {
       const res = await getAggregationOptions(
         searchIndexToUse,
@@ -119,19 +123,23 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
         showDeleted,
         optionPageSize,
         isNLPActive,
-        searchText
+        searchText,
+        sourceFields
       );
 
       buckets = res.data.aggregations[`sterms#${searchKeyToUse}`].buckets;
     }
 
-    setOptions(uniqWith(getOptionsFromAggregationBucket(buckets), isEqual));
+    setOptions(
+      uniqWith(getOptionsFromAggregationBucket(buckets, sourceFields), isEqual)
+    );
   };
 
   const getInitialOptions = async (
     key: string,
     fieldSearchIndex?: SearchIndex,
-    fieldSearchKey?: string
+    fieldSearchKey?: string,
+    sourceFields?: string
   ) => {
     const staticOptions = getStaticOptions(key);
     if (staticOptions) {
@@ -143,7 +151,13 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
     setIsOptionsLoading(true);
     setOptions([]);
     try {
-      await fetchDefaultOptions(index, key, fieldSearchIndex, fieldSearchKey);
+      await fetchDefaultOptions(
+        index,
+        key,
+        fieldSearchIndex,
+        fieldSearchKey,
+        sourceFields
+      );
     } catch (error) {
       showErrorToast(error as AxiosError);
     } finally {
@@ -155,7 +169,8 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
     value: string,
     key: string,
     fieldSearchIndex?: SearchIndex,
-    fieldSearchKey?: string
+    fieldSearchKey?: string,
+    sourceFields?: string
   ) => {
     const staticOptions = getStaticOptions(key);
     if (staticOptions) {
@@ -173,7 +188,7 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
     setOptions([]);
     try {
       if (!value) {
-        getInitialOptions(key, fieldSearchIndex, fieldSearchKey);
+        getInitialOptions(key, fieldSearchIndex, fieldSearchKey, sourceFields);
 
         return;
       }
@@ -190,11 +205,18 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
         showDeleted,
         undefined,
         isNLPActive,
-        searchText
+        searchText,
+        sourceFields
       );
 
-      const buckets = res.data.aggregations[`sterms#${searchKeyToUse}`].buckets;
-      setOptions(uniqWith(getOptionsFromAggregationBucket(buckets), isEqual));
+      const buckets =
+        res.data.aggregations[`sterms#${searchKeyToUse}`]?.buckets ?? [];
+      setOptions(
+        uniqWith(
+          getOptionsFromAggregationBucket(buckets, sourceFields),
+          isEqual
+        )
+      );
     } catch (error) {
       showErrorToast(error as AxiosError);
     } finally {
@@ -228,10 +250,21 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
               onFieldValueSelect({ ...field, value: updatedValues })
             }
             onGetInitialOptions={(key) =>
-              getInitialOptions(key, field.searchIndex, field.searchKey)
+              getInitialOptions(
+                key,
+                field.searchIndex,
+                field.searchKey,
+                field.sourceFields
+              )
             }
             onSearch={(value, key) =>
-              getFilterOptions(value, key, field.searchIndex, field.searchKey)
+              getFilterOptions(
+                value,
+                key,
+                field.searchIndex,
+                field.searchKey,
+                field.sourceFields
+              )
             }
           />
         ) : (
@@ -256,10 +289,21 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
               onFieldValueSelect({ ...field, value: updatedValues });
             }}
             onGetInitialOptions={(key) =>
-              getInitialOptions(key, field.searchIndex, field.searchKey)
+              getInitialOptions(
+                key,
+                field.searchIndex,
+                field.searchKey,
+                field.sourceFields
+              )
             }
             onSearch={(value, key) =>
-              getFilterOptions(value, key, field.searchIndex, field.searchKey)
+              getFilterOptions(
+                value,
+                key,
+                field.searchIndex,
+                field.searchKey,
+                field.sourceFields
+              )
             }
           />
         );

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
@@ -21,7 +21,10 @@ import { SearchIndex } from '../../enums/search.enum';
 import useCustomLocation from '../../hooks/useCustomLocation/useCustomLocation';
 import { useSearchStore } from '../../hooks/useSearchStore';
 import { QueryFilterInterface } from '../../pages/ExplorePage/ExplorePage.interface';
-import { getOptionsFromAggregationBucket } from '../../utils/AdvancedSearchPureUtils';
+import {
+  getOptionsFromAggregationBucket,
+  getQuickFilterSourceFields,
+} from '../../utils/AdvancedSearchPureUtils';
 import {
   getCombinedQueryFilterObject,
   getQuickFilterWithDeletedFlag,
@@ -127,7 +130,8 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
         sourceFields
       );
 
-      buckets = res.data.aggregations[`sterms#${searchKeyToUse}`].buckets;
+      buckets =
+        res.data.aggregations[`sterms#${searchKeyToUse}`]?.buckets ?? [];
     }
 
     setOptions(
@@ -254,7 +258,7 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
                 key,
                 field.searchIndex,
                 field.searchKey,
-                field.sourceFields
+                getQuickFilterSourceFields(field)
               )
             }
             onSearch={(value, key) =>
@@ -263,7 +267,7 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
                 key,
                 field.searchIndex,
                 field.searchKey,
-                field.sourceFields
+                getQuickFilterSourceFields(field)
               )
             }
           />
@@ -293,7 +297,7 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
                 key,
                 field.searchIndex,
                 field.searchKey,
-                field.sourceFields
+                getQuickFilterSourceFields(field)
               )
             }
             onSearch={(value, key) =>
@@ -302,7 +306,7 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
                 key,
                 field.searchIndex,
                 field.searchKey,
-                field.sourceFields
+                getQuickFilterSourceFields(field)
               )
             }
           />

--- a/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreV1.component.tsx
@@ -46,6 +46,7 @@ import {
 import { SIZE, SORT_ORDER } from '../../enums/common.enum';
 import { EntityType } from '../../enums/entity.enum';
 import { SearchIndex } from '../../enums/search.enum';
+import { useQuickFilterLabels } from '../../hooks/useQuickFilterLabels';
 import { QueryFilterInterface } from '../../pages/ExplorePage/ExplorePage.interface';
 import {
   exportSearchResultsCsvStream,
@@ -131,6 +132,11 @@ const ExploreV1: React.FC<ExploreProps> = ({
   const searchQueryParam = useMemo(
     () => (isString(parsedSearch.search) ? parsedSearch.search : ''),
     [location.search]
+  );
+
+  const hitSources = useMemo(
+    () => (searchResults?.hits?.hits ?? []).map((hit) => hit._source),
+    [searchResults]
   );
 
   const { toggleModal, sqlQuery, queryFilter, onResetAllFilters } =
@@ -385,6 +391,15 @@ const ExploreV1: React.FC<ExploreProps> = ({
     });
   };
 
+  // Selected values round trip through the URL as lowercased aggregation keys.
+  // Labels are presentational, so only the rendered fields are hydrated — query
+  // building keeps reading the raw state, whose keys never change.
+  const quickFilterFields = useQuickFilterLabels({
+    fields: selectedQuickFilters,
+    sources: hitSources,
+    index: activeTabKey,
+  });
+
   const exploreLeftPanel = useMemo(() => {
     if (tabItems.length === 0) {
       return loading ? (
@@ -522,7 +537,7 @@ const ExploreV1: React.FC<ExploreProps> = ({
             <ExploreQuickFilters
               showSelectedCounts
               aggregations={aggregations}
-              fields={selectedQuickFilters}
+              fields={quickFilterFields}
               fieldsWithNullValues={SUPPORTED_EMPTY_FILTER_FIELDS}
               index={activeTabKey}
               showDeleted={showDeleted}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/compositions/useListingData.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/compositions/useListingData.tsx
@@ -13,6 +13,7 @@
 
 import { useCallback, useEffect } from 'react';
 import { SearchIndex } from '../../../../enums/search.enum';
+import { useQuickFilterLabels } from '../../../../hooks/useQuickFilterLabels';
 import { getAggregations } from '../../../../utils/ExplorePureUtils';
 import { ExploreQuickFilterField } from '../../../Explore/ExplorePage.interface';
 import { useDataFetching } from '../data/useDataFetching';
@@ -153,6 +154,14 @@ export const useListingData = <
   // selectedEntities should be an array of IDs, not entities
   const selectedEntities = selectionState.selectedEntities;
 
+  // The URL carries only the lowercased aggregation key, so the chips and the
+  // checked dropdown options get their casing restored here.
+  const hydratedFilters = useQuickFilterLabels({
+    fields: parsedFilters,
+    sources: dataFetching.entities,
+    index: searchIndex,
+  });
+
   // Refetch function to reload data with current filters
   const refetch = useCallback(() => {
     dataFetching.searchEntities(
@@ -184,7 +193,7 @@ export const useListingData = <
     isSelected: selectionState.isSelected,
     clearSelection: selectionState.clearSelection,
     urlState,
-    parsedFilters,
+    parsedFilters: hydratedFilters,
     actionHandlers,
     filterOptions: {},
     aggregations: getAggregations(dataFetching.aggregations || {}),

--- a/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
@@ -21,6 +21,7 @@ export const COMMON_DROPDOWN_ITEMS = [
   {
     label: 'label.domain-plural',
     key: EntityFields.DOMAINS,
+    sourceFields: 'domains.displayName',
   },
   {
     label: 'label.data-product-plural',
@@ -30,22 +31,27 @@ export const COMMON_DROPDOWN_ITEMS = [
   {
     label: 'label.owner-plural',
     key: EntityFields.OWNERS,
+    sourceFields: 'ownerDisplayName',
   },
   {
     label: 'label.tag',
     key: EntityFields.TAG,
+    sourceFields: 'tags.tagFQN',
   },
   {
     label: 'label.tier',
     key: EntityFields.TIER,
+    sourceFields: 'tier.tagFQN',
   },
   {
     label: 'label.service',
     key: EntityFields.SERVICE,
+    sourceFields: 'service.displayName',
   },
   {
     label: 'label.service-type',
     key: EntityFields.SERVICE_TYPE,
+    sourceFields: 'serviceType',
   },
 ];
 
@@ -57,6 +63,7 @@ export const DATA_ASSET_DROPDOWN_ITEMS = [
   {
     label: 'label.domain-plural',
     key: EntityFields.DOMAINS,
+    sourceFields: 'domains.displayName',
   },
   {
     label: 'label.data-product-plural',
@@ -66,26 +73,32 @@ export const DATA_ASSET_DROPDOWN_ITEMS = [
   {
     label: 'label.owner-plural',
     key: EntityFields.OWNERS,
+    sourceFields: 'ownerDisplayName',
   },
   {
     label: 'label.tag',
     key: EntityFields.TAG,
+    sourceFields: 'tags.tagFQN',
   },
   {
     label: 'label.tier',
     key: EntityFields.TIER,
+    sourceFields: 'tier.tagFQN',
   },
   {
     label: 'label.certification',
     key: EntityFields.CERTIFICATION,
+    sourceFields: 'certification.tagLabel.tagFQN',
   },
   {
     label: 'label.service',
     key: EntityFields.SERVICE,
+    sourceFields: 'service.displayName',
   },
   {
     label: 'label.service-type',
     key: EntityFields.SERVICE_TYPE,
+    sourceFields: 'serviceType',
   },
 ];
 
@@ -93,10 +106,12 @@ export const TABLE_DROPDOWN_ITEMS = [
   {
     label: 'label.database',
     key: EntityFields.DATABASE,
+    sourceFields: 'database.displayName',
   },
   {
     label: 'label.schema',
     key: EntityFields.DATABASE_SCHEMA,
+    sourceFields: 'databaseSchema.displayName',
   },
   {
     label: 'label.column',
@@ -116,10 +131,12 @@ export const DASHBOARD_DROPDOWN_ITEMS = [
   {
     label: 'label.data-model',
     key: EntityFields.DATA_MODEL,
+    sourceFields: 'dataModels.displayName',
   },
   {
     label: 'label.chart',
     key: EntityFields.CHART,
+    sourceFields: 'charts.displayName',
   },
   {
     label: 'label.project',
@@ -146,6 +163,7 @@ export const PIPELINE_DROPDOWN_ITEMS = [
   {
     label: 'label.task',
     key: EntityFields.TASK,
+    sourceFields: 'tasks.displayName',
   },
 ];
 
@@ -210,18 +228,22 @@ export const GLOSSARY_DROPDOWN_ITEMS = [
   {
     label: 'label.domain-plural',
     key: EntityFields.DOMAINS,
+    sourceFields: 'domains.displayName',
   },
   {
     label: 'label.owner-plural',
     key: EntityFields.OWNERS,
+    sourceFields: 'ownerDisplayName',
   },
   {
     label: 'label.tag',
     key: EntityFields.TAG,
+    sourceFields: 'tags.tagFQN',
   },
   {
     label: 'label.glossary-plural',
     key: EntityFields.GLOSSARY,
+    sourceFields: 'glossary.name',
   },
   {
     label: 'label.status',
@@ -233,10 +255,12 @@ export const TAG_DROPDOWN_ITEMS = [
   {
     label: 'label.domain-plural',
     key: EntityFields.DOMAINS,
+    sourceFields: 'domains.displayName',
   },
   {
     label: 'label.classification',
     key: EntityFields.CLASSIFICATION,
+    sourceFields: 'classification.name',
   },
 ];
 
@@ -244,10 +268,12 @@ export const DATA_PRODUCT_DROPDOWN_ITEMS = [
   {
     label: 'label.domain-plural',
     key: EntityFields.DOMAINS,
+    sourceFields: 'domains.displayName',
   },
   {
     label: 'label.owner-plural',
     key: EntityFields.OWNERS,
+    sourceFields: 'ownerDisplayName',
   },
 ];
 
@@ -262,22 +288,27 @@ export const DOMAIN_DATAPRODUCT_DROPDOWN_ITEMS = [
   {
     label: 'label.owner-plural',
     key: EntityFields.OWNERS,
+    sourceFields: 'ownerDisplayName',
   },
   {
     label: 'label.tag',
     key: EntityFields.TAG,
+    sourceFields: 'tags.tagFQN',
   },
   {
     label: 'label.tier',
     key: EntityFields.TIER,
+    sourceFields: 'tier.tagFQN',
   },
   {
     label: 'label.service',
     key: EntityFields.SERVICE,
+    sourceFields: 'service.displayName',
   },
   {
     label: 'label.service-type',
     key: EntityFields.SERVICE_TYPE,
+    sourceFields: 'serviceType',
   },
 ];
 
@@ -292,26 +323,32 @@ export const GLOSSARY_ASSETS_DROPDOWN_ITEMS = [
   {
     label: 'label.domain-plural',
     key: EntityFields.DOMAINS,
+    sourceFields: 'domains.displayName',
   },
   {
     label: 'label.owner-plural',
     key: EntityFields.OWNERS,
+    sourceFields: 'ownerDisplayName',
   },
   {
     label: 'label.tag',
     key: EntityFields.TAG,
+    sourceFields: 'tags.tagFQN',
   },
   {
     label: 'label.tier',
     key: EntityFields.TIER,
+    sourceFields: 'tier.tagFQN',
   },
   {
     label: 'label.service',
     key: EntityFields.SERVICE,
+    sourceFields: 'service.displayName',
   },
   {
     label: 'label.service-type',
     key: EntityFields.SERVICE_TYPE,
+    sourceFields: 'serviceType',
   },
 ];
 
@@ -326,26 +363,32 @@ export const TAG_ASSETS_DROPDOWN_ITEMS = [
   {
     label: 'label.domain-plural',
     key: EntityFields.DOMAINS,
+    sourceFields: 'domains.displayName',
   },
   {
     label: 'label.owner-plural',
     key: EntityFields.OWNERS,
+    sourceFields: 'ownerDisplayName',
   },
   {
     label: 'label.tag',
     key: EntityFields.TAG,
+    sourceFields: 'tags.tagFQN',
   },
   {
     label: 'label.tier',
     key: EntityFields.TIER,
+    sourceFields: 'tier.tagFQN',
   },
   {
     label: 'label.service',
     key: EntityFields.SERVICE,
+    sourceFields: 'service.displayName',
   },
   {
     label: 'label.service-type',
     key: EntityFields.SERVICE_TYPE,
+    sourceFields: 'serviceType',
   },
 ];
 

--- a/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
@@ -17,41 +17,99 @@ import { SearchIndex } from '../enums/search.enum';
 import { LabelType } from '../generated/type/tagLabel';
 import { t } from '../utils/i18next/LocalUtil';
 
+/**
+ * Aggregation field -> `_source` path used to recover the original casing of a
+ * quick-filter option.
+ *
+ * Every `.keyword` field listed here is indexed through `lowercase_normalizer`,
+ * so terms aggregations return lowercased bucket keys while `_source` keeps the
+ * value as the user typed it. Passing the `_source` path as `sourceFields` adds
+ * a `top_hits` sub-aggregation the UI reads the display label from; the bucket
+ * key stays the filter value, so query building and shared URLs are unaffected.
+ *
+ * Fields indexed without the normalizer (`columnDescriptionStatus`, `fileType`,
+ * `fileExtension`, `mlFeatures.name`) already aggregate in their original case
+ * and are deliberately absent — an entry there would only cost an extra
+ * `top_hits` round trip.
+ */
+export const QUICK_FILTER_SOURCE_FIELDS: Partial<Record<EntityFields, string>> =
+  {
+    [EntityFields.OWNERS]: 'ownerDisplayName',
+    [EntityFields.DOMAINS]: 'domains.displayName',
+    [EntityFields.DATA_PRODUCT]: 'dataProducts.displayName',
+    [EntityFields.TAG]: 'tags.tagFQN',
+    [EntityFields.COLUMN_TAG]: 'columns.tags.tagFQN',
+    [EntityFields.TIER]: 'tier.tagFQN',
+    [EntityFields.CERTIFICATION]: 'certification.tagLabel.tagFQN',
+    [EntityFields.CLASSIFICATION_TAGS]: 'classificationTags',
+    [EntityFields.GLOSSARY_TERMS]: 'glossaryTags',
+    [EntityFields.GLOSSARY]: 'glossary.name',
+    [EntityFields.CLASSIFICATION]: 'classification.name',
+    [EntityFields.SERVICE]: 'service.displayName',
+    [EntityFields.SERVICE_NAME]: 'service.name',
+    [EntityFields.DATABASE]: 'database.displayName',
+    [EntityFields.DATABASE_NAME]: 'database.name',
+    [EntityFields.DATABASE_SCHEMA]: 'databaseSchema.displayName',
+    [EntityFields.DATABASE_SCHEMA_NAME]: 'databaseSchema.name',
+    [EntityFields.TABLE_NAME]: 'table.name',
+    [EntityFields.TABLE_DISPLAY_NAME]: 'table.displayName',
+    [EntityFields.COLUMN]: 'columns.name',
+    [EntityFields.CONTAINER_COLUMN]: 'dataModel.columns.name',
+    [EntityFields.FIELD]: 'fields.name',
+    [EntityFields.SCHEMA_FIELD]: 'messageSchema.schemaFields.name',
+    [EntityFields.REQUEST_SCHEMA_FIELD]: 'requestSchema.schemaFields.name',
+    [EntityFields.RESPONSE_SCHEMA_FIELD]: 'responseSchema.schemaFields.name',
+    [EntityFields.CHART]: 'charts.displayName',
+    [EntityFields.TASK]: 'tasks.displayName',
+    [EntityFields.DATA_MODEL]: 'dataModels.displayName',
+    [EntityFields.API_COLLECTION]: 'apiCollection.displayName',
+    [EntityFields.PARENT]: 'parent.displayName',
+    [EntityFields.DIRECTORY]: 'directory.displayName',
+    [EntityFields.SPREADSHEET]: 'spreadsheet.displayName',
+    [EntityFields.PROJECT]: 'project',
+    [EntityFields.NAME_KEYWORD]: 'name',
+    [EntityFields.DISPLAY_NAME_KEYWORD]: 'displayName',
+    [EntityFields.FULLY_QUALIFIED_NAME]: 'fullyQualifiedName',
+    [EntityFields.SERVICE_TYPE]: 'serviceType',
+    [EntityFields.DATA_MODEL_TYPE]: 'dataModelType',
+    [EntityFields.DATA_PRODUCT_TYPE]: 'dataProductType',
+    [EntityFields.DOMAIN_TYPE]: 'domainType',
+    [EntityFields.VISIBILITY]: 'visibility',
+    [EntityFields.PORTFOLIO_PRIORITY]: 'portfolioPriority',
+    [EntityFields.LIFECYCLE_STAGE]: 'lifecycleStage',
+    [EntityFields.TABLE_TYPE]: 'tableType',
+    [EntityFields.DATA_TYPE]: 'dataType',
+    [EntityFields.ENTITY_STATUS]: 'entityStatus',
+  };
+
 export const COMMON_DROPDOWN_ITEMS = [
   {
     label: 'label.domain-plural',
     key: EntityFields.DOMAINS,
-    sourceFields: 'domains.displayName',
   },
   {
     label: 'label.data-product-plural',
     key: EntityFields.DATA_PRODUCT,
-    sourceFields: 'dataProducts.displayName',
   },
   {
     label: 'label.owner-plural',
     key: EntityFields.OWNERS,
-    sourceFields: 'ownerDisplayName',
   },
   {
     label: 'label.tag',
     key: EntityFields.TAG,
-    sourceFields: 'tags.tagFQN',
   },
   {
     label: 'label.tier',
     key: EntityFields.TIER,
-    sourceFields: 'tier.tagFQN',
   },
   {
     label: 'label.service',
     key: EntityFields.SERVICE,
-    sourceFields: 'service.displayName',
   },
   {
     label: 'label.service-type',
     key: EntityFields.SERVICE_TYPE,
-    sourceFields: 'serviceType',
   },
 ];
 
@@ -63,42 +121,34 @@ export const DATA_ASSET_DROPDOWN_ITEMS = [
   {
     label: 'label.domain-plural',
     key: EntityFields.DOMAINS,
-    sourceFields: 'domains.displayName',
   },
   {
     label: 'label.data-product-plural',
     key: EntityFields.DATA_PRODUCT,
-    sourceFields: 'dataProducts.displayName',
   },
   {
     label: 'label.owner-plural',
     key: EntityFields.OWNERS,
-    sourceFields: 'ownerDisplayName',
   },
   {
     label: 'label.tag',
     key: EntityFields.TAG,
-    sourceFields: 'tags.tagFQN',
   },
   {
     label: 'label.tier',
     key: EntityFields.TIER,
-    sourceFields: 'tier.tagFQN',
   },
   {
     label: 'label.certification',
     key: EntityFields.CERTIFICATION,
-    sourceFields: 'certification.tagLabel.tagFQN',
   },
   {
     label: 'label.service',
     key: EntityFields.SERVICE,
-    sourceFields: 'service.displayName',
   },
   {
     label: 'label.service-type',
     key: EntityFields.SERVICE_TYPE,
-    sourceFields: 'serviceType',
   },
 ];
 
@@ -106,12 +156,10 @@ export const TABLE_DROPDOWN_ITEMS = [
   {
     label: 'label.database',
     key: EntityFields.DATABASE,
-    sourceFields: 'database.displayName',
   },
   {
     label: 'label.schema',
     key: EntityFields.DATABASE_SCHEMA,
-    sourceFields: 'databaseSchema.displayName',
   },
   {
     label: 'label.column',
@@ -131,12 +179,10 @@ export const DASHBOARD_DROPDOWN_ITEMS = [
   {
     label: 'label.data-model',
     key: EntityFields.DATA_MODEL,
-    sourceFields: 'dataModels.displayName',
   },
   {
     label: 'label.chart',
     key: EntityFields.CHART,
-    sourceFields: 'charts.displayName',
   },
   {
     label: 'label.project',
@@ -163,7 +209,6 @@ export const PIPELINE_DROPDOWN_ITEMS = [
   {
     label: 'label.task',
     key: EntityFields.TASK,
-    sourceFields: 'tasks.displayName',
   },
 ];
 
@@ -228,22 +273,18 @@ export const GLOSSARY_DROPDOWN_ITEMS = [
   {
     label: 'label.domain-plural',
     key: EntityFields.DOMAINS,
-    sourceFields: 'domains.displayName',
   },
   {
     label: 'label.owner-plural',
     key: EntityFields.OWNERS,
-    sourceFields: 'ownerDisplayName',
   },
   {
     label: 'label.tag',
     key: EntityFields.TAG,
-    sourceFields: 'tags.tagFQN',
   },
   {
     label: 'label.glossary-plural',
     key: EntityFields.GLOSSARY,
-    sourceFields: 'glossary.name',
   },
   {
     label: 'label.status',
@@ -255,12 +296,10 @@ export const TAG_DROPDOWN_ITEMS = [
   {
     label: 'label.domain-plural',
     key: EntityFields.DOMAINS,
-    sourceFields: 'domains.displayName',
   },
   {
     label: 'label.classification',
     key: EntityFields.CLASSIFICATION,
-    sourceFields: 'classification.name',
   },
 ];
 
@@ -268,12 +307,10 @@ export const DATA_PRODUCT_DROPDOWN_ITEMS = [
   {
     label: 'label.domain-plural',
     key: EntityFields.DOMAINS,
-    sourceFields: 'domains.displayName',
   },
   {
     label: 'label.owner-plural',
     key: EntityFields.OWNERS,
-    sourceFields: 'ownerDisplayName',
   },
 ];
 
@@ -288,27 +325,22 @@ export const DOMAIN_DATAPRODUCT_DROPDOWN_ITEMS = [
   {
     label: 'label.owner-plural',
     key: EntityFields.OWNERS,
-    sourceFields: 'ownerDisplayName',
   },
   {
     label: 'label.tag',
     key: EntityFields.TAG,
-    sourceFields: 'tags.tagFQN',
   },
   {
     label: 'label.tier',
     key: EntityFields.TIER,
-    sourceFields: 'tier.tagFQN',
   },
   {
     label: 'label.service',
     key: EntityFields.SERVICE,
-    sourceFields: 'service.displayName',
   },
   {
     label: 'label.service-type',
     key: EntityFields.SERVICE_TYPE,
-    sourceFields: 'serviceType',
   },
 ];
 
@@ -323,32 +355,26 @@ export const GLOSSARY_ASSETS_DROPDOWN_ITEMS = [
   {
     label: 'label.domain-plural',
     key: EntityFields.DOMAINS,
-    sourceFields: 'domains.displayName',
   },
   {
     label: 'label.owner-plural',
     key: EntityFields.OWNERS,
-    sourceFields: 'ownerDisplayName',
   },
   {
     label: 'label.tag',
     key: EntityFields.TAG,
-    sourceFields: 'tags.tagFQN',
   },
   {
     label: 'label.tier',
     key: EntityFields.TIER,
-    sourceFields: 'tier.tagFQN',
   },
   {
     label: 'label.service',
     key: EntityFields.SERVICE,
-    sourceFields: 'service.displayName',
   },
   {
     label: 'label.service-type',
     key: EntityFields.SERVICE_TYPE,
-    sourceFields: 'serviceType',
   },
 ];
 
@@ -363,32 +389,26 @@ export const TAG_ASSETS_DROPDOWN_ITEMS = [
   {
     label: 'label.domain-plural',
     key: EntityFields.DOMAINS,
-    sourceFields: 'domains.displayName',
   },
   {
     label: 'label.owner-plural',
     key: EntityFields.OWNERS,
-    sourceFields: 'ownerDisplayName',
   },
   {
     label: 'label.tag',
     key: EntityFields.TAG,
-    sourceFields: 'tags.tagFQN',
   },
   {
     label: 'label.tier',
     key: EntityFields.TIER,
-    sourceFields: 'tier.tagFQN',
   },
   {
     label: 'label.service',
     key: EntityFields.SERVICE,
-    sourceFields: 'service.displayName',
   },
   {
     label: 'label.service-type',
     key: EntityFields.SERVICE_TYPE,
-    sourceFields: 'serviceType',
   },
 ];
 

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useQuickFilterLabels.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useQuickFilterLabels.test.ts
@@ -1,0 +1,265 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import { ExploreQuickFilterField } from '../components/Explore/ExplorePage.interface';
+import { EntityFields } from '../enums/AdvancedSearch.enum';
+import { SearchIndex } from '../enums/search.enum';
+import { getAggregationOptions } from '../utils/ExploreUtils';
+import { useQuickFilterLabels } from './useQuickFilterLabels';
+
+jest.mock('../utils/ExploreUtils', () => ({
+  getAggregationOptions: jest.fn(),
+}));
+
+const mockGetAggregationOptions = getAggregationOptions as jest.Mock;
+
+const TERM_KEY = 'enterprise business glossary.advanced shipment notification';
+const TERM_LABEL =
+  'Enterprise Business Glossary.Advanced Shipment Notification';
+
+const glossaryFields = (optionKeys: string[]): ExploreQuickFilterField[] => [
+  {
+    key: EntityFields.GLOSSARY_TERMS,
+    label: 'label.glossary-term-plural',
+    value: optionKeys.map((key) => ({ key, label: key })),
+  },
+];
+
+const aggregationResponse = (keys: string[], labels: string[]) => ({
+  data: {
+    aggregations: {
+      [`sterms#${EntityFields.GLOSSARY_TERMS}`]: {
+        buckets: keys.map((key, index) => ({
+          key,
+          doc_count: 1,
+          'top_hits#top': {
+            hits: { hits: [{ _source: { glossaryTags: [labels[index]] } }] },
+          },
+        })),
+      },
+    },
+  },
+});
+
+const renderQuickFilterLabels = (
+  fields: ExploreQuickFilterField[],
+  sources: unknown[]
+) =>
+  renderHook(() =>
+    useQuickFilterLabels({ fields, sources, index: SearchIndex.DATA_PRODUCT })
+  );
+
+describe('useQuickFilterLabels', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('takes the casing from the listed rows without an extra request', async () => {
+    const { result } = renderQuickFilterLabels(glossaryFields([TERM_KEY]), [
+      { glossaryTags: [TERM_LABEL] },
+    ]);
+
+    await waitFor(() =>
+      expect(result.current[0].value?.[0].label).toBe(TERM_LABEL)
+    );
+
+    expect(mockGetAggregationOptions).not.toHaveBeenCalled();
+  });
+
+  it('resolves a value the listed rows cannot explain with one aggregation', async () => {
+    mockGetAggregationOptions.mockResolvedValue(
+      aggregationResponse([TERM_KEY], [TERM_LABEL])
+    );
+
+    // The row on this page carries a sibling value of the same field, so the
+    // selected value's casing is not present in the current results.
+    const { result } = renderQuickFilterLabels(glossaryFields([TERM_KEY]), [
+      { glossaryTags: ['Some Other Glossary.Some Other Term'] },
+    ]);
+
+    await waitFor(() =>
+      expect(result.current[0].value?.[0].label).toBe(TERM_LABEL)
+    );
+
+    expect(mockGetAggregationOptions).toHaveBeenCalledTimes(1);
+    expect(mockGetAggregationOptions).toHaveBeenCalledWith(
+      SearchIndex.DATA_PRODUCT,
+      EntityFields.GLOSSARY_TERMS,
+      TERM_KEY,
+      '',
+      false,
+      false,
+      undefined,
+      false,
+      '',
+      'glossaryTags'
+    );
+  });
+
+  it('keeps a resolved label while paging through rows that lack the value', async () => {
+    mockGetAggregationOptions.mockResolvedValue(
+      aggregationResponse([TERM_KEY], [TERM_LABEL])
+    );
+
+    const fields = glossaryFields([TERM_KEY]);
+    const { result, rerender } = renderHook(
+      ({ sources }: { sources: unknown[] }) =>
+        useQuickFilterLabels({
+          fields,
+          sources,
+          index: SearchIndex.DATA_PRODUCT,
+        }),
+      { initialProps: { sources: [{ glossaryTags: [TERM_LABEL] }] } }
+    );
+
+    await waitFor(() =>
+      expect(result.current[0].value?.[0].label).toBe(TERM_LABEL)
+    );
+
+    rerender({ sources: [{ glossaryTags: ['Unrelated.Value'] }] });
+
+    expect(result.current[0].value?.[0].label).toBe(TERM_LABEL);
+    expect(mockGetAggregationOptions).not.toHaveBeenCalled();
+  });
+
+  it('keeps the lowercased key when the aggregation cannot resolve it', async () => {
+    mockGetAggregationOptions.mockResolvedValue(aggregationResponse([], []));
+
+    const { result } = renderQuickFilterLabels(glossaryFields([TERM_KEY]), []);
+
+    await waitFor(() => expect(mockGetAggregationOptions).toHaveBeenCalled());
+
+    expect(result.current[0].value?.[0].label).toBe(TERM_KEY);
+    // A value that resolves to nothing must not be retried in a loop.
+    expect(mockGetAggregationOptions).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the lowercased key when the aggregation request fails', async () => {
+    mockGetAggregationOptions.mockRejectedValue(new Error('network'));
+
+    const { result } = renderQuickFilterLabels(glossaryFields([TERM_KEY]), []);
+
+    await waitFor(() => expect(mockGetAggregationOptions).toHaveBeenCalled());
+
+    expect(result.current[0].value?.[0].label).toBe(TERM_KEY);
+  });
+
+  it('keeps a label that resolves after another value started resolving', async () => {
+    const secondKey = 'enterprise business glossary.purchase order';
+    const secondLabel = 'Enterprise Business Glossary.Purchase Order';
+    const deferred: Record<string, (value: unknown) => void> = {};
+    mockGetAggregationOptions.mockImplementation(
+      (_index, _key, value: string) =>
+        new Promise((resolve) => {
+          deferred[value] = resolve;
+        })
+    );
+
+    const { result, rerender } = renderHook(
+      ({ fields }: { fields: ExploreQuickFilterField[] }) =>
+        useQuickFilterLabels({
+          fields,
+          sources: [],
+          index: SearchIndex.DATA_PRODUCT,
+        }),
+      { initialProps: { fields: glossaryFields([TERM_KEY]) } }
+    );
+
+    await waitFor(() =>
+      expect(mockGetAggregationOptions).toHaveBeenCalledTimes(1)
+    );
+
+    // A second value starts resolving while the first request is still in
+    // flight. The two requests are independent, so neither supersedes the other.
+    rerender({ fields: glossaryFields([TERM_KEY, secondKey]) });
+
+    await waitFor(() =>
+      expect(mockGetAggregationOptions).toHaveBeenCalledTimes(2)
+    );
+
+    deferred[secondKey](aggregationResponse([secondKey], [secondLabel]));
+    await waitFor(() =>
+      expect(result.current[0].value?.[1].label).toBe(secondLabel)
+    );
+
+    deferred[TERM_KEY](aggregationResponse([TERM_KEY], [TERM_LABEL]));
+    await waitFor(() =>
+      expect(result.current[0].value?.[0].label).toBe(TERM_LABEL)
+    );
+  });
+
+  it('asks for an unresolvable value once, not on every row change', async () => {
+    mockGetAggregationOptions.mockResolvedValue(aggregationResponse([], []));
+
+    const fields = glossaryFields([TERM_KEY]);
+    const { rerender } = renderHook(
+      ({ sources }: { sources: unknown[] }) =>
+        useQuickFilterLabels({
+          fields,
+          sources,
+          index: SearchIndex.DATA_PRODUCT,
+        }),
+      { initialProps: { sources: [{ glossaryTags: ['Unrelated.Value'] }] } }
+    );
+
+    await waitFor(() => expect(mockGetAggregationOptions).toHaveBeenCalled());
+
+    rerender({ sources: [{ glossaryTags: ['Another.Value'] }] });
+    rerender({ sources: [] });
+
+    expect(mockGetAggregationOptions).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not request anything for a field aggregated in its original case', async () => {
+    const { result } = renderQuickFilterLabels(
+      [
+        {
+          key: EntityFields.ENTITY_TYPE,
+          label: 'label.entity-type-plural',
+          value: [{ key: 'table', label: 'table' }],
+        },
+      ],
+      []
+    );
+
+    await waitFor(() => expect(result.current[0].value?.[0].key).toBe('table'));
+
+    expect(mockGetAggregationOptions).not.toHaveBeenCalled();
+  });
+
+  it('requests each unresolved value of a multi-select field once', async () => {
+    const secondKey = 'enterprise business glossary.purchase order';
+    const secondLabel = 'Enterprise Business Glossary.Purchase Order';
+    mockGetAggregationOptions.mockImplementation((_index, _key, value) =>
+      Promise.resolve(
+        value === TERM_KEY
+          ? aggregationResponse([TERM_KEY], [TERM_LABEL])
+          : aggregationResponse([secondKey], [secondLabel])
+      )
+    );
+
+    const { result } = renderQuickFilterLabels(
+      glossaryFields([TERM_KEY, secondKey]),
+      []
+    );
+
+    await waitFor(() =>
+      expect(result.current[0].value?.map((option) => option.label)).toEqual([
+        TERM_LABEL,
+        secondLabel,
+      ])
+    );
+
+    expect(mockGetAggregationOptions).toHaveBeenCalledTimes(2);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useQuickFilterLabels.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useQuickFilterLabels.ts
@@ -1,0 +1,246 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ExploreQuickFilterField } from '../components/Explore/ExplorePage.interface';
+import { SearchIndex } from '../enums/search.enum';
+import {
+  applyQuickFilterLabels,
+  getOptionsFromAggregationBucket,
+  getQuickFilterSourceFields,
+  hydrateQuickFilterLabels,
+} from '../utils/AdvancedSearchPureUtils';
+import { getAggregationOptions } from '../utils/ExploreUtils';
+
+// A label resolved once is kept so the casing survives paging and result-scope
+// changes. Bounded because the key space is every filter value the page has seen.
+const MAX_REMEMBERED_LABELS = 500;
+
+// A NUL cannot occur in an aggregation key or a filter value, so the two
+// halves of the cache key can never be confused for one another.
+const CACHE_KEY_SEPARATOR = '\u0000';
+
+interface UseQuickFilterLabelsProps {
+  /** Selected filter fields, with values restored from the URL. */
+  fields: ExploreQuickFilterField[];
+  /** `_source` documents of the rows currently listed. */
+  sources: unknown[];
+  index: SearchIndex | SearchIndex[];
+}
+
+interface ResolvedLabel {
+  cacheKey: string;
+  label: string;
+}
+
+interface PendingLabel extends Pick<ResolvedLabel, 'cacheKey'> {
+  field: ExploreQuickFilterField;
+  optionKey: string;
+  sourceFields: string;
+}
+
+const getCacheKey = (fieldKey: string, optionKey: string) =>
+  `${fieldKey}${CACHE_KEY_SEPARATOR}${optionKey}`;
+
+const withRememberedLabels = (
+  remembered: Map<string, string>,
+  resolved: ResolvedLabel[]
+): Map<string, string> => {
+  const additions = resolved.filter(
+    (entry) => remembered.get(entry.cacheKey) !== entry.label
+  );
+  if (additions.length === 0) {
+    return remembered;
+  }
+
+  const next = new Map(remembered);
+  additions.forEach((entry) => next.set(entry.cacheKey, entry.label));
+  // Map iterates in insertion order, so the oldest keys are dropped first.
+  while (next.size > MAX_REMEMBERED_LABELS) {
+    const oldestKey = next.keys().next().value;
+    if (oldestKey === undefined) {
+      break;
+    }
+    next.delete(oldestKey);
+  }
+
+  return next;
+};
+
+/**
+ * Restores the original casing of selected quick-filter values.
+ *
+ * The URL carries only the lowercased aggregation key, so chips and checked
+ * dropdown options would otherwise read in lowercase after a reload or on a
+ * shared link. Casing comes from the rows already listed wherever possible,
+ * which costs nothing; a value the rows cannot explain — its only matching row
+ * sits on another page, or a sibling value of the same field crowds it out — is
+ * resolved with one targeted aggregation per value, which is exact.
+ */
+export const useQuickFilterLabels = ({
+  fields,
+  sources,
+  index,
+}: UseQuickFilterLabelsProps): ExploreQuickFilterField[] => {
+  const [rememberedLabels, setRememberedLabels] = useState<Map<string, string>>(
+    () => new Map()
+  );
+  // A value is asked for at most once per page lifetime, so one that resolves to
+  // nothing is not re-requested every time the rows change.
+  const attemptedKeys = useRef(new Set<string>());
+  const isUnmounted = useRef(false);
+  useEffect(
+    () => () => {
+      isUnmounted.current = true;
+    },
+    []
+  );
+
+  const markAttempted = useCallback((cacheKey: string) => {
+    if (attemptedKeys.current.size >= MAX_REMEMBERED_LABELS) {
+      attemptedKeys.current.clear();
+    }
+    attemptedKeys.current.add(cacheKey);
+  }, []);
+
+  const fieldsFromSources = useMemo(
+    () => hydrateQuickFilterLabels(fields, sources),
+    [fields, sources]
+  );
+
+  // Whatever the current rows explain is worth keeping for later pages.
+  useEffect(() => {
+    const fromSources = fieldsFromSources.flatMap((field) =>
+      (field.value ?? [])
+        .filter((option) => option.label !== option.key)
+        .map((option) => ({
+          cacheKey: getCacheKey(field.key, option.key),
+          label: option.label,
+        }))
+    );
+
+    setRememberedLabels((remembered) =>
+      withRememberedLabels(remembered, fromSources)
+    );
+  }, [fieldsFromSources]);
+
+  const pendingLabels = useMemo(() => {
+    const pending: PendingLabel[] = [];
+
+    fieldsFromSources.forEach((field) => {
+      const sourceFields = getQuickFilterSourceFields(field);
+      if (!sourceFields) {
+        return;
+      }
+
+      (field.value ?? []).forEach((option) => {
+        const cacheKey = getCacheKey(field.key, option.key);
+        if (
+          option.label === option.key &&
+          !rememberedLabels.has(cacheKey) &&
+          !attemptedKeys.current.has(cacheKey)
+        ) {
+          pending.push({
+            cacheKey,
+            field,
+            optionKey: option.key,
+            sourceFields,
+          });
+        }
+      });
+    });
+
+    return pending;
+  }, [fieldsFromSources, rememberedLabels]);
+
+  // Keyed on what is actually pending, so a value that resolves to nothing is
+  // not retried in a loop.
+  const pendingSignature = useMemo(
+    () => pendingLabels.map((pending) => pending.cacheKey).join(','),
+    [pendingLabels]
+  );
+
+  const resolvePending = useCallback(
+    async ({
+      cacheKey,
+      field,
+      optionKey,
+      sourceFields,
+    }: PendingLabel): Promise<ResolvedLabel | undefined> => {
+      const searchKey = field.searchKey ?? field.key;
+      try {
+        const response = await getAggregationOptions(
+          field.searchIndex ?? index,
+          searchKey,
+          optionKey,
+          '',
+          false,
+          false,
+          undefined,
+          false,
+          '',
+          sourceFields
+        );
+        const buckets =
+          response.data.aggregations[`sterms#${searchKey}`]?.buckets ?? [];
+        const label = getOptionsFromAggregationBucket(
+          buckets,
+          sourceFields
+        ).find((option) => option.key === optionKey)?.label;
+
+        return label && label !== optionKey ? { cacheKey, label } : undefined;
+      } catch {
+        // Casing is cosmetic: keep the lowercased key rather than toasting.
+        return undefined;
+      }
+    },
+    [index]
+  );
+
+  const rememberResolved = useCallback((resolved?: ResolvedLabel) => {
+    if (isUnmounted.current || !resolved) {
+      return;
+    }
+
+    setRememberedLabels((remembered) =>
+      withRememberedLabels(remembered, [resolved])
+    );
+  }, []);
+
+  useEffect(() => {
+    if (!pendingSignature) {
+      return;
+    }
+
+    // Each value resolves independently and writes only its own cache key, so
+    // there is nothing for a later request to supersede — a result is merged
+    // whenever it lands, however it interleaves with the others.
+    pendingLabels.forEach((pending) => {
+      markAttempted(pending.cacheKey);
+      resolvePending(pending).then(rememberResolved);
+    });
+  }, [
+    pendingSignature,
+    pendingLabels,
+    markAttempted,
+    resolvePending,
+    rememberResolved,
+  ]);
+
+  return useMemo(
+    () =>
+      applyQuickFilterLabels(fieldsFromSources, (field, optionKey) =>
+        rememberedLabels.get(getCacheKey(field.key, optionKey))
+      ),
+    [fieldsFromSources, rememberedLabels]
+  );
+};

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ColumnBulkOperations/ColumnGrid/constants/ColumnGrid.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ColumnBulkOperations/ColumnGrid/constants/ColumnGrid.constants.ts
@@ -43,7 +43,6 @@ export const COLUMN_GRID_FILTERS: ExploreQuickFilterField[] = [
     label: i18n.t('label.service'),
     key: EntityFields.SERVICE,
     hideCounts: true,
-    sourceFields: 'service.displayName',
   },
   {
     label: i18n.t('label.service-type'),
@@ -54,7 +53,6 @@ export const COLUMN_GRID_FILTERS: ExploreQuickFilterField[] = [
     label: i18n.t('label.domain-plural'),
     key: EntityFields.DOMAINS,
     hideCounts: true,
-    sourceFields: 'domains.displayName',
   },
   {
     label: i18n.t('label.asset-type'),

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ColumnBulkOperations/ColumnGrid/constants/ColumnGrid.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ColumnBulkOperations/ColumnGrid/constants/ColumnGrid.constants.ts
@@ -43,6 +43,7 @@ export const COLUMN_GRID_FILTERS: ExploreQuickFilterField[] = [
     label: i18n.t('label.service'),
     key: EntityFields.SERVICE,
     hideCounts: true,
+    sourceFields: 'service.displayName',
   },
   {
     label: i18n.t('label.service-type'),
@@ -53,6 +54,7 @@ export const COLUMN_GRID_FILTERS: ExploreQuickFilterField[] = [
     label: i18n.t('label.domain-plural'),
     key: EntityFields.DOMAINS,
     hideCounts: true,
+    sourceFields: 'domains.displayName',
   },
   {
     label: i18n.t('label.asset-type'),

--- a/openmetadata-ui/src/main/resources/ui/src/rest/miscAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/miscAPI.ts
@@ -21,7 +21,7 @@ import { AsyncDeleteJob } from '../context/AsyncDeleteProvider/AsyncDeleteProvid
 import { SearchIndex } from '../enums/search.enum';
 import { AuthenticationConfiguration } from '../generated/configuration/authenticationConfiguration';
 import { AuthorizerConfiguration } from '../generated/configuration/authorizerConfiguration';
-import { SearchRequest } from '../generated/search/searchRequest';
+import { AggregationRequest } from '../generated/search/aggregationRequest';
 import { ValidationResponse } from '../generated/system/validationResponse';
 import { Paging } from '../generated/type/paging';
 import { SearchResponse } from '../interface/search.interface';
@@ -246,18 +246,18 @@ export const getAggregateFieldOptions = (
 
 /**
  * Posts aggregate field options request with parameters in the body.
- * @param {SearchRequest} body - The search request body containing the parameters.
+ * @param {AggregationRequest} body - The aggregation request body containing the parameters.
  * @return {Promise<SearchResponse<ExploreSearchIndex>>} A promise that resolves to the search response
  * containing the aggregate field options.
  */
 export const postAggregateFieldOptions = ({
   fieldValue,
   ...rest
-}: SearchRequest) => {
+}: AggregationRequest) => {
   const withWildCardValue = fieldValue
     ? `.*${escapeESReservedCharacters(fieldValue)}.*`
     : '.*';
-  const body: SearchRequest = {
+  const body: AggregationRequest = {
     fieldValue: withWildCardValue,
     ...rest,
   };

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchPureUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchPureUtils.test.ts
@@ -11,8 +11,13 @@
  *  limitations under the License.
  */
 import { Bucket } from 'Models';
+import { EntityFields } from '../enums/AdvancedSearch.enum';
 import { EntityType } from '../enums/entity.enum';
-import { getOptionsFromAggregationBucket } from './AdvancedSearchPureUtils';
+import {
+  getOptionsFromAggregationBucket,
+  getQuickFilterSourceFields,
+  hydrateQuickFilterLabels,
+} from './AdvancedSearchPureUtils';
 
 const buckets = [
   { key: 'table', doc_count: 1734 },
@@ -36,8 +41,6 @@ describe('getOptionsFromAggregationBucket', () => {
       { key: 'tableColumn', label: 'tableColumn', count: 21500 },
     ]);
   });
-
-
 
   it('excludes aggregation keys that should not appear as quick filters', () => {
     const result = getOptionsFromAggregationBucket(buckets);
@@ -85,10 +88,7 @@ describe('getOptionsFromAggregationBucket', () => {
         },
       } as unknown as Bucket;
 
-      const [option] = getOptionsFromAggregationBucket(
-        [bucket],
-        'tier.tagFQN'
-      );
+      const [option] = getOptionsFromAggregationBucket([bucket], 'tier.tagFQN');
 
       expect(option.key).toBe('tier.tier1');
       expect(option.label).toBe('Tier.Tier1');
@@ -158,6 +158,45 @@ describe('getOptionsFromAggregationBucket', () => {
       expect(option.label).toBe('Aaron Johnson');
     });
 
+    it('leaves the bucket key alone rather than labelling it with a sibling value', () => {
+      const bucket = {
+        key: 'pii.sensitive',
+        doc_count: 1,
+        'top_hits#top': {
+          hits: {
+            hits: [
+              {
+                // The bucket's own value is missing from this document, so any
+                // element picked here would be a different tag.
+                _source: { tags: [{ tagFQN: 'Tier.Tier1' }] },
+              },
+            ],
+          },
+        },
+      } as unknown as Bucket;
+
+      const [option] = getOptionsFromAggregationBucket([bucket], 'tags.tagFQN');
+
+      expect(option.label).toBe('pii.sensitive');
+    });
+
+    it('leaves the bucket key alone when a string-array holds only other values', () => {
+      const bucket = {
+        key: 'aaron johnson',
+        doc_count: 1,
+        'top_hits#top': {
+          hits: { hits: [{ _source: { ownerDisplayName: ['Bob Smith'] } }] },
+        },
+      } as unknown as Bucket;
+
+      const [option] = getOptionsFromAggregationBucket(
+        [bucket],
+        'ownerDisplayName'
+      );
+
+      expect(option.label).toBe('aaron johnson');
+    });
+
     it('picks the matching entry from a multi-value string-array by bucket key', () => {
       const bucket = {
         key: 'aaron johnson',
@@ -183,5 +222,149 @@ describe('getOptionsFromAggregationBucket', () => {
       expect(option.key).toBe('aaron johnson');
       expect(option.label).toBe('Aaron Johnson');
     });
+  });
+});
+
+describe('getQuickFilterSourceFields', () => {
+  it('resolves the shared source path for a field that does not pin one', () => {
+    expect(
+      getQuickFilterSourceFields({
+        key: EntityFields.GLOSSARY_TERMS,
+        label: 'label.glossary-term-plural',
+      })
+    ).toBe('glossaryTags');
+  });
+
+  it('prefers the path pinned on the field', () => {
+    expect(
+      getQuickFilterSourceFields({
+        key: EntityFields.OWNERS,
+        label: 'label.owner-plural',
+        sourceFields: 'owners.displayName',
+      })
+    ).toBe('owners.displayName');
+  });
+
+  it('returns undefined for a field aggregated in its original case', () => {
+    expect(
+      getQuickFilterSourceFields({
+        key: EntityFields.ENTITY_TYPE,
+        label: 'label.entity-type-plural',
+      })
+    ).toBeUndefined();
+  });
+});
+
+describe('hydrateQuickFilterLabels', () => {
+  const glossaryFilter = {
+    key: EntityFields.GLOSSARY_TERMS,
+    label: 'label.glossary-term-plural',
+    value: [
+      {
+        key: 'enterprise business glossary.advanced shipment notification',
+        label: 'enterprise business glossary.advanced shipment notification',
+      },
+    ],
+  };
+
+  it('restores the original casing of a selected value from the listed rows', () => {
+    const [field] = hydrateQuickFilterLabels(
+      [glossaryFilter],
+      [
+        {
+          glossaryTags: [
+            'Enterprise Business Glossary.Advanced Shipment Notification',
+          ],
+        },
+      ]
+    );
+
+    expect(field.value?.[0]).toEqual({
+      key: 'enterprise business glossary.advanced shipment notification',
+      label: 'Enterprise Business Glossary.Advanced Shipment Notification',
+    });
+  });
+
+  it('resolves a path that crosses an array of objects', () => {
+    const [field] = hydrateQuickFilterLabels(
+      [
+        {
+          key: EntityFields.TAG,
+          label: 'label.tag',
+          value: [{ key: 'pii.sensitive', label: 'pii.sensitive' }],
+        },
+      ],
+      [{ tags: [{ tagFQN: 'Tier.Tier1' }, { tagFQN: 'PII.Sensitive' }] }]
+    );
+
+    expect(field.value?.[0].label).toBe('PII.Sensitive');
+  });
+
+  it('keeps the field identity when no row carries the selected value', () => {
+    const fields = [glossaryFilter];
+    const result = hydrateQuickFilterLabels(fields, [
+      { glossaryTags: ['Some.Other Term'] },
+    ]);
+
+    expect(result[0]).toBe(glossaryFilter);
+  });
+
+  it('skips rows that are not objects', () => {
+    const [field] = hydrateQuickFilterLabels(
+      [glossaryFilter],
+      [
+        null,
+        'not-a-row',
+        {
+          glossaryTags: [
+            'Enterprise Business Glossary.Advanced Shipment Notification',
+          ],
+        },
+      ]
+    );
+
+    expect(field.value?.[0].label).toBe(
+      'Enterprise Business Glossary.Advanced Shipment Notification'
+    );
+  });
+
+  it('keeps the field identity when there are no rows to read from', () => {
+    const fields = [glossaryFilter];
+
+    expect(hydrateQuickFilterLabels(fields, [])[0]).toBe(glossaryFilter);
+  });
+
+  it('leaves a label already resolved by the dropdown untouched', () => {
+    const resolved = {
+      key: EntityFields.GLOSSARY_TERMS,
+      label: 'label.glossary-term-plural',
+      value: [
+        {
+          key: 'enterprise business glossary.advanced shipment notification',
+          label: 'Enterprise Business Glossary.Advanced Shipment Notification',
+        },
+      ],
+    };
+
+    expect(
+      hydrateQuickFilterLabels(
+        [resolved],
+        [{ glossaryTags: ['SHOUTED.VALUE'] }]
+      )[0]
+    ).toBe(resolved);
+  });
+
+  it('leaves a field aggregated in its original case untouched', () => {
+    const fields = [
+      {
+        key: EntityFields.ENTITY_TYPE,
+        label: 'label.entity-type-plural',
+        value: [{ key: 'table', label: 'table' }],
+      },
+    ];
+
+    expect(hydrateQuickFilterLabels(fields, [{ entityType: 'Table' }])[0]).toBe(
+      fields[0]
+    );
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchPureUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchPureUtils.test.ts
@@ -1,0 +1,187 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { Bucket } from 'Models';
+import { EntityType } from '../enums/entity.enum';
+import { getOptionsFromAggregationBucket } from './AdvancedSearchPureUtils';
+
+const buckets = [
+  { key: 'table', doc_count: 1734 },
+  { key: 'tableColumn', doc_count: 21500 },
+  { key: EntityType.INGESTION_PIPELINE, doc_count: 5 },
+] as Bucket[];
+
+describe('getOptionsFromAggregationBucket', () => {
+  it('returns an empty array when buckets is falsy', () => {
+    expect(
+      getOptionsFromAggregationBucket(undefined as unknown as Bucket[])
+    ).toEqual([]);
+  });
+
+  it('uses the raw bucket key as label when no sourceFields is provided', () => {
+    const result = getOptionsFromAggregationBucket([
+      { key: 'tableColumn', doc_count: 21500 },
+    ] as Bucket[]);
+
+    expect(result).toEqual([
+      { key: 'tableColumn', label: 'tableColumn', count: 21500 },
+    ]);
+  });
+
+
+
+  it('excludes aggregation keys that should not appear as quick filters', () => {
+    const result = getOptionsFromAggregationBucket(buckets);
+
+    expect(
+      result.some((option) => option.key === EntityType.INGESTION_PIPELINE)
+    ).toBe(false);
+  });
+
+  it('defaults count to 0 when doc_count is missing', () => {
+    const [option] = getOptionsFromAggregationBucket([
+      { key: 'table' },
+    ] as Bucket[]);
+
+    expect(option.count).toBe(0);
+  });
+
+  describe('sourceFields - top_hits label extraction', () => {
+    it('reads label from flat _source field when sourceFields is set', () => {
+      const bucket = {
+        key: 'john doe',
+        doc_count: 3,
+        'top_hits#top': {
+          hits: { hits: [{ _source: { ownerDisplayName: 'John Doe' } }] },
+        },
+      } as unknown as Bucket;
+
+      const [option] = getOptionsFromAggregationBucket(
+        [bucket],
+        'ownerDisplayName'
+      );
+
+      expect(option.key).toBe('john doe');
+      expect(option.label).toBe('John Doe');
+    });
+
+    it('reads label from nested single-object _source path', () => {
+      const bucket = {
+        key: 'tier.tier1',
+        doc_count: 2,
+        'top_hits#top': {
+          hits: {
+            hits: [{ _source: { tier: { tagFQN: 'Tier.Tier1' } } }],
+          },
+        },
+      } as unknown as Bucket;
+
+      const [option] = getOptionsFromAggregationBucket(
+        [bucket],
+        'tier.tagFQN'
+      );
+
+      expect(option.key).toBe('tier.tier1');
+      expect(option.label).toBe('Tier.Tier1');
+    });
+
+    it('matches the correct array element by bucket key (not always [0])', () => {
+      const bucket = {
+        key: 'my domain',
+        doc_count: 1,
+        'top_hits#top': {
+          hits: {
+            hits: [
+              {
+                _source: {
+                  domains: [
+                    { displayName: 'Other Domain' },
+                    { displayName: 'My Domain' },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      } as unknown as Bucket;
+
+      const [option] = getOptionsFromAggregationBucket(
+        [bucket],
+        'domains.displayName'
+      );
+
+      expect(option.key).toBe('my domain');
+      expect(option.label).toBe('My Domain');
+    });
+
+    it('falls back to bucket key when no top_hits data is present', () => {
+      const bucket = {
+        key: 'my domain',
+        doc_count: 1,
+      } as unknown as Bucket;
+
+      const [option] = getOptionsFromAggregationBucket(
+        [bucket],
+        'domains.displayName'
+      );
+
+      expect(option.key).toBe('my domain');
+      expect(option.label).toBe('my domain');
+    });
+
+    it('reads label from string-array _source field (ownerDisplayName pattern)', () => {
+      const bucket = {
+        key: 'aaron johnson',
+        doc_count: 1,
+        'top_hits#top': {
+          hits: {
+            hits: [{ _source: { ownerDisplayName: ['Aaron Johnson'] } }],
+          },
+        },
+      } as unknown as Bucket;
+
+      const [option] = getOptionsFromAggregationBucket(
+        [bucket],
+        'ownerDisplayName'
+      );
+
+      expect(option.key).toBe('aaron johnson');
+      expect(option.label).toBe('Aaron Johnson');
+    });
+
+    it('picks the matching entry from a multi-value string-array by bucket key', () => {
+      const bucket = {
+        key: 'aaron johnson',
+        doc_count: 1,
+        'top_hits#top': {
+          hits: {
+            hits: [
+              {
+                _source: {
+                  ownerDisplayName: ['Bob Smith', 'Aaron Johnson'],
+                },
+              },
+            ],
+          },
+        },
+      } as unknown as Bucket;
+
+      const [option] = getOptionsFromAggregationBucket(
+        [bucket],
+        'ownerDisplayName'
+      );
+
+      expect(option.key).toBe('aaron johnson');
+      expect(option.label).toBe('Aaron Johnson');
+    });
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchPureUtils.ts
@@ -22,6 +22,7 @@ import {
   DOMAIN_DATAPRODUCT_DROPDOWN_ITEMS,
   GLOSSARY_ASSETS_DROPDOWN_ITEMS,
   LINEAGE_DROPDOWN_ITEMS,
+  QUICK_FILTER_SOURCE_FIELDS,
   TAG_ASSETS_DROPDOWN_ITEMS,
 } from '../constants/AdvancedSearch.constants';
 import { NOT_INCLUDE_AGGREGATION_QUICK_FILTER } from '../constants/explore.constants';
@@ -42,6 +43,7 @@ import type {
   TopicSearchSource,
 } from '../interface/search.interface';
 import { getEntityName } from './EntityNameUtils';
+import { extractSourceValue } from './SearchPureUtils';
 
 export const getAssetsPageQuickFilters = (
   type?: AssetsOfEntity
@@ -207,59 +209,95 @@ export const getServiceOptions = (
     : option.text;
 };
 
-const extractSourceValue = (
-  src: Record<string, unknown>,
+export const getQuickFilterSourceFields = (
+  field: ExploreQuickFilterField
+): string | undefined =>
+  field.sourceFields ?? QUICK_FILTER_SOURCE_FIELDS[field.key as EntityFields];
+
+const findSourceLabel = (
+  sources: unknown[],
   path: string,
   bucketKey: string
 ): string | undefined => {
-  const parts = path.split('.');
-  let val: unknown = src;
-
-  for (let i = 0; i < parts.length; i++) {
-    const part = parts[i];
-    if (Array.isArray(val)) {
-      // When we hit an array mid-traversal, find the element whose resolved
-      // leaf value case-insensitively equals the bucket key, falling back to [0].
-      const remainingPath = parts.slice(i).join('.');
-      const match = (val as unknown[]).find((item) => {
-        const leaf = extractSourceValue(
-          item as Record<string, unknown>,
-          remainingPath,
-          bucketKey
-        );
-
-        return leaf?.toLowerCase() === bucketKey.toLowerCase();
-      });
-      const chosen = match ?? (val as unknown[])[0];
-      if (chosen === undefined) {
-        return undefined;
-      }
-
-      return extractSourceValue(
-        chosen as Record<string, unknown>,
-        remainingPath,
-        bucketKey
-      );
-    } else if (val && typeof val === 'object' && part in (val as object)) {
-      val = (val as Record<string, unknown>)[part];
-    } else {
-      return undefined;
+  for (const source of sources) {
+    if (!source || typeof source !== 'object') {
+      continue;
+    }
+    const value = extractSourceValue(
+      source as Record<string, unknown>,
+      path,
+      bucketKey
+    );
+    if (value?.toLowerCase() === bucketKey.toLowerCase()) {
+      return value;
     }
   }
 
-  // Terminal value may be a string[] (e.g. ownerDisplayName: ["Aaron Johnson"])
-  if (Array.isArray(val)) {
-    const strings = (val as unknown[]).filter(
-      (item): item is string => typeof item === 'string'
-    );
-    const match = strings.find(
-      (s) => s.toLowerCase() === bucketKey.toLowerCase()
-    );
+  return undefined;
+};
 
-    return match ?? strings[0];
+/**
+ * Rewrites the labels of already-selected quick-filter values.
+ *
+ * Only the lowercased bucket key survives a round trip through the URL, so a
+ * reloaded or shared listing would render its chips and checked options in
+ * lowercase. `resolveLabel` supplies the original casing for one value; a field
+ * keeps its identity when nothing resolves, so an unchanged filter set does not
+ * re-render. Values that already carry a resolved label are left alone.
+ */
+export const applyQuickFilterLabels = (
+  fields: ExploreQuickFilterField[],
+  resolveLabel: (
+    field: ExploreQuickFilterField,
+    optionKey: string
+  ) => string | undefined
+): ExploreQuickFilterField[] =>
+  fields.map((field) => {
+    if (isEmpty(field.value)) {
+      return field;
+    }
+
+    let hasResolvedLabel = false;
+    const value = (field.value ?? []).map((option) => {
+      // A label that already differs from the key came from the dropdown, where
+      // the aggregation resolved it against `_source`.
+      if (option.label !== option.key) {
+        return option;
+      }
+
+      const label = resolveLabel(field, option.key);
+      if (!label || label === option.key) {
+        return option;
+      }
+      hasResolvedLabel = true;
+
+      return { ...option, label };
+    });
+
+    return hasResolvedLabel ? { ...field, value } : field;
+  });
+
+/**
+ * Recovers selected-value casing from the rows currently listed: every hit of a
+ * filtered result set carries the value that matched in its `_source`, so no
+ * extra request is needed for the common case. A value whose only matching row
+ * sits on another page stays unresolved here — see `useQuickFilterLabels`.
+ */
+export const hydrateQuickFilterLabels = (
+  fields: ExploreQuickFilterField[],
+  sources: unknown[]
+): ExploreQuickFilterField[] => {
+  if (isEmpty(sources)) {
+    return fields;
   }
 
-  return typeof val === 'string' ? val : undefined;
+  return applyQuickFilterLabels(fields, (field, optionKey) => {
+    const sourceFields = getQuickFilterSourceFields(field);
+
+    return sourceFields
+      ? findSourceLabel(sources, sourceFields, optionKey)
+      : undefined;
+  });
 };
 
 export const getOptionsFromAggregationBucket = (

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchPureUtils.ts
@@ -207,7 +207,65 @@ export const getServiceOptions = (
     : option.text;
 };
 
-export const getOptionsFromAggregationBucket = (buckets: Bucket[]) => {
+const extractSourceValue = (
+  src: Record<string, unknown>,
+  path: string,
+  bucketKey: string
+): string | undefined => {
+  const parts = path.split('.');
+  let val: unknown = src;
+
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (Array.isArray(val)) {
+      // When we hit an array mid-traversal, find the element whose resolved
+      // leaf value case-insensitively equals the bucket key, falling back to [0].
+      const remainingPath = parts.slice(i).join('.');
+      const match = (val as unknown[]).find((item) => {
+        const leaf = extractSourceValue(
+          item as Record<string, unknown>,
+          remainingPath,
+          bucketKey
+        );
+
+        return leaf?.toLowerCase() === bucketKey.toLowerCase();
+      });
+      const chosen = match ?? (val as unknown[])[0];
+      if (chosen === undefined) {
+        return undefined;
+      }
+
+      return extractSourceValue(
+        chosen as Record<string, unknown>,
+        remainingPath,
+        bucketKey
+      );
+    } else if (val && typeof val === 'object' && part in (val as object)) {
+      val = (val as Record<string, unknown>)[part];
+    } else {
+      return undefined;
+    }
+  }
+
+  // Terminal value may be a string[] (e.g. ownerDisplayName: ["Aaron Johnson"])
+  if (Array.isArray(val)) {
+    const strings = (val as unknown[]).filter(
+      (item): item is string => typeof item === 'string'
+    );
+    const match = strings.find(
+      (s) => s.toLowerCase() === bucketKey.toLowerCase()
+    );
+
+    return match ?? strings[0];
+  }
+
+  return typeof val === 'string' ? val : undefined;
+};
+
+export const getOptionsFromAggregationBucket = (
+  buckets: Bucket[],
+  sourceFields?: string
+) => {
   if (!buckets) {
     return [];
   }
@@ -217,11 +275,30 @@ export const getOptionsFromAggregationBucket = (buckets: Bucket[]) => {
       (item) =>
         !NOT_INCLUDE_AGGREGATION_QUICK_FILTER.includes(item.key as EntityType)
     )
-    .map((option) => ({
-      key: option.key,
-      label: option.key,
-      count: option.doc_count ?? 0,
-    }));
+    .map((option) => {
+      let label = option.key;
+
+      if (sourceFields) {
+        const topHitsData = (option as Record<string, unknown>)[
+          'top_hits#top'
+        ] as
+          | {
+              hits?: {
+                hits?: Array<{ _source?: Record<string, unknown> }>;
+              };
+            }
+          | undefined;
+        const src = topHitsData?.hits?.hits?.[0]?._source;
+        const extracted = src
+          ? extractSourceValue(src, sourceFields, option.key)
+          : undefined;
+        if (extracted) {
+          label = extracted;
+        }
+      }
+
+      return { key: option.key, label, count: option.doc_count ?? 0 };
+    });
 };
 
 export const formatQueryValueBasedOnType = (

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx
@@ -50,7 +50,8 @@ export const getAggregationOptions = async (
   deleted = false,
   size = 10,
   isNLPEnabled = false,
-  queryText?: string
+  queryText?: string,
+  sourceFields?: string
 ) => {
   return isIndependent
     ? postAggregateFieldOptions({
@@ -59,13 +60,14 @@ export const getAggregationOptions = async (
         fieldValue: value,
         query: filter,
         size,
+        ...(sourceFields ? { topHits: { size: 1 } } : {}),
       })
     : getAggregateFieldOptions(
         index,
         key,
         value,
         filter,
-        undefined,
+        sourceFields,
         deleted,
         isNLPEnabled,
         queryText

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SearchClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SearchClassBase.test.ts
@@ -229,7 +229,6 @@ describe('SearchClassBase', () => {
     const dataProductFilter = {
       label: 'label.data-product-plural',
       key: EntityFields.DATA_PRODUCT,
-      sourceFields: 'dataProducts.displayName',
     };
 
     expect(searchClassBase.getDropDownItems(SearchIndex.TABLE)).toContainEqual(

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SearchPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SearchPureUtils.ts
@@ -48,6 +48,69 @@ export const getEntityTypeFromSearchIndex = (searchIndex: string) => {
   return commonAssets[searchIndex] || null;
 };
 
+/**
+ * Resolves the display value of an aggregation bucket from a `_source` document.
+ *
+ * Terms aggregations on `lowercase_normalizer` keyword fields return lowercased
+ * bucket keys, while `_source` keeps the original casing — so the label comes
+ * from the `top_hits` sub-aggregation the `sourceFields` request parameter adds.
+ * The path may cross arrays (`tags.tagFQN`, `columns.name`) or end on one
+ * (`glossaryTags`, `ownerDisplayName`); in both cases the element that
+ * case-insensitively equals the bucket key wins, since one document can carry
+ * many values for the same field and only one of them belongs to this bucket.
+ */
+export const extractSourceValue = (
+  src: Record<string, unknown>,
+  path: string,
+  bucketKey: string
+): string | undefined => {
+  const parts = path.split('.');
+  let val: unknown = src;
+
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (Array.isArray(val)) {
+      // Mid-traversal array: only the element whose resolved leaf value
+      // case-insensitively equals the bucket key belongs to this bucket. There
+      // is deliberately no positional fallback — a sibling value (the second
+      // tag of a doc carrying two) would be a wrong label, which is worse than
+      // the lowercased bucket key the caller falls back to.
+      const remainingPath = parts.slice(i).join('.');
+      const match = (val as unknown[]).find((item) => {
+        const leaf = extractSourceValue(
+          item as Record<string, unknown>,
+          remainingPath,
+          bucketKey
+        );
+
+        return leaf?.toLowerCase() === bucketKey.toLowerCase();
+      });
+
+      return match === undefined
+        ? undefined
+        : extractSourceValue(
+            match as Record<string, unknown>,
+            remainingPath,
+            bucketKey
+          );
+    } else if (val && typeof val === 'object' && part in (val as object)) {
+      val = (val as Record<string, unknown>)[part];
+    } else {
+      return undefined;
+    }
+  }
+
+  // Terminal value may be a string[] (e.g. ownerDisplayName: ["Aaron Johnson"]),
+  // where the same reasoning applies: match the bucket key or resolve nothing.
+  if (Array.isArray(val)) {
+    return (val as unknown[])
+      .filter((item): item is string => typeof item === 'string')
+      .find((item) => item.toLowerCase() === bucketKey.toLowerCase());
+  }
+
+  return typeof val === 'string' ? val : undefined;
+};
+
 export const parseBucketsData = (
   buckets: Array<Bucket>,
   sourceFields?: string,
@@ -93,15 +156,8 @@ export const parseBucketsData = (
 
     const actualValue =
       sourceFields && topHitsSource
-        ? sourceFields
-            .split('.')
-            .reduce(
-              (obj: unknown, key: string): unknown =>
-                obj && typeof obj === 'object' && obj !== null && key in obj
-                  ? (obj as Record<string, unknown>)[key]
-                  : undefined,
-              topHitsSource
-            ) ?? bucket.key
+        ? extractSourceValue(topHitsSource, sourceFields, bucket.key) ??
+          bucket.key
         : bucket.key;
 
     return {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SearchUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SearchUtils.test.ts
@@ -136,6 +136,63 @@ describe('getGroupLabel', () => {
 });
 
 describe('parseBucketsData', () => {
+  it('resolves a source path that crosses an array of objects', () => {
+    const buckets = [
+      {
+        key: 'pii.sensitive',
+        doc_count: 3,
+        'top_hits#top': {
+          hits: {
+            hits: [
+              {
+                _source: {
+                  tags: [{ tagFQN: 'Tier.Tier1' }, { tagFQN: 'PII.Sensitive' }],
+                },
+              },
+            ],
+          },
+        },
+      },
+    ];
+
+    const result = parseBucketsData(buckets, 'tags.tagFQN');
+
+    expect(result).toEqual([
+      { value: 'PII.Sensitive', title: 'PII.Sensitive' },
+    ]);
+  });
+
+  it('resolves a source path that ends on a string array', () => {
+    const buckets = [
+      {
+        key: 'enterprise business glossary.advanced shipment notification',
+        doc_count: 1,
+        'top_hits#top': {
+          hits: {
+            hits: [
+              {
+                _source: {
+                  glossaryTags: [
+                    'Enterprise Business Glossary.Advanced Shipment Notification',
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+    ];
+
+    const result = parseBucketsData(buckets, 'glossaryTags');
+
+    expect(result).toEqual([
+      {
+        value: 'Enterprise Business Glossary.Advanced Shipment Notification',
+        title: 'Enterprise Business Glossary.Advanced Shipment Notification',
+      },
+    ]);
+  });
+
   it('should parse buckets with only key property', () => {
     const buckets = [
       { key: 'value1', doc_count: 1 },


### PR DESCRIPTION
## Describe your changes

Cherry-pick of #32190 to the 1.13 branch.

Because #32190 builds on the `sourceFields` plumbing introduced in #31307 (which was not on 1.13), this PR carries two commits:

1. **#31307** — proper casing for Explore quick filters via `sourceFields` (prerequisite)
2. **#32190** — quick-filter casing for glossary terms/tags across all pages, `QUICK_FILTER_SOURCE_FIELDS` map, `useQuickFilterLabels` hook, shared `extractSourceValue` bucket parser

### Backport adaptations (1.13 diverged from main)

- `ExploreQuickFilters`/`getOptionsFromAggregationBucket`: 1.13 has no `getOptionLabelFormatter`/`addEntityTypeIcons`/`hasSelectedFieldValues` (main-only Explore redesign), so the signature is `(buckets, sourceFields?)` and page aggregations are skipped only when `sourceFields` is set.
- `postAggregateFieldOptions` switched from the generated `SearchRequest` type to `AggregationRequest` (matches main and the `POST /search/aggregate` backend contract) so `topHits` is typed.
- `ExploreV1`: only the `hitSources` memo and `useQuickFilterLabels` hydration were taken; main-only chips/browse-tree code was left out.
- Ported the standalone `playwright/utils/searchAggregation.ts` helper (from #31873) that the Data Product certification spec relies on; the eslint rule from that PR was not ported.
- Dropped main-only `KNOWLEDGE_PAGE_DROPDOWN_ITEMS` and label-formatter unit tests.

### Verification

- `npx tsc --noEmit` — no errors in touched files (remaining errors are pre-existing on 1.13)
- `yarn jest` on the 6 touched suites — 166/166 pass
- `eslint` + `prettier` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)