### PR TITLE
Fixes #32475: keep Status.filtered keys strings for nameless entities

### DIFF
--- a/ingestion/src/metadata/ingestion/api/status.py
+++ b/ingestion/src/metadata/ingestion/api/status.py
@@ -30,6 +30,8 @@ logger = ingestion_logger()
 MAX_STACK_TRACE_LENGTH = 1_000_000
 # Max items per list rendered in as_string() to bound memory usage
 MAX_STATUS_DISPLAY_ITEMS = 1_000
+# Placeholder for filtered entities that carry no name
+UNKNOWN_FILTER_KEY = "<unknown>"
 
 TruncatedStr = Annotated[str | None, AfterValidator(lambda v: v[:MAX_STACK_TRACE_LENGTH] if v else None)]
 
@@ -97,8 +99,11 @@ class Status(BaseModel):
     def warning(self, key: str, reason: str) -> None:
         self.warnings.append({key: reason})
 
-    def filter(self, key: str, reason: str) -> None:
-        self.filtered.append({key: reason})
+    def filter(self, key: str | None, reason: str) -> None:
+        # Sources can legitimately hand us a nameless entity (e.g. a Tableau workbook
+        # published to a Personal Space has no project), and `filtered` is typed
+        # dict[str, str] — a None key makes the Status un-revalidatable.
+        self.filtered.append({key if key is not None else UNKNOWN_FILTER_KEY: reason})
 
     def as_string(self) -> str:
         def literal_safe(v: Any) -> Any:

--- a/ingestion/tests/cli_e2e/test_cli_tableau.py
+++ b/ingestion/tests/cli_e2e/test_cli_tableau.py
@@ -503,7 +503,9 @@ class TableauCliTest(CliCommonDashboard.TestSuite):
             params={"service": TableauExpectedValues.SERVICE_NAME},
         ).entities
 
-        for datamodel in datamodels:
+        # The Tableau site is shared and gains workbooks outside this test's control, so
+        # assert only on the fixture this test owns instead of on everything ingested.
+        for datamodel in (dm for dm in datamodels if dm.name.root in TableauExpectedValues.EXPECTED_DATAMODEL_NAMES):
             if hasattr(datamodel, "columns") and datamodel.columns:
                 for column in datamodel.columns:
                     if hasattr(column, "dataType") and column.dataType:
@@ -513,7 +515,7 @@ class TableauCliTest(CliCommonDashboard.TestSuite):
                                 DataType.RECORD,
                                 f"Calculated field '{column.displayName}' should keep the RECORD wrapper",
                             )
