### PR TITLE
Fixes 32405: re-seed a profile row's draft when its editor opens

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/Profile/components/DomainsRow.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/Profile/components/DomainsRow.tsx
@@ -145,7 +145,10 @@ const DomainsRow: React.FC<DomainsRowProps> = ({
         />
       }
       onCancel={() => setDraftIds(initialIds)}
-      onEnterEdit={() => fetchDomains('')}
+      onEnterEdit={() => {
+        setDraftIds(initialIds);
+        fetchDomains('');
+      }}
       onSave={handleSave}
     />
   );

--- a/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/Profile/components/PersonaRow.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/Profile/components/PersonaRow.test.tsx
@@ -1,0 +1,106 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { EntityType } from '../../../../../enums/entity.enum';
+import { User } from '../../../../../generated/entity/teams/user';
+import PersonaRow from './PersonaRow';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('../../../../../hooks/authHooks', () => ({
+  useAuth: () => ({ isAdminUser: true }),
+}));
+
+jest.mock('../../../../../rest/PersonaAPI', () => ({
+  searchPersonas: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../../../../../utils/ToastUtils', () => ({
+  showErrorToast: jest.fn(),
+}));
+
+// The Autocomplete's own behaviour is not under test here — the draft state
+// that feeds it is. Rendering the selected labels keeps the assertion readable.
+jest.mock('@openmetadata/ui-core-components', () => {
+  const actual = jest.requireActual('@openmetadata/ui-core-components');
+
+  return {
+    ...actual,
+    Autocomplete: ({
+      selectedItems,
+    }: {
+      selectedItems: { id: string; label: string }[];
+    }) => (
+      <div data-testid="persona-multiselect">
+        {selectedItems.map((item) => (
+          <span data-testid={`draft-${item.id}`} key={item.id}>
+            {item.label}
+          </span>
+        ))}
+      </div>
+    ),
+  };
+});
+
+const PERSONA = {
+  id: 'persona-1',
+  type: EntityType.PERSONA,
+  name: 'data-engineer',
+  displayName: 'Data Engineer',
+};
+
+const userWithoutPersonas = { id: 'user-1', name: 'john' } as User;
+const userWithPersonas = {
+  ...userWithoutPersonas,
+  personas: [PERSONA],
+} as User;
+
+describe('PersonaRow', () => {
+  it('should save the personas the row is displaying when they arrive after mount', async () => {
+    const updateUserDetails = jest.fn().mockResolvedValue(undefined);
+
+    // ProfilePage seeds userData from the application store, which carries no
+    // personas; getUserByName backfills them a moment later. The draft is
+    // seeded at mount, so without a re-seed on entering edit mode the row would
+    // save the empty set it captured and silently drop every persona.
+    const { rerender } = render(
+      <PersonaRow
+        updateUserDetails={updateUserDetails}
+        userData={userWithoutPersonas}
+      />
+    );
+
+    rerender(
+      <PersonaRow
+        updateUserDetails={updateUserDetails}
+        userData={userWithPersonas}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('persona-edit'));
+
+    expect(screen.getByTestId(`draft-${PERSONA.id}`)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('persona-save'));
+
+    await waitFor(() =>
+      expect(updateUserDetails).toHaveBeenCalledWith(
+        { personas: [PERSONA] },
+        'personas'
+      )
+    );
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/Profile/components/PersonaRow.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/Profile/components/PersonaRow.tsx
@@ -87,8 +87,15 @@ const PersonaRow: React.FC<PersonaRowProps> = ({
       .catch((err) => showErrorToast(err as AxiosError));
   }, []);
 
-  // Stable so InlineEditCard's onEnterEdit effect fires the initial fetch once.
-  const handleEnterEdit = useCallback(() => fetchPersonas(''), [fetchPersonas]);
+  // `draftPersonaIds` is seeded once at mount, and ProfilePage mounts this row
+  // against the store's `currentUser` — which carries no personas until the
+  // getUserByName backfill lands. Re-seeding the draft here means the editor
+  // always opens from what the row is currently displaying, so a save can never
+  // write back a set captured before a refresh.
+  const handleEnterEdit = useCallback(() => {
+    setDraftPersonaIds(initialPersonaIds);
+    fetchPersonas('');
+  }, [fetchPersonas, initialPersonaIds]);
 
   const searchPersonasDebounced = useMemo(
     () => debounce((query: string) => fetchPersonas(query), 300),

--- a/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/Profile/components/RolesRow.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/Profile/components/RolesRow.tsx
@@ -167,7 +167,10 @@ const RolesRow: React.FC<RolesRowProps> = ({ userData, updateUserDetails }) => {
         />
       }
       onCancel={() => setDraftRoleIds(initialRoleIds)}
-      onEnterEdit={() => fetchRoles('')}
+      onEnterEdit={() => {
+        setDraftRoleIds(initialRoleIds);
+        fetchRoles('');
+      }}
       onSave={handleSave}
     />
   );

--- a/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/Profile/components/TeamsRow.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/Profile/components/TeamsRow.tsx
@@ -155,7 +155,10 @@ const TeamsRow: React.FC<TeamsRowProps> = ({ userData, updateUserDetails }) => {
         />
       }
       onCancel={() => setDraftTeamIds(initialTeamIds)}
-      onEnterEdit={loadTeams}
+      onEnterEdit={() => {
+        setDraftTeamIds(initialTeamIds);
+        loadTeams();
+      }}
       onSave={handleSave}
     />
   );


### PR DESCRIPTION
### Describe your changes:

Fixes #32405

The profile page's four multi-select rows — Persona, Domains, Teams, Roles — seed their draft id list once with `useState(initialIds)` and only resync it on cancel. Nothing resyncs when `userData` changes underneath them.

`ProfilePage` mounts these rows against the application store's `currentUser`, which carries no `personas` / `domains` / `teams` / `roles`; those fields arrive with the `getUserByName` backfill a moment later. The view re-renders when they land — the draft does not. Opening the editor and saving then PATCHes the empty set captured at mount, clearing every assignment the row is visibly displaying, with a 200 and no error.

Each row now re-seeds its draft from the current props in `onEnterEdit`:

```tsx
onEnterEdit={() => {
  setDraftIds(initialIds);
  fetchDomains('');
}}
```

`DefaultPersonaRow` already did exactly this (`onEnterEdit={() => setDraftDefaultId(userData.defaultPersona?.id)}`); this brings the other four in line.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — one line per row, matching the pattern the fifth row already uses.

Considered and rejected: syncing with a `useEffect` on `initialIds`. That would also overwrite a draft the user is actively editing if a background refresh lands mid-edit, trading a silent wipe for silent edit loss. Re-seeding at the moment the editor opens fixes the stale-draft window without ever touching an in-progress edit, and leaves the existing `onCancel` resync as-is.

#
### Tests:

#### Use cases covered
- A row mounted before its data arrives, then re-rendered with it, saves the data it is displaying rather than the empty set it captured at mount.

#### Unit tests
- [x] Added `PersonaRow.test.tsx` — mounts without personas, re-renders with them, opens the editor and saves, asserting the PATCH payload carries the persona.
- Verified as a real regression guard: with the fix reverted the test **fails** (`updateUserDetails` called with `personas: []`); with the fix it passes.

#### Backend integration tests
- [x] Not applicable — UI only.

#### Ingestion integration tests
- [x] Not applicable.

#### Playwright (UI) tests
- Existing Collate specs already cover this path (`persona assignment persists, and its removal persists too`, and its domains twin); they were failing/flaking precisely because of this bug — a stale-draft save returns 200 while removing nothing, so the chip is still there after the modal is reopened.

#### Manual testing performed
1. `yarn test --testPathPattern PersonaRow` — 1 passed; and 1 failed with the fix reverted, confirming the guard.
2. `npx eslint` on all five files — 0 errors. The 10 warnings it prints are pre-existing: the identical count is reported on `origin/main` with these changes stashed.
3. `npx tsc --noEmit` — no findings in any changed file.
4. `npx prettier` — clean.

#
### UI screen recording / screenshots:

Not applicable — no visual change; the fix is in which values a row's editor starts from.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR is linked to a GitHub issue via `Fixes` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: no visual change (see above).
- [x] I have added tests and listed them above.

Bug fix:
- [x] I have added a test that covers the exact scenario we are fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
