### PR TITLE
Fixes 32491: return 404 from the incident-status by-id endpoints instead of a 500

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/QueryCostRecordResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/QueryCostRecordResourceIT.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.sdk.exceptions.OpenMetadataException;
+import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.sdk.network.RequestOptions;
+
+/**
+ * {@code GET /v1/queryCostRecord/{id}} resolves the record and then dereferences it to scope its
+ * authorization check at {@code costRecord.getQueryReference().getId()}. Because
+ * {@code EntityTimeSeriesRepository.getById} answers a missing row with {@code null}, an id with no
+ * row used to raise a NullPointerException that the exception mapper rendered as a 500.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+public class QueryCostRecordResourceIT {
+
+  @Test
+  void byIdEndpointReturnsNotFoundForUnknownId() {
+    OpenMetadataException error =
+        assertThrows(
+            OpenMetadataException.class,
+            () ->
+                SdkClients.adminClient()
+                    .getHttpClient()
+                    .executeForString(
+                        HttpMethod.GET,
+                        "/v1/queryCostRecord/" + UUID.randomUUID(),
+                        null,
+                        RequestOptions.builder().build()));
+    assertEquals(
+        404, error.getStatusCode(), "an id with no row must be a 404, not a NullPointerException");
+  }
+}

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/StaleIncidentStatusIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/StaleIncidentStatusIT.java
@@ -13,7 +13,9 @@
 package org.openmetadata.it.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -46,6 +48,7 @@ import org.openmetadata.schema.tests.type.TestCaseStatus;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.ColumnDataType;
 import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.sdk.exceptions.OpenMetadataException;
 import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.network.HttpMethod;
 import org.openmetadata.sdk.network.RequestOptions;
@@ -59,6 +62,10 @@ import org.openmetadata.service.jdbi3.TestCaseResolutionStatusRepository;
  * missing made {@code GET /dataQuality/testCases/testCaseIncidentStatus/stateId/{stateId}} fail with
  * {@code EntityRelationshipNotFoundException}, and deleting the rows left both the relationship and
  * the stale {@code incidentId} on the test case behind.
+ *
+ * <p>The by-id sibling has the same exposure from the other direction: an id with no row at all —
+ * from a stale {@code incidentId}, or from a caller passing a stateId where a record id belongs —
+ * must answer 404 rather than dereferencing a null record into a 500.
  */
 @Execution(ExecutionMode.CONCURRENT)
 @ExtendWith(TestNamespaceExtension.class)
@@ -179,6 +186,50 @@ public class StaleIncidentStatusIT {
     resolutionStatusRepository().deleteById(UUID.randomUUID(), true);
   }
 
