### PR TITLE
Fixes #25847: Include bot user in bot list responses [2.0]

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BotResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BotResourceIT.java
@@ -195,6 +195,29 @@ public class BotResourceIT extends BaseEntityIT<Bot, CreateBot> {
   }
 
   @Test
+  void get_entityListIncludesRequiredBotUser_200_OK(TestNamespace ns) {
+    User botUser = createBotUser(ns);
+    Bot created =
+        createEntity(
+            new CreateBot()
+                .withName(ns.prefix("listed_bot"))
+                .withDescription("Bot returned by the list endpoint")
+                .withBotUser(botUser.getName()));
+
+    ListParams params = new ListParams();
+    params.setLimit(1000000);
+    params.setFields("*");
+    Bot listed =
+        listEntities(params).getData().stream()
+            .filter(bot -> bot.getId().equals(created.getId()))
+            .findFirst()
+            .orElseThrow();
+
+    assertNotNull(listed.getBotUser(), "Listed bot must include its required bot user");
+    assertEquals(botUser.getId(), listed.getBotUser().getId());
+  }
+
+  @Test
   void put_botDescription_200_OK(TestNamespace ns) {
     OpenMetadataClient client = SdkClients.adminClient();
     User botUser = createBotUser(ns);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/BotRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/BotRepository.java
@@ -13,7 +13,10 @@
 
 package org.openmetadata.service.jdbi3;
 
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
@@ -46,6 +49,21 @@ public class BotRepository extends EntityRepository<Bot> {
   @Override
   public void setFields(Bot entity, Fields fields, RelationIncludes relationIncludes) {
     entity.withBotUser(getBotUser(entity));
+  }
+
+  @Override
+  public void setFieldsInBulk(Fields fields, List<Bot> entities) {
+    if (nullOrEmpty(entities)) {
+      return;
+    }
+
+    Map<UUID, List<EntityReference>> botUsers =
+        batchFetchFromIdsManyToOne(entities, Relationship.CONTAINS, Entity.USER);
+    for (Bot bot : entities) {
+      List<EntityReference> userReferences = botUsers.get(bot.getId());
+      bot.withBotUser(nullOrEmpty(userReferences) ? null : userReferences.getFirst());
+    }
+    super.setFieldsInBulk(fields, entities);
   }
 
   @Override


### PR DESCRIPTION
### Describe your changes:

Fixes #25847

Backport of #32398 to `2.0`.

Bot list responses were missing the required `botUser` relationship because the repository only hydrated it on the single-entity path. This change batch-loads the relationship for list responses so Python SDK `list_all_entities` calls can deserialize `Bot` entities.

Verified with the focused `BotResourceIT#get_entityListIncludesRequiredBotUser_200_OK` integration test against an isolated Testcontainers stack.

### Type of change:

- [x] Bug fix

### Checklist:

- [x] My PR is linked to GitHub issue #25847.
- [x] I added an integration test covering the exact list-response regression.