-                        else:
+                        elif column.displayName in TableauExpectedValues.EXPECTED_DATAMODEL_FIELDS:
                             self.assertNotEqual(
                                 column.dataType,
                                 DataType.RECORD,

--- a/ingestion/tests/unit/test_status.py
+++ b/ingestion/tests/unit/test_status.py
@@ -12,6 +12,7 @@
 Tests for metadata.ingestion.api.status.Status
 """
 
+from ast import literal_eval
 from unittest import TestCase
 
 from metadata.generated.schema.entity.services.ingestionPipelines.status import (
@@ -20,6 +21,7 @@ from metadata.generated.schema.entity.services.ingestionPipelines.status import 
 from metadata.ingestion.api.status import (
     MAX_STACK_TRACE_LENGTH,
     MAX_STATUS_DISPLAY_ITEMS,
+    UNKNOWN_FILTER_KEY,
     Status,
     TruncatedStackTraceError,
 )
@@ -133,6 +135,20 @@ class TestStatus(TestCase):
     def test_filter_appends_dict(self):
         self.status.filter("entity_name", "filtered out")
         self.assertEqual(self.status.filtered, [{"entity_name": "filtered out"}])
+
+    def test_filter_replaces_none_key_with_placeholder(self):
+        """A nameless filtered entity must not poison the dict[str, str] key."""
+        self.status.filter(None, "filtered out")
+        self.assertEqual(self.status.filtered, [{UNKNOWN_FILTER_KEY: "filtered out"}])
+
+    def test_status_with_none_filter_key_round_trips(self):
+        """as_string() output of a nameless filter must revalidate as a Status."""
+        self.status.filter(None, "Project / Workspace Filtered Out")
+        revalidated = Status.model_validate(literal_eval(self.status.as_string()))
+        self.assertEqual(
+            revalidated.filtered,
+            [{UNKNOWN_FILTER_KEY: "Project / Workspace Filtered Out"}],
+        )
 
     # ── truncation of stack traces ───────────────────────────────────
 


### PR DESCRIPTION
### Describe your changes:

Fixes #32475

I made `Status.filter()` substitute a placeholder key when the caller has no name for the entity it filtered, because `Status.filtered` is typed `List[Dict[str, str]]` and a `None` key makes the whole `Status` fail its own validation. A Tableau workbook published to a Personal Space has no project, so `get_project_name` returns `None` without raising and `dashboard_service` calls `status.filter(None, "Project / Workspace Filtered Out")` — which is what has made the nightly `py-cli-e2e-tests (tableau)` lane red since 2026-08-27, since the e2e helper re-parses the printed status with `Status.model_validate`. I fixed it centrally in `Status.filter` rather than in the Tableau source, because any connector that can filter a nameless entity can produce it. Separately, I scoped the Tableau e2e `_validate_field_types` to the fixture it owns: it asserted "every field outside `EXPECTED_RECORD_FIELDS` must have collapsed" across *all* ingested data models, so a workbook published to the shared E2E Tableau site (`CalculatedDSWorkbook`, whose calculated field correctly keeps the RECORD wrapper) failed a test unrelated to it.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered

- A source filters an entity that has no name (Tableau workbook in a Personal Space, with a `projectFilterPattern` active) → the entry is recorded as `{'<unknown>': 'Project / Workspace Filtered Out'}` and the printed `Status` still round-trips through `Status.model_validate`.
- A source filters a named entity → unchanged, key is the entity name.
- The Tableau e2e field-type assertions hold for the `Sales Summary` fixture and ignore workbooks published to the shared test site by others.

#### Unit tests

- [x] I added unit tests for the new/changed logic.
- Files updated: `ingestion/tests/unit/test_status.py`
  - `test_filter_replaces_none_key_with_placeholder` — the placeholder substitution.
  - `test_status_with_none_filter_key_round_trips` — regression test for the exact CI failure: `as_string()` output of a nameless filter revalidates as a `Status` (the path `base/test_cli.py:121` takes).
- Coverage: **74%** line coverage on `metadata/ingestion/api/status.py` from `tests/unit/test_status.py` alone, with **every changed line covered** — the 12 missed statements are pre-existing and untouched by this PR (`scanned`, `scanned_all`, `updated`, `increment_record_count`).

```
$ pytest ingestion/tests/unit/test_status.py -q
17 passed in 0.07s

Name                                      Stmts   Miss Branch BrPart  Cover   Missing
src/metadata/ingestion/api/status.py         70     12     16      0    74%   73-77, 86-91, 94-95, 98
```

Confirmed the test fails before the fix and passes after, against the real code path:

```
RED (pre-fix) reproduced: 1 validation error for Status
GREEN (post-fix): [{'<unknown>': 'Project / Workspace Filtered Out'}]
```

#### Backend integration tests

- [x] Not applicable (no backend API changes).

#### Ingestion integration tests

- Files updated: `ingestion/tests/cli_e2e/test_cli_tableau.py` (`_validate_field_types` scoped to `EXPECTED_DATAMODEL_NAMES`). The nightly `py-cli-e2e-tests (tableau)` lane exercises this; it needs the shared Tableau site credentials, so it cannot be run from a fork.
- Field-*presence* coverage (`test_cli_tableau.py:405-415`) and the mirror-column collapse coverage over all 13 `Sales Summary` fields are unchanged — the assertion is narrowed only to exclude data models the test does not own.

#### Playwright (UI) tests

- [x] Not applicable (no UI changes).

#### Manual testing performed

1. Reproduced the CI error locally against the real model: appended `{None: ...}` to `Status.filtered` as `dashboard_service` did, then called `Status.model_validate(literal_eval(status.as_string()))` → same `1 validation error for Status / filtered.0.None.[key]` pydantic error as the failing job.
2. Re-ran the same round-trip through the fixed `Status.filter(None, ...)` → validates, yielding `[{'<unknown>': 'Project / Workspace Filtered Out'}]`.
3. Checked the assertions that now actually run once the status parses: `assert_not_including` and `assert_for_vanilla_ingestion` (`test_cli_tableau.py:537,556`) override the base with `len(filtered) >= 5` and lower-bound record counts, so the 18 filtered entries and the extra ingested workbook in the current site state pass; `failures` and `warnings` were both `[]` in the failing job's status dump.
4. `ruff format --check` and `ruff check` clean on all three files.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable — no schema changes.
- [x] For UI changes: not applicable — no UI changes.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

- [x] I have added a test that covers the exact scenario we are fixing (`test_status_with_none_filter_key_round_trips`, and issue #32475 is referenced in this PR for future reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)