### PR TITLE
feat(ui): add dark mode switcher

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/index.html
+++ b/openmetadata-ui/src/main/resources/ui/index.html
@@ -36,15 +36,26 @@
       and re-painting once React reads localStorage. Mirrors Linear's inline
       splash trick (see linear.app/changelog): pre-paint reads of stable
       localStorage keys avoid a visible re-theme on cold load. The bundle's
-      ThemeProvider re-reads the same `ui-theme` key on mount and stays in
-      sync with the class we set here. `appStart` mark gives the bundle a
+      ThemeProvider uses the same saved-theme then OS-theme order on mount and
+      stays in sync with the class we set here. `appStart` mark gives the bundle a
       RUM anchor to measure HTML-parse → first paint vs. JS-ready.
     -->
-    <script nonce="${cspNonce}">
+    <script id="theme-restore" nonce="${cspNonce}">
       try {
-        if (localStorage.getItem('ui-theme') === 'dark') {
-          document.documentElement.classList.add('dark-mode');
-        }
+        const savedTheme = localStorage.getItem('ui-theme');
+        const followsDarkSystemTheme =
+          savedTheme !== 'light' &&
+          savedTheme !== 'dark' &&
+          typeof window.matchMedia === 'function' &&
+          window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const restoredTheme =
+          savedTheme === 'dark' || followsDarkSystemTheme ? 'dark' : 'light';
+
+        document.documentElement.classList.toggle(
+          'dark-mode',
+          restoredTheme === 'dark'
+        );
+        document.documentElement.style.colorScheme = restoredTheme;
       } catch (e) {}
       try {
         performance.mark('appStart');
@@ -253,8 +264,8 @@
       }
 
       /*
-        Dark variant — applied by the pre-paint script above when
-        localStorage.ui-theme is "dark". Matches the dark-mode CSS variables
+        Dark variant — applied by the pre-paint script above for a saved dark
+        preference or a dark OS preference. Matches the dark-mode CSS variables
         the bundle eventually sets via ThemeProvider, so the visual transition
         from shell to React UI is seamless instead of a light→dark flash.
       */

--- a/openmetadata-ui/src/main/resources/ui/index.html
+++ b/openmetadata-ui/src/main/resources/ui/index.html
@@ -36,27 +36,21 @@
       and re-painting once React reads localStorage. Mirrors Linear's inline
       splash trick (see linear.app/changelog): pre-paint reads of stable
       localStorage keys avoid a visible re-theme on cold load. The bundle's
-      ThemeProvider uses the same saved-theme then OS-theme order on mount and
-      stays in sync with the class we set here. `appStart` mark gives the bundle a
-      RUM anchor to measure HTML-parse → first paint vs. JS-ready.
+      ThemeProvider uses the same saved-theme-or-light order on mount and stays
+      in sync with the class we set here. `appStart` mark gives the bundle a RUM
+      anchor to measure HTML-parse → first paint vs. JS-ready.
     -->
     <script id="theme-restore" nonce="${cspNonce}">
+      let restoredTheme = 'light';
       try {
         const savedTheme = localStorage.getItem('ui-theme');
-        const followsDarkSystemTheme =
-          savedTheme !== 'light' &&
-          savedTheme !== 'dark' &&
-          typeof window.matchMedia === 'function' &&
-          window.matchMedia('(prefers-color-scheme: dark)').matches;
-        const restoredTheme =
-          savedTheme === 'dark' || followsDarkSystemTheme ? 'dark' : 'light';
-
-        document.documentElement.classList.toggle(
-          'dark-mode',
-          restoredTheme === 'dark'
-        );
-        document.documentElement.style.colorScheme = restoredTheme;
+        restoredTheme = savedTheme === 'dark' ? 'dark' : 'light';
       } catch (e) {}
+      document.documentElement.classList.toggle(
+        'dark-mode',
+        restoredTheme === 'dark'
+      );
+      document.documentElement.style.colorScheme = restoredTheme;
       try {
         performance.mark('appStart');
       } catch (e) {}
