### PR TITLE
fix(gcs): use double_value for total_bytes metric

### DIFF
--- a/ingestion/src/metadata/ingestion/source/storage/gcs/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/storage/gcs/metadata.py
@@ -498,6 +498,10 @@ class GcsSource(StorageServiceSource):
                 name=f"projects/{bucket.project_id}", filter=filter_, interval=interval
             )
             point = list(timeseries)[-1].points[-1]
+            # total_bytes is DOUBLE in Cloud Monitoring; object_count is INT64.
+            # protobuf silently returns 0 when the wrong oneof field is read.
+            if metric == GCSMetric.BUCKET_SIZE_BYTES:
+                return point.value.double_value  # noqa: TRY300
             return point.value.int64_value  # noqa: TRY300
         except Exception:
             logger.debug(traceback.format_exc())

--- a/ingestion/tests/unit/topology/storage/test_gcs_storage.py
+++ b/ingestion/tests/unit/topology/storage/test_gcs_storage.py
@@ -489,3 +489,51 @@ class StorageUnitTest(TestCase):
     def return_metadata_entry(self):
         container_config = StorageContainerConfig.model_validate(MOCK_METADATA_FILE_RESPONSE)
         return container_config.entries
+
+
+class TestFetchMetric(TestCase):
+    """Unit tests for GcsSource._fetch_metric value-type dispatch."""
+
+    def setUp(self):
+        from metadata.ingestion.source.storage.gcs.metadata import GCSMetric
+
+        self.GCSMetric = GCSMetric
+
+        self.source = Mock(spec=GcsSource)
+        self.source.gcs_clients = Mock()
+
+        # Wire _fetch_metric as the real implementation bound to self.source
+        self.source._fetch_metric = GcsSource._fetch_metric.__get__(
+            self.source, GcsSource
+        )
+        self.source._get_time_interval = Mock(return_value=Mock())
+
+    def _make_timeseries(self, double_value=0.0, int64_value=0):
+        point_value = Mock()
+        point_value.double_value = double_value
+        point_value.int64_value = int64_value
+        point = Mock()
+        point.value = point_value
+        ts = Mock()
+        ts.points = [point]
+        return [ts]
+
+    def test_bucket_size_bytes_uses_double_value(self):
+        self.source.gcs_clients.metrics_client.list_time_series.return_value = (
+            self._make_timeseries(double_value=1234.5, int64_value=0)
+        )
+        bucket = Mock()
+        bucket.name = "my-bucket"
+        bucket.project_id = "my-project"
+        result = self.source._fetch_metric(bucket, self.GCSMetric.BUCKET_SIZE_BYTES)
+        self.assertEqual(result, 1234.5)
+
+    def test_number_of_objects_uses_int64_value(self):
+        self.source.gcs_clients.metrics_client.list_time_series.return_value = (
+            self._make_timeseries(double_value=0.0, int64_value=42)
+        )
+        bucket = Mock()
+        bucket.name = "my-bucket"
+        bucket.project_id = "my-project"
+        result = self.source._fetch_metric(bucket, self.GCSMetric.NUMBER_OF_OBJECTS)
+        self.assertEqual(result, 42)

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
@@ -1845,4 +1845,78 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
           "Glossary reviewer count should match");
     }
   }
