### PR TITLE
Fixes #32428: unblock UI Checkstyle and make Playwright lint failures readable

### DIFF
--- a/.github/workflows/ui-checkstyle.yml
+++ b/.github/workflows/ui-checkstyle.yml
@@ -317,7 +317,7 @@ jobs:
           # A path filter, not --exclude-dir: that matches a basename at any depth.
           MATCHES=$(grep -rnE 'eslint-disable(-next-line|-line)?[[:space:]]*(\*/|--|$)|eslint-disable.*om-playwright/justified-rule-disable|/\*[[:space:]]*eslint[[:space:]][^*]*(om-)?playwright/[a-z-]+[[:space:]]*:' \
                playwright/ --include='*.ts' --include='*.tsx' --include='*.js' --include='*.jsx' \
-               | grep -v '^playwright/eslint-rules/' || true)
+               | grep -v '^playwright/eslint-rules/' | head -30 | cut -c1-300 || true)
           if [ -n "$MATCHES" ]; then
             echo "$MATCHES"
             echo "::error::Found a blanket 'eslint-disable' (no rule list) or a disable of om-playwright/justified-rule-disable itself. Both bypass the Playwright lint guardrails entirely and are never allowed, justified or not. Disable individual rules instead, each with a justification, e.g. // eslint-disable-next-line om-playwright/no-positional-locator -- <why>."
@@ -336,10 +336,28 @@ jobs:
           # warns; errorCount is what fails. Never key off the exit code alone -- it
           # is 2 even when a real violation is also present, which would swallow it.
           yarn lint:playwright -f json > /tmp/pw-lint.json 2> /tmp/pw-lint.err || true
+
+          # ESLint's json formatter emits the whole report as a SINGLE line, so grep/head over it
+          # returns one multi-megabyte "line". Written to $GITHUB_OUTPUT that overflows the job
+          # output expression limit, and the job dies at "Evaluate and set job outputs" -- which
+          # blanks every needs.checkstyle.output and leaves the PR with a red check and no comment.
+          # Render one bounded line per error here; never grep the raw JSON.
           ERRORS=$(node -e "
             const fs=require('fs');
             const m=/(\[[\s\S]*\])/.exec(fs.readFileSync('/tmp/pw-lint.json','utf8'));
             const d=m?JSON.parse(m[1]):[];
+            const cwd=process.cwd()+'/';
+            const lines=[];
+            for (const f of d) {
+              for (const x of f.messages) {
+                if (x.severity !== 2) continue;
+                lines.push(f.filePath.replace(cwd,'')+':'+x.line+':'+x.column+'  '+x.ruleId+'  '+x.message);
+              }
+            }
+            const out=lines.slice(0,30).map(function(l){return l.slice(0,300);});
+            // Trailing newline matters: this file is appended to /tmp/pw-guardrails.out, and
+            // without it the last error would be glued onto whatever line is appended next.
+            fs.writeFileSync('/tmp/pw-lint-errors.txt', out.length?out.join('\n')+'\n':'');
             console.log(d.reduce((n,f)=>n+f.errorCount,0));
           ")
           if grep -q 'suppressions left that do not occur anymore' /tmp/pw-lint.err; then
@@ -351,12 +369,20 @@ jobs:
             RESULT=0
           else
             RESULT=$?
-            [ "$ERRORS" -eq 0 ] || sed 's/\x1b\[[0-9;]*m//g' /tmp/pw-lint.json | grep -E '"ruleId"' | head -20 >> /tmp/pw-guardrails.out
+            [ "$ERRORS" -eq 0 ] || cat /tmp/pw-lint-errors.txt >> /tmp/pw-guardrails.out
           fi
           if [ "$RESULT" -ne 0 ]; then
             cat /tmp/pw-guardrails.out
             # `|| true`: a grep matching nothing exits 1 under `bash -eo pipefail`.
-            OUT=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/pw-guardrails.out | grep -E 'error|Error|not ok|fail|stale' | head -30) || true
+            # `cut`: this value becomes a job output, where one over-long line is enough to break
+            # job-output evaluation for the entire job.
+            # The last alternative is the rendered lint line shape (`path:line:col  rule  msg`).
+            # Without it a lint failure is filtered out entirely -- no rule message carries the
+            # word "error", so the comment would name the check and then list nothing.
+            OUT=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/pw-guardrails.out | grep -E 'error|Error|not ok|fail|stale|^[^ ]+:[0-9]+:[0-9]+ ' | head -30 | cut -c1-300) || true
+            # continue-on-error renders this step with a green check, so without an annotation the
+            # run page gives no hint which step actually failed.
+            echo "::error title=Playwright guardrails + ESLint::${ERRORS} ESLint error(s) under playwright/, or a failing guardrail check. See the UI Checkstyle comment on this PR."
             echo "changed_files<<EOF" >> "$GITHUB_OUTPUT"
             echo "$OUT" >> "$GITHUB_OUTPUT"
             echo "EOF" >> "$GITHUB_OUTPUT"