@@ -265,9 +259,9 @@
 
       /*
         Dark variant — applied by the pre-paint script above for a saved dark
-        preference or a dark OS preference. Matches the dark-mode CSS variables
-        the bundle eventually sets via ThemeProvider, so the visual transition
-        from shell to React UI is seamless instead of a light→dark flash.
+        preference. Matches the dark-mode CSS variables the bundle eventually
+        sets via ThemeProvider, so the visual transition from shell to React UI
+        is seamless instead of a light→dark flash.
       */
       .dark-mode .om-boot-shell {
         background: #0e0f11;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.component.tsx
@@ -40,6 +40,12 @@ import { useAuthProvider } from '../../../Auth/AuthProviders/AuthProvider';
 import ProfilePicture from '../../../common/ProfilePicture/ProfilePicture';
 import ThemeModeSwitcher from '../../../ThemeModeSwitcher/ThemeModeSwitcher';
 import './user-profile-icon.less';
+
+// Toggle owns its label markup, so scope the typography override here to keep
+// the shared AI menu styling unchanged while matching the Classic mode row.
+const CLASSIC_THEME_SWITCHER_CLASS =
+  'tw:w-full tw:pl-6 tw:[&>div>p]:text-xs tw:[&>div>p]:font-semibold';
+
 type ListMenuItemProps = {
   listItems: EntityReference[];
   labelRenderer: (item: EntityReference) => ReactNode;
@@ -372,7 +378,7 @@ export const UserProfileIcon = () => {
       {
         key: 'theme-mode',
         icon: '',
-        label: <ThemeModeSwitcher className="tw:w-full" />,
+        label: <ThemeModeSwitcher className={CLASSIC_THEME_SWITCHER_CLASS} />,
         type: 'group',
       },
       {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.component.tsx
@@ -89,17 +89,6 @@ const renderLimitedListMenuItem = ({
       ];
 };
 
-const renderProfileDropdown = (menu: ReactNode) => (
-  <>
-    {menu}
-    {/* Ant Design closes Dropdown after any Menu selection, so the theme control
-        lives in the footer to let users see the theme change in place. */}
-    <div className="profile-dropdown w-68 tw:border-t tw:border-secondary tw:bg-primary tw:px-4 tw:py-3">
-      <ThemeModeSwitcher className="tw:w-full" />
-    </div>
-  </>
-);
-
 export const UserProfileIcon = () => {
   const { currentUser, selectedPersona, setSelectedPersona } =
     useApplicationStore();
@@ -375,6 +364,14 @@ export const UserProfileIcon = () => {
         type: 'group',
       },
       ...navbarUtilClassBase.getUserProfileExtraItems(),
+      // A group label keeps the embedded switch non-selectable so Ant Design
+      // does not close the dropdown while the user previews the new theme.
+      {
+        key: 'theme-mode',
+        icon: '',
+        label: <ThemeModeSwitcher className="tw:w-full" />,
+        type: 'group',
+      },
       {
         type: 'divider',
       },
@@ -409,7 +406,6 @@ export const UserProfileIcon = () => {
 
   return (
     <Dropdown
-      dropdownRender={renderProfileDropdown}
       menu={{
         items,
         defaultOpenKeys: ['personas', 'roles', 'inheritedRoles', 'teams'],

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.component.tsx
@@ -38,6 +38,7 @@ import {
 import { getEmptyTextFromUserProfileItem } from '../../../../utils/UsersPureUtils';
 import { useAuthProvider } from '../../../Auth/AuthProviders/AuthProvider';
 import ProfilePicture from '../../../common/ProfilePicture/ProfilePicture';
+import ThemeModeSwitcher from '../../../ThemeModeSwitcher/ThemeModeSwitcher';
 import './user-profile-icon.less';
 type ListMenuItemProps = {
   listItems: EntityReference[];
@@ -87,6 +88,17 @@ const renderLimitedListMenuItem = ({
         ],
       ];
 };
+
+const renderProfileDropdown = (menu: ReactNode) => (
+  <>
+    {menu}
+    {/* Ant Design closes Dropdown after any Menu selection, so the theme control
+        lives in the footer to let users see the theme change in place. */}
+    <div className="profile-dropdown w-68 tw:border-t tw:border-secondary tw:bg-primary tw:px-4 tw:py-3">
+      <ThemeModeSwitcher className="tw:w-full" />
+    </div>
+  </>
+);
 
 export const UserProfileIcon = () => {
   const { currentUser, selectedPersona, setSelectedPersona } =
@@ -397,6 +409,7 @@ export const UserProfileIcon = () => {
 
   return (
     <Dropdown
+      dropdownRender={renderProfileDropdown}
       menu={{
         items,
         defaultOpenKeys: ['personas', 'roles', 'inheritedRoles', 'teams'],

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.component.tsx
@@ -364,6 +364,9 @@ export const UserProfileIcon = () => {
         type: 'group',
       },
       ...navbarUtilClassBase.getUserProfileExtraItems(),
+      {
+        type: 'divider',
+      },
       // A group label keeps the embedded switch non-selectable so Ant Design
       // does not close the dropdown while the user previews the new theme.
       {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.test.tsx
@@ -307,6 +307,11 @@ describe('UserProfileIcon', () => {
     const switcher = await screen.findByRole('switch', {
       name: 'label.dark-mode',
     });
+    const profileDropdown = screen
+      .getByText('label.logout')
+      .closest('.profile-dropdown');
+
+    expect(profileDropdown).toContainElement(switcher);
 
     fireEvent.click(switcher);
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.test.tsx
@@ -13,6 +13,7 @@
 
 import { fireEvent, render, screen } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
+import { ThemeProvider } from '../../../../context/UntitledUIThemeProvider/theme-provider';
 import { User } from '../../../../generated/entity/teams/user';
 import { EntityReference } from '../../../../generated/entity/type';
 import { useApplicationStore } from '../../../../hooks/useApplicationStore';
@@ -26,12 +27,16 @@ jest.mock('../../../../hooks/authHooks', () => ({
     onLogoutHandler: jest.fn(),
   }),
 }));
+jest.mock('../../../AppModeSwitcher/AppModeSwitcher', () => ({
+  __esModule: true,
+  default: () => <span>app-mode-switcher</span>,
+}));
 jest.mock('../../../../utils/NavbarUtilClassBase', () => ({
   __esModule: true,
   default: {
     getUserProfileExtraItems: jest
       .fn()
-      .mockReturnValue([{ key: 'app-mode', label: 'app-mode-extra-item' }]),
+      .mockReturnValue([{ key: 'extra-item', label: 'app-mode-extra-item' }]),
   },
 }));
 const translationState = {
@@ -129,7 +134,9 @@ const createMockStoreData = (overrides = {}) => ({
 });
 
 const MockWrapper = ({ children }: { children: React.ReactNode }) => (
-  <BrowserRouter>{children}</BrowserRouter>
+  <BrowserRouter>
+    <ThemeProvider>{children}</ThemeProvider>
+  </BrowserRouter>
 );
 
 describe('UserProfileIcon', () => {
@@ -139,6 +146,12 @@ describe('UserProfileIcon', () => {
     jest.clearAllMocks();
     mockUseApplicationStore.mockReturnValue(createMockStoreData());
     translationState.language = 'en';
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark-mode');
+    document.documentElement.style.removeProperty('color-scheme');
   });
 
   const openDropdown = () => {
@@ -278,5 +291,27 @@ describe('UserProfileIcon', () => {
     expect(screen.getByText('Rollen')).toBeInTheDocument();
     expect(screen.getByText('Teams')).toBeInTheDocument();
     expect(screen.getByText('Abmelden')).toBeInTheDocument();
+  });
+
+  it('updates the theme from the profile dropdown', async () => {
+    localStorage.setItem('ui-theme', 'light');
+
+    render(
+      <MockWrapper>
+        <UserProfileIcon />
+      </MockWrapper>
+    );
+
+    const dropdownTrigger = openDropdown();
+
+    const switcher = await screen.findByRole('switch', {
+      name: 'label.dark-mode',
+    });
+
+    fireEvent.click(switcher);
+
+    expect(switcher).toBeChecked();
+    expect(dropdownTrigger).toHaveClass('ant-dropdown-open');
+    expect(localStorage.getItem('ui-theme')).toBe('dark');
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.test.tsx
@@ -310,9 +310,15 @@ describe('UserProfileIcon', () => {
     const profileDropdown = screen
       .getByText('label.logout')
       .closest('.profile-dropdown');
+    const switcherRow = switcher.closest('label');
     const themeMenuGroup = switcher.closest('.ant-dropdown-menu-item-group');
 
     expect(profileDropdown).toContainElement(switcher);
+    expect(switcherRow).toHaveClass(
+      'tw:pl-6',
+      'tw:[&>div>p]:text-xs',
+      'tw:[&>div>p]:font-semibold'
+    );
     expect(themeMenuGroup?.previousElementSibling).toHaveClass(
       'ant-dropdown-menu-item-divider'
     );

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.test.tsx
@@ -310,8 +310,12 @@ describe('UserProfileIcon', () => {
     const profileDropdown = screen
       .getByText('label.logout')
       .closest('.profile-dropdown');
+    const themeMenuGroup = switcher.closest('.ant-dropdown-menu-item-group');
 
     expect(profileDropdown).toContainElement(switcher);
+    expect(themeMenuGroup?.previousElementSibling).toHaveClass(
+      'ant-dropdown-menu-item-divider'
+    );
 
     fireEvent.click(switcher);
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.test.tsx
@@ -27,10 +27,6 @@ jest.mock('../../../../hooks/authHooks', () => ({
     onLogoutHandler: jest.fn(),
   }),
 }));
-jest.mock('../../../AppModeSwitcher/AppModeSwitcher', () => ({
-  __esModule: true,
-  default: () => <span>app-mode-switcher</span>,
-}));
 jest.mock('../../../../utils/NavbarUtilClassBase', () => ({
   __esModule: true,
   default: {

--- a/openmetadata-ui/src/main/resources/ui/src/components/ThemeModeSwitcher/ThemeModeSwitcher.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ThemeModeSwitcher/ThemeModeSwitcher.test.tsx
@@ -27,7 +27,7 @@ describe('ThemeModeSwitcher', () => {
 
   it('shows and updates the active theme', () => {
     render(
-      <ThemeProvider defaultTheme="light">
+      <ThemeProvider>
         <ThemeModeSwitcher />
       </ThemeProvider>
     );
@@ -51,7 +51,7 @@ describe('ThemeModeSwitcher', () => {
 
   it('uses the full row with the label separated from the toggle', () => {
     render(
-      <ThemeProvider defaultTheme="light">
+      <ThemeProvider>
         <ThemeModeSwitcher />
       </ThemeProvider>
     );

--- a/openmetadata-ui/src/main/resources/ui/src/components/ThemeModeSwitcher/ThemeModeSwitcher.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ThemeModeSwitcher/ThemeModeSwitcher.test.tsx
@@ -1,0 +1,51 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '../../context/UntitledUIThemeProvider/theme-provider';
+import ThemeModeSwitcher from './ThemeModeSwitcher';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('ThemeModeSwitcher', () => {
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark-mode');
+  });
+
+  it('shows and updates the active theme', () => {
+    render(
+      <ThemeProvider defaultTheme="light">
+        <ThemeModeSwitcher />
+      </ThemeProvider>
+    );
+
+    const switcher = screen.getByRole('switch', { name: 'label.dark-mode' });
+
+    expect(switcher).not.toBeChecked();
+
+    fireEvent.click(switcher);
+
+    expect(switcher).toBeChecked();
+    expect(localStorage.getItem('ui-theme')).toBe('dark');
+    expect(document.documentElement).toHaveClass('dark-mode');
+
+    fireEvent.click(switcher);
+
+    expect(switcher).not.toBeChecked();
+    expect(localStorage.getItem('ui-theme')).toBe('light');
+    expect(document.documentElement).not.toHaveClass('dark-mode');
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/ThemeModeSwitcher/ThemeModeSwitcher.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ThemeModeSwitcher/ThemeModeSwitcher.test.tsx
@@ -48,4 +48,23 @@ describe('ThemeModeSwitcher', () => {
     expect(localStorage.getItem('ui-theme')).toBe('light');
     expect(document.documentElement).not.toHaveClass('dark-mode');
   });
+
+  it('uses the full row with the label separated from the toggle', () => {
+    render(
+      <ThemeProvider defaultTheme="light">
+        <ThemeModeSwitcher />
+      </ThemeProvider>
+    );
+
+    const switcherRow = screen
+      .getByRole('switch', { name: 'label.dark-mode' })
+      .closest('label');
+
+    expect(switcherRow).toHaveClass(
+      'tw:w-full',
+      'tw:flex-row-reverse',
+      'tw:items-center',
+      'tw:justify-between'
+    );
+  });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/ThemeModeSwitcher/ThemeModeSwitcher.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ThemeModeSwitcher/ThemeModeSwitcher.tsx
@@ -12,6 +12,7 @@
  */
 
 import { Toggle } from '@openmetadata/ui-core-components';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '../../context/UntitledUIThemeProvider/theme-provider';
 
@@ -25,7 +26,10 @@ const ThemeModeSwitcher = ({ className }: ThemeModeSwitcherProps) => {
 
   return (
     <Toggle
-      className={className}
+      className={classNames(
+        'tw:w-full tw:flex-row-reverse tw:items-center tw:justify-between',
+        className
+      )}
       isSelected={theme === 'dark'}
       label={t('label.dark-mode')}
       onChange={(isDarkMode) => setTheme(isDarkMode ? 'dark' : 'light')}

--- a/openmetadata-ui/src/main/resources/ui/src/components/ThemeModeSwitcher/ThemeModeSwitcher.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ThemeModeSwitcher/ThemeModeSwitcher.tsx
@@ -1,0 +1,36 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Toggle } from '@openmetadata/ui-core-components';
+import { useTranslation } from 'react-i18next';
+import { useTheme } from '../../context/UntitledUIThemeProvider/theme-provider';
+
+interface ThemeModeSwitcherProps {
+  className?: string;
+}
+
+const ThemeModeSwitcher = ({ className }: ThemeModeSwitcherProps) => {
+  const { setTheme, theme } = useTheme();
+  const { t } = useTranslation();
+
+  return (
+    <Toggle
+      className={className}
+      isSelected={theme === 'dark'}
+      label={t('label.dark-mode')}
+      onChange={(isDarkMode) => setTheme(isDarkMode ? 'dark' : 'light')}
+    />
+  );
+};
+
+export default ThemeModeSwitcher;

--- a/openmetadata-ui/src/main/resources/ui/src/context/UntitledUIThemeProvider/theme-boot.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/context/UntitledUIThemeProvider/theme-boot.test.ts
@@ -1,0 +1,58 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { readFileSync } from 'fs';
+
+const getThemeRestoreScript = () => {
+  const indexHtml = readFileSync('index.html', 'utf8');
+  const parsedHtml = new DOMParser().parseFromString(indexHtml, 'text/html');
+  const script = parsedHtml.querySelector<HTMLScriptElement>('#theme-restore');
+
+  if (!script?.textContent) {
+    throw new Error('Theme restore script is missing from index.html');
+  }
+
+  return script.textContent;
+};
+
+const executeThemeRestore = () => {
+  const restoreTheme = new Function(getThemeRestoreScript());
+  restoreTheme();
+};
+
+describe('theme restore boot script', () => {
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark-mode');
+    document.documentElement.style.removeProperty('color-scheme');
+  });
+
+  it('uses the OS dark theme before the application bundle loads', () => {
+    window.matchMedia = jest.fn().mockReturnValue({ matches: true });
+
+    executeThemeRestore();
+
+    expect(document.documentElement).toHaveClass('dark-mode');
+    expect(document.documentElement).toHaveStyle({ colorScheme: 'dark' });
+  });
+
+  it('keeps an explicit light preference when the OS theme is dark', () => {
+    localStorage.setItem('ui-theme', 'light');
+    window.matchMedia = jest.fn().mockReturnValue({ matches: true });
+
+    executeThemeRestore();
+
+    expect(document.documentElement).not.toHaveClass('dark-mode');
+    expect(document.documentElement).toHaveStyle({ colorScheme: 'light' });
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/context/UntitledUIThemeProvider/theme-boot.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/context/UntitledUIThemeProvider/theme-boot.test.ts
@@ -32,13 +32,24 @@ const executeThemeRestore = () => {
 
 describe('theme restore boot script', () => {
   afterEach(() => {
+    jest.restoreAllMocks();
     localStorage.clear();
     document.documentElement.classList.remove('dark-mode');
     document.documentElement.style.removeProperty('color-scheme');
   });
 
-  it('uses the OS dark theme before the application bundle loads', () => {
+  it('uses light mode before the application bundle loads without a preference', () => {
     window.matchMedia = jest.fn().mockReturnValue({ matches: true });
+
+    executeThemeRestore();
+
+    expect(document.documentElement).not.toHaveClass('dark-mode');
+    expect(document.documentElement).toHaveStyle({ colorScheme: 'light' });
+  });
+
+  it('restores an explicit dark preference before the application bundle loads', () => {
+    localStorage.setItem('ui-theme', 'dark');
+    window.matchMedia = jest.fn().mockReturnValue({ matches: false });
 
     executeThemeRestore();
 
@@ -46,9 +57,20 @@ describe('theme restore boot script', () => {
     expect(document.documentElement).toHaveStyle({ colorScheme: 'dark' });
   });
 
-  it('keeps an explicit light preference when the OS theme is dark', () => {
+  it('restores an explicit light preference before the application bundle loads', () => {
     localStorage.setItem('ui-theme', 'light');
     window.matchMedia = jest.fn().mockReturnValue({ matches: true });
+
+    executeThemeRestore();
+
+    expect(document.documentElement).not.toHaveClass('dark-mode');
+    expect(document.documentElement).toHaveStyle({ colorScheme: 'light' });
+  });
+
+  it('uses light mode when the stored preference cannot be read', () => {
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('Storage is unavailable');
+    });
 
     executeThemeRestore();
 

--- a/openmetadata-ui/src/main/resources/ui/src/context/UntitledUIThemeProvider/theme-provider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/UntitledUIThemeProvider/theme-provider.test.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { ThemeProvider, useTheme } from './theme-provider';
 
 const ThemeProbe = () => {
@@ -38,9 +38,25 @@ const renderProvider = () =>
   );
 
 const setSystemTheme = (theme: 'light' | 'dark') => {
+  let changeListener: ((event: MediaQueryListEvent) => void) | undefined;
+  const mediaQuery = {
+    matches: theme === 'dark',
+    addEventListener: jest.fn(
+      (_event: string, listener: (event: MediaQueryListEvent) => void) => {
+        changeListener = listener;
+      }
+    ),
+    removeEventListener: jest.fn(),
+  };
+
   window.matchMedia = jest
     .fn()
-    .mockReturnValue({ matches: theme === 'dark' } as MediaQueryList);
+    .mockReturnValue(mediaQuery as unknown as MediaQueryList);
+
+  return (nextTheme: 'light' | 'dark') => {
+    mediaQuery.matches = nextTheme === 'dark';
+    changeListener?.({ matches: mediaQuery.matches } as MediaQueryListEvent);
+  };
 };
 
 describe('ThemeProvider', () => {
@@ -70,6 +86,22 @@ describe('ThemeProvider', () => {
     expect(screen.getByTestId('active-theme')).toHaveTextContent('light');
     expect(document.documentElement).not.toHaveClass('dark-mode');
     expect(document.documentElement).toHaveStyle({ colorScheme: 'light' });
+  });
+
+  it('follows system color scheme changes until a preference is selected', () => {
+    const changeSystemTheme = setSystemTheme('light');
+    renderProvider();
+
+    act(() => changeSystemTheme('dark'));
+
+    expect(screen.getByTestId('active-theme')).toHaveTextContent('dark');
+    expect(document.documentElement).toHaveClass('dark-mode');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use light theme' }));
+    act(() => changeSystemTheme('dark'));
+
+    expect(screen.getByTestId('active-theme')).toHaveTextContent('light');
+    expect(document.documentElement).not.toHaveClass('dark-mode');
   });
 
   it('persists explicit dark and light selections', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/context/UntitledUIThemeProvider/theme-provider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/UntitledUIThemeProvider/theme-provider.test.tsx
@@ -61,23 +61,35 @@ const setSystemTheme = (theme: 'light' | 'dark') => {
 
 describe('ThemeProvider', () => {
   afterEach(() => {
+    jest.restoreAllMocks();
     localStorage.clear();
     document.documentElement.classList.remove('dark-mode');
     document.documentElement.style.removeProperty('color-scheme');
   });
 
-  it('uses the system color scheme when no preference is stored', () => {
+  it('uses light mode when no preference is stored', () => {
     setSystemTheme('dark');
+
+    renderProvider();
+
+    expect(screen.getByTestId('active-theme')).toHaveTextContent('light');
+    expect(document.documentElement).not.toHaveClass('dark-mode');
+    expect(document.documentElement).toHaveStyle({ colorScheme: 'light' });
+    expect(localStorage.getItem('ui-theme')).toBeNull();
+  });
+
+  it('uses a stored preference instead of the default light mode', () => {
+    setSystemTheme('light');
+    localStorage.setItem('ui-theme', 'dark');
 
     renderProvider();
 
     expect(screen.getByTestId('active-theme')).toHaveTextContent('dark');
     expect(document.documentElement).toHaveClass('dark-mode');
     expect(document.documentElement).toHaveStyle({ colorScheme: 'dark' });
-    expect(localStorage.getItem('ui-theme')).toBeNull();
   });
 
-  it('uses a stored preference instead of the system color scheme', () => {
+  it('restores a stored light preference when the system theme is dark', () => {
     setSystemTheme('dark');
     localStorage.setItem('ui-theme', 'light');
 
@@ -88,20 +100,48 @@ describe('ThemeProvider', () => {
     expect(document.documentElement).toHaveStyle({ colorScheme: 'light' });
   });
 
-  it('follows system color scheme changes until a preference is selected', () => {
+  it('treats an invalid stored value as no preference', () => {
+    setSystemTheme('dark');
+    localStorage.setItem('ui-theme', 'invalid');
+
+    renderProvider();
+
+    expect(screen.getByTestId('active-theme')).toHaveTextContent('light');
+    expect(localStorage.getItem('ui-theme')).toBeNull();
+  });
+
+  it('keeps light mode when the system color scheme changes', () => {
     const changeSystemTheme = setSystemTheme('light');
     renderProvider();
 
     act(() => changeSystemTheme('dark'));
 
-    expect(screen.getByTestId('active-theme')).toHaveTextContent('dark');
-    expect(document.documentElement).toHaveClass('dark-mode');
-
-    fireEvent.click(screen.getByRole('button', { name: 'Use light theme' }));
-    act(() => changeSystemTheme('dark'));
-
     expect(screen.getByTestId('active-theme')).toHaveTextContent('light');
     expect(document.documentElement).not.toHaveClass('dark-mode');
+  });
+
+  it('uses light mode when the stored preference cannot be read', () => {
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('Storage is unavailable');
+    });
+
+    expect(() => renderProvider()).not.toThrow();
+    expect(screen.getByTestId('active-theme')).toHaveTextContent('light');
+    expect(document.documentElement).not.toHaveClass('dark-mode');
+    expect(document.documentElement).toHaveStyle({ colorScheme: 'light' });
+  });
+
+  it('updates the theme when the preference cannot be persisted', () => {
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('Storage is unavailable');
+    });
+    renderProvider();
+
+    expect(() =>
+      fireEvent.click(screen.getByRole('button', { name: 'Use dark theme' }))
+    ).not.toThrow();
+    expect(screen.getByTestId('active-theme')).toHaveTextContent('dark');
+    expect(document.documentElement).toHaveClass('dark-mode');
   });
 
   it('persists explicit dark and light selections', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/context/UntitledUIThemeProvider/theme-provider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/UntitledUIThemeProvider/theme-provider.test.tsx
@@ -1,0 +1,89 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider, useTheme } from './theme-provider';
+
+const ThemeProbe = () => {
+  const { setTheme, theme } = useTheme();
+
+  return (
+    <>
+      <span data-testid="active-theme">{theme}</span>
+      <button type="button" onClick={() => setTheme('dark')}>
+        Use dark theme
+      </button>
+      <button type="button" onClick={() => setTheme('light')}>
+        Use light theme
+      </button>
+    </>
+  );
+};
+
+const renderProvider = () =>
+  render(
+    <ThemeProvider>
+      <ThemeProbe />
+    </ThemeProvider>
+  );
+
+const setSystemTheme = (theme: 'light' | 'dark') => {
+  window.matchMedia = jest
+    .fn()
+    .mockReturnValue({ matches: theme === 'dark' } as MediaQueryList);
+};
+
+describe('ThemeProvider', () => {
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark-mode');
+    document.documentElement.style.removeProperty('color-scheme');
+  });
+
+  it('uses the system color scheme when no preference is stored', () => {
+    setSystemTheme('dark');
+
+    renderProvider();
+
+    expect(screen.getByTestId('active-theme')).toHaveTextContent('dark');
+    expect(document.documentElement).toHaveClass('dark-mode');
+    expect(document.documentElement).toHaveStyle({ colorScheme: 'dark' });
+    expect(localStorage.getItem('ui-theme')).toBeNull();
+  });
+
+  it('uses a stored preference instead of the system color scheme', () => {
+    setSystemTheme('dark');
+    localStorage.setItem('ui-theme', 'light');
+
+    renderProvider();
+
+    expect(screen.getByTestId('active-theme')).toHaveTextContent('light');
+    expect(document.documentElement).not.toHaveClass('dark-mode');
+    expect(document.documentElement).toHaveStyle({ colorScheme: 'light' });
+  });
+
+  it('persists explicit dark and light selections', () => {
+    setSystemTheme('light');
+    renderProvider();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use dark theme' }));
+
+    expect(localStorage.getItem('ui-theme')).toBe('dark');
+    expect(document.documentElement).toHaveClass('dark-mode');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use light theme' }));
+
+    expect(localStorage.getItem('ui-theme')).toBe('light');
+    expect(document.documentElement).not.toHaveClass('dark-mode');
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/context/UntitledUIThemeProvider/theme-provider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/UntitledUIThemeProvider/theme-provider.tsx
@@ -11,7 +11,14 @@
  *  limitations under the License.
  */
 import type { ReactNode } from 'react';
-import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import {
   BrandColors,
   Theme,
@@ -39,7 +46,7 @@ interface ThemeProviderProps {
    */
   darkModeClass?: string;
   /**
-   * The default theme to use if no theme is stored in localStorage.
+   * The fallback theme when neither storage nor a system preference is available.
    * @default "light"
    */
   defaultTheme?: Theme;
@@ -237,8 +244,8 @@ export const ThemeProvider = ({
   storageKey = 'ui-theme',
   darkModeClass = 'dark-mode',
 }: ThemeProviderProps) => {
-  const [theme, setTheme] = useState<Theme>(() => {
-    if (typeof globalThis !== 'undefined') {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    if (typeof globalThis.localStorage !== 'undefined') {
       const savedTheme = localStorage.getItem(storageKey) as Theme | null;
 
       if (savedTheme === 'light' || savedTheme === 'dark') {
@@ -248,20 +255,33 @@ export const ThemeProvider = ({
       localStorage.removeItem(storageKey);
     }
 
+    if (typeof globalThis.matchMedia === 'function') {
+      return globalThis.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light';
+    }
+
     return defaultTheme;
   });
+
+  const setTheme = useCallback(
+    (nextTheme: Theme) => {
+      // System-derived initialization stays ephemeral so later visits can keep
+      // following the OS until the user or desktop shell makes an explicit choice.
+      if (typeof globalThis.localStorage !== 'undefined') {
+        localStorage.setItem(storageKey, nextTheme);
+      }
+      setThemeState(nextTheme);
+    },
+    [storageKey]
+  );
 
   useEffect(() => {
     const root = globalThis.document.documentElement;
 
     root.classList.toggle(darkModeClass, theme === 'dark');
-
-    if (theme === 'dark') {
-      localStorage.setItem(storageKey, theme);
-    } else {
-      localStorage.removeItem(storageKey);
-    }
-  }, [theme, darkModeClass, storageKey]);
+    root.style.colorScheme = theme;
+  }, [theme, darkModeClass]);
 
   useEffect(() => {
     const root = globalThis.document.documentElement;
@@ -282,7 +302,7 @@ export const ThemeProvider = ({
 
   const values = useMemo(
     () => ({ theme, brandColors, setTheme }),
-    [theme, brandColors]
+    [theme, brandColors, setTheme]
   );
 
   return (

--- a/openmetadata-ui/src/main/resources/ui/src/context/UntitledUIThemeProvider/theme-provider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/UntitledUIThemeProvider/theme-provider.tsx
@@ -26,6 +26,31 @@ import {
 } from './theme-provider.interface';
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+const SYSTEM_THEME_QUERY = '(prefers-color-scheme: dark)';
+
+const getStoredTheme = (storageKey: string): Theme | null => {
+  if (typeof globalThis.localStorage === 'undefined') {
+    return null;
+  }
+
+  const savedTheme = localStorage.getItem(storageKey) as Theme | null;
+
+  if (savedTheme === 'light' || savedTheme === 'dark') {
+    return savedTheme;
+  }
+
+  localStorage.removeItem(storageKey);
+
+  return null;
+};
+
+const getSystemTheme = (): Theme | null => {
+  if (typeof globalThis.matchMedia !== 'function') {
+    return null;
+  }
+
+  return globalThis.matchMedia(SYSTEM_THEME_QUERY).matches ? 'dark' : 'light';
+};
 
 export const useTheme = (): ThemeContextType => {
   const context = useContext(ThemeContext);
@@ -244,25 +269,9 @@ export const ThemeProvider = ({
   storageKey = 'ui-theme',
   darkModeClass = 'dark-mode',
 }: ThemeProviderProps) => {
-  const [theme, setThemeState] = useState<Theme>(() => {
-    if (typeof globalThis.localStorage !== 'undefined') {
-      const savedTheme = localStorage.getItem(storageKey) as Theme | null;
-
-      if (savedTheme === 'light' || savedTheme === 'dark') {
-        return savedTheme;
-      }
-
-      localStorage.removeItem(storageKey);
-    }
-
-    if (typeof globalThis.matchMedia === 'function') {
-      return globalThis.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'light';
-    }
-
-    return defaultTheme;
-  });
+  const [theme, setThemeState] = useState<Theme>(
+    () => getStoredTheme(storageKey) ?? getSystemTheme() ?? defaultTheme
+  );
 
   const setTheme = useCallback(
     (nextTheme: Theme) => {
@@ -282,6 +291,28 @@ export const ThemeProvider = ({
     root.classList.toggle(darkModeClass, theme === 'dark');
     root.style.colorScheme = theme;
   }, [theme, darkModeClass]);
+
+  useEffect(() => {
+    if (typeof globalThis.matchMedia !== 'function') {
+      return;
+    }
+
+    const systemTheme = globalThis.matchMedia(SYSTEM_THEME_QUERY);
+    const handleSystemThemeChange = (event: MediaQueryListEvent) => {
+      // A stored value means the user or desktop shell has explicitly opted
+      // out of following later OS changes.
+      if (getStoredTheme(storageKey) !== null) {
+        return;
+      }
+
+      setThemeState(event.matches ? 'dark' : 'light');
+    };
+
+    systemTheme.addEventListener('change', handleSystemThemeChange);
+
+    return () =>
+      systemTheme.removeEventListener('change', handleSystemThemeChange);
+  }, [storageKey]);
 
   useEffect(() => {
     const root = globalThis.document.documentElement;

--- a/openmetadata-ui/src/main/resources/ui/src/context/UntitledUIThemeProvider/theme-provider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/UntitledUIThemeProvider/theme-provider.tsx
@@ -26,30 +26,26 @@ import {
 } from './theme-provider.interface';
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
-const SYSTEM_THEME_QUERY = '(prefers-color-scheme: dark)';
+const DEFAULT_THEME: Theme = 'light';
 
 const getStoredTheme = (storageKey: string): Theme | null => {
-  if (typeof globalThis.localStorage === 'undefined') {
-    return null;
+  try {
+    if (typeof globalThis.localStorage === 'undefined') {
+      return null;
+    }
+
+    const savedTheme = localStorage.getItem(storageKey) as Theme | null;
+
+    if (savedTheme === 'light' || savedTheme === 'dark') {
+      return savedTheme;
+    }
+
+    localStorage.removeItem(storageKey);
+  } catch {
+    // Privacy restrictions can block storage access; treat that as no preference.
   }
-
-  const savedTheme = localStorage.getItem(storageKey) as Theme | null;
-
-  if (savedTheme === 'light' || savedTheme === 'dark') {
-    return savedTheme;
-  }
-
-  localStorage.removeItem(storageKey);
 
   return null;
-};
-
-const getSystemTheme = (): Theme | null => {
-  if (typeof globalThis.matchMedia !== 'function') {
-    return null;
-  }
-
-  return globalThis.matchMedia(SYSTEM_THEME_QUERY).matches ? 'dark' : 'light';
 };
 
 export const useTheme = (): ThemeContextType => {
@@ -70,11 +66,6 @@ interface ThemeProviderProps {
    * @default "dark-mode"
    */
   darkModeClass?: string;
-  /**
-   * The fallback theme when neither storage nor a system preference is available.
-   * @default "light"
-   */
-  defaultTheme?: Theme;
   /**
    * The key to use to store the theme in localStorage.
    * @default "ui-theme"
@@ -265,20 +256,21 @@ const clearBrandCssVars = (root: HTMLElement) => {
 export const ThemeProvider = ({
   children,
   brandColors,
-  defaultTheme = 'light',
   storageKey = 'ui-theme',
   darkModeClass = 'dark-mode',
 }: ThemeProviderProps) => {
   const [theme, setThemeState] = useState<Theme>(
-    () => getStoredTheme(storageKey) ?? getSystemTheme() ?? defaultTheme
+    () => getStoredTheme(storageKey) ?? DEFAULT_THEME
   );
 
   const setTheme = useCallback(
     (nextTheme: Theme) => {
-      // System-derived initialization stays ephemeral so later visits can keep
-      // following the OS until the user or desktop shell makes an explicit choice.
-      if (typeof globalThis.localStorage !== 'undefined') {
-        localStorage.setItem(storageKey, nextTheme);
+      try {
+        if (typeof globalThis.localStorage !== 'undefined') {
+          localStorage.setItem(storageKey, nextTheme);
+        }
+      } catch {
+        // Persistence failure must not block theme changes for the current session.
       }
       setThemeState(nextTheme);
     },
@@ -291,28 +283,6 @@ export const ThemeProvider = ({
     root.classList.toggle(darkModeClass, theme === 'dark');
     root.style.colorScheme = theme;
   }, [theme, darkModeClass]);
-
-  useEffect(() => {
-    if (typeof globalThis.matchMedia !== 'function') {
-      return;
-    }
-
-    const systemTheme = globalThis.matchMedia(SYSTEM_THEME_QUERY);
-    const handleSystemThemeChange = (event: MediaQueryListEvent) => {
-      // A stored value means the user or desktop shell has explicitly opted
-      // out of following later OS changes.
-      if (getStoredTheme(storageKey) !== null) {
-        return;
-      }
-
-      setThemeState(event.matches ? 'dark' : 'light');
-    };
-
-    systemTheme.addEventListener('change', handleSystemThemeChange);
-
-    return () =>
-      systemTheme.removeEventListener('change', handleSystemThemeChange);
-  }, [storageKey]);
 
   useEffect(() => {
     const root = globalThis.document.documentElement;

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
@@ -597,6 +597,7 @@
     "dag-view": "عرض DAG",
     "daily": "يومي",
     "daily-active-users-on-the-platform": "المستخدمون النشطون يوميًا على المنصة",
+    "dark-mode": "الوضع الداكن",
     "dashboard": "لوحة المعلومات",
     "dashboard-data-model": "نموذج بيانات لوحة المعلومات",
     "dashboard-data-model-plural": "نماذج بيانات لوحات المعلومات",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
@@ -597,6 +597,7 @@
     "dag-view": "DAG-Ansicht",
     "daily": "Täglich",
     "daily-active-users-on-the-platform": "Täglich aktive Benutzer auf der Plattform",
+    "dark-mode": "Dunkelmodus",
     "dashboard": "Dashboard",
     "dashboard-data-model": "Dashboard-Datenmodell",
     "dashboard-data-model-plural": "Dashboard-Datenmodelle",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
@@ -597,6 +597,7 @@
     "dag-view": "DAG view",
     "daily": "Daily",
     "daily-active-users-on-the-platform": "Daily Active Users on the Platform",
+    "dark-mode": "Dark mode",
     "dashboard": "Dashboard",
     "dashboard-data-model": "Dashboard Data Model",
     "dashboard-data-model-plural": "Dashboard Data Models",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
@@ -597,6 +597,7 @@
     "dag-view": "Vista DAG",
     "daily": "Diario",
     "daily-active-users-on-the-platform": "Usuarios activos diarios en la plataforma",
+    "dark-mode": "Modo oscuro",
     "dashboard": "Panel",
     "dashboard-data-model": "Panel del Modelo de Datos",
     "dashboard-data-model-plural": "Panel de los Modelos de Datos",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
@@ -597,6 +597,7 @@
     "dag-view": "Vue DAG",
     "daily": "Quotidien",
     "daily-active-users-on-the-platform": "Utilisateurs Actifs Quotidiens sur la Plateforme",
+    "dark-mode": "Mode sombre",
     "dashboard": "Tableau de Bord",
     "dashboard-data-model": "Modèle de Données du Tableau de Bord",
     "dashboard-data-model-plural": "Modèles de Données du Tableau de Bord",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
@@ -597,6 +597,7 @@
     "dag-view": "Vista de DAG",
     "daily": "Diario",
     "daily-active-users-on-the-platform": "Usuarios activos diarios na plataforma",
+    "dark-mode": "Modo escuro",
     "dashboard": "Panel",
     "dashboard-data-model": "Modelo de datos do panel",
     "dashboard-data-model-plural": "Modelos de datos de paneis",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
@@ -597,6 +597,7 @@
     "dag-view": "תצוגת גרף מופע",
     "daily": "יומי",
     "daily-active-users-on-the-platform": "משתמשים פעילים יומיים בפלטפורמה",
+    "dark-mode": "מצב כהה",
     "dashboard": "דשבורד",
     "dashboard-data-model": "מודל נתונים של לוח בקרה",
     "dashboard-data-model-plural": "מודלי נתונים",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
@@ -597,6 +597,7 @@
     "dag-view": "DAGビュー",
     "daily": "毎日",
     "daily-active-users-on-the-platform": "プラットフォームの1日アクティブユーザー数",
+    "dark-mode": "ダークモード",
     "dashboard": "ダッシュボード",
     "dashboard-data-model": "ダッシュボードデータモデル",
     "dashboard-data-model-plural": "ダッシュボードデータモデル",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
@@ -597,6 +597,7 @@
     "dag-view": "DAG 뷰",
     "daily": "매일",
     "daily-active-users-on-the-platform": "플랫폼의 일일 활성 사용자",
+    "dark-mode": "다크 모드",
     "dashboard": "대시보드",
     "dashboard-data-model": "대시보드 데이터 모델",
     "dashboard-data-model-plural": "대시보드 데이터 모델등",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
@@ -597,6 +597,7 @@
     "dag-view": "DAG दृश्य",
     "daily": "दररोज",
     "daily-active-users-on-the-platform": "प्लॅटफॉर्मवरील दैनिक सक्रिय वापरकर्ते",
+    "dark-mode": "गडद मोड",
     "dashboard": "डॅशबोर्ड",
     "dashboard-data-model": "डॅशबोर्ड डेटा मॉडेल",
     "dashboard-data-model-plural": "डॅशबोर्ड डेटा मॉडेल्स",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
@@ -597,6 +597,7 @@
     "dag-view": "DAG-weergave",
     "daily": "Dagelijks",
     "daily-active-users-on-the-platform": "Dagelijks actieve gebruikers op het platform",
+    "dark-mode": "Donkere modus",
     "dashboard": "Dashboard",
     "dashboard-data-model": "Dashboard-datamodel",
     "dashboard-data-model-plural": "Dashboard datamodellen",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
@@ -597,6 +597,7 @@
     "dag-view": "نمای دگ",
     "daily": "روزانه",
     "daily-active-users-on-the-platform": "کاربران فعال روزانه در پلتفرم",
+    "dark-mode": "حالت تاریک",
     "dashboard": "داشبورد",
     "dashboard-data-model": "مدل داده داشبورد",
     "dashboard-data-model-plural": "مدل‌های داده داشبورد",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
@@ -597,6 +597,7 @@
     "dag-view": "Visualização DAG",
     "daily": "Diário",
     "daily-active-users-on-the-platform": "Usuários Ativos Diários na Plataforma",
+    "dark-mode": "Modo escuro",
     "dashboard": "Painel",
     "dashboard-data-model": "Modelo de dados do painel",
     "dashboard-data-model-plural": "Modelos de Dados do Painel",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
@@ -597,6 +597,7 @@
     "dag-view": "Visualização DAG",
     "daily": "Diário",
     "daily-active-users-on-the-platform": "Utilizadors Ativos Diários na Plataforma",
+    "dark-mode": "Modo escuro",
     "dashboard": "Painel",
     "dashboard-data-model": "Modelo de Dados do Painel",
     "dashboard-data-model-plural": "Modelos de Dados do Painel",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
@@ -597,6 +597,7 @@
     "dag-view": "Просмотр DAG",
     "daily": "Ежедневно",
     "daily-active-users-on-the-platform": "Количество активных пользователей на платформе",
+    "dark-mode": "Тёмный режим",
     "dashboard": "Дашборд",
     "dashboard-data-model": "Модель данных дашборда",
     "dashboard-data-model-plural": "Дашборды моделей данных",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/sv-se.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/sv-se.json
@@ -597,6 +597,7 @@
     "dag-view": "DAG-vy",
     "daily": "Dagligen",
     "daily-active-users-on-the-platform": "Dagliga aktiva användare på plattformen",
+    "dark-mode": "Mörkt läge",
     "dashboard": "Instrumentpanel",
     "dashboard-data-model": "Instrumentpanelens datamodell",
     "dashboard-data-model-plural": "Instrumentpanelens datamodeller",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
@@ -597,6 +597,7 @@
     "dag-view": "มุมมอง DAG",
     "daily": "รายวัน",
     "daily-active-users-on-the-platform": "ผู้ใช้ที่ใช้งานอยู่รายวันบนแพลตฟอร์ม",
+    "dark-mode": "โหมดมืด",
     "dashboard": "แดชบอร์ด",
     "dashboard-data-model": "โมเดลข้อมูลแดชบอร์ด",
     "dashboard-data-model-plural": "โมเดลข้อมูลแดชบอร์ด",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
@@ -597,6 +597,7 @@
     "dag-view": "DAG görünümü",
     "daily": "Günlük",
     "daily-active-users-on-the-platform": "Platformdaki Günlük Aktif Kullanıcı Sayısı",
+    "dark-mode": "Koyu mod",
     "dashboard": "Kontrol Paneli",
     "dashboard-data-model": "Kontrol Paneli Veri Modeli",
     "dashboard-data-model-plural": "Kontrol Paneli Veri Modelleri",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
@@ -597,6 +597,7 @@
     "dag-view": "DAG 视图",
     "daily": "每日",
     "daily-active-users-on-the-platform": "平台上的每日活跃用户",
+    "dark-mode": "深色模式",
     "dashboard": "仪表板",
     "dashboard-data-model": "仪表板数据模型",
     "dashboard-data-model-plural": "仪表板数据模型",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
@@ -597,6 +597,7 @@
     "dag-view": "DAG 檢視",
     "daily": "每日",
     "daily-active-users-on-the-platform": "平台上每日活躍使用者",
+    "dark-mode": "深色模式",
     "dashboard": "儀表板",
     "dashboard-data-model": "儀表板資料模型",
     "dashboard-data-model-plural": "儀表板資料模型",


### PR DESCRIPTION
### Describe your changes:

Backport of #32383 and #32472 to `2.0`.

Part of https://github.com/open-metadata/openmetadata-collate/issues/6035 (theme switcher subtask).

This PR adds a dark/light theme switcher to the Classic profile menu. The theme provider now:

- restores a valid saved light or dark preference;
- defaults to light mode when no valid preference is stored, regardless of the OS color scheme;
- persists explicit light and dark selections through the existing `ui-theme` key;
- keeps `setTheme` stable for the desktop theme bridge; and
- synchronizes the document class and native browser `color-scheme`.

The pre-paint restore script uses the same saved-preference-or-light rule so an OS-dark browser does not paint dark before React initializes the light default.

The `2.0` branch does not contain the AI user-menu surface, so the AI-specific changes from #32383 are not applicable here.

https://github.com/user-attachments/assets/f62f2bea-ddbc-4613-8afd-b92a543042c2

#
### Type of change:

- [x] New feature
- [x] Bug fix

#
### High-level design:

`ThemeModeSwitcher` is a shared controlled wrapper around the UI core `Toggle` and the existing `useTheme` context. The Classic profile dropdown renders it as a non-selectable menu group so switching themes does not close the menu.

The provider resolves initial state from a valid local-storage preference and otherwise uses light mode. It does not follow later OS color-scheme changes. Storage access failures also fall back to light without blocking session-only theme changes. The existing desktop bridge remains compatible because it uses the same key and calls the stable provider setter.

This change is backward compatible and requires no data migration.

#
### Tests:

#### Use cases covered

- Classic profile dropdown switches themes and remains open.
- The switcher reflects the active light/dark state and persists both choices.
- A saved preference overrides the default light mode.
- Missing, invalid, or inaccessible storage falls back to light.
- OS color-scheme changes do not alter the application theme.
- The pre-paint script and provider use the same initialization rule.
- The document dark class and native color scheme stay synchronized.

#### Unit tests

- [x] Added and updated focused component/provider tests.
- 21 focused tests pass across the provider, boot script, shared switcher, and Classic profile menu.

#### UI checks

- [x] ESLint, Prettier, and import organization pass on all changed TypeScript files.

#### Backend integration tests

- [x] Not applicable (no backend API changes).

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Not added; focused component tests cover theme initialization and the profile-menu surface.

#
### UI screen recording / screenshots:

See the recording linked above.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` (the source issue is in the Collate repository).
- [x] My PR is linked to the source GitHub issue above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable; no schema changes.
- [x] For UI changes: I attached a screen recording above.
- [x] I have added tests and listed them above.
