### PR TITLE
Fixes #32548: Support BigQuery STRUCT profiling

### DIFF
--- a/ingestion/src/metadata/profiler/interface/sqlalchemy/bigquery/profiler_interface.py
+++ b/ingestion/src/metadata/profiler/interface/sqlalchemy/bigquery/profiler_interface.py
@@ -14,10 +14,12 @@ Interfaces with database for all database engine
 supporting sqlalchemy abstraction layer
 """
 
+from collections.abc import Iterable
 from copy import deepcopy
-from typing import cast
+from typing import Any, cast
 
 from sqlalchemy import Column, inspect
+from sqlalchemy.sql.type_api import TypeEngine
 
 from metadata.generated.schema.entity.data.table import SystemProfile
 from metadata.generated.schema.security.credentials.gcpValues import SingleProjectId
@@ -63,7 +65,11 @@ class BigQueryProfilerInterface(SQAProfilerInterface):
         )
         return instance.get_system_metrics()
 
-    def _get_struct_columns(self, columns: dict, parent: str):
+    def _get_struct_columns(
+        self,
+        columns: Iterable[tuple[str, TypeEngine[Any]]],
+        parent: str,
+    ):
         """"""
         # pylint: disable=import-outside-toplevel
         from sqlalchemy_bigquery import STRUCT
@@ -73,7 +79,11 @@ class BigQueryProfilerInterface(SQAProfilerInterface):
             if not isinstance(value, STRUCT):
                 col = Column(f"{parent}.{key}", value)
                 # pylint: disable=protected-access
-                col._set_parent(self.table.__table__)
+                col._set_parent(
+                    self.table.__table__,
+                    all_names={c.name: c for c in self.table.__table__.columns},
+                    allow_replacements=True,
+                )
                 # pylint: enable=protected-access
                 columns_list.append(col)
             else:

--- a/ingestion/tests/unit/observability/profiler/sqlalchemy/bigquery/test_bigquery_profiler_sql.py
+++ b/ingestion/tests/unit/observability/profiler/sqlalchemy/bigquery/test_bigquery_profiler_sql.py
@@ -19,8 +19,12 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.sqltypes import NullType
+from sqlalchemy_bigquery import STRUCT
 from sqlalchemy_bigquery.base import BigQueryDialect
 
+from metadata.profiler.interface.sqlalchemy.bigquery.profiler_interface import (
+    BigQueryProfilerInterface,
+)
 from metadata.profiler.interface.sqlalchemy.profiler_interface import (
     SQAProfilerInterface,
 )
@@ -98,6 +102,18 @@ def _grouped_output_label(sql, source):
     match = re.search(r"AS `([^`]+)` FROM `" + re.escape(source) + "`", sql)
     assert match, f"No grouped output alias found in:\n{sql}"
     return match.group(1)
+
+
+def test_struct_columns_are_attached_to_the_profiled_table():
+    struct = STRUCT(email=sa.String)
+    table = sa.Table(TABLE_NAME, sa.MetaData(), sa.Column("customer", struct))
+    profiler = object.__new__(BigQueryProfilerInterface)
+    profiler._table = SimpleNamespace(__table__=table)
+
+    columns = profiler._get_struct_columns(struct._STRUCT_fields, "customer")
+
+    assert [column.name for column in columns] == [NESTED_COLUMN]
+    assert columns[0].table is table
 
 
 def test_nested_struct_countif_references_the_grouped_subquery_alias():


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #32548

I updated BigQuery STRUCT-column expansion to pass SQLAlchemy 2's required parent-registration context and added a regression test because the old SQLAlchemy 1.x call crashes every profiled table containing a STRUCT.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- BigQuery profiling attaches a flattened STRUCT leaf column to the profiled SQLAlchemy table.
- Nested STRUCT paths continue to compile with the real BigQuery dialect.

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Files updated: `ingestion/tests/unit/observability/profiler/sqlalchemy/bigquery/test_bigquery_profiler_sql.py`
- BigQuery profiler suite: 12 passed with `sqlalchemy-bigquery==1.16.0`.
- Focused tests: 8 passed with `sqlalchemy-bigquery==1.17.2`.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Ran a local YAML profiler workflow against the `Spider2 BigQuery` service on OpenMetadata at `localhost:8585`.
- All-table STRUCT smoke run (`metrics: [rowCount]`): 92/92 tables profiled, 184 profiler records, 92 REST writes, zero warnings/errors, exit code 0.
- The OpenMetadata API returned a fresh profile with a row count for all 92 tables.
- A default-metric spot check processed 4 GA4 tables and 519 profiler records with zero profiler errors before switching to the bounded all-table smoke run.

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
- `make py_format_check`
- `git diff --check origin/main...HEAD`
- Live BigQuery profiling with the supplied service-account key and a separate billing project.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing.
