### PR TITLE
fix(ingestion): pin anyio<4.15 in the mlflow test image to unblock py-tests shard-2 (2.0)

### DIFF
--- a/ingestion/tests/integration/sources/mlmodels/mlflow/conftest.py
+++ b/ingestion/tests/integration/sources/mlmodels/mlflow/conftest.py
@@ -27,6 +27,7 @@ The following steps are taken:
 import io
 import time
 import uuid
+from contextlib import suppress
 from dataclasses import dataclass
 from typing import Optional
 
@@ -127,12 +128,10 @@ def mlflow_environment():
 
             mlflow_port = config.mlflow_configs.exposed_port
             for _ in range(30):
-                try:
-                    response = requests.get(f"http://localhost:{mlflow_port}/health")
-                    if response.status_code == 200:
+                with suppress(Exception):
+                    if requests.get(f"http://localhost:{mlflow_port}/health").status_code == 200:
                         break
-                except Exception:
-                    time.sleep(2)
+                time.sleep(2)
             else:
                 raise RuntimeError("MLflow server did not become ready in time.")
 
@@ -146,11 +145,14 @@ def build_and_get_mlflow_container(
 ):
     docker_client = DockerClient()
 
+    # anyio 4.15 lazily imports its submodules without exposing from_thread, which
+    # starlette's WSGIMiddleware calls, so every mlflow server response 500s. Drop the
+    # bound once anyio restores the attribute or starlette imports the submodule.
     dockerfile = io.BytesIO(
         b"""
         FROM python:3.10-slim-buster
         RUN python -m pip install --upgrade pip
-        RUN pip install cryptography "mlflow>=3.10.0,<3.11" boto3 pymysql
+        RUN pip install cryptography "mlflow>=3.10.0,<3.11" boto3 pymysql "anyio<4.15"
         """
     )
 


### PR DESCRIPTION
### Describe your changes:

Fixes #32528

Backport of #32525 to `2.0`.

`py-tests` shard-2 fails on this branch exactly as it did on `main`. The MLflow fixture builds a throwaway MLflow server image with an unlocked `pip install`, so it picks up [anyio 4.15.0](https://pypi.org/project/anyio/4.15.0/) (published 2026-09-02T21:46:35Z). anyio 4.15 made its submodules lazily imported without exposing `from_thread`, which Starlette's `WSGIMiddleware` calls, so every MLflow server response is a 500 and `/health` never returns 200:

```
ERROR tests/integration/sources/mlmodels/mlflow/test_mlflow.py::test_mlflow
RuntimeError: MLflow server did not become ready in time.

AttributeError: module 'anyio' has no attribute 'from_thread'
```

The auto cherry-pick bot could not land this: it cherry-picked cleanly and then tried to push straight to `2.0`, which `2.0.x-protection` rejects (`GH013 ... Changes must be made through a pull request`). Hence this PR.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

Same two changes as #32525: constrain the fixture image to `anyio<4.15`, and move `time.sleep(2)` out of the `except` block in the readiness loop so a non-200 response waits instead of burning all 30 attempts in milliseconds.

Identical to the `main` change.

#
### Tests:

#### Use cases covered

- The MLflow fixture builds an image whose server answers `/health` with 200.
- The MLflow tracking API answers through the WSGI adapter instead of 500ing.

#### Unit tests

Not applicable: test-fixture-only change.

#### Backend integration tests

Not applicable: no server changes.

#### Ingestion integration tests

Verified on `main` in #32525: all six `Integration Tests (shard-2)` jobs green across the MySQL and Postgres lanes on 3.10/3.11/3.12.

End-to-end locally, building the Dockerfile bytes from this branch's `conftest.py` and starting the fixture's own containers:

| anyio | `GET /health` |
|---|---|
| 4.15.0 (before) | 500, `AttributeError: module 'anyio' has no attribute 'from_thread'` |
| 4.14.2 (after) | 200 |

Lint verified with this branch's own pinned tooling: `ruff~=0.15.12` `check` and `format --check` both clean.

#### Playwright (UI) tests

Not applicable.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable, no schema change.
- [x] I have added a test that covers the exact scenario we are fixing: the existing `test_mlflow` is that test; this PR restores it.
