### PR TITLE
fix(ui): default theme to light mode

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/index.html
+++ b/openmetadata-ui/src/main/resources/ui/index.html
@@ -36,27 +36,21 @@
       and re-painting once React reads localStorage. Mirrors Linear's inline
       splash trick (see linear.app/changelog): pre-paint reads of stable
       localStorage keys avoid a visible re-theme on cold load. The bundle's
-      ThemeProvider uses the same saved-theme then OS-theme order on mount and
-      stays in sync with the class we set here. `appStart` mark gives the bundle a
-      RUM anchor to measure HTML-parse → first paint vs. JS-ready.
+      ThemeProvider uses the same saved-theme-or-light order on mount and stays
+      in sync with the class we set here. `appStart` mark gives the bundle a RUM
+      anchor to measure HTML-parse → first paint vs. JS-ready.
     -->
     <script id="theme-restore" nonce="${cspNonce}">
+      let restoredTheme = 'light';
       try {
         const savedTheme = localStorage.getItem('ui-theme');
-        const followsDarkSystemTheme =
-          savedTheme !== 'light' &&
-          savedTheme !== 'dark' &&
-          typeof window.matchMedia === 'function' &&
-          window.matchMedia('(prefers-color-scheme: dark)').matches;
-        const restoredTheme =
-          savedTheme === 'dark' || followsDarkSystemTheme ? 'dark' : 'light';
-
-        document.documentElement.classList.toggle(
-          'dark-mode',
-          restoredTheme === 'dark'
-        );
-        document.documentElement.style.colorScheme = restoredTheme;
+        restoredTheme = savedTheme === 'dark' ? 'dark' : 'light';
       } catch (e) {}
+      document.documentElement.classList.toggle(
+        'dark-mode',
+        restoredTheme === 'dark'
+      );
+      document.documentElement.style.colorScheme = restoredTheme;
       try {
         performance.mark('appStart');
       } catch (e) {}
