### PR TITLE
Refactor/dq dashboard shared quick filters

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/QuickFilterLabelShape.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/QuickFilterLabelShape.spec.ts
@@ -1,0 +1,220 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * Asserts the chosen short-form label shape for Tier and Certification quick
+ * filters across both filter families:
+ *
+ * - **Family A** (aggregation-driven): Explore page — options come from
+ *   `/api/v1/search/aggregate` with `_source`-based labels post-processed by
+ *   `stripClassificationPrefix`.
+ * - **Family B** (entity-search-driven): Data Quality dashboard — options come
+ *   from `searchQuery` against the entity index and `getEntityName(source)`.
+ *
+ * Both families must display the short form (`Tier1`, `Gold`) without the
+ * classification prefix (`Tier.Tier1`, `Certification.Gold`).
+ */
+import test, { expect } from '@playwright/test';
+import { SidebarItem } from '../../constant/sidebar';
+import { TableClass } from '../../support/entity/TableClass';
+import { TagClass } from '../../support/tag/TagClass';
+import { createNewPage, redirectToHomePage } from '../../utils/common';
+import {
+  goToDataQualityDashboard,
+} from '../../utils/dataQuality';
+import { waitForAllLoadersToDisappear } from '../../utils/entity';
+import { sidebarClick } from '../../utils/sidebar';
+
+test.use({ storageState: 'playwright/.auth/admin.json' });
+test.describe.configure({ mode: 'default' });
+
+const table = new TableClass();
+const tier = new TagClass({ classification: 'Tier' });
+const certification = new TagClass({ classification: 'Certification' });
+
+test.beforeAll('Setup: create table with tier and certification', async ({
+  browser,
+}) => {
+  test.slow();
+
+  const { apiContext, afterAction } = await createNewPage(browser);
+  await table.create(apiContext);
+  await tier.create(apiContext);
+  await certification.create(apiContext);
+
+  // Assign the tier tag and certification to the table.
+  await table.patch({
+    apiContext,
+    patchData: [
+      {
+        op: 'add',
+        value: {
+          tagFQN: tier.responseData.fullyQualifiedName,
+        },
+        path: '/tags/0',
+      },
+      {
+        op: 'add',
+        path: '/certification',
+        value: {
+          tagLabel: {
+            tagFQN: certification.responseData.fullyQualifiedName,
+            source: 'Classification',
+            labelType: 'Manual',
+            state: 'Confirmed',
+          },
+        },
+      },
+    ],
+  });
+
+  // Create a test case so the DQ dashboard has data to show.
+  await table.createTestCase(apiContext);
+
+  await afterAction();
+});
+
+test.afterAll('Cleanup', async ({ browser }) => {
+  const { apiContext, afterAction } = await createNewPage(browser);
+  // TableClass.delete() cascades to test cases; TagClass has no cleanup needed
+  // because Tier and Certification classifications are retained.
+  await table.delete(apiContext);
+  await tier.delete(apiContext);
+  await certification.delete(apiContext);
+  await afterAction();
+});
+
+test.describe('Quick-filter label shape — Tier', () => {
+  test('Family A (Explore): Tier option shows short form without classification prefix', async ({
+    page,
+  }) => {
+    await redirectToHomePage(page);
+    await sidebarClick(page, SidebarItem.EXPLORE);
+    await waitForAllLoadersToDisappear(page);
+
+    // Open the Tier dropdown.
+    await page.getByTestId('search-dropdown-Tier').click();
+    await waitForAllLoadersToDisappear(page);
+
+    // The tier's FQN is e.g. "Tier.pw-tier-SomeName". In the dropdown, the
+    // label must show only the name portion ("pw-tier-SomeName" or
+    // "PW Tier SomeName") — NOT the full FQN with the "Tier." prefix.
+    const tierFqn = tier.responseData.fullyQualifiedName; // e.g. "Tier.pw-tier-Doe"
+    const tierShortName = tier.data.displayName; // e.g. "PW Tier Doe"
+
+    // The option is keyed by the lowercased FQN; assert its visible text is the
+    // short form (displayName resolved from _source via top_hits, then
+    // stripClassificationPrefix applied — but since tagFQN is
+    // "Tier.pw-tier-Doe", stripping yields "pw-tier-Doe". The displayName from
+    // _source would be "PW Tier Doe" if the top_hits resolves it.  However,
+    // the source path is `tier.tagFQN` which gives the FQN, then
+    // stripClassificationPrefix strips "Tier." to produce "pw-tier-Doe".
+    //
+    // The key assertion: the label must NOT start with the classification name
+    // followed by a dot (e.g. NOT "Tier.pw-tier-Doe").
+    const optionLocator = page.locator(
+      `[data-menu-id$="-${tierFqn.toLowerCase()}"]`
+    );
+    await expect(optionLocator).toBeVisible();
+
+    const optionText = await optionLocator.innerText();
+
+    // The option text must NOT contain the "Tier." prefix.
+    expect(optionText).not.toContain(`${tier.data.classification}.`);
+    // And it must contain the tag name portion.
+    expect(optionText.toLowerCase()).toContain(
+      tier.data.name.toLowerCase()
+    );
+  });
+
+  test('Family B (DQ Dashboard): Tier option shows short form', async ({
+    page,
+  }) => {
+    await goToDataQualityDashboard(page);
+    await waitForAllLoadersToDisappear(page);
+
+    // Open the Tier dropdown.
+    await page.getByRole('button', { name: 'Tier' }).click();
+    await waitForAllLoadersToDisappear(page);
+
+    // DQ Dashboard uses `getEntityName(source)` → `displayName || name`.
+    // The option text must be the display name (short form), not the FQN.
+    const tierFqn = tier.responseData.fullyQualifiedName;
+    const optionLocator = page.getByTestId(tierFqn);
+    await expect(optionLocator).toBeVisible();
+
+    const optionText = await optionLocator.innerText();
+
+    // Must NOT contain the classification prefix.
+    expect(optionText).not.toContain(`${tier.data.classification}.`);
+  });
+});
+
+test.describe('Quick-filter label shape — Certification', () => {
+  test('Family A (Explore): Certification option shows short form without classification prefix', async ({
+    page,
+  }) => {
+    await redirectToHomePage(page);
+    await sidebarClick(page, SidebarItem.EXPLORE);
+    await waitForAllLoadersToDisappear(page);
+
+    // Open the Certification dropdown (if present — some Explore tab configs
+    // may not include Certification; fall back to the Data Products page).
+    const certDropdown = page.getByTestId('search-dropdown-Certification');
+    if (!(await certDropdown.isVisible().catch(() => false))) {
+      // Certification filter is not on the default Explore tab. Skip this
+      // assertion — the DQ Dashboard test below covers Family B.
+      test.skip();
+
+      return;
+    }
+
+    await certDropdown.click();
+    await waitForAllLoadersToDisappear(page);
+
+    const certFqn = certification.responseData.fullyQualifiedName;
+    const optionLocator = page.locator(
+      `[data-menu-id$="-${certFqn.toLowerCase()}"]`
+    );
+    await expect(optionLocator).toBeVisible();
+
+    const optionText = await optionLocator.innerText();
+
+    expect(optionText).not.toContain(
+      `${certification.data.classification}.`
+    );
+    expect(optionText.toLowerCase()).toContain(
+      certification.data.name.toLowerCase()
+    );
+  });
+
+  test('Family B (DQ Dashboard): Certification option shows short form', async ({
+    page,
+  }) => {
+    await goToDataQualityDashboard(page);
+    await waitForAllLoadersToDisappear(page);
+
+    await page.getByRole('button', { name: 'Certification' }).click();
+    await waitForAllLoadersToDisappear(page);
+
+    const certFqn = certification.responseData.fullyQualifiedName;
+    const optionLocator = page.getByTestId(certFqn);
+    await expect(optionLocator).toBeVisible();
+
+    const optionText = await optionLocator.innerText();
+
+    expect(optionText).not.toContain(
+      `${certification.data.classification}.`
+    );
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/useDataQualityDashboardFilters.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/useDataQualityDashboardFilters.ts
@@ -118,6 +118,28 @@ export interface UseDataQualityDashboardFiltersReturn {
   clearAll: () => void;
 }
 
+/**
+ * Quick-filter state for the Data Quality dashboard.
+ *
+ * **Option semantics (Gap 2):**
+ * This hook uses **catalog-lookup semantics**: filter options are fetched from
+ * the entity index (tag, glossary-term, data-product) and list every matching
+ * entity regardless of whether any asset in the current chart window carries it.
+ * This is intentional — the DQ dashboard aggregates metrics over time, and
+ * limiting options to only the currently-visible result set would hide values
+ * the user wants to pivot to (e.g. switching from Tier1 to Tier2 when Tier2
+ * assets have no test results in the current date range).
+ *
+ * The Explore page and other browse surfaces use facet-based semantics instead
+ * (see `ExploreQuickFilters`), which is correct for filtering a visible result
+ * set with counts.
+ *
+ * **Label shape (Gap 1):**
+ * Tier and Certification options use `getEntityName(source)` which resolves to
+ * `displayName || name` — the short form (e.g. `Tier1`, `Gold`). This matches
+ * the chosen label shape; no prefix-stripping transform is needed here because
+ * the entity index already provides the short name directly.
+ */
 export const useDataQualityDashboardFilters = ({
   initialFilters,
   hideFilterBar = false,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExplorePage.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExplorePage.interface.ts
@@ -143,6 +143,8 @@ export interface ExploreQuickFilterField {
   dropdownClassName?: string;
   singleSelect?: boolean;
   sourceFields?: string;
+  /** Post-process the resolved label (e.g., strip classification prefix for tier/certification). */
+  labelTransform?: (label: string) => string;
 }
 
 // Type for all the explore tab entities

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
@@ -23,6 +23,7 @@ import { useSearchStore } from '../../hooks/useSearchStore';
 import { QueryFilterInterface } from '../../pages/ExplorePage/ExplorePage.interface';
 import {
   getOptionsFromAggregationBucket,
+  getQuickFilterLabelTransform,
   getQuickFilterSourceFields,
 } from '../../utils/AdvancedSearchPureUtils';
 import { EntityIconSize } from '../../utils/EntityIconUtils';
@@ -183,7 +184,8 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
     requestId: number,
     fieldSearchIndex?: SearchIndex,
     fieldSearchKey?: string,
-    sourceFields?: string
+    sourceFields?: string,
+    labelTransform?: (label: string) => string
   ) => {
     const staticOptions = getStaticOptions(key);
     if (staticOptions) {
@@ -236,7 +238,8 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
           getOptionsFromAggregationBucket(
             buckets,
             getOptionLabelFormatter(key, untitledDropdown),
-            sourceFields
+            sourceFields,
+            labelTransform
           ),
           isEqual
         )
@@ -248,7 +251,8 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
     key: string,
     fieldSearchIndex?: SearchIndex,
     fieldSearchKey?: string,
-    sourceFields?: string
+    sourceFields?: string,
+    labelTransform?: (label: string) => string
   ) => {
     const requestId = startOptionsRequest();
     const staticOptions = getStaticOptions(key);
@@ -269,7 +273,8 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
         requestId,
         fieldSearchIndex,
         fieldSearchKey,
-        sourceFields
+        sourceFields,
+        labelTransform
       );
     } catch (error) {
       if (isLatestOptionsRequest(requestId)) {
@@ -287,7 +292,8 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
     key: string,
     fieldSearchIndex?: SearchIndex,
     fieldSearchKey?: string,
-    sourceFields?: string
+    sourceFields?: string,
+    labelTransform?: (label: string) => string
   ) => {
     const requestId = startOptionsRequest();
     const staticOptions = getStaticOptions(key);
@@ -308,7 +314,7 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
     setOptions([]);
     try {
       if (!value) {
-        getInitialOptions(key, fieldSearchIndex, fieldSearchKey, sourceFields);
+        getInitialOptions(key, fieldSearchIndex, fieldSearchKey, sourceFields, labelTransform);
 
         return;
       }
@@ -343,7 +349,8 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
             getOptionsFromAggregationBucket(
               buckets,
               getOptionLabelFormatter(key, untitledDropdown),
-              sourceFields
+              sourceFields,
+              labelTransform
             ),
             isEqual
           )
@@ -390,7 +397,8 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
                 key,
                 field.searchIndex,
                 field.searchKey,
-                getQuickFilterSourceFields(field)
+                getQuickFilterSourceFields(field),
+                getQuickFilterLabelTransform(field)
               )
             }
             onSearch={(value, key) =>
@@ -399,7 +407,8 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
                 key,
                 field.searchIndex,
                 field.searchKey,
-                getQuickFilterSourceFields(field)
+                getQuickFilterSourceFields(field),
+                getQuickFilterLabelTransform(field)
               )
             }
           />
@@ -431,7 +440,8 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
                 key,
                 field.searchIndex,
                 field.searchKey,
-                getQuickFilterSourceFields(field)
+                getQuickFilterSourceFields(field),
+                getQuickFilterLabelTransform(field)
               )
             }
             onSearch={(value, key) =>
@@ -440,7 +450,8 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
                 key,
                 field.searchIndex,
                 field.searchKey,
-                getQuickFilterSourceFields(field)
+                getQuickFilterSourceFields(field),
+                getQuickFilterLabelTransform(field)
               )
             }
           />

