### PR TITLE
Fixes #32519: Make the JavaUIIT suite a required status check

### DIFF
--- a/.github/workflows/java-playwright-nightly.yml
+++ b/.github/workflows/java-playwright-nightly.yml
@@ -15,11 +15,14 @@
 #
 # The schedule trigger is intentionally disabled while the suite stabilises. Run it
 # on demand via workflow_dispatch (pick the branch to test as the ref); it also runs
-# automatically on any PR that touches search-indexing code (see the pull_request
-# `paths` filter below), exercising this whole suite (both engines + search-it) against
-# the PR head in embedded mode. Re-add `schedule: - cron: '0 2 * * *'` once green on main.
+# automatically on any PR that touches search-indexing code (see the `changes` job's
+# paths-filter), exercising this whole suite (both engines + search-it) against the PR head
+# in embedded mode. Re-add `schedule: - cron: '0 2 * * *'` once green on main.
 #
 # Topology:
+#   - changes: dorny/paths-filter deciding whether the search-indexing paths were touched;
+#     everything below is skipped when they were not, so the required `java-ui-it` gate still
+#     reports green on unrelated PRs.
 #   - build-image: builds the openmetadata-dist tarball and bakes the local
 #     openmetadata-server:jpw-snapshot image (BuildKit + GHA layer cache), saves it
 #     to a workflow artifact, and primes the Maven cache for downstream jobs.
@@ -30,6 +33,7 @@
 #   - search-it-nightly: server-global destructive search ITs (tests/search/*IT.java) via
 #     `mvn verify -P search-it`. They run on the embedded bootstrap (testcontainers), not the
 #     baked image, so this job is independent of build-image and runs them serially.
+#   - java-ui-it: the required status check. Aggregates the three jobs above under `always()`.
 
 name: JavaUIIT Integration Tests Running on PRs
 
@@ -71,35 +75,26 @@ on:
         required: false
         type: string
         default: '60'
-  # Auto-run on PRs that modify search-indexing code (paths below): the full suite runs against
-  # the PR head in embedded mode (testcontainers), NOT the external cluster — so a change to the
-  # reindex app, search clients, or index mappings is validated before merge without anyone
-  # remembering a label. Uses `pull_request` (NOT pull_request_target) on purpose: fork PRs run
-  # WITHOUT secrets, so untrusted code never executes with credentials; same-repo branch PRs (the
-  # common case here) still get secrets and full check reporting.
+  # Auto-run on PRs that modify search-indexing code: the full suite runs against the PR head in
+  # embedded mode (testcontainers), NOT the external cluster — so a change to the reindex app,
+  # search clients, or index mappings is validated before merge without anyone remembering a label.
+  # Uses `pull_request` (NOT pull_request_target) on purpose: fork PRs run WITHOUT secrets, so
+  # untrusted code never executes with credentials; same-repo branch PRs (the common case here)
+  # still get secrets and full check reporting.
+  #
+  # `java-ui-it` is a REQUIRED status check on main, so there is deliberately no `paths:` filter
+  # here: a path-filtered workflow never reports on PRs that miss the filter, and the required
+  # context would hang at "Expected — waiting for status" forever. Path selection lives in the
+  # `changes` job below instead (dorny/paths-filter), which skips the expensive jobs while the
+  # gate still reports green. `merge_group` is required for the same reason — without it the
+  # merge queue waits out `check_response_timeout_minutes` and fails.
   pull_request:
-    paths:
-      # --- Production search-indexing code (openmetadata-service) ---
-      - "openmetadata-service/src/main/java/org/openmetadata/service/search/**"
-      - "openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/**"
-      - "openmetadata-service/src/main/java/org/openmetadata/service/resources/searchindex/**"
-      - "openmetadata-service/src/main/java/org/openmetadata/service/resources/search/**"
-      - "openmetadata-service/src/main/java/org/openmetadata/service/resources/testsupport/**"
-      - "openmetadata-service/src/main/java/org/openmetadata/service/events/lifecycle/handlers/SearchIndexHandler.java"
-      # --- Index mappings + loader (canonical source lives in the spec module) ---
-      - "openmetadata-spec/src/main/resources/elasticsearch/**"
-      - "openmetadata-spec/src/main/java/org/openmetadata/search/**"
-      # --- The search ITs / UIITs, their test harness, and the Maven profiles that run them ---
-      - "openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/**"
-      - "openmetadata-integration-tests/src/test/java/org/openmetadata/it/search/**"
-      - "openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/scenarios/search/**"
-      - "openmetadata-integration-tests/pom.xml"
-      # --- This workflow itself ---
-      - ".github/workflows/java-playwright-nightly.yml"
+  merge_group:
 
 permissions:
   contents: read
   checks: write
