### PR TITLE
feat(ui): use the Ontology Studio glyph in the sidebar (backport #32324 to 2.0)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/constants/LeftSidebar.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/LeftSidebar.constants.ts
@@ -26,7 +26,6 @@ import { ReactComponent as MarketplaceIcon } from '../assets/svg/ic-data-marketp
 import { ReactComponent as DomainsIcon } from '../assets/svg/ic-domain.svg';
 import { ReactComponent as HomeIcon } from '../assets/svg/ic-home.svg';
 import { ReactComponent as IncidentMangerIcon } from '../assets/svg/ic-incident-manager.svg';
-import { ReactComponent as LineageIcon } from '../assets/svg/ic-lineage.svg';
 import { ReactComponent as ObservabilityIcon } from '../assets/svg/ic-observability.svg';
 import { ReactComponent as OverviewIcon } from '../assets/svg/ic-overview.svg';
 import { ReactComponent as PlatformLineageIcon } from '../assets/svg/ic-platform-lineage.svg';
@@ -42,7 +41,7 @@ import { ReactComponent as DocumentsIcon } from '../assets/svg/sidebar-icons/doc
 import { LeftSidebarItem } from '../components/MyData/LeftSidebar/LeftSidebar.interface';
 import { SidebarItem } from '../enums/sidebar.enum';
 import { DataInsightTabs } from '../interface/data-insight.interface';
-import { createIconWithStroke } from '../utils/IconUtils';
+import { createIconWithStroke, OntologyStudioIcon } from '../utils/IconUtils';
 import { ENTITY_PATH, PLACEHOLDER_ROUTE_TAB, ROUTES } from './constants';
 
 type UntitledIconType = React.ComponentType<{
@@ -186,7 +185,7 @@ export const SIDEBAR_LIST: Array<LeftSidebarItem> = [
         key: ROUTES.ONTOLOGY_EXPLORER,
         title: 'label.ontology-explorer',
         redirect_url: ROUTES.ONTOLOGY_EXPLORER,
-        icon: LineageIcon,
+        icon: OntologyStudioIcon,
         dataTestId: `app-bar-item-${SidebarItem.ONTOLOGY_EXPLORER}`,
       },
       {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/IconUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/IconUtils.tsx
@@ -137,23 +137,42 @@ export const ICON_MAP: Record<
 };
 
 /**
+ * An icon whose stroke weight can be overridden — the shape `@untitledui`
+ * icons expose (their own props type is wider, so they need a cast).
+ */
+export type StrokableIcon = ComponentType<{
+  size?: number;
+  strokeWidth?: number;
+  style?: React.CSSProperties;
+}>;
+
+/**
  * Creates an icon component with custom stroke width
  * @param IconComponent - The icon component from @untitledui/icons
  * @param strokeWidth - Custom stroke width (default icons use 2)
  * @returns Wrapped icon component with custom stroke width
  */
 export const createIconWithStroke = (
-  IconComponent: ComponentType<{
-    size?: number;
-    strokeWidth?: number;
-    style?: React.CSSProperties;
-  }>,
+  IconComponent: StrokableIcon,
   strokeWidth: number
 ) => {
   return (props: { size?: number; style?: React.CSSProperties }) => (
     <IconComponent {...props} strokeWidth={strokeWidth} />
   );
 };
+
+/**
+ * The Ontology Studio glyph, as every nav entry leading there renders it —
+ * classic sidebar and app-mode sub-nav — so the two surfaces cannot drift
+ * apart. Restroked to 1.2, the weight the hand-drawn nav SVGs beside it use:
+ * `@untitledui` icons ship at stroke 2, which at nav size reads noticeably
+ * heavier than the items around it. The page header draws the same glyph
+ * unrestroked, because there it sits reversed-out on a brand-solid badge.
+ */
+export const OntologyStudioIcon = createIconWithStroke(
+  LayersThree01 as StrokableIcon,
+  1.2
+);
 
 /**
  * Get the default icon for an entity type


### PR DESCRIPTION
### Describe your changes:

Backport of #32324 to `2.0`. Cherry-pick of 057f1de7657c880a6756413d8fbfdb05a28e2ed4, **partial** — see below.

The Ontology Studio page header renders `LayersThree01` in a brand-solid square, but the classic sidebar entry that leads there used `ic-lineage.svg`. This points it at the shared `OntologyStudioIcon` — `LayersThree01` restroked to 1.2 via `createIconWithStroke`, the weight the hand-drawn nav SVGs beside it draw at (raw `@untitledui` icons ship at stroke 2, ~39% heavier at nav size).

**2 of the 3 files applied cleanly. One hunk is intentionally dropped:**

| File | On `2.0` |
|---|---|
| `constants/LeftSidebar.constants.ts` | applied clean — `LineageIcon` → `OntologyStudioIcon` |
| `utils/IconUtils.tsx` | applied clean — adds exported `StrokableIcon` type + `OntologyStudioIcon` |
| `components/governance/govern/govern.module.tsx` | **dropped — file does not exist on this branch** |

`govern.module.tsx` is the app-mode governance sub-nav, which landed on `main` in #31911 (2026-08-29), after `2.0` diverged (2026-07-24). Its half of the original change — the `label.ontology-explorer` → `label.ontology-studio` relabel and the glyph swap — has no target here. Git reported this as a clean modify/delete conflict, not a content conflict.

The shared `OntologyStudioIcon` is still hoisted into `IconUtils` rather than inlined in the sidebar, so this file matches `main` and future picks touching it apply cleanly. Its doc comment still mentions the app-mode surface for that reason.

Verified after the pick: no remaining reference to `LineageIcon` or `ic-lineage.svg` anywhere in `ui/src` on this branch (the only near-match is the unrelated `PlatformLineageIcon` / `ic-platform-lineage.svg`), and `LayersThree01` + `ComponentType` are already imported in `2.0`'s `IconUtils.tsx`. No new translation keys — the sidebar title is unchanged on this branch.

#
### Type of change:
- [x] Improvement

#
### Tests:

No test files in the original PR, and none added — the change is an icon reference plus a typed wrapper.

Not built or type-checked locally (this backport was prepared in a bare scratch worktree with no `node_modules`); CI on this PR covers `tsc` and lint.

#
### UI screen recording / screenshots:

See #32324 for the screenshot. The classic-sidebar half is what this backport carries; the app-mode half of that screenshot does not apply to `2.0`.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
