### PR TITLE
Backport #32378 to 1.13: cap pygtrie below 2.6 so `import airflow` works on Python 3.10

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -45,6 +45,12 @@ VERSIONS = {
     "pydantic": "pydantic>=2.12.5,<3",
     "pydantic-settings": "pydantic-settings~=2.0,>=2.14.2",  # GHSA-4xgf-cpjx-pc3j secrets_dir symlink escape
     "pydomo": "pydomo~=0.3",
+    # 2.6.0 annotates with typing.Self (3.11+) but declares no requires-python floor, so
+    # pip/uv installs it on 3.10 and `import pygtrie` raises AttributeError. Airflow pulls
+    # it in unpinned (apache-airflow-core/task-sdk require pygtrie>=2.5.0) and imports it
+    # from airflow._shared.logging.structlog, which breaks `import airflow` on our main CI
+    # interpreter. Drop the cap once pygtrie declares its floor or 3.10 support is dropped.
+    "pygtrie": "pygtrie<2.6",
     "pymysql": "pymysql~=1.0",
     "pyodbc": "pyodbc~=5.3.0",
     "numpy": "numpy>=2,<3",
@@ -206,6 +212,7 @@ plugins: Dict[str, Set[str]] = {
         "opentelemetry-exporter-otlp==1.37.0",
         "attrs",
         VERSIONS["airflow"],
+        VERSIONS["pygtrie"],
         # Transitive floor pins for Airflow 3.x stack — Dependabot CVEs.
         "apache-airflow-providers-http>=6.0.0",  # CVE-2025-69219 unsafe pickle RCE
         "apache-airflow-providers-opensearch>=1.9.1",  # CVE-2026-43826 credential leak
@@ -482,6 +489,7 @@ test = {
     # Install Airflow as it's not part of `all` plugin
     "opentelemetry-exporter-otlp==1.37.0",
     VERSIONS["airflow"],
+    VERSIONS["pygtrie"],
     "boto3-stubs",
     "mypy-boto3-glue",
     "coverage",


### PR DESCRIPTION
### Describe your changes:

Backport of #32378 to `1.13`. Original issue: #32377.

`pygtrie 2.6.0` (published 2026-09-01T11:06Z) annotates with `typing.Self` (PEP 673, Python 3.11+) but declares **no `requires-python` floor**, so pip and uv install it on 3.10, where it is unimportable:

```
$ python3.10 -c "import pygtrie"
AttributeError: module 'typing' has no attribute 'Self'   # pygtrie.py:83, `def __copy__(self) -> _t.Self`
```

`apache-airflow-core` and `apache-airflow-task-sdk` both require `pygtrie>=2.5.0` with no ceiling, and `airflow._shared.logging.structlog` imports it at module level — reached from `airflow/__init__.py` via `configuration.initialize_secrets_backends()`. The `AttributeError` therefore surfaces as:

```
ImportError: cannot import name 'Connection' from 'airflow.models'
```

which on `main` took out `python / Unit Tests & Static Checks (3.10)` and `python / Integration Tests (shard-3, 3.10)`, turning `py-tests-status` red and evicting every PR touching `ingestion/` from the merge queue.

**Why `1.13` needs it.** This branch pins `apache-airflow==3.3.1` (so it pulls `apache-airflow-core`/`task-sdk` and their uncapped `pygtrie>=2.5.0`), runs `MAIN_PYTHON_VERSION: "3.10"` with a `["3.10","3.11","3.12"]` matrix, and does not carry the cap. `pygtrie 2.6.0` is now PyPI's latest, so any fresh resolution here selects it. The breakage is currently latent only because recent runs on this base have had their Python jobs path-filtered to `skipped`; the first PR that touches `ingestion/` and actually runs the suite will be blocked.

Cherry-picked clean, no conflicts — identical three-line change (cap in `VERSIONS`, applied to the `airflow` plugin extra and to the `test` extra, which is where CI actually pulls Airflow in).

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — dependency cap backport.

#
### Tests:

#### Use cases covered
- `ingestion[test]` resolves on Python 3.10 with an importable `pygtrie`
- `import airflow` works, so the Airflow connector unit tests and integration shard-3 collect

#### Unit tests
- [x] Not applicable — dependency constraint; verification is the resolver and CI itself.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion code changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed

Full resolver dry-run of the affected extra against **this branch** on Python 3.10 — no conflict:

```
$ python3.10 -m pip install --dry-run --ignore-installed "./ingestion[test]"
  pygtrie: 2.5.0
  apache-airflow: 3.3.1
  apache-airflow-core: 3.3.1
```

`ruff check` and `ruff format --check` clean. This PR's own `py-tests` run on 3.10 is the real regression test.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR is linked to the original issue (#32377) and forward-fix (#32378) above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
