### PR TITLE
refactor(ui): clear sonarjs/cognitive-complexity residue and promote to error (stacked on #32493)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/eslint.config.mjs
+++ b/openmetadata-ui/src/main/resources/ui/eslint.config.mjs
@@ -339,10 +339,10 @@ export default [
       // t() keys and label./message./server. strings and is enforced at error.
       'sonarjs/no-duplicate-string': 'off',
       'openmetadata-i18n/no-duplicate-string': 'error',
-      'sonarjs/cognitive-complexity': ['warn', 15], // 85
 
       // Complexity and structure. SonarCloud gates these on new code; these
       // surface the same findings locally and in the editor.
+      'sonarjs/cognitive-complexity': ['error', 15], // cleared tree-wide; blocks regressions
       'sonarjs/cyclomatic-complexity': 'error', // cleared tree-wide; blocks regressions
       'sonarjs/expression-complexity': 'warn', // 15
       'sonarjs/no-nested-conditional': 'warn', // 16

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DomainLabelV2/DomainLabelV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DomainLabelV2/DomainLabelV2.tsx
@@ -14,7 +14,15 @@ import { Card, Tooltip, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { compare } from 'fast-json-patch';
 import { get, isEmpty, isUndefined } from 'lodash';
-import { lazy, useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Dispatch,
+  lazy,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as DomainIcon } from '../../../assets/svg/ic-domain.svg';
 import { ReactComponent as InheritIcon } from '../../../assets/svg/ic-inherit.svg';
@@ -46,6 +54,77 @@ const DomainSelectableList = withSuspenseFallback(
   null
 );
 
+const resolveDomainsForPatch = (
+  selectedDomain: EntityReference | EntityReference[]
+): EntityReference[] => {
+  if (Array.isArray(selectedDomain)) {
+    return selectedDomain;
+  }
+
+  return isEmpty(selectedDomain) ? [] : [selectedDomain];
+};
+
+const saveDomainViaOnUpdate = async (
+  selectedDomain: EntityReference | EntityReference[],
+  onUpdate: DomainLabelProps['onUpdate'],
+  setActiveDomain: Dispatch<SetStateAction<EntityReference[]>>
+): Promise<void> => {
+  if (!onUpdate) {
+    return;
+  }
+
+  try {
+    await onUpdate(selectedDomain);
+    const updatedDomains = Array.isArray(selectedDomain)
+      ? selectedDomain
+      : [selectedDomain];
+    setActiveDomain(updatedDomains);
+  } catch (err) {
+    showErrorToast(err as AxiosError);
+  }
+};
+
+const saveDomainViaApi = async (
+  selectedDomain: EntityReference | EntityReference[],
+  entityType: AssetsUnion,
+  entityFqn: string,
+  entityId: string,
+  setActiveDomain: Dispatch<SetStateAction<EntityReference[]>>,
+  afterDomainUpdateAction?: DomainLabelProps['afterDomainUpdateAction']
+): Promise<void> => {
+  const entityDetails = getEntityAPIfromSource(entityType)(entityFqn, {
+    fields: 'domains',
+  });
+
+  try {
+    const entityDetailsResponse = await entityDetails;
+    if (!entityDetailsResponse) {
+      return;
+    }
+
+    const jsonPatch = compare(entityDetailsResponse, {
+      ...entityDetailsResponse,
+      domains: resolveDomainsForPatch(selectedDomain),
+    });
+
+    const api = getAPIfromSource(entityType);
+    const res = await api(entityId, jsonPatch);
+
+    const entityDomains = get(res, 'domains', {});
+    if (Array.isArray(entityDomains)) {
+      setActiveDomain(entityDomains);
+    } else {
+      // update the domain details here
+      setActiveDomain(isEmpty(entityDomains) ? [] : [entityDomains]);
+    }
+    !isUndefined(afterDomainUpdateAction) &&
+      afterDomainUpdateAction(res as DataAssetWithDomains);
+  } catch (err) {
+    // Handle errors as needed
+    showErrorToast(err as AxiosError);
+  }
+};
+
 export const DomainLabelV2 = <
   T extends {
     domains?: EntityReference[];
@@ -68,53 +147,23 @@ export const DomainLabelV2 = <
   const handleDomainSave = useCallback(
     async (selectedDomain: EntityReference | EntityReference[]) => {
       if (props.onUpdate) {
-        try {
-          await props.onUpdate(selectedDomain);
-          const updatedDomains = Array.isArray(selectedDomain)
-            ? selectedDomain
-            : [selectedDomain];
-          setActiveDomain(updatedDomains);
-        } catch (err) {
-          showErrorToast(err as AxiosError);
-        }
+        await saveDomainViaOnUpdate(
+          selectedDomain,
+          props.onUpdate,
+          setActiveDomain
+        );
 
         return;
       }
 
-      const entityDetails = getEntityAPIfromSource(entityType as AssetsUnion)(
+      await saveDomainViaApi(
+        selectedDomain,
+        entityType as AssetsUnion,
         entityFqn,
-        { fields: 'domains' }
+        entityId,
+        setActiveDomain,
+        props.afterDomainUpdateAction
       );
-
-      try {
-        const entityDetailsResponse = await entityDetails;
-        if (entityDetailsResponse) {
-          const jsonPatch = compare(entityDetailsResponse, {
-            ...entityDetailsResponse,
-            domains: Array.isArray(selectedDomain)
-              ? selectedDomain
-              : isEmpty(selectedDomain)
-              ? []
-              : [selectedDomain],
-          });
-
-          const api = getAPIfromSource(entityType as AssetsUnion);
-          const res = await api(entityId, jsonPatch);
-
-          const entityDomains = get(res, 'domains', {});
-          if (Array.isArray(entityDomains)) {
-            setActiveDomain(entityDomains);
-          } else {
-            // update the domain details here
-            setActiveDomain(isEmpty(entityDomains) ? [] : [entityDomains]);
-          }
-          !isUndefined(props.afterDomainUpdateAction) &&
-            props.afterDomainUpdateAction(res as DataAssetWithDomains);
-        }
-      } catch (err) {
-        // Handle errors as needed
-        showErrorToast(err as AxiosError);
-      }
     },
     [entityType, entityId, entityFqn, props.onUpdate]
   );

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ODCSImportModal/ODCSImportModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ODCSImportModal/ODCSImportModal.component.tsx
@@ -156,9 +156,7 @@ const resolveODCSSchemaObjects = async (
       selectedObjectName = objects[0];
     } else if (objects.length > 1) {
       const matchingObject = entityName
-        ? objects.find(
-            (obj) => obj.toLowerCase() === entityName.toLowerCase()
-          )
+        ? objects.find((obj) => obj.toLowerCase() === entityName.toLowerCase())
         : undefined;
       selectedObjectName = matchingObject ?? '';
     }

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ODCSImportModal/ODCSImportModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ODCSImportModal/ODCSImportModal.component.tsx
@@ -136,6 +136,39 @@ const buildMergedContractForPatch = (
   return mergedForPatch;
 };
 
+type ODCSSchemaObjectsResolution = {
+  objects: string[];
+  hasMultipleObjects: boolean;
+  selectedObjectName: string;
+};
+
+const resolveODCSSchemaObjects = async (
+  content: string,
+  entityName?: string
+): Promise<ODCSSchemaObjectsResolution> => {
+  try {
+    const parseResult: ODCSParseResult = await parseODCSYaml(content);
+    const objects = parseResult.schemaObjects ?? [];
+    const hasMultipleObjects = parseResult.hasMultipleObjects ?? false;
+
+    let selectedObjectName = '';
+    if (objects.length === 1) {
+      selectedObjectName = objects[0];
+    } else if (objects.length > 1) {
+      const matchingObject = entityName
+        ? objects.find(
+            (obj) => obj.toLowerCase() === entityName.toLowerCase()
+          )
+        : undefined;
+      selectedObjectName = matchingObject ?? '';
+    }
+
+    return { objects, hasMultipleObjects, selectedObjectName };
+  } catch {
+    return { objects: [], hasMultipleObjects: false, selectedObjectName: '' };
+  }
+};
+
 const ContractImportModal: React.FC<ContractImportModalProps> = ({
   visible,
   entityId,
@@ -333,27 +366,13 @@ const ContractImportModal: React.FC<ContractImportModalProps> = ({
           setParseError(null);
 
           if (isODCSFormat) {
-            try {
-              const parseResult: ODCSParseResult = await parseODCSYaml(content);
-              const objects = parseResult.schemaObjects ?? [];
-              setSchemaObjects(objects);
-              setHasMultipleObjects(parseResult.hasMultipleObjects ?? false);
-
-              if (objects.length === 1) {
-                setSelectedObjectName(objects[0]);
-              } else if (objects.length > 1) {
-                const matchingObject = entityName
-                  ? objects.find(
-                      (obj) => obj.toLowerCase() === entityName.toLowerCase()
-                    )
-                  : undefined;
-                setSelectedObjectName(matchingObject ?? '');
-              }
-            } catch {
-              setSchemaObjects([]);
-              setHasMultipleObjects(false);
-              setSelectedObjectName('');
-            }
+            const resolution = await resolveODCSSchemaObjects(
+              content,
+              entityName
+            );
+            setSchemaObjects(resolution.objects);
+            setHasMultipleObjects(resolution.hasMultipleObjects);
+            setSelectedObjectName(resolution.selectedObjectName);
           }
         } else {
           setParsedContract(null);

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityExportModalProvider/EntityExportModalProvider.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityExportModalProvider/EntityExportModalProvider.component.tsx
@@ -93,7 +93,10 @@ const runCSVPollAttempt = async (
   jobId: string,
   getPolledJob: () => Promise<CsvAsyncJob>,
   applyPolledJob: (job: CsvAsyncJob) => boolean,
-  isPollingStale: (pollingState: CSVExportPollingState, jobId: string) => boolean
+  isPollingStale: (
+    pollingState: CSVExportPollingState,
+    jobId: string
+  ) => boolean
 ): Promise<CSVPollAttemptOutcome> => {
   try {
     const job = await getPolledJob();

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityExportModalProvider/EntityExportModalProvider.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityExportModalProvider/EntityExportModalProvider.component.tsx
@@ -84,6 +84,36 @@ interface CSVExportPollingState {
   timer?: ReturnType<typeof setTimeout>;
 }
 
+type CSVPollAttemptOutcome =
+  | { status: 'stop' }
+  | { status: 'continue'; failed: boolean };
+
+const runCSVPollAttempt = async (
+  pollingState: CSVExportPollingState,
+  jobId: string,
+  getPolledJob: () => Promise<CsvAsyncJob>,
+  applyPolledJob: (job: CsvAsyncJob) => boolean,
+  isPollingStale: (pollingState: CSVExportPollingState, jobId: string) => boolean
+): Promise<CSVPollAttemptOutcome> => {
+  try {
+    const job = await getPolledJob();
+
+    if (isPollingStale(pollingState, jobId)) {
+      return { status: 'stop' };
+    }
+
+    return applyPolledJob(job)
+      ? { status: 'stop' }
+      : { status: 'continue', failed: false };
+  } catch {
+    if (pollingState.abortController.signal.aborted) {
+      return { status: 'stop' };
+    }
+
+    return { status: 'continue', failed: true };
+  }
+};
+
 export const EntityExportModalProvider = ({
   children,
 }: {
@@ -486,28 +516,27 @@ export const EntityExportModalProvider = ({
             return;
           }
 
-          try {
-            const job = await getPolledJob();
+          const outcome = await runCSVPollAttempt(
+            pollingState,
+            jobId,
+            getPolledJob,
+            applyPolledJob,
+            isPollingStale
+          );
 
-            if (isPollingStale(pollingState, jobId)) {
-              return;
-            }
+          if (outcome.status === 'stop') {
+            return;
+          }
 
-            consecutiveFailures = 0;
-            if (applyPolledJob(job)) {
-              return;
-            }
-          } catch {
-            if (pollingState.abortController.signal.aborted) {
-              return;
-            }
-
+          if (outcome.failed) {
             consecutiveFailures++;
             if (
               consecutiveFailures === CSV_EXPORT_MAX_CONSECUTIVE_POLL_FAILURES
             ) {
               markCSVExportStatusUnavailable(jobId);
             }
+          } else {
+            consecutiveFailures = 0;
           }
         }
       })();

--- a/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/SearchDropdown.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/SearchDropdown.tsx
@@ -31,6 +31,7 @@ import classNames from 'classnames';
 import { debounce, isEmpty, isUndefined } from 'lodash';
 import {
   FC,
+  Key,
   ReactNode,
   useCallback,
   useEffect,
@@ -54,6 +55,41 @@ import {
   SearchDropdownOption,
   SearchDropdownProps,
 } from './SearchDropdown.interface';
+
+type MenuSelectionResult = {
+  updatedValues: SearchDropdownOption[];
+  updatedNullSelected: boolean;
+};
+
+// Pure computation of the next selected-options / null-option state for a
+// menu item click, kept outside the component so it stays free of nesting.
+const resolveMenuSelection = (
+  singleSelect: boolean,
+  selectedOptions: SearchDropdownOption[],
+  option: SearchDropdownOption | undefined,
+  currentKey: Key,
+  nullOptionSelected: boolean
+): MenuSelectionResult => {
+  const isAlreadySelected = selectedOptions.some(
+    (opt) => opt.key === currentKey
+  );
+
+  if (singleSelect) {
+    const isNewSelection = !isAlreadySelected && option;
+
+    return {
+      updatedValues: isNewSelection && option ? [option] : [],
+      updatedNullSelected: isNewSelection ? false : nullOptionSelected,
+    };
+  }
+
+  const updatedValues = isAlreadySelected
+    ? selectedOptions.filter((opt) => opt.key !== currentKey)
+    : [...selectedOptions, ...(option ? [option] : [])];
+
+  return { updatedValues, updatedNullSelected: nullOptionSelected };
+};
+
 const SearchDropdown: FC<SearchDropdownProps> = ({
   dropdownClassName,
   isSuggestionsLoading,
@@ -197,28 +233,19 @@ const SearchDropdown: FC<SearchDropdownProps> = ({
   const handleMenuItemClick: MenuItemProps['onClick'] = (info) => {
     const currentKey = info.key;
     const option = options.find((op) => op.key === currentKey);
-    let updatedValues: SearchDropdownOption[];
-    let updatedNullSelected = nullOptionSelected;
 
-    if (singleSelect) {
-      const isAlreadySelected = selectedOptions.some(
-        (opt) => opt.key === currentKey
-      );
-      updatedValues = !isAlreadySelected && option ? [option] : [];
-      if (!isAlreadySelected && option) {
-        updatedNullSelected = false;
-        setNullOptionSelected(false);
-      }
-    } else {
-      const isAlreadySelected = selectedOptions.some(
-        (opt) => opt.key === currentKey
-      );
-      updatedValues = isAlreadySelected
-        ? selectedOptions.filter((opt) => opt.key !== currentKey)
-        : [...selectedOptions, ...(option ? [option] : [])];
-    }
+    const { updatedValues, updatedNullSelected } = resolveMenuSelection(
+      Boolean(singleSelect),
+      selectedOptions,
+      option,
+      currentKey,
+      nullOptionSelected
+    );
 
     setSelectedOptions(updatedValues);
+    if (updatedNullSelected !== nullOptionSelected) {
+      setNullOptionSelected(updatedNullSelected);
+    }
 
     if (immediateApply) {
       emitChange(updatedValues, updatedNullSelected);

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/AsyncSelectList/TreeAsyncSelectList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/AsyncSelectList/TreeAsyncSelectList.tsx
@@ -94,6 +94,88 @@ interface ExtendedTreeNode {
   children?: ExtendedTreeNode[];
 }
 
+type MultiSelectRawValue = {
+  disabled: boolean;
+  halfChecked: boolean;
+  label: React.ReactNode;
+  value: string;
+};
+
+// Combine the fetched glossaries, active search results and any pre-selected
+// options into a single pool to resolve a selected value's display data from.
+const buildGlossaryPool = (
+  glossaries: Glossary[],
+  searchOptions: Glossary[] | null,
+  initialOptions?: SelectOption[]
+): ModifiedGlossaryTerm[] =>
+  [
+    ...glossaries,
+    ...(isNull(searchOptions) ? [] : searchOptions),
+    ...(initialOptions ?? []),
+  ] as ModifiedGlossaryTerm[];
+
+// Resolve the display option for a raw selected value, falling back to the
+// value itself when it can't be matched against the glossary pool.
+const resolveSelectOption = (
+  value: string,
+  glossaryPool: ModifiedGlossaryTerm[]
+): SelectOption => {
+  const initialData = findItemByFqn(glossaryPool, value, false);
+
+  return initialData
+    ? {
+        value: initialData.fullyQualifiedName ?? '',
+        label: getEntityName(initialData),
+        data: initialData as SelectOption['data'],
+      }
+    : { value, label: value };
+};
+
+// Like resolveSelectOption, but reuses the previously selected tag's own
+// data when it is already present instead of re-resolving it.
+const resolveMultiSelectOption = (
+  value: string,
+  lastSelectedMap: Map<string, SelectOption>,
+  glossaryPool: ModifiedGlossaryTerm[]
+): SelectOption => {
+  if (lastSelectedMap.has(value)) {
+    return lastSelectedMap.get(value) as SelectOption;
+  }
+
+  return resolveSelectOption(value, glossaryPool);
+};
+
+// Filter out siblings of a newly selected, mutually exclusive option so only
+// the latest pick from that group stays checked.
+const filterMutuallyExclusiveSiblings = (
+  rawValues: MultiSelectRawValue[],
+  newlySelected: MultiSelectRawValue[],
+  nodeParentMap: Map<
+    string,
+    { node: ExtendedTreeNode; parent: ExtendedTreeNode | null }
+  >,
+  getSiblingValues: (
+    parent: ExtendedTreeNode | null,
+    currentValue: string
+  ) => string[]
+): MultiSelectRawValue[] => {
+  let filteredRawValues = [...rawValues];
+  for (const newVal of newlySelected) {
+    const { node, parent } = nodeParentMap.get(newVal.value) || {
+      node: null,
+      parent: null,
+    };
+    if (node?.isParentMutuallyExclusive) {
+      const siblingValues = new Set(getSiblingValues(parent, newVal.value));
+      filteredRawValues = filteredRawValues.filter(
+        (v) => !siblingValues.has(v.value)
+      );
+    }
+  }
+
+  return filteredRawValues;
+};
+
 const TreeAsyncSelectList: FC<TreeAsyncSelectListProps> = ({
   onChange,
   initialOptions,
@@ -304,12 +386,7 @@ const TreeAsyncSelectList: FC<TreeAsyncSelectListProps> = ({
   ) => {
     if (isMultiSelect) {
       // Handle multi-select mode
-      const rawValues = values as {
-        disabled: boolean;
-        halfChecked: boolean;
-        label: React.ReactNode;
-        value: string;
-      }[];
+      const rawValues = values as MultiSelectRawValue[];
 
       // Determine newly selected values
       const previousValueSet = new Set(
@@ -320,83 +397,42 @@ const TreeAsyncSelectList: FC<TreeAsyncSelectListProps> = ({
       );
 
       // Filter out siblings of mutually exclusive selections
-      let filteredRawValues = [...rawValues];
-      for (const newVal of newlySelected) {
-        const { node, parent } = nodeParentMap.get(newVal.value) || {
-          node: null,
-          parent: null,
-        };
-        if (node?.isParentMutuallyExclusive) {
-          const siblingValues = new Set(getSiblingValues(parent, newVal.value));
-          filteredRawValues = filteredRawValues.filter(
-            (v) => !siblingValues.has(v.value)
-          );
-        }
-      }
+      const filteredRawValues = filterMutuallyExclusiveSiblings(
+        rawValues,
+        newlySelected,
+        nodeParentMap,
+        getSiblingValues
+      );
 
-      const selectedValues = filteredRawValues.map(({ value }) => {
-        const lastSelectedMap = new Map(
-          selectedTagsRef.current.map((tag) => [tag.value, tag])
-        );
-        if (lastSelectedMap.has(value)) {
-          return lastSelectedMap.get(value) as SelectOption;
-        }
-        const initialData = findItemByFqn(
-          [
-            ...glossaries,
-            ...(isNull(searchOptions) ? [] : searchOptions),
-            ...(initialOptions ?? []),
-          ] as ModifiedGlossaryTerm[],
-          value,
-          false
-        );
-
-        return initialData
-          ? {
-              value: initialData.fullyQualifiedName ?? '',
-              label: getEntityName(initialData),
-              data: initialData,
-            }
-          : {
-              value,
-              label: value,
-            };
-      });
+      const lastSelectedMap = new Map(
+        selectedTagsRef.current.map((tag) => [tag.value, tag])
+      );
+      const glossaryPool = buildGlossaryPool(
+        glossaries,
+        searchOptions,
+        initialOptions
+      );
+      const selectedValues = filteredRawValues.map(({ value }) =>
+        resolveMultiSelectOption(value, lastSelectedMap, glossaryPool)
+      );
       selectedTagsRef.current = selectedValues as SelectOption[];
       onChange?.(selectedValues);
-    } else {
+    } else if (values) {
       // Handle single-select mode
-      if (values) {
-        const value = values as string;
+      const value = values as string;
+      const glossaryPool = buildGlossaryPool(
+        glossaries,
+        searchOptions,
+        initialOptions
+      );
+      const selectedValue = resolveSelectOption(value, glossaryPool);
 
-        const initialData = findItemByFqn(
-          [
-            ...glossaries,
-            ...(isNull(searchOptions) ? [] : searchOptions),
-            ...(initialOptions ?? []),
-          ] as ModifiedGlossaryTerm[],
-          value,
-          false
-        );
-
-        const selectedValue = initialData
-          ? {
-              value: initialData.fullyQualifiedName ?? '',
-              label: getEntityName(initialData),
-              data: initialData,
-            }
-          : {
-              value,
-              label: value,
-            };
-
-        selectedTagsRef.current = [selectedValue as SelectOption];
-        onChange?.(selectedValue as SelectOption);
-      } else {
-        // Nothing selected
-        selectedTagsRef.current = [];
-        onChange?.([]);
-      }
+      selectedTagsRef.current = [selectedValue];
+      onChange?.(selectedValue);
+    } else {
+      // Nothing selected
+      selectedTagsRef.current = [];
+      onChange?.([]);
     }
   };
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageNodeUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageNodeUtils.ts
@@ -238,6 +238,23 @@ const getTracedNode = (
   return nodes.filter((n) => tracedEdgeIds.has(n.id));
 };
 
+// Push every node from a BFS traversal (by id) into `prevTraced` that isn't
+// already present, mutating it in place so callers see the merged history.
+const mergeNewlyTracedNodes = (
+  prevTraced: Node[],
+  visitedNodeIds: Set<string>,
+  nodes: Node[]
+): void => {
+  for (const nodeId of visitedNodeIds) {
+    if (!prevTraced.some((n) => n.id === nodeId)) {
+      const tracedNode = nodes.find((n) => n.id === nodeId);
+      if (tracedNode) {
+        prevTraced.push(tracedNode);
+      }
+    }
+  }
+};
+
 export const getAllTracedNodes = (
   node: Node,
   nodes: Node[],
@@ -270,14 +287,7 @@ export const getAllTracedNodes = (
     }
   }
 
-  for (const nodeId of visitedNodeIds) {
-    if (!prevTraced.some((n) => n.id === nodeId)) {
-      const tracedNode = nodes.find((n) => n.id === nodeId);
-      if (tracedNode) {
-        prevTraced.push(tracedNode);
-      }
-    }
-  }
+  mergeNewlyTracedNodes(prevTraced, visitedNodeIds, nodes);
 
   return result;
 };

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx
@@ -210,6 +210,35 @@ export const fetchEntityData = async ({
   const isNlqSearch = isNLPRequestEnabled && !isEmpty(searchQueryParam);
   const searchRequest = isNlqSearch ? nlqSearch : searchQuery;
 
+  const runSearchWithoutQueryParam = async () => {
+    // If no searchQueryParam, make searchAPICall with current searchIndex
+    const searchPayload = {
+      query: '',
+      searchIndex,
+      queryFilter: combinedQueryFilter,
+      sortField: sortValue,
+      sortOrder: sortOrder,
+      pageNumber: page,
+      pageSize: size,
+      includeDeleted: showDeleted,
+      trackTotalHits: true,
+      explain: showRankingDetails,
+      excludeSourceFields: ['columns', 'queries', 'columnNames', 'dataModel'],
+    };
+
+    try {
+      const res = await searchRequest(searchPayload);
+      setSearchResults(res as SearchResponse<ExploreSearchIndex>);
+      setUpdatedAggregations(res.aggregations);
+    } catch (error) {
+      if (isElasticsearchError(error)) {
+        setShowIndexNotFoundAlert(true);
+      } else {
+        showErrorToast(error as AxiosError);
+      }
+    }
+  };
+
   try {
     if (searchQueryParam) {
       const countPayload = {
@@ -349,32 +378,7 @@ export const fetchEntityData = async ({
         }
       }
     } else {
-      // If no searchQueryParam, make searchAPICall with current searchIndex
-      const searchPayload = {
-        query: '',
-        searchIndex,
-        queryFilter: combinedQueryFilter,
-        sortField: sortValue,
-        sortOrder: sortOrder,
-        pageNumber: page,
-        pageSize: size,
-        includeDeleted: showDeleted,
-        trackTotalHits: true,
-        explain: showRankingDetails,
-        excludeSourceFields: ['columns', 'queries', 'columnNames', 'dataModel'],
-      };
-
-      try {
-        const res = await searchRequest(searchPayload);
-        setSearchResults(res as SearchResponse<ExploreSearchIndex>);
-        setUpdatedAggregations(res.aggregations);
-      } catch (error) {
-        if (isElasticsearchError(error)) {
-          setShowIndexNotFoundAlert(true);
-        } else {
-          showErrorToast(error as AxiosError);
-        }
-      }
+      await runSearchWithoutQueryParam();
     }
 
     return true;


### PR DESCRIPTION
## What

Clears **`sonarjs/cognitive-complexity`** (threshold 15) tree-wide and promotes the rule from `warn` → **`error`** in `eslint.config.mjs`, so CI blocks any regression.

Part of the ESLint burndown epic (#30977), complexity-family sub-issue #30984. This is the **last rule of the complexity family**.

> **⚠️ Stacked PR — base is `ShaileshParmar11/eslint-cyclomatic-complexity` (#32493), not `main`.**
> Merge #32493 first. The diff here is only the residue that #32493 does not already fix.

## Why it is stacked

Cognitive complexity and cyclomatic complexity measure nearly the same thing, so the same
decomposition clears both. Measured against #32493's head with the rule at `error`, only
**7 findings in 7 files** survive — #32493 already fixes ~92% of this rule as a side effect.

Building this on `main` instead produced a **71-file / 391-hunk / ~21k-line** conflict with #32493,
because both branches were rewriting the same functions to the same end. Stacking reduces this PR
to **8 files** and makes it genuinely reviewable.

## How

Behavior-preserving decomposition only — **no `eslint-disable`, no `any`, no logic changes**. Each
file was only slightly over threshold (16–19 vs 15 allowed), so one well-chosen extraction per
finding was enough:

| File | Was | Fix |
|---|---|---|
| `DomainLabelV2.tsx` | 19 | extracted `resolveDomainsForPatch`, `saveDomainViaOnUpdate`, `saveDomainViaApi` |
| `ExploreUtils.tsx` | 18 | extracted the no-`searchQueryParam` branch of `fetchEntityData` |
| `ODCSImportModal.component.tsx` | 17 | extracted `resolveODCSSchemaObjects` out of `reader.onload` |
| `EntityExportModalProvider.component.tsx` | 17 | extracted `runCSVPollAttempt` out of the polling loop |
| `SearchDropdown.tsx` | 16 | extracted `resolveMenuSelection` |
| `TreeAsyncSelectList.tsx` | 16 | split `handleChange` into four pure helpers |
| `EntityLineageNodeUtils.ts` | 16 | extracted `mergeNewlyTracedNodes` |

## Verification

All gates run against **`454f2ba5`** (#32493's head) as the baseline, not `main`:

- **Tree-wide ESLint at `error`**: `eslint --quiet 'src/**/*.{ts,tsx}'` → **0 findings, exit 0**.
- **No type regressions**: full `tsc --noEmit` per-file vs base — **591 errors on both sides**, zero
  files with a higher count anywhere in the tree.
- **No suppression smuggling**: per-file counts of `eslint-disable`, `any`, `as unknown as`,
  `@ts-ignore` and `antd` imports vs base — **no increase in any**.
- **`tw-deprecation-guard`**: no new Antd imports.
- **CI checkstyle sequence**: exit 0, second run produces **zero residual diff**.
- **Jest**: 705/706 suites pass. The one failure is `SinkTaskForm.test.tsx`, which OOMs — see below.

## ⚠️ Pre-existing failure inherited from the base

`SinkTaskForm.test.tsx` exhausts an 8 GB heap on this branch. It is **not caused by this PR** — it
reproduces on #32493's head with no changes, and passes on `origin/main` in 3.4s (28 tests).
#32493's `ui-coverage-tests` job is failing for the same reason.

Cause: #32493 changed the `useEffect` deps in `SinkTaskForm.tsx` from `[node]` to
`[node, buildSinkMetaValues]`, where `buildSinkMetaValues` is a `useCallback` keyed on `t`. The test
mocks `useTranslation` to return a fresh `t` each render, so the callback identity changes every
render → the effect re-fires → `setFormData` with a new object → re-render → infinite loop.

The fix belongs in #32493: make `buildSinkMetaValues` a module-level function taking `t` as a
parameter and restore the effect deps to `[node]`. Verified locally — 28 tests pass in 3.2s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
