### PR TITLE
fix(ui): prevent 400 on second domain tag update (#32358)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetailPage/DomainDetailPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetailPage/DomainDetailPage.component.tsx
@@ -126,6 +126,9 @@ const DomainDetailPage = () => {
         const response = await patchDomains(activeDomain.id, jsonPatch);
 
         setActiveDomain(response);
+        // Re-fetch with full fields so the cache includes extension,
+        // votes, certification — fields the PATCH response omits.
+        void queryClient.invalidateQueries({ queryKey: domainCacheKey });
 
         if (activeDomain?.name !== updatedData.name) {
           navigate(getDomainPath(response.fullyQualifiedName));

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetailPage/DomainDetailPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetailPage/DomainDetailPage.test.tsx
@@ -11,13 +11,15 @@
  *  limitations under the License.
  */
 
-import { waitFor } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { Domain } from '../../../generated/entity/domains/domain';
 import { DOMAINS_LIST } from '../../../mocks/Domains.mock';
 import { ENTITY_PERMISSIONS } from '../../../mocks/Permissions.mock';
-import { getDomainByName } from '../../../rest/domainAPI';
+import { getDomainByName, patchDomains } from '../../../rest/domainAPI';
 import { renderWithQueryClient } from '../../../test/unit/test-utils';
 import PageLayoutV1 from '../../PageLayoutV1/PageLayoutV1';
+import DomainDetails from '../DomainDetails/DomainDetails.component';
 import DomainDetailPage from './DomainDetailPage.component';
 
 // Mock i18n to prevent 'add' method error
@@ -37,7 +39,13 @@ jest.mock('react-helmet-async', () => ({
   ),
 }));
 
-jest.mock('../../../rest/domainAPI');
+jest.mock('../../../rest/domainAPI', () => ({
+  getDomainByName: jest.fn(),
+  patchDomains: jest.fn(),
+  addFollower: jest.fn(),
+  removeFollower: jest.fn(),
+  updateDomainVotes: jest.fn(),
+}));
 jest.mock('../../../hooks/useApplicationStore', () => ({
   useApplicationStore: () => ({
     currentUser: { id: '1' },
@@ -66,6 +74,12 @@ jest.mock('../../../context/PermissionProvider/PermissionProvider', () => ({
 
 const mockGetDomainByName = getDomainByName as jest.MockedFunction<
   typeof getDomainByName
+>;
+const mockPatchDomains = patchDomains as jest.MockedFunction<
+  typeof patchDomains
+>;
+const MockDomainDetails = DomainDetails as jest.MockedFunction<
+  typeof DomainDetails
 >;
 
 describe('DomainDetailPage', () => {
@@ -126,5 +140,87 @@ describe('DomainDetailPage', () => {
         expect.anything()
       );
     });
+  });
+
+  it('should invalidate the domain query after a successful PATCH to refetch full fields', async () => {
+    const domainWithTags: Domain = {
+      ...DOMAINS_LIST[0],
+      tags: [
+        {
+          tagFQN: 'PII.Sensitive',
+          source: 'Classification',
+          labelType: 'Manual',
+          state: 'Confirmed',
+        },
+      ],
+    } as Domain;
+
+    const patchResponse: Domain = {
+      ...DOMAINS_LIST[0],
+      tags: [
+        {
+          tagFQN: 'PII.Sensitive',
+          source: 'Classification',
+          labelType: 'Manual',
+          state: 'Confirmed',
+        },
+        {
+          tagFQN: 'PersonalData.Personal',
+          source: 'Classification',
+          labelType: 'Manual',
+          state: 'Confirmed',
+        },
+      ],
+      version: 0.5,
+    } as Domain;
+
+    mockGetDomainByName.mockResolvedValue(domainWithTags);
+    mockPatchDomains.mockResolvedValue(patchResponse);
+
+    const { queryClient } = renderWithQueryClient(
+      <MemoryRouter>
+        <DomainDetailPage />
+      </MemoryRouter>
+    );
+
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    await waitFor(() => {
+      expect(mockGetDomainByName).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(MockDomainDetails).toHaveBeenCalled();
+    });
+
+    const onUpdateProp = MockDomainDetails.mock.calls.at(-1)?.[0]?.onUpdate;
+
+    expect(onUpdateProp).toBeDefined();
+
+    const updatedDomain: Domain = {
+      ...domainWithTags,
+      tags: [
+        ...(domainWithTags.tags ?? []),
+        {
+          tagFQN: 'PersonalData.Personal',
+          source: 'Classification',
+          labelType: 'Manual',
+          state: 'Confirmed',
+        },
+      ],
+    } as Domain;
+
+    await act(async () => {
+      await onUpdateProp?.(updatedDomain);
+    });
+
+    expect(mockPatchDomains).toHaveBeenCalledTimes(1);
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: expect.arrayContaining(['domain', 'test-domain']),
+      })
+    );
+
+    invalidateSpy.mockRestore();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.test.tsx
@@ -266,6 +266,41 @@ describe('TagsContainerV2 handleSave', () => {
     }
   });
 
+  it('preserves style: null without converting it to an empty object', async () => {
+    const tagWithNullStyle: EntityTags = {
+      tagFQN: PERSONAL_DATA_FQN,
+      source: TagSource.Classification,
+      labelType: LabelType.Manual,
+      state: State.Confirmed,
+      style: null as unknown as EntityTags['style'],
+      appliedBy: 'admin',
+      appliedAt: new Date(APPLIED_AT_ISO),
+    };
+
+    const onSelectionChange = jest.fn().mockResolvedValue(undefined);
+    renderTagsContainer({
+      selectedTags: [piiSensitiveTag],
+      onSelectionChange,
+    });
+
+    await enterEditMode();
+
+    expect(capturedOnSubmit).toBeDefined();
+
+    await act(async () => {
+      await capturedOnSubmit?.([
+        { value: PERSONAL_DATA_FQN, data: tagWithNullStyle },
+      ]);
+    });
+
+    expect(onSelectionChange).toHaveBeenCalledTimes(1);
+
+    const emitted = onSelectionChange.mock.calls[0][0] as TagLabel[];
+    const tag = emitted.find((t) => t.tagFQN === PERSONAL_DATA_FQN);
+
+    expect(tag?.style).toBeNull();
+  });
+
   it('add-one-remove-another in same save keeps surviving tag fields intact', async () => {
     const onSelectionChange = jest.fn().mockResolvedValue(undefined);
     renderTagsContainer({

--- a/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.tsx
@@ -185,7 +185,7 @@ const TagsContainerV2 = ({
         name: option.name,
         displayName: option.displayName,
         description: option.description,
-        style: option.style ?? {},
+        style: option.style,
         href: option.href,
         appliedBy: option.appliedBy,
         appliedAt: option.appliedAt,


### PR DESCRIPTION
## Summary

Backport of #32358 to `2.0`.

Fixes the Sentry issue where `PATCH /api/v1/domains/{id}` returns 400 when a user updates tags on a domain twice in succession (first update succeeds, second fails).

**Sentry:** https://collate-3b.sentry.io/issues/7703855605/

**Root cause — two contributing bugs:**

- **`TagsContainerV2.handleSave`** converted `style: null` → `style: {}` via `option.style ?? {}`. This created a spurious `replace /tags/0/style` operation in the `fast-json-patch` diff that could interact with tag validation (mutually-exclusive checks after `addDerivedTags`) to reject the request.
- **`DomainDetailPage.handleDomainUpdate`** replaced the entire React Query cache with the PATCH response via `setActiveDomain(response)`. The PATCH endpoint only returns `patchFields` (parent, children, experts, tags, owners, followers) — not extension, votes, or certification. Subsequent updates built their `compare()` diff from this incomplete baseline.

**Fix:**
- Preserve the server's `style` value as-is (`style: option.style` instead of `style: option.style ?? {}`)
- Keep the optimistic `setActiveDomain(response)` but follow it with `queryClient.invalidateQueries({ queryKey: domainCacheKey })`, so the cache is re-hydrated with the full entity (extension, votes, certification) rather than a partial one

## Backport notes

Cherry-picked cleanly from `c0e42293` (squash merge of #32358) with `-x`; **no conflicts** and no adaptation needed. Diff is byte-identical to the original: 4 files, +138/-4. `queryClient` and `domainCacheKey` already exist on `2.0` in `DomainDetailPage.component.tsx`, so the added line resolves without further changes.

## Test plan

- [x] Navigate to a domain, add a classification tag, verify PATCH succeeds
- [x] Immediately add a second tag from a different classification, verify PATCH succeeds (was 400 before)
- [x] Verify existing tags are preserved after both updates
- [x] Removing a certification no longer leaves the stale value in the UI (covered by the `invalidateQueries` change and the Playwright `DomainTierCertificationVoting` test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

_`skip-pr-checks` applied per the 2.0 backport convention (#32416, #32395): a backport has no issue of its own to link — the original issue is tracked on #32358._
