### PR TITLE
fix(ui): handle test case picker request failures

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.test.tsx
@@ -362,7 +362,7 @@ describe('AddTestCaseList', () => {
       });
     });
 
-    it('applies testCaseFilters when provided', async () => {
+    it('uses testCaseFilters without a match-all query when search is empty', async () => {
       const testCaseFilters = 'testSuiteFullyQualifiedName:sample.test.suite';
 
       await act(async () => {
@@ -371,7 +371,7 @@ describe('AddTestCaseList', () => {
 
       await waitFor(() => {
         expect(mockGetListTestCaseBySearch).toHaveBeenCalledWith({
-          q: `* && ${testCaseFilters}`,
+          q: testCaseFilters,
           limit: 25,
           offset: 0,
         });

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.test.tsx
@@ -23,6 +23,7 @@ import { EntityReference, TestCase } from '../../../generated/tests/testCase';
 import { getAggregateFieldOptions } from '../../../rest/miscAPI';
 import { searchQuery } from '../../../rest/searchAPI';
 import { getListTestCaseBySearch } from '../../../rest/testAPI';
+import { showErrorToast } from '../../../utils/ToastUtils';
 import { AddTestCaseList } from './AddTestCaseList.component';
 import { AddTestCaseModalProps } from './AddTestCaseList.interface';
 
@@ -71,6 +72,10 @@ jest.mock('../../../utils/FqnUtils', () => ({
 }));
 jest.mock('../../../rest/testAPI', () => ({
   getListTestCaseBySearch: jest.fn(),
+}));
+
+jest.mock('../../../utils/ToastUtils', () => ({
+  showErrorToast: jest.fn(),
 }));
 
 jest.mock('../../../rest/searchAPI', () => ({
@@ -282,6 +287,19 @@ describe('AddTestCaseList', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('empty-placeholder')).toBeInTheDocument();
+    });
+  });
+
+  it('handles test case fetch failures without an unhandled rejection', async () => {
+    const fetchError = new Error('Failed to fetch test cases');
+    mockGetListTestCaseBySearch.mockRejectedValueOnce(fetchError);
+
+    await act(async () => {
+      renderWithRouter(mockProps);
+    });
+
+    await waitFor(() => {
+      expect(showErrorToast).toHaveBeenCalledWith(fetchError);
     });
   });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.tsx
@@ -270,8 +270,12 @@ export const AddTestCaseList = ({
       try {
         setIsLoading(true);
         const globalSearch = searchText ? `*${searchText}*` : WILD_CARD_CHAR;
+        // The search/list endpoint rejects `* && filter`; without free text,
+        // testCaseFilters is already the complete scoped query.
         const q = testCaseFilters
-          ? `${globalSearch} && ${testCaseFilters}`
+          ? searchText
+            ? `${globalSearch} && ${testCaseFilters}`
+            : testCaseFilters
           : globalSearch;
 
         const columnNamesFromKeys =

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.tsx
@@ -22,6 +22,7 @@ import {
   Typography,
 } from 'antd';
 import type { CheckboxChangeEvent } from 'antd/es/checkbox';
+import { AxiosError } from 'axios';
 import { debounce } from 'lodash';
 import isEmpty from 'lodash/isEmpty';
 import VirtualList from 'rc-virtual-list';
@@ -62,6 +63,7 @@ import { getEntityFQN } from '../../../utils/FeedUtilsPure';
 import { getNameFromFQN } from '../../../utils/FqnUtils';
 import { getEntityDetailsPath } from '../../../utils/RouterUtils';
 import { replacePlus } from '../../../utils/StringUtils';
+import { showErrorToast } from '../../../utils/ToastUtils';
 import Loader from '../../common/Loader/Loader';
 import Searchbar from '../../common/SearchBarComponent/SearchBar.component';
 import { SearchDropdownOption } from '../../SearchDropdown/SearchDropdown.interface';
@@ -332,6 +334,8 @@ export const AddTestCaseList = ({
             : (prevItems) => [...prevItems, ...testCaseResponse.data]
         );
         setPageNumber(page);
+      } catch (error) {
+        showErrorToast(error as AxiosError);
       } finally {
         setIsLoading(false);
       }


### PR DESCRIPTION
## Summary

- avoid sending the invalid `* && <suite filter>` query when the test case picker loads without free-text input
- handle test case list request failures inside the picker, show the standard error toast, and always clear the loading state
- add focused regression coverage for both the suite-filter query and rejected list requests

This is the `2.0` backport of the test case picker fix from #32488. The main-branch error-handling commit was cherry-picked, together with the small query correction required on `2.0` because that branch does not contain #31142.

## Root cause

The query composition was introduced in #26293 (`7b4eb186f3186adc2ac05186e6fabb7231e7447b`) while adding test-case selection for test-suite ingestion pipelines. On the initial picker load, the UI combined the match-all token with the suite filter:

```text
* && testSuite.fullyQualifiedName:"<suite FQN>"
```

`GET /api/v1/dataQuality/testCases/search/list` rejects that query with HTTP 400. `getListTestCaseBySearch` intentionally propagates request errors so each consumer can choose its own UI behavior, but `AddTestCaseList.fetchTestCases` only had `try/finally`; the rejected promise therefore reached the browser's global `unhandledrejection` handler and was reported by Sentry.

On `main`, #31142 removed this Lucene query composition as part of a broader data-quality search change. That broader change is not present on `2.0`, so this backport applies the release-compatible correction: when there is no free-text search, the suite filter itself is the complete query. Searches with text keep the existing 2.0 Lucene behavior.

## Steps to reproduce

1. Open a basic test suite that has an ingestion pipeline.
2. Navigate to **Edit Ingestion** for that pipeline.
3. Open the test-case selection step and allow the picker to load without entering search text.
4. Observe a request like:

   ```text
   GET /api/v1/dataQuality/testCases/search/list?q=%2A%20%26%26%20testSuite.fullyQualifiedName%3A%22<suite FQN>%22&limit=25&offset=0
   ```

5. Before this fix, the endpoint returns 400 and the Axios rejection is unhandled. After this fix, the initial request uses only the suite filter; any request failure is handled locally and shown through the standard error toast.

## Test plan

- `AddTestCaseList.component.test.tsx`: 46 tests passed
- ESLint on the changed component and test
- Prettier check on the changed component and test
- `git diff --check origin/2.0...HEAD`

## Related

- Tracking issue: #32516
- Sentry issue: https://collate-3b.sentry.io/issues/7706798759/
- Main fix: #32488
- Query composition introduction: #26293
- Original Collate issue: https://github.com/open-metadata/OpenMetadata-Collate/issues/3045
