### PR TITLE
Backport #32313 to 2.0: preserve math equations through frontend and backend sanitizers

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/DescriptionSanitizer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/DescriptionSanitizer.java
@@ -131,6 +131,19 @@ public final class DescriptionSanitizer {
           .allowElements("details", "summary")
           // Definition lists
           .allowElements("dl", "dt", "dd")
+          // Math equation node (BlockEditor MathEquation extension)
+          .allowElements("block-math-equation")
+          .allowAttributes("math_equation")
+          .onElements("block-math-equation")
+          .allowAttributes("isediting")
+          .matching(
+              (elementName, attributeName, value) -> {
+                if ("true".equals(value) || "false".equals(value)) {
+                  return value;
+                }
+                return null;
+              })
+          .onElements("block-math-equation")
           .toFactory();
 
   private static final Pattern ENTITY_LINK_PATTERN = Pattern.compile("<#E::[^<>]+>");

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/DescriptionSanitizerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/DescriptionSanitizerTest.java
@@ -258,6 +258,27 @@ class DescriptionSanitizerTest {
   }
 
   @Test
+  void mathEquationElementIsPreserved() {
+    String input =
+        "<block-math-equation math_equation=\"$x^2 + y^2 = z^2$\" isediting=\"false\"></block-math-equation>";
+    String result = DescriptionSanitizer.sanitize(input);
+
+    assertTrue(result.contains("<block-math-equation"));
+    assertTrue(result.contains("math_equation="));
+    assertTrue(result.contains("isediting=\"false\""));
+  }
+
+  @Test
+  void mathEquationIsEditingRejectsNonBoolean() {
+    String input =
+        "<block-math-equation math_equation=\"x\" isediting=\"onclick=alert(1)\"></block-math-equation>";
+    String result = DescriptionSanitizer.sanitize(input);
+
+    assertTrue(result.contains("<block-math-equation"));
+    assertFalse(result.contains("onclick"));
+  }
+
+  @Test
   void entityMentionAttributesOnAnchorArePreservedForMention() {
     String input =
         "<a data-type=\"mention\" data-id=\"u1\" data-label=\"admin\""

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BlockEditorMathEquations.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BlockEditorMathEquations.spec.ts
@@ -1,0 +1,88 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { expect } from '@playwright/test';
+import { TableClass } from '../../support/entity/TableClass';
+import {
+  createNewPage,
+  descriptionBox,
+  redirectToHomePage,
+} from '../../utils/common';
+import { test } from '../fixtures/pages';
+
+let table: TableClass;
+
+test.use({ storageState: 'playwright/.auth/admin.json' });
+
+test.beforeAll(async ({ browser }) => {
+  const { apiContext, afterAction } = await createNewPage(browser);
+  table = new TableClass();
+  await table.create(apiContext);
+  await afterAction();
+});
+
+test.afterAll(async ({ browser }) => {
+  const { apiContext, afterAction } = await createNewPage(browser);
+  await table.delete(apiContext);
+  await afterAction();
+});
+
+test.beforeEach(async ({ page }) => {
+  await redirectToHomePage(page);
+  await table.visitEntityPage(page);
+});
+
+test.describe('BlockEditor math equations', { tag: ['@Discovery'] }, () => {
+  test('math equation inserted with $$ syntax persists after save and reload', async ({
+    page,
+  }) => {
+    await page.getByTestId('edit-description').click();
+
+    // Scope editor to the modal — the editor opens in [role="dialog"].description-markdown-editor,
+    // NOT inside asset-description-container (that's the view-only container)
+    const editor = page
+      .locator('[role="dialog"].description-markdown-editor')
+      .locator(descriptionBox);
+
+    await expect(editor).toBeVisible();
+    await editor.click();
+
+    // Type the equation — keyboard input is required to trigger the $$ input rule
+    await page.keyboard.type('$$x^2 + y^2 = z^2$$');
+
+    // The input rule should have converted the typed text to a MathEquation node
+    await expect(editor.locator('.block-math-equation')).toBeVisible();
+
+    // Hoist waitForResponse above the click that triggers it (Playwright lint rule)
+    const patchRequest = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'PATCH' && response.status() === 200
+    );
+    await page.getByTestId('save').click();
+    await patchRequest;
+
+    // After save the description container should contain the rendered equation
+    await expect(
+      page
+        .getByTestId('asset-description-container')
+        .locator('.block-math-equation')
+    ).toBeVisible();
+
+    // Reload to verify persistence through the full save→backend→reload round-trip
+    await page.reload();
+    await expect(
+      page
+        .getByTestId('asset-description-container')
+        .locator('.block-math-equation')
+    ).toBeVisible();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/MathEquation/math-equation.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/MathEquation/math-equation.less
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 .math-equation-wrapper {
+  user-select: none;
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
@@ -45,13 +46,9 @@
 }
 
 .react-renderer.node-MathEquation.ProseMirror-selectednode {
-  background-color: black;
   .math-equation-wrapper {
     .edit-button {
-      color: white;
+      opacity: 1;
     }
-  }
-  &.has-focus {
-    color: white;
   }
 }

--- a/openmetadata-ui/src/main/resources/ui/src/utils/sanitize.utils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/sanitize.utils.test.ts
@@ -87,6 +87,38 @@ describe('getSanitizeContent', () => {
     });
   });
 
+  describe('Math equations', () => {
+    it('should preserve a block-math-equation tag', () => {
+      const input =
+        '<block-math-equation math_equation="x^2"></block-math-equation>';
+      const result = getSanitizeContent(input);
+
+      expect(result).toBe(input);
+    });
+
+    it('should preserve math equations mixed with HTML content', () => {
+      const input =
+        '<p>Formula</p><block-math-equation math_equation="x^2"></block-math-equation>';
+      const result = getSanitizeContent(input);
+
+      expect(result).toContain(
+        '<block-math-equation math_equation="x^2"></block-math-equation>'
+      );
+      expect(result).toContain('<p>Formula</p>');
+    });
+
+    it('should preserve math equations alongside entity links', () => {
+      const input =
+        '<block-math-equation math_equation="y=mx+b"></block-math-equation><#E::team::Accounting|@Accounting>';
+      const result = getSanitizeContent(input);
+
+      expect(result).toContain(
+        '<block-math-equation math_equation="y=mx+b"></block-math-equation>'
+      );
+      expect(result).toContain('<#E::team::Accounting|@Accounting>');
+    });
+  });
+
   describe('Preserve inline styling and classes', () => {
     it('should preserve span elements with class attributes', () => {
       const input =

--- a/openmetadata-ui/src/main/resources/ui/src/utils/sanitize.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/sanitize.utils.ts
@@ -13,6 +13,10 @@
 import DOMPurify from 'dompurify';
 
 export const getSanitizeContent = (html: string): string => {
+  // Nonce makes placeholders unique per call, preventing collisions if the
+  // user's text itself contains a placeholder-shaped string.
+  const nonce = Math.random().toString(36).slice(2, 10);
+
   // Protect math equations from DOMPurify's unknown-tag stripping
   const mathEquationRegex =
     /<block-math-equation[^>]*>[\s\S]*?<\/block-math-equation>/g;
@@ -22,7 +26,7 @@ export const getSanitizeContent = (html: string): string => {
   const mathProtected = html.replaceAll(mathEquationRegex, (match) => {
     mathEquations.push(match);
 
-    return `__MATH_EQUATION_${mathEquationIndex++}__`;
+    return `__OM_MATH_EQ_${nonce}_${mathEquationIndex++}__`;
   });
 
   // Protect entity links from DOMPurify encoding
@@ -33,21 +37,25 @@ export const getSanitizeContent = (html: string): string => {
   const protectedHtml = mathProtected.replaceAll(entityLinkRegex, (match) => {
     entityLinks.push(match);
 
-    return `__ENTITY_LINK_${entityLinkIndex++}__`;
+    return `__OM_ENTITY_LINK_${nonce}_${entityLinkIndex++}__`;
   });
 
-  // Sanitize the content with standard DOMPurify settings
   const sanitizedContent = DOMPurify.sanitize(protectedHtml);
 
-  // Restore entity links
+  // Restore entity links — use replacer fn so '$' in values is inserted verbatim
   let restoredContent = sanitizedContent;
   entityLinks.forEach((link, index) => {
-    restoredContent = restoredContent.replace(`__ENTITY_LINK_${index}__`, link);
+    restoredContent = restoredContent.replace(
+      `__OM_ENTITY_LINK_${nonce}_${index}__`,
+      () => link
+    );
   });
 
-  // Restore math equations
   mathEquations.forEach((eq, index) => {
-    restoredContent = restoredContent.replace(`__MATH_EQUATION_${index}__`, eq);
+    restoredContent = restoredContent.replace(
+      `__OM_MATH_EQ_${nonce}_${index}__`,
+      () => eq
+    );
   });
 
   return restoredContent;

--- a/openmetadata-ui/src/main/resources/ui/src/utils/sanitize.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/sanitize.utils.ts
@@ -13,12 +13,24 @@
 import DOMPurify from 'dompurify';
 
 export const getSanitizeContent = (html: string): string => {
-  // First, temporarily replace entity links to protect them from encoding
+  // Protect math equations from DOMPurify's unknown-tag stripping
+  const mathEquationRegex =
+    /<block-math-equation[^>]*>[\s\S]*?<\/block-math-equation>/g;
+  const mathEquations: string[] = [];
+  let mathEquationIndex = 0;
+
+  const mathProtected = html.replaceAll(mathEquationRegex, (match) => {
+    mathEquations.push(match);
+
+    return `__MATH_EQUATION_${mathEquationIndex++}__`;
+  });
+
+  // Protect entity links from DOMPurify encoding
   const entityLinkRegex = /<#E::[^>]+>/g;
   const entityLinks: string[] = [];
   let entityLinkIndex = 0;
 
-  const protectedHtml = html.replaceAll(entityLinkRegex, (match) => {
+  const protectedHtml = mathProtected.replaceAll(entityLinkRegex, (match) => {
     entityLinks.push(match);
 
     return `__ENTITY_LINK_${entityLinkIndex++}__`;
@@ -31,6 +43,11 @@ export const getSanitizeContent = (html: string): string => {
   let restoredContent = sanitizedContent;
   entityLinks.forEach((link, index) => {
     restoredContent = restoredContent.replace(`__ENTITY_LINK_${index}__`, link);
+  });
+
+  // Restore math equations
+  mathEquations.forEach((eq, index) => {
+    restoredContent = restoredContent.replace(`__MATH_EQUATION_${index}__`, eq);
   });
 
   return restoredContent;


### PR DESCRIPTION
## Summary

Backport of #32313 (fixes #32276) to the `2.0` release branch.

Math equations (`<block-math-equation>` nodes) inserted via the BlockEditor's `$$...$$` syntax were silently stripped on save due to two independent sanitizer layers:

1. **Frontend (`sanitize.utils.ts`)** — DOMPurify strips unknown HTML tags. Applied the placeholder-protect pattern (with per-call nonce) already used for entity links: stash `<block-math-equation>` tags before sanitizing, restore after.
2. **Backend (`DescriptionSanitizer.java`)** — OWASP HTML sanitizer uses an explicit allowlist. Added `block-math-equation` element with `math_equation` attribute (LaTeX, rendered client-side by KaTeX) and `isediting` restricted to `"true"`/`"false"`.
3. **CSS (`math-equation.less`)** — Fixed selection-state bug where `background-color: black` + `color: white` made KaTeX text invisible when clicked.

## Changes backported

- `DescriptionSanitizer.java` — allow `block-math-equation` through OWASP sanitizer
- `DescriptionSanitizerTest.java` — 2 new test cases
- `sanitize.utils.ts` — nonce-based placeholder protection for math equations
- `sanitize.utils.test.ts` — 3 new Jest cases
- `math-equation.less` — fix selected-node color bug
- `BlockEditorMathEquations.spec.ts` — new Playwright E2E spec (save + reload round-trip)

## Test plan

- [ ] Frontend Jest: `sanitize.utils.test.ts` — 13/13 pass
- [ ] Backend JUnit: `DescriptionSanitizerTest.java` — 28/28 pass
- [ ] Playwright E2E: math equation survives save + page reload

🤖 Generated with [Claude Code](https://claude.ai/claude-code)