### PR TITLE
Backport #32350 to 1.13: emit ChangeEvents for bulk entity updates

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BulkChangeEventIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BulkChangeEventIT.java
@@ -1,0 +1,423 @@
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openmetadata.it.factories.DatabaseSchemaTestFactory;
+import org.openmetadata.it.factories.DatabaseServiceTestFactory;
+import org.openmetadata.it.util.BulkApi;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.TestNamespace;
+import org.openmetadata.it.util.TestNamespaceExtension;
+import org.openmetadata.schema.api.data.CreateTable;
+import org.openmetadata.schema.api.events.AlertFilteringInput;
+import org.openmetadata.schema.api.events.CreateEventSubscription;
+import org.openmetadata.schema.entity.data.DatabaseSchema;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.entity.events.Argument;
+import org.openmetadata.schema.entity.events.ArgumentsInput;
+import org.openmetadata.schema.entity.events.EventSubscription;
+import org.openmetadata.schema.entity.events.SubscriptionDestination;
+import org.openmetadata.schema.entity.services.DatabaseService;
+import org.openmetadata.schema.type.ChangeEvent;
+import org.openmetadata.schema.type.Column;
+import org.openmetadata.schema.type.ColumnDataType;
+import org.openmetadata.schema.type.EventType;
+import org.openmetadata.schema.type.FieldChange;
+import org.openmetadata.schema.type.Webhook;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.sdk.models.ListResponse;
+import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.sdk.network.RequestOptions;
+import org.openmetadata.service.Entity;
+
+/**
+ * Integration tests for ChangeEvent emission on the bulk create/update path ({@code PUT
+ * /v1/tables/bulk}) — the endpoint the ingestion REST sink uses for every data asset.
+ *
+ * <p>Regression coverage for #32092, where {@code updateWithDeferredStore()} never populated the
+ * incremental change description, so every bulk entity update was classified {@code
+ * ENTITY_NO_CHANGE} and no row was written to {@code change_event}. The entity and its version
+ * history were persisted, so the write looked successful while every downstream consumer —
+ * observability alerts, notification alerts, the activity feed, and the audit log — saw nothing.
+ *
+ * <p>The rule these tests hold the bulk path to, scoped to event emission rather than versioning:
+ * for every entity a batch actually changed, the same change event must be written that a single
+ * PUT would have written. Bulk deliberately skips session consolidation, so versions are not
+ * expected to match across the two paths.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+@ExtendWith(TestNamespaceExtension.class)
+public class BulkChangeEventIT {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+  private static final String EVENTS_PATH = "/v1/events";
+  private static final String EVENT_SUBSCRIPTIONS_PATH = "/v1/events/subscriptions";
+  private static final String TABLE = Entity.TABLE;
+  private static final Duration EVENT_TIMEOUT = Duration.ofSeconds(30);
+
+  /**
+   * A bulk update that adds a column must emit ENTITY_UPDATED carrying a top-level {@code columns}
+   * entry in fieldsAdded — that is exactly what {@code matchAnyFieldChange({'columns', ...})} in the
+   * "Get Schema Changes" alert rule matches on. Runs as ingestion-bot to mirror the real sink.
+   */
+  @Test
+  void test_bulkColumnAdd_emitsEntityUpdatedChangeEvent(TestNamespace ns) throws Exception {
+    String schemaFqn = setupSchema(ns);
+    CreateTable create = table(ns, schemaFqn, "evt_add", null);
+    BulkApi.upsert("tables", List.of(create), false, BulkApi.botToken());
+
+    String fqn = tableFqn(schemaFqn, create.getName());
+    Table before = getTable(fqn);
+    long since = System.currentTimeMillis();
+
+    BulkApi.upsert(
+        "tables", List.of(withExtraColumn(create, "added_col")), false, BulkApi.botToken());
+
+    ChangeEvent event = awaitUpdatedEvent(before.getId(), since);
+    assertTrue(
+        fieldNames(event.getChangeDescription().getFieldsAdded()).contains("columns"),
+        "bulk column add must record a top-level 'columns' change, got: "
+            + fieldNames(event.getChangeDescription().getFieldsAdded()));
+    assertTrue(
+        getTable(fqn).getVersion() > before.getVersion(), "bulk column add must bump the version");
+  }
+
+  /**
+   * A bulk update that changes nothing must emit no event, so the fix does not turn into the
+   * opposite failure of re-notifying on every ingestion cycle (#31782). Covers both routes to "no
+   * change": the {@code sourceHash} fast-path that short-circuits before any diffing (what real
+   * connectors hit, since they always stamp a hash) and the full diff that finds nothing.
+   */
+  @ParameterizedTest(name = "no-op bulk update emits no event [sourceHash={0}]")
+  @ValueSource(booleans = {true, false})
+  void test_bulkNoOpUpdate_emitsNoChangeEvent(boolean withSourceHash, TestNamespace ns)
+      throws Exception {
+    String schemaFqn = setupSchema(ns);
+    CreateTable create =
+        table(ns, schemaFqn, "evt_noop_" + withSourceHash, withSourceHash ? "stable-hash" : null);
+    BulkApi.upsert("tables", List.of(create), false, BulkApi.botToken());
+
+    Table before = getTable(tableFqn(schemaFqn, create.getName()));
+    long since = System.currentTimeMillis();
+
+    BulkApi.upsert("tables", List.of(create), false, BulkApi.botToken());
+
+    assertNoUpdatedEvent(before.getId(), since);
+    assertEquals(
+        before.getVersion(),
+        getTable(tableFqn(schemaFqn, create.getName())).getVersion(),
+        "an unchanged bulk re-send must not bump the version");
+  }
+
+  /**
+   * The same column add through the single-entity endpoint produces an event of the same shape.
+   * Asserts on event emission only — bulk skips consolidation by design, so versions are not
+   * expected to line up across the two paths.
+   */
+  @Test
+  void test_bulkUpdate_matchesSingleEntityPut(TestNamespace ns) throws Exception {
+    String schemaFqn = setupSchema(ns);
+
+    CreateTable bulkTable = table(ns, schemaFqn, "evt_cmp_bulk", null);
+    BulkApi.upsert("tables", List.of(bulkTable), false, BulkApi.botToken());
+    Table bulkBefore = getTable(tableFqn(schemaFqn, bulkTable.getName()));
+    long bulkSince = System.currentTimeMillis();
+    BulkApi.upsert(
+        "tables", List.of(withExtraColumn(bulkTable, "added_col")), false, BulkApi.botToken());
+    ChangeEvent bulkEvent = awaitUpdatedEvent(bulkBefore.getId(), bulkSince);
+
+    CreateTable putTable = table(ns, schemaFqn, "evt_cmp_put", null);
+    BulkApi.upsert("tables", List.of(putTable), false, BulkApi.botToken());
+    Table putBefore = getTable(tableFqn(schemaFqn, putTable.getName()));
+    long putSince = System.currentTimeMillis();
+    putTable(withExtraColumn(putTable, "added_col"));
+    ChangeEvent putEvent = awaitUpdatedEvent(putBefore.getId(), putSince);
+
+    assertEquals(
+        putEvent.getEventType(),
+        bulkEvent.getEventType(),
+        "bulk and single PUT must agree on the event type");
+    assertEquals(
+        fieldNames(putEvent.getChangeDescription().getFieldsAdded()),
+        fieldNames(bulkEvent.getChangeDescription().getFieldsAdded()),
+        "bulk and single PUT must agree on which fields changed");
+  }
+
+  /**
+   * Bulk-PUTting a soft-deleted entity restores it, and {@code updateDeleted()} records a {@code
+   * deleted} field change — so this now emits ENTITY_UPDATED where before the fix it emitted
+   * nothing. New behaviour, matching the single-PUT path, pinned here so it cannot regress silently.
+   */
+  @Test
+  void test_bulkUndeleteViaBulkPut_emitsEvent(TestNamespace ns) throws Exception {
+    String schemaFqn = setupSchema(ns);
+    CreateTable create = table(ns, schemaFqn, "evt_undel", null);
+    BulkApi.upsert("tables", List.of(create), false, BulkApi.botToken());
+
+    String fqn = tableFqn(schemaFqn, create.getName());
+    Table created = getTable(fqn);
+    softDelete(created.getId().toString());
+    long since = System.currentTimeMillis();
+
+    BulkApi.upsert("tables", List.of(create), false, BulkApi.botToken());
+
+    ChangeEvent event = awaitUpdatedEvent(created.getId(), since);
+    assertNotNull(event.getChangeDescription(), "un-delete event must carry a change description");
+    assertTrue(
+        allFieldNames(event).contains("deleted"),
+        "bulk un-delete must record the 'deleted' field change, got: " + allFieldNames(event));
+  }
+
+  /**
+   * End-to-end assertion the issue asks for: a "Get Schema Changes" observability alert scoped to
+   * the table must receive the event a bulk column add produces. Filter-rejected events are never
+   * counted, so {@code totalEventsCount} incrementing is itself proof the rule matched.
+   */
+  @Test
+  void test_bulkColumnAdd_triggersSchemaChangeAlert(TestNamespace ns) throws Exception {
+    String schemaFqn = setupSchema(ns);
+    CreateTable create = table(ns, schemaFqn, "evt_alert", null);
+    BulkApi.upsert("tables", List.of(create), false, BulkApi.botToken());
+
+    String fqn = tableFqn(schemaFqn, create.getName());
+    EventSubscription alert = createSchemaChangeAlert(ns, fqn);
+    long baseline = totalEventsCount(alert.getId());
+
+    BulkApi.upsert(
+        "tables", List.of(withExtraColumn(create, "alert_col")), false, BulkApi.botToken());
+
+    Awaitility.await("schema-change alert receives the bulk update")
+        .pollInterval(Duration.ofSeconds(1))
+        .atMost(EVENT_TIMEOUT)
+        .untilAsserted(
+            () ->
+                assertTrue(
+                    totalEventsCount(alert.getId()) > baseline,
+                    "alert must count the bulk-produced change event"));
+  }
+
+  // ---------------------------------------------------------------- change events
+
+  private ChangeEvent awaitUpdatedEvent(UUID entityId, long since) {
+    return Awaitility.await("ENTITY_UPDATED change event for " + entityId)
+        .pollInterval(Duration.ofMillis(500))
+        .atMost(EVENT_TIMEOUT)
+        .until(() -> findUpdatedEvent(entityId, since), Objects::nonNull);
+  }
+
+  /**
+   * Asserts no event appears, and keeps asserting it for a few seconds. The event stream is
+   * asynchronous, so a single read straight after the write would pass simply by being early.
+   */
+  private void assertNoUpdatedEvent(UUID entityId, long since) {
+    Awaitility.await("no ENTITY_UPDATED change event for " + entityId)
+        .during(Duration.ofSeconds(5))
+        .atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(
+            () ->
+                assertNull(
+                    findUpdatedEvent(entityId, since),
+                    "an unchanged bulk re-send must not emit a change event"));
+  }
+
+  private ChangeEvent findUpdatedEvent(UUID entityId, long since) throws Exception {
+    Map<String, String> queryParams = new HashMap<>();
+    queryParams.put("entityUpdated", TABLE);
+    queryParams.put("timestamp", Long.toString(since));
+    RequestOptions options = RequestOptions.builder().queryParams(queryParams).build();
+    String json =
+        SdkClients.adminClient()
+            .getHttpClient()
+            .executeForString(HttpMethod.GET, EVENTS_PATH, null, options);
+    ListResponse<ChangeEvent> events =
+        JsonUtils.readValue(json, new TypeReference<ListResponse<ChangeEvent>>() {});
+    if (events == null || events.getData() == null) {
+      return null;
+    }
+    return events.getData().stream()
+        .filter(event -> entityId.equals(event.getEntityId()))
+        .filter(event -> event.getEventType() == EventType.ENTITY_UPDATED)
+        .findFirst()
+        .orElse(null);
+  }
+
+  private List<String> fieldNames(List<FieldChange> changes) {
+    List<String> names = new ArrayList<>();
+    for (FieldChange change : changes) {
+      names.add(change.getName());
+    }
+    return names;
+  }
+
+  private List<String> allFieldNames(ChangeEvent event) {
+    List<String> names = new ArrayList<>();
+    names.addAll(fieldNames(event.getChangeDescription().getFieldsAdded()));
+    names.addAll(fieldNames(event.getChangeDescription().getFieldsUpdated()));
+    names.addAll(fieldNames(event.getChangeDescription().getFieldsDeleted()));
+    return names;
+  }
+
+  // ---------------------------------------------------------------- alert
+
+  private EventSubscription createSchemaChangeAlert(TestNamespace ns, String tableFqn) {
+    ArgumentsInput fqnFilter =
+        new ArgumentsInput()
+            .withName("filterByFqn")
+            .withEffect(ArgumentsInput.Effect.INCLUDE)
+            .withPrefixCondition(ArgumentsInput.PrefixCondition.AND)
+            .withArguments(
+                List.of(new Argument().withName("fqnList").withInput(List.of(tableFqn))));
+    ArgumentsInput schemaChangeAction =
+        new ArgumentsInput()
+            .withName("GetTableSchemaChanges")
+            .withEffect(ArgumentsInput.Effect.INCLUDE)
+            .withPrefixCondition(ArgumentsInput.PrefixCondition.AND)
+            .withArguments(List.of());
+
+    CreateEventSubscription request =
+        new CreateEventSubscription()
+            .withName(ns.prefix("schema_change_alert"))
+            .withAlertType(CreateEventSubscription.AlertType.OBSERVABILITY)
+            .withResources(List.of(TABLE))
+            .withEnabled(true)
+            .withPollInterval(1)
+            .withBatchSize(10)
+            .withInput(
+                new AlertFilteringInput()
+                    .withFilters(List.of(fqnFilter))
+                    .withActions(List.of(schemaChangeAction)))
+            .withDestinations(webhookDestination());
+
+    EventSubscription subscription = SdkClients.adminClient().eventSubscriptions().create(request);
+    ns.trackRoot(Entity.EVENT_SUBSCRIPTION, subscription);
+    return subscription;
+  }
+
+  private List<SubscriptionDestination> webhookDestination() {
+    Webhook webhook =
+        new Webhook().withEndpoint(URI.create("http://localhost:8585/api/v1/test/webhook/test"));
+    return List.of(
+        new SubscriptionDestination()
+            .withId(UUID.randomUUID())
+            .withType(SubscriptionDestination.SubscriptionType.WEBHOOK)
+            .withCategory(SubscriptionDestination.SubscriptionCategory.EXTERNAL)
+            .withConfig(webhook));
+  }
+
+  private long totalEventsCount(UUID subscriptionId) throws Exception {
+    String path = EVENT_SUBSCRIPTIONS_PATH + "/id/" + subscriptionId + "/eventsRecord";
+    String json =
+        SdkClients.adminClient()
+            .getHttpClient()
+            .executeForString(HttpMethod.GET, path, null, RequestOptions.builder().build());
+    return OBJECT_MAPPER.readTree(json).path("totalEventsCount").asLong();
+  }
+
+  // ---------------------------------------------------------------- fixtures
+
+  private String setupSchema(TestNamespace ns) {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+    DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
+    return schema.getFullyQualifiedName();
+  }
+
+  private CreateTable table(
+      TestNamespace ns, String schemaFqn, String baseName, String sourceHash) {
+    CreateTable createTable =
+        new CreateTable()
+            .withName(ns.prefix(baseName))
+            .withDatabaseSchema(schemaFqn)
+            .withColumns(List.of(new Column().withName("c1").withDataType(ColumnDataType.STRING)));
+    createTable.setSourceHash(sourceHash);
+    return createTable;
+  }
+
+  private CreateTable withExtraColumn(CreateTable base, String columnName) {
+    List<Column> columns = new ArrayList<>(base.getColumns());
+    columns.add(new Column().withName(columnName).withDataType(ColumnDataType.STRING));
+    CreateTable copy =
+        new CreateTable()
+            .withName(base.getName())
+            .withDatabaseSchema(base.getDatabaseSchema())
+            .withColumns(columns);
+    // A connector re-stamps the hash whenever the source changed; keeping the old one would send
+    // the entity down the sourceHash fast-path and skip the diff entirely.
+    copy.setSourceHash(base.getSourceHash() == null ? null : base.getSourceHash() + "-changed");
+    return copy;
+  }
+
+  private String tableFqn(String schemaFqn, String tableName) {
+    return schemaFqn + "." + tableName;
+  }
+
+  private Table getTable(String fqn) throws Exception {
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(
+                URI.create(
+                    SdkClients.getServerUrl()
+                        + "/v1/tables/name/"
+                        + fqn
+                        + "?fields=columns,sourceHash&include=all"))
+            .header("Authorization", "Bearer " + SdkClients.getAdminToken())
+            .GET()
+            .build();
+    HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+    assertEquals(200, response.statusCode(), "get table " + fqn + ": " + response.body());
+    Table table = OBJECT_MAPPER.readValue(response.body(), Table.class);
+    assertNotNull(table.getId());
+    return table;
+  }
+
+  private void putTable(CreateTable create) throws Exception {
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(SdkClients.getServerUrl() + "/v1/tables"))
+            .header("Authorization", "Bearer " + BulkApi.botToken())
+            .header("Content-Type", "application/json")
+            .PUT(HttpRequest.BodyPublishers.ofString(OBJECT_MAPPER.writeValueAsString(create)))
+            .build();
+    HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+    assertTrue(
+        response.statusCode() == 200 || response.statusCode() == 201,
+        "single PUT failed: " + response.statusCode() + " " + response.body());
+  }
+
+  private void softDelete(String tableId) throws Exception {
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(SdkClients.getServerUrl() + "/v1/tables/" + tableId))
+            .header("Authorization", "Bearer " + SdkClients.getAdminToken())
+            .DELETE()
+            .build();
+    HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+    assertTrue(
+        response.statusCode() == 200 || response.statusCode() == 204,
+        "soft delete failed: " + response.statusCode() + " " + response.body());
+  }
+}

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/util/BulkApi.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/util/BulkApi.java
@@ -1,0 +1,57 @@
+package org.openmetadata.it.util;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+import org.openmetadata.it.auth.JwtAuthProvider;
+import org.openmetadata.schema.type.api.BulkOperationResult;
+
+/**
+ * Helpers for driving the bulk create/update ({@code PUT /v1/{collection}/bulk}) endpoint over raw
+ * HTTP. The SDK fluent clients do not expose this endpoint, so the integration tests call it
+ * directly.
+ */
+public final class BulkApi {
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+  private static final HttpClient HTTP = HttpClient.newHttpClient();
+
+  private BulkApi() {}
+
+  /** Mints a JWT for the default ingestion bot so bot-only update rules can be exercised. */
+  public static String botToken() {
+    return JwtAuthProvider.tokenFor(
+        "ingestion-bot@open-metadata.org",
+        "ingestion-bot@open-metadata.org",
+        new String[] {"bot"},
+        86400);
+  }
+
+  public static BulkOperationResult upsert(
+      String collection, List<?> createRequests, boolean overrideMetadata, String token)
+      throws Exception {
+    String url =
+        SdkClients.getServerUrl()
+            + "/v1/"
+            + collection
+            + "/bulk?overrideMetadata="
+            + overrideMetadata;
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .header("Authorization", "Bearer " + token)
+            .header("Content-Type", "application/json")
+            .PUT(HttpRequest.BodyPublishers.ofString(MAPPER.writeValueAsString(createRequests)))
+            .build();
+    HttpResponse<String> response = HTTP.send(request, HttpResponse.BodyHandlers.ofString());
+    if (response.statusCode() != 200) {
+      throw new IllegalStateException(
+          "Bulk upsert failed: " + response.statusCode() + " " + response.body());
+    }
+    return MAPPER.readValue(response.body(), BulkOperationResult.class);
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -3848,8 +3848,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
     try (var ignored = phase("putEntityUpdate")) {
       entityUpdater.update();
     }
-    EventType change =
-        entityUpdater.incrementalFieldsChanged() ? EventType.ENTITY_UPDATED : ENTITY_NO_CHANGE;
+    EventType change = entityUpdater.getChangeType();
     try (var ignored = phase("putSetInheritedFields")) {
       setInheritedFields(updated, new Fields(allowedFields));
     }
@@ -3886,8 +3885,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
     try (var ignored = phase("putEntityUpdateImport")) {
       entityUpdater.updateForImport();
     }
-    EventType change =
-        entityUpdater.incrementalFieldsChanged() ? EventType.ENTITY_UPDATED : ENTITY_NO_CHANGE;
+    EventType change = entityUpdater.getChangeType();
     try (var ignored = phase("putSetInheritedFieldsImport")) {
       setInheritedFields(updated, new Fields(allowedFields));
     }
@@ -4087,10 +4085,8 @@ public abstract class EntityRepository<T extends EntityInterface> {
       }
     }
     updated.setChangeDescription(entityUpdater.getIncrementalChangeDescription());
-    if (entityUpdater.incrementalFieldsChanged()) {
-      return new PatchResponse<>(Status.OK, withHref(uriInfo, updated), ENTITY_UPDATED);
-    }
-    return new PatchResponse<>(Status.OK, withHref(uriInfo, updated), ENTITY_NO_CHANGE);
+    return new PatchResponse<>(
+        Status.OK, withHref(uriInfo, updated), entityUpdater.getChangeType());
   }
 
   /**
@@ -8051,7 +8047,15 @@ public abstract class EntityRepository<T extends EntityInterface> {
     protected final User updatingUser;
     private boolean entityChanged = false;
     private boolean versionChanged = false;
+
+    /**
+     * Diff produced by THIS request. Every {@code EntityUpdater} entry point must populate this
+     * before its caller classifies the change: {@link #getChangeType()} reads it, and a null value
+     * is indistinguishable from "nothing changed", which silently drops the ChangeEvent (see
+     * #32092).
+     */
     @Getter protected ChangeDescription incrementalChangeDescription = null;
