### PR TITLE
Fixes #32425: Resolve backend CodeQL alerts

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/ConfigurationReader.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/ConfigurationReader.java
@@ -1,5 +1,7 @@
 package org.openmetadata.service.apps;
 
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.dropwizard.configuration.ConfigurationException;
@@ -7,8 +9,10 @@ import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.Map;
 import org.apache.commons.text.StringSubstitutor;
 import org.openmetadata.schema.api.configuration.apps.AppPrivateConfig;
@@ -17,6 +21,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ConfigurationReader {
+  private static final Path APPLICATIONS_DIRECTORY = Path.of("applications");
+  private static final String CONFIG_FILE_NAME = "config.yaml";
   private static final Logger log = LoggerFactory.getLogger(ConfigurationReader.class);
   private final StringSubstitutor substitutor;
   private final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
@@ -36,8 +42,8 @@ public class ConfigurationReader {
 
   public AppPrivateConfig readConfigFromResource(String appName)
       throws IOException, ConfigurationException {
-    String configFilePath = "applications/" + appName + "/config.yaml";
-    URL resource = ConfigurationReader.class.getClassLoader().getResource(configFilePath);
+    final String configFilePath = resolveConfigFilePath(appName);
+    final URL resource = ConfigurationReader.class.getClassLoader().getResource(configFilePath);
     if (resource == null) {
       throw new IOException("Configuration file not found: " + configFilePath);
     }
@@ -45,7 +51,7 @@ public class ConfigurationReader {
     return JsonUtils.convertValue(readConfigResource(configFilePath), AppPrivateConfig.class);
   }
 
-  public Map<String, Object> readConfigResource(String resourcePath)
+  private Map<String, Object> readConfigResource(String resourcePath)
       throws IOException, ConfigurationException {
     try {
       return (Map<String, Object>)
@@ -56,5 +62,19 @@ public class ConfigurationReader {
     } catch (ClassCastException e) {
       throw new RuntimeException("Configuration file is not a valid YAML file", e);
     }
+  }
+
+  private String resolveConfigFilePath(String appName) {
+    if (nullOrEmpty(appName)) {
+      throw new IllegalArgumentException("Application name is required");
+    }
+
+    final Path configFilePath =
+        APPLICATIONS_DIRECTORY.resolve(appName).resolve(CONFIG_FILE_NAME).normalize();
+    if (configFilePath.isAbsolute() || !configFilePath.startsWith(APPLICATIONS_DIRECTORY)) {
+      throw new IllegalArgumentException(
+          "Application name resolves outside the application configuration directory");
+    }
+    return configFilePath.toString().replace(File.separatorChar, '/');
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/webAnalytics/processors/WebAnalyticsUserActivityAggregator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/webAnalytics/processors/WebAnalyticsUserActivityAggregator.java
@@ -67,7 +67,7 @@ public class WebAnalyticsUserActivityAggregator
     Map<UUID, WebAnalyticUserActivityReportData> userActivityReportData =
         (HashMap<UUID, WebAnalyticUserActivityReportData>)
             contextData.get(USER_ACTIVITY_REPORT_DATA_KEY);
-    int totalSessionDurationSeconds = 0;
+    long totalSessionDurationSeconds = 0;
 
     for (List<Long> timestampList : userActivityData.sessions().values()) {
       totalSessionDurationSeconds +=
@@ -80,7 +80,7 @@ public class WebAnalyticsUserActivityAggregator
             .withUserName(userActivityData.userName())
             .withTeam(userActivityData.team())
             .withTotalSessions(userActivityData.totalSessions())
-            .withTotalSessionDuration(totalSessionDurationSeconds)
+            .withTotalSessionDuration(Math.toIntExact(totalSessionDurationSeconds))
             .withTotalPageView(userActivityData.totalPageView())
             .withLastSession(userActivityData.lastSession());
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/socket/FeedServlet.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/socket/FeedServlet.java
@@ -25,6 +25,8 @@ import org.apache.felix.http.javaxwrappers.HttpServletResponseWrapper;
 @Slf4j
 @WebServlet("/api/v1/push/feed/*")
 public class FeedServlet extends HttpServlet {
+  private static final String ERROR_RESPONSE_MESSAGE = "Failed to process feed request";
+
   @Override
   protected void service(HttpServletRequest request, HttpServletResponse response)
       throws IOException {
@@ -43,11 +45,9 @@ public class FeedServlet extends HttpServlet {
           .handleRequest(wrappedRequest, wrappedResponse);
       LOG.info(
           "[FeedServlet] Request handled successfully, response status: {}", response.getStatus());
-    } catch (Exception ex) {
-      LOG.error("[FeedServlet] Error Encountered : {}", ex.getMessage(), ex);
-      response
-          .getWriter()
-          .println(String.format("[FeedServlet] Error Encountered : %s", ex.getMessage()));
+    } catch (IOException | RuntimeException ex) {
+      LOG.error("[FeedServlet] Error encountered", ex);
+      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, ERROR_RESPONSE_MESSAGE);
     }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/incidentSeverityClassifier/LogisticRegressionIncidentSeverityClassifier.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/incidentSeverityClassifier/LogisticRegressionIncidentSeverityClassifier.java
@@ -57,7 +57,7 @@ public class LogisticRegressionIncidentSeverityClassifier
   private double[] dotProduct(double[] vectorX) {
     // compute the dot product of the input vector and the coef. matrix
     double[] result = new double[coefMatrix[0].length];
-    for (int i = 0; i < coefMatrix.length; i++) {
+    for (int i = 0; i < coefMatrix[0].length; i++) {
       double sum = 0;
       for (int j = 0; j < vectorX.length; j++) {
         sum += vectorX[j] * coefMatrix[j][i];

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/incidentSeverityClassifier/LogisticRegressionIncidentSeverityClassifier.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/incidentSeverityClassifier/LogisticRegressionIncidentSeverityClassifier.java
@@ -58,7 +58,7 @@ public class LogisticRegressionIncidentSeverityClassifier
     // compute the dot product of the input vector and the coef. matrix
     double[] result = new double[coefMatrix[0].length];
     for (int i = 0; i < coefMatrix.length; i++) {
-      int sum = 0;
+      double sum = 0;
       for (int j = 0; j < vectorX.length; j++) {
         sum += vectorX[j] * coefMatrix[j][i];
       }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/workflows/webAnalytics/processors/WebAnalyticsUserActivityAggregatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/workflows/webAnalytics/processors/WebAnalyticsUserActivityAggregatorTest.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.apps.bundles.insights.workflows.webAnalytics.processors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.openmetadata.service.apps.bundles.insights.workflows.webAnalytics.WebAnalyticsWorkflow.USER_ACTIVITY_REPORT_DATA_KEY;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.analytics.WebAnalyticUserActivityReportData;
+import org.openmetadata.service.apps.bundles.insights.workflows.webAnalytics.WebAnalyticsWorkflow;
+import org.openmetadata.service.exception.SearchIndexException;
+
+class WebAnalyticsUserActivityAggregatorTest {
+
+  @Test
+  void aggregatesSessionDurationsAndUpdatesStats() throws SearchIndexException {
+    final UUID userId = UUID.randomUUID();
+    final WebAnalyticsWorkflow.UserActivityData userActivityData =
+        new WebAnalyticsWorkflow.UserActivityData(
+            "test-user",
+            userId,
+            "test-team",
+            Map.of(
+                UUID.randomUUID(), List.of(1_000L, 3_500L),
+                UUID.randomUUID(), List.of(10_000L, 15_900L)),
+            4,
+            2,
+            15_900L);
+    final Map<UUID, WebAnalyticUserActivityReportData> reportData = new HashMap<>();
+    final Map<String, Object> contextData = new HashMap<>();
+    contextData.put(USER_ACTIVITY_REPORT_DATA_KEY, reportData);
+    final WebAnalyticsUserActivityAggregator aggregator = new WebAnalyticsUserActivityAggregator(1);
+
+    final Map<UUID, WebAnalyticUserActivityReportData> result =
+        aggregator.process(Map.of(userId, userActivityData), contextData);
+
+    assertSame(reportData, result);
+    assertEquals(7, result.get(userId).getTotalSessionDuration());
+    assertEquals(4, result.get(userId).getTotalPageView());
+    assertEquals(2, result.get(userId).getTotalSessions());
+    assertEquals(15_900L, result.get(userId).getLastSession());
+    assertEquals(1, aggregator.getStats().getSuccessRecords());
+    assertEquals(0, aggregator.getStats().getFailedRecords());
+  }
+
+  @Test
+  void rejectsTotalSessionDurationOutsideIntegerRange() {
+    final UUID userId = UUID.randomUUID();
+    final long overflowingDurationMillis = (Integer.MAX_VALUE + 1L) * 1000;
+    final WebAnalyticsWorkflow.UserActivityData userActivityData =
+        new WebAnalyticsWorkflow.UserActivityData(
+            "test-user",
+            userId,
+            "test-team",
+            Map.of(UUID.randomUUID(), List.of(0L, overflowingDurationMillis)),
+            2,
+            1,
+            overflowingDurationMillis);
+    final Map<String, Object> contextData = new HashMap<>();
+    contextData.put(
+        USER_ACTIVITY_REPORT_DATA_KEY, new HashMap<UUID, WebAnalyticUserActivityReportData>());
+
+    final WebAnalyticsUserActivityAggregator aggregator = new WebAnalyticsUserActivityAggregator(1);
+
+    assertThrows(
+        SearchIndexException.class,
+        () -> aggregator.process(Map.of(userId, userActivityData), contextData));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/apps/ConfigurationReaderTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/apps/ConfigurationReaderTest.java
@@ -9,6 +9,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openmetadata.schema.api.configuration.apps.AppPrivateConfig;
 import org.openmetadata.service.apps.ConfigurationReader;
 
@@ -49,5 +52,21 @@ public class ConfigurationReaderTest {
   public void missingConfig() {
     ConfigurationReader reader = new ConfigurationReader();
     assertThrows(IOException.class, () -> reader.readConfigFromResource("missing"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"../TestApplication", "nested/../../TestApplication", "/TestApplication"})
+  void rejectsConfigPathsOutsideApplicationsDirectory(String appName) {
+    final ConfigurationReader reader = new ConfigurationReader();
+
+    assertThrows(IllegalArgumentException.class, () -> reader.readConfigFromResource(appName));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void rejectsMissingApplicationName(String appName) {
+    final ConfigurationReader reader = new ConfigurationReader();
+
+    assertThrows(IllegalArgumentException.class, () -> reader.readConfigFromResource(appName));
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/socket/FeedServletTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/socket/FeedServletTest.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.socket;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.socket.engineio.server.EngineIoServer;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+class FeedServletTest {
+
+  @Test
+  void serviceDelegatesValidRequestsToEngineIoServer() throws IOException {
+    final HttpServletRequest request = mock(HttpServletRequest.class);
+    final HttpServletResponse response = mock(HttpServletResponse.class);
+    final WebSocketManager webSocketManager = mock(WebSocketManager.class);
+    final EngineIoServer engineIoServer = mock(EngineIoServer.class);
+    when(webSocketManager.getEngineIoServer()).thenReturn(engineIoServer);
+
+    try (MockedStatic<WebSocketManager> manager = mockStatic(WebSocketManager.class)) {
+      manager.when(WebSocketManager::getInstance).thenReturn(webSocketManager);
+
+      new FeedServlet().service(request, response);
+    }
+
+    verify(engineIoServer).handleRequest(any(), any());
+    verify(response, never()).sendError(anyInt(), any());
+  }
+
+  @Test
+  void serviceDoesNotExposeInternalExceptionMessage() throws IOException {
+    final String sensitiveMessage = "/srv/openmetadata/private/config.yaml";
+    final HttpServletRequest request = mock(HttpServletRequest.class);
+    final HttpServletResponse response = mock(HttpServletResponse.class);
+    final WebSocketManager webSocketManager = mock(WebSocketManager.class);
+    final EngineIoServer engineIoServer = mock(EngineIoServer.class);
+    final StringWriter responseBody = new StringWriter();
+    when(response.getWriter()).thenReturn(new PrintWriter(responseBody));
+    when(webSocketManager.getEngineIoServer()).thenReturn(engineIoServer);
+    doThrow(new IOException(sensitiveMessage)).when(engineIoServer).handleRequest(any(), any());
+
+    try (MockedStatic<WebSocketManager> manager = mockStatic(WebSocketManager.class)) {
+      manager.when(WebSocketManager::getInstance).thenReturn(webSocketManager);
+
+      new FeedServlet().service(request, response);
+    }
+
+    final ArgumentCaptor<String> errorMessage = ArgumentCaptor.forClass(String.class);
+    verify(response)
+        .sendError(eq(HttpServletResponse.SC_INTERNAL_SERVER_ERROR), errorMessage.capture());
+    assertFalse(errorMessage.getValue().contains(sensitiveMessage));
+    assertFalse(responseBody.toString().contains(sensitiveMessage));
+    verify(response, never()).getWriter();
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/incidentSeverityClassifier/LogisticRegressionIncidentSeverityClassifierTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/incidentSeverityClassifier/LogisticRegressionIncidentSeverityClassifierTest.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.util.incidentSeverityClassifier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.tests.type.Severity;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.TagLabel;
+import org.openmetadata.schema.type.Votes;
+
+class LogisticRegressionIncidentSeverityClassifierTest {
+
+  @Test
+  void classifyIncidentSeverityPreservesFractionalWeightedScores() {
+    final Table entity =
+        new Table()
+            .withTags(List.of(new TagLabel().withName("Tier1")))
+            .withVotes(new Votes().withUpVotes(536));
+
+    final Severity severity =
+        new LogisticRegressionIncidentSeverityClassifier().classifyIncidentSeverity(entity);
+
+    assertEquals(Severity.Severity4, severity);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "Tier1,true,0,0,Severity1",
+    "Tier2,true,2170,0,Severity2",
+    "Tier3,true,2790,430,Severity3",
+    "Tier4,true,0,0,Severity4"
+  })
+  void classifyIncidentSeveritySupportsTierSpecificPredictions(
+      String tier, boolean hasOwner, int followerCount, int upVotes, Severity expectedSeverity) {
+    final Table entity =
+        new Table()
+            .withTags(List.of(new TagLabel().withName(tier)))
+            .withFollowers(Collections.nCopies(followerCount, new EntityReference()))
+            .withVotes(new Votes().withUpVotes(upVotes));
+    if (hasOwner) {
+      entity.withOwners(List.of(new EntityReference()));
+    }
+
+    assertEquals(
+        expectedSeverity,
+        new LogisticRegressionIncidentSeverityClassifier().classifyIncidentSeverity(entity));
+  }
+
+  @Test
+  void classifyIncidentSeverityRecognizesTier5() {
+    final Table entity = new Table().withTags(List.of(new TagLabel().withName("Tier5")));
+
+    assertNotNull(
+        new LogisticRegressionIncidentSeverityClassifier().classifyIncidentSeverity(entity));
+  }
+
+  @Test
+  void classifyIncidentSeverityReturnsNullWithoutRecognizedTier() {
+    final Table entity = new Table().withTags(List.of(new TagLabel().withName("TierUnknown")));
+
+    assertNull(new LogisticRegressionIncidentSeverityClassifier().classifyIncidentSeverity(entity));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/incidentSeverityClassifier/LogisticRegressionIncidentSeverityClassifierTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/incidentSeverityClassifier/LogisticRegressionIncidentSeverityClassifierTest.java
@@ -14,7 +14,6 @@
 package org.openmetadata.service.util.incidentSeverityClassifier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Collections;
@@ -70,7 +69,8 @@ class LogisticRegressionIncidentSeverityClassifierTest {
   void classifyIncidentSeverityRecognizesTier5() {
     final Table entity = new Table().withTags(List.of(new TagLabel().withName("Tier5")));
 
-    assertNotNull(
+    assertEquals(
+        Severity.Severity5,
         new LogisticRegressionIncidentSeverityClassifier().classifyIncidentSeverity(entity));
   }
 


### PR DESCRIPTION
### Describe your changes:

Fixes #32425

This PR resolves backend CodeQL alerts [1699](https://github.com/open-metadata/OpenMetadata/security/code-scanning/1699), [1700](https://github.com/open-metadata/OpenMetadata/security/code-scanning/1700), [1721](https://github.com/open-metadata/OpenMetadata/security/code-scanning/1721), and [1905](https://github.com/open-metadata/OpenMetadata/security/code-scanning/1905). It preserves numeric precision, rejects totals outside the existing Integer model boundary, contains application configuration resources beneath `applications/`, and prevents feed responses from exposing internal exception details.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

Numeric accumulators now use the source calculation's required precision, with `Math.toIntExact` applied only at the existing Integer schema boundary so overflow fails instead of silently wrapping.

Application configuration paths are resolved and normalized beneath the `applications/` classpath root, rejected when absolute or outside that root, and passed to a private raw resource reader. A stricter application-name allowlist was avoided to preserve valid existing names and nested resource layouts.

Feed processing keeps full exception details in server logs while returning a fixed HTTP 500 message to clients. No schema, data migration, UI, or rollout changes are required.

#
### Tests:

#### Use cases covered

- Fractional classifier weights affect the predicted severity correctly.
- Valid web-analytics sessions aggregate durations and update workflow statistics.
- Session totals outside the Integer model range fail instead of wrapping.
- Valid application configurations continue loading with environment substitution.
- Parent traversal, nested traversal, absolute paths, and missing application names are rejected.
- Valid feed requests delegate to Engine.IO.
- Feed failures return a generic HTTP 500 without exposing internal details.

#### Unit tests

- [x] I added unit tests for the new and changed logic.
- Files added or updated:
  - `LogisticRegressionIncidentSeverityClassifierTest.java`
  - `WebAnalyticsUserActivityAggregatorTest.java`
  - `ConfigurationReaderTest.java`
  - `FeedServletTest.java`
- Changed-class line coverage:
  - `ConfigurationReader`: 100.0%
  - `WebAnalyticsUserActivityAggregator`: 100.0%
  - `FeedServlet`: 100.0%
  - `LogisticRegressionIncidentSeverityClassifier`: 90.9%

#### Backend integration tests

- [x] Not applicable — no REST resource contract or entity behavior changed.

#### Ingestion integration tests

- [x] Not applicable — no ingestion changes.

#### Playwright (UI) tests

- [x] Not applicable — no UI changes.

#### Manual testing performed

1. Ran `mvn test -pl openmetadata-service -Pstatic-code-analysis -Dtest=LogisticRegressionIncidentSeverityClassifierTest,WebAnalyticsUserActivityAggregatorTest,ConfigurationReaderTest,FeedServletTest` and verified 19 tests passed.
2. Ran `mvn test-compile -pl openmetadata-service` and verified the module compiled successfully.
3. Ran `mvn -pl openmetadata-service spotless:check` and verified all Java files were clean.
4. Generated the JaCoCo report and verified every changed service class met the 90% line-coverage target.

#
### UI screen recording / screenshots:

Not applicable — no UI changes.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`.
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] Hard-to-understand behavior is documented where applicable.
- [x] JSON Schema changes are not applicable.
- [x] UI recordings are not applicable.
- [x] I have added tests and listed them above.
- [x] I have added tests that cover the exact scenarios being fixed.
