### PR TITLE
fix(tags): make provider immutable for system Classifications/Tags (#29974)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ClassificationResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ClassificationResourceIT.java
@@ -276,6 +276,60 @@ public class ClassificationResourceIT extends BaseEntityIT<Classification, Creat
   }
 
   @Test
+  void patch_systemClassificationProvider_rejected(TestNamespace ns) throws Exception {
+    // #29974: flipping a system classification's provider to user via PATCH must be rejected -
+    // otherwise it loses its delete protection and system metadata can be removed, leaving the
+    // instance in a partially-deleted inconsistent state.
+    Classification tier = SdkClients.adminClient().classifications().getByName("Tier");
+    assertEquals(ProviderType.SYSTEM, tier.getProvider());
+
+    JsonNode providerToUser =
+        new ObjectMapper()
+            .readTree("[{\"op\":\"replace\",\"path\":\"/provider\",\"value\":\"user\"}]");
+    assertThrows(
+        InvalidRequestException.class,
+        () ->
+            SdkClients.adminClient()
+                .getHttpClient()
+                .execute(
+                    HttpMethod.PATCH,
+                    "/v1/classifications/" + tier.getId(),
+                    providerToUser,
+                    Classification.class),
+        "Changing the provider of a system classification should be rejected");
+
+    Classification reloaded = SdkClients.adminClient().classifications().getByName("Tier");
+    assertEquals(
+        ProviderType.SYSTEM, reloaded.getProvider(), "System provider must remain unchanged");
+  }
+
+  @Test
+  void put_systemClassificationProvider_preserved(TestNamespace ns) throws Exception {
+    // A PUT carrying a user provider must not downgrade a system classification - the system
+    // provider is preserved silently instead of stored as user.
+    Classification tier = SdkClients.adminClient().classifications().getByName("Tier");
+    assertEquals(ProviderType.SYSTEM, tier.getProvider());
+
+    CreateClassification putBody =
+        new CreateClassification()
+            .withName(tier.getName())
+            .withDescription(tier.getDescription())
+            .withMutuallyExclusive(tier.getMutuallyExclusive())
+            .withProvider(ProviderType.USER);
+    Classification updated =
+        SdkClients.adminClient()
+            .getHttpClient()
+            .execute(HttpMethod.PUT, "/v1/classifications", putBody, Classification.class);
+    assertEquals(
+        ProviderType.SYSTEM, updated.getProvider(), "PUT must not downgrade the system provider");
+
+    // Reload to confirm the system provider was persisted, not just reflected in the response.
+    Classification reloaded = SdkClients.adminClient().classifications().getByName("Tier");
+    assertEquals(
+        ProviderType.SYSTEM, reloaded.getProvider(), "System provider must remain persisted");
+  }
+
+  @Test
   void test_classificationOwnerPermissions(TestNamespace ns) {
     // Create classification without owners
     CreateClassification request = new CreateClassification();

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TagResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TagResourceIT.java
@@ -40,6 +40,7 @@ import org.openmetadata.schema.type.AssetCertification;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Paging;
 import org.openmetadata.schema.type.PredefinedRecognizer;
+import org.openmetadata.schema.type.ProviderType;
 import org.openmetadata.schema.type.Recognizer;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.utils.ResultList;
@@ -1851,6 +1852,57 @@ public class TagResourceIT extends BaseEntityIT<Tag, CreateTag> {
     createSchema.setName(ns.shortPrefix(name));
     createSchema.setDatabase(databaseFqn);
     return SdkClients.adminClient().databaseSchemas().create(createSchema);
+  }
+
+  @Test
+  void patch_systemTagProvider_rejected(TestNamespace ns) throws Exception {
+    // #29974: a seeded system tag (its provider inherited from the system classification, see
+    // TagResource) must not have its provider flipped to user via PATCH - that strips the delete
+    // protection that keeps system tags from being removed.
+    Tag goldTag = SdkClients.adminClient().tags().getByName("Certification.Gold");
+    assertEquals(ProviderType.SYSTEM, goldTag.getProvider());
+
+    JsonNode providerToUser =
+        new ObjectMapper()
+            .readTree("[{\"op\":\"replace\",\"path\":\"/provider\",\"value\":\"user\"}]");
+    assertThrows(
+        InvalidRequestException.class,
+        () ->
+            SdkClients.adminClient()
+                .getHttpClient()
+                .execute(
+                    HttpMethod.PATCH, "/v1/tags/" + goldTag.getId(), providerToUser, Tag.class),
+        "Changing the provider of a system tag should be rejected");
+
+    Tag reloaded = SdkClients.adminClient().tags().getByName("Certification.Gold");
+    assertEquals(
+        ProviderType.SYSTEM, reloaded.getProvider(), "System provider must remain unchanged");
+  }
+
+  @Test
+  void put_systemTagProvider_preserved(TestNamespace ns) throws Exception {
+    // A PUT carrying a user provider must not downgrade a seeded system tag - the system provider
+    // is preserved silently instead of stored as user.
+    Tag goldTag = SdkClients.adminClient().tags().getByName("Certification.Gold");
+    assertEquals(ProviderType.SYSTEM, goldTag.getProvider());
+
+    CreateTag putBody =
+        new CreateTag()
+            .withName(goldTag.getName())
+            .withClassification("Certification")
+            .withDescription(goldTag.getDescription())
+            .withProvider(ProviderType.USER);
+    Tag updated =
+        SdkClients.adminClient()
+            .getHttpClient()
+            .execute(HttpMethod.PUT, "/v1/tags", putBody, Tag.class);
+    assertEquals(
+        ProviderType.SYSTEM, updated.getProvider(), "PUT must not downgrade the system provider");
+
+    // Reload to confirm the system provider was persisted, not just reflected in the response.
+    Tag reloaded = SdkClients.adminClient().tags().getByName("Certification.Gold");
+    assertEquals(
+        ProviderType.SYSTEM, reloaded.getProvider(), "System provider must remain persisted");
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ClassificationRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ClassificationRepository.java
@@ -522,6 +522,7 @@ public class ClassificationRepository extends EntityRepository<Classification> {
     public void entitySpecificUpdate(boolean consolidatingChanges) {
       // Mutually exclusive cannot be updated
       updated.setMutuallyExclusive(original.getMutuallyExclusive());
+      restrictSystemProviderChange(updated::setProvider);
       preserveAutoClassificationConfigOnPut();
       compareAndUpdate(
           "disabled",

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -8782,6 +8782,26 @@ public abstract class EntityRepository<T extends EntityInterface> {
       return false;
     }
 
+    /**
+     * Blocks downgrading a system entity's provider to user, which would strip its delete/rename
+     * protection (#29974). Both update paths prevent it, only the response differs: a PATCH change is
+     * deliberate and rejected with a 400; a PUT's provider defaults to user when omitted (ambiguous),
+     * so the system provider is kept silently rather than break PUTs that never meant to change it.
+     */
+    protected final void restrictSystemProviderChange(Consumer<ProviderType> providerSetter) {
+      if (!ProviderType.SYSTEM.equals(original.getProvider())) {
+        return;
+      }
+      if (operation.isPatch()) {
+        if (!ProviderType.SYSTEM.equals(updated.getProvider())) {
+          throw new IllegalArgumentException(
+              CatalogExceptionMessage.systemEntityModifyNotAllowed(original.getName(), entityType));
+        }
+        return;
+      }
+      providerSetter.accept(original.getProvider());
+    }
+
     protected final void compareAndUpdate(String fieldName, Runnable updater) {
       if (shouldCompare(fieldName)) {
         updater.run();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TagRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TagRepository.java
@@ -1010,6 +1010,7 @@ public class TagRepository extends EntityRepository<Tag> {
     @Transaction
     @Override
     public void entitySpecificUpdate(boolean consolidatingChanges) {
+      restrictSystemProviderChange(updated::setProvider);
       preserveRecognizerConfigOnPut();
       compareAndUpdate("mutuallyExclusive", this::run);
       compareAndUpdate(


### PR DESCRIPTION
## Describe your changes

Fixes #29974.

The PUT/PATCH API allowed changing a **system** Classification/Tag's `provider` from `system` to `user`. Once downgraded, the entity lost its delete/rename protection (`checkSystemEntityDeletion`), so it could be deleted — leaving the instance with some default system tags removed and others stuck, a partially-modified, inconsistent metadata state.

### Fix
A shared guard in `EntityRepository.EntityUpdater` (`restrictSystemProviderChange`), wired into the Classification and Tag updaters:

- **PATCH** that changes a system entity's provider → rejected with **400** (`systemEntityModifyNotAllowed`), the same exception family as the existing system delete/rename guards.
- **PUT** — a `CreateClassification`/`CreateTag` defaults `provider` to `user` when omitted, so a naive reject would break the legitimate "disable a system tag" flow. Instead the system provider is **preserved silently** (matching the existing `preserveAutoClassificationConfigOnPut` / `preserveRecognizerConfigOnPut` idiom), which still prevents the downgrade.

User-provider entities are unaffected; the guard only engages when the stored entity is `system`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How was this tested

Added integration tests (run against the embedded stack — **all 4 pass**):

| Test | Asserts |
|---|---|
| `ClassificationResourceIT.patch_systemClassificationProvider_rejected` | PATCH `Tier` provider→user ⇒ 400, provider stays `system` |
| `ClassificationResourceIT.put_systemClassificationProvider_preserved` | PUT `Tier` with provider=user ⇒ provider preserved as `system` |
| `TagResourceIT.patch_systemTagProvider_rejected` | PATCH `Certification.Gold` provider→user ⇒ 400, provider stays `system` |
| `TagResourceIT.put_systemTagProvider_preserved` | PUT `Certification.Gold` with provider=user ⇒ provider preserved as `system` |

```
mvn -pl openmetadata-integration-tests test -Dtest='ClassificationResourceIT#patch_systemClassificationProvider_rejected+put_systemClassificationProvider_preserved,TagResourceIT#patch_systemTagProvider_rejected+put_systemTagProvider_preserved'
=> Tests run: 4, Failures: 0, Errors: 0
```

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes