### PR TITLE
Backport to 2.0: Fixes #32256: Queries tab shows parent table's description provenance

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityDescription/Description.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityDescription/Description.test.tsx
@@ -335,6 +335,7 @@ describe('Description', () => {
   it('should render the authored-by footer when change metadata is present', () => {
     mockUseGenericContext.mockReturnValue({
       isVersionView: false,
+      type: EntityType.TABLE,
       changeSummary: {
         description: {
           changeSource: ChangeSource.Manual,
@@ -348,6 +349,27 @@ describe('Description', () => {
     render(<Description {...defaultProps} />);
 
     expect(screen.getByTestId('authored-by-footer')).toBeInTheDocument();
+  });
+
+  it('should not inherit the page-level change summary when entityType differs from the context entity', () => {
+    // Regression test for #32256: a Query rendered on a Table page must not pick up the
+    // table's description-provenance from the GenericProvider context.
+    mockUseGenericContext.mockReturnValue({
+      isVersionView: false,
+      type: EntityType.TABLE,
+      changeSummary: {
+        description: {
+          changeSource: ChangeSource.Suggested,
+          changedBy: 'admin',
+          changedAt: 1700000000000,
+        },
+      },
+      onThreadLinkSelect: mockOnThreadLinkSelect,
+    });
+
+    render(<Description {...defaultProps} entityType={EntityType.QUERY} />);
+
+    expect(screen.queryByTestId('authored-by-footer')).not.toBeInTheDocument();
   });
 
   it('should not render the authored-by footer when change metadata is absent', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityDescription/Description.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityDescription/Description.tsx
@@ -74,10 +74,20 @@ const Description = ({
   changeSummaryEntry,
 }: DescriptionProps) => {
   const navigate = useNavigate();
-  const { isVersionView, changeSummary, onThreadLinkSelect } =
-    useGenericContext<Domain>();
+  const {
+    isVersionView,
+    changeSummary,
+    onThreadLinkSelect,
+    type: contextEntityType,
+  } = useGenericContext<Domain>();
+  // The context's changeSummary belongs to the page-level entity. Only fall back to it
+  // when the entity being rendered is that same entity — otherwise a nested Description
+  // (e.g. a Query in TableQueryRightPanel) inherits the parent table's provenance.
   const descriptionChangeSummary =
-    changeSummaryEntry ?? changeSummary?.['description'];
+    changeSummaryEntry ??
+    (entityType === contextEntityType
+      ? changeSummary?.['description']
+      : undefined);
   const { suggestions, selectedUserSuggestions } = useSuggestionsContext();
   const [isEditDescription, setIsEditDescription] = useState(false);
   const { fqn } = useFqn();


### PR DESCRIPTION
### Describe your changes:

Backport of #32292 to the `2.0` release branch.

Fixes #32256

Cherry-picked from `main` commit [`02b1550f4f`](https://github.com/open-metadata/OpenMetadata/commit/02b1550f4f). Clean apply, no conflicts.

The `Description` component silently fell back to the page-level `GenericProvider` change summary whenever `changeSummaryEntry` was not passed. `TableQueryRightPanel` renders a `Query` description on a Table page without that prop, so any query showed the table's provenance ("Accepted by admin • 6 days ago"). This scopes the fallback to only apply when the rendered `entityType` matches the context entity's `type`.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change (5 lines in `Description.tsx` + a regression test), cherry-picked as-is.

#
### Tests:

#### Use cases covered
- On a table whose description came from an accepted AI suggestion, opening the **Queries** tab no longer shows the table's "Accepted by … 6 days ago" line under a freshly-created query's description.
- Rendering `<Description>` for an entity that matches the surrounding `GenericProvider` still shows the page-level change summary as before.

#### Unit tests
- `Description.test.tsx` — 26/26 pass on the 2.0 branch (includes the new regression test `should not inherit the page-level change summary when entityType differs from the context entity`).

#### Backend / Ingestion / Playwright
- [x] Not applicable (UI-only change).

#### Manual testing performed
- Verified on `main` prior to backport; cherry-pick is a clean apply.

#
### UI screen recording / screenshots:

Not applicable — the fix removes an incorrect metadata line under an existing panel.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My PR title includes `Fixes #32256`.
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have added a regression test covering the exact scenario we are fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)