### PR TITLE
fix(ingestion): pin anyio<4.15 in the mlflow test image to unblock py-tests shard-2

### DIFF
--- a/ingestion/tests/integration/sources/mlmodels/mlflow/conftest.py
+++ b/ingestion/tests/integration/sources/mlmodels/mlflow/conftest.py
@@ -145,11 +145,14 @@ def build_and_get_mlflow_container(
 ):
     docker_client = DockerClient()
 
+    # anyio 4.15 lazily imports its submodules without exposing from_thread, which
+    # starlette's WSGIMiddleware calls, so every mlflow server response 500s. Drop the
+    # bound once anyio restores the attribute or starlette imports the submodule.
     dockerfile = io.BytesIO(
         b"""
         FROM python:3.10-slim-buster
         RUN python -m pip install --upgrade pip
-        RUN pip install cryptography "mlflow>=3.10.0,<3.11" boto3 pymysql
+        RUN pip install cryptography "mlflow>=3.10.0,<3.11" boto3 pymysql "anyio<4.15"
         """
     )
 

--- a/ingestion/tests/integration/sources/mlmodels/mlflow/conftest.py
+++ b/ingestion/tests/integration/sources/mlmodels/mlflow/conftest.py
@@ -27,6 +27,7 @@ The following steps are taken:
 import io
 import time
 import uuid
+from contextlib import suppress
 from dataclasses import dataclass
 
 import pymysql
@@ -126,12 +127,10 @@ def mlflow_environment():
 
             mlflow_port = config.mlflow_configs.exposed_port
             for _ in range(30):
-                try:
-                    response = requests.get(f"http://localhost:{mlflow_port}/health")
-                    if response.status_code == 200:
+                with suppress(Exception):
+                    if requests.get(f"http://localhost:{mlflow_port}/health").status_code == 200:
                         break
-                except Exception:
-                    time.sleep(2)
+                time.sleep(2)
             else:
                 raise RuntimeError("MLflow server did not become ready in time.")
 


### PR DESCRIPTION
### Describe your changes:

Fixes #32528

`tests/integration/sources/mlmodels/mlflow/test_mlflow.py::test_mlflow` has been erroring during fixture setup on **every** branch since 2026-09-02 21:59 UTC, failing `python / Integration Tests (shard-2)` on all three Python versions and ejecting PRs from the merge queue.

```
ERROR tests/integration/sources/mlmodels/mlflow/test_mlflow.py::test_mlflow
RuntimeError: MLflow server did not become ready in time.
  ingestion/tests/integration/sources/mlmodels/mlflow/conftest.py:136
```

Not a code regression. No commit landed on `main` between the last green run and the first red one.

| | |
|---|---|
| Last green `shard-2` | 2026-09-02T21:08:14Z |
| [`anyio` 4.15.0](https://pypi.org/project/anyio/4.15.0/) published to PyPI | 2026-09-02T21:46:35Z |
| First red `shard-2` | 2026-09-02T21:59:31Z |
| `main` unchanged across that window | `f1ed7b42` (14:47Z) → `83c7612b` (2026-09-03 04:16Z) |

Since then: 48 failed `py-tests` runs across 23 branches, 10 PRs ejected from the merge queue (#31848, #31990, #32014, #32074, #32181, #32306, #32342, #32375, #32427, #32492), plus `1.13` and `2.0` backport branches.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

**Root cause.** The fixture builds a throwaway MLflow **server** image with an unlocked install, so transitive dependencies float:

```
RUN pip install cryptography "mlflow>=3.10.0,<3.11" boto3 pymysql
```

anyio 4.15.0 changed `anyio` and `anyio.abc` to import their submodules lazily ([agronholm/anyio#1169](https://github.com/agronholm/anyio/pull/1169)), and `from_thread` is not exposed by that mechanism. Starlette's `WSGIMiddleware` calls `anyio.from_thread.run(...)` without importing the submodule, and MLflow serves its tracking API through that adapter, so every request returns 500:

```
File ".../starlette/middleware/wsgi.py", line 136, in start_response
    anyio.from_thread.run(
File ".../anyio/_lazyimport.py", line 41, in __getattr__
    raise AttributeError(
AttributeError: module 'anyio' has no attribute 'from_thread'
```

`/health` never returns 200, so the readiness loop gives up.

**Second commit.** The same loop's `time.sleep(2)` sat inside the `except` block, so a response that arrives but is not 200 never slept: all 30 attempts burned in milliseconds instead of the intended 60s. This is not what made the test fail, but it is why the fixture reported "did not become ready" almost instantly and why a server that 500s during warm-up is indistinguishable from one that is down. Moving the sleep out restores the intended budget. Drop this commit if you would rather keep the change to one line.

**Nothing shipped is affected.** The MLflow connector depends on `mlflow-skinny` (`ingestion/setup.py:370`), which ships no server and never reaches `WSGIMiddleware`. The CI ingestion venv itself installed `anyio-4.15.0` and the other 146 tests in the same shard passed. This Dockerfile is built inside the test, never published and never scanned.

**No security regression.** anyio has no published GitHub security advisories, and 4.15.0 is a feature release with no security fix, so the bound reintroduces nothing. The `mlflow>=3.10.0` floor that #28231 set to clear Snyk high/critical findings is untouched.

**Rejected alternatives.**
- *Bump MLflow past the `<3.11` cap.* Does not constrain anyio. Verified: MLflow 3.14.0 also resolves starlette 1.6.0 + anyio 4.15.0 and hits the same path; [opendatahub-io/agentic-ci#382](https://github.com/opendatahub-io/agentic-ci/pull/382) reports the same for 3.15.2.
- *Relax the readiness probe.* It would hide a server returning 500 for every request.
- *Pin anyio anywhere outside this image.* The ingestion runtime is unaffected and should keep floating.

The bound can be removed once anyio restores the attribute or starlette imports the submodule; that condition is in the code comment.

#
### Tests:

#### Use cases covered

- The MLflow fixture builds an image whose server answers `/health` with 200.
- The MLflow tracking API, which the connector actually calls, answers through the WSGI adapter rather than 500ing.

#### Unit tests

Not applicable: test-fixture-only change.

#### Backend integration tests

Not applicable: no server changes.

#### Ingestion integration tests

`ruff check` and `ruff format --check` (pinned `ruff~=0.15.12`) pass on the changed file.

End-to-end, driving the Dockerfile bytes extracted from this branch's `conftest.py` and starting the same three containers with the fixture's own commands (`mysql:8.4.5` with `--log-bin-trust-function-creators=1`, `minio/minio:RELEASE.2022-12-02T19-19-22Z`, the built MLflow image):

```
resolved: anyio 4.14.2  mlflow 3.10.1  starlette 1.6.0
READY after 8s
GET /health                                    -> 200
GET /api/2.0/mlflow/experiments/search         -> 200
```

A/B control on the same setup, changing only the anyio bound:

| anyio | `GET /health` |
|---|---|
| 4.15.0 (before this PR) | 500, `AttributeError: module 'anyio' has no attribute 'from_thread'` |
| 4.14.2 (after this PR) | 200 |

#### Playwright (UI) tests

Not applicable.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable, no schema change.
- [x] I have added a test that covers the exact scenario we are fixing: the existing `test_mlflow` is that test; this PR restores it.

**Backports needed:** `1.13` and `2.0` carry the same unpinned line and are failing the same way.