+  pull-requests: read
 
 concurrency:
   # One run per PR (or per ref for dispatch/cron); a new push cancels the prior in-flight run.
@@ -110,7 +105,51 @@ env:
   SERVER_IMAGE_TAG: openmetadata-server:jpw-snapshot
 
 jobs:
+  # Path selection for the required `java-ui-it` check. The workflow itself has no `paths:`
+  # filter (see the trigger comment); this job decides whether the 90-minute matrix actually
+  # runs. Keep this filter list as the single source of truth for "search-indexing code".
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      search: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && 'true' || steps.filter.outputs.search }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        if: ${{ github.event_name == 'merge_group' }}
+        with:
+          fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
+      - uses: dorny/paths-filter@v4
+        id: filter
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+        with:
+          base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || '' }}
+          filters: |
+            search:
+              # --- Production search-indexing code (openmetadata-service) ---
+              - 'openmetadata-service/src/main/java/org/openmetadata/service/search/**'
+              - 'openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/**'
+              - 'openmetadata-service/src/main/java/org/openmetadata/service/resources/searchindex/**'
+              - 'openmetadata-service/src/main/java/org/openmetadata/service/resources/search/**'
+              - 'openmetadata-service/src/main/java/org/openmetadata/service/resources/testsupport/**'
+              - 'openmetadata-service/src/main/java/org/openmetadata/service/events/lifecycle/handlers/SearchIndexHandler.java'
+              # --- Index mappings + loader (canonical source lives in the spec module) ---
+              - 'openmetadata-spec/src/main/resources/elasticsearch/**'
+              - 'openmetadata-spec/src/main/java/org/openmetadata/search/**'
+              # --- The search ITs / UIITs, their test harness, and the Maven profiles that run them ---
+              - 'openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/**'
+              - 'openmetadata-integration-tests/src/test/java/org/openmetadata/it/search/**'
+              - 'openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/scenarios/search/**'
+              - 'openmetadata-integration-tests/pom.xml'
+              # --- This workflow itself ---
+              - '.github/workflows/java-playwright-nightly.yml'
+
   build-image:
