### PR TITLE
ci: fork-gate the knowledge-graph e2e Maven cache save

### DIFF
--- a/.github/workflows/playwright-knowledge-graph-postgresql-e2e.yml
+++ b/.github/workflows/playwright-knowledge-graph-postgresql-e2e.yml
@@ -217,8 +217,9 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Cache Maven Dependencies
-        uses: actions/cache@v6
+      - name: Restore Maven Dependencies
+        id: maven-cache
+        uses: actions/cache/restore@v6
         with:
           path: ~/.m2
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -242,6 +243,20 @@ jobs:
 
       - name: Build with Maven
         run: mvn -DskipTests clean package
+
+      - name: Save Maven Dependencies
+        # Fork PRs under pull_request_target skip the save — actions/cache-poisoning.
+        # The restore above stays ungated so forks are not forced into a cold
+        # ~/.m2 download; only the write into main's cache scope is blocked.
+        if: >-
+          steps.maven-cache.outputs.cache-hit != 'true' &&
+          !(github.event_name == 'pull_request_target' &&
+            github.event.pull_request.head.repo.full_name != github.repository)
+        continue-on-error: true
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
 
       - name: Upload OpenMetadata distribution
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
### Describe your changes:

No linked issue — direct burn-down of CodeQL code-scanning alerts **2287**, **2288** and **2289** (`actions/cache-poisoning/poisonable-step`, High), tracked in the Security tab. Follow-up to #32436, which fixed the same class everywhere else.

`playwright-knowledge-graph-postgresql-e2e.yml`'s `build` job still used a combined `actions/cache@v6` for `~/.m2`. That workflow triggers on `pull_request_target`, and its checkout deliberately takes the fork head (`allow-unsafe-pr-checkout: true`), so a fork PR ran in the **base branch's cache scope** with untrusted code on disk and then saved `~/.m2` under `main`'s own key. The key hashes `**/pom.xml` only — a fork that changes nothing but the build lands its payload on the exact key `main` restores from, and `restore-keys: ${{ runner.os }}-maven-` widens that to any prefix match.

#
### Type of change:
- [x] Improvement

#
### High-level design:

Split into an ungated `actions/cache/restore@v6` and a fork-gated `actions/cache/save@v6` placed after `Build with Maven`:

```yaml
      - name: Save Maven Dependencies
        if: >-
          steps.maven-cache.outputs.cache-hit != 'true' &&
          !(github.event_name == 'pull_request_target' &&
            github.event.pull_request.head.repo.full_name != github.repository)
```

**Why split rather than gate the step.** `actions/cache@vN` restores *and* saves in one action, so an `if:` on the step suppresses both. Gating it whole would have forced every fork PR into a cold `~/.m2` download for no security gain — reading `main`'s cache into a fork job grants the fork nothing it did not already have, since the same content is public. This is the same correction applied across #32436 after review, and the shape now matches `playwright-e2e-reusable.yml` and the ingestion-venv cache in `setup-openmetadata-test-environment`.

`cache-hit != 'true'` reproduces what the combined action did implicitly: skip the write when the exact key was already restored. With `restore-keys` in play a prefix-only match reports `cache-hit: false`, so a stale-prefix restore still refreshes the entry under the new pom hash.

**Rollout:** config-only. Same-repo `pull_request`, `merge_group` and `workflow_dispatch` runs are unaffected; fork PRs under `pull_request_target` restore as before but no longer write.

**Note on the alerts.** The three alerts will most likely **not** auto-close. CodeQL's `poisonable-step` query does not evaluate the `if:` guard on the cache-write step — alert 2288 points at `Restore openmetadata-ui dist cache`, which has carried that exact guard since long before this PR and is still flagged, and none of the 29 cache-poisoning alerts closed after #32436 merged. They need dismissing as false positives once this lands. The value of this PR is closing the actual fork→`main` write, not the alert count.

#
### Tests:

#### Use cases covered
- Fork PR under `pull_request_target`: restores `~/.m2` as before, writes nothing into the base-branch cache scope.
- Same-repo `pull_request` / `merge_group` / `workflow_dispatch`: restores and saves exactly as before — no cold-build regression on the common path.
- Exact cache hit: the save is skipped, matching the combined action's previous behaviour.

#### Unit tests
Not applicable — no application code changed. One workflow YAML file.

#### Backend / Ingestion integration tests
Not applicable.

#### Playwright (UI) tests
Not applicable — this is the Knowledge Graph E2E *harness*; the specs it runs are unchanged.

#### Manual testing performed
1. `yaml.safe_load` on the changed workflow — parses.
2. Enumerated every cache step in the file and asserted the invariant: the one `actions/cache/save` carries the fork guard, the `actions/cache/restore` does not, and no combined `actions/cache@vN` remains.
3. `actionlint` on the changed file — no findings.

#
### UI screen recording / screenshots:

Not applicable — no UI changes.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` — no linked issue; alerts are tracked in the Security tab.
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above — see note above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable, no schema changes.
- [x] For UI changes: not applicable, no UI changes.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above — not applicable, CI configuration only.

#
### Follow-up (not in this PR):

Read-write cache saves still unguarded under `pull_request_target`: `~/.m2` in `integration-tests-mysql-elasticsearch.yml` (×2), `integration-tests-postgres-elasticsearch-redis.yml` (×2), `integration-tests-postgres-opensearch.yml` (×2), `maven-sonar-build.yml`, and the yarn/npm caches in `yarn-coverage.yml` (×2). Also `.github/actions/cache-ui-dist`, which is still a combined `actions/cache@v5` skipped wholesale on fork PRs — splitting it means moving the save out of the composite and into each caller, after that caller's maven step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
