### PR TITLE
[1.13] refactor: OIDC login handler and MCP callback auth handling

### DIFF
--- a/docker/development/docker-compose-fuseki.yml
+++ b/docker/development/docker-compose-fuseki.yml
@@ -34,7 +34,7 @@ services:
         condition: service_healthy
 
   fuseki:
-    # Build from the in-repo Dockerfile (Fuseki 5.6.0) instead of the
+    # Build from the in-repo Dockerfile (Fuseki 6.2.0) instead of the
     # unmaintained `stain/jena-fuseki` Docker Hub image, which capped at 5.1.0
     # and never picked up the 2025 admin-side Fuseki CVE fixes (CVE-2025-49656,
     # CVE-2025-50151 — both fixed in Jena 5.5.0). The `image:` tag below names
@@ -43,7 +43,7 @@ services:
     build:
       context: ../rdf-store
       dockerfile: Dockerfile
-    image: openmetadata-fuseki:5.6.0
+    image: openmetadata-fuseki:6.2.0
     container_name: openmetadata-fuseki
     hostname: fuseki
     ports:

--- a/docker/development/docker-compose-postgres-fuseki.yml
+++ b/docker/development/docker-compose-postgres-fuseki.yml
@@ -573,7 +573,7 @@ services:
     build:
       context: ../rdf-store
       dockerfile: Dockerfile
-    image: openmetadata-fuseki:5.6.0
+    image: openmetadata-fuseki:6.2.0
     container_name: openmetadata-fuseki
     hostname: fuseki
     ports:

--- a/docker/docker-compose-quickstart/Dockerfile.fuseki-alpine
+++ b/docker/docker-compose-quickstart/Dockerfile.fuseki-alpine
@@ -1,5 +1,5 @@
 # Use eclipse-temurin which supports ARM64
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:21-jre
 
 # Install minimal packages
 RUN apt-get update && \
@@ -8,7 +8,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Set Fuseki version and paths
-ENV FUSEKI_VERSION=5.6.0
+ENV FUSEKI_VERSION=6.2.0
 ENV FUSEKI_HOME=/fuseki
 ENV FUSEKI_BASE=/fuseki
 

--- a/docker/docker-compose-quickstart/Dockerfile.fuseki-arm64
+++ b/docker/docker-compose-quickstart/Dockerfile.fuseki-arm64
@@ -1,5 +1,5 @@
 # Multi-architecture Dockerfile for Apache Jena Fuseki
-FROM eclipse-temurin:17-jre-jammy
+FROM eclipse-temurin:21-jre-jammy
 
 # Fix for GPG signature issues and install dependencies
 RUN apt-get update || true && \
