### PR TITLE
[2.0] fix(test): isolate Java CI fixtures

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentPaginationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentPaginationIT.java
@@ -54,6 +54,7 @@ public class IncidentPaginationIT {
   private OpenMetadataClient client;
   private List<TestCase> testCases;
   private String databaseSchemaFqn;
+  private String tableFqn;
 
   @BeforeAll
   public void setup() throws Exception {
@@ -78,6 +79,7 @@ public class IncidentPaginationIT {
             .getFullyQualifiedName();
 
     Table table = createTestTable();
+    tableFqn = table.getFullyQualifiedName();
     String testDefFqn =
         client
             .testDefinitions()
@@ -157,7 +159,12 @@ public class IncidentPaginationIT {
 
   @Test
   public void testPaginationFirstPage() throws Exception {
-    ListParams params = new ListParams().withLimit(PAGE_SIZE).withOffset(0).withLatest(true);
+    ListParams params =
+        new ListParams()
+            .withLimit(PAGE_SIZE)
+            .withOffset(0)
+            .withLatest(true)
+            .addFilter("originEntityFQN", tableFqn);
 
     ListResponse<TestCaseResolutionStatus> response =
         client.testCaseResolutionStatuses().searchList(params);
@@ -165,17 +172,26 @@ public class IncidentPaginationIT {
     assertNotNull(response);
     assertEquals(
         PAGE_SIZE, response.getData().size(), "First page should return " + PAGE_SIZE + " results");
-    assertTrue(
-        response.getPaging().getTotal() >= TEST_DATA_SIZE,
-        "Total should be at least " + TEST_DATA_SIZE);
+    assertEquals(
+        TEST_DATA_SIZE,
+        response.getPaging().getTotal(),
+        "Scoped total must be exactly the fixture size");
   }
 
   @Test
   public void testPaginationSecondPage() throws Exception {
     ListParams firstPageParams =
-        new ListParams().withLimit(PAGE_SIZE).withOffset(0).withLatest(true);
+        new ListParams()
+            .withLimit(PAGE_SIZE)
+            .withOffset(0)
+            .withLatest(true)
+            .addFilter("originEntityFQN", tableFqn);
     ListParams secondPageParams =
-        new ListParams().withLimit(PAGE_SIZE).withOffset(PAGE_SIZE).withLatest(true);
+        new ListParams()
+            .withLimit(PAGE_SIZE)
+            .withOffset(PAGE_SIZE)
+            .withLatest(true)
+            .addFilter("originEntityFQN", tableFqn);
 
     AtomicReference<ListResponse<TestCaseResolutionStatus>> firstPageRef = new AtomicReference<>();
     AtomicReference<ListResponse<TestCaseResolutionStatus>> secondPageRef = new AtomicReference<>();
@@ -215,21 +231,31 @@ public class IncidentPaginationIT {
 
   @Test
   public void testPaginationLastPage() throws Exception {
-    ListParams params = new ListParams().withLimit(PAGE_SIZE).withOffset(0).withLatest(true);
+    ListParams params =
+        new ListParams()
+            .withLimit(PAGE_SIZE)
+            .withOffset(0)
+            .withLatest(true)
+            .addFilter("originEntityFQN", tableFqn);
     ListResponse<TestCaseResolutionStatus> firstPage =
         client.testCaseResolutionStatuses().searchList(params);
     int total = firstPage.getPaging().getTotal();
     int lastPageOffset = ((total - 1) / PAGE_SIZE) * PAGE_SIZE;
 
     ListParams lastPageParams =
-        new ListParams().withLimit(PAGE_SIZE).withOffset(lastPageOffset).withLatest(true);
+        new ListParams()
+            .withLimit(PAGE_SIZE)
+            .withOffset(lastPageOffset)
+            .withLatest(true)
+            .addFilter("originEntityFQN", tableFqn);
     ListResponse<TestCaseResolutionStatus> lastPage =
         client.testCaseResolutionStatuses().searchList(lastPageParams);
 
     assertNotNull(lastPage);
-    assertTrue(
-        lastPage.getData().size() > 0 && lastPage.getData().size() <= PAGE_SIZE,
-        "Last page should have between 1 and " + PAGE_SIZE + " results");
+    assertEquals(
+        total - lastPageOffset,
+        lastPage.getData().size(),
+        "Scoped last page must hold exactly the remainder of the fixture");
   }
 
   @Test
@@ -247,7 +273,12 @@ public class IncidentPaginationIT {
 
   @Test
   public void testOffsetBeyondResults() throws Exception {
-    ListParams params = new ListParams().withLimit(PAGE_SIZE).withOffset(10000).withLatest(true);
+    ListParams params =
+        new ListParams()
+            .withLimit(PAGE_SIZE)
+            .withOffset(10000)
+            .withLatest(true)
+            .addFilter("originEntityFQN", tableFqn);
 
     ListResponse<TestCaseResolutionStatus> response =
         client.testCaseResolutionStatuses().searchList(params);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/lineage/LineagePermissionFilterTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/lineage/LineagePermissionFilterTest.java
@@ -52,6 +52,12 @@ class LineagePermissionFilterTest {
   @BeforeAll
   static void registerRepository() {
     TableRepository tableRepository = mock(TableRepository.class);
+    // This registration is global and never torn down, so the stand-in must answer the indexing
+    // policy hooks the way the real repository does. A bare mock answers false, which would make
+    // Entity.isSearchIndexable/isVectorEmbeddable report every table as excluded for the rest of
+    // the JVM.
+    when(tableRepository.isSearchIndexable(any())).thenReturn(true);
+    when(tableRepository.isVectorEmbeddable(any())).thenReturn(true);
     when(tableRepository.getEntityType()).thenReturn(Entity.TABLE);
     when(tableRepository.getFields(anyString())).thenReturn(Fields.EMPTY_FIELDS);
     when(tableRepository.get(isNull(), anyList(), any(Fields.class), any(Include.class)))


### PR DESCRIPTION
### Describe your changes:

No linked issue — this is a CI-only test-isolation fix for failures reported on #32535.

The failures recur on unrelated `2.0` PRs, so they are branch-level test problems rather than
regressions in #32535:

- Scope `IncidentPaginationIT` pagination requests to the table created by the fixture. Parallel
  integration tests can no longer change the page contents or total through unrelated incidents.
  This backports the applicable test hardening from #30367.
- Make the process-global `TableRepository` mock in `LineagePermissionFilterTest` preserve the real
  search-index and vector-embedding policy. A bare Mockito mock returned `false` for both policy
  hooks and made later Elasticsearch/OpenSearch sink tests return before exercising their mocks.
  This backports the `2.0`-applicable part of #32537.

The failed test jobs on #32372 were audited as well:

- Its MySQL/Elasticsearch integration report has the same `IncidentPaginationIT` failure fixed
  here.
- Its Python 3.10 unit job and two integration shards failed while importing Airflow because
  `pygtrie 2.6.0` uses `typing.Self`. That was fixed on `2.0` by merged PR #32432 / commit
  `59b9b4c0d5916bc5280c18a596c5d33241d15f92`, which is already an ancestor of this branch.
- Its remaining Python 3.11 integration job received runner shutdown signal 143 and has no test
  failure to fix in the repository.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A — test-isolation fixes only.

#
### Tests:

#### Use cases covered

- Incident pagination asserts against only the 11 incidents created by its fixture.
- Elasticsearch and OpenSearch embedding tests remain valid after
  `LineagePermissionFilterTest` has registered its repository mock in the same JVM.

#### Unit tests

- [x] Existing tests cover the changed behavior.
- Forced the CI-sensitive execution order:

```text
mvn -pl openmetadata-service test -Dsurefire.runOrder=reversealphabetical \
  -Dtest='LineagePermissionFilterTest,OpenSearchBulkSinkBehaviorTest,ElasticSearchBulkSinkBehaviorTest'
```

Result: 45 tests run, 0 failures, 0 errors, 0 skipped.

#### Backend integration tests

- [x] Updated the existing `IncidentPaginationIT` regression coverage.
- Ran the actual MySQL + Elasticsearch parallel-lane integration test locally:

```text
mvn -pl openmetadata-integration-tests verify -Pmysql-elasticsearch \
  -DintegrationTests.lane=parallel -Dit.test=IncidentPaginationIT
```

Result: 8 tests run, 0 failures, 0 errors, 0 skipped.

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Not applicable (no UI changes).

#### Manual testing performed

Not applicable; covered by the ordered unit suite and integration-test compilation above.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added or updated tests and listed them above.

<!-- Bug fix -->
- [x] Existing tests cover the exact CI failures being fixed.
