### PR TITLE
ci: redact auth headers from Playwright PR comments

### DIFF
--- a/.github/scripts/publish_playwright_pr_comment.cjs
+++ b/.github/scripts/publish_playwright_pr_comment.cjs
@@ -13,6 +13,24 @@
 
 'use strict';
 
+// The payload arrives as an artifact built by the untrusted E2E run, and
+// Playwright error text carries the failing request's headers — including the
+// ephemeral admin JWT the fixtures mint. Redact again here, at the trust
+// boundary, so no bearer header can reach a PR comment (and GitHub secret
+// scanning) even if the producing workflow skips its own pass. This duplicates
+// `render_playwright_summary.cjs` deliberately: this helper is loaded from the
+// default branch with write permissions and must stay self-contained.
+const SENSITIVE_HEADER_PATTERN =
+  /((?:proxy-authorization|authorization|set-cookie|cookie|x-auth-token|x-api-key|api-key)[ \t]*[:=][ \t]*)[^\r\n]*/gi;
+const JSON_WEB_TOKEN_PATTERN =
+  /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g;
+
+function redactSecrets(value) {
+  return String(value ?? '')
+    .replace(SENSITIVE_HEADER_PATTERN, '$1<redacted>')
+    .replace(JSON_WEB_TOKEN_PATTERN, '<redacted>');
+}
+
 module.exports = async function publishPlaywrightPrComment({
   github,
   context,
@@ -616,7 +634,7 @@ module.exports = async function publishPlaywrightPrComment({
     lines.push(`### Pipeline and setup failures (${infrastructureIssueCount})`);
     lines.push('');
     for (const issue of infrastructureIssues) {
-      lines.push(`- <code>${escapeHtml(issue)}</code>`);
+      lines.push(`- <code>${escapeHtml(redactSecrets(issue))}</code>`);
     }
     if (infrastructureIssueCount > infrastructureIssues.length) {
       lines.push(
@@ -762,7 +780,9 @@ module.exports = async function publishPlaywrightPrComment({
         )}</code> (shard ${escapeHtml(failure.shard)})</summary>`
       );
       lines.push('');
-      lines.push(`<pre><code>${escapeHtml(failure.error)}</code></pre>`);
+      lines.push(
+        `<pre><code>${escapeHtml(redactSecrets(failure.error))}</code></pre>`
+      );
       lines.push('</details>');
       lines.push('');
     }

--- a/.github/scripts/render_playwright_summary.cjs
+++ b/.github/scripts/render_playwright_summary.cjs
@@ -13,6 +13,23 @@
 
 'use strict';
 
+// Playwright appends the failing request's full call log — headers included —
+// to `error.message`, so a timed-out API call carries the ephemeral admin JWT
+// the E2E fixtures mint. Publishing that verbatim trips GitHub secret scanning
+// on every red run. `publish_playwright_pr_comment.cjs` keeps its own copy on
+// purpose: it is the trusted helper loaded from the default branch and must not
+// depend on files this workflow could supply.
+const SENSITIVE_HEADER_PATTERN =
+  /((?:proxy-authorization|authorization|set-cookie|cookie|x-auth-token|x-api-key|api-key)[ \t]*[:=][ \t]*)[^\r\n]*/gi;
+const JSON_WEB_TOKEN_PATTERN =
+  /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g;
+
+function redactSecrets(value) {
+  return String(value ?? '')
+    .replace(SENSITIVE_HEADER_PATTERN, '$1<redacted>')
+    .replace(JSON_WEB_TOKEN_PATTERN, '<redacted>');
+}
+
 async function renderPlaywrightSummary({ github, context, core }) {
   const fs = require('fs');
   const path = require('path');
@@ -312,7 +329,9 @@ async function renderPlaywrightSummary({ github, context, core }) {
               file: specFile,
               status: test.status,
               retries: results.length - 1,
-              error: lastResult.error?.message || firstResult.error?.message || '',
+              error: redactSecrets(
+                lastResult.error?.message || firstResult.error?.message || ''
+              ),
             };
             if (specFile.endsWith('.setup.ts') || specFile.endsWith('.teardown.ts')) {
               lifecycleTests.push(testResult);
@@ -776,7 +795,7 @@ async function renderPlaywrightSummary({ github, context, core }) {
     infrastructureIssueCount: infrastructureIssues.length,
     infrastructureIssues: infrastructureIssues
       .slice(0, 100)
-      .map(issue => boundedString(issue, 500)),
+      .map(issue => boundedString(redactSecrets(issue), 500)),
     failures: allGenuine.slice(0, 30).map(test => ({
       shard: boundedString(test.shard, 64),
       file: boundedString(test.file, 300),
@@ -825,4 +844,4 @@ async function renderPlaywrightSummary({ github, context, core }) {
   }
 }
 
-module.exports = { renderPlaywrightSummary };
+module.exports = { renderPlaywrightSummary, redactSecrets };

--- a/.github/scripts/tests/test_playwright_pr_comment.py
+++ b/.github/scripts/tests/test_playwright_pr_comment.py
@@ -24,7 +24,9 @@ def test_comment_workflow_uses_a_small_trusted_helper_wrapper():
     )
 
 
-def render_comment(tmp_path: Path, payload: dict) -> subprocess.CompletedProcess[str]:
+def render_comment(
+    tmp_path: Path, payload: dict, conclusion: str = "success"
+) -> subprocess.CompletedProcess[str]:
     payload_path = tmp_path / "summary.json"
     payload_path.write_text(json.dumps(payload), encoding="utf-8")
     harness = f"""
@@ -43,7 +45,7 @@ const context = {{
       id: 123456,
       run_attempt: 1,
       event: 'pull_request',
-      conclusion: 'success',
+      conclusion: {json.dumps(conclusion)},
       head_sha: sourceSha,
       repository: {{ id: 1 }},
       pull_requests: [{{ number: pull.number, base: {{ repo: {{ id: 1 }} }} }}],
@@ -238,3 +240,67 @@ def test_v2_rejects_inconsistent_lifecycle_total(tmp_path: Path):
 
     assert result.returncode != 0
     assert "sum of shard lifecycleFlaky counts" in result.stderr
+
+
+LEAKED_JWT = (
+    "eyJraWQiOiJHYjM4OWEtOWY3Ni1nZGpzLWE5MmotMDI0MmJrOTQzNTYiLCJhbGciOiJSUzI1NiJ9"
+    ".eyJpc3MiOiJvcGVuLW1ldGFkYXRhLm9yZyIsInN1YiI6ImFkbWluIn0"
+    ".dkLypt-7l9jR74XoUkNjjThCSylew4igwwBp89sfuAB0QDn9eHWjj"
+)
+
+CALL_LOG_WITH_TOKEN = (
+    "TimeoutError: apiRequestContext.get: Timeout 30000ms exceeded.\n"
+    "Call log:\n"
+    "  - → GET http://localhost:8585/api/v1/apps/name/SearchIndexingApplication\n"
+    "    - accept: */*\n"
+    f"    - Authorization: Bearer {LEAKED_JWT}\n"
+    "    - Connection: keep-alive\n"
+)
+
+
+def failing_payload_with_leaked_token() -> dict:
+    payload = current_payload()
+    payload["totals"]["passed"] = 10
+    payload["totals"]["failed"] = 1
+    payload["shards"][0]["failed"] = 1
+    payload["failures"] = [
+        {
+            "shard": "chromium-01",
+            "file": "playwright/e2e/Pages/SearchSettings.spec.ts",
+            "title": "Update global search settings",
+            "error": CALL_LOG_WITH_TOKEN,
+        }
+    ]
+    payload["performance"]["blockingTargetsMet"] = True
+    return payload
+
+
+def test_failure_error_never_publishes_authorization_headers(tmp_path: Path):
+    result = render_comment(
+        tmp_path, failing_payload_with_leaked_token(), conclusion="failure"
+    )
+
+    assert result.returncode == 0, result.stderr
+    body = json.loads(result.stdout)["body"]
+    assert LEAKED_JWT not in body
+    assert "Bearer" not in body
+    assert "Authorization: &lt;redacted&gt;" in body
+    # The surrounding call log still has to be readable, or the comment stops
+    # being useful for triage.
+    assert "Timeout 30000ms exceeded" in body
+    assert "accept: */*" in body
+
+
+def test_infrastructure_issues_are_redacted(tmp_path: Path):
+    payload = current_payload()
+    payload["infrastructureIssueCount"] = 1
+    payload["infrastructureIssues"] = [
+        f"Shard 1 uploaded invalid results JSON: cookie=jwtToken={LEAKED_JWT}"
+    ]
+
+    result = render_comment(tmp_path, payload, conclusion="failure")
+
+    assert result.returncode == 0, result.stderr
+    body = json.loads(result.stdout)["body"]
+    assert LEAKED_JWT not in body
+    assert "Shard 1 uploaded invalid results JSON" in body

--- a/.github/scripts/tests/test_playwright_secret_redaction.py
+++ b/.github/scripts/tests/test_playwright_secret_redaction.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[3]
+RENDERER = ROOT / ".github/scripts/render_playwright_summary.cjs"
+PUBLISHER = ROOT / ".github/scripts/publish_playwright_pr_comment.cjs"
+
+LEAKED_JWT = (
+    "eyJraWQiOiJHYjM4OWEtOWY3Ni1nZGpzLWE5MmotMDI0MmJrOTQzNTYiLCJhbGciOiJSUzI1NiJ9"
+    ".eyJpc3MiOiJvcGVuLW1ldGFkYXRhLm9yZyIsInN1YiI6ImFkbWluIn0"
+    ".dkLypt-7l9jR74XoUkNjjThCSylew4igwwBp89sfuAB0QDn9eHWjj"
+)
+
+
+def redact(value: str) -> str:
+    harness = f"""
+const {{ redactSecrets }} = require({json.dumps(str(RENDERER))});
+process.stdout.write(JSON.stringify(redactSecrets({json.dumps(value)})));
+"""
+    result = subprocess.run(
+        ["node", "-e", harness],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_bearer_header_value_is_removed_and_the_call_log_survives():
+    call_log = (
+        "TimeoutError: apiRequestContext.get: Timeout 30000ms exceeded.\n"
+        "Call log:\n"
+        "  - → GET http://localhost:8585/api/v1/apps/name/SearchIndexing\n"
+        "    - accept: */*\n"
+        f"    - Authorization: Bearer {LEAKED_JWT}\n"
+        "    - Connection: keep-alive\n"
+    )
+
+    redacted = redact(call_log)
+
+    assert LEAKED_JWT not in redacted
+    assert "Bearer" not in redacted
+    assert "    - Authorization: <redacted>\n" in redacted
+    assert "Timeout 30000ms exceeded" in redacted
+    assert "    - accept: */*\n" in redacted
+    assert "    - Connection: keep-alive\n" in redacted
+
+
+def test_redaction_stops_at_the_end_of_the_header_line():
+    redacted = redact("authorization: secret\nnext line survives")
+
+    assert redacted == "authorization: <redacted>\nnext line survives"
+
+
+def test_other_credential_headers_are_covered():
+    for header in (
+        "Authorization",
+        "proxy-authorization",
+        "Cookie",
+        "set-cookie",
+        "X-Auth-Token",
+        "x-api-key",
+        "api-key",
+    ):
+        assert redact(f"{header}: super-secret") == f"{header}: <redacted>"
+
+    assert redact("cookie=jwtToken=super-secret") == "cookie=<redacted>"
+
+
+def test_bare_json_web_tokens_are_removed_without_a_header():
+    redacted = redact(f"navigating to http://localhost:8585/?token={LEAKED_JWT}")
+
+    assert LEAKED_JWT not in redacted
+    assert redacted.endswith("?token=<redacted>")
+
+
+def test_ordinary_failure_text_is_left_alone():
+    message = "expect(locator).toBeVisible() failed\nLocator: getByTestId('save')"
+
+    assert redact(message) == message
+
+
+def read_redaction_block(path: Path) -> str:
+    source = path.read_text(encoding="utf-8")
+    match = re.search(
+        r"const SENSITIVE_HEADER_PATTERN =.*?^}$",
+        source,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert match, f"{path.name} no longer defines redactSecrets"
+    return match.group(0)
+
+
+def test_the_publisher_copy_cannot_drift_from_the_renderer_copy():
+    """The trusted publisher keeps its own copy so it stays self-contained; pin
+    the two implementations together so a fix to one is a fix to both."""
+    assert read_redaction_block(RENDERER) == read_redaction_block(PUBLISHER)


### PR DESCRIPTION
### Describe your changes:

Playwright appends the failing request's full call log — headers included — to `error.message`. When an E2E API call times out, that message contains the ephemeral admin JWT the fixtures mint:

```
Call log:
  - → GET http://localhost:8585/api/v1/apps/name/SearchIndexingApplication
    - accept: */*
    - Authorization: Bearer eyJ...
```

The `playwright-summary` comment pasted that text verbatim, so every red E2E run had a chance of publishing a bearer header into a PR comment and opening a GitHub secret-scanning alert (`http_bearer_authentication_header`). Roughly a dozen such alerts exist today, all pointing at bot comments rather than at code.

The tokens themselves are worthless — they are scoped to the throwaway `localhost:8585` CI container, signed with the dev keypair already committed at `conf/private_key.der`, and expire 4 hours after issue. The problem is the recurring noise: real alerts get buried under bot-generated false positives that someone has to triage by hand every time.

This PR stops producing them.

#
### Type of change:
- [x] Improvement

#
### High-level design:

Redaction happens in two places, on purpose:

1. **At the source** — `render_playwright_summary.cjs` redacts when it captures `error.message`. This covers both consumers of that string: the Actions job summary (public on a public repo) and the JSON comment payload.
2. **At the trust boundary** — `publish_playwright_pr_comment.cjs` redacts again before rendering. That helper is loaded from the default branch and runs with write permissions in a `workflow_run` context, while its input is an artifact produced by the untrusted PR run. Redacting there means no bearer header can reach a comment even if the producing side is bypassed or regresses.

The publisher keeps its own copy of the ~10-line helper rather than `require`-ing a shared module: it is the trusted, privileged script and should not grow file dependencies. `test_the_publisher_copy_cannot_drift_from_the_renderer_copy` pins the two implementations byte-for-byte, so a fix to one has to be a fix to both.

What gets redacted: `authorization`, `proxy-authorization`, `cookie`, `set-cookie`, `x-auth-token`, `x-api-key`, `api-key` header values, plus bare JWT-shaped tokens anywhere in the text (they also show up in URLs). Redaction is line-scoped, so the rest of the call log stays intact and the comment remains useful for triage.

#
### Tests:

#### Use cases covered
- A failing test whose Playwright error carries `Authorization: Bearer <jwt>` publishes a PR comment with the header value replaced by `<redacted>`, the surrounding call log intact, and no `Bearer` substring anywhere in the body
- An infrastructure issue string carrying a token is redacted the same way
- Ordinary assertion failure text (`expect(locator).toBeVisible() failed`) is passed through unchanged
- The renderer and publisher redaction helpers cannot drift apart

#### Unit tests
- [x] Added `.github/scripts/tests/test_playwright_secret_redaction.py` — header coverage, line-scoping, bare JWTs, no-op on ordinary text, drift guard
- [x] Extended `.github/scripts/tests/test_playwright_pr_comment.py` with two end-to-end cases that drive the real publisher over a payload containing a leaked token and assert the rendered comment is clean

```
$ python3 -m pytest .github/scripts/tests/test_playwright_secret_redaction.py \
                    .github/scripts/tests/test_playwright_pr_comment.py -q
14 passed in 1.45s
```

Also replayed the actual leaked comment body from a past run through the new helper: the JWT and the `Bearer` prefix are gone, the call log around them still reads normally.

#### Integration tests
N/A — CI reporting scripts only.

#### Playwright tests
N/A — no UI change.

#
### Manual testing steps:
Not needed; the two scripts are exercised directly by the tests above. The next red Playwright run on any PR will show the redacted call log in the summary comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)