@@ -14,7 +14,7 @@ RUN apt-get update || true && \
     rm -rf /var/lib/apt/lists/*
 
 # Set Fuseki version
-ENV FUSEKI_VERSION=5.6.0
+ENV FUSEKI_VERSION=6.2.0
 ENV FUSEKI_HOME=/fuseki
 
 # Download and install Fuseki

--- a/docker/docker-compose-quickstart/Dockerfile.fuseki-multiarch
+++ b/docker/docker-compose-quickstart/Dockerfile.fuseki-multiarch
@@ -1,6 +1,6 @@
 # Multi-architecture Fuseki build
 # eclipse-temurin replaces the deprecated openjdk Docker Hub images.
-FROM --platform=$TARGETPLATFORM eclipse-temurin:17-jre-jammy
+FROM --platform=$TARGETPLATFORM eclipse-temurin:21-jre-jammy
 
 # Install required packages
 RUN apt-get update && \
@@ -10,7 +10,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Set Fuseki version and paths
-ENV FUSEKI_VERSION=5.6.0
+ENV FUSEKI_VERSION=6.2.0
 ENV FUSEKI_HOME=/fuseki
 ENV FUSEKI_BASE=/fuseki
 

--- a/docker/docker-compose-quickstart/Dockerfile.fuseki-simple
+++ b/docker/docker-compose-quickstart/Dockerfile.fuseki-simple
@@ -3,7 +3,7 @@ FROM --platform=$BUILDPLATFORM alpine:latest AS downloader
 
 RUN apk add --no-cache wget tar
 
-ENV FUSEKI_VERSION=5.6.0
+ENV FUSEKI_VERSION=6.2.0
 WORKDIR /tmp
 
 RUN wget -q https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz && \
@@ -11,7 +11,7 @@ RUN wget -q https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-${F
     mv apache-jena-fuseki-${FUSEKI_VERSION} /fuseki-dist
 
 # Runtime: eclipse-temurin replaces the deprecated openjdk Docker Hub images.
-FROM eclipse-temurin:17-jre-jammy
+FROM eclipse-temurin:21-jre-jammy
 
 ENV FUSEKI_HOME=/fuseki
 ENV FUSEKI_BASE=/fuseki

--- a/docker/docker-compose-quickstart/Dockerfile.fuseki-working
+++ b/docker/docker-compose-quickstart/Dockerfile.fuseki-working
@@ -1,9 +1,9 @@
 # Simple Fuseki build that works on ARM64
 # eclipse-temurin replaces the deprecated openjdk Docker Hub images.
-FROM eclipse-temurin:17-jre-jammy
+FROM eclipse-temurin:21-jre-jammy
 
 # Set Fuseki version and paths
-ENV FUSEKI_VERSION=5.6.0
+ENV FUSEKI_VERSION=6.2.0
 ENV FUSEKI_HOME=/fuseki
 ENV FUSEKI_BASE=/fuseki
 

--- a/docker/docker-compose-quickstart/docker-compose-fuseki-rosetta.yml
+++ b/docker/docker-compose-quickstart/docker-compose-fuseki-rosetta.yml
@@ -3,12 +3,12 @@ services:
   fuseki:
     # Force AMD64 platform with Rosetta 2 emulation
     platform: linux/amd64
-    # Build from the in-repo Dockerfile (Fuseki 5.6.0). See
+    # Build from the in-repo Dockerfile (Fuseki 6.2.0). See
     # docker-compose-fuseki.yml for the full rationale.
     build:
       context: ../rdf-store
       dockerfile: Dockerfile
-    image: openmetadata-fuseki:5.6.0
+    image: openmetadata-fuseki:6.2.0
     container_name: fuseki-standalone
     hostname: fuseki
     ports:

--- a/docker/docker-compose-quickstart/docker-compose-fuseki-standalone.yml
+++ b/docker/docker-compose-quickstart/docker-compose-fuseki-standalone.yml
@@ -1,12 +1,12 @@
 # Standalone Apache Jena Fuseki for RDF/Knowledge Graph storage
 services:
   fuseki:
-    # Build from the in-repo Dockerfile (Fuseki 5.6.0). See
+    # Build from the in-repo Dockerfile (Fuseki 6.2.0). See
     # ../development/docker-compose-fuseki.yml for the full rationale.
     build:
       context: ../rdf-store
       dockerfile: Dockerfile
-    image: openmetadata-fuseki:5.6.0
+    image: openmetadata-fuseki:6.2.0
     container_name: fuseki-standalone
     hostname: fuseki
     ports:

--- a/docker/docker-compose-quickstart/docker-compose-rdf.yml
+++ b/docker/docker-compose-quickstart/docker-compose-rdf.yml
@@ -74,14 +74,14 @@ services:
           memory: 2G
 
   # Apache Jena Fuseki for RDF/Knowledge Graph storage. Built from the
-  # in-repo Dockerfile (Fuseki 5.6.0) — see ../development/docker-compose-fuseki.yml
+  # in-repo Dockerfile (Fuseki 6.2.0) — see ../development/docker-compose-fuseki.yml
   # for why we don't use the unmaintained stain/jena-fuseki image.
   fuseki:
     container_name: openmetadata_fuseki
     build:
       context: ../rdf-store
       dockerfile: Dockerfile
-    image: openmetadata-fuseki:5.6.0
+    image: openmetadata-fuseki:6.2.0
     restart: always
     environment:
       # Local-dev defaults — production deployments MUST override via the

--- a/docker/rdf-store/Dockerfile
+++ b/docker/rdf-store/Dockerfile
@@ -2,10 +2,15 @@
 # eclipse-temurin replaces the deprecated `openjdk` Docker Hub images
 # (`openjdk:17-jdk-slim` was removed from the registry — CI builds against it
 # fail with "manifest unknown"). JRE is enough since this image only runs the
-# Fuseki shell launcher; no compilation happens inside the container.
-FROM eclipse-temurin:17-jre-jammy
+# Fuseki shell launcher; no compilation happens inside the container. The JRE is
+# 21 because Fuseki 6.x is compiled with --release 21; on a 17 JRE the server
+# dies at startup with UnsupportedClassVersionError.
+FROM eclipse-temurin:21-jre-jammy
 
-ENV FUSEKI_VERSION=5.6.0
+# 6.2.0 fixes CVE-2026-61372: the SPARQL Update engine accepted LOAD source
+# URLs pointing at local resources, so an authenticated update could read data
+# off this container's filesystem. No 5.x release carries the fix.
+ENV FUSEKI_VERSION=6.2.0
 ENV FUSEKI_HOME=/fuseki
 # FUSEKI_BASE must point at the directory containing shiro.ini so Fuseki picks
 # up our auth config on boot. Without this, Fuseki falls back to its built-in

--- a/docs/rdf-local-development.md
+++ b/docs/rdf-local-development.md
@@ -165,7 +165,10 @@ The Fuseki container (`docker/development/docker-compose-fuseki.yml`):
 ```yaml
 services:
   fuseki:
-    image: stain/jena-fuseki:5.0.0
+    build:
+      context: ../rdf-store
+      dockerfile: Dockerfile
+    image: openmetadata-fuseki:6.2.0
     container_name: openmetadata-fuseki
     ports:
       - "3030:3030"

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/auth/handlers/McpCallbackServlet.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/auth/handlers/McpCallbackServlet.java
@@ -4,7 +4,6 @@ import static org.openmetadata.service.security.AuthenticationCodeFlowHandler.OI
 import static org.openmetadata.service.security.SecurityUtil.findEmailFromClaims;
 import static org.openmetadata.service.security.SecurityUtil.findUserNameFromClaims;
 
-import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.pkce.CodeVerifier;
@@ -217,13 +216,21 @@ public class McpCallbackServlet extends HttpServlet {
 
     String expectedIssuer;
     try {
+      ssoHandler.getClient().getConfiguration().ensuresMetadataResolverInitialized();
       expectedIssuer =
-          ssoHandler.getClient().getConfiguration().getProviderMetadata().getIssuer().getValue();
+          ssoHandler
+              .getClient()
+              .getConfiguration()
+              .getOpMetadataResolver()
+              .load()
+              .getIssuer()
+              .getValue();
     } catch (Exception e) {
-      LOG.warn(
-          "Could not extract issuer from OIDC provider metadata, will use default: {}",
-          e.getMessage());
       expectedIssuer = authConfig.getAuthority();
+      LOG.warn(
+          "Could not extract issuer from OIDC provider metadata, using default: {}",
+          expectedIssuer,
+          e);
     }
 
     String expectedAudience = null;
@@ -462,11 +469,11 @@ public class McpCallbackServlet extends HttpServlet {
         throw new IllegalStateException("No OIDC credentials found in session after SSO callback");
       }
 
-      JWT idToken = credentials.getIdToken();
+      String idTokenString = credentials.getIdToken();
 
       JWTClaimsSet claimsSet;
       try {
-        claimsSet = getIdTokenValidator(ssoHandler).validateAndDecode(idToken.serialize());
+        claimsSet = getIdTokenValidator(ssoHandler).validateAndDecode(idTokenString);
         LOG.debug("ID token signature validated successfully in standard SSO flow");
       } catch (IdTokenValidator.IdTokenValidationException e) {
         LOG.error(

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -20,12 +20,12 @@
     <java.saml>2.9.0</java.saml>
     <xmlsec.version>2.3.4</xmlsec.version>
     <quartz.version>2.5.0-rc2</quartz.version>
-    <pac4j.version>5.7.10</pac4j.version>
+    <pac4j.version>6.5.6</pac4j.version>
     <maven-javadoc-plugin.version>3.6.0</maven-javadoc-plugin.version>
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     <socket.io-client.version>2.1.1</socket.io-client.version>
     <json-smart.version>2.5.2</json-smart.version>
-    <jetty.version>12.1.7</jetty.version>
+    <jetty.version>12.1.10</jetty.version>
     <logback-core.version>1.5.36</logback-core.version>
     <logback-classic.version>1.5.36</logback-classic.version>
     <resilience4j-ratelimiter.version>2.3.0</resilience4j-ratelimiter.version>
@@ -34,6 +34,13 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-bom</artifactId>
+        <version>${jetty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bom</artifactId>

--- a/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplication.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplication.java
@@ -58,6 +58,7 @@ import javax.naming.ConfigurationException;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.sys.JenaSystem;
 import org.eclipse.jetty.ee10.servlet.FilterHolder;
 import org.eclipse.jetty.ee10.servlet.ServletHandler;
 import org.eclipse.jetty.ee10.servlet.ServletHolder;
@@ -235,6 +236,18 @@ public class OpenMetadataApplication extends Application<OpenMetadataApplication
           NoSuchAlgorithmException {
 
     this.environment = environment;
+
+    // Initialize Jena before anything can touch org.apache.jena.vocabulary.RDF. On Jena 6.2.0
+    // InitJenaCore's TypeMapper.reset() registers the RDF 1.2 datatypes by reading RDF.dtLangString
+    // and friends, so if RDF is the first Jena class the JVM initializes, its <clinit> triggers
+    // JenaSystem.init() re-entrantly on the same thread and TypeMapper reads those fields while
+    // they
+    // are still null: NPE inside a static initializer, which then leaves *every* Jena class in the
+    // JVM permanently unusable ("Could not initialize class org.apache.jena.graph.NodeFactory").
+    // Jena 5.6.0 did not have this cycle. An explicit init here is idempotent and orders the
+    // subsystem startup ahead of the RDF resources, which construct Jena objects even when RDF is
+    // disabled. Remove once the RDF/TypeMapper init cycle is fixed upstream.
+    JenaSystem.init();
 
     OpenMetadataApplicationConfigHolder.initialize(catalogConfig);
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
@@ -18,7 +18,6 @@ import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.proc.BadJOSEException;
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.jwt.proc.BadJWTException;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
@@ -640,7 +639,9 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
     } catch (Exception e) {
       throw new TechnicalException(e);
     }
-    return resolveProviderMetadata(client.getConfiguration()).getAuthorizationEndpointURI().toString()
+    return resolveProviderMetadata(client.getConfiguration())
+            .getAuthorizationEndpointURI()
+            .toString()
         + '?'
         + queryString;
   }
@@ -937,8 +938,7 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
         String.format(
             "%s?id_token=%s&email=%s&name=%s",
             redirectUri,
-            java.net.URLEncoder.encode(
-                credentials.getIdToken(), StandardCharsets.UTF_8),
+            java.net.URLEncoder.encode(credentials.getIdToken(), StandardCharsets.UTF_8),
             java.net.URLEncoder.encode(email, StandardCharsets.UTF_8),
             java.net.URLEncoder.encode(userName, StandardCharsets.UTF_8));
     response.sendRedirect(url);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
@@ -118,7 +118,7 @@ import org.pac4j.oidc.client.GoogleOidcClient;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.AzureAd2OidcConfiguration;
 import org.pac4j.oidc.config.OidcConfiguration;
-import org.pac4j.oidc.config.PrivateKeyJWTClientAuthnMethodConfig;
+import org.pac4j.oidc.config.method.IPrivateKeyJwtClientAuthnMethodConfig;
 import org.pac4j.oidc.credentials.OidcCredentials;
 
 @Slf4j
@@ -518,7 +518,7 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
       LOG.debug("Authentication response successful");
       AuthenticationSuccessResponse successResponse = (AuthenticationSuccessResponse) response;
 
-      OIDCProviderMetadata metadata = client.getConfiguration().getProviderMetadata();
+      OIDCProviderMetadata metadata = resolveProviderMetadata(client.getConfiguration());
       if (metadata.supportsAuthorizationResponseIssuerParam()
           && !metadata.getIssuer().equals(successResponse.getIssuer())) {
         throw new TechnicalException("Issuer mismatch, possible mix-up attack.");
@@ -534,11 +534,15 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
       validateAndSendTokenRequest(session, credentials, computedCallbackUrl);
 
       // Log Error if the Refresh Token is null
-      if (credentials.getRefreshToken() == null) {
+      if (credentials.toRefreshToken() == null) {
         LOG.error("Refresh token is null for user session: {}", session.getId());
       }
 
-      validateNonceIfRequired(session, credentials.getIdToken().getJWTClaimsSet());
+      JWT idToken = credentials.toIdToken();
+      if (idToken == null) {
+        throw new TechnicalException("ID token not returned by OIDC provider");
+      }
+      validateNonceIfRequired(session, idToken.getJWTClaimsSet());
 
       // Put Credentials in Session
       session.setAttribute(OIDC_CREDENTIAL_PROFILE, credentials);
@@ -600,15 +604,13 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
       if (credentials.isPresent()) {
         LOG.debug("Credentials Found For User Session: {} ", session.getId());
         JwtResponse jwtResponse = new JwtResponse();
-        jwtResponse.setAccessToken(credentials.get().getIdToken().getParsedString());
+        JWT idToken = credentials.get().toIdToken();
+        if (idToken == null) {
+          throw new TechnicalException("ID token not found for user session");
+        }
+        jwtResponse.setAccessToken(credentials.get().getIdToken());
         jwtResponse.setExpiryDuration(
-            credentials
-                .get()
-                .getIdToken()
-                .getJWTClaimsSet()
-                .getExpirationTime()
-                .toInstant()
-                .getEpochSecond());
+            idToken.getJWTClaimsSet().getExpirationTime().toInstant().getEpochSecond());
         writeJsonResponse(httpServletResponse, JsonUtils.pojoToJson(jwtResponse));
       } else {
         // Hotfix #30304: do NOT logout/invalidate here. A login may be in flight on this very
@@ -638,7 +640,7 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
     } catch (Exception e) {
       throw new TechnicalException(e);
     }
-    return client.getConfiguration().getProviderMetadata().getAuthorizationEndpointURI().toString()
+    return resolveProviderMetadata(client.getConfiguration()).getAuthorizationEndpointURI().toString()
         + '?'
         + queryString;
   }
@@ -656,7 +658,7 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
 
   private Optional<OidcCredentials> getUserCredentialsFromSession(HttpSession session) {
     OidcCredentials credentials = (OidcCredentials) session.getAttribute(OIDC_CREDENTIAL_PROFILE);
-    if (credentials != null && credentials.getRefreshToken() != null) {
+    if (credentials != null && credentials.toRefreshToken() != null) {
       LOG.trace("Credentials found in session: {}", credentials);
       renewOidcCredentials(session, credentials);
       return Optional.of(credentials);
@@ -682,7 +684,7 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
           (CodeVerifier) session.getAttribute(client.getCodeVerifierSessionAttributeName());
       AuthorizationCodeGrant grant =
           new AuthorizationCodeGrant(
-              oidcCredentials.getCode(), new URI(computedCallbackUrl), verifier);
+              oidcCredentials.toAuthorizationCode(), new URI(computedCallbackUrl), verifier);
       TokenRequest request = createTokenRequest(grant);
       executeAuthorizationCodeTokenRequest(session, request, oidcCredentials);
     }
@@ -724,17 +726,17 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
     // get authorization code
     AuthorizationCode code = successResponse.getAuthorizationCode();
     if (code != null) {
-      credentials.setCode(code);
+      credentials.setCode(code.getValue());
     }
     // get ID token
     JWT idToken = successResponse.getIDToken();
     if (idToken != null) {
-      credentials.setIdToken(idToken);
+      credentials.setIdToken(idToken.serialize());
     }
     // get access token
     AccessToken accessToken = successResponse.getAccessToken();
     if (accessToken != null) {
-      credentials.setAccessToken(accessToken);
+      credentials.setAccessTokenObject(accessToken);
     }
 
     return credentials;
@@ -765,6 +767,11 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
     }
   }
 
+  private static OIDCProviderMetadata resolveProviderMetadata(OidcConfiguration configuration) {
+    configuration.ensuresMetadataResolverInitialized();
+    return configuration.getOpMetadataResolver().load();
+  }
+
   protected Map<String, List<String>> retrieveCallbackParameters(HttpServletRequest request) {
     Map<String, String[]> requestParameters = request.getParameterMap();
     Map<String, List<String>> map = new HashMap<>();
@@ -780,7 +787,7 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
     if (configuration.getSecret() != null) {
       // check authentication methods
       List<ClientAuthenticationMethod> metadataMethods =
-          configuration.findProviderMetadata().getTokenEndpointAuthMethods();
+          resolveProviderMetadata(configuration).getTokenEndpointAuthMethods();
 
       ClientAuthenticationMethod preferredMethod = getPreferredAuthenticationMethod(configuration);
 
@@ -816,7 +823,7 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
         Secret clientSecret = new Secret(configuration.getSecret());
         clientAuthenticationMechanism = new ClientSecretBasic(clientID, clientSecret);
       } else if (ClientAuthenticationMethod.PRIVATE_KEY_JWT.equals(chosenMethod)) {
-        PrivateKeyJWTClientAuthnMethodConfig privateKetJwtConfig =
+        IPrivateKeyJwtClientAuthnMethodConfig privateKetJwtConfig =
             configuration.getPrivateKeyJWTClientAuthnMethodConfig();
         assertNotNull("privateKetJwtConfig", privateKetJwtConfig);
         JWSAlgorithm jwsAlgo = privateKetJwtConfig.getJwsAlgorithm();
@@ -828,7 +835,7 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
           clientAuthenticationMechanism =
               new PrivateKeyJWT(
                   clientID,
-                  configuration.findProviderMetadata().getTokenEndpointURI(),
+                  resolveProviderMetadata(configuration).getTokenEndpointURI(),
                   jwsAlgo,
                   privateKey,
                   keyID,
@@ -902,7 +909,10 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
   private void sendRedirectWithToken(
       HttpSession httpSession, HttpServletResponse response, OidcCredentials credentials)
       throws ParseException, IOException {
-    JWT jwt = credentials.getIdToken();
+    JWT jwt = credentials.toIdToken();
+    if (jwt == null) {
+      throw new TechnicalException("ID token not found for user session");
+    }
     Map<String, Object> claims = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     claims.putAll(jwt.getJWTClaimsSet().getClaims());
 
@@ -928,7 +938,7 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
             "%s?id_token=%s&email=%s&name=%s",
             redirectUri,
             java.net.URLEncoder.encode(
-                credentials.getIdToken().getParsedString(), StandardCharsets.UTF_8),
+                credentials.getIdToken(), StandardCharsets.UTF_8),
             java.net.URLEncoder.encode(email, StandardCharsets.UTF_8),
             java.net.URLEncoder.encode(userName, StandardCharsets.UTF_8));
     response.sendRedirect(url);
@@ -1033,7 +1043,7 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
   }
 
   public void refreshTokenRequest(HttpSession httpSession, OidcCredentials credentials) {
-    var refreshToken = credentials.getRefreshToken();
+    RefreshToken refreshToken = credentials.toRefreshToken();
     if (refreshToken != null) {
       try {
         final var request = createTokenRequest(new RefreshTokenGrant(refreshToken));
@@ -1070,7 +1080,11 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
 
             // Get the claims from the stored credentials
             Map<String, Object> claims = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-            claims.putAll(storedCredentials.getIdToken().getJWTClaimsSet().getClaims());
+            JWT storedIdToken = storedCredentials.toIdToken();
+            if (storedIdToken == null) {
+              throw new TechnicalException("ID token not found for user session");
+            }
+            claims.putAll(storedIdToken.getJWTClaimsSet().getClaims());
 
             String username = findUserNameFromClaims(claimsMapping, claimsOrder, claims);
             User user = Entity.getEntityByName(Entity.USER, username, "id", Include.NON_DELETED);
@@ -1087,7 +1101,7 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
                         false,
                         ServiceTokenType.OM_USER);
             // Set the access token to the new JWT token
-            credentials.setIdToken(SignedJWT.parse(jwtAuthMechanism.getJWTToken()));
+            credentials.setIdToken(jwtAuthMechanism.getJWTToken());
           }
           return;
         } else {
@@ -1115,7 +1129,7 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
 
     HttpURLConnection connection = null;
     try {
-      RefreshToken refreshToken = azureAdProfile.getRefreshToken();
+      RefreshToken refreshToken = azureAdProfile.toRefreshToken();
       if (refreshToken == null || refreshToken.getValue() == null) {
         throw new TechnicalException("No refresh token available to request new access token.");
       }
@@ -1125,7 +1139,7 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
           HttpConstants.CONTENT_TYPE_HEADER, HttpConstants.APPLICATION_FORM_ENCODED_HEADER_VALUE);
       headers.put(HttpConstants.ACCEPT_HEADER, HttpConstants.APPLICATION_JSON);
 
-      URL tokenEndpointURL = azureConfig.findProviderMetadata().getTokenEndpointURI().toURL();
+      URL tokenEndpointURL = resolveProviderMetadata(azureConfig).getTokenEndpointURI().toURL();
       connection = HttpUtils.openPostConnection(tokenEndpointURL, headers);
 
       String requestBody = azureConfig.makeOauth2TokenRequest(refreshToken.getValue());
@@ -1148,14 +1162,14 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
       String body = HttpUtils.readBody(connection);
       Map<String, Object> res = JsonUtils.readValue(body, new TypeReference<>() {});
 
-      azureAdProfile.setAccessToken(new BearerAccessToken((String) res.get("access_token")));
-      azureAdProfile.setRefreshToken(new RefreshToken((String) res.get("refresh_token")));
+      azureAdProfile.setAccessTokenObject(new BearerAccessToken((String) res.get("access_token")));
+      azureAdProfile.setRefreshTokenObject(new RefreshToken((String) res.get("refresh_token")));
 
       if (res.containsKey("id_token")) {
-        azureAdProfile.setIdToken(SignedJWT.parse((String) res.get("id_token")));
+        azureAdProfile.setIdToken((String) res.get("id_token"));
       }
 
-    } catch (IOException | ParseException e) {
+    } catch (IOException e) {
       throw new TechnicalException("Exception while refreshing Azure AD token", e);
     } finally {
       HttpUtils.closeConnection(connection);
@@ -1192,12 +1206,12 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
   private TokenRequest createTokenRequest(final AuthorizationGrant grant) {
     if (clientAuthentication != null) {
       return new TokenRequest(
-          client.getConfiguration().findProviderMetadata().getTokenEndpointURI(),
+          resolveProviderMetadata(client.getConfiguration()).getTokenEndpointURI(),
           this.clientAuthentication,
           grant);
     } else {
       return new TokenRequest(
-          client.getConfiguration().findProviderMetadata().getTokenEndpointURI(),
+          resolveProviderMetadata(client.getConfiguration()).getTokenEndpointURI(),
           new ClientID(client.getConfiguration().getClientId()),
           grant);
     }
@@ -1245,7 +1259,11 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
     populateCredentialsFromTokenResponse(tokenSuccessResponse, credentials);
 
     // Check expiry, azure on first go itself is returning a expried token sometimes
-    Date expirationTime = credentials.getIdToken().getJWTClaimsSet().getExpirationTime();
+    JWT idToken = credentials.toIdToken();
+    if (idToken == null) {
+      throw new TechnicalException("ID token not returned by OIDC provider");
+    }
+    Date expirationTime = idToken.getJWTClaimsSet().getExpirationTime();
     if (expirationTime != null
         && expirationTime.before(Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTime())) {
       renewOidcCredentials(session, credentials);
@@ -1255,12 +1273,12 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
   private void populateCredentialsFromTokenResponse(
       OIDCTokenResponse tokenSuccessResponse, OidcCredentials credentials) {
     OIDCTokens oidcTokens = tokenSuccessResponse.getOIDCTokens();
-    credentials.setAccessToken(oidcTokens.getAccessToken());
+    credentials.setAccessTokenObject(oidcTokens.getAccessToken());
     if (oidcTokens.getRefreshToken() != null) {
-      credentials.setRefreshToken(oidcTokens.getRefreshToken());
+      credentials.setRefreshTokenObject(oidcTokens.getRefreshToken());
     }
     if (oidcTokens.getIDToken() != null) {
-      credentials.setIdToken(oidcTokens.getIDToken());
+      credentials.setIdToken(oidcTokens.getIDToken().serialize());
     }
   }
 
@@ -1300,7 +1318,7 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
 
       // Validate provider metadata
       OIDCProviderMetadata providerMetadata =
-          tempHandler.client.getConfiguration().findProviderMetadata();
+          resolveProviderMetadata(tempHandler.client.getConfiguration());
       if (providerMetadata == null) {
         throw new IllegalArgumentException("Failed to retrieve provider metadata from server URL");
       }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/AuthenticationCodeFlowHandlerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/AuthenticationCodeFlowHandlerTest.java
@@ -97,6 +97,7 @@ import org.pac4j.oidc.config.AzureAd2OidcConfiguration;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.config.PrivateKeyJWTClientAuthnMethodConfig;
 import org.pac4j.oidc.credentials.OidcCredentials;
+import org.pac4j.oidc.metadata.IOidcOpMetadataResolver;
 import sun.misc.Unsafe;
 
 @ExtendWith(MockitoExtension.class)
@@ -106,6 +107,30 @@ class AuthenticationCodeFlowHandlerTest {
   @Mock private HttpServletResponse response;
   @Mock private HttpSession session;
   @Mock private ServletOutputStream outputStream;
+
+  @Test
+  void resolveProviderMetadata_initializesAndLoadsPac4jV6Resolver() throws Exception {
+    OidcConfiguration configuration = mock(OidcConfiguration.class);
+    Method resolverAccessor = OidcConfiguration.class.getMethod("getOpMetadataResolver");
+    Object resolver = mock(resolverAccessor.getReturnType());
+    OIDCProviderMetadata metadata = mock(OIDCProviderMetadata.class);
+    Method load = resolverAccessor.getReturnType().getMethod("load");
+
+    when(resolverAccessor.invoke(configuration)).thenReturn(resolver);
+    when(load.invoke(resolver)).thenReturn(metadata);
+
+    Method resolveProviderMetadata =
+        AuthenticationCodeFlowHandler.class.getDeclaredMethod(
+            "resolveProviderMetadata", OidcConfiguration.class);
+    resolveProviderMetadata.setAccessible(true);
+
+    assertEquals(metadata, resolveProviderMetadata.invoke(null, configuration));
+    OidcConfiguration verifiedConfiguration = verify(configuration);
+    OidcConfiguration.class
+        .getMethod("ensuresMetadataResolverInitialized")
+        .invoke(verifiedConfiguration);
+    load.invoke(verify(resolver));
+  }
 
   @Test
   void buildOidcClientAllowsMissingClientAuthenticationMethodForGoogle() throws Exception {
@@ -537,8 +562,7 @@ class AuthenticationCodeFlowHandlerTest {
   void buildCredentialsCopiesAuthorizationArtifacts() throws Exception {
     AuthenticationCodeFlowHandler handler = newHandler();
     SignedJWT idToken =
-        new SignedJWT(
-            new JWSHeader(JWSAlgorithm.HS256), new JWTClaimsSet.Builder().subject("user").build());
+        SignedJWT.parse(signedJwt(new JWTClaimsSet.Builder().subject("user").build()));
     AccessToken accessToken = new BearerAccessToken("access-token");
     AuthenticationSuccessResponse successResponse =
         new AuthenticationSuccessResponse(
@@ -557,9 +581,9 @@ class AuthenticationCodeFlowHandlerTest {
             new Class<?>[] {AuthenticationSuccessResponse.class},
             successResponse);
 
-    assertEquals("auth-code", credentials.getCode().getValue());
-    assertEquals(idToken, credentials.getIdToken());
-    assertEquals(accessToken, credentials.getAccessToken());
+    assertEquals("auth-code", credentials.getCode());
+    assertEquals(idToken.serialize(), credentials.getIdToken());
+    assertEquals(accessToken, credentials.toAccessToken());
   }
 
   @Test
@@ -606,15 +630,15 @@ class AuthenticationCodeFlowHandlerTest {
   }
 
   @Test
-  void handleCallbackWithoutSessionReturnsErrorResponse() {
+  void handleCallbackWithoutSessionClearsCookieAndRedirectsToSignin() throws Exception {
     AuthenticationCodeFlowHandler handler =
         assertDoesNotThrow(AuthenticationCodeFlowHandlerTest::newHandler);
-    assertDoesNotThrow(() -> when(response.getOutputStream()).thenReturn(outputStream));
+    assertDoesNotThrow(() -> setField(handler, "serverUrl", "https://openmetadata.example.com"));
     when(request.getSession(false)).thenReturn(null);
 
     handler.handleCallback(request, response);
 
-    verify(response).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    verify(response).sendRedirect("https://openmetadata.example.com/signin");
   }
 
   @Test
@@ -777,13 +801,13 @@ class AuthenticationCodeFlowHandlerTest {
               "RefreshClient"));
 
       OidcCredentials credentials = new OidcCredentials();
-      credentials.setRefreshToken(new RefreshToken("old-refresh-token"));
+      credentials.setRefreshTokenObject(new RefreshToken("old-refresh-token"));
 
       handler.refreshTokenRequest(session, credentials);
 
-      assertEquals("refreshed-access-token", credentials.getAccessToken().getValue());
-      assertEquals("refreshed-refresh-token", credentials.getRefreshToken().getValue());
-      assertEquals("refreshed-user", credentials.getIdToken().getJWTClaimsSet().getSubject());
+      assertEquals("refreshed-access-token", credentials.toAccessToken().getValue());
+      assertEquals("refreshed-refresh-token", credentials.toRefreshToken().getValue());
+      assertEquals("refreshed-user", credentials.toIdToken().getJWTClaimsSet().getSubject());
     }
   }
 
@@ -833,7 +857,7 @@ class AuthenticationCodeFlowHandlerTest {
       setField(handler, "tokenValidity", 600);
 
       OidcCredentials sessionCredentials = new OidcCredentials();
-      sessionCredentials.setIdToken(SignedJWT.parse(sessionIdToken));
+      sessionCredentials.setIdToken(sessionIdToken);
       when(session.getAttribute(AuthenticationCodeFlowHandler.OIDC_CREDENTIAL_PROFILE))
           .thenReturn(sessionCredentials);
 
@@ -861,13 +885,13 @@ class AuthenticationCodeFlowHandlerTest {
           .thenReturn(jwtAuthMechanism);
 
       OidcCredentials credentials = new OidcCredentials();
-      credentials.setRefreshToken(new RefreshToken("old-refresh-token"));
+      credentials.setRefreshTokenObject(new RefreshToken("old-refresh-token"));
 
       handler.refreshTokenRequest(session, credentials);
 
-      assertEquals("provider-access-token", credentials.getAccessToken().getValue());
-      assertEquals("provider-refresh-token", credentials.getRefreshToken().getValue());
-      assertEquals(generatedOmJwt, credentials.getIdToken().getParsedString());
+      assertEquals("provider-access-token", credentials.toAccessToken().getValue());
+      assertEquals("provider-refresh-token", credentials.toRefreshToken().getValue());
+      assertEquals(generatedOmJwt, credentials.getIdToken());
     }
   }
 
@@ -898,7 +922,7 @@ class AuthenticationCodeFlowHandlerTest {
               "RefreshFailureClient"));
 
       OidcCredentials credentials = new OidcCredentials();
-      credentials.setRefreshToken(new RefreshToken("old-refresh-token"));
+      credentials.setRefreshTokenObject(new RefreshToken("old-refresh-token"));
 
       TechnicalException exception =
           assertThrows(
@@ -939,7 +963,7 @@ class AuthenticationCodeFlowHandlerTest {
               "RefreshHandlerClient"));
 
       OidcCredentials credentials = new OidcCredentials();
-      credentials.setRefreshToken(new RefreshToken("old-refresh-token"));
+      credentials.setRefreshTokenObject(new RefreshToken("old-refresh-token"));
       when(request.getSession(false)).thenReturn(session);
       when(session.getAttribute(AuthenticationCodeFlowHandler.OIDC_CREDENTIAL_PROFILE))
           .thenReturn(credentials);
@@ -948,9 +972,9 @@ class AuthenticationCodeFlowHandlerTest {
 
       handler.handleRefresh(request, response);
 
-      assertEquals("fresh-access-token", credentials.getAccessToken().getValue());
-      assertEquals("fresh-refresh-token", credentials.getRefreshToken().getValue());
-      assertEquals(refreshedIdToken, credentials.getIdToken().getParsedString());
+      assertEquals("fresh-access-token", credentials.toAccessToken().getValue());
+      assertEquals("fresh-refresh-token", credentials.toRefreshToken().getValue());
+      assertEquals(refreshedIdToken, credentials.getIdToken());
       verify(session)
           .setAttribute(AuthenticationCodeFlowHandler.OIDC_CREDENTIAL_PROFILE, credentials);
       verify(outputStream).print(org.mockito.ArgumentMatchers.contains(refreshedIdToken));
@@ -959,7 +983,8 @@ class AuthenticationCodeFlowHandlerTest {
   }
 
   @Test
-  void handleRefreshWithoutCredentialsFallsBackToLogout() throws Exception {
+  void handleRefreshWithoutCredentialsRespondsUnauthorizedWithoutInvalidatingSession()
+      throws Exception {
     AuthenticationCodeFlowHandler handler =
         assertDoesNotThrow(AuthenticationCodeFlowHandlerTest::newHandler);
     assertDoesNotThrow(() -> setField(handler, "serverUrl", "https://openmetadata.example.com"));
@@ -967,11 +992,11 @@ class AuthenticationCodeFlowHandlerTest {
     when(session.getAttribute(AuthenticationCodeFlowHandler.OIDC_CREDENTIAL_PROFILE))
         .thenReturn(null);
     when(session.getId()).thenReturn("missing-credentials-session");
+    when(response.getOutputStream()).thenReturn(outputStream);
 
     handler.handleRefresh(request, response);
 
-    verify(session).invalidate();
-    verify(response).sendRedirect("https://openmetadata.example.com/logout");
+    verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
   }
 
   @Test
@@ -994,7 +1019,7 @@ class AuthenticationCodeFlowHandlerTest {
                     "id_token", refreshedIdToken)))) {
       AuthenticationCodeFlowHandler handler = newHandler();
       OidcCredentials credentials = new OidcCredentials();
-      credentials.setRefreshToken(new RefreshToken("azure-old-refresh-token"));
+      credentials.setRefreshTokenObject(new RefreshToken("azure-old-refresh-token"));
 
       invokePrivate(
           handler,
@@ -1003,9 +1028,9 @@ class AuthenticationCodeFlowHandlerTest {
           azureOidcConfiguration(tokenServer.tokenEndpoint()),
           credentials);
 
-      assertEquals("azure-access-token", credentials.getAccessToken().getValue());
-      assertEquals("azure-refresh-token", credentials.getRefreshToken().getValue());
-      assertEquals(refreshedIdToken, credentials.getIdToken().getParsedString());
+      assertEquals("azure-access-token", credentials.toAccessToken().getValue());
+      assertEquals("azure-refresh-token", credentials.toRefreshToken().getValue());
+      assertEquals(refreshedIdToken, credentials.getIdToken());
     }
   }
 
@@ -1606,7 +1631,7 @@ class AuthenticationCodeFlowHandlerTest {
     configuration.setScope("openid profile");
     configuration.setResponseType("code");
     configuration.setResponseMode("query");
-    configuration.setProviderMetadata(providerMetadata(supportedMethods, tokenEndpoint));
+    setProviderMetadata(configuration, providerMetadata(supportedMethods, tokenEndpoint));
     return configuration;
   }
 
@@ -1622,9 +1647,17 @@ class AuthenticationCodeFlowHandlerTest {
     configuration.setClientId("azure-client");
     configuration.setSecret("azure-secret");
     configuration.setTenant("organizations");
-    configuration.setProviderMetadata(
+    setProviderMetadata(
+        configuration,
         providerMetadata(List.of(ClientAuthenticationMethod.CLIENT_SECRET_POST), tokenEndpoint));
     return configuration;
+  }
+
+  private static void setProviderMetadata(
+      OidcConfiguration configuration, OIDCProviderMetadata metadata) {
+    IOidcOpMetadataResolver resolver = mock(IOidcOpMetadataResolver.class);
+    lenient().when(resolver.load()).thenReturn(metadata);
+    configuration.setOpMetadataResolver(resolver);
   }
 
   private static OIDCProviderMetadata providerMetadata(

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
     <jsonpath.version>2.9.0</jsonpath.version>
     <everit.version>1.14.4</everit.version>
     <json-patch.version>1.13</json-patch.version>
-    <jetty.version>12.1.7</jetty.version>
+    <jetty.version>12.1.10</jetty.version>
     <jakarta-el.version>5.0.0-M1</jakarta-el.version>
     <mcp-sdk.version>1.1.1</mcp-sdk.version>
     <lettuce.version>6.7.1.RELEASE</lettuce.version>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <httpasyncclient.version>4.1.5</httpasyncclient.version>
     <openapiswagger.version>2.2.25</openapiswagger.version>
     <httpclient.version>4.5.14</httpclient.version>
-    <spring.version>6.2.19</spring.version>
+    <spring.version>7.0.9</spring.version>
     <log4j.version>2.25.5</log4j.version>
     <org.junit.jupiter.version>5.11.4</org.junit.jupiter.version>
     <org.junit.platform.version>1.11.4</org.junit.platform.version>

--- a/pom.xml
+++ b/pom.xml
@@ -124,8 +124,14 @@
          JenaFusekiStorage to abstract over API differences between Jena 4 and
          Jena 5 with a CompletableFuture wrapper around every RDFConnection
          call. Jena 6 requires Java 21 — already our project minimum, so no
-         JDK bump needed. -->
-    <jena.version>5.6.0</jena.version>
+         JDK bump needed.
+
+         6.2.0 fixes CVE-2026-61372 (SPARQL Update LOAD accepted URLs pointing
+         at local resources, so an update could read data off the machine
+         running the engine; 6.2.0 restricts them to http/ftp). There is no
+         5.x line with the fix — 5.6.0 is the last 5.x release — so the only
+         way off the CVE is the major bump. Do not go back below 6.2.0. -->
+    <jena.version>6.2.0</jena.version>
 
     <sonar.projectKey>open-metadata_OpenMetadata</sonar.projectKey>
     <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>


### PR DESCRIPTION
Backports the pac4j 6.5.6 OIDC compatibility changes, Spring 7.0.9, and Apache Jena/Fuseki 6.2.0 to 1.13.

Also aligns the 1.13 service Jetty dependency management with main/2.0 at 12.1.10, including the Jetty BOM. This fixes the observed runtime linkage mismatch where Jetty server 12.1.7 resolved jetty-util 12.1.1.

Validation:
- `AuthenticationCodeFlowHandlerTest`: 51 passed
- `AlertUtilTest`, `RuleEvaluatorTest`, `ExpressionValidatorTest`: 89 passed
- service and MCP Maven reactor packages passed
- live isolated service on port 9595 with MySQL 13306 and Elasticsearch 19200: mock custom-OIDC code flow, callback, token validation, and authenticated API call passed
- 250 authenticated live Spring SpEL policy-expression validations returned HTTP 204