### PR TITLE
fix(ui): handle test case picker request errors

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.test.tsx
@@ -23,6 +23,7 @@ import { EntityReference, TestCase } from '../../../generated/tests/testCase';
 import { getAggregateFieldOptions } from '../../../rest/miscAPI';
 import { searchQuery } from '../../../rest/searchAPI';
 import { getListTestCaseBySearch } from '../../../rest/testAPI';
+import { showErrorToast } from '../../../utils/ToastUtils';
 import { AddTestCaseList } from './AddTestCaseList.component';
 import { AddTestCaseModalProps } from './AddTestCaseList.interface';
 
@@ -73,6 +74,10 @@ jest.mock('../../../utils/FqnUtils', () => ({
 }));
 jest.mock('../../../rest/testAPI', () => ({
   getListTestCaseBySearch: jest.fn(),
+}));
+
+jest.mock('../../../utils/ToastUtils', () => ({
+  showErrorToast: jest.fn(),
 }));
 
 jest.mock('../../../rest/searchAPI', () => ({
@@ -284,6 +289,19 @@ describe('AddTestCaseList', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('empty-placeholder')).toBeInTheDocument();
+    });
+  });
+
+  it('handles test case fetch failures without an unhandled rejection', async () => {
+    const fetchError = new Error('Failed to fetch test cases');
+    mockGetListTestCaseBySearch.mockRejectedValueOnce(fetchError);
+
+    await act(async () => {
+      renderWithRouter(mockProps);
+    });
+
+    await waitFor(() => {
+      expect(showErrorToast).toHaveBeenCalledWith(fetchError);
     });
   });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.tsx
@@ -22,6 +22,7 @@ import {
   Typography,
 } from 'antd';
 import type { CheckboxChangeEvent } from 'antd/es/checkbox';
+import { AxiosError } from 'axios';
 import { debounce } from 'lodash';
 import isEmpty from 'lodash/isEmpty';
 import VirtualList from 'rc-virtual-list';
@@ -62,6 +63,7 @@ import { getEntityFQN } from '../../../utils/FeedUtilsPure';
 import { getNameFromFQN } from '../../../utils/FqnUtils';
 import { getEntityDetailsPath } from '../../../utils/RouterUtils';
 import { replacePlus } from '../../../utils/StringUtils';
+import { showErrorToast } from '../../../utils/ToastUtils';
 import Loader from '../../common/Loader/Loader';
 import Searchbar from '../../common/SearchBarComponent/SearchBar.component';
 import { SearchDropdownOption } from '../../SearchDropdown/SearchDropdown.interface';
@@ -328,6 +330,8 @@ export const AddTestCaseList = ({
             : (prevItems) => [...prevItems, ...testCaseResponse.data]
         );
         setPageNumber(page);
+      } catch (error) {
+        showErrorToast(error as AxiosError);
       } finally {
         setIsLoading(false);
       }


### PR DESCRIPTION
## Summary

- handle rejected test case picker requests inside the shared `fetchTestCases` function
- surface the existing error toast without allowing the rejection to reach the browser's global unhandled-rejection handler
- add regression coverage for a failed test case search/list request

Tracking issue: #32516

## Root cause

The production event was triggered when **Select all test cases** was disabled on a test suite ingestion page. The picker loaded the suite's test cases with an empty search term, and the older query composition combined the match-all marker with the suite filter:

```text
* && testSuite.fullyQualifiedName:"<suiteFQN>"
```

`GET /api/v1/dataQuality/testCases/search/list` rejected that query with HTTP 400. `AddTestCaseList` did not handle rejections at either async call site, so the failed request also surfaced through `onunhandledrejection` as the reported `AxiosError`.

The invalid query composition was introduced in [#26293](https://github.com/open-metadata/OpenMetadata/pull/26293) (`7b4eb186f3186adc2ac05186e6fabb7231e7447b`) while implementing [openmetadata-collate#3045](https://github.com/open-metadata/openmetadata-collate/issues/3045). The existing wildcard behavior and the new unconditional `&&` composition combined to create the invalid empty-search request.

Current `main` already contains the broader query correction from [#31142](https://github.com/open-metadata/OpenMetadata/pull/31142) (`22c8f427a2b504bae2f04beff81b43e1e0866492`): empty searches omit `q`, and suite scope is sent through first-class API parameters. This PR closes the remaining UI error-handling gap so a rejected picker request cannot become an unhandled browser error.

## Fix

`fetchTestCases` now catches request failures at the same boundary that owns its loading and result state. The handler displays the standard error toast and absorbs the rejected promise without replacing already-loaded test cases or changing pagination state. This also protects any future caller without requiring it to remember a separate `.catch(...)`.

## Steps to reproduce

1. Open `/test-suites/<suiteFQN>/edit-ingestion/<pipelineFQN>` for a test suite ingestion pipeline.
2. Leave the search field empty and disable **Select all test cases**.
3. In a build with the original regression, observe this request:
   `GET /api/v1/dataQuality/testCases/search/list?q=*%20%26%26%20testSuite.fullyQualifiedName%3A%22<suiteFQN>%22&limit=25&offset=0`.
4. The endpoint responds with HTTP 400, and the rejection reaches the browser's global unhandled-rejection handler.

The remaining error-handling gap on `main` can also be reproduced by making `/dataQuality/testCases/search/list` return any 4xx/5xx response while the picker initially loads or requests another page. Before this change, the request rejection is unhandled; after it, the UI shows the standard error toast and preserves its current list state.

Observed in [Sentry issue 7706798759](https://collate-3b.sentry.io/issues/7706798759/), release `2.0.202609020000`.

## Tests

- verified the new test fails on `main` before the implementation change because the rejection escapes and the error toast is not called
- `jest src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.test.tsx --runInBand --silent` — 46 passed
- ESLint completed with 0 errors for both changed files
- Prettier check passed for both changed files
- formatter round-trip left the diff unchanged
- `git diff --check`