+
     private final ChangeSource changeSource;
     @Setter private boolean useOptimisticLocking;
     @Setter private Set<String> patchedFields;
@@ -8301,12 +8305,19 @@ public abstract class EntityRepository<T extends EntityInterface> {
      * <p>Skips consolidateChanges/revert — those are for interactive user sessions where the same
      * user edits the same entity multiple times within a session window. Bulk API is used by
      * ingestion connectors where each run is a distinct update.
+     *
+     * <p>Still captures the incremental change description: skipping consolidation does not mean
+     * skipping the per-request diff, which is what the caller classifies the change event from.
+     * Omitting it made every bulk update look like ENTITY_NO_CHANGE (see #32092).
      */
     @Transaction
     public final void updateWithDeferredStore() {
       changeDescription = new ChangeDescription();
       try (var ignored = phase("entityUpdateDiffDeferred")) {
         updateInternal();
+      }
+      try (var ignored = phase("entityUpdateIncrementalChangeDeferred")) {
+        captureIncrementalFromCurrentChange();
       }
 
       versionChanged = updateVersion(original.getVersion());
@@ -9257,6 +9268,11 @@ public abstract class EntityRepository<T extends EntityInterface> {
       return !incrementalChangeDescription.getFieldsAdded().isEmpty()
           || !incrementalChangeDescription.getFieldsUpdated().isEmpty()
           || !incrementalChangeDescription.getFieldsDeleted().isEmpty();
+    }
+
+    /** Event type produced by this update: ENTITY_UPDATED when this request changed any field. */
+    public final EventType getChangeType() {
+      return incrementalFieldsChanged() ? ENTITY_UPDATED : ENTITY_NO_CHANGE;
     }
 
     public final <K> boolean recordChange(String field, K orig, K updated) {
@@ -12000,7 +12016,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
           for (var updater : changedUpdaters) {
             postUpdate(updater.getOriginal(), updater.getUpdated());
             updater.runDeferredReactOperations();
-            var changeType = updater.incrementalFieldsChanged() ? ENTITY_UPDATED : ENTITY_NO_CHANGE;
+            var changeType = updater.getChangeType();
             buildChangeEventJsonForBulkOperation(updater.getUpdated(), changeType, userName)
                 .ifPresent(changeEventJsons::add);
           }
@@ -12055,7 +12071,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
           if (updater.isVersionChanged() || updater.isEntityChanged()) {
             postUpdate(updater.getOriginal(), updater.getUpdated());
             updater.runDeferredReactOperations();
-            var changeType = updater.incrementalFieldsChanged() ? ENTITY_UPDATED : ENTITY_NO_CHANGE;
+            var changeType = updater.getChangeType();
             buildChangeEventJsonForBulkOperation(updater.getUpdated(), changeType, userName)
                 .ifPresent(changeEventJsons::add);
           }


### PR DESCRIPTION
### Describe your changes:

Backport of #32350 (`Fixes #32092`) to `1.13`. This is the branch the issue was reported against
(1.13.3, Pylon 21043).

`PUT /v1/{collection}/bulk` persisted entity updates and version history but wrote no `change_event`
row, so `Get Schema Changes` alerts never fired on metadata ingestion, and no ingestion-driven update
was auditable. `EntityUpdater.updateWithDeferredStore()` (the bulk path) ran `updateInternal()` without
the `captureIncrementalFromCurrentChange()` step its three sibling entry points run, leaving
`incrementalChangeDescription` null, which `incrementalFieldsChanged()` reads as "nothing changed".
Every bulk update was therefore classified `ENTITY_NO_CHANGE` and dropped by
`buildChangeEventJsonForBulkOperation`.

Full analysis, blast radius and manual-test tables are in #32350.

This did not reach `1.13` automatically: #32350 merged without the `To release` label, and that
workflow no longer targets `1.13` in any case.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

Two commits.

1. **`git cherry-pick -x a3e5f5f4b030c818f8a52b0bb99eab46a94d13e3`**, with one conflict resolved.
   `1.13` does not have `private boolean entityStored = false;` (introduced by #28675, never
   backported). That line is *context* for the new javadoc hunk, not something #32350 adds, so the
   resolution drops it and keeps only the javadoc. Verified rather than eyeballed: the added and
   removed lines of this commit are byte-identical to the `main` commit's, and
   `BulkChangeEventIT.java` is byte-identical to the file on `main`.

2. **`test: add the BulkApi harness helper required by BulkChangeEventIT on 1.13`.**
   `openmetadata-integration-tests/.../it/util/BulkApi.java` does not exist on `1.13` (it came in with
   #28155 and #31375, neither backported), so the test would not compile. Added as a separate commit
   so it reads as a test-harness prerequisite rather than part of the fix. It is `main`'s file trimmed
   to the two methods `BulkChangeEventIT` actually calls, `botToken()` and
   `upsert(collection, requests, overrideMetadata, token)`. The `deleteStale*` helpers are omitted
   because they need `BulkDeleteStaleRequest`, a schema that does not exist on `1.13`.

   `?overrideMetadata=` is a no-op here: `1.13`'s `bulkCreateOrUpdate` does not declare the query
   param, JAX-RS ignores unknown params, and every call site passes `false`.

Everything else the test needs is already present and signature-compatible on `1.13`:
`DatabaseSchemaTestFactory.createSimple`, `DatabaseServiceTestFactory.createPostgres`,
`SdkClients.{adminClient,getAdminToken,getServerUrl}`, `JwtAuthProvider.tokenFor`,
`RequestOptions.builder().queryParams`, `executeForString`, `eventSubscriptions()`, `ListResponse`
and `BulkOperationResult`.

The companion 2.0 backport is #32535.

#
### Tests:

#### Backend integration tests

- [x] `BulkChangeEventIT` (6 cases), brought over unchanged.

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Not applicable (no UI changes).

#### Manual testing performed

Built and ran locally on this branch, all 11 modules from source in-reactor so the test exercises
this code and not a cached artifact:

```
mvn -pl openmetadata-integration-tests -am package -Dtest=BulkChangeEventIT
-> Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
```

`spotless:check` on `openmetadata-service` and `openmetadata-integration-tests` is green.

**Negative control on this branch.** Since the fix hunk had to be conflict-resolved here, I rebuilt
`1.13` with only the `captureIncrementalFromCurrentChange()` call removed and re-ran the suite:

```
Tests run: 6, Failures: 0, Errors: 4, Skipped: 0
  test_bulkColumnAdd_emitsEntityUpdatedChangeEvent   ConditionTimeout ... was null
  test_bulkColumnAdd_triggersSchemaChangeAlert       alert must count the bulk-produced change event
  test_bulkUndeleteViaBulkPut_emitsEvent             ConditionTimeout ... was null
  test_bulkUpdate_matchesSingleEntityPut             ConditionTimeout ... was null
```

Same 4-of-6 signature reported on `main` in #32350, so the resolved hunk is the load-bearing one on
`1.13` and the two no-op cases correctly pass either way. The tree was restored afterwards.

#
### Notes for reviewers

Carried over from #32350 and still applicable on `1.13`:

- **Expect more `change_event` rows.** This restores pre-1.13 volume for ingestion updates, bounded by
  the existing `DataRetention` app. Customers who created alerts while the bug was live have not seen
  this traffic before. Worth a release note.
- **Bulk-PUT of a soft-deleted entity now emits an event**, consistent with the single-PUT path.
- **The recursive delete/restore cascade still emits one event, not N.** Deliberate, documented in
  `persistBulkUpdaters()`, and shares `updateWithDeferredStore()` with this fix.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] For JSON Schema changes: not applicable, no schema changes.
- [x] For UI changes: not applicable, no UI changes.
- [x] I have added a test that covers the exact scenario we are fixing.


_On `skip-pr-checks`: a PR whose base is not the default branch cannot create GitHub's native `closingIssuesReferences` link, so the metadata gate has no way to see the linked issue and can never be satisfied here. The issue is #32092, already closed by #32350._
