### PR TITLE
ci(ui-checkstyle): cap changed_files output at 16 KiB (unblock #32384)

### DIFF
--- a/.github/workflows/ui-checkstyle.yml
+++ b/.github/workflows/ui-checkstyle.yml
@@ -321,8 +321,14 @@ jobs:
           if [ -n "$MATCHES" ]; then
             echo "$MATCHES"
             echo "::error::Found a blanket 'eslint-disable' (no rule list) or a disable of om-playwright/justified-rule-disable itself. Both bypass the Playwright lint guardrails entirely and are never allowed, justified or not. Disable individual rules instead, each with a justification, e.g. // eslint-disable-next-line om-playwright/no-positional-locator -- <why>."
+            # Cap the value written to $GITHUB_OUTPUT: GitHub Actions' template
+            # evaluator OOMs when reading a step-output larger than ~32 KiB, so
+            # a runaway `MATCHES` (unbounded grep across all Playwright files)
+            # would take down the job's outputs block. head -c 16000 keeps
+            # every path here under the limit.
             echo "changed_files<<EOF" >> "$GITHUB_OUTPUT"
-            echo "$MATCHES" >> "$GITHUB_OUTPUT"
+            printf '%s' "$MATCHES" | head -c 16000 >> "$GITHUB_OUTPUT"
+            echo "" >> "$GITHUB_OUTPUT"
             echo "EOF" >> "$GITHUB_OUTPUT"
             exit 1
           fi
@@ -357,8 +363,10 @@ jobs:
             cat /tmp/pw-guardrails.out
             # `|| true`: a grep matching nothing exits 1 under `bash -eo pipefail`.
             OUT=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/pw-guardrails.out | grep -E 'error|Error|not ok|fail|stale' | head -30) || true
+            # See the MATCHES block above for the 16 KiB cap rationale.
             echo "changed_files<<EOF" >> "$GITHUB_OUTPUT"
-            echo "$OUT" >> "$GITHUB_OUTPUT"
+            printf '%s' "$OUT" | head -c 16000 >> "$GITHUB_OUTPUT"
+            echo "" >> "$GITHUB_OUTPUT"
             echo "EOF" >> "$GITHUB_OUTPUT"
             exit 1
           fi
@@ -380,8 +388,10 @@ jobs:
           yarn pretty:base --write $CHANGED_FILES || RC=$?
           if [ -n "$(git status --porcelain)" ]; then
             FILES=$(git status --porcelain | awk '{print "  - `" $2 "`"}' | head -30)
+            # See the MATCHES block above for the 16 KiB cap rationale.
             echo "changed_files<<EOF" >> "$GITHUB_OUTPUT"
-            echo "$FILES" >> "$GITHUB_OUTPUT"
+            printf '%s' "$FILES" | head -c 16000 >> "$GITHUB_OUTPUT"
+            echo "" >> "$GITHUB_OUTPUT"
             echo "EOF" >> "$GITHUB_OUTPUT"
             git checkout -- .
             git clean -fd


### PR DESCRIPTION
## Summary

The \`ui-checkstyle\` workflow's aggregation step OOMs on GitHub's expression evaluator when the \`lint_playwright\` step's \`changed_files\` output grows past ~32 KiB. Cap each of the three code paths that write to \`\$GITHUB_OUTPUT\` at 16 KiB via \`head -c 16000\`, so a runaway grep can't take down the whole checkstyle job.

## Root cause

Three paths in the \`lint_playwright\` step populate the \`changed_files\` step output:

1. blanket-\`eslint-disable\` grep across \`playwright/\` — output size uncapped
2. guardrail failures — line-capped via \`head -30\` but per-line length uncapped
3. \`git status --porcelain\` after auto-fix — same \`head -30\` line cap

All three are then emitted to \`\$GITHUB_OUTPUT\`, and referenced from the workflow's \`outputs\` block:

\`\`\`yaml
lint_playwright_changed_files: \${{ steps.lint_playwright.outputs.changed_files }}
\`\`\`

GitHub Actions' expression evaluator has a per-value memory budget (~32 KiB in practice). ESLint's JSON formatter emits **all findings on one line**, so \`grep -E '\"ruleId\"' | head -20\` returns a single 7 MB blob that the outputs block can't evaluate:

\`\`\`
##[error]The template is not valid. .github/workflows/ui-checkstyle.yml
(Line: 111, Col: 38): The maximum allowed memory size was exceeded
while evaluating the following expression:
steps.lint_playwright.outputs.changed_files
\`\`\`

Reproducing locally:

\`\`\`
pw-lint.json byte size:  7,141,632 bytes
pw-lint.json line count: 6
longest single line:     7,141,256 chars
grep '\"ruleId\"' hits:   1  (the one giant line)
head -20 output:         still 7 MB (only 1 line to head)
\`\`\`

## Fix

Add \`head -c 16000\` next to each existing \`head -30\` line cap, so no matter how long the source lines are, the value going into \`\$GITHUB_OUTPUT\` stays comfortably under the template limit. 16 KiB is still enough for a human-readable snippet of what the lint saw. The full detail remains in the job log via the existing \`cat\` calls.

## Motivation — unblocks #32384

The Rolldown migration PR (#32384) can't get a green \`ui-checkstyle\` gate because it touches \`package.json\` (Rolldown swap) which triggers \`lint_playwright\`, which hits this evaluator crash. Because #32384's workflow uses \`pull_request_target\`, the workflow file **runs from \`main\`, not from the PR head** — so any fix to \`ui-checkstyle.yml\` has to land here first. This split PR is the minimal path to that.

## Test plan

- [ ] Verify \`ui-checkstyle\` on this PR still runs and passes with the cap in place (no regression when the outputs stay small).
- [ ] After merge, retry the Rolldown PR (#32384) and confirm its \`ui-checkstyle\` job passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)