### PR TITLE
Backport to 1.13: make the FQN split in view lineage quote-aware (#31483)

### DIFF
--- a/ingestion/src/metadata/ingestion/lineage/sql_lineage.py
+++ b/ingestion/src/metadata/ingestion/lineage/sql_lineage.py
@@ -272,9 +272,15 @@ def get_table_fqn_from_query_name(
     """
     Method to extract database, schema and table name
     from raw table name used in query
+
+    The split is quote-aware: connectors are free to put a `.` inside a single name
+    component (Dremio flattens nested folder paths into `folder.subfolder`), in which
+    case that component reaches us quoted. Splitting such a name on every `.` would
+    tear the quoted identifier in half and yield components with unbalanced quotes,
+    which `fqn.quote_name` then rejects with `Invalid name "folder`.
     """
 
-    split_table = table_name.split(".")
+    split_table = fqn.split_raw_name(table_name)
     empty_list: List[Any] = [None]  # Otherwise, there's a typing error in the concat
 
     if len(split_table) > 3:

--- a/ingestion/src/metadata/utils/db_utils.py
+++ b/ingestion/src/metadata/utils/db_utils.py
@@ -105,6 +105,14 @@ def get_view_lineage(
             schema_name = PUBLIC_SCHEMA
             schema_fallback = True
 
+        if table_entity.serviceType == DatabaseServiceType.Dremio:
+            # Dremio folders nest arbitrarily deep and are flattened into a single dotted
+            # schema name (`folder.subfolder`), but a Dremio query spells every folder out
+            # as its own path segment. The SQL parser keeps only the first two segments as
+            # the qualifier, so for anything nested two or more folders deep the parsed
+            # schema can never match the ingested one. Fall back to a schema wildcard.
+            schema_fallback = True
+
         end_time = time.time()
         logger.debug(
             f"[{query_hash}] Time taken to parse view lineage for: {table_fqn} is {end_time - start_time} seconds"

--- a/ingestion/src/metadata/utils/fqn.py
+++ b/ingestion/src/metadata/utils/fqn.py
@@ -98,6 +98,42 @@ def split(str_: str) -> List[str]:
     return splitter.split()
 
 
+def split_raw_name(name: str) -> List[str]:  # noqa: UP006
+    """
+    Split a partially-qualified raw name on the FQN separator, ignoring separators
+    that sit inside a quoted identifier.
+
+    Unlike :func:`split`, this is tolerant: it never raises, and for input without
+    quotes it is byte-for-byte equivalent to ``name.split(".")``. That matters because
+    callers feed it names harvested from parsed SQL, which may be unbalanced or
+    otherwise malformed -- those must degrade gracefully rather than blow up.
+
+    A quoted segment is returned with its quotes intact, so it can be handed straight
+    back to :func:`quote_name`:
+
+        >>> split_raw_name('"folder.subfolder".my_view')
+        ['"folder.subfolder"', 'my_view']
+        >>> split_raw_name("db.schema.table")
+        ['db', 'schema', 'table']
+    """
+    parts: List[str] = []  # noqa: UP006
+    current: List[str] = []  # noqa: UP006
+    within_quotes = False
+
+    for char in name:
+        if char == '"':
+            within_quotes = not within_quotes
+            current.append(char)
+        elif char == FQN_SEPARATOR and not within_quotes:
+            parts.append("".join(current))
+            current = []
+        else:
+            current.append(char)
+
+    parts.append("".join(current))
+    return parts
+
+
 def _build(*args, quote: bool = True) -> str:
     """
     Equivalent of Java's FullyQualifiedName#build

--- a/ingestion/tests/unit/lineage/test_sql_lineage.py
+++ b/ingestion/tests/unit/lineage/test_sql_lineage.py
@@ -251,6 +251,56 @@ class SqlLineageTest(TestCase):
 
         self.assertFalse([log for log in logger.output if log.startswith("ERROR")])
 
+    def test_table_name_from_query_with_dotted_schema(self):
+        """
+        A connector may put a `.` inside a single name component -- Dremio flattens
+        nested folder paths into `folder.subfolder` -- in which case that component
+        arrives quoted. It must survive as one component instead of being torn in half,
+        which used to surface as `ValueError: Invalid name "folder` (issue #31481).
+        """
+        assert get_table_fqn_from_query_name(
+            '"OpsDataViews.Reporting".vw_customer'
+        ) == (
+            None,
+            '"OpsDataViews.Reporting"',
+            "vw_customer",
+        )
+
+        assert get_table_fqn_from_query_name(
+            'Prod."OpsDataViews.Reporting".vw_customer'
+        ) == (
+            "Prod",
+            '"OpsDataViews.Reporting"',
+            "vw_customer",
+        )
+
+        # Deeply nested folders stay a single quoted schema rather than tripping the
+        # 4+ component branch and losing the schema altogether
+        assert get_table_fqn_from_query_name('"a.b.c.d".tab') == (
+            None,
+            '"a.b.c.d"',
+            "tab",
+        )
+
+        # A quoted table name containing a dot is likewise preserved
+        assert get_table_fqn_from_query_name('db.schema."tab.v2"') == (
+            "db",
+            "schema",
+            '"tab.v2"',
+        )
+
+    def test_table_name_from_query_is_quote_safe(self):
+        """
+        Names are harvested from parsed SQL, so malformed input must degrade rather
+        than raise -- get_table_fqn_from_query_name has no callers that catch ValueError.
+        """
+        assert get_table_fqn_from_query_name('"unbalanced') == (
+            None,
+            None,
+            '"unbalanced',
+        )
+        assert get_table_fqn_from_query_name('"a.b"."c.d"') == (None, '"a.b"', '"c.d"')
+
     def test_replace_target_table(self):
         """
         Test the _replace_target_table function

--- a/ingestion/tests/unit/test_fqn.py
+++ b/ingestion/tests/unit/test_fqn.py
@@ -487,3 +487,68 @@ class TestFqn(TestCase):
             "database_schema": "d",
             "table": "e",
         }
+
+    def test_split_raw_name_matches_str_split_without_quotes(self):
+        """
+        The quote-aware split must be a drop-in replacement for `str.split(".")`
+        on unquoted input, empty components included.
+        """
+        for raw in [
+            "db.schema.table",
+            "schema.table",
+            "table",
+            "",
+            "a..b",
+            ".a",
+            "a.",
+            "..",
+            "a.b.c.d.e",
+        ]:
+            assert fqn.split_raw_name(raw) == raw.split(".")
+
+    def test_split_raw_name_keeps_quoted_components_whole(self):
+        """
+        A `.` inside a quoted identifier is part of the name, not a separator (issue #31481).
+        Quotes are retained so the component can be fed straight back to quote_name.
+        """
+        assert fqn.split_raw_name('"folder.subfolder".my_view') == [
+            '"folder.subfolder"',
+            "my_view",
+        ]
+        assert fqn.split_raw_name('db."folder.subfolder".my_view') == [
+            "db",
+            '"folder.subfolder"',
+            "my_view",
+        ]
+        assert fqn.split_raw_name('"a.b.c.d"') == ['"a.b.c.d"']
+        assert fqn.split_raw_name('"a.b"."c.d"') == ['"a.b"', '"c.d"']
+
+    def test_split_raw_name_tolerates_malformed_input(self):
+        """Names come from parsed SQL, so unbalanced quotes must not raise."""
+        assert fqn.split_raw_name('"unbalanced') == ['"unbalanced']
+        assert fqn.split_raw_name('"unbalanced.name') == ['"unbalanced.name']
+        assert fqn.split_raw_name('a."b') == ["a", '"b']
+
+    def test_split_raw_name_output_is_quote_name_safe(self):
+        """
+        The whole point of the quote-aware split: every component it returns must be
+        acceptable to quote_name, so downstream FQN building cannot blow up.
+        """
+        for raw in [
+            '"folder.subfolder".my_view',
+            'db."folder.subfolder".my_view',
+            "db.schema.table",
+            '"a.b"."c.d"',
+        ]:
+            for part in fqn.split_raw_name(raw):
+                fqn.quote_name(part)
+
+    def test_dotted_schema_survives_fqn_round_trip(self):
+        """
+        Regression for Dremio view lineage (issue #31481): the FQN rebuilt from a split
+        component must equal the FQN that was ingested, for any folder nesting depth.
+        """
+        for folders in (["f1"], ["f1", "f2"], ["f1", "f2", "f3"]):
+            ingested = fqn._build("svc", "db", ".".join(folders), "vw")
+            _, database, schema, table = fqn.split(ingested)
+            assert fqn._build("svc", database, schema, table) == ingested


### PR DESCRIPTION
### Describe your changes:

Backport of #31483 (`Fixes #31481`) to `1.13`. Cherry-pick of `abc6d60f8ea9dacb309f1145fdd31fe5d0fb15b5`.

The fix merged to `main` on 2026-08-14 and was never backported, so every 1.13 build still has
the bug. `1.13.4-release` was tagged on 2026-08-21 — a week *after* the fix landed — and still
does not contain it:

| ref | `fqn.split_raw_name` | Dremio `schema_fallback` |
|---|---|---|
| `main` | present | present |
| `1.13` (head) | **absent** | **absent** |
| `1.13.4-release` | **absent** | **absent** |

### Why it matters

A Dremio lineage agent on 1.13.4 fails table-entity lookup for **every** source table and
produces **zero** lineage edges, while the workflow reports `Errors: 0 / Success %: 100.0` —
so the failure is silent. From a customer run on 2026-08-31 (387 occurrences in one workflow):

```
[2026-08-31 16:11:20] ERROR {metadata.Utils:sql_lineage:262} - Error searching for table entities for service [dremio dev]: Invalid name "IQDataViews
[2026-08-31 16:11:20] ERROR {metadata.Utils:sql_lineage:262} - Error searching for table entities for service [dremio dev]: Invalid name "DataProducts
...
Processed records: 0 / Errors: 0 / Success %: 100.0
```

`sql_lineage:262` is the `logger.error` in `search_table_entities` on the `1.13` branch
exactly, confirming the unfixed code is what runs.

Both halves of the original commit are needed. `fqn.split_raw_name` stops the
`ValueError: Invalid name "<prefix>` on the target side; the `db_utils.py` half sets
`schema_fallback = True` for Dremio, which is what lets the *source* side of the edge resolve
for views nested two or more folders deep. Backporting only the first would clear the error
text and still leave the edges missing.

### Type of change:

- [x] Bug fix

### Conflict resolution

One conflict, in `get_table_fqn_from_query_name`. The only semantic line is
`table_name.split(".")` → `fqn.split_raw_name(table_name)`; the rest of the hunk differs
between branches purely by formatting (`main` is ruff-formatted, `1.13` is `black==22.3.0`).
The ruff-only `# noqa: UP006` on the `empty_list` line was dropped, since that line is
unchanged on `1.13`; the ones inside the new `split_raw_name` were kept so the function stays
identical to `main` for future cherry-picks (`1.13` already carries `noqa: UP006` markers in
other modules).

The two test files were re-wrapped with the branch-pinned `black==22.3.0` / `isort` (line
length 88 vs. main's wider ruff setting). `make py_format_check`-equivalent on the five
touched files is clean. No behavioural difference from the original commit.

Verified on `1.13` that both symbols the cherry-pick depends on exist: `FQN_SEPARATOR` in
`fqn.py` and `Dremio` in the `databaseService.json` `serviceType` enum (so
`DatabaseServiceType.Dremio` resolves).

### Tests:

Same tests as #31483, unchanged apart from re-wrapping:

- `ingestion/tests/unit/test_fqn.py` — 5 tests: `str.split` equivalence on unquoted input
  (including empty components), quoted components kept whole, malformed/unbalanced input
  tolerated, every returned component accepted by `quote_name`, FQN round-trip at several
  nesting depths
- `ingestion/tests/unit/lineage/test_sql_lineage.py` — 2 tests: dotted schema and dotted table
  names, plus quote-safety on malformed input

#### Unit tests

Validated against the **released `openmetadata-ingestion==1.13.4` wheel** — the exact runtime
the customer is on — by installing it clean and A/B-ing the three source files:

| | pristine 1.13.4 | with this backport |
|---|---|---|
| the 7 tests carried over from #31483 | **6 failed**, 1 passed | **7 passed** |
| `tests/unit/lineage` + `tests/unit/test_fqn.py` | 13 failed, 394 passed, 2 skipped | 7 failed, **400 passed**, 2 skipped |

- **New failures introduced: 0.** Diffing the two `FAILED` lists, the only difference is the 6
  tests the fix is supposed to fix.
- The 7 residual failures are `tests/unit/lineage/queries/test_complex_query_patterns.py::test_update_merge_*`
  and are **identical before and after** — pre-existing on pristine 1.13.4 in this environment
  (`collate-sqllineage`/`sqlfluff` version drift), not touched by this change.
- 2 files could not be collected in this venv for missing optional connector deps
  (`test_databricks_lineage.py` → no `databricks` module, `test_pgspider_lineage_unit.py` →
  no `pgspider.psycopg2` dialect) and were excluded from both runs equally.

The pristine install also confirms the premise of this PR directly:
`hasattr(metadata.utils.fqn, "split_raw_name")` is `False` on 1.13.4 and `True` after.

#### Formatting

`black==22.3.0` (the version pinned in `ingestion/setup.py` on this branch) and `isort` both
report the five touched files clean.

#### Ingestion integration tests
- [ ] Not added, same as the original PR — reproducing needs a live Dremio instance with a view
  nested two folders deep. #31483 carries the live-Dremio validation table for the behaviour
  itself; this PR validates that the same code applies and passes on 1.13.

#### Backend integration tests
- [x] Not applicable (no backend changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

### UI screen recording / screenshots:

Not applicable.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR is a backport and references the original PR and issue above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable, no schema changes.
- [x] For UI changes: not applicable.
- [x] I have added tests (carried over from the original PR) and listed them above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
