### PR TITLE
fix(ui-core): columnheader loses its accessible name to the Group wrapper

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/table/table.test.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/table/table.test.tsx
@@ -41,6 +41,24 @@ const renderTable = (props: Partial<Parameters<typeof Table>[0]> = {}) =>
 const firstCell = () =>
   screen.getAllByRole('row')[1].querySelector('td, th') as HTMLElement;
 
+describe('Table header accessibility', () => {
+  it('names the columnheader from its title content', () => {
+    renderTable();
+
+    // The header content wrapper must stay a plain div: a role="group"
+    // wrapper makes Chromium compute an empty accessible name for the
+    // columnheader, breaking getByRole('columnheader', { name }).
+    expect(
+      screen.getByRole('columnheader', { name: 'Name' })
+    ).toBeInTheDocument();
+    expect(
+      screen
+        .getByRole('columnheader', { name: 'Name' })
+        .querySelector('[role="group"]')
+    ).toBeNull();
+  });
+});
+
 describe('Table sizes', () => {
   it('applies the compact scale', () => {
     renderTable({ size: 'compact' });

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/table/table.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/table/table.tsx
@@ -28,7 +28,6 @@ import {
   Cell as AriaCell,
   Collection as AriaCollection,
   Column as AriaColumn,
-  Group as AriaGroup,
   Row as AriaRow,
   Table as AriaTable,
   TableBody as AriaTableBody,
@@ -359,7 +358,10 @@ const TableHead = ({
         )
       }>
       {(state) => (
-        <AriaGroup className="tw:flex tw:items-center tw:gap-1">
+        // Layout only — a real Group (role="group") here makes Chromium
+        // compute an EMPTY accessible name for the columnheader, breaking
+        // every getByRole('columnheader', { name }) locator.
+        <div className="tw:flex tw:items-center tw:gap-1">
           <div className="tw:flex tw:items-center tw:gap-1">
             {label && (
               <span className="tw:text-xs tw:font-semibold tw:whitespace-nowrap tw:text-quaternary">
@@ -392,7 +394,7 @@ const TableHead = ({
                 strokeWidth={3}
               />
             ))}
-        </AriaGroup>
+        </div>
       )}
     </AriaColumn>
   );


### PR DESCRIPTION
## What
`TableHead` wraps all header content in a react-aria `Group`. Chromium computes an **empty accessible name** for a columnheader whose content sits inside `role="group"` — ARIA snapshots show `columnheader → group → "Entities"` with no name. Every `getByRole('columnheader', { name })` locator then misses, and header interactions (sort/filter clicks) in Playwright hang to test timeout on all tables built on this component (both the OSS tag-filter suite on migrated tables and Collate's AskCollate panel table hit this).

## How
The wrapper is layout-only — replace `Group` with a plain `div` (same classes). Name-from-content is restored; a regression test pins the columnheader's accessible name and the absence of a `role=group` wrapper.

## Testing
- `table.test.tsx`: new `Table header accessibility` spec passes; suite otherwise unchanged (the `full-width synthetic row` failure reproduces on plain `main` and is unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)