### PR TITLE
Fix case-sensitive TestSuite pipelineType in the 1.13.0 sampling migration — Backport 1.13 (#32417)

### DIFF
--- a/bootstrap/sql/migrations/native/1.13.5/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.13.5/mysql/schemaChanges.sql
@@ -1,0 +1,44 @@
+-- Repairs the TestSuite half of the 1.13.0 dynamic-sampling migration.
+-- 1.13.0 matched `pipelineType` against 'testSuite', but the enum value is 'TestSuite'
+-- (ingestionPipeline.json#/definitions/pipelineType). On the default utf8mb4_0900_ai_ci
+-- collation MySQL matched anyway, so most deployments already migrated and these statements
+-- are a no-op. They are replayed here for deployments whose `pipelineType` column carries a
+-- case-sensitive collation (e.g. utf8mb4_bin / utf8mb4_0900_as_cs), where 1.13.0 silently
+-- matched zero rows -- the same failure PostgreSQL hit unconditionally.
+-- Both statements carry the original guards, so replaying them is safe.
+
+-- ingestion_pipeline_entity (TestSuite pipelines): build profileSampleConfig (skip if already migrated)
+UPDATE ingestion_pipeline_entity
+SET json = JSON_SET(
+    json,
+    '$.sourceConfig.config.profileSampleConfig',
+    JSON_OBJECT(
+        'sampleConfigType', 'STATIC',
+        'config', JSON_OBJECT(
+            'profileSample', JSON_EXTRACT(json, '$.sourceConfig.config.profileSample'),
+            'profileSampleType', COALESCE(
+                JSON_EXTRACT(json, '$.sourceConfig.config.profileSampleType'),
+                CAST('"PERCENTAGE"' AS JSON)
+            ),
+            'samplingMethodType', JSON_EXTRACT(json, '$.sourceConfig.config.samplingMethodType')
+        )
+    )
+)
+WHERE pipelineType = 'TestSuite'
+  AND JSON_EXTRACT(json, '$.sourceConfig.config.profileSample') IS NOT NULL
+  AND JSON_TYPE(JSON_EXTRACT(json, '$.sourceConfig.config.profileSample')) != 'NULL'
+  AND NOT JSON_CONTAINS_PATH(json, 'one', '$.sourceConfig.config.profileSampleConfig');
+
+-- ingestion_pipeline_entity (TestSuite pipelines): remove old flat fields
+UPDATE ingestion_pipeline_entity
+SET json = JSON_REMOVE(
+    JSON_REMOVE(
+        JSON_REMOVE(json, '$.sourceConfig.config.samplingMethodType'),
+        '$.sourceConfig.config.profileSampleType'
+    ),
+    '$.sourceConfig.config.profileSample'
+)
+WHERE pipelineType = 'TestSuite'
+  AND (JSON_CONTAINS_PATH(json, 'one', '$.sourceConfig.config.profileSample')
+    OR JSON_CONTAINS_PATH(json, 'one', '$.sourceConfig.config.profileSampleType')
+    OR JSON_CONTAINS_PATH(json, 'one', '$.sourceConfig.config.samplingMethodType'));

--- a/bootstrap/sql/migrations/native/1.13.5/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.13.5/postgres/schemaChanges.sql
@@ -1,0 +1,39 @@
+-- Repairs the TestSuite half of the 1.13.0 dynamic-sampling migration.
+-- 1.13.0 matched `pipelineType` against 'testSuite', but the enum value is 'TestSuite'
+-- (ingestionPipeline.json#/definitions/pipelineType). PostgreSQL text comparison is
+-- case-sensitive, so both statements matched zero rows and the flat sampling fields were
+-- never folded into profileSampleConfig. Since testSuitePipeline.json is
+-- "additionalProperties": false and no longer declares those fields, the stranded rows now
+-- fail ingestion-side validation. The profiler half of 1.13.0 was unaffected.
+-- Both statements carry the original guards, so replaying them is safe.
+
+-- ingestion_pipeline_entity (TestSuite pipelines): build profileSampleConfig (skip if already migrated)
+UPDATE ingestion_pipeline_entity
+SET json = jsonb_set(
+    json::jsonb,
+    '{sourceConfig,config,profileSampleConfig}',
+    jsonb_build_object(
+        'sampleConfigType', 'STATIC',
+        'config', jsonb_build_object(
+            'profileSample', json::jsonb #> '{sourceConfig,config,profileSample}',
+            'profileSampleType', COALESCE(
+                json::jsonb #> '{sourceConfig,config,profileSampleType}',
+                '"PERCENTAGE"'::jsonb
+            ),
+            'samplingMethodType', json::jsonb #> '{sourceConfig,config,samplingMethodType}'
+        )
+    )
+)::json
+WHERE json #>> '{pipelineType}' = 'TestSuite'
+  AND json::jsonb #>> '{sourceConfig,config,profileSample}' IS NOT NULL
+  AND json::jsonb #> '{sourceConfig,config,profileSampleConfig}' IS NULL;
+
+-- ingestion_pipeline_entity (TestSuite pipelines): remove old flat fields
+UPDATE ingestion_pipeline_entity
+SET json = (json::jsonb #- '{sourceConfig,config,profileSample}'
+                        #- '{sourceConfig,config,profileSampleType}'
+                        #- '{sourceConfig,config,samplingMethodType}')::json
+WHERE json #>> '{pipelineType}' = 'TestSuite'
+  AND (json::jsonb #>> '{sourceConfig,config,profileSample}' IS NOT NULL
+    OR json::jsonb #>> '{sourceConfig,config,profileSampleType}' IS NOT NULL
+    OR json::jsonb #>> '{sourceConfig,config,samplingMethodType}' IS NOT NULL);


### PR DESCRIPTION
Backport of #32417 to `1.13`.

Cherry-picked from `e7f7343e7891` with `-x`, so authorship stays with @TeddyCr and the provenance line is in the commit message.

Final diff is **2 files, +83/−0** — byte-for-byte the same two files as the source PR (blob hashes `5ac3505d50ba` and `8c84c67b783d` match `refs/pull/32417/head` exactly).

## Why this matters on 1.13

The bug being repaired lives in this branch's own `1.13.0` migration:

```sql
-- bootstrap/sql/migrations/native/1.13.0/mysql/schemaChanges.sql:236,250
WHERE pipelineType = 'testSuite'
-- bootstrap/sql/migrations/native/1.13.0/postgres/schemaChanges.sql:256,265
WHERE json #>> '{pipelineType}' = 'testSuite'
```

The enum value is `TestSuite` (`ingestionPipeline.json#/definitions/pipelineType`). On MySQL's default `utf8mb4_0900_ai_ci` collation the lowercase literal matched anyway, so most deployments already migrated. Two groups did not:

- **MySQL with a case-sensitive collation** on `pipelineType` (`utf8mb4_bin`, `utf8mb4_0900_as_cs`) — matched zero rows silently.
- **PostgreSQL, unconditionally** — `#>>` JSON extraction is always case-sensitive, so it never matched.

Those deployments still have TestSuite pipelines carrying the flat `profileSample` / `profileSampleType` / `samplingMethodType` fields instead of the nested `profileSampleConfig`. This replays the two statements with the correct casing; both keep their original guards, so it is a no-op where 1.13.0 already succeeded.

## Notes on the port

**The source PR is still open.** #32417 has not merged to `main` yet, so this was picked from the PR head rather than a squash commit. If the PR changes before merge, this branch needs a refresh.

**Only the `1.13.5/` files are included, by design.** The source PR spans three commits:

| Commit | Content |
|---|---|
| `e7f7343e` | adds the migration to **both** `1.13.5/` and `2.0.1/` |
| `6da2856e` | removes the `2.0.1/` copies |
| `35df884a` | merge of `upstream/main` (unrelated) |

Net effect of the PR is the two `1.13.5/` files, which is what landed here. The transient `2.0.1/` copies were resolved away rather than added-then-removed across two commits — a `2.0.1` migration directory has no business on the 1.13 branch, even briefly.

**The directory is created fresh here.** On `main` the `1.13.5/` tree already exists as four empty placeholder files, so the source PR reads as an append into `schemaChanges.sql`. On `1.13` there was no `1.13.5/` directory at all, which is what made the raw cherry-pick conflict (`DU` on all four paths — merge base had the files, this branch did not).

**Only `schemaChanges.sql` is added, no `postDataMigrationSQLScript.sql`** — deliberate, and consistent with this branch:
- `1.12.12/` and `1.13.1/` on `1.13` already ship `schemaChanges.sql` alone.
- `MigrationFile.parseSQLFiles()` guards both reads with `if (new File(...).isFile())`, so an absent post-DDL script is skipped rather than failing.
- Adding an empty file would also have diverged from the source PR's net diff.

**Version alignment:** `1.13` is already at `<version>1.13.5</version>` (bumped in #32177), so the runner will pick up the new `1.13.5/` directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
