### PR TITLE
Fixes 32397: stop a wildcard include with no directory reducing to the workspace root

### DIFF
--- a/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/kafka_parser.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/kafka_parser.py
@@ -202,19 +202,21 @@ def glob_base_directory(include: str) -> str:
     The pipelines API only accepts an exact file, a directory, or a directory
     with a trailing `**`, and rejects every other wildcard form outright, so the
     reduction is just dropping the `**`. Truncating at any other stray wildcard
-    keeps an unexpected include pointed at a real directory rather than at a path
-    that cannot be read at all.
+    keeps an unexpected include pointed at a nested directory rather than at a
+    path that cannot be read at all.
 
-    An include with nothing before its wildcard has no directory to fall back to,
-    so it is returned as it came. Reducing it would land on the workspace root and
-    list everything under it, which is far worse than resolving nothing.
+    An include whose wildcard sits in the first path segment is the exception and
+    is returned as it came, because the only directory above it is the workspace
+    root. Reducing `**` or `/tx*` to `/` would list every notebook in the
+    workspace, and since the listing is no longer filtered they would all be
+    collected. Resolving nothing is the cheaper wrong answer.
     """
     wildcard = include.find("*")
     if wildcard == -1:
         return include
     base = include[:wildcard]
     if base.endswith("/"):
-        return base
+        return include if base == "/" else base
     parent = base.rsplit("/", 1)[0]
     return f"{parent}/" if parent else include
 

--- a/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/kafka_parser.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/kafka_parser.py
@@ -204,12 +204,19 @@ def glob_base_directory(include: str) -> str:
     reduction is just dropping the `**`. Truncating at any other stray wildcard
     keeps an unexpected include pointed at a real directory rather than at a path
     that cannot be read at all.
+
+    An include with nothing before its wildcard has no directory to fall back to,
+    so it is returned as it came. Reducing it would land on the workspace root and
+    list everything under it, which is far worse than resolving nothing.
     """
     wildcard = include.find("*")
     if wildcard == -1:
         return include
     base = include[:wildcard]
-    return base if base.endswith("/") else base.rsplit("/", 1)[0] + "/"
+    if base.endswith("/"):
+        return base
+    parent = base.rsplit("/", 1)[0]
+    return f"{parent}/" if parent else include
 
 
 def get_pipeline_libraries(pipeline_config: dict) -> List[DLTLibrarySource]:  # noqa: UP006

--- a/ingestion/tests/unit/topology/pipeline/test_databricks_dlt_sql_lineage.py
+++ b/ingestion/tests/unit/topology/pipeline/test_databricks_dlt_sql_lineage.py
@@ -920,3 +920,34 @@ class TestNullLibrariesInSpec:
     def test_an_empty_libraries_list_still_reaches_the_source_path_fallback(self):
         spec = {"catalog": CATALOG, "schema": SCHEMA, "libraries": [], "configuration": {"source_path": "/src/"}}
         assert self._listed_paths(spec) == ["/src/"]
+
+
+class TestWildcardWithNoDirectory:
+    """
+    An include whose wildcard has nothing before it has no directory to reduce to.
+    Falling back to `/` would list the whole workspace, which costs far more than
+    resolving nothing at all.
+    """
+
+    def test_a_bare_wildcard_is_returned_unchanged(self):
+        for include in ("**", "*", "*.sql", "?.sql"):
+            assert glob_base_directory(include) == include, include
+
+    def test_an_include_with_a_directory_still_reduces(self):
+        assert glob_base_directory("/tx/**") == "/tx/"
+        assert glob_base_directory("/tx/staging*") == "/tx/"
+        assert glob_base_directory("/tx/") == "/tx/"
+
+    def test_a_concrete_path_is_still_left_alone(self):
+        assert glob_base_directory("/tx/one.sql") == "/tx/one.sql"
+
+    def test_the_workspace_root_is_never_expanded(self):
+        """The listing must start where the include points, never at `/`."""
+        with patch.object(DatabrickspipelineSource, "__init__", lambda s, a, b: None):
+            source = DatabrickspipelineSource(None, None)
+        source.client = MagicMock()
+        source.client.list_workspace_objects.return_value = []
+        library = DLTLibrarySource(path=glob_base_directory("**"))
+        source._expand_workspace_directory(library)
+        listed = [call.args[0] for call in source.client.list_workspace_objects.call_args_list]
+        assert "/" not in listed

