### PR TITLE
fix(test): keep global mock TableRepository registrations index-policy safe

### DIFF
--- a/openmetadata-service/src/test/java/org/openmetadata/service/lineage/LineagePermissionFilterTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/lineage/LineagePermissionFilterTest.java
@@ -52,6 +52,12 @@ class LineagePermissionFilterTest {
   @BeforeAll
   static void registerRepository() {
     TableRepository tableRepository = mock(TableRepository.class);
+    // This registration is global and never torn down, so the stand-in must answer the indexing
+    // policy hooks the way the real repository does. A bare mock answers false, which would make
+    // Entity.isSearchIndexable/isVectorEmbeddable report every table as excluded for the rest of
+    // the JVM.
+    when(tableRepository.isSearchIndexable(any())).thenReturn(true);
+    when(tableRepository.isVectorEmbeddable(any())).thenReturn(true);
     when(tableRepository.getEntityType()).thenReturn(Entity.TABLE);
     when(tableRepository.getFields(anyString())).thenReturn(Fields.EMPTY_FIELDS);
     when(tableRepository.get(isNull(), anyList(), any(Fields.class), any(Include.class)))

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/rdf/RdfResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/rdf/RdfResourceTest.java
@@ -77,7 +77,14 @@ class RdfResourceTest {
 
   private static void registerTableRepository() {
     if (!Entity.hasEntityRepository(Entity.TABLE)) {
-      Entity.registerEntity(Table.class, Entity.TABLE, Mockito.mock(TableRepository.class));
+      TableRepository tableRepository = Mockito.mock(TableRepository.class);
+      // This registration is global and never torn down, so the stand-in must answer the indexing
+      // policy hooks the way the real repository does. A bare mock answers false, which would make
+      // Entity.isSearchIndexable/isVectorEmbeddable report every table as excluded for the rest of
+      // the JVM.
+      Mockito.doReturn(true).when(tableRepository).isSearchIndexable(any());
+      Mockito.doReturn(true).when(tableRepository).isVectorEmbeddable(any());
+      Entity.registerEntity(Table.class, Entity.TABLE, tableRepository);
     }
   }
 


### PR DESCRIPTION
### Describe your changes:

No linked issue — this is a CI-only test-isolation fix. Failing run:
https://github.com/open-metadata/OpenMetadata/runs/100566583607 (9 failures, `Test Report`).

`LineagePermissionFilterTest` (added 2026-09-02 in #32437) and `RdfResourceTest` (added 2026-08-29 in
#28042) both register a **bare** Mockito `TableRepository` into `Entity`'s static
`ENTITY_REPOSITORY_MAP` in `@BeforeAll`, and never tear it down. A bare mock answers `false` to
`isSearchIndexable` / `isVectorEmbeddable`, so every later test in the same surefire JVM that reaches
the gate in `ElasticSearchBulkSink.enrichWithEmbedding` (`:1112`) / `OpenSearchBulkSink.enrichWithEmbedding`
(`:1141`) returns early:

```java
if (!Entity.isVectorEmbeddable(entity)) { return json; }   // vector service + stats tracker never touched
```

which is why the 9 `enrichWithEmbedding*` tests fail with `Wanted but not invoked … Actually, there
were zero interactions with this mock`.

#30593 introduced that gate and had to stub both policy hooks in the two global registrations that
existed at the time (`EntityCsvTest`, `RuleEvaluatorTest`, each with a comment explaining why). The
two registrations added since did not carry the stubs over. This PR adds them.

It is intermittent in CI because surefire's default `runOrder` is `filesystem` — it only breaks when
the polluting class happens to be scheduled before the sink tests. First observed on 2026-09-02
18:12 UTC, then 2026-09-03 05:14 and 06:59 UTC; no occurrence in any run between 2026-08-15 and
2026-09-02.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — two-line stub at each registration site.

#
### Tests:

#### Use cases covered
- `openmetadata-service` unit suite is order-independent again: the bulk-sink vector-embedding tests
  pass whether or not `LineagePermissionFilterTest` / `RdfResourceTest` ran first in the same JVM.

#### Unit tests
No new tests — this fixes existing ones. Reproduced the failure and verified the fix by forcing the
polluting order (`alphabetical` sorts by FQN, so `apps.*` runs before `lineage.*` and hides it):

```
mvn -pl openmetadata-service test -Dsurefire.runOrder=reversealphabetical \
  -Dtest='RdfResourceTest,LineagePermissionFilterTest,OpenSearchBulkSinkBehaviorTest,ElasticSearchBulkSinkBehaviorTest'
```

Before (same 6 + 3 failures as CI):
```
ERROR  OpenSearchBulkSinkBehaviorTest    Tests run: 19, Failures: 6
```

After:
```
RdfResourceTest                   Tests run: 14, Failures: 0
LineagePermissionFilterTest       Tests run:  9, Failures: 0
OpenSearchBulkSinkBehaviorTest    Tests run: 19, Failures: 0
ElasticSearchBulkSinkBehaviorTest Tests run: 17, Failures: 0
Tests run: 59, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
```

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Covered by the ordered surefire runs above.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