+    needs: changes
+    if: ${{ needs.changes.outputs.search == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
@@ -133,8 +172,9 @@ jobs:
         with:
           # On a PR, test the PR head (the changed code). workflow_dispatch honours the
           # dispatched ref so feature branches can validate the nightly matrix before merge.
-          # Cron/anything else runs against main (EPIC #3731 / PR #28008).
-          ref: ${{ github.event.pull_request.head.sha || (github.event_name == 'workflow_dispatch' && github.ref || 'main') }}
+          # merge_group runs the merge-queue commit; cron/anything else is the default-branch
+          # head, which github.sha already is (EPIC #3731 / PR #28008).
+          ref: ${{ github.event.pull_request.head.sha || (github.event_name == 'workflow_dispatch' && github.ref || github.sha) }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5
@@ -204,7 +244,8 @@ jobs:
           retention-days: 1
 
   ui-it-nightly:
-    needs: build-image
+    needs: [changes, build-image]
+    if: ${{ needs.changes.outputs.search == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
@@ -226,7 +267,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha || (github.event_name == 'workflow_dispatch' && github.ref || 'main') }}
+          ref: ${{ github.event.pull_request.head.sha || (github.event_name == 'workflow_dispatch' && github.ref || github.sha) }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5
@@ -379,6 +420,8 @@ jobs:
     # the default PR profiles exclude them; here the `search-it` Maven profile runs them
     # serially on their own embedded-bootstrap server (testcontainers). That bootstrap is
     # independent of the baked image, so this job does not need build-image.
+    needs: changes
+    if: ${{ needs.changes.outputs.search == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
@@ -396,7 +439,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha || (github.event_name == 'workflow_dispatch' && github.ref || 'main') }}
+          ref: ${{ github.event.pull_request.head.sha || (github.event_name == 'workflow_dispatch' && github.ref || github.sha) }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5
@@ -458,3 +501,32 @@ jobs:
             text: "${{ job.status == 'success' && ':white_check_mark:' || ':fire:' }} Java Search ITs Nightly: ${{ job.status }}\nRef: ${{ github.ref_name }}\nLogs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_JAVA_PLAYWRIGHT_URL: ${{ secrets.SLACK_JAVA_PLAYWRIGHT_URL }}
+
+  # Required status check on main (ruleset `merge-rules`). Named to match the context exactly.
+  # `always()` so it reports on every PR: when nothing search-related changed the upstream jobs
+  # are skipped and this exits 0; otherwise every job must have succeeded.
+  java-ui-it:
+    name: java-ui-it
+    needs: [changes, build-image, ui-it-nightly, search-it-nightly]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ always() }}
+    steps:
+      - name: Verify JavaUIIT suite
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          SEARCH_CHANGED: ${{ needs.changes.outputs.search }}
+          BUILD_RESULT: ${{ needs.build-image.result }}
+          UI_IT_RESULT: ${{ needs.ui-it-nightly.result }}
+          SEARCH_IT_RESULT: ${{ needs.search-it-nightly.result }}
+        run: |
+          if [[ "$CHANGES_RESULT" == "success" && "$SEARCH_CHANGED" != "true" ]]; then
+            echo "No search-indexing paths changed."
+            exit 0
+          fi
+
+          if [[ "$CHANGES_RESULT" != "success" || "$BUILD_RESULT" != "success" \
+                || "$UI_IT_RESULT" != "success" || "$SEARCH_IT_RESULT" != "success" ]]; then
+            echo "JavaUIIT jobs did not complete successfully: changes=${CHANGES_RESULT}, build=${BUILD_RESULT}, ui-it=${UI_IT_RESULT}, search-it=${SEARCH_IT_RESULT}"
+            exit 1
+          fi


### PR DESCRIPTION
### Describe your changes:

Fixes #32519

The JavaUIIT suite (`ui-it-nightly` × [elasticsearch, opensearch] + `search-it-nightly`) already runs on PRs that touch search-indexing code, but its result gated nothing — a red run never blocked a merge. This makes it a required status check on `main`.

Adding the existing job contexts to the `merge-rules` ruleset as-is would have wedged the repo, so the workflow is first restructured into the shape every other required check here already uses (`integration-tests-mysql-elasticsearch.yml:50`/`:463`, `ui-checkstyle.yml`, `yarn-coverage.yml`):

- **`merge_group:` trigger added, `paths:` dropped from `pull_request`.** A path-filtered workflow simply never runs on PRs outside the filter, so the required context is never reported and those PRs sit at `Expected — waiting for status` forever. Without `merge_group`, the `ALLGREEN` merge queue waits out `check_response_timeout_minutes: 240` and fails.
- **New `changes` job** — the same 13 path globs, now via `dorny/paths-filter@v4` (checkout + `base: merge_group.base_sha` on merge_group only). `build-image`, `ui-it-nightly` and `search-it-nightly` are gated on its output, so unrelated PRs still skip the 90-minute matrix.
- **New `java-ui-it` gate job**, `if: always()`, `needs:` all three — exits 0 when nothing search-related changed, fails if any job did not succeed. Hard fail on `search-it-nightly` too, matching `integration-tests-mysql-elasticsearch`.
- **Checkout `ref` fallback `'main'` → `github.sha`** (3 sites) so merge_group runs test the queue commit instead of whatever `main` happens to be. Equivalent for cron/schedule, where `github.sha` is already the default-branch head.

`java-ui-it` has been added to the `required_status_checks` rule of the `merge-rules` ruleset.

#
### Type of change:
- [x] Improvement

#
### High-level design:

N/A — single-file CI change, described above.

#
### Tests:

#### Use cases covered
- A PR touching `openmetadata-service/.../search/**` runs the full matrix; `java-ui-it` is red if any job fails and blocks the merge.
- A PR touching nothing search-related still reports `java-ui-it` as green (the `changes` job short-circuits, upstream jobs skip) — it does not hang at `Expected — waiting for status`.
- A PR entering the merge queue reports `java-ui-it` on the `merge_group` event instead of timing out after 240 minutes.
- `workflow_dispatch` forces `search=true` and runs the full suite regardless of paths.

#### Unit tests
- [x] Not applicable — CI workflow definition, no product code.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. Parsed the edited workflow with PyYAML and dumped the job graph, confirming triggers `[workflow_dispatch, pull_request, merge_group]` and `changes → build-image → ui-it-nightly`, `changes → search-it-nightly`, all four feeding `java-ui-it (if: always())`.
2. Read back the `merge-rules` ruleset after the update and confirmed the nine required contexts plus every unrelated rule intact (ref conditions, bypass actor, 1 approving review + CODEOWNERS, merge_queue `ALLGREEN`).
3. **This PR is its own test:** it touches `.github/workflows/java-playwright-nightly.yml`, which is inside the filter, so the full matrix runs here and `java-ui-it` must go green before it can merge.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

> ⚠️ **Rollout order:** `java-ui-it` is already required on `main`, but the gate job only exists on this branch. Until this merges, open PRs will not report the context and are blocked (the `merge-rules` bypass team can still merge). This PR self-bootstraps — its head carries the gate job, so the check reports here. Merge it first, or temporarily set `merge-rules` to `evaluate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
