### PR TITLE
Fixes 6035: Add theme-aware Data Insights colors

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/DailyActiveUsersChart.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/DailyActiveUsersChart.tsx
@@ -26,16 +26,15 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
-import { GRAPH_BACKGROUND_COLOR } from '../../constants/constants';
 import {
   BAR_CHART_MARGIN,
-  DATA_INSIGHT_GRAPH_COLORS,
   DI_STRUCTURE,
   GRAPH_HEIGHT,
 } from '../../constants/DataInsight.constants';
 import { DataReportIndex } from '../../generated/dataInsight/dataInsightChart';
 import { DataInsightChartType } from '../../generated/dataInsight/dataInsightChartResult';
 import { DailyActiveUsers } from '../../generated/dataInsight/type/dailyActiveUsers';
+import { useDataInsightChartColors } from '../../hooks/insights/useDataInsightChartColors';
 import { ChartFilter } from '../../interface/data-insight.interface';
 import { getAggregateChartData } from '../../rest/DataInsightAPI';
 import { CustomTooltip, renderLegend } from '../../utils/DataInsightChartUtils';
@@ -58,6 +57,8 @@ const DailyActiveUsersChart: FC<Props> = ({ chartFilter, selectedDays }) => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const { t } = useTranslation();
+  const { axis, dataInsightSeries, grid, inactive } =
+    useDataInsightChartColors();
 
   const { data, total, relativePercentage } = useMemo(
     () => getFormattedActiveUsersData(dailyActiveUsers),
@@ -105,25 +106,27 @@ const DailyActiveUsersChart: FC<Props> = ({ chartFilter, selectedDays }) => {
           <Col span={DI_STRUCTURE.leftContainerSpan}>
             <ResponsiveContainer debounce={1} height={GRAPH_HEIGHT}>
               <LineChart data={data} margin={BAR_CHART_MARGIN}>
-                <CartesianGrid
-                  stroke={GRAPH_BACKGROUND_COLOR}
-                  vertical={false}
-                />
+                <CartesianGrid stroke={grid} vertical={false} />
                 <Legend
                   align="left"
                   content={() =>
-                    renderLegend({ payload: [] } as LegendProps, [])
+                    renderLegend(
+                      { payload: [] } as LegendProps,
+                      [],
+                      undefined,
+                      inactive
+                    )
                   }
                   layout="vertical"
                   verticalAlign="top"
                   wrapperStyle={{ left: '0px', top: '0px' }}
                 />
-                <XAxis dataKey="timestamp" />
-                <YAxis />
+                <XAxis dataKey="timestamp" tick={{ fill: axis }} />
+                <YAxis tick={{ fill: axis }} />
                 <Tooltip content={<CustomTooltip />} />
                 <Line
                   dataKey="activeUsers"
-                  stroke={DATA_INSIGHT_GRAPH_COLORS[3]}
+                  stroke={dataInsightSeries[3]}
                   type="monotone"
                 />
               </LineChart>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/DataInsightChartCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/DataInsightChartCard.tsx
@@ -42,6 +42,7 @@ import {
 import { SystemChartType } from '../../enums/DataInsight.enum';
 import { SearchIndex } from '../../enums/search.enum';
 import { DataInsightChart } from '../../generated/api/dataInsight/kpi/createKpiRequest';
+import { useDataInsightChartColors } from '../../hooks/insights/useDataInsightChartColors';
 import { useDataInsightProvider } from '../../pages/DataInsightPage/DataInsightProvider';
 import {
   DataInsightCustomChartResult,
@@ -100,6 +101,7 @@ export const DataInsightChartCard = ({
     entitiesSummary,
   } = useDataInsightProvider();
   const isPercentageGraph = isPercentageSystemGraph(type);
+  const chartColors = useDataInsightChartColors();
 
   const { rightSideEntityList, latestData, graphData, changeInValue } =
     useMemo(() => {
@@ -487,7 +489,8 @@ export const DataInsightChartCard = ({
               rightSideEntityList,
               activeKeys,
               activeMouseHoverKey,
-              isPercentageGraph
+              isPercentageGraph,
+              chartColors
             )}
           </ResponsiveContainer>
         </Col>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/DataInsightProgressBar.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/DataInsightProgressBar.test.tsx
@@ -16,6 +16,12 @@ import { MemoryRouter } from 'react-router-dom';
 import { act } from 'react-test-renderer';
 import DataInsightProgressBar from './DataInsightProgressBar';
 
+jest.mock('../../hooks/insights/useDataInsightChartColors', () => ({
+  useDataInsightChartColors: jest.fn().mockReturnValue({
+    progress: '#123456',
+  }),
+}));
+
 const MOCK_DATA = {
   changeInValue: -0.32000000000000006,
   className: 'm-b-md',
@@ -65,5 +71,15 @@ describe('Test DataInsightProgressBar Component', () => {
     const progressBarLabel = screen.getByText('CustomStatistic.component');
 
     expect(progressBarLabel).toBeInTheDocument();
+  });
+
+  it('uses the active theme color for the progress stroke', async () => {
+    const { container } = render(<DataInsightProgressBar {...MOCK_DATA} />, {
+      wrapper: MemoryRouter,
+    });
+
+    expect(container.querySelector('.ant-progress-bg')).toHaveStyle({
+      backgroundColor: '#123456',
+    });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/DataInsightProgressBar.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/DataInsightProgressBar.tsx
@@ -16,6 +16,7 @@ import { Progress } from 'antd';
 import classNames from 'classnames';
 import { round } from 'lodash';
 import { ReactComponent as IconSuccessBadge } from '../../assets/svg/success-badge.svg';
+import { useDataInsightChartColors } from '../../hooks/insights/useDataInsightChartColors';
 import CustomStatistic from './CustomStatistic';
 
 interface DataInsightProgressBarProps {
@@ -57,6 +58,8 @@ const DataInsightProgressBar = ({
   duration,
   showProgress = true,
 }: DataInsightProgressBarProps) => {
+  const { progress: progressColor } = useDataInsightChartColors();
+
   return (
     <div
       className={classNames(className)}
@@ -75,7 +78,7 @@ const DataInsightProgressBar = ({
             className="data-insight-progress-bar"
             format={() => renderProgressTarget(target, suffix)}
             percent={progress}
-            strokeColor="#B3D4F4"
+            strokeColor={progressColor}
           />
           {showSuccessInfo && progress >= 100 && (
             <Icon

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/KPIChart.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/KPIChart.test.tsx
@@ -16,6 +16,15 @@ import { act } from 'react-test-renderer';
 import { KPI_LIST } from '../../pages/KPIPage/KPIMock.mock';
 import KPIChart from './KPIChart';
 
+jest.mock('../../hooks/insights/useDataInsightChartColors', () => ({
+  useDataInsightChartColors: jest.fn().mockReturnValue({
+    axis: '#123456',
+    dataInsightSeries: ['#234567'],
+    grid: '#345678',
+    inactive: '#456789',
+  }),
+}));
+
 jest.mock('../../rest/KpiAPI', () => ({
   getListKPIs: jest
     .fn()

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/KPIChart.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/KPIChart.tsx
@@ -31,13 +31,11 @@ import {
 } from 'recharts';
 import {
   DEFAULT_CHART_OPACITY,
-  GRAPH_BACKGROUND_COLOR,
   HOVER_CHART_OPACITY,
   ROUTES,
 } from '../../constants/constants';
 import {
   BAR_CHART_MARGIN,
-  DATA_INSIGHT_GRAPH_COLORS,
   DI_STRUCTURE,
   GRAPH_HEIGHT,
 } from '../../constants/DataInsight.constants';
@@ -47,6 +45,7 @@ import {
   KpiResult,
   KpiTargetType,
 } from '../../generated/dataInsight/kpi/kpi';
+import { useDataInsightChartColors } from '../../hooks/insights/useDataInsightChartColors';
 import {
   ChartFilter,
   UIKpiResult,
@@ -80,6 +79,8 @@ const KPIChart: FC<Props> = ({
 }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { axis, dataInsightSeries, grid, inactive } =
+    useDataInsightChartColors();
 
   const [kpiResults, setKpiResults] = useState<
     Record<string, DataInsightCustomChartResult['results']>
@@ -249,10 +250,7 @@ const KPIChart: FC<Props> = ({
                   height={GRAPH_HEIGHT}
                   id="kpi-chart">
                   <LineChart margin={BAR_CHART_MARGIN}>
-                    <CartesianGrid
-                      stroke={GRAPH_BACKGROUND_COLOR}
-                      vertical={false}
-                    />
+                    <CartesianGrid stroke={grid} vertical={false} />
                     <Tooltip
                       content={
                         <CustomTooltip
@@ -264,14 +262,20 @@ const KPIChart: FC<Props> = ({
                     <XAxis
                       allowDuplicatedCategory={false}
                       dataKey="day"
+                      tick={{ fill: axis }}
                       tickFormatter={(value) => formatDate(value)}
                       type="category"
                     />
-                    <YAxis dataKey="count" />
+                    <YAxis dataKey="count" tick={{ fill: axis }} />
                     <Legend
                       align="left"
                       content={(props) =>
-                        renderLegend(props as LegendProps, activeKeys)
+                        renderLegend(
+                          props as LegendProps,
+                          activeKeys,
+                          undefined,
+                          inactive
+                        )
                       }
                       key="name"
                       layout="horizontal"
@@ -293,7 +297,7 @@ const KPIChart: FC<Props> = ({
                         }
                         key={key}
                         name={key}
-                        stroke={DATA_INSIGHT_GRAPH_COLORS[i]}
+                        stroke={dataInsightSeries[i % dataInsightSeries.length]}
                         strokeOpacity={
                           isEmpty(activeMouseHoverKey) ||
                           key === activeMouseHoverKey

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/KPILatestResultsV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/KPILatestResultsV1.test.tsx
@@ -14,6 +14,13 @@ import { findByTestId, render, screen } from '@testing-library/react';
 import { UIKpiResult } from '../../interface/data-insight.interface';
 import KPILatestResultsV1 from './KPILatestResultsV1';
 
+jest.mock('../../hooks/insights/useDataInsightChartColors', () => ({
+  useDataInsightChartColors: jest.fn().mockReturnValue({
+    kpiBackgrounds: ['#123456', '#234567'],
+    kpiSeries: ['#345678', '#456789'],
+  }),
+}));
+
 const mockProps = {
   'description-coverage-completed-description-fraction': {
     timestamp: 1701396413075,
@@ -86,5 +93,19 @@ describe('KPILatestResultsV1', () => {
     expect(kpi).toBeInTheDocument();
 
     expect(await findByTestId(kpi, 'kpi-success')).toBeInTheDocument();
+  });
+
+  it('uses active theme colors for KPI status presentation', async () => {
+    const { container } = render(
+      <KPILatestResultsV1 kpiLatestResultsRecord={mockProps} />
+    );
+
+    expect(container.querySelector('.kpi-days-section')).toHaveStyle({
+      backgroundColor: '#123456',
+      color: '#345678',
+    });
+    expect(container.querySelector('.ant-progress-bg')).toHaveStyle({
+      backgroundColor: '#345678',
+    });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/KPILatestResultsV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/KPILatestResultsV1.tsx
@@ -16,11 +16,8 @@ import { Col, Progress, Row, Space, Tooltip, Typography } from 'antd';
 import { toNumber } from 'lodash';
 import { FC, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  KPI_WIDGET_GRAPH_BG_COLORS,
-  KPI_WIDGET_GRAPH_COLORS,
-} from '../../constants/DataInsight.constants';
 import { KpiTargetType } from '../../generated/api/dataInsight/kpi/createKpiRequest';
+import { useDataInsightChartColors } from '../../hooks/insights/useDataInsightChartColors';
 import { UIKpiResult } from '../../interface/data-insight.interface';
 import { getKpiResultFeedback } from '../../utils/DataInsightUtils';
 import { getDaysRemaining } from '../../utils/date-time/DateTimeUtils';
@@ -32,6 +29,7 @@ interface Props {
 
 const KPILatestResultsV1: FC<Props> = ({ kpiLatestResultsRecord }) => {
   const { t } = useTranslation();
+  const { kpiBackgrounds, kpiSeries } = useDataInsightChartColors();
   const { latestResultsList } = useMemo(() => {
     return { latestResultsList: Object.entries(kpiLatestResultsRecord) };
   }, [kpiLatestResultsRecord]);
@@ -67,6 +65,8 @@ const KPILatestResultsV1: FC<Props> = ({ kpiLatestResultsRecord }) => {
         const daysLeft = getDaysRemaining(resultData.endDate);
 
         const isTargetMet = targetResult.targetMet;
+        const seriesColor = kpiSeries[index % kpiSeries.length];
+        const backgroundColor = kpiBackgrounds[index % kpiBackgrounds.length];
 
         return (
           <Row data-testid={name} key={name}>
@@ -74,8 +74,8 @@ const KPILatestResultsV1: FC<Props> = ({ kpiLatestResultsRecord }) => {
               <div
                 className="kpi-days-section"
                 style={{
-                  color: KPI_WIDGET_GRAPH_COLORS[index],
-                  backgroundColor: KPI_WIDGET_GRAPH_BG_COLORS[index],
+                  backgroundColor,
+                  color: seriesColor,
                 }}>
                 {isTargetMet ? (
                   <>
@@ -119,7 +119,7 @@ const KPILatestResultsV1: FC<Props> = ({ kpiLatestResultsRecord }) => {
                   percent={Number(currentProgress)}
                   showInfo={false}
                   size="small"
-                  strokeColor={KPI_WIDGET_GRAPH_COLORS[index]}
+                  strokeColor={seriesColor}
                 />
                 <div className="d-flex justify-space-between">
                   <div className="flex-1">

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/PageViewsByEntitiesChart.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/PageViewsByEntitiesChart.tsx
@@ -27,7 +27,6 @@ import {
 } from 'recharts';
 import {
   DEFAULT_CHART_OPACITY,
-  GRAPH_BACKGROUND_COLOR,
   HOVER_CHART_OPACITY,
 } from '../../constants/constants';
 import {
@@ -38,6 +37,7 @@ import {
 import { DataReportIndex } from '../../generated/dataInsight/dataInsightChart';
 import { DataInsightChartType } from '../../generated/dataInsight/dataInsightChartResult';
 import { PageViewsByEntities } from '../../generated/dataInsight/type/pageViewsByEntities';
+import { useDataInsightChartColors } from '../../hooks/insights/useDataInsightChartColors';
 import { ChartFilter } from '../../interface/data-insight.interface';
 import { getAggregateChartData } from '../../rest/DataInsightAPI';
 import { entityChartColor } from '../../utils/ColorUtils';
@@ -76,6 +76,7 @@ const PageViewsByEntitiesChart: FC<Props> = ({ chartFilter, selectedDays }) => {
   }, [entities, latestData]);
 
   const { t } = useTranslation();
+  const { axis, grid } = useDataInsightChartColors();
 
   const fetchPageViewsByEntities = async () => {
     setIsLoading(true);
@@ -134,9 +135,9 @@ const PageViewsByEntitiesChart: FC<Props> = ({ chartFilter, selectedDays }) => {
           />
           <ResponsiveContainer debounce={1} height={GRAPH_HEIGHT}>
             <LineChart data={data} margin={BAR_CHART_MARGIN}>
-              <CartesianGrid stroke={GRAPH_BACKGROUND_COLOR} vertical={false} />
-              <XAxis dataKey="timestamp" />
-              <YAxis />
+              <CartesianGrid stroke={grid} vertical={false} />
+              <XAxis dataKey="timestamp" tick={{ fill: axis }} />
+              <YAxis tick={{ fill: axis }} />
               <Tooltip
                 content={<CustomTooltip />}
                 wrapperStyle={{ pointerEvents: 'auto' }}

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/data-insight-detail.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsight/data-insight-detail.less
@@ -13,8 +13,8 @@
 
 @import (reference) '../../styles/variables.less';
 
-@label-color: var(--om-legacy-color-6b7280);
-@summary-card-bg-hover: var(--om-legacy-color-f0f1f3);
+@label-color: var(--om-color-text-tertiary);
+@summary-card-bg-hover: var(--om-color-interactive-hover);
 
 .data-insight-card {
   border-radius: @border-rad-md;
@@ -25,7 +25,7 @@
   }
   .custom-data-insight-tooltip {
     .ant-card-head {
-      border-bottom: 1px solid @border-color;
+      border-bottom: 1px solid var(--om-color-border);
       .ant-card-head-title {
         padding: 0;
       }

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/KPIWidget/KPILegend/KPILegend.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/KPIWidget/KPILegend/KPILegend.tsx
@@ -16,8 +16,8 @@ import { toNumber } from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as CheckIcon } from '../../../../../assets/svg/ic-check-circle-new.svg';
-import { KPI_WIDGET_GRAPH_COLORS } from '../../../../../constants/Widgets.constant';
 import { KpiTargetType } from '../../../../../generated/api/dataInsight/kpi/createKpiRequest';
+import { useDataInsightChartColors } from '../../../../../hooks/insights/useDataInsightChartColors';
 import { UIKpiResult } from '../../../../../interface/data-insight.interface';
 import { getKpiResultFeedback } from '../../../../../utils/DataInsightUtils';
 import { getDaysRemaining } from '../../../../../utils/date-time/DateTimeUtils';
@@ -55,13 +55,13 @@ const KPILegend: React.FC<KPILegendProps> = ({
   isFullSize,
 }) => {
   const { t } = useTranslation();
+  const { kpiSeries } = useDataInsightChartColors();
   const entries = Object.entries(kpiLatestResultsRecord);
 
   return (
     <div className="w-full h-full kpi-legend d-flex flex-column p-sm">
       {entries.map(([key, resultData], index) => {
-        const color =
-          KPI_WIDGET_GRAPH_COLORS[index % KPI_WIDGET_GRAPH_COLORS.length];
+        const color = kpiSeries[index % kpiSeries.length];
         const daysLeft = getDaysRemaining(resultData.endDate);
         const targetResult = resultData.targetResult[0];
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/KPIWidget/KPIWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/KPIWidget/KPIWidget.component.tsx
@@ -32,7 +32,6 @@ import {
   CHART_WIDGET_DAYS_DURATION,
   ROUTES,
 } from '../../../../constants/constants';
-import { KPI_WIDGET_GRAPH_COLORS } from '../../../../constants/Widgets.constant';
 import { SIZE } from '../../../../enums/common.enum';
 import { TabSpecificField } from '../../../../enums/entity.enum';
 import {
@@ -40,6 +39,7 @@ import {
   KpiResult,
   KpiTargetType,
 } from '../../../../generated/dataInsight/kpi/kpi';
+import { useDataInsightChartColors } from '../../../../hooks/insights/useDataInsightChartColors';
 import { UIKpiResult } from '../../../../interface/data-insight.interface';
 import { DataInsightCustomChartResult } from '../../../../rest/DataInsightAPI';
 import {
@@ -71,6 +71,8 @@ const KPIWidget = ({
   handleLayoutUpdate,
 }: KPIWidgetProps) => {
   const { t } = useTranslation();
+  const { activeDotBorder, axis, grid, kpiSeries } =
+    useDataInsightChartColors();
   const navigate = useNavigate();
   const [kpiList, setKpiList] = useState<Array<Kpi>>([]);
   const [isKPIListLoading, setIsKPIListLoading] = useState<boolean>(true);
@@ -305,12 +307,12 @@ const KPIWidget = ({
                     y2="1">
                     <stop
                       offset="0%"
-                      stopColor={KPI_WIDGET_GRAPH_COLORS[i]}
+                      stopColor={kpiSeries[i % kpiSeries.length]}
                       stopOpacity={0.4}
                     />
                     <stop
                       offset="100%"
-                      stopColor={KPI_WIDGET_GRAPH_COLORS[i]}
+                      stopColor={kpiSeries[i % kpiSeries.length]}
                       stopOpacity={0.05}
                     />
                   </linearGradient>
@@ -328,7 +330,7 @@ const KPIWidget = ({
               />
 
               <CartesianGrid
-                stroke="#E4E6EB"
+                stroke={grid}
                 strokeDasharray="3 3"
                 vertical={false}
               />
@@ -338,7 +340,7 @@ const KPIWidget = ({
                 axisLine={false}
                 dataKey="day"
                 interval="preserveStartEnd"
-                tick={{ fill: '#888', fontSize: 12 }}
+                tick={{ fill: axis, fontSize: 12 }}
                 tickFormatter={(value: number) =>
                   customFormatDateTime(value, 'd MMM, yy')
                 }
@@ -349,15 +351,15 @@ const KPIWidget = ({
 
               <YAxis
                 axisLine={{
-                  stroke: '#E4E6EB',
+                  stroke: grid,
                   strokeWidth: 1,
                   strokeDasharray: '3 3',
                 }}
                 domain={domain}
                 padding={{ top: 0, bottom: 0 }}
-                tick={{ fill: '#888', fontSize: 12 }}
+                tick={{ fill: axis, fontSize: 12 }}
                 tickLine={{
-                  stroke: '#E4E6EB',
+                  stroke: grid,
                   strokeWidth: 1,
                   strokeDasharray: '3 3',
                 }}
@@ -368,20 +370,20 @@ const KPIWidget = ({
                 <Area
                   activeDot={{
                     r: 5,
-                    fill: KPI_WIDGET_GRAPH_COLORS[i],
-                    stroke: '#fff',
+                    fill: kpiSeries[i % kpiSeries.length],
+                    stroke: activeDotBorder,
                     strokeWidth: 2,
                   }}
                   dataKey={key}
                   dot={{
-                    stroke: KPI_WIDGET_GRAPH_COLORS[i],
+                    stroke: kpiSeries[i % kpiSeries.length],
                     strokeWidth: 2,
-                    fill: KPI_WIDGET_GRAPH_COLORS[i],
+                    fill: kpiSeries[i % kpiSeries.length],
                     r: 4,
                   }}
                   fill={`url(#gradient-${key})`}
                   key={key}
-                  stroke={KPI_WIDGET_GRAPH_COLORS[i]}
+                  stroke={kpiSeries[i % kpiSeries.length]}
                   strokeWidth={2}
                   type="monotone"
                 />
@@ -407,6 +409,10 @@ const KPIWidget = ({
     ticks,
     kpiLatestResults,
     kpiTooltipValueFormatter,
+    activeDotBorder,
+    axis,
+    grid,
+    kpiSeries,
   ]);
 
   useEffect(() => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/KPIWidget/KPIWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/KPIWidget/KPIWidget.test.tsx
@@ -11,13 +11,49 @@
  *  limitations under the License.
  */
 import { render, screen } from '@testing-library/react';
+import { PropsWithChildren } from 'react';
 import { act } from 'react-test-renderer';
 import { MOCK_KPI_LIST_RESPONSE } from '../../../../pages/KPIPage/KPIMock.mock';
 import { getListKPIs } from '../../../../rest/KpiAPI';
 import KPIWidget from './KPIWidget.component';
 
-jest.mock('../../../../constants/DataInsight.constants', () => ({
-  DATA_INSIGHT_GRAPH_COLORS: ['#E7B85D'],
+jest.mock('../../../../hooks/insights/useDataInsightChartColors', () => ({
+  useDataInsightChartColors: jest.fn().mockReturnValue({
+    activeDotBorder: '#123456',
+    axis: '#234567',
+    grid: '#345678',
+    kpiSeries: ['#456789'],
+  }),
+}));
+
+jest.mock('recharts', () => ({
+  Area: ({
+    activeDot,
+    stroke,
+  }: {
+    activeDot: { stroke: string };
+    stroke: string;
+  }) => (
+    <div
+      data-active-dot-stroke={activeDot.stroke}
+      data-stroke={stroke}
+      data-testid="kpi-area"
+    />
+  ),
+  AreaChart: ({ children }: PropsWithChildren) => <svg>{children}</svg>,
+  CartesianGrid: ({ stroke }: { stroke: string }) => (
+    <div data-stroke={stroke} data-testid="kpi-grid" />
+  ),
+  ResponsiveContainer: ({ children }: PropsWithChildren) => (
+    <div>{children}</div>
+  ),
+  Tooltip: () => null,
+  XAxis: ({ tick }: { tick: { fill: string } }) => (
+    <div data-fill={tick.fill} data-testid="kpi-x-axis" />
+  ),
+  YAxis: ({ tick }: { tick: { fill: string } }) => (
+    <div data-fill={tick.fill} data-testid="kpi-y-axis" />
+  ),
 }));
 
 jest.mock('../../../../constants/constants', () => {
@@ -26,7 +62,6 @@ jest.mock('../../../../constants/constants', () => {
   return {
     ...actualConstants,
     CHART_WIDGET_DAYS_DURATION: 14,
-    GRAPH_BACKGROUND_COLOR: '#000000',
   };
 });
 
@@ -119,19 +154,25 @@ const widgetProps = {
 
 describe('KPIWidget', () => {
   it('renders widget with header', async () => {
-    render(<KPIWidget {...widgetProps} />);
+    await act(async () => {
+      render(<KPIWidget {...widgetProps} />);
+    });
 
     expect(await screen.findByTestId('widget-header')).toBeInTheDocument();
   });
 
   it('renders widget wrapper', async () => {
-    render(<KPIWidget {...widgetProps} />);
+    await act(async () => {
+      render(<KPIWidget {...widgetProps} />);
+    });
 
     expect(await screen.findByTestId('KnowledgePanel.KPI')).toBeInTheDocument();
   });
 
   it('should fetch kpi list api initially', async () => {
-    render(<KPIWidget {...widgetProps} />);
+    await act(async () => {
+      render(<KPIWidget {...widgetProps} />);
+    });
 
     expect(getListKPIs).toHaveBeenCalledWith({ fields: 'dataInsightChart' });
   });
@@ -147,25 +188,54 @@ describe('KPIWidget', () => {
     expect(await screen.findByTestId('kpi-widget')).toBeInTheDocument();
   });
 
+  it('uses active theme colors for the chart presentation', async () => {
+    await act(async () => {
+      render(<KPIWidget {...widgetProps} />);
+    });
+
+    expect(await screen.findByTestId('kpi-grid')).toHaveAttribute(
+      'data-stroke',
+      '#345678'
+    );
+    expect(screen.getByTestId('kpi-x-axis')).toHaveAttribute(
+      'data-fill',
+      '#234567'
+    );
+    expect(screen.getByTestId('kpi-y-axis')).toHaveAttribute(
+      'data-fill',
+      '#234567'
+    );
+    expect(screen.getAllByTestId('kpi-area')[0]).toHaveAttribute(
+      'data-active-dot-stroke',
+      '#123456'
+    );
+    expect(screen.getAllByTestId('kpi-area')[0]).toHaveAttribute(
+      'data-stroke',
+      '#456789'
+    );
+  });
+
   it('should render WidgetEmptyState if no data there', async () => {
     (getListKPIs as jest.Mock).mockImplementation(() =>
       Promise.resolve({ data: [] })
     );
 
-    render(
-      <KPIWidget
-        {...widgetProps}
-        currentLayout={[
-          {
-            i: 'testWidgetKey',
-            x: 0,
-            y: 0,
-            w: 1,
-            h: 1,
-          },
-        ]}
-      />
-    );
+    await act(async () => {
+      render(
+        <KPIWidget
+          {...widgetProps}
+          currentLayout={[
+            {
+              i: 'testWidgetKey',
+              x: 0,
+              y: 0,
+              w: 1,
+              h: 1,
+            },
+          ]}
+        />
+      );
+    });
 
     // Wait for loading to complete and empty state to render
     expect(

--- a/openmetadata-ui/src/main/resources/ui/src/constants/DataInsight.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/DataInsight.constants.ts
@@ -42,19 +42,24 @@ export const DI_STRUCTURE = {
 
 export const GRAPH_HEIGHT = 500;
 
-export const DATA_INSIGHT_GRAPH_COLORS = [
-  '#E7B85D',
-  '#416BB3',
-  '#66B5AD',
-  '#8D6AF1',
-  '#699994',
-  '#6A86EB',
-  '#7A57A6',
-  '#7DC177',
-  '#AD4F82',
-  '#C870C5',
-  '#D87F7F',
-  '#DA996A',
+/**
+ * Recharts and Ant Progress receive concrete colors from the theme hook. Keep
+ * token references paired with fallbacks so SSR and test environments remain
+ * deterministic when computed styles are unavailable.
+ */
+export const DATA_INSIGHT_GRAPH_COLOR_TOKENS = [
+  { token: 'var(--om-color-warning-400)', fallback: '#E7B85D' },
+  { token: 'var(--om-color-blue-dark-700)', fallback: '#416BB3' },
+  { token: 'var(--om-color-teal-500)', fallback: '#66B5AD' },
+  { token: 'var(--om-color-violet-500)', fallback: '#8D6AF1' },
+  { token: 'var(--om-color-gray-blue-500)', fallback: '#699994' },
+  { token: 'var(--om-color-blue-500)', fallback: '#6A86EB' },
+  { token: 'var(--om-color-purple-500)', fallback: '#7A57A6' },
+  { token: 'var(--om-color-green-500)', fallback: '#7DC177' },
+  { token: 'var(--om-color-pink-600)', fallback: '#AD4F82' },
+  { token: 'var(--om-color-fuchsia-500)', fallback: '#C870C5' },
+  { token: 'var(--om-color-error-400)', fallback: '#D87F7F' },
+  { token: 'var(--om-color-orange-400)', fallback: '#DA996A' },
 ];
 
 export const INITIAL_CHART_FILTER: ChartFilter = {
@@ -161,10 +166,13 @@ export const BASE_COLORS = [
   '#F48FB1',
 ];
 
-export const KPI_WIDGET_GRAPH_COLORS = [
-  '#7262F6',
-  '#6AD2FF',
-  '#2ED3B7',
-  '#E478FA',
+export const KPI_WIDGET_GRAPH_COLOR_TOKENS = [
+  { token: 'var(--om-color-violet-500)', fallback: '#7262F6' },
+  { token: 'var(--om-color-blue-light-400)', fallback: '#6AD2FF' },
+  { token: 'var(--om-color-teal-400)', fallback: '#2ED3B7' },
+  { token: 'var(--om-color-fuchsia-400)', fallback: '#E478FA' },
 ];
-export const KPI_WIDGET_GRAPH_BG_COLORS = ['#F4F2FF', '#ECFBFF'];
+export const KPI_WIDGET_GRAPH_BG_COLOR_TOKENS = [
+  { token: 'var(--om-color-purple-50)', fallback: '#F4F2FF' },
+  { token: 'var(--om-color-blue-light-50)', fallback: '#ECFBFF' },
+];

--- a/openmetadata-ui/src/main/resources/ui/src/constants/Widgets.constant.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/Widgets.constant.ts
@@ -205,19 +205,3 @@ export const applySortToData = (
       return sortedData;
   }
 };
-
-export const KPI_WIDGET_GRAPH_COLORS = [
-  '#7262F6',
-  '#6AD2FF',
-  '#2ED3B7',
-  '#E478FA',
-  //   TODO: Add more colors for more KPIs
-  '#7262F6',
-  '#6AD2FF',
-  '#2ED3B7',
-  '#E478FA',
-  '#7262F6',
-  '#6AD2FF',
-  '#2ED3B7',
-  '#E478FA',
-];

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/insights/useDataInsightChartColors.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/insights/useDataInsightChartColors.test.tsx
@@ -1,0 +1,115 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { ReactNode } from 'react';
+import {
+  ThemeProvider,
+  useTheme,
+} from '../../context/UntitledUIThemeProvider/theme-provider';
+import { useDataInsightChartColors } from './useDataInsightChartColors';
+
+const TEST_THEME_STORAGE_KEY = 'data-insight-chart-colors-test';
+let setActiveTheme: ReturnType<typeof useTheme>['setTheme'];
+
+const ThemeController = ({ children }: { children: ReactNode }) => {
+  const { setTheme } = useTheme();
+  setActiveTheme = setTheme;
+
+  return <>{children}</>;
+};
+
+const TestThemeProvider = ({ children }: { children: ReactNode }) => (
+  <ThemeProvider defaultTheme="light" storageKey={TEST_THEME_STORAGE_KEY}>
+    <ThemeController>{children}</ThemeController>
+  </ThemeProvider>
+);
+
+describe('useDataInsightChartColors', () => {
+  afterEach(() => {
+    localStorage.removeItem(TEST_THEME_STORAGE_KEY);
+    document.documentElement.className = '';
+    document.documentElement.removeAttribute('style');
+  });
+
+  it('resolves chart colors again when the active theme changes', () => {
+    document.documentElement.style.setProperty(
+      '--om-color-border-secondary',
+      '#112233'
+    );
+    document.documentElement.style.setProperty(
+      '--om-color-text-tertiary',
+      '#223344'
+    );
+
+    const { result } = renderHook(() => useDataInsightChartColors(), {
+      wrapper: TestThemeProvider,
+    });
+
+    expect(result.current.grid).toBe('#112233');
+    expect(result.current.axis).toBe('#223344');
+
+    act(() => {
+      document.documentElement.style.setProperty(
+        '--om-color-border-secondary',
+        '#aabbcc'
+      );
+      document.documentElement.style.setProperty(
+        '--om-color-text-tertiary',
+        '#bbccdd'
+      );
+      setActiveTheme('dark');
+    });
+
+    expect(result.current.grid).toBe('#aabbcc');
+    expect(result.current.axis).toBe('#bbccdd');
+  });
+
+  it('resolves semantic surfaces and categorical palettes for chart consumers', () => {
+    document.documentElement.style.setProperty(
+      '--om-color-bg-primary',
+      '#123456'
+    );
+    document.documentElement.style.setProperty(
+      '--om-color-text-disabled',
+      '#234567'
+    );
+    document.documentElement.style.setProperty(
+      '--om-color-brand-200',
+      '#345678'
+    );
+    document.documentElement.style.setProperty(
+      '--om-color-warning-400',
+      '#456789'
+    );
+    document.documentElement.style.setProperty(
+      '--om-color-purple-50',
+      '#56789a'
+    );
+    document.documentElement.style.setProperty(
+      '--om-color-violet-500',
+      '#6789ab'
+    );
+
+    const { result } = renderHook(() => useDataInsightChartColors(), {
+      wrapper: TestThemeProvider,
+    });
+
+    expect(result.current.activeDotBorder).toBe('#123456');
+    expect(result.current.inactive).toBe('#234567');
+    expect(result.current.progress).toBe('#345678');
+    expect(result.current.dataInsightSeries[0]).toBe('#456789');
+    expect(result.current.kpiBackgrounds[0]).toBe('#56789a');
+    expect(result.current.kpiSeries[0]).toBe('#6789ab');
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/insights/useDataInsightChartColors.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/insights/useDataInsightChartColors.test.tsx
@@ -17,9 +17,11 @@ import {
   ThemeProvider,
   useTheme,
 } from '../../context/UntitledUIThemeProvider/theme-provider';
+import { BrandColors } from '../../context/UntitledUIThemeProvider/theme-provider.interface';
 import { useDataInsightChartColors } from './useDataInsightChartColors';
 
 const TEST_THEME_STORAGE_KEY = 'data-insight-chart-colors-test';
+let activeBrandColors: BrandColors | undefined;
 let setActiveTheme: ReturnType<typeof useTheme>['setTheme'];
 
 const ThemeController = ({ children }: { children: ReactNode }) => {
@@ -30,12 +32,19 @@ const ThemeController = ({ children }: { children: ReactNode }) => {
 };
 
 const TestThemeProvider = ({ children }: { children: ReactNode }) => (
-  <ThemeProvider defaultTheme="light" storageKey={TEST_THEME_STORAGE_KEY}>
+  <ThemeProvider
+    brandColors={activeBrandColors}
+    defaultTheme="light"
+    storageKey={TEST_THEME_STORAGE_KEY}>
     <ThemeController>{children}</ThemeController>
   </ThemeProvider>
 );
 
 describe('useDataInsightChartColors', () => {
+  beforeEach(() => {
+    activeBrandColors = undefined;
+  });
+
   afterEach(() => {
     localStorage.removeItem(TEST_THEME_STORAGE_KEY);
     document.documentElement.className = '';
@@ -111,5 +120,29 @@ describe('useDataInsightChartColors', () => {
     expect(result.current.dataInsightSeries[0]).toBe('#456789');
     expect(result.current.kpiBackgrounds[0]).toBe('#56789a');
     expect(result.current.kpiSeries[0]).toBe('#6789ab');
+  });
+
+  it('resolves chart colors again when brand colors change', () => {
+    document.documentElement.style.setProperty(
+      '--om-color-text-tertiary',
+      '#112233'
+    );
+
+    const { rerender, result } = renderHook(() => useDataInsightChartColors(), {
+      wrapper: TestThemeProvider,
+    });
+
+    expect(result.current.axis).toBe('#112233');
+
+    act(() => {
+      document.documentElement.style.setProperty(
+        '--om-color-text-tertiary',
+        '#aabbcc'
+      );
+      activeBrandColors = { primaryColor: '#123456' };
+      rerender();
+    });
+
+    expect(result.current.axis).toBe('#aabbcc');
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/insights/useDataInsightChartColors.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/insights/useDataInsightChartColors.ts
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { useMemo } from 'react';
+import {
+  DATA_INSIGHT_GRAPH_COLOR_TOKENS,
+  KPI_WIDGET_GRAPH_BG_COLOR_TOKENS,
+  KPI_WIDGET_GRAPH_COLOR_TOKENS,
+} from '../../constants/DataInsight.constants';
+import { useTheme } from '../../context/UntitledUIThemeProvider/theme-provider';
+import { resolveCssColor } from '../../utils/common/cssColor.utils';
+
+const AXIS_COLOR = 'var(--om-color-text-tertiary, #535862)';
+const GRID_COLOR = 'var(--om-color-border-secondary, #E9EAEB)';
+const ACTIVE_DOT_BORDER_COLOR = 'var(--om-color-bg-primary, #FFFFFF)';
+const INACTIVE_COLOR = 'var(--om-color-text-disabled, #717680)';
+const PROGRESS_COLOR = 'var(--om-color-brand-200, #B3D4F4)';
+
+const resolveColorTokens = (
+  definitions: ReadonlyArray<{ token: string; fallback: string }>
+) => definitions.map(({ token, fallback }) => resolveCssColor(token, fallback));
+
+export const useDataInsightChartColors = () => {
+  const { theme } = useTheme();
+
+  return useMemo(() => {
+    // SVG presentation attributes need concrete values, so resolve them again
+    // after the root theme class changes instead of passing CSS variables.
+    void theme;
+
+    return {
+      activeDotBorder: resolveCssColor(ACTIVE_DOT_BORDER_COLOR, '#FFFFFF'),
+      axis: resolveCssColor(AXIS_COLOR, '#535862'),
+      dataInsightSeries: resolveColorTokens(DATA_INSIGHT_GRAPH_COLOR_TOKENS),
+      grid: resolveCssColor(GRID_COLOR, '#E9EAEB'),
+      inactive: resolveCssColor(INACTIVE_COLOR, '#717680'),
+      kpiBackgrounds: resolveColorTokens(KPI_WIDGET_GRAPH_BG_COLOR_TOKENS),
+      kpiSeries: resolveColorTokens(KPI_WIDGET_GRAPH_COLOR_TOKENS),
+      progress: resolveCssColor(PROGRESS_COLOR, '#B3D4F4'),
+    };
+  }, [theme]);
+};

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/insights/useDataInsightChartColors.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/insights/useDataInsightChartColors.ts
@@ -31,11 +31,12 @@ const resolveColorTokens = (
 ) => definitions.map(({ token, fallback }) => resolveCssColor(token, fallback));
 
 export const useDataInsightChartColors = () => {
-  const { theme } = useTheme();
+  const { brandColors, theme } = useTheme();
 
   return useMemo(() => {
     // SVG presentation attributes need concrete values, so resolve them again
-    // after the root theme class changes instead of passing CSS variables.
+    // after theme classes or runtime brand variables change.
+    void brandColors;
     void theme;
 
     return {
@@ -48,5 +49,5 @@ export const useDataInsightChartColors = () => {
       kpiSeries: resolveColorTokens(KPI_WIDGET_GRAPH_COLOR_TOKENS),
       progress: resolveCssColor(PROGRESS_COLOR, '#B3D4F4'),
     };
-  }, [theme]);
+  }, [brandColors, theme]);
 };

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightChartUtils.style.less
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightChartUtils.style.less
@@ -11,6 +11,6 @@
  *  limitations under the License.
  */
 
-.custom-data-insight-tooltip-title {
+.ant-typography.custom-data-insight-tooltip-title {
   color: var(--om-color-text-primary);
 }

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightChartUtils.style.less
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightChartUtils.style.less
@@ -1,0 +1,16 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+.custom-data-insight-tooltip-title {
+  color: var(--om-color-text-primary);
+}

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightChartUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightChartUtils.test.tsx
@@ -1,0 +1,88 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { PropsWithChildren } from 'react';
+import {
+  renderDataInsightLineChart,
+  renderLegend,
+} from './DataInsightChartUtils';
+
+jest.mock('recharts', () => ({
+  CartesianGrid: ({ stroke }: { stroke: string }) => (
+    <div data-stroke={stroke} data-testid="data-insight-grid" />
+  ),
+  Line: ({ stroke }: { stroke: string }) => (
+    <div data-stroke={stroke} data-testid="data-insight-line" />
+  ),
+  LineChart: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  Surface: ({ children }: PropsWithChildren) => <svg>{children}</svg>,
+  Tooltip: () => null,
+  XAxis: ({ tick }: { tick?: { fill: string } }) => (
+    <div data-fill={tick?.fill} data-testid="data-insight-x-axis" />
+  ),
+  YAxis: ({ tick }: { tick?: { fill: string } }) => (
+    <div data-fill={tick?.fill} data-testid="data-insight-y-axis" />
+  ),
+}));
+
+const CHART_COLORS = {
+  axis: '#123456',
+  grid: '#234567',
+  inactive: '#345678',
+};
+
+describe('DataInsightChartUtils theme colors', () => {
+  it('applies active theme colors to reusable line charts', () => {
+    render(
+      Reflect.apply(renderDataInsightLineChart, null, [
+        [{ day: 1, table: 2 }],
+        ['table'],
+        [],
+        '',
+        false,
+        CHART_COLORS,
+      ])
+    );
+
+    expect(screen.getByTestId('data-insight-grid')).toHaveAttribute(
+      'data-stroke',
+      '#234567'
+    );
+    expect(screen.getByTestId('data-insight-x-axis')).toHaveAttribute(
+      'data-fill',
+      '#123456'
+    );
+    expect(screen.getByTestId('data-insight-y-axis')).toHaveAttribute(
+      'data-fill',
+      '#123456'
+    );
+  });
+
+  it('applies the active theme muted color to inactive legends', () => {
+    const legend = {
+      payload: [{ color: '#abcdef', value: 'Table' }],
+    };
+
+    render(
+      Reflect.apply(renderLegend, null, [
+        legend,
+        ['Dashboard'],
+        undefined,
+        CHART_COLORS.inactive,
+      ])
+    );
+
+    expect(screen.getByText('Table')).toHaveStyle({ color: '#345678' });
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightChartUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightChartUtils.test.tsx
@@ -14,6 +14,7 @@
 import { render, screen } from '@testing-library/react';
 import { PropsWithChildren } from 'react';
 import {
+  CustomTooltip,
   renderDataInsightLineChart,
   renderLegend,
 } from './DataInsightChartUtils';
@@ -43,6 +44,28 @@ const CHART_COLORS = {
 };
 
 describe('DataInsightChartUtils theme colors', () => {
+  it('uses the semantic text color for tooltip titles', () => {
+    render(
+      <CustomTooltip
+        active
+        payload={[
+          {
+            color: '#abcdef',
+            dataKey: 'count',
+            name: 'Description coverage',
+            payload: { term: 'Sep 1, 2026' },
+            value: 76.27,
+          },
+        ]}
+        timeStampKey="term"
+      />
+    );
+
+    expect(screen.getByRole('heading', { name: 'Sep 1, 2026' })).toHaveClass(
+      'custom-data-insight-tooltip-title'
+    );
+  });
+
   it('applies active theme colors to reusable line charts', () => {
     render(
       Reflect.apply(renderDataInsightLineChart, null, [

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightChartUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightChartUtils.tsx
@@ -25,7 +25,6 @@ import {
 } from 'recharts';
 import {
   DEFAULT_CHART_OPACITY,
-  GRAPH_BACKGROUND_COLOR,
   GRAYED_OUT_COLOR,
   HOVER_CHART_OPACITY,
 } from '../constants/constants';
@@ -42,7 +41,8 @@ import { customFormatDateTime, formatDate } from './date-time/DateTimeUtils';
 export const renderLegend = (
   legendData: LegendProps,
   activeKeys = [] as string[],
-  valueFormatter?: (value: string) => string
+  valueFormatter?: (value: string) => string,
+  inactiveColor = GRAYED_OUT_COLOR
 ) => {
   const { payload = [] } = legendData;
 
@@ -70,13 +70,13 @@ export const renderLegend = (
             }>
             <Surface className="m-r-xss" height={14} version="1.1" width={14}>
               <rect
-                fill={isActive ? entry.color : GRAYED_OUT_COLOR}
+                fill={isActive ? entry.color : inactiveColor}
                 height="14"
                 rx="2"
                 width="14"
               />
             </Surface>
-            <span style={{ color: isActive ? 'inherit' : GRAYED_OUT_COLOR }}>
+            <span style={{ color: isActive ? 'inherit' : inactiveColor }}>
               {valueFormatter ? valueFormatter(entry.value) : entry.value}
             </span>
           </li>
@@ -166,11 +166,12 @@ export const renderDataInsightLineChart = (
   labels: string[],
   activeKeys: string[],
   activeMouseHoverKey: string,
-  isPercentage: boolean
+  isPercentage: boolean,
+  colors: { axis: string; grid: string }
 ) => {
   return (
     <LineChart data={graphData} margin={BAR_CHART_MARGIN}>
-      <CartesianGrid stroke={GRAPH_BACKGROUND_COLOR} vertical={false} />
+      <CartesianGrid stroke={colors.grid} vertical={false} />
       <Tooltip
         content={
           <CustomTooltip isPercentage={isPercentage} timeStampKey="day" />
@@ -180,10 +181,12 @@ export const renderDataInsightLineChart = (
       <XAxis
         allowDuplicatedCategory={false}
         dataKey="day"
+        tick={{ fill: colors.axis }}
         tickFormatter={(value: number) => customFormatDateTime(value, 'MMM dd')}
         type="category"
       />
       <YAxis
+        tick={{ fill: colors.axis }}
         tickFormatter={
           isPercentage
             ? (value: number) => axisTickFormatter(value, '%')

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightChartUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightChartUtils.tsx
@@ -32,6 +32,7 @@ import { BAR_CHART_MARGIN } from '../constants/DataInsight.constants';
 import { DataInsightChartTooltipProps } from '../interface/data-insight.interface';
 import { axisTickFormatter } from './ChartUtils';
 import { entityChartColor } from './ColorUtils';
+import './DataInsightChartUtils.style.less';
 import {
   getEntryFormattedValue,
   getRandomHexColor,
@@ -115,7 +116,10 @@ export const CustomTooltip = (props: DataInsightChartTooltipProps) => {
         className="custom-data-insight-tooltip"
         style={cardStyles}
         title={
-          <Typography.Title level={5} style={titleStyles}>
+          <Typography.Title
+            className="custom-data-insight-tooltip-title"
+            level={5}
+            style={titleStyles}>
             {timestamp}
           </Typography.Title>
         }>


### PR DESCRIPTION
### Describe your changes:

Fixes #6035

This stacked PR makes Data Insights and KPI chart presentation respond to the active theme. It resolves semantic and categorical color tokens to concrete SVG/canvas-safe values, refreshes those values when the theme changes, and replaces the remaining dark-only chart, progress, legend, and panel colors in this slice.

Depends on #32482 and targets its feature branch so the theme work can be reviewed and backported as a stack.

https://github.com/user-attachments/assets/e84e09e1-11c2-4511-a5d9-11bba28ec2d8

<img width="1512" height="741" alt="Screenshot 2026-09-03 at 8 51 13 PM" src="https://github.com/user-attachments/assets/de7ddfa2-5ef0-4a49-9fad-e99cebe7c724" />
<img width="1512" height="803" alt="Screenshot 2026-09-03 at 8 51 27 PM" src="https://github.com/user-attachments/assets/da833dc3-88e5-4947-ab12-a88c3f91cc94" />


#
### Type of change:

- [x] Improvement

#
### High-level design:

- Add a shared `useDataInsightChartColors` hook that resolves registered `--om-color-*` tokens with deterministic fallbacks and recomputes them when the active theme changes.
- Route reusable Data Insights charts, KPI charts, legends, progress bars, axes, grids, and active dots through the resolved theme palette.
- Preserve categorical series identity while cycling finite palettes safely for arbitrary KPI counts.
- Keep graph data, requests, and chart interaction behavior unchanged; this layer only updates presentation.

#
### Tests:

#### Use cases covered

- Data Insights colors are resolved again during an in-place light/dark theme switch.
- Reusable line charts receive theme-aware grid, axis, and inactive legend colors.
- KPI widgets and progress/status components receive theme-aware presentation colors.
- KPI series palettes wrap safely when the number of results exceeds the palette length.

#### Unit tests

- [x] I added unit tests for the new/changed logic.
- Files added/updated:
  - `useDataInsightChartColors.test.tsx`
  - `DataInsightChartUtils.test.tsx`
  - `DataInsightProgressBar.test.tsx`
  - `KPILatestResultsV1.test.tsx`
  - `KPIChart.test.tsx`
  - `KPIWidget.test.tsx`
- Result: 21 focused tests passed across 6 suites.

#### Backend integration tests

- [x] Not applicable (no backend API changes).

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Not applicable for this presentation-only slice; behavior is covered by focused component and hook tests.

#### Manual testing performed

1. Switched the theme in the hook harness and verified computed chart colors update without remounting graph data.
2. Ran the exact UI checkstyle sequence on all 18 changed TypeScript files (0 errors).
3. Ran the design-token audit report and confirmed the changed Data Insights LESS file has no findings.

#
### UI screen recording / screenshots:

To be added during review after validating against a local Data Insights dataset.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable; no schema changes.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

#### Improvement

- [x] I have added tests around the new logic.
- [x] For connector/ingestion changes: not applicable.