+  @Test
+  void byIdEndpointReturnsNotFoundForUnknownId() {
+    OpenMetadataException error =
+        assertThrows(
+            OpenMetadataException.class,
+            () -> SdkClients.adminClient().testCaseResolutionStatuses().get(UUID.randomUUID()));
+    assertEquals(
+        404, error.getStatusCode(), "an id with no row must be a 404, not a NullPointerException");
+  }
+
+  /**
+   * The production trigger: {@code TestCase.incidentId} carries the incident's stateId, so a client
+   * that feeds it to the by-id endpoint always misses the record table.
+   */
+  @Test
+  void byIdEndpointReturnsNotFoundForStateId(TestNamespace ns) throws Exception {
+    Table table = createTable(ns, "byIdState");
+    TestCase testCase = createTestCase(table, "byIdStateCase_" + ns.uniqueShortId());
+    TestCaseResolutionStatus incident = createIncidentRecord(testCase);
+
+    assertNotEquals(
+        incident.getId(), incident.getStateId(), "stateId and record id must be distinct ids");
+    OpenMetadataException error =
+        assertThrows(
+            OpenMetadataException.class,
+            () -> SdkClients.adminClient().testCaseResolutionStatuses().get(incident.getStateId()));
+    assertEquals(404, error.getStatusCode(), "a stateId is not a record id, so it must 404");
+  }
+
+  /** The not-found guard must not swallow a record that does exist. */
+  @Test
+  void byIdEndpointReturnsHealthyRecord(TestNamespace ns) throws Exception {
+    Table table = createTable(ns, "byIdOk");
+    TestCase testCase = createTestCase(table, "byIdOkCase_" + ns.uniqueShortId());
+    TestCaseResolutionStatus incident = createIncidentRecord(testCase);
+
+    TestCaseResolutionStatus fetched =
+        SdkClients.adminClient().testCaseResolutionStatuses().get(incident.getId());
+
+    assertEquals(incident.getId(), fetched.getId());
+    assertNotNull(fetched.getTestCaseReference(), "testCaseReference must be resolved");
+    assertEquals(testCase.getId(), fetched.getTestCaseReference().getId());
+  }
+
   private JsonNode readData(String response) throws Exception {
     assertNotNull(response, "endpoint must not fail");
     JsonNode data = MAPPER.readTree(response).get("data");
@@ -188,6 +239,11 @@ public class StaleIncidentStatusIT {
 
   /** Creates a real incident by ingesting a failing result, and returns its stateId. */
   private UUID createIncident(TestCase testCase) {
+    return createIncidentRecord(testCase).getStateId();
+  }
+
+  /** Creates a real incident by ingesting a failing result, and returns the opened record. */
+  private TestCaseResolutionStatus createIncidentRecord(TestCase testCase) {
     OpenMetadataClient client = SdkClients.adminClient();
     CreateTestCaseResult result =
         new CreateTestCaseResult()
@@ -199,8 +255,9 @@ public class StaleIncidentStatusIT {
     TestCaseResolutionStatus latest =
         resolutionStatusRepository().getLatestRecord(testCase.getFullyQualifiedName());
     assertNotNull(latest, "a failing result should have opened an incident");
+    assertNotNull(latest.getId());
     assertNotNull(latest.getStateId());
-    return latest.getStateId();
+    return latest;
   }
 
   /** Simulates the production corruption: rows survive but lose their parentOf relationship. */

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/StaleIncidentStatusIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/StaleIncidentStatusIT.java
@@ -230,6 +230,41 @@ public class StaleIncidentStatusIT {
     assertEquals(testCase.getId(), fetched.getTestCaseReference().getId());
   }
 
+  /**
+   * The write path shares the same guard, and regressing it would 500 rather than 404 exactly as the
+   * read path did. The record is resolved before the patch is applied, so an empty patch is enough.
+   */
+  @Test
+  void patchByIdReturnsNotFoundForUnknownId() {
+    OpenMetadataException error =
+        assertThrows(
+            OpenMetadataException.class,
+            () ->
+                SdkClients.adminClient()
+                    .testCaseResolutionStatuses()
+                    .patch(UUID.randomUUID(), MAPPER.createArrayNode()));
+    assertEquals(
+        404, error.getStatusCode(), "an id with no row must be a 404, not a NullPointerException");
+  }
+
+  @Test
+  void patchByIdReturnsNotFoundForStateId(TestNamespace ns) throws Exception {
+    Table table = createTable(ns, "patchState");
+    TestCase testCase = createTestCase(table, "patchStateCase_" + ns.uniqueShortId());
+    TestCaseResolutionStatus incident = createIncidentRecord(testCase);
+
+    assertNotEquals(
+        incident.getId(), incident.getStateId(), "stateId and record id must be distinct ids");
+    OpenMetadataException error =
+        assertThrows(
+            OpenMetadataException.class,
+            () ->
+                SdkClients.adminClient()
+                    .testCaseResolutionStatuses()
+                    .patch(incident.getStateId(), MAPPER.createArrayNode()));
+    assertEquals(404, error.getStatusCode(), "a stateId is not a record id, so it must 404");
+  }
+
   private JsonNode readData(String response) throws Exception {
     assertNotNull(response, "endpoint must not fail");
     JsonNode data = MAPPER.readTree(response).get("data");

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesRepository.java
@@ -30,6 +30,7 @@ import org.openmetadata.schema.type.Relationship;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.service.Entity;
+import org.openmetadata.service.exception.CatalogExceptionMessage;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.search.SearchAggregation;
 import org.openmetadata.service.search.SearchAggregationNode;
@@ -382,6 +383,21 @@ public abstract class EntityTimeSeriesRepository<T extends EntityTimeSeriesInter
     }
     T entityRecord = JsonUtils.readValue(jsonRecord, entityClass);
     setInheritedFields(entityRecord);
+    return entityRecord;
+  }
+
+  /**
+   * {@link #getById} answers a missing row with {@code null}, which a resource that has to
+   * dereference the record — to authorize against the entity it belongs to, say — turns into a
+   * NullPointerException and a 500. Callers that want the read to fail rather than degrade should
+   * use this instead, so the miss surfaces as a 404.
+   */
+  public T getByIdOrNotFound(UUID id) {
+    T entityRecord = getById(id);
+    if (entityRecord == null) {
+      throw EntityNotFoundException.byMessage(
+          CatalogExceptionMessage.entityNotFound(entityType, id));
+    }
     return entityRecord;
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResolutionStatusResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResolutionStatusResource.java
@@ -387,7 +387,10 @@ public class TestCaseResolutionStatusResource
             content =
                 @Content(
                     mediaType = "application/json",
-                    schema = @Schema(implementation = TestCaseResolutionStatus.class)))
+                    schema = @Schema(implementation = TestCaseResolutionStatus.class))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Test case failure status for instance {id} is not found")
       })
   public TestCaseResolutionStatus get(
       @Context SecurityContext securityContext,
@@ -395,7 +398,7 @@ public class TestCaseResolutionStatusResource
           @PathParam("id")
           UUID testCaseResolutionStatusId) {
     TestCaseResolutionStatus testCaseResolutionStatus =
-        repository.getById(testCaseResolutionStatusId);
+        getResolutionStatusOrThrow(testCaseResolutionStatusId);
     TestCase testCase =
         Entity.getEntityByName(
             Entity.TEST_CASE,
@@ -615,7 +618,7 @@ public class TestCaseResolutionStatusResource
                       }))
           JsonPatch patch) {
 
-    TestCaseResolutionStatus testCaseResolutionStatus = repository.getById(id);
+    TestCaseResolutionStatus testCaseResolutionStatus = getResolutionStatusOrThrow(id);
     TestCase testCase =
         Entity.getEntityByName(
             Entity.TEST_CASE,
@@ -823,6 +826,22 @@ public class TestCaseResolutionStatusResource
       resourceContext = TestCaseResourceContext.builder().build();
     }
     return resourceContext;
+  }
+
+  /**
+   * {@link org.openmetadata.service.jdbi3.EntityTimeSeriesRepository#getById} answers a missing row
+   * with {@code null}, and both the read and the patch handler have to dereference the record to
+   * resolve the test case the authorization check is scoped to. Resolve it here so an id with no row
+   * — a stale {@code incidentId}, or a stateId passed where a record id belongs — is a 404 rather
+   * than a NullPointerException mapped to a 500.
+   */
+  private TestCaseResolutionStatus getResolutionStatusOrThrow(UUID id) {
+    TestCaseResolutionStatus testCaseResolutionStatus = repository.getById(id);
+    if (testCaseResolutionStatus == null) {
+      throw EntityNotFoundException.byMessage(
+          CatalogExceptionMessage.entityNotFound(Entity.TEST_CASE_RESOLUTION_STATUS, id));
+    }
+    return testCaseResolutionStatus;
   }
 
   protected static List<AuthRequest> buildViewAuthRequests(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResolutionStatusResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResolutionStatusResource.java
@@ -398,7 +398,7 @@ public class TestCaseResolutionStatusResource
           @PathParam("id")
           UUID testCaseResolutionStatusId) {
     TestCaseResolutionStatus testCaseResolutionStatus =
-        getResolutionStatusOrThrow(testCaseResolutionStatusId);
+        repository.getByIdOrNotFound(testCaseResolutionStatusId);
     TestCase testCase =
         Entity.getEntityByName(
             Entity.TEST_CASE,
@@ -618,7 +618,7 @@ public class TestCaseResolutionStatusResource
                       }))
           JsonPatch patch) {
 
-    TestCaseResolutionStatus testCaseResolutionStatus = getResolutionStatusOrThrow(id);
+    TestCaseResolutionStatus testCaseResolutionStatus = repository.getByIdOrNotFound(id);
     TestCase testCase =
         Entity.getEntityByName(
             Entity.TEST_CASE,
@@ -826,22 +826,6 @@ public class TestCaseResolutionStatusResource
       resourceContext = TestCaseResourceContext.builder().build();
     }
     return resourceContext;
-  }
-
-  /**
-   * {@link org.openmetadata.service.jdbi3.EntityTimeSeriesRepository#getById} answers a missing row
-   * with {@code null}, and both the read and the patch handler have to dereference the record to
-   * resolve the test case the authorization check is scoped to. Resolve it here so an id with no row
-   * — a stale {@code incidentId}, or a stateId passed where a record id belongs — is a 404 rather
-   * than a NullPointerException mapped to a 500.
-   */
-  private TestCaseResolutionStatus getResolutionStatusOrThrow(UUID id) {
-    TestCaseResolutionStatus testCaseResolutionStatus = repository.getById(id);
-    if (testCaseResolutionStatus == null) {
-      throw EntityNotFoundException.byMessage(
-          CatalogExceptionMessage.entityNotFound(Entity.TEST_CASE_RESOLUTION_STATUS, id));
-    }
-    return testCaseResolutionStatus;
   }
 
   protected static List<AuthRequest> buildViewAuthRequests(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/query/QueryCostResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/query/QueryCostResource.java
@@ -65,14 +65,17 @@ public class QueryCostResource
             content =
                 @Content(
                     mediaType = "application/json",
-                    schema = @Schema(implementation = QueryCostRecord.class)))
+                    schema = @Schema(implementation = QueryCostRecord.class))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Query cost record for instance {id} is not found")
       })
   public QueryCostRecord get(
       @Context SecurityContext securityContext,
       @Parameter(description = "Get query cost record by id", schema = @Schema(type = "UUID"))
           @PathParam("id")
-          UUID testCaseResolutionStatusId) {
-    QueryCostRecord costRecord = repository.getById(testCaseResolutionStatusId);
+          UUID id) {
+    QueryCostRecord costRecord = repository.getByIdOrNotFound(id);
     OperationContext queryCostOperationContext =
         new OperationContext(Entity.QUERY, MetadataOperation.VIEW_ALL);
     ResourceContextInterface queryResourceContext =


### PR DESCRIPTION
### Describe your changes:

Fixes #32491

`EntityTimeSeriesRepository.getById` answers a missing row with `null`. Both the read and the patch handler on `TestCaseResolutionStatusResource` dereference that record to resolve the test case their authorization check is scoped to, so an id with no row threw a `NullPointerException` that the exception mapper rendered as a 500:

```
Cannot invoke "org.openmetadata.schema.tests.type.TestCaseResolutionStatus.getTestCaseReference()"
because "testCaseResolutionStatus" is null
```

The null is the record itself, not the reference — `setInheritedFields` is never reached, because `getById` returns at its `jsonRecord == null` guard.

The dereference arrived with #23448, which replaced the static `authorize` call with a data-driven one; before that the handler was `return repository.getById(id);` and a missing row was simply an empty body.

Callers reach it easily because two different ids are in play on this resource — the record id on `/{id}`, and the incident `stateId` on `/stateId/{stateId}`. `TestCase.incidentId` carries the **stateId** (`TestCaseResolutionStatusRepository.getOngoingIncidentStateId` returns `latest.getStateId()`, and `TestCaseIndex` stamps that into the `incidentId` search field), so a client that feeds `incidentId` to the by-id endpoint misses the record table every time. A stale `incidentId` left behind by a deleted incident does the same.

Both handlers now resolve the record through `EntityTimeSeriesRepository.getByIdOrNotFound`, and the operation documents its 404 so the generated spec matches.

The guard lives on the repository rather than in this resource because that is the layer producing the `null`, and it can build the message from its own `entityType` via `CatalogExceptionMessage`. It was otherwise going to be the third variant of the same check in the tree — `EntityTimeSeriesRepository.patch` throws inline with a hand-built message, `AttachmentResource.getAssetById` returns `Response.status(NOT_FOUND)`. `QueryCostResource.get` had the identical unguarded dereference (`repository.getById(...)` then `costRecord.getQueryReference().getId()`) — visibly copied from this handler, down to the `testCaseResolutionStatusId` path-param name — so it now calls the same guard. Its path-param variable is renamed to `id`; the wire contract is unaffected because the `@PathParam` value was already `"id"`.

`getById` keeps returning `null` — eight other resources call it and some callers depend on that, so the throwing variant is additive.

The **repository's** `EntityTimeSeriesRepository.patch` method deliberately keeps its own inline check rather than routing through `getByIdOrNotFound`: it reads the raw JSON and skips `setInheritedFields`, so going through `getById` would populate `testCaseReference` on the original and change what the patch diff sees. Same-looking guard, different contract.

To be unambiguous, since "patch" names two different things here: the **PATCH handler** on this resource *is* changed, and is covered by tests below. `EntityTimeSeriesRepository.patch` is not.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- A caller requesting an incident-status id that has no row gets 404, not 500
- A caller passing a `stateId` where a record id belongs (the production trigger, e.g. from `TestCase.incidentId`) gets 404
- A caller requesting a real incident-status record still gets it back with its `testCaseReference` resolved
- The same on `GET /v1/queryCostRecord/{id}`, which had the identical unguarded dereference

#### Unit tests
Not applicable — the change is a null guard on a JAX-RS handler whose behaviour is only observable as an HTTP status code, so it is covered by integration tests rather than a mocked unit test.

#### Backend integration tests
- [x] I added integration tests in `openmetadata-integration-tests/` for the changed API endpoints.
- Files updated: `openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/StaleIncidentStatusIT.java`
  - `byIdEndpointReturnsNotFoundForUnknownId`
  - `byIdEndpointReturnsNotFoundForStateId`
  - `byIdEndpointReturnsHealthyRecord`
  - `patchByIdReturnsNotFoundForUnknownId`
  - `patchByIdReturnsNotFoundForStateId`

- File added: `openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/QueryCostRecordResourceIT.java`
  - `byIdEndpointReturnsNotFoundForUnknownId`

The incident-status cases live in `StaleIncidentStatusIT` because it already covers stale incident state on the sibling `stateId` endpoint. Query cost gets its own file since none existed.

**Red/green evidence.** With the fix backed out and the tests unchanged:

```
Tests run: 3, Failures: 2, Errors: 0, Skipped: 0   # GET
byIdEndpointReturnsNotFoundForUnknownId
  ==> an id with no row must be a 404, not a NullPointerException: expected: <404> but was: <500>
byIdEndpointReturnsNotFoundForStateId
  ==> a stateId is not a record id, so it must 404: expected: <404> but was: <500>
```

`byIdEndpointReturnsHealthyRecord` passed in that run, so the two failures are the guard rather than the harness. With the fix restored:

The PATCH pair was red-checked the same way, by removing the guard from the PATCH handler alone:

```
Tests run: 2, Failures: 2, Errors: 0, Skipped: 0   # PATCH
patchByIdReturnsNotFoundForUnknownId  ==> expected: <404> but was: <500>
patchByIdReturnsNotFoundForStateId    ==> expected: <404> but was: <500>
```

With the guard in place:

```
Tests run: 10, Failures: 0, Errors: 0, Skipped: 0 -- StaleIncidentStatusIT
BUILD SUCCESS
```

The query-cost case was red-checked the same way — with the guard removed from that handler alone, `expected: <404> but was: <500>`.

Both classes together, with every guard in place:

```
Tests run: 11, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

(11 = 5 pre-existing + 5 new incident-status + 1 new query-cost. Run with `-DsearchType=opensearch`.)

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Covered by the integration tests above, which drive the real endpoint through the SDK client against a testcontainers-backed stack (Postgres + OpenSearch) and assert on the HTTP status code — the same thing a manual `curl` would check.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable, no schema changes.
- [x] For UI changes: not applicable, no UI changes.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

Bug fix
- [x] I have added a test that covers the exact scenario we are fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013D3LpP12bP6RBF2tFo5Rmn


