### PR TITLE
Fixes #28077: [SNOWFLAKE INGESTION METADATA] Duplicate column case

### DIFF
--- a/ingestion/src/metadata/profiler/orm/converter/base.py
+++ b/ingestion/src/metadata/profiler/orm/converter/base.py
@@ -14,6 +14,7 @@ Converter logic to transform an OpenMetadata Table Entity
 to an SQLAlchemy ORM class.
 """
 
+from collections import Counter
 from typing import cast
 
 import sqlalchemy
@@ -71,7 +72,9 @@ def check_if_should_quote_column_name(table_service_type) -> bool | None:
     return None
 
 
-def build_orm_col(idx: int, col: Column, table_service_type, *, _quote=None) -> sqlalchemy.Column:
+def build_orm_col(
+    idx: int, col: Column, table_service_type, *, _quote=None, key: str | None = None
+) -> sqlalchemy.Column:
     """
     Cook the ORM column from our metadata instance
     information.
@@ -95,8 +98,29 @@ def build_orm_col(idx: int, col: Column, table_service_type, *, _quote=None) -> 
         type_=converter_registry[table_service_type]().map_types(col, table_service_type),
         primary_key=not bool(idx),  # The first col seen is used as PK
         quote=quote,
-        key=str(col.name.root).lower(),  # Add lowercase column name as key for snowflake case sensitive columns
+        # Add lowercase column name as key for snowflake case sensitive columns
+        key=key or str(col.name.root).lower(),
     )
