### PR TITLE
Backport #32207 to 1.13: stop KafkaConnect emitting topic-namespace membership as lineage

### DIFF
--- a/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/client.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/client.py
@@ -119,9 +119,54 @@ JAVA_NAMED_GROUP_PATTERN = re.compile(r"\(\?<(?![=!])(\w+)>")
 
 
 # Statuses that mean the route itself is absent, as opposed to a request that failed.
-# Confluent Cloud answers 404 "route_not_found" for /connectors/{name}/topics; a proxy
-# in front of Connect may answer 405 or 501 instead.
+# Confluent Cloud answers 404 "route_not_found" for /connectors/{name}/topics, and a proxy
+# in front of Connect may answer 405 or 501. These are properties of the deployment, so
+# re-asking per connector only costs a doomed request each time.
 UNSUPPORTED_ROUTE_STATUS_CODES = frozenset({404, 405, 501})
+
+# A worker started with topic.tracking.enable=false answers 403 with this message. A 403
+# is only latched off when the body says so: a proxy or per-route RBAC can also answer 403
+# while the endpoint exists, and latching on the status alone would silently disable
+# runtime topic discovery for every connector behind the first such response.
+TOPIC_TRACKING_DISABLED_MARKER = "topic tracking is disabled"
+
+# Config keys naming a topic the connector creates for its own bookkeeping rather than
+# for data. Debezium's schema history and the Connect error-handling dead letter queue.
+INTERNAL_TOPIC_CONFIG_KEYS = (
+    "schema.history.internal.kafka.topic",
+    "database.history.kafka.topic",
+    "errors.deadletterqueue.topic.name",
+)
+
+
+def extract_internal_topic_names(connector_config: Optional[dict]) -> set[str]:  # noqa: UP045
+    """
+    Topic names a connector creates for its own bookkeeping, derived from its config.
+
+    Connect's active-topic tracking legitimately reports these next to data topics:
+    Debezium's schema-change topic is named exactly ``topic.prefix``, and its transaction
+    metadata topic ``topic.prefix + ".transaction"``. They are metadata plumbing, not data
+    assets, so they must never become lineage endpoints.
+
+    Derived from configuration rather than matched by shape on purpose. A rule like "ends
+    in .transaction" would delete a legitimately named customer topic, whereas the config
+    states the actual names. Names that do not exist for a given connector simply never
+    match, which is what makes this safe for connectors that have no such topics.
+    """
+    names: set[str] = set()
+    if not isinstance(connector_config, dict):
+        return names
+
+    prefix = connector_config.get("topic.prefix") or connector_config.get("database.server.name")
+    if prefix:
+        names.update({prefix, f"{prefix}.transaction"})
+
+    for key in INTERNAL_TOPIC_CONFIG_KEYS:
+        configured = connector_config.get(key)
+        if configured:
+            names.add(configured)
+
+    return names
 
 
 def _to_python_replacement(replacement: str) -> str:
@@ -235,18 +280,19 @@ class KafkaConnectClient:
         self, connector_details: KafkaConnectPipelineDetails, connector_name: str
     ) -> None:
         """Helper method to enrich connector details with additional information."""
-        connector_details.topics = self.get_connector_topics(connector=connector_name)
+        # Config first: the topic listing needs it to recognise the connector's own
+        # bookkeeping topics, and fetching it once here avoids a second round trip.
         connector_details.config = self.get_connector_config(connector=connector_name)
+        connector_details.topics = self.get_connector_topics(
+            connector=connector_name, connector_config=connector_details.config
+        )
         if connector_details.config:
             connector_details.description = connector_details.config.get(
                 "description", None
             )
 
             # For CDC connectors without explicit topics, try to infer from server name
-            if (
-                not connector_details.topics
-                and connector_details.conn_type.lower() == "source"
-            ):
+            if not connector_details.topics and (connector_details.conn_type or "").lower() == "source":
                 database_server_name = connector_details.config.get(
                     "database.server.name"
                 ) or connector_details.config.get("topic.prefix")
@@ -458,16 +504,25 @@ class KafkaConnectClient:
                     for topic in result.get("topics") or []
                 ]
         except Exception as exc:
-            status_code = getattr(getattr(exc, "response", None), "status_code", None)
-            if status_code in UNSUPPORTED_ROUTE_STATUS_CODES:
+            response = getattr(exc, "response", None)
+            status_code = getattr(response, "status_code", None)
+            tracking_disabled = status_code == 403 and TOPIC_TRACKING_DISABLED_MARKER in (
+                f"{getattr(response, 'text', '')} {exc}".lower()
+            )
+            if status_code in UNSUPPORTED_ROUTE_STATUS_CODES or tracking_disabled:
                 if self._topics_endpoint_supported is None:
                     self._topics_endpoint_supported = False