--- a/ingestion/tests/unit/topology/pipeline/test_databricks_dlt_sql_lineage.py
+++ b/ingestion/tests/unit/topology/pipeline/test_databricks_dlt_sql_lineage.py
@@ -933,10 +933,16 @@ class TestWildcardWithNoDirectory:
         for include in ("**", "*", "*.sql", "?.sql"):
             assert glob_base_directory(include) == include, include
 
+    def test_a_first_segment_wildcard_is_returned_unchanged(self):
+        """`/tx*` reduces to `/`, so it is left alone for the same reason."""
+        for include in ("/tx*", "/tx**", "/*.sql"):
+            assert glob_base_directory(include) == include, include
+
     def test_an_include_with_a_directory_still_reduces(self):
         assert glob_base_directory("/tx/**") == "/tx/"
         assert glob_base_directory("/tx/staging*") == "/tx/"
         assert glob_base_directory("/tx/") == "/tx/"
+        assert glob_base_directory("/a/b/tx*") == "/a/b/"
 
     def test_a_concrete_path_is_still_left_alone(self):
         assert glob_base_directory("/tx/one.sql") == "/tx/one.sql"


### PR DESCRIPTION
### Describe your changes:

Fixes #32397

`glob_base_directory` reduces a `spec.libraries` glob include to the directory the caller should list. It truncates at the first wildcard and falls back to the parent directory when the truncation does not already end in `/`.

With nothing before the wildcard there is no parent, so the fallback landed on the workspace root:

```
glob_base_directory("**")     -> "/"
glob_base_directory("*")      -> "/"
glob_base_directory("*.sql")  -> "/"
```

`_expand_workspace_directory` then walked from `/` to `max_depth`, listing every notebook and file in the workspace instead of skipping an include it cannot resolve.

Such an include is now returned unchanged, so it resolves to nothing. That is far cheaper than listing everything, and an include that carries a directory still reduces exactly as before.

Defensive only. The pipelines API rejects `*`, `?`, and a bare `**`, so a working pipeline cannot produce one. Reported by an automated reviewer on the 2.0 backport of #31654.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A, small change.

#
### Tests:

#### Use cases covered
- `**`, `*`, `*.sql` and `?.sql` are returned unchanged rather than reduced to `/`.
- `/tx/**`, `/tx/staging*` and `/tx/` still reduce to `/tx/`.
- `/tx/one.sql` is still left alone.
- `_expand_workspace_directory` never lists `/` for a bare wildcard include.

#### Unit tests
- [x] I added unit tests for the changed logic.
- File updated: `ingestion/tests/unit/topology/pipeline/test_databricks_dlt_sql_lineage.py` (`TestWildcardWithNoDirectory`, 4 tests)
- Verified they fail without the fix: reverting the guard fails exactly `test_a_bare_wildcard_is_returned_unchanged` and `test_the_workspace_root_is_never_expanded`, while the two control tests covering directory includes and concrete paths still pass.
- No regressions: 159 passing across the Databricks pipeline suites.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable. The change is a guard in a pure path-reduction helper, covered by unit tests.

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. Confirmed the reduction on `main` returns `/` for `**`, `*` and `*.sql`.
2. Confirmed the fixed reduction returns those includes unchanged, and that every directory-bearing include reduces as before.
3. Ran the Databricks unit suites on this branch.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.
- [x] I have added tests and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.