@@ -575,9 +601,18 @@ jobs:
             const eslintSummary  = ${{ toJSON(needs.checkstyle.outputs.eslint_summary) }} || '';
             const eslintDetails  = ${{ toJSON(needs.checkstyle.outputs.eslint_details) }} || '';
 
+            // The checkstyle job can die before its outputs are evaluated — a step output too
+            // large for the job-output expression limit does exactly that. Every entry above is
+            // then blank, so without this branch the PR gets a red required check and no comment.
+            const jobResult = '${{ needs.checkstyle.result }}';
+            // Only a genuine failure. `cancelled` is the concurrency group superseding this run,
+            // and `skipped` is a PR with no UI changes — neither is worth a red comment.
+            const jobFailed = jobResult === 'failure';
+            const unexplained = jobFailed && failures.length === 0;
+
             // Warnings do not fail the build, so a comment posted only on
             // failure would hide them entirely — which defeats the warn tier.
-            if (failures.length === 0 && !eslintFindings) {
+            if (failures.length === 0 && !eslintFindings && !jobFailed) {
               if (commentId) {
                 await github.rest.issues.deleteComment({
                   owner: context.repo.owner,
@@ -596,9 +631,23 @@ jobs:
               return lines.join('\n');
             });
 
-            const title = failures.length
+            const title = failures.length || unexplained
               ? '### ❌ UI Checkstyle Failed'
               : '### ⚠️ UI Checkstyle passed — lint findings in changed files';
+
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const unexplainedSection = unexplained
+              ? [
+                  `#### ❌ The checkstyle job ended as \`${jobResult}\` before it could report`,
+                  '',
+                  'No individual check reported a result, so the job itself failed rather than a',
+                  'specific check — most often a step whose output was too large to evaluate as a',
+                  'job output. The step annotations on the run say which step it was.',
+                  '',
+                  `[View run](${runUrl})`,
+                  '',
+                ]
+              : [];
 
             const eslintSection = eslintFindings
               ? [
@@ -616,6 +665,7 @@ jobs:
               '<!-- check:ui-checkstyle-summary -->',
               title,
               '',
+              ...unexplainedSection,
               ...sections.flatMap(s => [s, '']),
               ...eslintSection,
               '---',

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts
@@ -281,7 +281,10 @@ test.describe('Search Settings', () => {
       ).toBeVisible();
 
       await openMatchingFieldsPanel(page);
-      await page.getByTestId('field-container-header').first().click();
+      // Named field rather than whichever row happens to render first: the assertion below is
+      // that the server annotates `highlight`, which only means something on a field the index
+      // mapping can actually highlight -- an analyzed text field such as `description`.
+      await page.getByTestId('field-configuration-panel-description').click();
 
       const highlightFieldToggle = page.getByTestId('highlight-field-switch');
 


### PR DESCRIPTION
### Describe your changes:

Fixes #32428

Two fixes to one failure. `UI Checkstyle` is red on `main` for any PR whose diff touches `playwright/**`, `package.json`, or `eslint*` — and when it fails, it says nothing.

**1. `SearchSettings.spec.ts` — the violation itself**

The spec had 3 `om-playwright/no-positional-locator` errors against an `eslint-suppressions.json` baseline of 2. The third was added at line 284 by #31839 without bumping the baseline (`ui-checkstyle` was already red on that PR; it was merged directly rather than through the merge queue).

Replaced `getByTestId('field-container-header').first()` with `getByTestId('field-configuration-panel-description')` — the naming convention this same spec already uses at lines 419 and 655. `description` is deliberate rather than incidental: the assertion below it is that the server annotates `highlight`, which only means something on a field the index mapping can actually highlight.

**2. `ui-checkstyle.yml` — why nobody saw it**

ESLint's `-f json` formatter emits the entire report as a **single line**, so `grep '"ruleId"' | head -20` returned one ~7 MB "line". That reached `$GITHUB_OUTPUT` as `changed_files`, and job-output evaluation then blew GitHub's expression memory limit:

```
##[error]Fail to evaluate job outputs
##[error]The template is not valid. .github/workflows/ui-checkstyle.yml (Line: 111, Col: 38):
The maximum allowed memory size was exceeded ... steps.lint_playwright.outputs.changed_files
```

The `checkstyle` job died at `Complete job`, which defeated the step's `continue-on-error` and blanked every `needs.checkstyle.outputs.*` — so the report job's script hit `failures.length === 0` and posted **no comment at all**. Self-concealing: the more lint errors, the bigger the JSON, the more certain the job dies before naming them.

Changes:
- Render one bounded line per error (`file:line:col  rule  message`) instead of grepping single-line JSON.
- Cap every value that becomes a job output (`head -30 | cut -c1-300`), including the previously uncapped blanket-`eslint-disable` grep.
- Keep rendered lint lines through the `OUT` filter — no rule message contains the word "error", so the old filter would have named the check and then listed nothing.
- Emit a `::error::` annotation, since `continue-on-error` renders the failing step with a green check.
- Report job: when `checkstyle` ends as `failure` with no per-check results, say so with a link to the run instead of silently posting nothing.

#
### Type of change:
- [x] Bug fix

#
### Tests:

Verified locally against the real inputs rather than by inspection.

**Spec fix** — the exact three commands the CI step runs:
```
lint errors: 0
stale suppressions: none
yarn test:eslint-rules  # fail 0
node scripts/generate-playwright-rule-table.mjs --check  # OK
```
Plus the CI lint sequence (organize-imports → eslint --fix → prettier) on the changed file: 0 errors, no diff beyond the intended change.

**Workflow fix** — extracted the patched block straight out of the YAML and ran it under `bash -e` against the **actual 7,127,840-byte report** from the failing run ([33593475877](https://github.com/open-metadata/OpenMetadata/actions/runs/33593475877)):

| | before | after |
|---|---|---|
| `$GITHUB_OUTPUT` value | 7,127,868 chars on 1 line | 952 bytes, 4 lines, longest 300 |
| `ERRORS` count | 3 | 3 |
| errors named in output | none (job died first) | all 3, with `file:line:col  rule` |

Also confirmed the guardrail TAP line (`not ok 3 - …`) and the lint lines both survive the `OUT` filter together, and that the `github-script` block still parses.

**Note:** `pull_request_target` runs the workflow from the *base* branch, so this PR's own run exercises the **old** `ui-checkstyle.yml`. It should still go green — with 0 lint errors the failure path is never entered. The workflow fix takes effect for PRs opened after merge.

#
### Manual test steps:

Not applicable — CI-only change. The spec fix is covered by the existing `SearchSettings.spec.ts` Playwright run.