+                    remedy = (
+                        " The worker reports topic tracking as disabled: set "
+                        "topic.tracking.enable=true on the Connect workers to restore it."
+                        if tracking_disabled
+                        else ""
+                    )
                     logger.info(
-                        f"Connect /connectors/{{name}}/topics is unavailable on this"
-                        f" cluster ({exc}); falling back to topic names declared in"
-                        " connector configs. Connectors that route by row value"
-                        " (e.g. a Debezium outbox EventRouter) cannot be resolved"
-                        " this way."
+                        f"Connect /connectors/{{name}}/topics is unavailable on this cluster ({exc})."
+                        f"{remedy} Falling back to topic names declared in connector configs. "
+                        "Connectors that route by row value (e.g. a Debezium outbox EventRouter) "
+                        "cannot be resolved this way."
                     )
             else:
                 logger.warning(
@@ -478,49 +533,81 @@ class KafkaConnectClient:
             logger.debug(traceback.format_exc())
         return None
 
-    def get_connector_topics(
-        self, connector: str
-    ) -> Optional[List[KafkaConnectTopics]]:
+    def _list_data_topics_from_api(
+        self,
+        connector: str,
+        connector_config: Optional[dict],  # noqa: UP045
+    ) -> Optional[List[KafkaConnectTopics]]:  # noqa: UP006, UP045
         """
-        Get the list of topics for a connector.
+        The topics the Connect runtime says this connector touched, minus its own
+        bookkeeping topics.
 
-        Prefers what the Connect runtime reports, falling back to the topic names
-        declared in the connector configuration.
+        Returns None when that leaves nothing, so the caller falls back to the
+        config-declared names. Active-topic tracking records what a connector has
+        touched so far, so a connector that has produced nothing, or so far only its own
+        schema-change topic, is at a cold start rather than asserting it has no data
+        topics. Its declared names are still the better answer.
+        """
+        topics = self._list_topics_from_api(connector)
+        if not topics:
+            return None
+
+        excluded = extract_internal_topic_names(connector_config)
+        data_topics = [topic for topic in topics if topic.name not in excluded]
+        dropped = len(topics) - len(data_topics)
+        if dropped:
+            logger.debug(
+                f"Excluded {dropped} internal topic(s) from connector '{connector}': "
+                f"{sorted(excluded & {topic.name for topic in topics})}"
+            )
+        return data_topics or None
+
+    @staticmethod
+    def _parse_topics_from_config(connector_config: Optional[dict]) -> Optional[List[KafkaConnectTopics]]:  # noqa: UP006, UP045
+        """Topic names written explicitly in the connector config, as a sink's `topics` list is."""
+        if not connector_config:
+            return None
+
+        topics = []
+        for key in ConnectorConfigKeys.TOPIC_KEYS:
+            topic_value = connector_config.get(key)
+            # Either a single topic or a comma-separated list.
+            if isinstance(topic_value, str):
+                topics.extend(KafkaConnectTopics(name=name.strip()) for name in topic_value.split(",") if name.strip())
+        return topics or None
+
+    def get_connector_topics(
+        self,
+        connector: str,
+        connector_config: Optional[dict] = None,  # noqa: UP045
+    ) -> Optional[List[KafkaConnectTopics]]:  # noqa: UP006, UP045
+        """
+        Get the list of data topics for a connector, most authoritative source first.
+
+        The Connect runtime knows what the connector actually produced or consumed,
+        including a routed name that appears nowhere in the config, so it wins. The
+        config-declared names are the fallback for deployments that do not serve it.
 
         Args:
             connector (str): The name of the connector.
+            connector_config (dict): The connector's config, when the caller already
+                holds it. Fetched on demand otherwise.
 
         Returns:
-            Optional[List[KafkaConnectTopics]]: A list of KafkaConnectTopics objects
-                                            representing the connector's topics,
-                                            or None if the connector is not found
-                                            or an error occurs.
+            Optional[List[KafkaConnectTopics]]: The connector's data topics, or None when
+                                            neither source names one.
         """
         try:
-            topics = self._list_topics_from_api(connector)
+            config = connector_config if connector_config is not None else self.get_connector_config(connector)
+
+            topics = self._list_data_topics_from_api(connector, config)
             if topics:
                 return topics
 
-            config = self.get_connector_config(connector=connector)
-            if config:
-                topics = []
-                # Check common topic configuration keys
-                for key in ConnectorConfigKeys.TOPIC_KEYS:
-                    if key in config:
-                        topic_value = config[key]
-                        # Handle single topic or comma-separated list
-                        if isinstance(topic_value, str):
-                            topic_list = [t.strip() for t in topic_value.split(",")]
-                            topics.extend(
-                                [KafkaConnectTopics(name=topic) for topic in topic_list]
-                            )
-
-                if topics:
-                    logger.info(
-                        f"Extracted {len(topics)} topics from connector config"
-                        f" for {connector}"
-                    )
-                    return topics
+            topics = self._parse_topics_from_config(config)
+            if topics:
+                logger.info(f"Extracted {len(topics)} topics from connector config for {connector}")
+                return topics
         except Exception as exc:
             logger.debug(traceback.format_exc())
             logger.error(f"Unable to get connector Topics {exc}")

--- a/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/metadata.py
@@ -15,7 +15,7 @@ KafkaConnect source to extract metadata from OM UI
 import re
 import traceback
 from datetime import datetime
-from typing import Iterable, List, Optional, Pattern
+from typing import Iterable, List, Optional  # noqa: UP035
 
 from metadata.generated.schema.api.data.createPipeline import CreatePipelineRequest
 from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
@@ -1157,7 +1157,6 @@ class KafkaconnectSource(PipelineServiceSource):
         Search for topics matching a regex pattern.
         Used for S3 sink connectors with topics.regex config.
         """
-        import re  # pylint: disable=import-outside-toplevel
 
         topics_found = []
 
@@ -1495,36 +1494,45 @@ class KafkaconnectSource(PipelineServiceSource):
         effective_messaging_service: Optional[str],
     ) -> List[KafkaConnectTopics]:
         """
-        Resolve topics for a source connector, trying in order: Debezium outbox
-        EventRouter pattern matching, CDC topic names from config, then a prefix
-        search in the messaging service.
-        """
-        topics_to_process = []
-        has_event_router = self._has_outbox_event_router(pipeline_details.config)
-        if has_event_router:
-            logger.info(
-                "Detected Debezium outbox EventRouter - resolving topics by routing pattern"
-            )
-            topics_to_process = self._resolve_outbox_topics(
-                connector_config=pipeline_details.config or {},
-                messaging_service_name=effective_messaging_service,
-            )
+        Resolve topics for a source connector from configuration alone.
 
-        if not topics_to_process and has_event_router:
-            # The EventRouter rewrites the topic before publish, so the pre-transform
-            # "{prefix}.{schema}.{table}" name provably names no real topic. Falling back
-            # to it only produced misleading "topic not found" warnings.
+        Only names that configuration determines are produced here. An outbox EventRouter
+        whose ``route.topic.replacement`` still carries a ``${...}`` token picks its
+        destination from a row value, so no name is derivable and the connector resolves
+        nothing rather than guessing.
+
+        Two guesses were removed because neither can attribute a topic to a table:
+
+        - A wildcard built from ``route.topic.replacement`` describes a superset. Two
+          connectors routing into one namespace reduce to the same pattern while owning
+          disjoint topics, so generating from it gave each of them the other's edges.
+        - The ``topic.prefix`` namespace scan assumes a topic name still encodes its
+          source table, which holds only while no router rewrites it. Reached by an
+          EventRouter connector it linked the outbox table to whichever internal topics
+          shared the prefix.
+
+        The runtime's own active-topic list (KIP-558) is the only source that knows a
+        row-derived routed name, and it is consulted before this method is ever called.
+        """
+        if self._has_outbox_event_router(pipeline_details.config):
+            static_topic = self._static_outbox_topic(pipeline_details.config or {})
+            if static_topic:
+                logger.info(f"Outbox EventRouter routes every event to '{static_topic}'")
+                return [KafkaConnectTopics(name=static_topic)]
+
             logger.warning(
                 f"Outbox EventRouter topics could not be resolved for '{pipeline_details.name}'. "
-                "The routed topic name is derived from row data and is not derivable from the "
-                "connector config; set an explicit static prefix in route.topic.replacement, or "
-                "ensure the routed topics are ingested in the messaging service."
+                "Its route.topic.replacement resolves per row, so the destination is not derivable "
+                "from the connector config and no lineage is emitted. Enable topic.tracking.enable "
+                "on the Connect workers so the runtime can report the connector's real topics. "
+                "Confluent Cloud does not expose that endpoint for managed connectors."
             )
-        elif not topics_to_process:
-            topics_to_process = self._parse_cdc_topics_from_config(
-                pipeline_details=pipeline_details,
-                database_server_name=database_server_name,
-            )
+            return []
+
+        topics_to_process = self._parse_cdc_topics_from_config(
+            pipeline_details=pipeline_details,
+            database_server_name=database_server_name,
+        )
 
         if not topics_to_process and effective_messaging_service:
             logger.info(
@@ -1537,7 +1545,26 @@ class KafkaconnectSource(PipelineServiceSource):
 
         return topics_to_process
 
-    def _has_outbox_event_router(self, connector_config: Optional[dict]) -> bool:
+    def _static_outbox_topic(self, connector_config: dict) -> Optional[str]:  # noqa: UP045
+        """
+        The destination of an outbox EventRouter whose ``route.topic.replacement`` holds
+        no ``${...}`` token.
+
+        Such a replacement names one fixed topic for every routed event, which makes it
+        as deterministic as any other config-declared name. Only a replacement that still
+        interpolates a row value is unresolvable. Any RegexRouter later in the chain is
+        applied so the name matches the topic that is actually published.
+
+        Returns None when the key is absent: an absent replacement means the routed name
+        is unknown, and synthesising Debezium's default would invent a claim.
+        """
+        transform = self._event_router_transform(connector_config)
+        replacement = connector_config.get(f"transforms.{transform}.route.topic.replacement") if transform else None
+        if not replacement or "${" in replacement:
+            return None
+        return apply_topic_routing_transforms(replacement, connector_config)
+
+    def _has_outbox_event_router(self, connector_config: Optional[dict]) -> bool:  # noqa: UP045
         """Return True if the connector uses a Debezium outbox EventRouter SMT."""
         has_event_router = False
         if connector_config:
@@ -1553,49 +1580,7 @@ class KafkaconnectSource(PipelineServiceSource):
                     break
         return has_event_router
 
-    def _build_outbox_topic_pattern(self, connector_config: dict) -> Optional[Pattern]:
-        """
-        Build a regex matching topics produced by a Debezium outbox EventRouter.
-
-        The routed topic comes from ``route.topic.replacement``, whose ``${...}``
-        tokens (e.g. ``${routedByValue}``) are row-level values unknown at
-        ingestion time, so they become wildcards. Any RegexRouter in the chain is
-        applied to the template so the two transforms compose.
-        """
-        pattern = None
-        transform = self._event_router_transform(connector_config)
-        template = (
-            connector_config.get(
-                f"transforms.{transform}.route.topic.replacement",
-                "outbox.event.${routedByValue}",
-            )
-            if transform
-            else None
-        )
-        if template:
-            routed_value_token = "routedByValuePlaceholderToken"
-            templated = re.sub(r"\$\{[^}]*\}", routed_value_token, template)
-            templated = apply_topic_routing_transforms(templated, connector_config)
-            static_text = re.sub(
-                r"[^A-Za-z0-9]", "", templated.replace(routed_value_token, "")
-            )
-            if not static_text:
-                logger.warning(
-                    f"Outbox route.topic.replacement '{template}' has no static text; refusing to build a "
-                    "near-catch-all pattern that would link the outbox table to unrelated topics."
-                )
-            else:
-                escaped = re.escape(templated).replace(routed_value_token, ".*")
-                try:
-                    pattern = re.compile(f"^{escaped}$")
-                except re.error as exc:
-                    logger.warning(
-                        f"Unable to build outbox topic pattern from '{template}': {exc}"
-                    )
-
-        return pattern
-
-    def _event_router_transform(self, connector_config: dict) -> Optional[str]:
+    def _event_router_transform(self, connector_config: dict) -> Optional[str]:  # noqa: UP045
         """Return the name of the connector's Debezium outbox EventRouter transform, if any."""
         transform_name = None
         transforms = [
@@ -1611,44 +1596,7 @@ class KafkaconnectSource(PipelineServiceSource):
                 break
         return transform_name
 
-    def _resolve_outbox_topics(
-        self,
-        connector_config: dict,
-        messaging_service_name: Optional[str],
-    ) -> List[KafkaConnectTopics]:
-        """
-        Resolve Debezium outbox topics by matching the EventRouter routing pattern
-        against topics already ingested in the messaging service.
-        """
-        topics_found = []
-        pattern = self._build_outbox_topic_pattern(connector_config)
-
-        if not pattern:
-            logger.debug(
-                "No outbox EventRouter pattern could be derived from connector config"
-            )
-        elif not messaging_service_name:
-            logger.warning(
-                "Cannot resolve outbox topics without a messaging service. "
-                "Ensure the messaging service is configured and topics are ingested."
-            )
-        else:
-            for topic in self._get_service_topics(messaging_service_name):
-                topic_name = model_str(topic.name)
-                if pattern.match(topic_name):
-                    topics_found.append(
-                        KafkaConnectTopics(
-                            name=topic_name, fqn=model_str(topic.fullyQualifiedName)
-                        )
-                    )
-                    logger.debug(f"Matched outbox topic: {topic_name}")
-            logger.info(
-                f"Resolved {len(topics_found)} outbox topic(s) via EventRouter pattern '{pattern.pattern}'"
-            )
-
-        return topics_found
-
-    def _get_service_topics(self, messaging_service_name: str) -> List[Topic]:
+    def _get_service_topics(self, messaging_service_name: str) -> List[Topic]:  # noqa: UP006
         """Return all topics for a messaging service, caching per service name."""
         if messaging_service_name not in self._topics_cache:
             self._topics_cache[messaging_service_name] = list(

--- a/ingestion/tests/unit/topology/pipeline/test_kafkaconnect.py
+++ b/ingestion/tests/unit/topology/pipeline/test_kafkaconnect.py
@@ -1389,75 +1389,6 @@ class TestKafkaConnectTopicRoutingTransforms(TestCase):
 
         assert [t.name for t in topics] == ["prod.global.sales.outbox"]
 
-    def test_resolve_outbox_topics_matches_ingested_topic(self):
-        """
-        EventRouter routes by a row value (${routedByValue}) unknowable at
-        ingestion time, so the outbox topic must be matched by pattern against
-        topics already ingested in the messaging service.
-        """
-        config = {
-            "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
-            "topic.prefix": "ecommerce.sales",
-            "table.include.list": "prod.sales.outbox",
-            "transforms": "outbox",
-            "transforms.outbox.type": "io.debezium.transforms.outbox.EventRouter",
-            "transforms.outbox.route.topic.replacement": "prod.global.sales.${routedByValue}_v1",
-        }
-        source = self._make_source()
-        source.metadata.list_all_entities.return_value = [
-            self._topic("prod.global.sales.orderCreated_v1"),
-            self._topic("prod.global.sales.orderCancelled_v1"),
-            self._topic("unrelated.topic"),
-        ]
-
-        topics = source._resolve_outbox_topics(
-            connector_config=config, messaging_service_name="Kafka"
-        )
-
-        names = sorted(t.name for t in topics)
-        assert names == [
-            "prod.global.sales.orderCancelled_v1",
-            "prod.global.sales.orderCreated_v1",
-        ]
-        assert all(t.fqn for t in topics)
-
-    def test_resolve_outbox_topics_no_messaging_service_returns_empty(self):
-        """Without a messaging service the outbox topics cannot be matched."""
-        config = {
-            "transforms": "outbox",
-            "transforms.outbox.type": "io.debezium.transforms.outbox.EventRouter",
-            "transforms.outbox.route.topic.replacement": "prod.global.sales.${routedByValue}_v1",
-        }
-        source = self._make_source()
-
-        topics = source._resolve_outbox_topics(
-            connector_config=config, messaging_service_name=None
-        )
-
-        assert topics == []
-
-    def test_resolve_outbox_topics_composes_following_regex_router(self):
-        """An EventRouter followed by a RegexRouter must compose into one pattern."""
-        config = {
-            "transforms": "outbox,route",
-            "transforms.outbox.type": "io.debezium.transforms.outbox.EventRouter",
-            "transforms.outbox.route.topic.replacement": "outbox.event.${routedByValue}",
-            "transforms.route.type": "org.apache.kafka.connect.transforms.RegexRouter",
-            "transforms.route.regex": r"outbox\.event\.(.*)",
-            "transforms.route.replacement": "prod.global.sales.$1_v1",
-        }
-        source = self._make_source()
-        source.metadata.list_all_entities.return_value = [
-            self._topic("prod.global.sales.orderCreated_v1"),
-            self._topic("prod.global.other.thing"),
-        ]
-
-        topics = source._resolve_outbox_topics(
-            connector_config=config, messaging_service_name="Kafka"
-        )
-
-        assert [t.name for t in topics] == ["prod.global.sales.orderCreated_v1"]
-
     def test_apply_regex_router_named_group(self):
         """Java named groups (?<name>...) with ${name} replacement convert and apply."""
         from metadata.ingestion.source.pipeline.kafkaconnect.client import (
@@ -1474,27 +1405,6 @@ class TestKafkaConnectTopicRoutingTransforms(TestCase):
         assert (
             apply_topic_routing_transforms("outbox.event.orderCreated", config)
             == "prod.global.orderCreated_v1"
-        )
-
-    def test_outbox_bare_replacement_is_not_catch_all(self):
-        """A replacement with no static part must NOT match every topic in the service."""
-        config = {
-            "transforms": "outbox",
-            "transforms.outbox.type": "io.debezium.transforms.outbox.EventRouter",
-            "transforms.outbox.route.topic.replacement": "${routedByValue}",
-        }
-        source = self._make_source()
-        source.metadata.list_all_entities.return_value = [
-            self._topic("some.unrelated.topic"),
-            self._topic("another.domain.topic"),
-        ]
-
-        assert source._build_outbox_topic_pattern(config) is None
-        assert (
-            source._resolve_outbox_topics(
-                connector_config=config, messaging_service_name="Kafka"
-            )
-            == []
         )
 
     def test_outbox_fanout_identifies_outbox_table_by_event_columns(self):
@@ -1539,17 +1449,6 @@ class TestKafkaConnectTopicRoutingTransforms(TestCase):
             source._is_outbox_fanout(pipeline, orders, topics, single_dataset=True)
             is True
         )
-
-    def test_outbox_separator_only_replacement_is_not_a_pattern(self):
-        """A replacement whose static part is only separators must not build a near-catch-all pattern."""
-        config = {
-            "transforms": "outbox",
-            "transforms.outbox.type": "io.debezium.transforms.outbox.EventRouter",
-            "transforms.outbox.route.topic.replacement": "${routedByValue}.${aggregateid}",
-        }
-        source = self._make_source()
-
-        assert source._build_outbox_topic_pattern(config) is None
 
 
 class TestKafkaConnectTransformLineageEdges(TestCase):
@@ -1647,8 +1546,17 @@ class TestKafkaConnectTransformLineageEdges(TestCase):
         self.last_source = source
         return table_entity, [r.right for r in results if r.right is not None]
 
-    def test_outbox_event_router_yields_lineage_edges(self):
-        """Outbox EventRouter must emit table -> topic edges for every routed topic."""
+    def test_outbox_event_router_without_runtime_topics_yields_no_edges(self):
+        """
+        A routing pattern must not be used to find the outbox topics. It matches a
+        namespace, and two connectors routing into one namespace produce the same
+        pattern while owning disjoint topics, so generating from it hands each of them
+        the other's edges.
+
+        Without the runtime's active-topic list there is nothing to attribute, so the
+        connector emits nothing. ``test_outbox_event_router_yields_edges_from_connector_topics``
+        covers the case where the runtime does supply them.
+        """
         config = {
             "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
             "topic.prefix": "ecommerce.sales",
@@ -1663,13 +1571,9 @@ class TestKafkaConnectTransformLineageEdges(TestCase):
             "unrelated.topic",
         ]
 
-        table_entity, edges = self._run_lineage(config, ingested)
+        _, edges = self._run_lineage(config, ingested)
 
-        assert len(edges) == 2
-        for edge in edges:
-            assert edge.edge.fromEntity.type == "table"
-            assert edge.edge.fromEntity.id.root == table_entity.id
-            assert edge.edge.toEntity.type == "topic"
+        assert edges == []
 
     def test_outbox_event_router_yields_edges_from_connector_topics(self):
         """
@@ -1696,6 +1600,32 @@ class TestKafkaConnectTransformLineageEdges(TestCase):
         for edge in edges:
             assert edge.edge.fromEntity.id.root == table_entity.id
             assert edge.edge.toEntity.type == "topic"
+
+    def test_prefix_scan_matches_one_topic_per_dataset(self):
+        """
+        The topic.prefix scan returns every topic under the namespace, so what keeps it
+        from becoming namespace-membership lineage is the 1:1 match that follows: each
+        dataset takes the single topic whose name resolves to it, and the rest are
+        dropped. Only an outbox EventRouter fans one table out to many topics, and such
+        a connector never reaches the scan.
+        """
+        config = {
+            "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+            "topic.prefix": "ecommerce.sales",
+            # `tables` yields a dataset but is not read by _parse_cdc_topics_from_config,
+            # so resolution falls through to the namespace scan with a dataset in hand.
+            "tables": "prod.sales.orders",
+        }
+        under_prefix = [
+            "ecommerce.sales.prod.sales.orders",
+            "ecommerce.sales.prod.sales.customers",
+            "ecommerce.sales.prod.sales.payments",
+            "ecommerce.sales.transaction",
+        ]
+
+        _table_entity, edges = self._run_lineage(config, under_prefix)
+
+        assert len(edges) == 1, "the scan must not fan a dataset out across the namespace"
 
     def test_multi_table_outbox_connector_does_not_fan_out(self):
         """
@@ -2280,3 +2210,456 @@ class TestConnectorTopicsFromRuntime:
         assert [t.name for t in topics] == ["prod.ern.cashout.delayedCashouts"]
         assert client.client.list_connector_topics.call_count == 3
         assert client._topics_endpoint_supported is True
+
+
+class TestInternalTopicExclusion:
+    """
+    The Connect runtime legitimately reports a connector's own bookkeeping topics as
+    "active": Debezium's schema-change topic is named exactly ``topic.prefix``, and its
+    transaction-metadata topic ``topic.prefix + '.transaction'``. Both are measured, and
+    both are metadata plumbing rather than data assets, so neither may become a lineage
+    endpoint.
+
+    The names come from the connector's own config, never from name patterns: matching
+    ``*.transaction`` by name would delete a legitimately named customer topic.
+    """
+
+    def _client(self):
+        client = object.__new__(KafkaConnectClient)
+        client.client = MagicMock()
+        client.is_confluent_cloud = False
+        client._topics_endpoint_supported = None
+        return client
+
+    def test_schema_change_and_transaction_topics_are_excluded(self):
+        client = self._client()
+        client.client.list_connector_topics.return_value = {
+            "outbox-wallet": {
+                "topics": [
+                    "prod.ern.moneywallet.walletEntity_v1",
+                    "rigA.wallet.topiccol",
+                    "rigA.wallet.topiccol.transaction",
+                ]
+            }
+        }
+        client.get_connector_config = MagicMock(return_value={"topic.prefix": "rigA.wallet.topiccol"})
+
+        topics = client.get_connector_topics("outbox-wallet")
+
+        assert [t.name for t in topics] == ["prod.ern.moneywallet.walletEntity_v1"]
+
+    def test_schema_history_and_dlq_topics_are_excluded(self):
+        client = self._client()
+        client.client.list_connector_topics.return_value = {
+            "sink-wallet": {
+                "topics": [
+                    "prod.ern.moneywallet.walletEntity_v1",
+                    "schema-history.rigA.wallet",
+                    "dlq-sink-wallet",
+                ]
+            }
+        }
+        client.get_connector_config = MagicMock(
+            return_value={
+                "schema.history.internal.kafka.topic": "schema-history.rigA.wallet",
+                "errors.deadletterqueue.topic.name": "dlq-sink-wallet",
+            }
+        )
+
+        topics = client.get_connector_topics("sink-wallet")
+
+        assert [t.name for t in topics] == ["prod.ern.moneywallet.walletEntity_v1"]
+
+    def test_a_customer_topic_named_like_an_internal_one_survives(self):
+        """
+        Exclusion is by configured name, not by shape. A connector whose topic.prefix is
+        unrelated must keep a data topic that merely ends in ".transaction".
+        """
+        client = self._client()
+        client.client.list_connector_topics.return_value = {
+            "payments": {"topics": ["prod.ern.payments.transaction", "prod.ern.payments.refund_v1"]}
+        }
+        client.get_connector_config = MagicMock(return_value={"topic.prefix": "rigA.payments"})
+
+        topics = client.get_connector_topics("payments")
+
+        assert [t.name for t in topics] == [
+            "prod.ern.payments.transaction",
+            "prod.ern.payments.refund_v1",
+        ]
+
+
+def _source_with_topics(topic_names):
+    """A KafkaconnectSource whose only stubbed boundary is the OpenMetadata topic listing."""
+    from metadata.ingestion.source.pipeline.kafkaconnect.metadata import (
+        KafkaconnectSource,
+    )
+
+    source = object.__new__(KafkaconnectSource)
+    source.lineage_results = []
+    source._database_services_cache = []
+    source._messaging_services_cache = []
+    source._topics_cache = {}
+    source.metadata = MagicMock()
+    # These tests assert on which topic NAMES get resolved, not on entity lookup, and a
+    # bare MagicMock here fails TopicResolutionResult validation.
+    source.metadata.get_by_name.return_value = None
+
+    def list_all_entities(entity, params=None, **kwargs):
+        for name in topic_names:
+            topic = MagicMock()
+            topic.name = name
+            topic.fullyQualifiedName = f'confluent-prod."{name}"'
+            yield topic
+
+    source.metadata.list_all_entities.side_effect = list_all_entities
+    return source
+
+
+class TestNamespaceScanRequiresAttribution:
+    """
+    The topic.prefix namespace scan is only sound when no topic-rewriting SMT is
+    configured, because that is exactly the condition under which a topic name still
+    encodes its source table. With a router in the chain the scan asserts membership it
+    cannot verify.
+    """
+
+    OUTBOX_CONFIG = {  # noqa: RUF012
+        "connector.class": "MySqlCdcSourceV2",
+        "topic.prefix": "earnin.moneywallet.prod",
+        "table.include.list": "moneywallet.outbox",
+        "transforms": "outbox",
+        "transforms.outbox.type": "io.debezium.transforms.outbox.EventRouter",
+        "transforms.outbox.route.by.field": "_topic",
+        "transforms.outbox.route.topic.replacement": "${routedByValue}",
+    }
+
+    def test_event_router_connector_never_reaches_the_prefix_scan(self):
+        """
+        Regression for the shipped defect. The existing guard test passes
+        effective_messaging_service=None, which is the one value for which the prefix
+        scan below it cannot run. Every real deployment sets it, and with it set the
+        scan linked the outbox table to Debezium's transaction-metadata topic.
+        """
+        source = _source_with_topics(
+            [
+                "earnin.moneywallet.prod.lcc-d21vnd.transaction",
+                "earnin.moneywallet.prod.message",
+                "prod.ern.moneywallet.walletEntity_v1",
+            ]
+        )
+        details = KafkaConnectPipelineDetails(name="outbox-moneywallet-prod", type="source", config=self.OUTBOX_CONFIG)
+
+        topics = source._resolve_source_topics(
+            pipeline_details=details,
+            database_server_name="earnin.moneywallet.prod",
+            effective_messaging_service="confluent-prod",
+        )
+
+        assert [t.name for t in topics] == [], "an EventRouter connector must not namespace-scan"
+
+    def test_plain_cdc_still_resolves_through_the_prefix_scan(self):
+        """With no rewriting SMT the scan is sound, and must keep working."""
+        source = _source_with_topics(["rigA.plaincdc.walletdb.customers", "rigA.plaincdc.walletdb.orders"])
+        config = {"connector.class": "MySqlCdcSourceV2", "topic.prefix": "rigA.plaincdc"}
+        details = KafkaConnectPipelineDetails(name="plain-cdc", type="source", config=config)
+
+        topics = source._resolve_source_topics(
+            pipeline_details=details,
+            database_server_name="rigA.plaincdc",
+            effective_messaging_service="confluent-prod",
+        )
+
+        assert sorted(t.name for t in topics) == [
+            "rigA.plaincdc.walletdb.customers",
+            "rigA.plaincdc.walletdb.orders",
+        ]
+
+    def test_include_list_resolves_exact_names_without_scanning(self):
+        """
+        With table.include.list the topic names are constructed exactly, so the namespace
+        scan is never reached and a same-prefix internal topic cannot be picked up.
+        """
+        source = _source_with_topics(
+            [
+                "rigA.plaincdc.walletdb.customers",
+                "rigA.plaincdc.lcc-d21vnd.transaction",
+            ]
+        )
+        config = {
+            "connector.class": "MySqlCdcSourceV2",
+            "topic.prefix": "rigA.plaincdc",
+            "table.include.list": "walletdb.customers",
+        }
+        details = KafkaConnectPipelineDetails(name="plain-cdc", type="source", config=config)
+
+        topics = source._resolve_source_topics(
+            pipeline_details=details,
+            database_server_name="rigA.plaincdc",
+            effective_messaging_service="confluent-prod",
+        )
+
+        assert [t.name for t in topics] == ["rigA.plaincdc.walletdb.customers"]
+
+
+class TestRoutingPatternsDoNotGenerateTopics:
+    """
+    A wildcard built from route.topic.replacement describes a superset of the connector's
+    topics, so it cannot attribute a topic to a table. Two connectors routing into one
+    namespace reduce to the same pattern while owning disjoint topics, so generating from
+    the pattern gives each of them the other's edges.
+    """
+
+    @staticmethod
+    def _config(replacement):
+        config = {
+            "connector.class": "MySqlCdcSourceV2",
+            "topic.prefix": "rigA.wallet.suffixcol",
+            "table.include.list": "walletdb.outbox_suffix_col",
+            "transforms": "outbox",
+            "transforms.outbox.type": "io.debezium.transforms.outbox.EventRouter",
+            "transforms.outbox.route.by.field": "_route_suffix",
+        }
+        if replacement is not None:
+            config["transforms.outbox.route.topic.replacement"] = replacement
+        return config
+
+    def test_static_prefix_pattern_no_longer_claims_the_namespace(self):
+        source = _source_with_topics(
+            [
+                "prod.ern.moneywallet.settings_v1",
+                "prod.ern.moneywallet.ledgerEntry_v1",
+                "prod.ern.moneywallet.walletEntity_v1",
+            ]
+        )
+        details = KafkaConnectPipelineDetails(
+            name="outbox-wallet-suffix",
+            type="source",
+            config=self._config("prod.ern.moneywallet.${routedByValue}"),
+        )
+
+        topics = source._resolve_source_topics(
+            pipeline_details=details,
+            database_server_name="rigA.wallet.suffixcol",
+            effective_messaging_service="confluent-prod",
+        )
+
+        assert [t.name for t in topics] == [], "a routing pattern must not generate candidates"
+
+    def test_fully_static_replacement_is_config_deterministic(self):
+        """
+        A replacement with no ${...} token routes every event to one fixed topic, so the
+        destination is as derivable as any other declared name and must still resolve
+        without the runtime. Only a replacement that interpolates a row value is unknown.
+        """
+        source = _source_with_topics(["prod.events.all", "prod.events.settings_v1", "prod.events.orderPlaced_v1"])
+        details = KafkaConnectPipelineDetails(
+            name="outbox-static", type="source", config=self._config("prod.events.all")
+        )
+
+        topics = source._resolve_source_topics(
+            pipeline_details=details,
+            database_server_name="rigA.wallet.suffixcol",
+            effective_messaging_service="confluent-prod",
+        )
+
+        assert [t.name for t in topics] == ["prod.events.all"], (
+            "a static replacement names exactly one topic, with no namespace scan or pattern match"
+        )
+
+    def test_static_replacement_composes_with_a_following_regex_router(self):
+        """The published name is what survives the SMT chain, so later routers apply."""
+        config = self._config("outbox.event.all")
+        config["transforms"] = "outbox,reroute"
+        config["transforms.reroute.type"] = "org.apache.kafka.connect.transforms.RegexRouter"
+        config["transforms.reroute.regex"] = r"outbox\.event\.(.*)"
+        config["transforms.reroute.replacement"] = "prod.events.$1"
+        source = _source_with_topics(["prod.events.all"])
+        details = KafkaConnectPipelineDetails(name="outbox-static", type="source", config=config)
+
+        topics = source._resolve_source_topics(
+            pipeline_details=details,
+            database_server_name="rigA.wallet.suffixcol",
+            effective_messaging_service="confluent-prod",
+        )
+
+        assert [t.name for t in topics] == ["prod.events.all"]
+
+    def test_absent_route_topic_replacement_resolves_nothing(self):
+        """
+        An absent key means the routed name is unknown. The old code synthesised
+        "outbox.event.${routedByValue}", which invented a claim and matched nothing in
+        the deployment where this was found.
+        """
+        source = _source_with_topics(["outbox.event.wallet", "prod.ern.moneywallet.walletEntity_v1"])
+        details = KafkaConnectPipelineDetails(name="outbox-no-replacement", type="source", config=self._config(None))
+
+        topics = source._resolve_source_topics(
+            pipeline_details=details,
+            database_server_name="rigA.wallet.suffixcol",
+            effective_messaging_service="confluent-prod",
+        )
+
+        assert [t.name for t in topics] == []
+
+
+class TestConnectorEnrichmentOrdering:
+    """
+    The topic listing needs the connector's config to recognise that connector's own
+    bookkeeping topics, so enrichment must fetch config first and hand it to the topic
+    call. Reordering these two, or dropping the hand-off, silently costs a second round
+    trip per connector and leaves the internal-topic exclusion with nothing to match on.
+    """
+
+    def test_config_is_fetched_first_and_passed_to_the_topic_listing(self):
+        from metadata.ingestion.source.pipeline.kafkaconnect.client import (
+            KafkaConnectClient,
+        )
+
+        client = object.__new__(KafkaConnectClient)
+        client.client = MagicMock()
+        client.is_confluent_cloud = False
+        client._topics_endpoint_supported = None
+
+        config = {"topic.prefix": "rigA.wallet", "description": "wallet outbox"}
+        calls = []
+        client.get_connector_config = MagicMock(side_effect=lambda connector: calls.append("config") or config)
+        client.get_connector_topics = MagicMock(
+            side_effect=lambda connector, connector_config=None: (
+                calls.append(("topics", connector_config)) or [KafkaConnectTopics(name="prod.events.orderPlaced_v1")]
+            )
+        )
+
+        details = KafkaConnectPipelineDetails(name="outbox-wallet", type="source")
+        client._enrich_connector_details(details, "outbox-wallet")
+
+        assert calls[0] == "config", "config must be fetched before the topic listing"
+        assert calls[1] == ("topics", config), "the fetched config must be handed to the topic listing"
+        assert client.get_connector_config.call_count == 1, "config must not be fetched twice"
+        assert [t.name for t in details.topics] == ["prod.events.orderPlaced_v1"]
+        assert details.description == "wallet outbox"
+
+
+class TestColdStartFallsBackToDeclaredTopics:
+    """
+    Active-topic tracking records what a connector has touched so far, not what it will.
+    A connector that has produced nothing, or so far only its own schema-change topic, is
+    at a cold start rather than asserting it has no data topics, so its config-declared
+    names are still the better answer.
+
+    Falling back is safe because every remaining fallback is deterministic: a sink's
+    declared topics, or CDC names built from table.include.list. Routing patterns no
+    longer generate candidates, and the namespace scan is restricted to connectors with
+    no topic-rewriting SMT.
+    """
+
+    def _client(self):
+        client = object.__new__(KafkaConnectClient)
+        client.client = MagicMock()
+        client.is_confluent_cloud = False
+        client._topics_endpoint_supported = None
+        return client
+
+    def test_runtime_reporting_only_internal_topics_falls_back(self):
+        """
+        A connector that has emitted a schema change but no data rows reports only its
+        schema-change topic. That is a cold start, so its declared topic still resolves.
+        """
+        client = self._client()
+        client.client.list_connector_topics.return_value = {"datagen": {"topics": ["rigA.plaincdc"]}}
+        config = {"topic.prefix": "rigA.plaincdc", "kafka.topic": "orders"}
+
+        topics = client.get_connector_topics("datagen", connector_config=config)
+
+        assert [t.name for t in topics] == ["orders"]
+
+    def test_silent_runtime_still_falls_back_to_config(self):
+        """A sink that has not consumed yet must still resolve its declared subscription."""
+        client = self._client()
+        client.client.list_connector_topics.return_value = {"jdbc-sink": {"topics": []}}
+        config = {"topics": "orders,payments"}
+
+        topics = client.get_connector_topics("jdbc-sink", connector_config=config)
+
+        assert [t.name for t in topics] == ["orders", "payments"]
+
+    def test_cold_start_cdc_still_resolves_constructed_names(self):
+        """
+        Regression for a gate that suppressed inference whenever the runtime reported no
+        data topics. A freshly started CDC connector resolved nothing, losing the
+        deterministically constructed names it should have had.
+        """
+        source = _source_with_topics(["rigA.plaincdc.walletdb.customers", "rigA.plaincdc.walletdb.orders"])
+        config = {
+            "connector.class": "MySqlCdcSourceV2",
+            "topic.prefix": "rigA.plaincdc",
+            "table.include.list": "walletdb.customers,walletdb.orders",
+        }
+        details = KafkaConnectPipelineDetails(name="plain-cdc", type="source", config=config)
+
+        result = source._parse_and_resolve_topics(
+            pipeline_details=details,
+            database_server_name="rigA.plaincdc",
+            effective_messaging_service="confluent-prod",
+            is_storage_sink=False,
+        )
+
+        assert sorted(t.name for t in result.topics) == [
+            "rigA.plaincdc.walletdb.customers",
+            "rigA.plaincdc.walletdb.orders",
+        ]
+
+
+class TestForbiddenIsNotAlwaysUnsupported:
+    """
+    Connect answers 403 "Topic tracking is disabled." when topic.tracking.enable=false,
+    which is a property of the whole worker. A proxy or per-route RBAC can also answer 403
+    while the endpoint exists, and latching on the status alone would silently disable
+    runtime topic discovery for every connector behind the first such response.
+    """
+
+    def _client(self):
+        client = object.__new__(KafkaConnectClient)
+        client.client = MagicMock()
+        client.is_confluent_cloud = False
+        client._topics_endpoint_supported = None
+        return client
+
+    @staticmethod
+    def _forbidden(body):
+        exc = Exception("403 Client Error: Forbidden")
+        exc.response = SimpleNamespace(status_code=403, text=body)
+        return exc
+
+    def test_topic_tracking_disabled_latches_off(self):
+        client = self._client()
+        client.client.list_connector_topics.side_effect = self._forbidden(
+            '{"error_code":403,"message":"Topic tracking is disabled."}'
+        )
+        client.get_connector_config = MagicMock(return_value={"topics": "orders"})
+
+        for name in ("conn-a", "conn-b", "conn-c"):
+            client.get_connector_topics(name)
+
+        assert client.client.list_connector_topics.call_count == 1
+        assert client._topics_endpoint_supported is False
+
+    def test_authorization_403_does_not_latch_off(self):
+        """
+        An RBAC or proxy 403 is request-specific. Latching would strip runtime truth from
+        every later connector, including ones whose topics are perfectly readable.
+        """
+        client = self._client()
+        client.client.list_connector_topics.side_effect = [
+            self._forbidden('{"error_code":403,"message":"Forbidden"}'),
+            {"outbox-b": {"topics": ["prod.events.orderPlaced_v1"]}},
+        ]
+        client.get_connector_config = MagicMock(return_value={})
+
+        assert client.get_connector_topics("outbox-a") is None
+        assert client._topics_endpoint_supported is None, "an auth 403 must not disable the endpoint"
+
+        topics = client.get_connector_topics("outbox-b")
+
+        assert [t.name for t in topics] == ["prod.events.orderPlaced_v1"]
+        assert client.client.list_connector_topics.call_count == 2


### PR DESCRIPTION
Backport of #32207 to `1.13`. Fixes #32205 on this line.

Cherry-picked from `6901f1ebd`.

### What it changes

The connector treated membership of a topic namespace as evidence of lineage, through the `topic.prefix` scan and a wildcard built from `route.topic.replacement`. Neither can attribute a topic to a table, so two connectors sharing a namespace each claimed the other's topics, and an outbox EventRouter could end up linked only to Debezium's own internal topics.

Resolution now prefers the Connect runtime's active-topic list (KIP-558), subtracts the connector's own bookkeeping topics by the names its config gives them, and falls back only to names configuration actually determines. A 403 is treated as the endpoint being off only when the body reports topic tracking disabled.

### Conflict resolution

11 conflicts across the 3 files, all of them purely `black` at 88 columns on this line versus `ruff` at 120 on main. Resolved with `-X theirs` so each conflicting hunk takes main's version byte for byte while non-conflicting `1.13` code stays untouched.

`black` was deliberately **not** run afterwards, so the backported hunks stay byte-identical to main and future backports of these files apply cleanly. That is why this carries `skip-pr-checks`. The alternative, taking whole files from main, would have been a roughly 2100 line diff of unrelated reformatting.

### Verification

Measured on a purpose-built Kafka Connect + Debezium + MySQL + Postgres + MinIO rig covering 9 connectors, with ground truth established by the seed data:

| Scenario | Before | After |
|---|---|---|
| KIP-558 available | 70.8% precision | 100% precision, 100% recall |
| KIP-558 unavailable | 68.2% precision | 100% precision, 76.5% recall |

Unit tests run on this branch with a dedicated venv and its own generated models:

- `test_kafkaconnect.py` + `test_kafkaconnect_service_discovery.py`: **112 passed**, the same count as main, so no test was lost in the cherry-pick.
- All of `tests/unit/topology/pipeline/`: **765 passed**, 1 skipped, 3 failed.

The 3 failures are `test_airflow_connection.py` with `ModuleNotFoundError: No module named 'airflow'`, an optional dependency absent from the local venv. Confirmed pre-existing by running that file on `HEAD~1`, the branch tip before this cherry-pick, where the same 3 fail identically.