+
+  @Test
+  void test_createGlossaryTerm_sameNameUnderDifferentParents_succeeds(TestNamespace ns) {
+    // Regression test: two glossary terms sharing the same leaf name but living under different
+    // parents have distinct FQNs and must both be creatable. Previously the duplicate-name check
+    // on create matched any term with the same name anywhere in the glossary, regardless of
+    // parent, causing the second term ("Loan.Balance") to be rejected as a duplicate of the
+    // already-persisted "Account.Balance".
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    CreateGlossary createGlossary = createMinimalRequest(ns);
+    Glossary glossary = createEntity(createGlossary);
+    String glossaryFqn = glossary.getFullyQualifiedName();
+
+    GlossaryTerm account =
+        client
+            .glossaryTerms()
+            .create(
+                new CreateGlossaryTerm()
+                    .withName(ns.prefix("account"))
+                    .withGlossary(glossaryFqn)
+                    .withDescription("Account parent term"));
+    GlossaryTerm loan =
+        client
+            .glossaryTerms()
+            .create(
+                new CreateGlossaryTerm()
+                    .withName(ns.prefix("loan"))
+                    .withGlossary(glossaryFqn)
+                    .withDescription("Loan parent term"));
+
+    GlossaryTerm accountBalance =
+        client
+            .glossaryTerms()
+            .create(
+                new CreateGlossaryTerm()
+                    .withName("Balance")
+                    .withGlossary(glossaryFqn)
+                    .withParent(account.getFullyQualifiedName())
+                    .withDescription("Account balance definition"));
+    assertNotNull(accountBalance, "Account.Balance term should have been created");
+
+    GlossaryTerm loanBalance;
+    try {
+      loanBalance =
+          client
+              .glossaryTerms()
+              .create(
+                  new CreateGlossaryTerm()
+                      .withName("Balance")
+                      .withGlossary(glossaryFqn)
+                      .withParent(loan.getFullyQualifiedName())
+                      .withDescription("Loan balance definition"));
+    } catch (Exception e) {
+      fail(
+          "Creating 'Balance' under a different parent ('"
+              + loan.getFullyQualifiedName()
+              + "') should not be rejected as a duplicate of the existing '"
+              + accountBalance.getFullyQualifiedName()
+              + "': "
+              + e.getMessage());
+      return;
+    }
+
+    assertNotNull(loanBalance, "Loan.Balance term should have been created");
+    assertEquals("Balance", accountBalance.getName());
+    assertEquals("Balance", loanBalance.getName());
+    assertEquals(
+        account.getFullyQualifiedName() + ".Balance",
+        accountBalance.getFullyQualifiedName());
+    assertEquals(
+        loan.getFullyQualifiedName() + ".Balance",
+        loanBalance.getFullyQualifiedName());
+  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDataDAOs.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDataDAOs.java
@@ -378,6 +378,26 @@ public interface EntityDataDAOs {
         @Bind("termName") String termName,
         @Bind("excludeId") String excludeId);
 
+    // Duplicate-name check scoped to direct children of a single parent term (or glossary root),
+    // so that two terms with the same name under different parents are not flagged as duplicates.
+    // The NOT LIKE clause excludes grandchildren and deeper descendants, matching only the
+    // immediate next fqnHash segment.
+    @SqlQuery(
+        "SELECT COUNT(*) FROM glossary_term_entity WHERE fqnHash LIKE :parentHash "
+            + "AND fqnHash NOT LIKE :parentHashNested AND LOWER(name) = LOWER(:termName)")
+    int getGlossaryTermCountIgnoreCaseUnderParent(
+        @BindConcat(
+                value = "parentHash",
+                parts = {":fqnhash", ".%"},
+                hash = true)
+            String fqnhash,
+        @BindConcat(
+                value = "parentHashNested",
+                parts = {":fqnhash", ".%.%"},
+                hash = true)
+            String fqnhashRepeat,
+        @Bind("termName") String termName);
+
     @SqlQuery(
         "SELECT json FROM glossary_term_entity WHERE fqnHash LIKE :glossaryHash AND LOWER(name) = LOWER(:termName)")
     String getGlossaryTermByNameAndGlossaryIgnoreCase(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
@@ -2728,11 +2728,17 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
   }
 
   private void checkDuplicateTerms(GlossaryTerm entity) {
+    // Term names only need to be unique among siblings sharing the same parent (or, for
+    // top-level terms, among the glossary's direct children) since the FQN already
+    // disambiguates terms with the same name under different parents.
+    String parentFqn =
+        entity.getParent() != null
+            ? entity.getParent().getFullyQualifiedName()
+            : entity.getGlossary().getFullyQualifiedName();
     int count =
         daoCollection
             .glossaryTermDAO()
-            .getGlossaryTermCountIgnoreCase(
-                entity.getGlossary().getFullyQualifiedName(), entity.getName());
+            .getGlossaryTermCountIgnoreCaseUnderParent(parentFqn, parentFqn, entity.getName());
     if (count > 0) {
       throw new IllegalArgumentException(
           CatalogExceptionMessage.duplicateGlossaryTerm(


### PR DESCRIPTION
## Why

Cloud Monitoring reports `storage.googleapis.com/storage/total_bytes` as a **DOUBLE**-typed time series, but the ingestion code was unconditionally reading `point.value.int64_value`. Because protobuf `oneof` silently returns the zero-default when the wrong field accessor is used, `size` was always reported as `0` for every GCS bucket.

`object_count` is correctly INT64 and is unaffected.

Fixes #32422

## Changes

**`ingestion/src/metadata/ingestion/source/storage/gcs/metadata.py`**
- In `_fetch_metric()`: branch on `GCSMetric.BUCKET_SIZE_BYTES` to read `point.value.double_value`; all other metrics (currently `NUMBER_OF_OBJECTS`) continue to use `point.value.int64_value`.

**`ingestion/tests/unit/topology/storage/test_gcs_storage.py`**
- Added `TestFetchMetric` with two unit tests:
  - `test_bucket_size_bytes_uses_double_value` — mocks Cloud Monitoring and asserts `double_value` is returned for `BUCKET_SIZE_BYTES`
  - `test_number_of_objects_uses_int64_value` — asserts `int64_value` is returned for `NUMBER_OF_OBJECTS`

## How to test

1. Stand up a GCS ingestion pipeline against a real bucket with non-zero size.
2. After ingestion, verify the container entity's `size` field is non-zero.

Or run the new unit tests:
```
cd ingestion && pytest tests/unit/topology/storage/test_gcs_storage.py::TestFetchMetric -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=59516083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 3/5</h2>

The GCS correction appears sound, but the glossary changes are not safe to merge until CSV parent moves and parent-only duplicate collisions are handled.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**CSV moves create duplicates** <a href="https://github.com/open-metadata/OpenMetadata/pull/32486#discussion_r4063006202">▶</a>
2. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Parent moves bypass uniqueness** <a href="https://github.com/open-metadata/OpenMetadata/pull/32486#discussion_r4063006210">▶</a>

<details open><summary>Summary</summary>

This PR corrects GCS bucket-size extraction by reading Cloud Monitoring's DOUBLE value and also changes glossary-term uniqueness and CSV matching to operate within a direct parent.

- Reads `total_bytes` from `double_value` while retaining `int64_value` for object counts.
- Adds focused unit coverage for both GCS metric value types.
- Allows equal glossary leaf names beneath different parents.
- Adds parent-scoped glossary DAO queries and create-path integration coverage.
- The glossary changes regress CSV parent moves and omit collision validation for parent-only moves.
</details>

<details open><summary>Diagram</summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  CSV[CSV term row] --> FQN[Build target-parent FQN]
  FQN --> Exact{Existing target FQN?}
  Exact -- Yes --> Update[Update matched term]
  Exact -- No --> Parent[Search target parent and name]
  Parent -- Match --> Update
  Parent -- No match --> Create[Create new term]
  Old[Existing term beneath old parent] -. cannot match target-parent search .-> Parent
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(glossary): address reviewer feedback..."](https://github.com/open-metadata/openmetadata/commit/1ec5fe12f679b7d9c0c92baf3a6a1ad3cedf16e6)</sub>

<!-- /greptile_comment -->