@@ -265,9 +259,9 @@
 
       /*
         Dark variant — applied by the pre-paint script above for a saved dark
-        preference or a dark OS preference. Matches the dark-mode CSS variables
-        the bundle eventually sets via ThemeProvider, so the visual transition
-        from shell to React UI is seamless instead of a light→dark flash.
+        preference. Matches the dark-mode CSS variables the bundle eventually
+        sets via ThemeProvider, so the visual transition from shell to React UI
+        is seamless instead of a light→dark flash.
       */
       .dark-mode .om-boot-shell {
         background: #0e0f11;

--- a/openmetadata-ui/src/main/resources/ui/src/components/ThemeModeSwitcher/ThemeModeSwitcher.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ThemeModeSwitcher/ThemeModeSwitcher.test.tsx
@@ -27,7 +27,7 @@ describe('ThemeModeSwitcher', () => {
 
   it('shows and updates the active theme', () => {
     render(
-      <ThemeProvider defaultTheme="light">
+      <ThemeProvider>
         <ThemeModeSwitcher />
       </ThemeProvider>
     );
@@ -51,7 +51,7 @@ describe('ThemeModeSwitcher', () => {
 
   it('uses the full row with the label separated from the toggle', () => {
     render(
-      <ThemeProvider defaultTheme="light">
+      <ThemeProvider>
         <ThemeModeSwitcher />
       </ThemeProvider>
     );

--- a/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/AIUserMenu/AIUserMenu.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/discovery/personal-space/AIUserMenu/AIUserMenu.test.tsx
@@ -180,7 +180,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
 const renderMenu = () =>
   render(
     <MemoryRouter>
-      <ThemeProvider defaultTheme="light">
+      <ThemeProvider>
         <AIUserMenu />
       </ThemeProvider>
     </MemoryRouter>

--- a/openmetadata-ui/src/main/resources/ui/src/context/UntitledUIThemeProvider/theme-boot.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/context/UntitledUIThemeProvider/theme-boot.test.ts
@@ -32,13 +32,24 @@ const executeThemeRestore = () => {
 
 describe('theme restore boot script', () => {
   afterEach(() => {
+    jest.restoreAllMocks();
     localStorage.clear();
     document.documentElement.classList.remove('dark-mode');
     document.documentElement.style.removeProperty('color-scheme');
   });
 
-  it('uses the OS dark theme before the application bundle loads', () => {
+  it('uses light mode before the application bundle loads without a preference', () => {
     window.matchMedia = jest.fn().mockReturnValue({ matches: true });
+
+    executeThemeRestore();
+
+    expect(document.documentElement).not.toHaveClass('dark-mode');
+    expect(document.documentElement).toHaveStyle({ colorScheme: 'light' });
+  });
+
+  it('restores an explicit dark preference before the application bundle loads', () => {
+    localStorage.setItem('ui-theme', 'dark');
+    window.matchMedia = jest.fn().mockReturnValue({ matches: false });
 
     executeThemeRestore();
 
@@ -46,9 +57,20 @@ describe('theme restore boot script', () => {
     expect(document.documentElement).toHaveStyle({ colorScheme: 'dark' });
   });
 
-  it('keeps an explicit light preference when the OS theme is dark', () => {
+  it('restores an explicit light preference before the application bundle loads', () => {
     localStorage.setItem('ui-theme', 'light');
     window.matchMedia = jest.fn().mockReturnValue({ matches: true });
+
+    executeThemeRestore();
+
+    expect(document.documentElement).not.toHaveClass('dark-mode');
+    expect(document.documentElement).toHaveStyle({ colorScheme: 'light' });
+  });
+
+  it('uses light mode when the stored preference cannot be read', () => {
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('Storage is unavailable');
+    });
 
     executeThemeRestore();
 

--- a/openmetadata-ui/src/main/resources/ui/src/context/UntitledUIThemeProvider/theme-provider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/UntitledUIThemeProvider/theme-provider.test.tsx
@@ -61,23 +61,35 @@ const setSystemTheme = (theme: 'light' | 'dark') => {
 
 describe('ThemeProvider', () => {
   afterEach(() => {
+    jest.restoreAllMocks();
     localStorage.clear();
     document.documentElement.classList.remove('dark-mode');
     document.documentElement.style.removeProperty('color-scheme');
   });
 
-  it('uses the system color scheme when no preference is stored', () => {
+  it('uses light mode when no preference is stored', () => {
     setSystemTheme('dark');
+
+    renderProvider();
+
+    expect(screen.getByTestId('active-theme')).toHaveTextContent('light');
+    expect(document.documentElement).not.toHaveClass('dark-mode');
+    expect(document.documentElement).toHaveStyle({ colorScheme: 'light' });
+    expect(localStorage.getItem('ui-theme')).toBeNull();
+  });
+
+  it('uses a stored preference instead of the default light mode', () => {
+    setSystemTheme('light');
+    localStorage.setItem('ui-theme', 'dark');
 
     renderProvider();
 
     expect(screen.getByTestId('active-theme')).toHaveTextContent('dark');
     expect(document.documentElement).toHaveClass('dark-mode');
     expect(document.documentElement).toHaveStyle({ colorScheme: 'dark' });
-    expect(localStorage.getItem('ui-theme')).toBeNull();
   });
 
-  it('uses a stored preference instead of the system color scheme', () => {
+  it('restores a stored light preference when the system theme is dark', () => {
     setSystemTheme('dark');
     localStorage.setItem('ui-theme', 'light');
 
@@ -88,20 +100,48 @@ describe('ThemeProvider', () => {
     expect(document.documentElement).toHaveStyle({ colorScheme: 'light' });
   });
 
-  it('follows system color scheme changes until a preference is selected', () => {
+  it('treats an invalid stored value as no preference', () => {
+    setSystemTheme('dark');
+    localStorage.setItem('ui-theme', 'invalid');
+
+    renderProvider();
+
+    expect(screen.getByTestId('active-theme')).toHaveTextContent('light');
+    expect(localStorage.getItem('ui-theme')).toBeNull();
+  });
+
+  it('keeps light mode when the system color scheme changes', () => {
     const changeSystemTheme = setSystemTheme('light');
     renderProvider();
 
     act(() => changeSystemTheme('dark'));
 
-    expect(screen.getByTestId('active-theme')).toHaveTextContent('dark');
-    expect(document.documentElement).toHaveClass('dark-mode');
-
-    fireEvent.click(screen.getByRole('button', { name: 'Use light theme' }));
-    act(() => changeSystemTheme('dark'));
-
     expect(screen.getByTestId('active-theme')).toHaveTextContent('light');
     expect(document.documentElement).not.toHaveClass('dark-mode');
+  });
+
+  it('uses light mode when the stored preference cannot be read', () => {
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('Storage is unavailable');
+    });
+
+    expect(() => renderProvider()).not.toThrow();
+    expect(screen.getByTestId('active-theme')).toHaveTextContent('light');
+    expect(document.documentElement).not.toHaveClass('dark-mode');
+    expect(document.documentElement).toHaveStyle({ colorScheme: 'light' });
+  });
+
+  it('updates the theme when the preference cannot be persisted', () => {
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('Storage is unavailable');
+    });
+    renderProvider();
+
+    expect(() =>
+      fireEvent.click(screen.getByRole('button', { name: 'Use dark theme' }))
+    ).not.toThrow();
+    expect(screen.getByTestId('active-theme')).toHaveTextContent('dark');
+    expect(document.documentElement).toHaveClass('dark-mode');
   });
 
   it('persists explicit dark and light selections', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/context/UntitledUIThemeProvider/theme-provider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/UntitledUIThemeProvider/theme-provider.tsx
@@ -26,30 +26,26 @@ import {
 } from './theme-provider.interface';
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
-const SYSTEM_THEME_QUERY = '(prefers-color-scheme: dark)';
+const DEFAULT_THEME: Theme = 'light';
 
 const getStoredTheme = (storageKey: string): Theme | null => {
-  if (typeof globalThis.localStorage === 'undefined') {
-    return null;
+  try {
+    if (typeof globalThis.localStorage === 'undefined') {
+      return null;
+    }
+
+    const savedTheme = localStorage.getItem(storageKey) as Theme | null;
+
+    if (savedTheme === 'light' || savedTheme === 'dark') {
+      return savedTheme;
+    }
+
+    localStorage.removeItem(storageKey);
+  } catch {
+    // Privacy restrictions can block storage access; treat that as no preference.
   }
-
-  const savedTheme = localStorage.getItem(storageKey) as Theme | null;
-
-  if (savedTheme === 'light' || savedTheme === 'dark') {
-    return savedTheme;
-  }
-
-  localStorage.removeItem(storageKey);
 
   return null;
-};
-
-const getSystemTheme = (): Theme | null => {
-  if (typeof globalThis.matchMedia !== 'function') {
-    return null;
-  }
-
-  return globalThis.matchMedia(SYSTEM_THEME_QUERY).matches ? 'dark' : 'light';
 };
 
 export const useTheme = (): ThemeContextType => {
@@ -70,11 +66,6 @@ interface ThemeProviderProps {
    * @default "dark-mode"
    */
   darkModeClass?: string;
-  /**
-   * The fallback theme when neither storage nor a system preference is available.
-   * @default "light"
-   */
-  defaultTheme?: Theme;
   /**
    * The key to use to store the theme in localStorage.
    * @default "ui-theme"
@@ -259,20 +250,21 @@ const clearBrandCssVars = (root: HTMLElement) => {
 export const ThemeProvider = ({
   children,
   brandColors,
-  defaultTheme = 'light',
   storageKey = 'ui-theme',
   darkModeClass = 'dark-mode',
 }: ThemeProviderProps) => {
   const [theme, setThemeState] = useState<Theme>(
-    () => getStoredTheme(storageKey) ?? getSystemTheme() ?? defaultTheme
+    () => getStoredTheme(storageKey) ?? DEFAULT_THEME
   );
 
   const setTheme = useCallback(
     (nextTheme: Theme) => {
-      // System-derived initialization stays ephemeral so later visits can keep
-      // following the OS until the user or desktop shell makes an explicit choice.
-      if (typeof globalThis.localStorage !== 'undefined') {
-        localStorage.setItem(storageKey, nextTheme);
+      try {
+        if (typeof globalThis.localStorage !== 'undefined') {
+          localStorage.setItem(storageKey, nextTheme);
+        }
+      } catch {
+        // Persistence failure must not block theme changes for the current session.
       }
       setThemeState(nextTheme);
     },
@@ -285,28 +277,6 @@ export const ThemeProvider = ({
     root.classList.toggle(darkModeClass, theme === 'dark');
     root.style.colorScheme = theme;
   }, [theme, darkModeClass]);
-
-  useEffect(() => {
-    if (typeof globalThis.matchMedia !== 'function') {
-      return;
-    }
-
-    const systemTheme = globalThis.matchMedia(SYSTEM_THEME_QUERY);
-    const handleSystemThemeChange = (event: MediaQueryListEvent) => {
-      // A stored value means the user or desktop shell has explicitly opted
-      // out of following later OS changes.
-      if (getStoredTheme(storageKey) !== null) {
-        return;
-      }
-
-      setThemeState(event.matches ? 'dark' : 'light');
-    };
-
-    systemTheme.addEventListener('change', handleSystemThemeChange);
-
-    return () =>
-      systemTheme.removeEventListener('change', handleSystemThemeChange);
-  }, [storageKey]);
 
   useEffect(() => {
     const root = globalThis.document.documentElement;


### PR DESCRIPTION
### Describe your changes:

Follow-up to #32383 and part of https://github.com/open-metadata/openmetadata-collate/issues/6035.

This PR changes theme initialization so a valid saved user preference remains authoritative, while users without a saved preference start in light mode. The operating system color scheme no longer selects or changes the application theme.

The pre-paint restore script follows the same rule, preventing an OS-dark browser from rendering a dark first paint before React initializes the light default.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

The theme provider now resolves initial state from local storage and then its existing light default. The OS color-scheme fallback and listener are removed. The inline restore script resolves only an explicitly saved dark preference as dark; saved light, missing, and invalid values render light.

This preserves explicit light/dark selections and their existing `ui-theme` storage contract.

#
### Tests:

#### Use cases covered

- No saved preference initializes the provider in light mode even when the OS is dark.
- A saved dark preference initializes the provider and document in dark mode.
- OS color-scheme changes do not change the application theme.
- The pre-paint script uses light without a saved preference and restores saved dark mode.
- Unavailable browser storage falls back to light without blocking session-only theme changes.
- Explicit user selections continue to persist.

#### Unit tests

- [x] Updated focused provider and boot-script tests.
- 32 focused tests pass across the provider, restore script, shared switcher, and both profile-menu surfaces.

#### UI checks

- [x] ESLint, Prettier, and import organization pass on the changed UI files.

#### Backend integration tests

- [x] Not applicable (no backend API changes).

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Not added; focused component tests cover the initialization behavior.

#
### UI screen recording / screenshots:

Not attached; this corrects the initial theme selection behavior covered by automated tests.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` (the source issue is in the Collate repository).
- [x] My PR is linked to the source GitHub issue above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable; no schema changes.
- [ ] For UI changes: no recording or screenshot is attached; automated tests cover the behavior.
- [x] I have added tests and listed them above.
