### PR TITLE
Fixes 6035: Add theme-aware canvas color resolution

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/scripts/design-tokens/check-drift.js
+++ b/openmetadata-ui/src/main/resources/ui/scripts/design-tokens/check-drift.js
@@ -27,6 +27,7 @@ const path = require('path');
 const STEPS = [
   ['gen-tokens.js', ['--check'], 'tokens.css generated block'],
   ['gen-token-reference.js', ['--check'], 'token-reference.md'],
+  ['gen-token-reference.test.js', [], 'token-reference completeness'],
   ['validate-tokens.js', [], 'token reference integrity'],
   ['check-coverage.js', [], 'spec links & coverage'],
 ];

--- a/openmetadata-ui/src/main/resources/ui/scripts/design-tokens/gen-token-reference.js
+++ b/openmetadata-ui/src/main/resources/ui/scripts/design-tokens/gen-token-reference.js
@@ -68,6 +68,7 @@ function resolve(name, defs, seen = new Set()) {
 
 const GROUPS = [
   { key: /^--om-space-/, title: 'Spacing', note: 'padding / margin / gap. See foundations/spacing.md.' },
+  { key: /^--om-page-/, title: 'Layout', note: 'Shared viewport and shell-derived dimensions.' },
   { key: /^--om-radius-/, title: 'Radius', note: 'border-radius. See foundations/radius.md.' },
   { key: /^--om-font-size-/, title: 'Font size', note: 'font-size. See foundations/typography.md.' },
   { key: /^--om-font-weight-/, title: 'Font weight', note: 'font-weight.' },

--- a/openmetadata-ui/src/main/resources/ui/scripts/design-tokens/gen-token-reference.test.js
+++ b/openmetadata-ui/src/main/resources/ui/scripts/design-tokens/gen-token-reference.test.js
@@ -1,0 +1,39 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { test } = require('node:test');
+
+const UI_ROOT = path.resolve(__dirname, '../..');
+const TOKENS_FILE = path.join(UI_ROOT, 'src/styles/tokens.css');
+const REFERENCE_FILE = path.join(UI_ROOT, 'specs/tokens/token-reference.md');
+
+test('documents every project token defined in tokens.css', () => {
+  const tokensCss = fs
+    .readFileSync(TOKENS_FILE, 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+  const reference = fs.readFileSync(REFERENCE_FILE, 'utf8');
+  const definedTokens = new Set(
+    [...tokensCss.matchAll(/(--om-[\w-]+)\s*:/g)].map((match) => match[1])
+  );
+  const documentedTokens = new Set(
+    [...reference.matchAll(/^\| `(--om-[\w-]+)` \|/gm)].map((match) => match[1])
+  );
+  const undocumentedTokens = [...definedTokens].filter(
+    (token) => !documentedTokens.has(token)
+  );
+
+  assert.deepEqual(undocumentedTokens, []);
+});

--- a/openmetadata-ui/src/main/resources/ui/scripts/design-tokens/legacy-colors.json
+++ b/openmetadata-ui/src/main/resources/ui/scripts/design-tokens/legacy-colors.json
@@ -89,6 +89,7 @@
   "--om-legacy-color-2f74eb": "#2f74eb",
   "--om-legacy-color-30-30-30-0-08": "rgb(30 30 30 / 8%)",
   "--om-legacy-color-3062d4": "#3062d4",
+  "--om-legacy-color-344054": "#344054",
   "--om-legacy-color-349dea": "#349dea",
   "--om-legacy-color-356fe7": "rgb(53, 111, 231)",
   "--om-legacy-color-37-99-235-0-12": "rgba(37, 99, 235, 0.12)",

--- a/openmetadata-ui/src/main/resources/ui/specs/tokens/token-reference.md
+++ b/openmetadata-ui/src/main/resources/ui/specs/tokens/token-reference.md
@@ -4,7 +4,7 @@
 
 Master map of every **project (`--om-*`) token** — the tokens components reference. Each references the matching upstream `globals.css` token (or holds a raw value) and resolves to the value shown. Full layering: [../README.md](../README.md).
 
-Total project tokens: **797**.
+Total project tokens: **799**.
 
 ## Spacing (61)
 
@@ -73,6 +73,14 @@ padding / margin / gap. See foundations/spacing.md.
 | `--om-space-208` | `208px` |
 | `--om-space-220` | `220px` |
 | `--om-space-290` | `290px` |
+
+## Layout (1)
+
+Shared viewport and shell-derived dimensions.
+
+| Token | Value |
+| --- | --- |
+| `--om-page-height` | `calc(100vh - var(--ant-navbar-height, 80px))` |
 
 ## Radius (24)
 
@@ -641,11 +649,11 @@ Fixed swatches; do NOT adapt to dark mode. Prefer semantic tokens.
 
 </details>
 
-## Legacy colors (239)
+## Legacy colors (240)
 
 Exact migrated one-offs (migration debt). Do not use in new code; re-express with a semantic token.
 
-<details><summary>Show all 239</summary>
+<details><summary>Show all 240</summary>
 
 | Token | Value |
 | --- | --- |
@@ -774,6 +782,7 @@ Exact migrated one-offs (migration debt). Do not use in new code; re-express wit
 | `--om-legacy-color-101828` | `#101828` |
 | `--om-legacy-color-111827` | `#111827` |
 | `--om-legacy-color-155724` | `#155724` |
+| `--om-legacy-color-344054` | `#344054` |
 | `--om-legacy-color-373737` | `#373737` |
 | `--om-legacy-color-444444` | `#444` |
 | `--om-legacy-color-515151` | `#515151` |

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/utils/graphStyles.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/utils/graphStyles.test.ts
@@ -50,6 +50,7 @@ const mockComputedStyle = (
   propertyValue = ''
 ): CSSStyleDeclaration =>
   ({
+    backgroundColor: color,
     color,
     getPropertyValue: () => propertyValue,
   } as unknown as CSSStyleDeclaration);

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/utils/graphStyles.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/utils/graphStyles.test.ts
@@ -177,7 +177,7 @@ describe('getCanvasColor', () => {
   it('returns the fallback hex when the token resolves to a transparent or non-color value', () => {
     jest
       .spyOn(window, 'getComputedStyle')
-      .mockReturnValue(mockComputedStyle('rgba(0, 0, 0, 0)', 'oklch(0 0 0)'));
+      .mockReturnValue(mockComputedStyle('rgba(0, 0, 0, 0)', '12px'));
 
     expect(getCanvasColor('var(--color-unresolvable)', '#fedcba')).toBe(
       '#fedcba'

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/utils/graphStyles.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/utils/graphStyles.ts
@@ -32,6 +32,7 @@ import {
   register,
 } from '@antv/g6';
 import { RelationshipType } from '../../../generated/entity/data/relationshipType';
+import { resolveCssColor } from '../../../utils/common/cssColor.utils';
 import {
   COLOR_META_BY_HEX,
   COMBO_FILL_DEFAULT,
@@ -185,92 +186,10 @@ register(
   CardinalityAwareQuadratic
 );
 
-const CSS_COLOR_CACHE_MAX = 200;
-const cssColorCache = new Map<string, string>();
 const COMBO_LABEL_CHAR_WIDTH = 7;
 const COMBO_LABEL_MEASURE_FONT = `${COMBO_LABEL_FONT_WEIGHT} ${COMBO_LABEL_FONT_SIZE}px sans-serif`;
 
-function parseVarName(cssVar: string): string {
-  const inner = cssVar.slice(4, -1).trim();
-  const firstComma = inner.indexOf(',');
-
-  return (firstComma > 0 ? inner.slice(0, firstComma) : inner).trim();
-}
-
-function cacheCssColor(cssVar: string, color: string): void {
-  if (cssColorCache.size >= CSS_COLOR_CACHE_MAX) {
-    const oldest = cssColorCache.keys().next().value;
-    if (oldest !== undefined) {
-      cssColorCache.delete(oldest);
-    }
-  }
-  cssColorCache.set(cssVar, color);
-}
-
-function isColorLike(val: string): boolean {
-  return (
-    val.length > 0 &&
-    (val.startsWith('rgb') || val.startsWith('#') || val.startsWith('hsl'))
-  );
-}
-
-/**
- * Resolves a color for Canvas/WebGL (G6): pass-through hex/rgb strings, or resolve `var(--token)`
- * to a concrete `rgb(...)` / `rgba(...)` value. G6 cannot paint raw `var()` in canvas backends.
- *
- * `:root` getPropertyValue often returns another `var()`, `oklch()`, etc., which fails `isColorLike`,
- * so we probe with a temporary element first (browser computes to rgb).
- */
-export function getCanvasColor(cssVar: string, fallbackHex: string): string {
-  if (typeof document === 'undefined') {
-    return fallbackHex;
-  }
-
-  if (!cssVar.startsWith('var(')) {
-    return cssVar;
-  }
-
-  const cached = cssColorCache.get(cssVar);
-  if (cached) {
-    cssColorCache.delete(cssVar);
-    cssColorCache.set(cssVar, cached);
-
-    return cached;
-  }
-
-  try {
-    const tempEl = document.createElement('div');
-    tempEl.style.color = cssVar;
-    tempEl.style.display = 'none';
-    document.body.appendChild(tempEl);
-    const fromCascade = getComputedStyle(tempEl).color;
-    document.body.removeChild(tempEl);
-
-    if (
-      fromCascade &&
-      fromCascade !== 'rgba(0, 0, 0, 0)' &&
-      isColorLike(fromCascade)
-    ) {
-      cacheCssColor(cssVar, fromCascade);
-
-      return fromCascade;
-    }
-
-    const varName = parseVarName(cssVar);
-    const rootVal = getComputedStyle(document.documentElement)
-      .getPropertyValue(varName)
-      .trim();
-    if (rootVal && isColorLike(rootVal)) {
-      cacheCssColor(cssVar, rootVal);
-
-      return rootVal;
-    }
-  } catch {
-    // Ignore
-  }
-
-  return fallbackHex;
-}
+export const getCanvasColor = resolveCssColor;
 
 export const STUDIO_EDIT_PORT_KEY = 'ontology-edit';
 export const STUDIO_EDIT_PORT_CLASS_NAME = `port-${STUDIO_EDIT_PORT_KEY}`;

--- a/openmetadata-ui/src/main/resources/ui/src/styles/temp.css
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/temp.css
@@ -731,16 +731,11 @@ body .list-option.rdw-option-active {
 
 :root {
   --ant-navbar-height: 80px;
-  /* Viewport height available to a page below the shell chrome. Pages use
-   * var(--om-page-height) instead of repeating calc(100vh - navbar).
-   * NOTE: a nested var() in a custom property is substituted at the scope
-   * where the custom property is declared, not where it is used — so this
-   * MUST be re-declared in every scope that overrides --ant-navbar-height
-   * (below, and each app shell), or those scopes keep the 80px value. */
-  --om-page-height: calc(100vh - var(--ant-navbar-height));
 }
 
 :root .extra-banner {
   --ant-navbar-height: 144px;
+  /* Custom properties inherit their computed value, so a scope that changes
+   * the shell height must also recompute the available page height. */
   --om-page-height: calc(100vh - var(--ant-navbar-height));
 }

--- a/openmetadata-ui/src/main/resources/ui/src/styles/tokens.css
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/tokens.css
@@ -101,6 +101,9 @@
   --om-line-height-normal: 1.5;
   --om-line-height-relaxed: 1.625;
 
+  /* -- Layout -- */
+  --om-page-height: calc(100vh - var(--ant-navbar-height, 80px));
+
   /* -- Elevation -- */
   --om-shadow-xs: var(--shadow-xs, 0px 1px 2px rgba(10, 13, 18, 0.05));
   --om-shadow-sm: var(--shadow-sm, 0px 1px 3px rgba(10, 13, 18, 0.1), 0px 1px 2px -1px rgba(10, 13, 18, 0.1));
@@ -613,6 +616,7 @@
   --om-legacy-color-2f74eb: #2f74eb;
   --om-legacy-color-30-30-30-0-08: rgb(30 30 30 / 8%);
   --om-legacy-color-3062d4: #3062d4;
+  --om-legacy-color-344054: #344054;
   --om-legacy-color-349dea: #349dea;
   --om-legacy-color-356fe7: rgb(53, 111, 231);
   --om-legacy-color-37-99-235-0-12: rgba(37, 99, 235, 0.12);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/common/cssColor.utils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/common/cssColor.utils.test.ts
@@ -129,6 +129,25 @@ describe('resolveCssColor', () => {
     );
   });
 
+  it.each([
+    ['rgba', 'rgba(20, 40, 60, 0.5)'],
+    ['hsla', 'hsla(240, 50%, 50%, 0.5)'],
+    ['oklch', 'oklch(0.7 0.15 240)'],
+    ['oklab', 'oklab(0.7 -0.05 -0.15)'],
+    ['lab', 'lab(70% -10 -20)'],
+    ['lch', 'lch(70% 30 240)'],
+    ['hwb', 'hwb(240 10% 20%)'],
+    ['display-p3', 'color(display-p3 0.2 0.4 0.8)'],
+  ])('returns the supported computed color %s', (tokenName, color) => {
+    jest
+      .spyOn(window, 'getComputedStyle')
+      .mockReturnValueOnce(mockComputedStyle(color));
+
+    expect(resolveCssColor(`var(--color-modern-${tokenName})`, '#fedcba')).toBe(
+      color
+    );
+  });
+
   it('does not treat an inherited text color as a resolved token', () => {
     jest
       .spyOn(window, 'getComputedStyle')

--- a/openmetadata-ui/src/main/resources/ui/src/utils/common/cssColor.utils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/common/cssColor.utils.test.ts
@@ -1,0 +1,142 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { resolveCssColor } from './cssColor.utils';
+
+const mockComputedStyle = (
+  color: string,
+  backgroundColor = color
+): CSSStyleDeclaration =>
+  ({
+    backgroundColor,
+    color,
+    getPropertyValue: () => '',
+  } as unknown as CSSStyleDeclaration);
+
+describe('resolveCssColor', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    document.documentElement.className = '';
+    document.documentElement.removeAttribute('style');
+  });
+
+  it('returns the fallback when the document is unavailable', () => {
+    jest
+      .spyOn(globalThis, 'document', 'get')
+      .mockReturnValue(undefined as unknown as Document);
+
+    expect(resolveCssColor('var(--color-missing)', '#abcdef')).toBe('#abcdef');
+  });
+
+  it('returns concrete colors without touching the DOM', () => {
+    const spy = jest.spyOn(window, 'getComputedStyle');
+
+    expect(resolveCssColor('#123456', '#000000')).toBe('#123456');
+    expect(resolveCssColor('rgb(1, 2, 3)', '#000000')).toBe('rgb(1, 2, 3)');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('caches a resolved token while the root visual state is unchanged', () => {
+    const spy = jest
+      .spyOn(window, 'getComputedStyle')
+      .mockReturnValueOnce(mockComputedStyle('rgb(1, 2, 3)'))
+      .mockReturnValue(mockComputedStyle('rgb(9, 9, 9)'));
+
+    expect(resolveCssColor('var(--color-cache-probe)', '#000000')).toBe(
+      'rgb(1, 2, 3)'
+    );
+    expect(resolveCssColor('var(--color-cache-probe)', '#000000')).toBe(
+      'rgb(1, 2, 3)'
+    );
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-resolves a token after the root theme class changes', () => {
+    const spy = jest
+      .spyOn(window, 'getComputedStyle')
+      .mockReturnValueOnce(mockComputedStyle('rgb(250, 250, 250)'))
+      .mockReturnValueOnce(mockComputedStyle('rgb(24, 24, 27)'));
+
+    expect(resolveCssColor('var(--color-theme-probe)', '#000000')).toBe(
+      'rgb(250, 250, 250)'
+    );
+
+    document.documentElement.classList.add('dark-mode');
+
+    expect(resolveCssColor('var(--color-theme-probe)', '#000000')).toBe(
+      'rgb(24, 24, 27)'
+    );
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-resolves a token after inline brand variables change', () => {
+    const spy = jest
+      .spyOn(window, 'getComputedStyle')
+      .mockReturnValueOnce(mockComputedStyle('rgb(21, 112, 239)'))
+      .mockReturnValueOnce(mockComputedStyle('rgb(127, 86, 217)'));
+
+    expect(resolveCssColor('var(--color-brand-probe)', '#000000')).toBe(
+      'rgb(21, 112, 239)'
+    );
+
+    document.documentElement.style.setProperty('--color-brand-500', '#7f56d9');
+
+    expect(resolveCssColor('var(--color-brand-probe)', '#000000')).toBe(
+      'rgb(127, 86, 217)'
+    );
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('evicts the least recently used color when the cache reaches its limit', () => {
+    let resolvedColor = 'rgb(1, 2, 3)';
+    const spy = jest
+      .spyOn(window, 'getComputedStyle')
+      .mockImplementation(() => mockComputedStyle(resolvedColor));
+
+    expect(resolveCssColor('var(--color-lru-0)', '#000000')).toBe(
+      'rgb(1, 2, 3)'
+    );
+
+    for (let index = 1; index <= 200; index++) {
+      resolveCssColor(`var(--color-lru-${index})`, '#000000');
+    }
+
+    resolvedColor = 'rgb(9, 9, 9)';
+
+    expect(resolveCssColor('var(--color-lru-0)', '#000000')).toBe(
+      'rgb(9, 9, 9)'
+    );
+    expect(spy).toHaveBeenCalledTimes(202);
+  });
+
+  it('returns the fallback for transparent or non-color values', () => {
+    jest
+      .spyOn(window, 'getComputedStyle')
+      .mockReturnValue(mockComputedStyle('rgba(0, 0, 0, 0)'));
+
+    expect(resolveCssColor('var(--color-unresolvable)', '#fedcba')).toBe(
+      '#fedcba'
+    );
+  });
+
+  it('does not treat an inherited text color as a resolved token', () => {
+    jest
+      .spyOn(window, 'getComputedStyle')
+      .mockReturnValueOnce(
+        mockComputedStyle('rgb(17, 24, 39)', 'rgba(0, 0, 0, 0)')
+      )
+      .mockReturnValueOnce(mockComputedStyle(''));
+
+    expect(resolveCssColor('var(--color-invalid)', '#fedcba')).toBe('#fedcba');
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/common/cssColor.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/common/cssColor.utils.ts
@@ -1,0 +1,105 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+const CSS_COLOR_CACHE_MAX = 200;
+const RESOLVED_COLOR_FORMAT = /^(?:rgb|#|hsl)/;
+const cssColorCache = new Map<string, string>();
+
+const getCssVariableName = (cssColor: string): string => {
+  const value = cssColor.slice(4, -1).trim();
+  const fallbackSeparator = value.indexOf(',');
+
+  return (
+    fallbackSeparator > 0 ? value.slice(0, fallbackSeparator) : value
+  ).trim();
+};
+
+const isResolvedColor = (value: string): boolean =>
+  value.length > 0 &&
+  value !== 'rgba(0, 0, 0, 0)' &&
+  RESOLVED_COLOR_FORMAT.test(value);
+
+const cacheColor = (key: string, color: string): void => {
+  if (cssColorCache.size >= CSS_COLOR_CACHE_MAX) {
+    const oldestKey = cssColorCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      cssColorCache.delete(oldestKey);
+    }
+  }
+  cssColorCache.set(key, color);
+};
+
+const getVisualStateKey = (root: HTMLElement): string =>
+  `${root.className}\u0000${root.getAttribute('style') ?? ''}`;
+
+/**
+ * Resolves a CSS custom property to a concrete color for Canvas/WebGL APIs.
+ * Root classes and inline variables are part of the cache key because both
+ * dark mode and custom branding can change the computed token at runtime.
+ */
+export const resolveCssColor = (
+  cssColor: string,
+  fallbackColor: string
+): string => {
+  if (typeof document === 'undefined') {
+    return fallbackColor;
+  }
+
+  if (!cssColor.startsWith('var(')) {
+    return cssColor;
+  }
+
+  const root = document.documentElement;
+  const cacheKey = `${cssColor}\u0000${getVisualStateKey(root)}`;
+  const cachedColor = cssColorCache.get(cacheKey);
+  if (cachedColor) {
+    cssColorCache.delete(cacheKey);
+    cssColorCache.set(cacheKey, cachedColor);
+
+    return cachedColor;
+  }
+
+  let probe: HTMLDivElement | undefined;
+
+  try {
+    probe = document.createElement('div');
+    // Unlike `color`, background color cannot inherit an unrelated valid value
+    // when a custom property is missing or invalid at computed-value time.
+    probe.style.backgroundColor = cssColor;
+    probe.style.display = 'none';
+    (document.body ?? root).appendChild(probe);
+
+    const cascadeColor = window.getComputedStyle(probe).backgroundColor;
+    if (isResolvedColor(cascadeColor)) {
+      cacheColor(cacheKey, cascadeColor);
+
+      return cascadeColor;
+    }
+
+    const variableColor = window
+      .getComputedStyle(root)
+      .getPropertyValue(getCssVariableName(cssColor))
+      .trim();
+    if (isResolvedColor(variableColor)) {
+      cacheColor(cacheKey, variableColor);
+
+      return variableColor;
+    }
+  } catch {
+    // Canvas styling is best-effort; callers provide a safe concrete fallback.
+  } finally {
+    probe?.remove();
+  }
+
+  return fallbackColor;
+};

--- a/openmetadata-ui/src/main/resources/ui/src/utils/common/cssColor.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/common/cssColor.utils.ts
@@ -12,7 +12,10 @@
  */
 
 const CSS_COLOR_CACHE_MAX = 200;
-const RESOLVED_COLOR_FORMAT = /^(?:rgb|#|hsl)/;
+// Browsers normalize computed colors to these notations; restricting the cache to them
+// prevents unresolved custom-property text from being mistaken for a valid color.
+const RESOLVED_COLOR_FORMAT =
+  /^(?:#|rgba?|hsla?|hwb|lab|lch|oklab|oklch|color)\b/;
 const cssColorCache = new Map<string, string>();
 
 const getCssVariableName = (cssColor: string): string => {


### PR DESCRIPTION
### Describe your changes:

Part of open-metadata/openmetadata-collate#6035

This adds the OSS foundation for theme-aware non-DOM rendering. Canvas and WebGL consumers can now resolve CSS color tokens through a shared bounded resolver without retaining stale light-theme or brand colors. Ontology Explorer now uses the shared resolver through its existing `getCanvasColor` API.

The change also centralizes `--om-page-height`, restores deterministic token drift, and ensures every project token appears in the generated token reference.

#
### Type of change:

- [x] Improvement

#
### High-level design:

- Resolve CSS custom properties through a temporary non-inherited `background-color` probe so invalid variables cannot fall back to unrelated inherited text colors.
- Cache successful resolutions in a 200-entry LRU keyed by the root class list and inline styles, which are the runtime inputs for dark mode and custom branding.
- Preserve the existing Ontology Explorer `getCanvasColor` API while moving its implementation into a shared utility.
- Define the shared page-height token in `tokens.css` and keep scoped recomputation where shell height changes.
- Extend the token drift gate so generated documentation must include every `--om-*` definition.

No migration or backward-compatibility concerns; existing concrete color inputs and fallback behavior are preserved.

#
### Tests:

#### Use cases covered

- Re-resolves canvas colors after light/dark root class changes.
- Re-resolves colors after inline brand variable changes.
- Returns caller fallbacks for missing, invalid, transparent, or non-color token values.
- Bounds the color cache and evicts least-recently-used entries.
- Ensures generated token documentation contains every project token.

#### Unit tests

- [x] Added unit tests for the new and changed logic.
- Files added/updated: `cssColor.utils.test.ts`, `graphStyles.test.ts`, `gen-token-reference.test.js`.
- Focused result: 22 tests passed.

#### Backend integration tests

- [x] Not applicable; no backend API changes.

#### Ingestion integration tests

- [x] Not applicable; no ingestion changes.

#### Playwright (UI) tests

- [x] Not applicable; this PR adds shared rendering infrastructure without a new user interaction.

#### Manual testing performed

No standalone visual flow is introduced in this foundation PR. Runtime theme, branding, fallback, and cache behavior are covered by focused unit tests.

#
### UI screen recording / screenshots:

Not applicable; component-level semantic token migrations will consume this foundation in follow-up PRs.

#
### Checklist:

- [x] I have read the CONTRIBUTING document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`.
- [x] My PR is linked to a GitHub issue above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] No JSON Schema changes are included.
- [x] UI recording is not applicable for this infrastructure-only slice.
- [x] I have added tests and listed them above.

#### Improvement

- [x] I have added tests around the new logic.