### PR TITLE
fix(ui): route the interface-mode menu item through NavbarUtilClassBase

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.component.tsx
@@ -37,7 +37,6 @@ import {
   getUserPath,
 } from '../../../../utils/RouterUtils';
 import { getEmptyTextFromUserProfileItem } from '../../../../utils/UsersPureUtils';
-import InterfaceModeMenuItem from '../../../AppModeSwitcher/InterfaceModeMenuItem';
 import { useAuthProvider } from '../../../Auth/AuthProviders/AuthProvider';
 import ProfilePicture from '../../../common/ProfilePicture/ProfilePicture';
 import ThemeModeSwitcher from '../../../ThemeModeSwitcher/ThemeModeSwitcher';
@@ -379,12 +378,6 @@ export const UserProfileIcon = () => {
       },
       {
         type: 'divider',
-      },
-      {
-        key: 'app-mode',
-        icon: '',
-        label: <InterfaceModeMenuItem />,
-        type: 'group',
       },
       ...navbarUtilClassBase.getUserProfileExtraItems(),
       {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/NavbarUtilClassBase.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/NavbarUtilClassBase.test.tsx
@@ -36,7 +36,10 @@ describe('NavbarUtilClassBase', () => {
     expect(stringifyResult).toContain('label.version');
   });
 
-  it('should return no user profile extra items by default', () => {
-    expect(navbarUtilClassBase.getUserProfileExtraItems()).toEqual([]);
+  it('should expose the interface-mode switch as the default extra item', () => {
+    const items = navbarUtilClassBase.getUserProfileExtraItems();
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ key: 'app-mode', type: 'group' });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/NavbarUtilClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/NavbarUtilClassBase.ts
@@ -11,6 +11,8 @@
  *  limitations under the License.
  */
 import { ItemType } from 'antd/lib/menu/hooks/useItems';
+import { createElement } from 'react';
+import InterfaceModeMenuItem from '../components/AppModeSwitcher/InterfaceModeMenuItem';
 import { HELP_ITEMS } from '../constants/Navbar.constants';
 
 class NavbarUtilClassBase {
@@ -18,8 +20,18 @@ class NavbarUtilClassBase {
     return HELP_ITEMS;
   }
 
+  // The Classic->AI interface switch ships through this hook (rather than
+  // hardcoded in UserProfileIcon) so white-label builds can replace it with a
+  // gated variant by overriding this method.
   public getUserProfileExtraItems(): ItemType[] {
-    return [];
+    return [
+      {
+        key: 'app-mode',
+        icon: '',
+        label: createElement(InterfaceModeMenuItem),
+        type: 'group',
+      },
+    ];
   }
 }
 


### PR DESCRIPTION
## What
`UserProfileIcon` renders the Classic⇄AI interface switch **twice** for any build that injects its own variant through `navbarUtilClassBase.getUserProfileExtraItems()`: once hardcoded (added in #32277) and once from the hook. Two `interface-mode-option-ai` buttons in the same dropdown break every Playwright locator on that testid (strict-mode violation).

## How
Move the default `app-mode` group item into `NavbarUtilClassBase.getUserProfileExtraItems()` and drop the hardcoded copy. OSS DOM is unchanged (same item, same position); a downstream override now replaces the item wholesale instead of duplicating it.

## Testing
- `NavbarUtilClassBase.test.tsx` updated: default extra items now carry exactly one `app-mode` group.
- `UserProfileIcon` suite passes unchanged (it already mocks the base class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)