### PR TITLE
feat(search): report embedding token usage instead of discarding it

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/client/BedrockEmbeddingClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/client/BedrockEmbeddingClient.java
@@ -282,7 +282,8 @@ public final class BedrockEmbeddingClient extends EmbeddingClient implements Aut
             .body(SdkBytes.fromUtf8String(body))
             .build();
     InvokeModelResponse response = bedrockClient.invokeModel(request);
-    return parseEmbeddingResult(family, response.body().asUtf8String());
+    // `text` here is already capped and possibly halved, so it is what the provider received.
+    return parseEmbeddingResult(family, response.body().asUtf8String(), text);
   }
 
   /**
@@ -375,10 +376,11 @@ public final class BedrockEmbeddingClient extends EmbeddingClient implements Aut
   }
 
   static float[] parseEmbeddingResponse(BedrockEmbeddingFamily family, String responseBody) {
-    return parseEmbeddingResult(family, responseBody).vector();
+    return parseEmbeddingResult(family, responseBody, null).vector();
   }
 
-  static EmbeddingResult parseEmbeddingResult(BedrockEmbeddingFamily family, String responseBody) {
+  static EmbeddingResult parseEmbeddingResult(
+      BedrockEmbeddingFamily family, String responseBody, String submittedText) {
     try {
       JsonNode root = MAPPER.readTree(responseBody);
       JsonNode embeddingNode = family.extractEmbedding(root);
@@ -389,7 +391,7 @@ public final class BedrockEmbeddingClient extends EmbeddingClient implements Aut
       for (int i = 0; i < embeddingNode.size(); i++) {
         embedding[i] = (float) embeddingNode.get(i).asDouble();
       }
-      return new EmbeddingResult(embedding, family.extractUsage(root));
+      return new EmbeddingResult(embedding, family.extractUsage(root), submittedText);
     } catch (IOException e) {
       throw new RuntimeException("Failed to parse Bedrock embedding response", e);
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/client/BedrockEmbeddingClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/client/BedrockEmbeddingClient.java
@@ -36,6 +36,7 @@ public final class BedrockEmbeddingClient extends EmbeddingClient implements Aut
   private static final String FIELD_EMBEDDING = "embedding";
   private static final String FIELD_EMBEDDINGS = "embeddings";
   private static final String FIELD_FLOAT = "float";
+  private static final String FIELD_INPUT_TEXT_TOKEN_COUNT = "inputTextTokenCount";
   private static final String COHERE_INPUT_TYPE_SEARCH_DOCUMENT = "search_document";
   private static final String COHERE_INPUT_TYPE_SEARCH_QUERY = "search_query";
   private static final String COHERE_TRUNCATE_END = "END";
@@ -91,6 +92,11 @@ public final class BedrockEmbeddingClient extends EmbeddingClient implements Aut
       JsonNode extractEmbedding(JsonNode root) {
         return root.get(FIELD_EMBEDDING);
       }
+
+      @Override
+      EmbeddingUsage extractUsage(JsonNode root) {
+        return titanUsage(root);
+      }
     },
     TITAN_V2(OptionalInt.empty(), TITAN_MAX_INPUT_CHARS) {
       @Override
@@ -105,6 +111,11 @@ public final class BedrockEmbeddingClient extends EmbeddingClient implements Aut
       @Override
       JsonNode extractEmbedding(JsonNode root) {
         return root.get(FIELD_EMBEDDING);
+      }
+
+      @Override
+      EmbeddingUsage extractUsage(JsonNode root) {
+        return titanUsage(root);
       }
     },
     COHERE(OptionalInt.of(COHERE_FIXED_DIMENSION), COHERE_MAX_INPUT_CHARS) {
@@ -136,6 +147,20 @@ public final class BedrockEmbeddingClient extends EmbeddingClient implements Aut
     abstract ObjectNode buildRequest(String text, int dimension, boolean isQuery);
 
     abstract JsonNode extractEmbedding(JsonNode root);
+
+    /**
+     * Input tokens the family's response reports, or {@code null} when it reports none. Cohere on
+     * Bedrock returns no count at all, so consumers that need a number must estimate one.
+     */
+    EmbeddingUsage extractUsage(JsonNode root) {
+      return null;
+    }
+
+    /** Titan families both report the count under the same field. */
+    static EmbeddingUsage titanUsage(JsonNode root) {
+      JsonNode tokens = root.get(FIELD_INPUT_TEXT_TOKEN_COUNT);
+      return tokens != null && tokens.isNumber() ? new EmbeddingUsage(tokens.asLong()) : null;
+    }
 
     OptionalInt fixedDimension() {
       return fixedDimension;
@@ -207,17 +232,27 @@ public final class BedrockEmbeddingClient extends EmbeddingClient implements Aut
 
   @Override
   protected float[] doEmbed(String text) {
-    return invokeEmbedding(text, false);
+    return invokeEmbedding(text, false).vector();
   }
 
   @Override
   protected float[] doEmbedQuery(String text) {
-    return invokeEmbedding(text, true);
+    return invokeEmbedding(text, true).vector();
   }
 
-  private float[] invokeEmbedding(String text, boolean isQuery) {
+  @Override
+  protected EmbeddingResult doEmbedWithUsage(String text, boolean query) {
+    return invokeEmbedding(text, query);
+  }
+
+  /**
+   * Usage reflects the call that succeeded. An oversized input that AWS rejects with a
+   * ValidationException is not a billable invocation, so the halving retries below contribute
+   * nothing to the count.
+   */
+  private EmbeddingResult invokeEmbedding(String text, boolean isQuery) {
     String input = family.cap(text);
-    float[] embedding = null;
+    EmbeddingResult embedding = null;
     int attempt = 0;
     while (embedding == null) {
       try {
@@ -237,7 +272,7 @@ public final class BedrockEmbeddingClient extends EmbeddingClient implements Aut
     return embedding;
   }
 
-  private float[] invokeOnce(String text, boolean isQuery) throws IOException {
+  private EmbeddingResult invokeOnce(String text, boolean isQuery) throws IOException {
     String body = buildRequestBody(family, text, dimension, isQuery);
     InvokeModelRequest request =
         InvokeModelRequest.builder()
@@ -247,7 +282,7 @@ public final class BedrockEmbeddingClient extends EmbeddingClient implements Aut
             .body(SdkBytes.fromUtf8String(body))
             .build();
     InvokeModelResponse response = bedrockClient.invokeModel(request);
-    return parseEmbeddingResponse(family, response.body().asUtf8String());
+    return parseEmbeddingResult(family, response.body().asUtf8String());
   }
 
   /**
@@ -340,6 +375,10 @@ public final class BedrockEmbeddingClient extends EmbeddingClient implements Aut
   }
 
   static float[] parseEmbeddingResponse(BedrockEmbeddingFamily family, String responseBody) {
+    return parseEmbeddingResult(family, responseBody).vector();
+  }
+
+  static EmbeddingResult parseEmbeddingResult(BedrockEmbeddingFamily family, String responseBody) {
     try {
       JsonNode root = MAPPER.readTree(responseBody);
       JsonNode embeddingNode = family.extractEmbedding(root);
@@ -350,7 +389,7 @@ public final class BedrockEmbeddingClient extends EmbeddingClient implements Aut
       for (int i = 0; i < embeddingNode.size(); i++) {
         embedding[i] = (float) embeddingNode.get(i).asDouble();
       }
-      return embedding;
+      return new EmbeddingResult(embedding, family.extractUsage(root));
     } catch (IOException e) {
       throw new RuntimeException("Failed to parse Bedrock embedding response", e);
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/client/EmbeddingClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/client/EmbeddingClient.java
@@ -33,12 +33,24 @@ public abstract class EmbeddingClient {
   /**
    * A vector plus the usage of the call that produced it. {@code usage} is {@code null} when the
    * provider does not report token counts (Google's {@code :embedContent} and Cohere on Bedrock
-   * never do), so consumers that need a number must estimate one from the input text.
+   * never do), so consumers that need a number must estimate one from the submitted text.
+   *
+   * <p>{@code submittedText} is what actually went to the provider, which is not always what the
+   * caller passed in: providers with a hard input limit truncate first (Cohere on Bedrock at 2048
+   * chars, well under a normal chunk). Estimating from the caller's string would then overstate
+   * every truncated call — and Cohere is precisely the family that reports no usage, so estimation
+   * is the only option there. {@code null} means the input went through unchanged.
    *
    * <p>A carrier only: the generated {@code equals}/{@code hashCode} compare {@code vector} by
    * identity, so do not use this record as a map key or in equality assertions.
    */
-  public record EmbeddingResult(float[] vector, EmbeddingUsage usage) {}
+  public record EmbeddingResult(float[] vector, EmbeddingUsage usage, String submittedText) {
+
+    /** For providers that submit the caller's input unchanged. */
+    public EmbeddingResult(float[] vector, EmbeddingUsage usage) {
+      this(vector, usage, null);
+    }
+  }
 
   /**
    * Notified after each successful embedding call, so a deployment can meter its own embedding
@@ -47,6 +59,13 @@ public abstract class EmbeddingClient {
    * <p>Called off the concurrency permit and after the circuit breaker has settled, and any
    * exception it throws is logged and swallowed — a listener is observability and must never fail
    * an embedding or open the circuit.
+   *
+   * <p>Runs synchronously on the calling thread, once per embedded chunk on the indexing path, so
+   * an implementation must not block. Accumulate and report out of band.
+   *
+   * @param text what the provider received, after any provider-side truncation — not necessarily
+   *     what the caller passed in. Estimating a token count from anything else overstates a
+   *     truncated call.
    */
   public interface UsageListener {
     void onUsage(String modelId, String text, EmbeddingUsage usage, boolean query);
@@ -130,7 +149,7 @@ public abstract class EmbeddingClient {
     // Deliberately outside invokeProvider: the permit is released and the circuit has settled by
     // now, so a slow listener cannot starve other callers and a throwing one cannot open the
     // circuit.
-    notifyUsage(text, result.usage(), query);
+    notifyUsage(submittedOr(result, text), result.usage(), query);
     return result.vector();
   }
 
@@ -152,6 +171,11 @@ public abstract class EmbeddingClient {
         concurrencyLimiter.release();
       }
     }
+  }
+
+  /** What the provider received: the truncated form when one was reported, else the input. */
+  private static String submittedOr(EmbeddingResult result, String text) {
+    return result.submittedText() != null ? result.submittedText() : text;
   }
 
   private void notifyUsage(String text, EmbeddingUsage usage, boolean query) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/client/EmbeddingClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/client/EmbeddingClient.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.configuration.LLMConfiguration;
 import org.openmetadata.schema.configuration.LLMEmbeddingsConfig;
@@ -25,7 +24,36 @@ public abstract class EmbeddingClient {
     HALF_OPEN
   }
 
+  /**
+   * Token usage the provider reported for a single embedding call. An embedding call has no output
+   * tokens — it returns a vector, not generated text — so the input count is the whole of it.
+   */
+  public record EmbeddingUsage(long inputTokens) {}
+
+  /**
+   * A vector plus the usage of the call that produced it. {@code usage} is {@code null} when the
+   * provider does not report token counts (Google's {@code :embedContent} and Cohere on Bedrock
+   * never do), so consumers that need a number must estimate one from the input text.
+   *
+   * <p>A carrier only: the generated {@code equals}/{@code hashCode} compare {@code vector} by
+   * identity, so do not use this record as a map key or in equality assertions.
+   */
+  public record EmbeddingResult(float[] vector, EmbeddingUsage usage) {}
+
+  /**
+   * Notified after each successful embedding call, so a deployment can meter its own embedding
+   * traffic without this class knowing anything about how that metering works.
+   *
+   * <p>Called off the concurrency permit and after the circuit breaker has settled, and any
+   * exception it throws is logged and swallowed — a listener is observability and must never fail
+   * an embedding or open the circuit.
+   */
+  public interface UsageListener {
+    void onUsage(String modelId, String text, EmbeddingUsage usage, boolean query);
+  }
+
   private final Semaphore concurrencyLimiter;
+  private volatile UsageListener usageListener;
   private final Object circuitLock = new Object();
   private CircuitState circuitState = CircuitState.CLOSED;
   private int consecutiveFailures = 0;
@@ -70,23 +98,50 @@ public abstract class EmbeddingClient {
     return doEmbed(text);
   }
 
+  /**
+   * Embed {@code text} and report whatever token usage the provider returned alongside the vector.
+   *
+   * <p>Defaults to the plain {@link #doEmbed}/{@link #doEmbedQuery} pair with no usage, so a client
+   * that overrides only those keeps working unchanged. Providers whose response carries a token
+   * count (Bedrock Titan's {@code inputTextTokenCount}, OpenAI's {@code usage.prompt_tokens})
+   * override this to surface it instead of discarding it.
+   */
+  protected EmbeddingResult doEmbedWithUsage(String text, boolean query) {
+    float[] vector = query ? doEmbedQuery(text) : doEmbed(text);
+    return new EmbeddingResult(vector, null);
+  }
+
+  /** Register the listener notified after each successful call. {@code null} disables reporting. */
+  public void setUsageListener(UsageListener usageListener) {
+    this.usageListener = usageListener;
+  }
+
   public final float[] embed(String text) {
-    return embedWithLimit(() -> doEmbed(text));
+    return embedWithLimit(text, false);
   }
 
   public final float[] embedQuery(String text) {
-    return embedWithLimit(() -> doEmbedQuery(text));
+    return embedWithLimit(text, true);
   }
 
-  private float[] embedWithLimit(Supplier<float[]> embedder) {
+  private float[] embedWithLimit(String text, boolean query) {
     guardCircuit();
+    EmbeddingResult result = invokeProvider(text, query);
+    // Deliberately outside invokeProvider: the permit is released and the circuit has settled by
+    // now, so a slow listener cannot starve other callers and a throwing one cannot open the
+    // circuit.
+    notifyUsage(text, result.usage(), query);
+    return result.vector();
+  }
+
+  private EmbeddingResult invokeProvider(String text, boolean query) {
     boolean permitAcquired = false;
     try {
       acquirePermit();
       permitAcquired = true;
-      float[] embedding = embedder.get();
+      EmbeddingResult result = doEmbedWithUsage(text, query);
       recordSuccess();
-      return embedding;
+      return result;
     } catch (RuntimeException failure) {
       // Record even a permit-acquisition failure so a promoted HALF_OPEN probe always resolves
       // (success -> closed, failure -> reopened) and never wedges the circuit half-open forever.
@@ -95,6 +150,18 @@ public abstract class EmbeddingClient {
     } finally {
       if (permitAcquired) {
         concurrencyLimiter.release();
+      }
+    }
+  }
+
+  private void notifyUsage(String text, EmbeddingUsage usage, boolean query) {
+    UsageListener listener = usageListener;
+    if (listener != null) {
+      try {
+        listener.onUsage(getModelId(), text, usage, query);
+      } catch (RuntimeException e) {
+        LOG.warn(
+            "Embedding usage listener failed for model {}: {}", getModelId(), e.getMessage(), e);
       }
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/client/OpenAIEmbeddingClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/client/OpenAIEmbeddingClient.java
@@ -18,6 +18,8 @@ import org.openmetadata.schema.configuration.LLMOpenAIEmbeddingConfig;
 @Slf4j
 public final class OpenAIEmbeddingClient extends EmbeddingClient {
   private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final String FIELD_USAGE = "usage";
+  private static final String FIELD_PROMPT_TOKENS = "prompt_tokens";
 
   private final HttpClient httpClient;
   private final String apiKey;
@@ -122,6 +124,16 @@ public final class OpenAIEmbeddingClient extends EmbeddingClient {
 
   @Override
   protected float[] doEmbed(String text) {
+    return invokeEmbedding(text).vector();
+  }
+
+  /** OpenAI embeddings do not distinguish query from document input, so {@code query} is unused. */
+  @Override
+  protected EmbeddingResult doEmbedWithUsage(String text, boolean query) {
+    return invokeEmbedding(text);
+  }
+
+  private EmbeddingResult invokeEmbedding(String text) {
     if (text == null || text.isBlank()) {
       throw new IllegalArgumentException("Input text must not be null or blank");
     }
@@ -155,7 +167,7 @@ public final class OpenAIEmbeddingClient extends EmbeddingClient {
             "OpenAI API returned status " + response.statusCode() + ": " + errorMsg);
       }
 
-      return parseEmbeddingResponse(response.body());
+      return parseEmbeddingResult(response.body());
     } catch (IOException e) {
       LOG.error("IO error calling OpenAI API: {}", e.getMessage(), e);
       throw new RuntimeException("OpenAI embedding generation failed due to IO error", e);
@@ -175,7 +187,7 @@ public final class OpenAIEmbeddingClient extends EmbeddingClient {
     return modelId;
   }
 
-  private float[] parseEmbeddingResponse(String responseBody) {
+  private EmbeddingResult parseEmbeddingResult(String responseBody) {
     try {
       JsonNode root = MAPPER.readTree(responseBody);
       JsonNode data = root.get("data");
@@ -190,10 +202,19 @@ public final class OpenAIEmbeddingClient extends EmbeddingClient {
       for (int i = 0; i < embeddingNode.size(); i++) {
         embedding[i] = (float) embeddingNode.get(i).asDouble();
       }
-      return embedding;
+      return new EmbeddingResult(embedding, extractUsage(root));
     } catch (IOException e) {
       throw new RuntimeException("Failed to parse OpenAI embedding response", e);
     }
+  }
+
+  /** Input tokens from the response's {@code usage} block, or {@code null} if absent. */
+  private static EmbeddingUsage extractUsage(JsonNode root) {
+    JsonNode usage = root.get(FIELD_USAGE);
+    JsonNode promptTokens = usage != null ? usage.get(FIELD_PROMPT_TOKENS) : null;
+    return promptTokens != null && promptTokens.isNumber()
+        ? new EmbeddingUsage(promptTokens.asLong())
+        : null;
   }
 
   private String extractErrorMessage(String responseBody) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/EmbeddingClientTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/EmbeddingClientTest.java
@@ -3,6 +3,7 @@ package org.openmetadata.service.search.vector;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -14,8 +15,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.service.search.vector.client.EmbeddingClient;
+import org.openmetadata.service.search.vector.client.EmbeddingClient.EmbeddingResult;
+import org.openmetadata.service.search.vector.client.EmbeddingClient.EmbeddingUsage;
 import org.openmetadata.service.search.vector.client.EmbeddingUnavailableException;
 
 class EmbeddingClientTest {
@@ -254,6 +258,112 @@ class EmbeddingClientTest {
         providerCalls.get(),
         "exactly one recovery probe may reach the provider while half-open");
     assertTrue(client.isAvailable());
+  }
+
+  @Test
+  void testUsageListenerDistinguishesQueryFromDocument() {
+    EmbeddingClient client = new MockEmbeddingClient(8);
+    List<Boolean> queryFlags = new ArrayList<>();
+    client.setUsageListener((modelId, text, usage, query) -> queryFlags.add(query));
+
+    client.embed("a document");
+    client.embedQuery("a question");
+
+    assertEquals(List.of(false, true), queryFlags);
+  }
+
+  @Test
+  void testUsageListenerReceivesModelAndText() {
+    EmbeddingClient client = new MockEmbeddingClient(8);
+    AtomicReference<String> seenModel = new AtomicReference<>();
+    AtomicReference<String> seenText = new AtomicReference<>();
+    client.setUsageListener(
+        (modelId, text, usage, query) -> {
+          seenModel.set(modelId);
+          seenText.set(text);
+        });
+
+    client.embed("the exact input");
+
+    assertEquals("mock-model", seenModel.get());
+    assertEquals("the exact input", seenText.get());
+  }
+
+  @Test
+  void testSubclassOverridingOnlyDoEmbedReportsNoUsage() {
+    // Backward compatibility: an existing client that never heard of doEmbedWithUsage still works,
+    // and reports null usage so consumers know to estimate.
+    EmbeddingClient client = new MockEmbeddingClient(8);
+    AtomicReference<EmbeddingUsage> seen = new AtomicReference<>(new EmbeddingUsage(-1L));
+    client.setUsageListener((modelId, text, usage, query) -> seen.set(usage));
+
+    assertEquals(8, client.embed("text").length);
+
+    assertNull(seen.get(), "a client that reports no usage must surface null, not a fabricated 0");
+  }
+
+  @Test
+  void testUsageListenerReceivesProviderReportedUsage() {
+    EmbeddingClient client =
+        new EmbeddingClient() {
+          @Override
+          protected float[] doEmbed(String text) {
+            return new float[] {1.0f};
+          }
+
+          @Override
+          protected EmbeddingResult doEmbedWithUsage(String text, boolean query) {
+            return new EmbeddingResult(new float[] {2.0f}, new EmbeddingUsage(42L));
+          }
+
+          @Override
+          public int getDimension() {
+            return 1;
+          }
+
+          @Override
+          public String getModelId() {
+            return "usage-test";
+          }
+        };
+    AtomicReference<EmbeddingUsage> seen = new AtomicReference<>();
+    client.setUsageListener((modelId, text, usage, query) -> seen.set(usage));
+
+    float[] vector = client.embed("text");
+
+    assertNotNull(seen.get());
+    assertEquals(42L, seen.get().inputTokens());
+    assertEquals(
+        2.0f, vector[0], "the usage-aware path must supply the vector, not the legacy doEmbed");
+  }
+
+  @Test
+  void testUsageListenerNotNotifiedOnFailure() {
+    AtomicInteger calls = new AtomicInteger(0);
+    EmbeddingClient client = failingClient(calls, false);
+    AtomicInteger notifications = new AtomicInteger(0);
+    client.setUsageListener((modelId, text, usage, query) -> notifications.incrementAndGet());
+
+    assertThrows(RuntimeException.class, () -> client.embed("text"));
+
+    assertEquals(0, notifications.get(), "a failed call bills nothing");
+  }
+
+  @Test
+  void testThrowingUsageListenerNeitherFailsEmbedNorOpensCircuit() {
+    // A listener is observability. If a metering bug throws on every call it must not take
+    // embeddings down with it, and must not be mistaken for a provider failure.
+    EmbeddingClient client = new MockEmbeddingClient(8);
+    client.setUsageListener(
+        (modelId, text, usage, query) -> {
+          throw new IllegalStateException("listener is broken");
+        });
+
+    for (int i = 0; i < 6; i++) {
+      assertEquals(8, client.embed("text").length);
+    }
+
+    assertTrue(client.isAvailable(), "listener failures must not count toward the circuit breaker");
   }
 
   private static EmbeddingClient failingClient(AtomicInteger calls, boolean permanent) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/EmbeddingClientTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/EmbeddingClientTest.java
@@ -366,6 +366,124 @@ class EmbeddingClientTest {
     assertTrue(client.isAvailable(), "listener failures must not count toward the circuit breaker");
   }
 
+  @Test
+  void embedQueryStillReachesADoEmbedQueryOverride() {
+    // The compatibility guarantee the whole usage hook rests on. Without this, collapsing the
+    // dispatch in embedWithLimit onto doEmbed would pass every other test in this file.
+    EmbeddingClient client =
+        new EmbeddingClient() {
+          @Override
+          protected float[] doEmbed(String text) {
+            return new float[] {1.0f};
+          }
+
+          @Override
+          protected float[] doEmbedQuery(String text) {
+            return new float[] {2.0f};
+          }
+
+          @Override
+          public int getDimension() {
+            return 1;
+          }
+
+          @Override
+          public String getModelId() {
+            return "dispatch-test";
+          }
+        };
+
+    assertEquals(1.0f, client.embed("a document")[0]);
+    assertEquals(
+        2.0f, client.embedQuery("a question")[0], "embedQuery must not collapse onto doEmbed");
+  }
+
+  @Test
+  void listenerSeesTheSubmittedTextNotTheCallersInput() {
+    // Cohere on Bedrock truncates at 2048 chars and reports no usage, so it is the one family that
+    // must be estimated from text — and the one where the caller's string is the wrong string.
+    EmbeddingClient client =
+        new EmbeddingClient() {
+          @Override
+          protected float[] doEmbed(String text) {
+            return new float[] {1.0f};
+          }
+
+          @Override
+          protected EmbeddingResult doEmbedWithUsage(String text, boolean query) {
+            return new EmbeddingResult(new float[] {1.0f}, null, text.substring(0, 2048));
+          }
+
+          @Override
+          public int getDimension() {
+            return 1;
+          }
+
+          @Override
+          public String getModelId() {
+            return "truncating-test";
+          }
+        };
+    AtomicReference<String> seen = new AtomicReference<>();
+    client.setUsageListener((modelId, text, usage, query) -> seen.set(text));
+
+    client.embed("x".repeat(5000));
+
+    assertEquals(
+        2048, seen.get().length(), "estimating from 5000 chars would bill 2952 never sent");
+  }
+
+  @Test
+  void aBlockingListenerDoesNotHoldTheConcurrencyPermit() throws InterruptedException {
+    // The design claim behind notifyUsage living outside invokeProvider. Move it back inside and
+    // this deadlocks on a one-permit client.
+    CountDownLatch listenerEntered = new CountDownLatch(1);
+    CountDownLatch releaseListener = new CountDownLatch(1);
+    AtomicInteger listenerCalls = new AtomicInteger(0);
+    EmbeddingClient client =
+        new EmbeddingClient(1) {
+          @Override
+          protected float[] doEmbed(String text) {
+            return new float[] {1.0f};
+          }
+
+          @Override
+          public int getDimension() {
+            return 1;
+          }
+
+          @Override
+          public String getModelId() {
+            return "permit-test";
+          }
+        };
+    client.setUsageListener(
+        (modelId, text, usage, query) -> {
+          if (listenerCalls.incrementAndGet() == 1) {
+            listenerEntered.countDown();
+            try {
+              releaseListener.await();
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            }
+          }
+        });
+
+    ExecutorService pool = Executors.newSingleThreadExecutor();
+    try {
+      CompletableFuture<float[]> blocked =
+          CompletableFuture.supplyAsync(() -> client.embed("first"), pool);
+      assertTrue(listenerEntered.await(2, TimeUnit.SECONDS), "the listener should be reached");
+
+      assertNotNull(client.embed("second"), "a blocked listener must not hold the only permit");
+
+      releaseListener.countDown();
+      assertNotNull(blocked.join());
+    } finally {
+      pool.shutdown();
+    }
+  }
+
   private static EmbeddingClient failingClient(AtomicInteger calls, boolean permanent) {
     return new EmbeddingClient() {
       @Override

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/client/BedrockEmbeddingClientTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/client/BedrockEmbeddingClientTest.java
@@ -3,6 +3,8 @@ package org.openmetadata.service.search.vector.client;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -15,6 +17,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.service.search.vector.client.BedrockEmbeddingClient.BedrockEmbeddingFamily;
+import org.openmetadata.service.search.vector.client.EmbeddingClient.EmbeddingResult;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelRequest;
@@ -227,6 +230,47 @@ class BedrockEmbeddingClientTest {
         BedrockEmbeddingClient.parseEmbeddingResponse(
             BedrockEmbeddingFamily.COHERE, "{\"embeddings\":{\"float\":[[0.4,0.5]]}}");
     assertArrayEquals(new float[] {0.4f, 0.5f}, embedding, DELTA);
+  }
+
+  @Test
+  void titanResponseReportsInputTokens() {
+    EmbeddingResult result =
+        BedrockEmbeddingClient.parseEmbeddingResult(
+            BedrockEmbeddingFamily.TITAN_V2, "{\"embedding\":[0.6,0.7],\"inputTextTokenCount\":2}");
+
+    assertArrayEquals(new float[] {0.6f, 0.7f}, result.vector(), DELTA);
+    assertNotNull(result.usage());
+    assertEquals(2L, result.usage().inputTokens());
+  }
+
+  @Test
+  void titanV1ResponseReportsInputTokens() {
+    EmbeddingResult result =
+        BedrockEmbeddingClient.parseEmbeddingResult(
+            BedrockEmbeddingFamily.TITAN_V1, "{\"embedding\":[0.1],\"inputTextTokenCount\":17}");
+
+    assertNotNull(result.usage());
+    assertEquals(17L, result.usage().inputTokens());
+  }
+
+  @Test
+  void titanResponseWithoutTokenCountReportsNoUsage() {
+    EmbeddingResult result =
+        BedrockEmbeddingClient.parseEmbeddingResult(
+            BedrockEmbeddingFamily.TITAN_V2, "{\"embedding\":[0.6,0.7]}");
+
+    assertNull(result.usage(), "an absent count must stay absent rather than becoming 0");
+  }
+
+  @Test
+  void cohereResponseReportsNoUsage() {
+    // Cohere on Bedrock returns no token count at all, so consumers must estimate one.
+    EmbeddingResult result =
+        BedrockEmbeddingClient.parseEmbeddingResult(
+            BedrockEmbeddingFamily.COHERE, "{\"embeddings\":[[0.1,0.2,0.3]]}");
+
+    assertArrayEquals(new float[] {0.1f, 0.2f, 0.3f}, result.vector(), DELTA);
+    assertNull(result.usage());
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/client/BedrockEmbeddingClientTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/client/BedrockEmbeddingClientTest.java
@@ -236,7 +236,9 @@ class BedrockEmbeddingClientTest {
   void titanResponseReportsInputTokens() {
     EmbeddingResult result =
         BedrockEmbeddingClient.parseEmbeddingResult(
-            BedrockEmbeddingFamily.TITAN_V2, "{\"embedding\":[0.6,0.7],\"inputTextTokenCount\":2}");
+            BedrockEmbeddingFamily.TITAN_V2,
+            "{\"embedding\":[0.6,0.7],\"inputTextTokenCount\":2}",
+            null);
 
     assertArrayEquals(new float[] {0.6f, 0.7f}, result.vector(), DELTA);
     assertNotNull(result.usage());
@@ -247,7 +249,9 @@ class BedrockEmbeddingClientTest {
   void titanV1ResponseReportsInputTokens() {
     EmbeddingResult result =
         BedrockEmbeddingClient.parseEmbeddingResult(
-            BedrockEmbeddingFamily.TITAN_V1, "{\"embedding\":[0.1],\"inputTextTokenCount\":17}");
+            BedrockEmbeddingFamily.TITAN_V1,
+            "{\"embedding\":[0.1],\"inputTextTokenCount\":17}",
+            null);
 
     assertNotNull(result.usage());
     assertEquals(17L, result.usage().inputTokens());
@@ -257,7 +261,7 @@ class BedrockEmbeddingClientTest {
   void titanResponseWithoutTokenCountReportsNoUsage() {
     EmbeddingResult result =
         BedrockEmbeddingClient.parseEmbeddingResult(
-            BedrockEmbeddingFamily.TITAN_V2, "{\"embedding\":[0.6,0.7]}");
+            BedrockEmbeddingFamily.TITAN_V2, "{\"embedding\":[0.6,0.7]}", null);
 
     assertNull(result.usage(), "an absent count must stay absent rather than becoming 0");
   }
@@ -267,7 +271,7 @@ class BedrockEmbeddingClientTest {
     // Cohere on Bedrock returns no token count at all, so consumers must estimate one.
     EmbeddingResult result =
         BedrockEmbeddingClient.parseEmbeddingResult(
-            BedrockEmbeddingFamily.COHERE, "{\"embeddings\":[[0.1,0.2,0.3]]}");
+            BedrockEmbeddingFamily.COHERE, "{\"embeddings\":[[0.1,0.2,0.3]]}", null);
 
     assertArrayEquals(new float[] {0.1f, 0.2f, 0.3f}, result.vector(), DELTA);
     assertNull(result.usage());

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/client/OpenAIEmbeddingClientTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/client/OpenAIEmbeddingClientTest.java
@@ -2,6 +2,7 @@ package org.openmetadata.service.search.vector.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -19,12 +20,14 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLSession;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.configuration.LLMConfiguration;
 import org.openmetadata.schema.configuration.LLMEmbeddingsConfig;
 import org.openmetadata.schema.configuration.LLMOpenAIConfig;
 import org.openmetadata.schema.configuration.LLMOpenAIEmbeddingConfig;
+import org.openmetadata.service.search.vector.client.EmbeddingClient.EmbeddingUsage;
 
 class OpenAIEmbeddingClientTest {
 
@@ -530,6 +533,38 @@ class OpenAIEmbeddingClientTest {
     assertEquals(0.1f, embedding[0], 0.001f);
     assertEquals(0.2f, embedding[1], 0.001f);
     assertEquals(0.3f, embedding[2], 0.001f);
+  }
+
+  @Test
+  void testUsageListenerReceivesPromptTokens() {
+    String response =
+        "{\"data\":[{\"embedding\":[0.1]}],\"model\":\"test\",\"usage\":{\"prompt_tokens\":7}}";
+    StubHttpClient httpClient = new StubHttpClient(response, 200);
+    OpenAIEmbeddingClient client =
+        new OpenAIEmbeddingClient(
+            httpClient, "test-key", "test-model", 1, "http://localhost/v1/embeddings", false);
+    AtomicReference<EmbeddingUsage> seen = new AtomicReference<>();
+    client.setUsageListener((modelId, text, usage, query) -> seen.set(usage));
+
+    client.embed("hello world");
+
+    assertNotNull(seen.get());
+    assertEquals(7L, seen.get().inputTokens());
+  }
+
+  @Test
+  void testEmptyUsageBlockReportsNoUsage() {
+    String response = "{\"data\":[{\"embedding\":[0.1]}],\"model\":\"test\",\"usage\":{}}";
+    StubHttpClient httpClient = new StubHttpClient(response, 200);
+    OpenAIEmbeddingClient client =
+        new OpenAIEmbeddingClient(
+            httpClient, "test-key", "test-model", 1, "http://localhost/v1/embeddings", false);
+    AtomicReference<EmbeddingUsage> seen = new AtomicReference<>(new EmbeddingUsage(-1L));
+    client.setUsageListener((modelId, text, usage, query) -> seen.set(usage));
+
+    client.embed("hello world");
+
+    assertNull(seen.get(), "an empty usage block must not become a fabricated 0");
   }
 
   @Test


### PR DESCRIPTION
Closes #32489

Bedrock Titan returns `inputTextTokenCount` and OpenAI returns `usage.prompt_tokens`. We read the vector out of the response and throw the rest away, so nothing downstream can tell how many tokens embeddings used.

## What this adds

- An optional `UsageListener` on `EmbeddingClient`, called after each successful embedding.
- A `doEmbedWithUsage(text, query)` hook that defaults to the current behaviour.
- Titan and OpenAI now surface the count they already receive.

## Notes

- Backward compatible. A client that only implements `doEmbed` is unaffected, and `GoogleEmbeddingClient` / `DjlEmbeddingClient` need no changes.
- No schema change, no new dependency, and no cost or billing concepts in the interface.
- Google and Cohere never send a count, so a listener still has to estimate for those two. It receives the text the provider actually got, after any truncation.
- The listener runs off the concurrency permit and after the circuit breaker settles. Anything it throws is logged and swallowed, so it can never fail an embedding or open the circuit.

## Tests

119 pass. Two of them were checked by breaking the code first: one fails if the `doEmbedQuery` dispatch is collapsed, one fails if the listener moves back inside the concurrency permit.