### PR TITLE
Backport #32336 to 1.13: Honor Data Product Domain Validation rule in the Add Assets picker

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesDisabled.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesDisabled.spec.ts
@@ -55,6 +55,7 @@ import {
   toastNotification,
 } from '../../utils/common';
 import { DATA_ASSET_RULES } from '../../utils/dataAssetRules';
+import { addAssetsToDataProduct } from '../../utils/domain';
 import {
   addMultiOwner,
   assignGlossaryTerm,
@@ -830,6 +831,11 @@ test.describe(
     const productDomain = new Domain();
     const crossDomainDataProduct = new DataProduct([productDomain]);
     const crossTable = new TableClass();
+    // Dedicated fixtures for the "Add Assets" picker test so its precondition
+    // (the Data Product starts with zero assets) is not affected by the
+    // asset-level assignment performed by the first test.
+    const pickerDataProduct = new DataProduct([productDomain]);
+    const pickerTable = new TableClass();
 
     test.beforeAll('Setup cross-domain data', async ({ browser }) => {
       const { apiContext, afterAction } = await performAdminLogin(browser);
@@ -837,11 +843,26 @@ test.describe(
       await productDomain.create(apiContext);
       await crossDomainDataProduct.create(apiContext);
       await crossTable.create(apiContext);
+      await pickerDataProduct.create(apiContext);
+      await pickerTable.create(apiContext);
+      // The picker table lives in a different domain than the Data Product.
+      await pickerTable.patch({
+        apiContext,
+        patchData: [
+          {
+            op: 'add',
+            path: '/domains',
+            value: [{ id: assetDomain.responseData.id, type: 'domain' }],
+          },
+        ],
+      });
       await afterAction();
     });
 
     test.afterAll('Cleanup cross-domain data', async ({ browser }) => {
       const { apiContext, afterAction } = await performAdminLogin(browser);
+      await pickerTable.delete(apiContext);
+      await pickerDataProduct.delete(apiContext);
       await crossTable.delete(apiContext);
       await crossDomainDataProduct.delete(apiContext);
       await productDomain.delete(apiContext);
@@ -869,6 +890,25 @@ test.describe(
             `data-product-${crossDomainDataProduct.responseData.fullyQualifiedName}`
           )
       ).toBeVisible();
+    });
+
+    // With the rule disabled, the "Add Assets" picker on a Data Product must
+    // surface assets from every domain, not only the Data Product's own domain,
+    // so a cross-domain asset can be added. This mirrors the asset-side fix from
+    // the reverse direction (#32297).
+    test('should list cross-domain assets in the Add Assets picker', async ({
+      page,
+    }) => {
+      await redirectToHomePage(page);
+      await pickerDataProduct.visitEntityPage(page);
+
+      // pickerTable belongs to assetDomain while pickerDataProduct belongs to
+      // productDomain; the helper fails if the card never appears in the picker.
+      await addAssetsToDataProduct(
+        page,
+        pickerDataProduct.responseData.fullyQualifiedName,
+        [pickerTable]
+      );
     });
   }
 );

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesEnabled.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesEnabled.spec.ts
@@ -325,6 +325,12 @@ test.describe(
     const sameDomainDataProduct = new DataProduct([assetDomain]);
     const otherDomainDataProduct = new DataProduct([productDomain]);
     const crossTable = new TableClass();
+    // Fixtures for the "Add Assets" picker test: a Data Product in
+    // productDomain, an asset in the same domain (must be offered) and an asset
+    // in a different domain (must be scoped out).
+    const pickerDataProduct = new DataProduct([productDomain]);
+    const sameDomainTable = new TableClass();
+    const otherDomainTable = new TableClass();
 
     test.beforeAll('Setup cross-domain data', async ({ browser }) => {
       const { apiContext, afterAction } = await performAdminLogin(browser);
@@ -333,11 +339,37 @@ test.describe(
       await sameDomainDataProduct.create(apiContext);
       await otherDomainDataProduct.create(apiContext);
       await crossTable.create(apiContext);
+      await pickerDataProduct.create(apiContext);
+      await sameDomainTable.create(apiContext);
+      await otherDomainTable.create(apiContext);
+      await sameDomainTable.patch({
+        apiContext,
+        patchData: [
+          {
+            op: 'add',
+            path: '/domains',
+            value: [{ id: productDomain.responseData.id, type: 'domain' }],
+          },
+        ],
+      });
+      await otherDomainTable.patch({
+        apiContext,
+        patchData: [
+          {
+            op: 'add',
+            path: '/domains',
+            value: [{ id: assetDomain.responseData.id, type: 'domain' }],
+          },
+        ],
+      });
       await afterAction();
     });
 
     test.afterAll('Cleanup cross-domain data', async ({ browser }) => {
       const { apiContext, afterAction } = await performAdminLogin(browser);
+      await otherDomainTable.delete(apiContext);
+      await sameDomainTable.delete(apiContext);
+      await pickerDataProduct.delete(apiContext);
       await crossTable.delete(apiContext);
       await sameDomainDataProduct.delete(apiContext);
       await otherDomainDataProduct.delete(apiContext);
@@ -388,6 +420,59 @@ test.describe(
       await otherSearchResponse;
 
       await expect(page.getByTestId(`tag-${otherDomainFqn}`)).not.toBeVisible();
+    });
+
+    // With the rule enabled, the "Add Assets" picker on a Data Product stays
+    // scoped to the Data Product's own domain, so an asset from a different
+    // domain is not offered (#32297).
+    test('should scope the Add Assets picker to the Data Product domain', async ({
+      page,
+    }) => {
+      await authenticateAdminPage(page);
+      await pickerDataProduct.visitEntityPage(page);
+
+      const initialSearch = page.waitForResponse(
+        '/api/v1/search/query?q=&index=all&*'
+      );
+      await page.getByTestId('data-product-details-add-button').click();
+      await initialSearch;
+
+      const drawer = page.getByTestId('asset-selection-modal');
+      await drawer.waitFor({ state: 'visible' });
+
+      const sameDomainName = sameDomainTable.entityResponseData.name;
+      const sameDomainFqn =
+        sameDomainTable.entityResponseData.fullyQualifiedName;
+      const otherDomainName = otherDomainTable.entityResponseData.name;
+      const otherDomainFqn =
+        otherDomainTable.entityResponseData.fullyQualifiedName;
+
+      // Positive control: an asset in the Data Product's domain is offered.
+      const sameDomainSearch = page.waitForResponse(
+        `/api/v1/search/query?q=${encodeURIComponent(
+          sameDomainName
+        )}&index=all&from=0&size=25&*`
+      );
+      await page.getByTestId('searchbar').fill(sameDomainName);
+      await sameDomainSearch;
+
+      await expect(
+        drawer.getByTestId(`table-data-card_${sameDomainFqn}`)
+      ).toBeVisible();
+
+      // Scoped to the Data Product's domain, so a cross-domain asset is not
+      // offered.
+      const otherDomainSearch = page.waitForResponse(
+        `/api/v1/search/query?q=${encodeURIComponent(
+          otherDomainName
+        )}&index=all&from=0&size=25&*`
+      );
+      await page.getByTestId('searchbar').fill(otherDomainName);
+      await otherDomainSearch;
+
+      await expect(
+        drawer.getByTestId(`table-data-card_${otherDomainFqn}`)
+      ).not.toBeVisible();
     });
   }
 );

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesEnabled.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesEnabled.spec.ts
@@ -428,7 +428,7 @@ test.describe(
     test('should scope the Add Assets picker to the Data Product domain', async ({
       page,
     }) => {
-      await authenticateAdminPage(page);
+      await redirectToHomePage(page);
       await pickerDataProduct.visitEntityPage(page);
 
       const initialSearch = page.waitForResponse(

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
@@ -58,10 +58,14 @@ import { ContractExecutionStatus } from '../../../generated/type/contractExecuti
 import { Style } from '../../../generated/type/tagLabel';
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
 import { useCustomPages } from '../../../hooks/useCustomPages';
+import { useEntityRules } from '../../../hooks/useEntityRules';
 import { useFqn } from '../../../hooks/useFqn';
 import { useMarketplaceStore } from '../../../hooks/useMarketplaceStore';
 import { FeedCounts } from '../../../interface/feed.interface';
-import { QueryFilterInterface } from '../../../pages/ExplorePage/ExplorePage.interface';
+import {
+  AnnouncementEntity,
+  getActiveAnnouncements,
+} from '../../../rest/announcementsAPI';
 import { getContractByEntityId } from '../../../rest/contractAPI';
 import {
   exportDataProductToODPSYaml,
@@ -150,6 +154,14 @@ const DataProductsDetailsPage = ({
     version: string;
   }>();
   const { fqn: dataProductFqn } = useFqn();
+  // The "Data Product Domain Validation" rule is a cross-cutting data-asset
+  // rule; read it against TABLE as a representative asset type since the "Add
+  // Assets" picker spans every asset type. Hold the strict domain-scoped
+  // default until the rules actually load (an empty rule set from the backend
+  // is indistinguishable from "not fetched yet").
+  const { entityRules, isRulesLoaded } = useEntityRules(EntityType.TABLE);
+  const requireDomainForDataProduct =
+    !isRulesLoaded || entityRules.requireDomainForDataProduct;
   const [dataProductPermission, setDataProductPermission] =
     useState<OperationPermission>(DEFAULT_ENTITY_PERMISSION);
   const [showActions, setShowActions] = useState(false);
@@ -989,14 +1001,13 @@ const DataProductsDetailsPage = ({
         })}
         entityFqn={dataProductFqn}
         open={isAssetDrawerOpen}
-        queryFilter={
-          getQueryFilterToIncludeDomain(
-            dataProduct.domains
-              ?.map((domain) => domain.fullyQualifiedName)
-              .join(', ') ?? '',
-            dataProduct.fullyQualifiedName ?? ''
-          ) as QueryFilterInterface
-        }
+        queryFilter={getQueryFilterToIncludeDomain(
+          dataProduct.domains
+            ?.map((domain) => domain.fullyQualifiedName ?? '')
+            .filter(Boolean) ?? [],
+          dataProduct.fullyQualifiedName ?? '',
+          requireDomainForDataProduct
+        )}
         type={AssetsOfEntity.DATA_PRODUCT}
         onCancel={closeAssetDrawer}
         onSave={() => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
@@ -62,10 +62,6 @@ import { useEntityRules } from '../../../hooks/useEntityRules';
 import { useFqn } from '../../../hooks/useFqn';
 import { useMarketplaceStore } from '../../../hooks/useMarketplaceStore';
 import { FeedCounts } from '../../../interface/feed.interface';
-import {
-  AnnouncementEntity,
-  getActiveAnnouncements,
-} from '../../../rest/announcementsAPI';
 import { getContractByEntityId } from '../../../rest/contractAPI';
 import {
   exportDataProductToODPSYaml,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DomainFilterUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DomainFilterUtils.test.ts
@@ -1,0 +1,127 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { EntityType } from '../enums/entity.enum';
+import { getQueryFilterToIncludeDomain } from './DomainFilterUtils';
+
+describe('getQueryFilterToIncludeDomain', () => {
+  const domainFqn = 'Domain.A';
+  const dataProductFqn = 'Domain.A.DataProduct1';
+
+  const getMustClauses = (
+    ...args: Parameters<typeof getQueryFilterToIncludeDomain>
+  ) => {
+    const must = getQueryFilterToIncludeDomain(...args).query.bool?.must;
+
+    if (Array.isArray(must)) {
+      return must;
+    }
+
+    return must ? [must] : [];
+  };
+
+  it('should scope results to the domain by default', () => {
+    const must = getMustClauses(domainFqn, dataProductFqn);
+
+    expect(must).toContainEqual({
+      term: { 'domains.fullyQualifiedName': domainFqn },
+    });
+  });
+
+  it('should scope results to the domain when domain is required', () => {
+    const must = getMustClauses(domainFqn, dataProductFqn, true);
+
+    expect(must).toContainEqual({
+      term: { 'domains.fullyQualifiedName': domainFqn },
+    });
+  });
+
+  it('should not scope results to the domain when domain is not required', () => {
+    const must = getMustClauses(domainFqn, dataProductFqn, false);
+
+    expect(must).not.toContainEqual({
+      term: { 'domains.fullyQualifiedName': domainFqn },
+    });
+  });
+
+  it('should use a single term when a one-element domain array is given', () => {
+    const must = getMustClauses([domainFqn], dataProductFqn, true);
+
+    expect(must).toContainEqual({
+      term: { 'domains.fullyQualifiedName': domainFqn },
+    });
+  });
+
+  it('should use a terms query when the Data Product spans multiple domains', () => {
+    const domains = ['Domain.A', 'Domain.B'];
+    const must = getMustClauses(domains, dataProductFqn, true);
+
+    expect(must).toContainEqual({
+      terms: { 'domains.fullyQualifiedName': domains },
+    });
+    expect(must).not.toContainEqual({
+      term: { 'domains.fullyQualifiedName': 'Domain.A, Domain.B' },
+    });
+  });
+
+  it('should fail closed with an empty terms query when domain is required but no domain is present', () => {
+    const must = getMustClauses([], dataProductFqn, true);
+
+    // An empty `terms` query matches no documents, so a domainless Data
+    // Product scopes to zero assets instead of every domain.
+    expect(must).toContainEqual({
+      terms: { 'domains.fullyQualifiedName': [] },
+    });
+  });
+
+  it('should not add any domain clause when domain is not required', () => {
+    const must = getMustClauses([], dataProductFqn, false);
+
+    expect(must.some((clause) => 'term' in clause || 'terms' in clause)).toBe(
+      false
+    );
+  });
+
+  it('should always exclude the already assigned data product and non-assignable entity types', () => {
+    [true, false].forEach((requireDomain) => {
+      const must = getMustClauses(domainFqn, dataProductFqn, requireDomain);
+
+      expect(must).toContainEqual({
+        bool: {
+          must_not: [
+            {
+              term: { 'dataProducts.fullyQualifiedName': dataProductFqn },
+            },
+          ],
+        },
+      });
+      expect(must).toContainEqual({
+        bool: {
+          must_not: [
+            {
+              terms: {
+                entityType: [
+                  EntityType.DATA_PRODUCT,
+                  EntityType.TEST_SUITE,
+                  EntityType.QUERY,
+                  EntityType.TEST_CASE,
+                  EntityType.TABLE_COLUMN,
+                ],
+              },
+            },
+          ],
+        },
+      });
+    });
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DomainFilterUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DomainFilterUtils.ts
@@ -21,49 +21,80 @@ import type {
 import { getEntityReferenceFromEntity } from './EntityReferenceUtils';
 
 export const getQueryFilterToIncludeDomain = (
-  domainFqn: string,
-  dataProductFqn: string
-) => ({
-  query: {
-    bool: {
-      must: [
-        {
-          term: {
-            'domains.fullyQualifiedName': domainFqn,
-          },
+  domainFqn: string | string[],
+  dataProductFqn: string,
+  requireDomain = true
+): QueryFilterInterface => {
+  const must: QueryFieldInterface[] = [];
+
+  // When the "Data Product Domain Validation" rule is disabled the backend
+  // permits assigning assets from any domain, so the picker must not scope
+  // results to the Data Product's own domain.
+  if (requireDomain) {
+    // A Data Product can belong to multiple domains; scope to any of them with
+    // a `terms` query instead of forcing a single-value `term` match (which
+    // never matches a comma-joined FQN and would return zero assets).
+    const domainFQNs = (Array.isArray(domainFqn) ? domainFqn : [domainFqn])
+      .map((fqn) => fqn?.trim())
+      .filter((fqn): fqn is string => Boolean(fqn));
+
+    if (domainFQNs.length === 1) {
+      must.push({
+        term: {
+          'domains.fullyQualifiedName': domainFQNs[0],
         },
-        {
-          bool: {
-            must_not: [
-              {
-                term: {
-                  'dataProducts.fullyQualifiedName': dataProductFqn,
-                },
-              },
-            ],
-          },
+      });
+    } else {
+      // For 0 FQNs this is an empty `terms` query, which matches no documents.
+      // That keeps the rule fail-closed: a domainless Data Product scopes to
+      // zero assets rather than silently listing assets from every domain.
+      must.push({
+        terms: {
+          'domains.fullyQualifiedName': domainFQNs,
         },
-        {
-          bool: {
-            must_not: [
-              {
-                terms: {
-                  entityType: [
-                    EntityType.DATA_PRODUCT,
-                    EntityType.TEST_SUITE,
-                    EntityType.QUERY,
-                    EntityType.TEST_CASE,
-                    EntityType.TABLE_COLUMN,
-                  ],
-                },
-              },
-            ],
+      });
+    }
+  }
+
+  must.push(
+    {
+      bool: {
+        must_not: [
+          {
+            term: {
+              'dataProducts.fullyQualifiedName': dataProductFqn,
+            },
           },
-        },
-      ],
+        ],
+      },
     },
-  },
-});
+    {
+      bool: {
+        must_not: [
+          {
+            terms: {
+              entityType: [
+                EntityType.DATA_PRODUCT,
+                EntityType.TEST_SUITE,
+                EntityType.QUERY,
+                EntityType.TEST_CASE,
+                EntityType.TABLE_COLUMN,
+              ],
+            },
+          },
+        ],
+      },
+    }
+  );
+
+  return {
+    query: {
+      bool: {
+        must,
+      },
+    },
+  };
+};
 
 export const getQueryFilterToExcludeDomainTerms = (
   fqn: string,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DomainUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DomainUtils.test.tsx
@@ -17,6 +17,18 @@ import {
   isDomainExist,
 } from '../utils/DomainFilterUtils';
 
+const mustClausesOf = (
+  result: ReturnType<typeof getQueryFilterToIncludeDomain>
+) => {
+  const must = result.query.bool?.must;
+
+  if (Array.isArray(must)) {
+    return must;
+  }
+
+  return must ? [must] : [];
+};
+
 jest.mock('../hooks/useDomainStore');
 jest.mock('./RouterUtils');
 
@@ -186,13 +198,13 @@ describe('isDomainExist', () => {
 
       const result = getQueryFilterToIncludeDomain(domainFqn, dataProductFqn);
 
-      const firstMust = result.query.bool.must[0] as {
+      const firstMust = mustClausesOf(result)[0] as {
         term: { 'domains.fullyQualifiedName': string };
       };
 
       expect(firstMust.term['domains.fullyQualifiedName']).toBe(domainFqn);
 
-      const secondMust = result.query.bool.must[1] as {
+      const secondMust = mustClausesOf(result)[1] as {
         bool: {
           must_not: Array<{
             term: { 'dataProducts.fullyQualifiedName': string };
@@ -211,7 +223,7 @@ describe('isDomainExist', () => {
 
       const result = getQueryFilterToIncludeDomain(domainFqn, dataProductFqn);
 
-      const thirdMust = result.query.bool.must[2] as {
+      const thirdMust = mustClausesOf(result)[2] as {
         bool: {
           must_not: Array<{
             terms: { entityType: EntityType[] };
@@ -234,13 +246,18 @@ describe('isDomainExist', () => {
 
       const result = getQueryFilterToIncludeDomain(domainFqn, dataProductFqn);
 
-      const firstMust = result.query.bool.must[0] as {
-        term: { 'domains.fullyQualifiedName': string };
-      };
+      // An empty domain FQN fails closed: it produces an empty `terms` query
+      // (which matches nothing) rather than an all-domains search.
+      expect(mustClausesOf(result)).toContainEqual({
+        terms: { 'domains.fullyQualifiedName': [] },
+      });
 
-      expect(firstMust.term['domains.fullyQualifiedName']).toBe('');
-
-      const secondMust = result.query.bool.must[1] as {
+      const dataProductMust = mustClausesOf(result).find(
+        (clause) =>
+          'bool' in clause &&
+          Array.isArray(clause.bool?.must_not) &&
+          'term' in (clause.bool.must_not[0] ?? {})
+      ) as {
         bool: {
           must_not: Array<{
             term: { 'dataProducts.fullyQualifiedName': string };
@@ -249,7 +266,7 @@ describe('isDomainExist', () => {
       };
 
       expect(
-        secondMust.bool.must_not[0].term['dataProducts.fullyQualifiedName']
+        dataProductMust.bool.must_not[0].term['dataProducts.fullyQualifiedName']
       ).toBe('');
     });
   });


### PR DESCRIPTION
### Describe your changes:

Backport of #32336 (Fixes #32297) to the `1.13` release branch.

The Data Product **"Add Assets" picker** now honors the **Data Product Domain Validation** rule:
- Rule **disabled** → the picker lists assets across all domains (and subdomains), so cross-domain assets can be added.
- Rule **enabled** (or rules not yet loaded) → the picker stays scoped to the Data Product's own domain(s), and **fails closed** (empty `terms`, matching nothing) when the Data Product has no domain.
- `getQueryFilterToIncludeDomain` accepts `string | string[]` and emits a `terms` query for multi-domain Data Products (a single `term` for one).

Cherry-picked from `5c198dc2f9` (squash-merge of #32336).

#
### Type of change:
- [x] Bug fix

#
### How the changes have been tested:
- Unit: `DomainFilterUtils.test.ts` / `DomainUtils.test.tsx` cover the scoping toggle, multi-domain `terms`, and the fail-closed empty case.
- Playwright: `DataAssetRulesDisabled/Enabled.spec.ts` cover cross-domain add (disabled) and domain-scoped exclusion (enabled).

> Note: the `1.13` branch has no `DataProductsDetailsPage.component.test.tsx`, so the component-level Jest additions from the source PR are omitted here; the shared util tests and Playwright specs carry the coverage.

#
### Checklist:
- [x] Backport of an already-reviewed and merged PR (#32336).

🤖 Generated with [Claude Code](https://claude.com/claude-code)