### PR TITLE
test(playwright): reopen dropdowns that close before the option is clicked

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts
@@ -1511,15 +1511,22 @@ test.describe(
           const pageSizeDropdown = page.getByTestId(
             'page-size-selection-dropdown'
           );
-          const pageSizeMenu = page.locator(
-            '.ant-dropdown:not(.ant-dropdown-hidden) .ant-dropdown-menu'
-          );
+          const pageSizeMenu = page
+            .getByRole('menu')
+            .filter({ hasText: '/ Page' });
 
           await expect(pageSizeDropdown).toBeVisible();
-          // NextPrevious inherits Ant Dropdown's hover trigger; clicking this
-          // button only runs its preventDefault handler and may not open the menu.
-          await pageSizeDropdown.hover();
-          await expect(pageSizeMenu).toBeVisible();
+
+          // Ant Dropdown opens on hover, so a re-render that shifts the footer out
+          // from under the pointer leaves the menu closed for good.
+          await expect(async () => {
+            await pageSizeDropdown.hover();
+            if (!(await pageSizeMenu.isVisible())) {
+              await pageSizeDropdown.click();
+            }
+            await expect(pageSizeMenu).toBeVisible({ timeout: 2_000 });
+          }).toPass({ timeout: 15_000, intervals: [500, 1_000, 2_000] });
+
           await expect(pageSizeMenu.getByRole('menuitem')).toHaveCount(3);
         });
       } finally {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestLibrary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestLibrary.spec.ts
@@ -764,13 +764,26 @@ test.describe(
 
         // Add a DQ Dimension — verifies that editing a test definition with existing
         // parameters does not prevent the dimension from being saved correctly.
-        await page.getByTestId('data-quality-dimension').click();
+        const dimensionField = page.getByTestId('data-quality-dimension');
         const accuracyOption = page.getByRole('option', {
           name: 'Accuracy',
           exact: true,
         });
-        await expect(accuracyOption).toBeVisible();
-        await accuracyOption.click();
+
+        // The listbox is a non-modal React Aria popover, so it is dismissed by any
+        // scroll of the pane holding the trigger — including the one Playwright
+        // emits to bring this field into view, delivered a frame after the popup
+        // opened. Reopen on each attempt; nothing else reopens it.
+        await expect(async () => {
+          if (!(await accuracyOption.isVisible())) {
+            await dimensionField.getByRole('button').click();
+            await expect(accuracyOption).toBeVisible({ timeout: 2_000 });
+          }
+          await selectOptionWithMouse(page, accuracyOption);
+          await expect(dimensionField).toContainText('Accuracy', {
+            timeout: 2_000,
+          });
+        }).toPass({ timeout: 20_000, intervals: [500, 1_000, 2_000] });
 
         // Save without providing parameter dataType or description — both are optional.
         const patchResponse = page.waitForResponse(


### PR DESCRIPTION
## Describe your changes

Fixes two Data Quality E2E failures where a dropdown was opened in a single un-retried step and the test then hung to its timeout when the dropdown closed underneath it.

### 1. `TestLibrary.spec.ts` — "external test definitions with read-only fields"

Failing on the `Accuracy` option of the **DQ Dimension** select:

```
Error: locator.click: Test timeout of 60000ms exceeded.
  - waiting for getByRole('option', { name: 'Accuracy', exact: true })
    - locator resolved to <div role="option" data-key="Accuracy" ...>
    - element is not stable
  - element was detached from the DOM, retrying
```

#32283 hardened the two selects in the **create** step with `selectOptionWithMouse`, but this one in the **edit** step was left as-is — and it is the one failing in CI.

Root cause, reproduced and measured against a local stack: the listbox is a **non-modal** React Aria popover (`isNonModal` on the shared `Popover`), and react-aria only arms `useCloseOnScroll` for non-modal popovers. That listener closes the popover on **any** scroll event whose target contains the trigger — including the scroll Playwright emits to bring a field below the fold into view, which is delivered a frame *after* the popup opened.

Instrumented event log at the moment of failure:

```
t=1310  react-aria focuses the listbox — popover is open
t=1316  scroll on DIV.drawer-form-content   ← the pane that CONTAINS the trigger
t=1322  popover data-exiting="true"          ← closed, 6 ms later
```

Direct causality test — open the dropdown with all scrolling settled, then nudge one pane by exactly 1 pixel:

| Nudge | Contains the trigger? | Result |
|---|---|---|
| `.drawer-doc-panel` 1207 → 1208 | no | stays open |
| `.drawer-form-content` 454 → 455 | **yes** | **closes** |

`expect(option).toBeVisible()` still passes during the close animation, and the `click()` that follows waits on a node that is already detached — with nothing to reopen the list, so the test burns its whole timeout. The fix reopens and re-resolves on each attempt.

### 2. `DataQuality.spec.ts` — "Pagination functionality in test cases list"

```
Locator: .ant-dropdown:not(.ant-dropdown-hidden) .ant-dropdown-menu
Error: element(s) not found
```

Failed **3/3 attempts on two separate runs** — not flaky. `NextPrevious` wraps the page-size button in an Ant `Dropdown`, which opens on **hover**, so the menu is only open while the pointer stays on the button. The failure screenshots show the test-cases list scrolled with the pagination footer off-screen: the hover landed, the rows re-rendered, the footer moved out from under the pointer, and the menu never opened.

Applies the hover-then-click retry already used for this same control in `playwright/utils/common.ts`, and moves the menu off Ant Design class selectors onto role-based locators (better through the antd → core-components migration).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

Test-only change; verified against a local stack (no product code touched).

| | Before | After |
|---|---|---|
| TestLibrary "read-only fields" | **2/10 failed** with the CI signature | 6/6 passed |
| DataQuality page-size open | n/a | verified by neutralising the `hover()` so **only** the click fallback could open the menu — passes, proving both the fallback and the new role-based locator |

The DataQuality test passes locally either way (the local list does not re-render the way CI's does), so a green run there would prove nothing — hence the forced-fallback verification instead.

## Notes for reviewers

There is a **product bug** behind the first failure that this PR does *not* fix: any core-components `Select` inside a scrollable pane loses its listbox if that pane scrolls, so a user who scrolls and clicks a dropdown in the same moment sees it flash open and shut.

The one-line fix — dropping `isNonModal` from `openmetadata-ui-core-components/.../base/select/popover.tsx` — is **not safe**: the comment there records that modal popovers leave `aria-hidden` on the whole app when the popover unmounts abruptly. react-aria exposes no way to keep non-modal *and* disable close-on-scroll, so this needs an owner decision. Happy to open a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)