+
+
+def build_orm_col_keys(columns: list[Column]) -> list[str]:
+    """Compute the SQLAlchemy `key` of each column, keeping them unique.
+
+    SQLAlchemy indexes the column collection of a table by `key`, which we lowercase
+    to handle case sensitive columns. Sources such as Snowflake allow columns that
+    only differ in their casing (e.g. `"Hotel_region"` and `HOTEL_REGION`), whose
+    lowercase keys would collide: only one of them would end up in the ORM table and
+    the mapper would fail with `column ... is not represented in the mapper's table`.
+
+    For those columns we keep the original name as the key so that all of them are
+    mapped and can be profiled or tested.
+    """
+    lowercase_count = Counter(str(col.name.root).lower() for col in columns)
+
+    return [
+        str(col.name.root).lower() if lowercase_count[str(col.name.root).lower()] == 1 else str(col.name.root)
+        for col in columns
+    ]
 
 
 def ometa_to_sqa_orm(
@@ -138,9 +162,10 @@ def ometa_to_sqa_orm(
     )
     orm_name = f"{orm_database_name}_{orm_schema_name}_{table.name.root}".replace(".", "_")
 
+    col_keys = build_orm_col_keys(table.columns)
     cols = {
         (col.name.root + "_" if col.name.root in SQA_RESERVED_ATTRIBUTES else col.name.root): build_orm_col(
-            idx, col, table.serviceType
+            idx, col, table.serviceType, key=col_keys[idx]
         )
         for idx, col in enumerate(table.columns)
     }

--- a/ingestion/tests/unit/observability/profiler/test_converter.py
+++ b/ingestion/tests/unit/observability/profiler/test_converter.py
@@ -87,6 +87,39 @@ def test_snowflake_case_sensitive_orm(mock_schema, mock_database, column_definit
         assert hasattr(orm_table, name)
 
 
+@patch("metadata.profiler.orm.converter.base.get_orm_schema", return_value="schema")
+@patch("metadata.profiler.orm.converter.base.get_orm_database", return_value="database")
+def test_columns_differing_only_in_case(mock_schema, mock_database):
+    """Snowflake allows columns that only differ in their casing. We lowercase the
+    SQA column key, so such columns used to collide and get dropped from the ORM
+    table, making the mapper fail with `column ... is not represented in the
+    mapper's table`.
+    """
+    column_definition = [
+        ("id_hotel", DataType.STRING),
+        ("Hotel_region", DataType.STRING),
+        ("HOTEL_REGION", DataType.STRING),
+    ]
+
+    columns = [Column(name=name, dataType=data_type) for name, data_type in column_definition]
+
+    table = Table(
+        id=UUID("1f8c1222-09a0-11ed-871b-ca4e864bb16a"),
+        name="duplicate_case_table",
+        columns=columns,
+        serviceType=DatabaseServiceType.Snowflake,
+    )
+
+    orm_table = ometa_to_sqa_orm(table, None)
+
+    # Both case variants are mapped, and the original names are kept
+    assert [name for name, _ in column_definition] == [col.name for col in orm_table.__table__.columns]
+    # Only the non-ambiguous column can be safely keyed by its lowercase name
+    assert orm_table.__table__.columns.keys() == ["id_hotel", "Hotel_region", "HOTEL_REGION"]
+    for name, _ in column_definition:
+        assert hasattr(orm_table, name)
+
+
 @patch("metadata.profiler.orm.converter.base.get_orm_schema", return_value="lowercase_schema")
 @patch("metadata.profiler.orm.converter.base.get_orm_database", return_value="DATABASE")
 def test_snowflake_lowercase_schema_is_quoted(mock_schema, mock_database):


### PR DESCRIPTION
> **This pull request was opened by an olivaw agent.** It is an input to review, not an approved change — read the diff, not this description.
>
> Fixes #28077

## What olivaw checked (machine-observed, §8.2/A.1)

- diff: non-empty
- build: not_run
- tests: not_run
- base: `77cae1608394c14e81054e8f6aab9c2a3e1eb999`
- head: `66827ec5ef5c10a355dc3290cab501d1add4e33b`

**No build or test command is configured for this workspace**, so only the diff's existence was checked. Set `run_config.build_cmd`/`test_cmd` to have olivaw verify its own work.

## What the agent says it did (unverified)

> Committed on `agent/issue-28077`.
> 
> ## Root cause
> 
> `ometa_to_sqa_orm` builds a declarative SQLAlchemy class from the OM table entity, and `build_orm_col` set every column's SQA `key` to the **lowercased** name (`ingestion/src/metadata/profiler/orm/converter/base.py:98`). SQLAlchemy indexes a table's column collection by `key`, so a Snowflake table containing both `"Hotel_region"` and `HOTEL_REGION` produced two columns with the key `hotel_region` — the second one evicted the first from `__table__.c`, and mapper configuration then blew up with exactly the error in the screenshot:
> 
> ```
> When configuring property 'Hotel_region' on ... column '<table>.Hotel_region' is not
> represented in the mapper's table. Use the `column_property()` function ...
> ```
> 
> Because the ORM class is built for the whole table, this killed *any* test on that table, not just tests on the duplicated column — matching the report.
> 
> ## Fix
> 
> `build_orm_col_keys` computes the keys for all columns at once: a column keeps the lowercase key only when its lowercase name is unambiguous; when two columns collide case-insensitively, each keeps its original (already unique) name as the key. `build_orm_col` takes an optional `key` and otherwise behaves as before, so the existing callers (Athena, Databricks, tableDiff) are untouched.
> 
> ## Verification
> 
> The repo has no Python env, so I generated the pydantic models (`scripts/datamodel_generation.py` + `make py_antlr`), installed the deps needed by the converter, and stubbed the unbuildable `data_diff` transitive dep.
> 
> - New test `test_columns_differing_only_in_case` in `ingestion/tests/unit/observability/profiler/test_converter.py` fails on the pre-fix code with the exact `ArgumentError` above and passes with the fix.
> - `tests/unit/observability/profiler/test_converter.py`: 10 passed.
> - Wider `tests/unit/observability/profiler` + `tests/unit/sampler`: 533 passed, 6 failed — all six are `ModuleNotFoundError` for optional connector packages (bigquery, teradata driver, `confluent_kafka`), unrelated to this change; the remaining collection errors are the same missing-dependency kind.
> - `ruff check` / `ruff format` clean.
