### PR TITLE
Fixes #32546: Fix find_context and search_company_context on Elasticsearch

### DIFF
--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CompanyContextTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CompanyContextTool.java
@@ -19,7 +19,7 @@ import org.openmetadata.schema.entity.context.MemoryVisibility;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.limits.Limits;
-import org.openmetadata.service.search.vector.OpenSearchVectorService;
+import org.openmetadata.service.search.vector.VectorIndexService;
 import org.openmetadata.service.search.vector.utils.DTOs.VectorSearchResponse;
 import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.security.DefaultAuthorizer;
@@ -148,7 +148,7 @@ public class CompanyContextTool implements McpTool {
   private static Map<String, Object> runSearch(
       String query, Map<String, Object> params, CatalogSecurityContext securityContext) {
     Map<String, Object> result;
-    OpenSearchVectorService vectorService = OpenSearchVectorService.getInstance();
+    VectorIndexService vectorService = Entity.getSearchRepository().getVectorIndexService();
     if (!Entity.getSearchRepository().isVectorEmbeddingEnabled() || vectorService == null) {
       result =
           errorResponse(
@@ -161,7 +161,7 @@ public class CompanyContextTool implements McpTool {
   }
 
   private static Map<String, Object> search(
-      OpenSearchVectorService vectorService,
+      VectorIndexService vectorService,
       String query,
       Map<String, Object> params,
       CatalogSecurityContext securityContext) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AIContextFinder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AIContextFinder.java
@@ -31,7 +31,7 @@ import org.openmetadata.schema.type.Relationship;
 import org.openmetadata.schema.type.aicontext.KnowledgeItem;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.search.vector.OpenSearchVectorService;
+import org.openmetadata.service.search.vector.VectorIndexService;
 import org.openmetadata.service.search.vector.utils.DTOs.VectorSearchResponse;
 import org.openmetadata.service.security.policyevaluator.SubjectContext;
 import org.openmetadata.service.workflows.searchIndex.ReindexingUtil;
@@ -122,7 +122,7 @@ public class AIContextFinder {
   private VectorSearchResponse searchKnowledge(String query, int size) {
     VectorSearchResponse response = null;
     if (Entity.getSearchRepository().isVectorEmbeddingEnabled()) {
-      OpenSearchVectorService service = OpenSearchVectorService.getInstance();
+      VectorIndexService service = Entity.getSearchRepository().getVectorIndexService();
       if (service != null) {
         try {
           // Over-fetch: collectHit dedupes chunk documents per FQN, so a long item occupying


### PR DESCRIPTION
### Describe your changes:

Fixes #32546

`AIContextFinder.searchKnowledge` and `CompanyContextTool` resolved the vector service through `OpenSearchVectorService.getInstance()`, which is null on Elasticsearch deployments, so `find_context` and `search_company_context` returned nothing on Elasticsearch even with semantic search enabled and the entity vector index populated. Both call sites only use methods declared on `VectorIndexService`, so they now resolve the service through `Entity.getSearchRepository().getVectorIndexService()`, as `SemanticSearchTool` already does. No behaviour change on OpenSearch: the repository returns the same `OpenSearchVectorService` instance there.

`AIContextBuilder` and `GetEntityTool` keep the OpenSearch singleton because they need `searchChunksByParent`, which `ElasticSearchVectorService` does not implement.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A, small change.

#
### Tests:

#### Use cases covered
- On an Elasticsearch deployment with semantic search enabled, `find_context` returns approved glossary terms and their candidate assets for a business question.
- On the same deployment, `search_company_context` executes the vector query instead of reporting the service as uninitialised.
- OpenSearch deployments are unaffected.

#### Unit tests
- No new tests: the change swaps a service lookup for the existing backend-agnostic accessor, and existing tests for `AIContextFinder` do not depend on the singleton.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).