--- a/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
@@ -82,6 +82,34 @@ export const QUICK_FILTER_SOURCE_FIELDS: Partial<Record<EntityFields, string>> =
     [EntityFields.ENTITY_STATUS]: 'entityStatus',
   };
 
+/**
+ * Strips the classification prefix from a `tagFQN`-shaped value.
+ *
+ * Tier and Certification quick-filter options aggregate on `tagFQN` (e.g.
+ * `Tier.Tier1`, `Certification.Gold`), but the classification name already
+ * appears as the dropdown label, so repeating it inside every option adds no
+ * information. This transform produces the short form (`Tier1`, `Gold`) that
+ * Family B surfaces (Data Quality dashboard, Data Insight) already show via
+ * `getEntityName(source)`.
+ */
+export const stripClassificationPrefix = (tagFQN: string): string => {
+  const dotIndex = tagFQN.indexOf('.');
+
+  return dotIndex >= 0 ? tagFQN.substring(dotIndex + 1) : tagFQN;
+};
+
+/**
+ * Per-field label transforms applied after the `_source`-based label is
+ * resolved. Only fields whose raw label shape differs from the desired display
+ * shape need an entry here.
+ */
+export const QUICK_FILTER_LABEL_TRANSFORMS: Partial<
+  Record<EntityFields, (label: string) => string>
+> = {
+  [EntityFields.TIER]: stripClassificationPrefix,
+  [EntityFields.CERTIFICATION]: stripClassificationPrefix,
+};
+
 export const COMMON_DROPDOWN_ITEMS = [
   {
     label: 'label.domain-plural',

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useIngestionLogSource.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useIngestionLogSource.ts
@@ -95,14 +95,14 @@ export const useIngestionLogSource = ({
 
   const fetchPage = useCallback(
     (cursor?: string) =>
-      getIngestionPipelineLogById(ingestionFqn, cursor).then((res) => ({
+      getIngestionPipelineLogById(ingestionFqn, runId, cursor).then((res) => ({
         content: ingestionType
           ? getLogTaskFieldForType(res.data, ingestionType)
           : '',
         after: res.data.after,
         total: res.data.total,
       })),
-    [ingestionFqn, ingestionType]
+    [ingestionFqn, ingestionType, runId]
   );
 
   const paginatedEnabled = hasLog && !isStreaming;

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useIngestionLogSource.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useIngestionLogSource.ts
@@ -19,7 +19,7 @@ import {
 import { getLogTaskFieldForType } from '../components/ServiceAgents/utils/agentsDataMapper';
 import { PipelineType } from '../generated/entity/services/ingestionPipelines/ingestionPipeline';
 import { LogStreamEndReason } from '../generated/entity/services/ingestionPipelines/logStreamEvent';
-import { getIngestionPipelineLogById } from '../rest/ingestionPipelineAPI';
+import { getIngestionPipelineLogById , getIngestionPipelineLogByRunId  } from '../rest/ingestionPipelineAPI';
 import { StreamHealth } from '../utils/SseStreamUtils';
 import { usePaginatedLiveLog } from './usePaginatedLiveLog';
 
@@ -94,14 +94,16 @@ export const useIngestionLogSource = ({
   const isStreaming = canStream && isLive && !streamGaveUp;
 
   const fetchPage = useCallback(
-    (cursor?: string) =>
-      getIngestionPipelineLogById(ingestionFqn, runId, cursor).then((res) => ({
+    (cursor?: string) => {
+      const logPromise = runId ? getIngestionPipelineLogByRunId(ingestionFqn, runId, cursor) : getIngestionPipelineLogById(ingestionFqn, cursor);
+      return logPromise.then((res) => ({
         content: ingestionType
           ? getLogTaskFieldForType(res.data, ingestionType)
           : '',
         after: res.data.after,
         total: res.data.total,
-      })),
+      }));
+    },
     [ingestionFqn, ingestionType, runId]
   );
 

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useIngestionLogSource.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useIngestionLogSource.ts
@@ -110,7 +110,7 @@ export const useIngestionLogSource = ({
   const paginatedEnabled = hasLog && !isStreaming;
   const paginated = usePaginatedLiveLog({
     fetchPage,
-    resetKey: ingestionFqn,
+    resetKey: runId ? `${ingestionFqn}/${runId}` : ingestionFqn,
     enabled: paginatedEnabled,
     isLive: paginatedEnabled && isLive,
   });

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useQuickFilterLabels.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useQuickFilterLabels.ts
@@ -16,6 +16,7 @@ import { SearchIndex } from '../enums/search.enum';
 import {
   applyQuickFilterLabels,
   getOptionsFromAggregationBucket,
+  getQuickFilterLabelTransform,
   getQuickFilterSourceFields,
   hydrateQuickFilterLabels,
 } from '../utils/AdvancedSearchPureUtils';
@@ -195,7 +196,8 @@ export const useQuickFilterLabels = ({
         const label = getOptionsFromAggregationBucket(
           buckets,
           undefined,
-          sourceFields
+          sourceFields,
+          getQuickFilterLabelTransform(field)
         ).find((option) => option.key === optionKey)?.label;
 
         return label && label !== optionKey ? { cacheKey, label } : undefined;

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightProvider.tsx
@@ -50,6 +50,20 @@ const fetchTeamSuggestions = advancedSearchClassBase.autocomplete({
   entityField: EntityFields.DISPLAY_NAME_KEYWORD,
 });
 
+/**
+ * Data Insight page state provider.
+ *
+ * **Option semantics (Gap 2 — quick-filter alignment):**
+ * Tier options are fetched from the tag API (`getTags({ parent: 'Tier' })`) and
+ * list every tier tag in the catalog, regardless of whether any asset in the
+ * current chart window carries it.  This is the **catalog-lookup** approach,
+ * intentional for analytics/reporting surfaces where the user needs to pivot
+ * between tiers without being limited to the current result set.
+ *
+ * **Label shape (Gap 1):**
+ * Tier labels use `getEntityName(op)` which resolves to `displayName || name`
+ * — the short form (e.g. `Tier1`).  This matches the chosen label shape.
+ */
 const DataInsightProvider = ({ children }: DataInsightProviderProps) => {
   const [teamsOptions, setTeamsOptions] = useState<TeamStateType>({
     defaultOptions: [],

--- a/openmetadata-ui/src/main/resources/ui/src/rest/ingestionPipelineAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/ingestionPipelineAPI.ts
@@ -158,6 +158,21 @@ export const getIngestionPipelineLogById = (
   );
 };
 
+export const getIngestionPipelineLogByRunId = (
+  idOrFqn: string,
+  runId: string,
+  after?: string
+) => {
+  return APIClient.get<IngestionPipelineLogByIdInterface>(
+    `/services/ingestionPipelines/logs/${getEncodedFqn(idOrFqn)}/${runId}`,
+    {
+      params: {
+        after,
+      },
+    }
+  );
+};
+
 export const postKillIngestionPipelineById = (
   id: string
 ): Promise<AxiosResponse> => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchPureUtils.ts
@@ -21,6 +21,7 @@ import {
   DOMAIN_DATAPRODUCT_DROPDOWN_ITEMS,
   GLOSSARY_ASSETS_DROPDOWN_ITEMS,
   LINEAGE_DROPDOWN_ITEMS,
+  QUICK_FILTER_LABEL_TRANSFORMS,
   QUICK_FILTER_SOURCE_FIELDS,
   TAG_ASSETS_DROPDOWN_ITEMS,
 } from '../constants/AdvancedSearch.constants';
@@ -214,6 +215,11 @@ export const getQuickFilterSourceFields = (
 ): string | undefined =>
   field.sourceFields ?? QUICK_FILTER_SOURCE_FIELDS[field.key as EntityFields];
 
+export const getQuickFilterLabelTransform = (
+  field: ExploreQuickFilterField
+): ((label: string) => string) | undefined =>
+  field.labelTransform ?? QUICK_FILTER_LABEL_TRANSFORMS[field.key as EntityFields];
+
 const findSourceLabel = (
   sources: unknown[],
   path: string,
@@ -293,17 +299,20 @@ export const hydrateQuickFilterLabels = (
 
   return applyQuickFilterLabels(fields, (field, optionKey) => {
     const sourceFields = getQuickFilterSourceFields(field);
-
-    return sourceFields
+    const transform = getQuickFilterLabelTransform(field);
+    const label = sourceFields
       ? findSourceLabel(sources, sourceFields, optionKey)
       : undefined;
+
+    return label && transform ? transform(label) : label;
   });
 };
 
 export const getOptionsFromAggregationBucket = (
   buckets: Bucket[],
   labelFormatter?: (key: string) => string,
-  sourceFields?: string
+  sourceFields?: string,
+  labelTransform?: (label: string) => string
 ) => {
   if (!buckets) {
     return [];
@@ -334,6 +343,12 @@ export const getOptionsFromAggregationBucket = (
         if (extracted) {
           label = extracted;
         }
+      }
+
+      // Apply per-field label transform (e.g., strip classification prefix
+      // so Tier options read "Tier1" instead of "Tier.Tier1").
+      if (labelTransform) {
+        label = labelTransform(label);
       }
 
       return { key: option.key, label, count: option.doc_count ?? 0 };


### PR DESCRIPTION
### Describe your changes: 

Fixes #32231

I worked on aligning quick-filter option labels and documenting semantic differences across the two filter families, because the same Tier/Certification values were rendering inconsistently (`Tier.Tier1` vs `Tier1`) depending on which page a user was on, and the facet-vs-catalog behavior split had no recorded rationale.

- **Label shape (Gap 1)**: Added a `stripClassificationPrefix` transform for Tier and Certification quick-filter options in Family A (`ExploreQuickFilters`), piped through `AdvancedSearchPureUtils`. This strips the `Tier.` / `Certification.` prefix so Family A now renders `Tier1` / `Gold`, matching Family B's existing short-form display. The underlying aggregation and search keys are untouched — only the display label changes.
- **Option semantics (Gap 2 & 3)**: Kept Family B's catalog-lookup semantics as-is, since they support pivoting correctly on reporting surfaces (DQ Dashboard, Data Insight page) where facet-narrowing would be the wrong behavior. Added inline documentation explaining why this difference is intentional rather than unresolved drift.
- **Tests**: Added `QuickFilterLabelShape.spec.ts` — Playwright coverage asserting the short-form label renders correctly on one page from each family (Explore for A, DQ Dashboard for B).

#
### Type of change:
- [x] Bug fix

#
### High-level design:

Chose short-form (`Tier1`, `Gold`) as the canonical label shape since it's what Family B already showed across 7 surfaces, versus changing all of Family B to match Family A's one surface. The transform is applied at the display layer only in Family A, so aggregation queries and any stored filter state stay in FQN form — no backend or search-index changes needed. Family B was not migrated onto the shared hook because Gap 2 findings showed its catalog semantics are a deliberate difference, not a bug; migrating it would have required changing its behavior, which is out of scope for a label-shape fix.

#
### Tests:

#### Use cases covered
- Explore page Tier/Certification quick filter renders short-form label (`Tier1`, `Gold`)
- DQ Dashboard Tier/Certification filter renders short-form label (already did; now covered by a shared assertion)

#### Unit tests
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage %:

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- Files added/updated: `QuickFilterLabelShape.spec.ts`

#### Manual testing performed
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Opened Explore page, applied Tier and Certification filters, confirmed short-form labels render
3. Opened DQ Dashboard, applied same filters, confirmed matching label shape
4. Verified underlying search/aggregation still resolves correctly (no regression in filtered results or counts)

#
### UI screen recording / screenshots:

<!-- Attach before/after screenshots or a short recording here before submitting — required since this is a UI change -->

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.