### PR TITLE
Fixes 6035: Make workflow graph theme-aware

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useWorkflowEdgeManagement.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useWorkflowEdgeManagement.test.ts
@@ -1,0 +1,123 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { Edge } from 'reactflow';
+import { useWorkflowEdgeManagement } from './useWorkflowEdgeManagement';
+
+const setEdges = jest.fn();
+
+const createProps = (): Parameters<typeof useWorkflowEdgeManagement>[0] => ({
+  edges: [],
+  editingEdge: null,
+  isViewMode: false,
+  nodes: [],
+  setEditingEdge: jest.fn(),
+  setEdges,
+  setFocusedConnection: jest.fn(),
+  setIsConnectionModalOpen: jest.fn(),
+  setModalPosition: jest.fn(),
+  setPendingConnection: jest.fn(),
+});
+
+describe('useWorkflowEdgeManagement', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    [
+      'reject',
+      'var(--om-color-fg-error, #D92D20)',
+      'var(--om-color-bg-error, #FEF3F2)',
+    ],
+    [
+      'qualityBand',
+      'var(--om-color-fg-brand, #1570EF)',
+      'var(--om-color-bg-brand, #EFF8FF)',
+    ],
+  ])(
+    'applies theme-aware colors when saving a %s connection',
+    (condition, labelColor, backgroundColor) => {
+      const { result } = renderHook(() =>
+        useWorkflowEdgeManagement(createProps())
+      );
+
+      act(() => {
+        result.current.handleConnectionSave(
+          {
+            source: 'source',
+            sourceHandle: null,
+            target: 'target',
+            targetHandle: null,
+          },
+          [{ value: condition }]
+        );
+      });
+
+      const updateEdges = setEdges.mock.calls[0][0] as (
+        edges: Edge[]
+      ) => Edge[];
+      const [edge] = updateEdges([]);
+
+      expect(edge.labelStyle).toEqual(
+        expect.objectContaining({ color: labelColor })
+      );
+      expect(edge.labelBgStyle).toEqual(
+        expect.objectContaining({
+          fill: backgroundColor,
+          stroke: 'var(--om-color-bg-primary, #FFFFFF)',
+        })
+      );
+      expect(edge.markerEnd).toEqual(
+        expect.objectContaining({
+          color: 'var(--om-color-border-primary)',
+        })
+      );
+    }
+  );
+
+  it('keeps repaired custom conditions aligned with serialized edge colors', () => {
+    const { result } = renderHook(() =>
+      useWorkflowEdgeManagement(createProps())
+    );
+
+    act(() => {
+      result.current.fixInvalidEdgeConditions('source', [
+        { name: 'qualityBand' },
+      ]);
+    });
+
+    const updateEdges = setEdges.mock.calls[0][0] as (edges: Edge[]) => Edge[];
+    const [edge] = updateEdges([
+      {
+        data: { condition: 'outdatedBand' },
+        id: 'source-target',
+        label: 'outdatedBand',
+        source: 'source',
+        target: 'target',
+      },
+    ]);
+
+    expect(edge.labelStyle).toEqual(
+      expect.objectContaining({
+        color: 'var(--om-color-fg-brand, #1570EF)',
+      })
+    );
+    expect(edge.labelBgStyle).toEqual(
+      expect.objectContaining({
+        fill: 'var(--om-color-bg-brand, #EFF8FF)',
+      })
+    );
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useWorkflowEdgeManagement.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useWorkflowEdgeManagement.ts
@@ -14,7 +14,10 @@
 import { useCallback } from 'react';
 import { Connection, Edge, MarkerType, Node } from 'reactflow';
 import { NodeSubType } from '../generated/governance/workflows/elements/nodeSubType';
-import { WORKFLOW_EDGE_THEME } from '../utils/WorkflowEdgeTheme';
+import {
+  getWorkflowConditionTheme,
+  WORKFLOW_EDGE_THEME,
+} from '../utils/WorkflowEdgeTheme';
 
 interface UseWorkflowEdgeManagementProps {
   nodes: Node[];
@@ -68,6 +71,9 @@ export const useWorkflowEdgeManagement = ({
             const newCondition =
               firstBand.name?.toLowerCase() || firstBand.name;
             const newLabel = firstBand.name;
+            const { backgroundColor, labelColor } = getWorkflowConditionTheme(
+              newCondition ?? ''
+            );
 
             return {
               ...edge,
@@ -84,20 +90,20 @@ export const useWorkflowEdgeManagement = ({
                 condition: newCondition,
               },
               style: {
-                stroke: T.success600,
+                stroke: labelColor,
                 strokeWidth: 2,
               },
               labelStyle: {
-                color: T.success600,
+                color: labelColor,
                 fontSize: '14px',
                 fontWeight: 600,
                 letterSpacing: '1px',
                 cursor: 'pointer',
               },
               labelBgStyle: {
-                fill: T.success100,
+                fill: backgroundColor,
                 fillOpacity: 1,
-                stroke: T.white,
+                stroke: T.labelBorder,
                 strokeWidth: 2,
                 rx: 5,
                 ry: 5,
@@ -146,20 +152,20 @@ export const useWorkflowEdgeManagement = ({
               condition: 'TRUE',
             },
             style: {
-              stroke: T.success600,
+              stroke: T.positiveLabel,
               strokeWidth: 2,
             },
             labelStyle: {
-              color: T.success600,
+              color: T.positiveLabel,
               fontSize: '14px',
               fontWeight: 600,
               letterSpacing: '1px',
               cursor: 'pointer',
             },
             labelBgStyle: {
-              fill: T.success100,
+              fill: T.positiveBackground,
               fillOpacity: 1,
-              stroke: T.white,
+              stroke: T.labelBorder,
               strokeWidth: 2,
               rx: 5,
               ry: 5,
@@ -183,6 +189,8 @@ export const useWorkflowEdgeManagement = ({
         return;
       }
 
+      const { backgroundColor, labelColor } =
+        getWorkflowConditionTheme(conditionLabel);
       const edgeId = `reactflow__edge-${connection.source}-${connection.target}`;
       const newEdge = {
         id: edgeId,
@@ -196,33 +204,27 @@ export const useWorkflowEdgeManagement = ({
           type: MarkerType.ArrowClosed,
           width: 16,
           height: 16,
-          color: T.gray400,
+          color: T.edge,
         },
         data: {
           conditions,
           condition: conditionLabel,
         },
         style: {
-          stroke: T.gray400,
+          stroke: T.edge,
           strokeWidth: 2,
         },
         labelStyle: {
-          color: conditions.some(
-            (c) => c.value === 'TRUE' || c.value === 'true'
-          )
-            ? T.success600
-            : T.labelFalse,
+          color: labelColor,
           fontSize: '14px',
           fontWeight: 600,
           letterSpacing: '1px',
           cursor: 'pointer',
         },
         labelBgStyle: {
-          fill: conditions.some((c) => c.value === 'TRUE' || c.value === 'true')
-            ? T.success100
-            : T.warning100,
+          fill: backgroundColor,
           fillOpacity: 1,
-          stroke: T.white,
+          stroke: T.labelBorder,
           strokeWidth: 2,
           rx: 5,
           ry: 5,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/WorkflowEdgeTheme.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/WorkflowEdgeTheme.ts
@@ -11,15 +11,49 @@
  *  limitations under the License.
  */
 
-/**
- * Edge styling aligned with openmetadata-ui-core-components tokens
- * (--color-success-*, --color-warning-*, gray scale).
- */
+// Keeping CSS variables intact lets React Flow repaint its SVG edges when the
+// root theme changes without rebuilding workflow nodes, edges, or layout state.
 export const WORKFLOW_EDGE_THEME = {
-  success600: '#079455',
-  success100: '#dcfae6',
-  warning100: '#fef0c7',
-  gray400: '#a4a7ae',
-  white: '#ffffff',
-  labelFalse: '#ca8a04',
+  customBackground: 'var(--om-color-bg-brand, #EFF8FF)',
+  customLabel: 'var(--om-color-fg-brand, #1570EF)',
+  // React Flow embeds marker colors in SVG URL ids, so fallback delimiters
+  // would make the generated marker reference browser-dependent.
+  edge: 'var(--om-color-border-primary)',
+  labelBorder: 'var(--om-color-bg-primary, #FFFFFF)',
+  negativeBackground: 'var(--om-color-bg-error, #FEF3F2)',
+  negativeLabel: 'var(--om-color-fg-error, #D92D20)',
+  positiveBackground: 'var(--om-color-bg-success, #ECFDF3)',
+  positiveLabel: 'var(--om-color-fg-success, #079455)',
+  warningBackground: 'var(--om-color-bg-warning, #FFFAEB)',
+  warningLabel: 'var(--om-color-fg-warning, #DC6803)',
 } as const;
+
+export const getWorkflowConditionTheme = (condition: string) => {
+  const normalizedCondition = condition.trim().toLowerCase();
+
+  if (normalizedCondition === 'true' || normalizedCondition === 'approve') {
+    return {
+      backgroundColor: WORKFLOW_EDGE_THEME.positiveBackground,
+      labelColor: WORKFLOW_EDGE_THEME.positiveLabel,
+    };
+  }
+
+  if (normalizedCondition === 'reject') {
+    return {
+      backgroundColor: WORKFLOW_EDGE_THEME.negativeBackground,
+      labelColor: WORKFLOW_EDGE_THEME.negativeLabel,
+    };
+  }
+
+  if (normalizedCondition === 'false') {
+    return {
+      backgroundColor: WORKFLOW_EDGE_THEME.warningBackground,
+      labelColor: WORKFLOW_EDGE_THEME.warningLabel,
+    };
+  }
+
+  return {
+    backgroundColor: WORKFLOW_EDGE_THEME.customBackground,
+    labelColor: WORKFLOW_EDGE_THEME.customLabel,
+  };
+};

--- a/openmetadata-ui/src/main/resources/ui/src/utils/WorkflowSerializer.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/WorkflowSerializer.test.ts
@@ -1,0 +1,97 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { ConditionValue } from '../constants/WorkflowBuilder.constants';
+import { WorkflowDefinition } from '../generated/governance/workflows/workflowDefinition';
+import { WORKFLOW_EDGE_THEME } from './WorkflowEdgeTheme';
+import { deserializeWorkflow } from './WorkflowSerializer';
+
+const createWorkflow = (condition?: string): WorkflowDefinition => ({
+  description: 'Workflow edge theme test',
+  edges: [{ condition, from: 'source', to: 'target' }],
+  name: 'workflowEdgeThemeTest',
+  nodes: [],
+});
+
+describe('WorkflowSerializer', () => {
+  it('uses semantic tokens for workflow edge roles', () => {
+    expect(WORKFLOW_EDGE_THEME).toEqual({
+      customBackground: 'var(--om-color-bg-brand, #EFF8FF)',
+      customLabel: 'var(--om-color-fg-brand, #1570EF)',
+      edge: 'var(--om-color-border-primary)',
+      labelBorder: 'var(--om-color-bg-primary, #FFFFFF)',
+      negativeBackground: 'var(--om-color-bg-error, #FEF3F2)',
+      negativeLabel: 'var(--om-color-fg-error, #D92D20)',
+      positiveBackground: 'var(--om-color-bg-success, #ECFDF3)',
+      positiveLabel: 'var(--om-color-fg-success, #079455)',
+      warningBackground: 'var(--om-color-bg-warning, #FFFAEB)',
+      warningLabel: 'var(--om-color-fg-warning, #DC6803)',
+    });
+  });
+
+  it.each([
+    [
+      'true',
+      'TRUE',
+      'var(--om-color-fg-success, #079455)',
+      'var(--om-color-bg-success, #ECFDF3)',
+    ],
+    [
+      'approve',
+      ConditionValue.APPROVE,
+      'var(--om-color-fg-success, #079455)',
+      'var(--om-color-bg-success, #ECFDF3)',
+    ],
+    [
+      'false',
+      'FALSE',
+      'var(--om-color-fg-warning, #DC6803)',
+      'var(--om-color-bg-warning, #FFFAEB)',
+    ],
+    [
+      'reject',
+      ConditionValue.REJECT,
+      'var(--om-color-fg-error, #D92D20)',
+      'var(--om-color-bg-error, #FEF3F2)',
+    ],
+    [
+      'qualityBand',
+      'qualityBand',
+      'var(--om-color-fg-brand, #1570EF)',
+      'var(--om-color-bg-brand, #EFF8FF)',
+    ],
+  ])(
+    'serializes the %s condition with theme-aware label colors',
+    (condition, label, labelColor, labelBackground) => {
+      const { edges } = deserializeWorkflow(createWorkflow(condition));
+      const [edge] = edges;
+
+      expect(edge).toEqual(
+        expect.objectContaining({
+          label,
+          labelBgStyle: expect.objectContaining({
+            fill: labelBackground,
+            stroke: 'var(--om-color-bg-primary, #FFFFFF)',
+          }),
+          labelStyle: expect.objectContaining({ color: labelColor }),
+          markerEnd: expect.objectContaining({
+            color: 'var(--om-color-border-primary)',
+          }),
+          style: expect.objectContaining({
+            stroke: 'var(--om-color-border-primary)',
+          }),
+        })
+      );
+    }
+  );
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/WorkflowSerializer.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/WorkflowSerializer.ts
@@ -28,6 +28,10 @@ import {
   NodeData,
   NodePosition,
 } from '../interface/WorkflowTypes.interface';
+import {
+  getWorkflowConditionTheme,
+  WORKFLOW_EDGE_THEME,
+} from './WorkflowEdgeTheme';
 
 const getUINodeType = (backendType: string, backendSubType: string): string => {
   if (
@@ -178,7 +182,6 @@ const convertBackendEdgeToReactFlow = (
   const isFalse = condition === 'false';
   const isApprove = condition === 'approve';
   const isReject = condition === 'reject';
-  const isPositive = isTrue || isApprove;
 
   let edgeStyle = {};
   let labelStyle = {};
@@ -202,30 +205,11 @@ const convertBackendEdgeToReactFlow = (
       strokeWidth: 2,
     };
 
-    let color: string;
-    if (isPositive) {
-      color = '#039855';
-    } else if (isReject) {
-      color = '#D92D20';
-    } else if (isFalse) {
-      color = '#EAB308';
-    } else {
-      color = '#2563EB';
-    }
-
-    let fill: string;
-    if (isPositive) {
-      fill = '#D1FADF';
-    } else if (isReject) {
-      fill = '#FEE4E2';
-    } else if (isFalse) {
-      fill = '#FEF0C7';
-    } else {
-      fill = '#EFF6FF';
-    }
+    const { backgroundColor, labelColor } =
+      getWorkflowConditionTheme(condition);
 
     labelStyle = {
-      color,
+      color: labelColor,
       fontSize: '14px',
       fontWeight: 600,
       letterSpacing: '1px',
@@ -233,9 +217,9 @@ const convertBackendEdgeToReactFlow = (
     };
 
     labelBgStyle = {
-      fill,
+      fill: backgroundColor,
       fillOpacity: 1,
-      stroke: '#FFF',
+      stroke: WORKFLOW_EDGE_THEME.labelBorder,
       strokeWidth: 2,
       rx: 5,
       ry: 5,
@@ -252,10 +236,10 @@ const convertBackendEdgeToReactFlow = (
       type: MarkerType.ArrowClosed,
       width: 16,
       height: 16,
-      color: '#A4A7AE',
+      color: WORKFLOW_EDGE_THEME.edge,
     },
     style: {
-      stroke: '#A4A7AE',
+      stroke: WORKFLOW_EDGE_THEME.edge,
       strokeWidth: 2,
       ...edgeStyle,
     },


### PR DESCRIPTION
### Describe your changes:

Fixes #6035

Stacked on #32529.

Makes workflow graph edges and condition labels use semantic theme tokens across deserialization, new connections, default labels, and repaired quality-band conditions. Existing React Flow SVG elements repaint from the active root theme without rebuilding workflow data or layout state.


https://github.com/user-attachments/assets/03f84172-49f2-4578-8490-af4422f06374



#
### Type of change:

- [x] Improvement

#
### High-level design:

`WorkflowEdgeTheme` defines semantic roles for neutral edges and positive, warning, negative, and custom condition labels. `WorkflowSerializer` and `useWorkflowEdgeManagement` share one condition-to-theme mapper, preventing loaded and edited workflows from drifting to different palettes. CSS variables remain intact for SVG rendering so in-place theme changes do not reset the workflow graph.

The neutral marker token intentionally omits a raw fallback because React Flow embeds marker colors in SVG URL identifiers; the registered root token supplies the value in both themes without introducing fallback delimiters into the identifier.

#
### Tests:

#### Use cases covered

- Loaded true, approve, false, reject, and custom conditions receive semantic theme roles.
- New reject and custom connections use the same palette as loaded workflows.
- Repaired custom quality-band conditions remain aligned with serialized colors.

#### Unit tests

- [x] Added focused serializer and workflow edge-management tests.
- 2 suites and 9 tests pass.

#### Backend integration tests

- [x] Not applicable; no backend API changes.

#### Ingestion integration tests

- [x] Not applicable; no ingestion changes.

#### Playwright (UI) tests

- [x] Not applicable; the SVG style contract and edit paths are covered by focused unit tests.

#### Manual testing performed

- Ran the UI organize-imports, ESLint, and Prettier sequence on all changed files.
- Ran the Tailwind design-system audit with zero errors.
- Ran `git diff --check`.

#
### UI screen recording / screenshots:

Not included; this stacked slice changes existing workflow graph colors without changing layout or interaction behavior.

#
### Checklist:

- [x] I have read the contributing document.
- [x] My PR title follows the required issue format.
- [x] My PR is linked to a GitHub issue.
- [x] I reviewed touched logic and documented the SVG marker constraint.
- [x] I have added tests and listed them above.