### PR TITLE
Backport #32115 to 2.0: declare the data asset types once and make the field catalog deterministic

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/DataInsightsApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/DataInsightsApp.java
@@ -9,6 +9,9 @@ import static org.openmetadata.service.workflows.searchIndex.ReindexingUtil.getI
 import es.co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -18,9 +21,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.openmetadata.schema.dataInsight.custom.DataAssetType;
 import org.openmetadata.schema.entity.app.App;
 import org.openmetadata.schema.entity.app.AppRunRecord;
 import org.openmetadata.schema.entity.app.FailureContext;
@@ -77,24 +82,30 @@ public class DataInsightsApp extends AbstractNativeApplication {
   private volatile boolean stopped = false;
   private final AtomicReference<DataInsightsWorkflow> activeWorkflow = new AtomicReference<>();
 
-  public final Set<String> dataAssetTypes =
-      Set.of(
-          "table",
-          "storedProcedure",
-          "databaseSchema",
-          "database",
-          "chart",
-          "dashboard",
-          "dashboardDataModel",
-          "pipeline",
-          "topic",
-          "container",
-          "searchIndex",
-          "mlmodel",
-          "dataProduct",
-          "glossaryTerm",
-          "tag",
-          "metric");
+  /**
+   * The entity types this app ingests: every {@link DataAssetType} that no live index aliases into
+   * the Data Insights wildcard.
+   *
+   * <p>The data-quality types are deliberately excluded. They reach {@code di-data-assets-*} through
+   * a {@code dataInsightAliases} entry in indexMapping.json that points at the live entity index, so
+   * Data Insights reads them without ever writing them. Creating or deleting a datastream for one
+   * would target that alias, and therefore live data, because {@link #getDataStreamName} would
+   * produce the very name the alias already occupies.
+   */
+  public Set<String> getDataAssetTypes() {
+    return Collections.unmodifiableSet(
+        Arrays.stream(DataAssetType.values())
+            .map(DataAssetType::value)
+            .filter(dataAssetType -> !isAliasedFromLiveIndex(dataAssetType))
+            .collect(Collectors.<String, LinkedHashSet<String>>toCollection(LinkedHashSet::new)));
+  }
+
+  private boolean isAliasedFromLiveIndex(String dataAssetType) {
+    IndexMapping indexMapping = searchRepository.getIndexMapping(dataAssetType);
+    return indexMapping != null
+        && indexMapping.getDataInsightAliases() != null
+        && !indexMapping.getDataInsightAliases().isEmpty();
+  }
 
   public DataInsightsApp(CollectionDAO collectionDAO, SearchRepository searchRepository) {
     super(collectionDAO, searchRepository);
@@ -138,7 +149,7 @@ public class DataInsightsApp extends AbstractNativeApplication {
             : "en";
 
     try {
-      for (String dataAssetType : dataAssetTypes) {
+      for (String dataAssetType : getDataAssetTypes()) {
         IndexMapping dataAssetIndex = searchRepository.getIndexMapping(dataAssetType);
         String dataStreamName =
             getDataStreamName(searchRepository.getClusterAlias(), dataAssetType);
@@ -160,7 +171,7 @@ public class DataInsightsApp extends AbstractNativeApplication {
     DataInsightsSearchInterface searchInterface = getSearchInterface();
 
     try {
-      for (String dataAssetType : dataAssetTypes) {
+      for (String dataAssetType : getDataAssetTypes()) {
         String dataStreamName =
             getDataStreamName(searchRepository.getClusterAlias(), dataAssetType);
         if (searchInterface.dataAssetDataStreamExists(dataStreamName)) {
@@ -413,7 +424,7 @@ public class DataInsightsApp extends AbstractNativeApplication {
             timestamp,
             batchSize,
             backfill,
-            dataAssetTypes,
+            getDataAssetTypes(),
             collectionDAO,
             searchRepository,
             getSearchInterface()));

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/search/DataInsightsSearchConfiguration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/search/DataInsightsSearchConfiguration.java
@@ -1,10 +1,42 @@
 package org.openmetadata.service.apps.bundles.insights.search;
 
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import lombok.Getter;
+import org.openmetadata.schema.dataInsight.custom.DataAssetType;
 
 @Getter
 public class DataInsightsSearchConfiguration {
-  private Map<String, List<String>> mappingFields;
+  private MappingFields mappingFields;
+
+  /**
+   * The per-type attribute lists from {@code dataInsights/config.json}: {@code common} applies to
+   * every document, and each remaining key adds the attributes specific to one entity type.
+   *
+   * <p>Those keys are typed as {@link DataAssetType} rather than kept as strings, so a key naming
+   * something Data Insights does not cover cannot exist. Jackson resolves them through the enum's
+   * {@code @JsonCreator}, which lets the file keep its flat shape while a misspelling fails at load
+   * instead of silently producing documents without their type-specific attributes.
+   */
+  @Getter
+  public static class MappingFields {
+    private List<String> common = List.of();
+    private final Map<DataAssetType, List<String>> byType = new EnumMap<>(DataAssetType.class);
+
+    @JsonAnySetter
+    void putByType(String entityType, List<String> attributeFields) {
+      try {
+        byType.put(DataAssetType.fromValue(entityType), attributeFields);
+      } catch (IllegalArgumentException e) {
+        // Chaining `e` would hide this message: Jackson's any-setter path reports the root cause,
+        // so the operator would see fromValue's bare "<key>" instead.
+        throw new IllegalArgumentException(
+            String.format(
+                "%s declares mappingFields for '%s', which is not a Data Insights asset type",
+                DataInsightsSearchInterface.DATA_INSIGHTS_SEARCH_CONFIG_PATH, entityType));
+      }
+    }
+  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/search/DataInsightsSearchInterface.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/search/DataInsightsSearchInterface.java
@@ -2,7 +2,9 @@ package org.openmetadata.service.apps.bundles.insights.search;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
+import org.openmetadata.schema.dataInsight.custom.DataAssetType;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.search.IndexMapping;
 import org.openmetadata.service.exception.UnhandledServerException;
@@ -71,11 +73,19 @@ public interface DataInsightsSearchInterface {
 
   default List<String> getEntityAttributeFields(
       DataInsightsSearchConfiguration dataInsightsSearchConfiguration, String entityType) {
-    List<String> entityAttributeFields =
-        dataInsightsSearchConfiguration.getMappingFields().get("common");
-    entityAttributeFields.addAll(
-        dataInsightsSearchConfiguration.getMappingFields().get(entityType));
-
+    DataInsightsSearchConfiguration.MappingFields mappingFields =
+        dataInsightsSearchConfiguration.getMappingFields();
+    List<String> typeFields = mappingFields.getByType().get(DataAssetType.fromValue(entityType));
+    if (typeFields == null) {
+      throw new IllegalStateException(
+          String.format(
+              "%s declares no mappingFields for '%s', so its documents would carry only the common attributes",
+              DATA_INSIGHTS_SEARCH_CONFIG_PATH, entityType));
+    }
+    // Copy: the common list is shared across every call, so appending to it in place would leak one
+    // entity type's attributes into the next.
+    List<String> entityAttributeFields = new ArrayList<>(mappingFields.getCommon());
+    entityAttributeFields.addAll(typeFields);
     return entityAttributeFields;
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataInsightSystemChartRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataInsightSystemChartRepository.java
@@ -9,8 +9,11 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -20,8 +23,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.glassfish.jersey.message.internal.OutboundJaxrsResponse;
 import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.dataInsight.custom.DataAssetType;
 import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChart;
 import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChartResultList;
 import org.openmetadata.schema.entity.app.AppRunRecord;
@@ -61,25 +66,22 @@ public class DataInsightSystemChartRepository extends EntityRepository<DataInsig
   private ScheduledExecutorService scheduler;
   private final Map<String, StreamingSession> activeSessions;
 
+  /**
+   * Every entity type reachable under {@link #DI_SEARCH_INDEX}, i.e. the ones DataInsightsApp
+   * ingests plus the ones aliased in from a live index. Derived from {@link DataAssetType} so this
+   * set cannot drift from the types Data Insights actually covers; it is used only to enumerate
+   * index names when building the custom-chart field catalog.
+   *
+   * <p>Iteration order is the enum's declaration order. The catalog appends records per type as it
+   * walks this set, so a salted order would vary the record order per JVM start and any consumer
+   * that resolves a duplicated field name by taking the first record would resolve it differently
+   * after a restart.
+   */
   public static final Set<String> dataAssetTypes =
-      Set.of(
-          "table",
-          "storedProcedure",
-          "databaseSchema",
-          "database",
-          "chart",
-          "dashboard",
-          "dashboardDataModel",
-          "pipeline",
-          "topic",
-          "container",
-          "searchIndex",
-          "mlmodel",
-          "dataProduct",
-          "glossaryTerm",
-          "tag",
-          "testCaseResult",
-          "testCaseResolutionStatus");
+      Collections.unmodifiableSet(
+          Arrays.stream(DataAssetType.values())
+              .map(DataAssetType::value)
+              .collect(Collectors.<String, LinkedHashSet<String>>toCollection(LinkedHashSet::new)));
 
   public static final String DI_SEARCH_INDEX_PREFIX = "di-data-assets";
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KpiRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KpiRepository.java
@@ -147,9 +147,9 @@ public class KpiRepository extends EntityRepository<Kpi> {
             kpi.withKpiResult(kpiResult);
           }
         }
-      } catch (IOException e) {
+      } catch (IOException | RuntimeException e) {
         // Log error but continue processing other KPIs
-        LOG.warn("Failed to fetch KPI results for chart {}: {}", entry.getKey(), e.getMessage());
+        LOG.warn("Failed to fetch KPI results for chart {}", entry.getKey(), e);
       }
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/DataInsightMetricFilter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/DataInsightMetricFilter.java
@@ -1,0 +1,53 @@
+package org.openmetadata.service.search;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Reads a Data Insight chart metric's {@code filter}.
+ *
+ * <p>Both engines used to parse that string inline, twice each, and both fell back to an unfiltered
+ * aggregation on any failure. Routing every read through here keeps a filter that cannot be parsed
+ * failing the same way everywhere: the caller gets {@code null} and leaves the aggregation
+ * unfiltered, exactly as before.
+ */
+public final class DataInsightMetricFilter {
+  private static final Logger LOG = LoggerFactory.getLogger(DataInsightMetricFilter.class);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final String QUERY_KEY = "query";
+  private static final String EMPTY_FILTER = "{}";
+
+  /**
+   * Prefix both engines name a filtered metric's wrapper aggregation with, and the whole order path
+   * a terms axis needs to rank by it. Naming the aggregation itself sorts on its document count;
+   * there is no metric key, so nothing built from this may contain a dot — an order path splits on
+   * {@code .} into a metric sub-field and the search is rejected outright when it does.
+   */
+  public static final String FILTER_AGG_KEY = "filter";
+
+  private DataInsightMetricFilter() {}
+
+  /**
+   * JSON text of the filter's {@code query} node, or null when the filter is absent, empty or
+   * unparseable. The {@code "{}"} comparison is an exact string match, which is what the inline
+   * parses did.
+   */
+  public static String queryJson(String filter) {
+    if (filter == null || filter.equals(EMPTY_FILTER)) {
+      return null;
+    }
+    try {
+      JsonNode queryNode = MAPPER.readTree(filter).get(QUERY_KEY);
+      return queryNode == null ? null : queryNode.toString();
+    } catch (JsonProcessingException e) {
+      // Warn without the throwable: these endpoints are polled, and the fallback is well defined.
+      // Only a parse failure falls back; anything else is a bug and must not be downgraded into a
+      // silently unfiltered chart.
+      LOG.warn("Ignoring a Data Insight metric filter that will not parse: {}", e.getMessage());
+      return null;
+    }
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchDataInsightAggregatorManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchDataInsightAggregatorManager.java
@@ -21,8 +21,10 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.text.WordUtils;
@@ -190,11 +192,36 @@ public class ElasticSearchDataInsightAggregatorManager implements DataInsightAgg
     return QueryCostRecordsAggregator.parseQueryCostResponse(searchResponse);
   }
 
+  /**
+   * Collects the leaf field names of one entity type's index mapping into {@code fieldList}.
+   *
+   * <p>The seen-set is seeded from {@code fieldList} rather than built fresh, because a datastream
+   * resolves to backing indices and this runs once per index: a per-call set would stop
+   * deduplicating across them. Seeding costs one pass over the accumulated list per call, where
+   * scanning it per field cost a pass per leaf.
+   */
   static void getFieldNames(
       Map<String, Property> properties,
       String prefix,
       List<Map<String, String>> fieldList,
       String entityType) {
+    Set<String> seen = new HashSet<>();
+    for (Map<String, String> field : fieldList) {
+      seen.add(seenKey(field.get("entityType"), field.get("name")));
+    }
+    collectFieldNames(properties, prefix, fieldList, entityType, seen);
+  }
+
+  private static String seenKey(String entityType, String name) {
+    return entityType + ' ' + name;
+  }
+
+  private static void collectFieldNames(
+      Map<String, Property> properties,
+      String prefix,
+      List<Map<String, String>> fieldList,
+      String entityType,
+      Set<String> seen) {
 
     if (properties == null) {
       return;
@@ -226,7 +253,11 @@ public class ElasticSearchDataInsightAggregatorManager implements DataInsightAgg
 
       // Only add non-object/nested leaf fields
       if (!"object".equals(type) && !"nested".equals(type)) {
-        if (fieldList.stream().noneMatch(e -> e.get("name").equals(finalFieldName))) {
+        // Deduplicate per entity type, not globally. A global dedup credits a shared field name
+        // to whichever type is iterated first, and the iteration source is a Set.of whose order is
+        // salted per JVM start: a type whose every field name was already claimed contributes
+        // nothing, and which types those are changes on restart.
+        if (seen.add(seenKey(entityType, finalFieldName))) {
           Map<String, String> fieldMap = new HashMap<>();
           fieldMap.put("name", finalFieldName);
           fieldMap.put("displayName", displayName);
@@ -241,7 +272,8 @@ public class ElasticSearchDataInsightAggregatorManager implements DataInsightAgg
       // formula's q= compiles to can reach them: every descendant of a nested field is unusable in
       // a custom chart and must not be advertised.
       if (property.isObject() && property.object().properties() != null) {
-        getFieldNames(property.object().properties(), baseFieldName, fieldList, entityType);
+        collectFieldNames(
+            property.object().properties(), baseFieldName, fieldList, entityType, seen);
       }
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchDynamicChartAggregatorInterface.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchDynamicChartAggregatorInterface.java
@@ -1,7 +1,5 @@
 package org.openmetadata.service.search.elasticsearch.dataInsightAggregators;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import es.co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
 import es.co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
 import es.co.elastic.clients.elasticsearch._types.aggregations.CardinalityAggregate;
@@ -9,7 +7,6 @@ import es.co.elastic.clients.elasticsearch._types.aggregations.DateHistogramBuck
 import es.co.elastic.clients.elasticsearch._types.aggregations.FilterAggregate;
 import es.co.elastic.clients.elasticsearch._types.aggregations.SingleMetricAggregateBase;
 import es.co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
-import es.co.elastic.clients.elasticsearch._types.aggregations.ValueCountAggregate;
 import es.co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import es.co.elastic.clients.elasticsearch.core.SearchRequest;
 import es.co.elastic.clients.elasticsearch.core.SearchResponse;
@@ -22,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.jena.atlas.logging.Log;
 import org.jetbrains.annotations.NotNull;
 import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChart;
 import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChartResult;
@@ -30,12 +26,12 @@ import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChartResultLi
 import org.openmetadata.schema.dataInsight.custom.FormulaHolder;
 import org.openmetadata.schema.dataInsight.custom.Function;
 import org.openmetadata.service.jdbi3.DataInsightSystemChartRepository;
+import org.openmetadata.service.search.DataInsightMetricFilter;
 import org.openmetadata.service.util.DataInsightFormulaEvaluator;
 
 public interface ElasticSearchDynamicChartAggregatorInterface {
 
   long MILLISECONDS_IN_DAY = 24L * 60 * 60 * 1000;
-  ObjectMapper mapper = new ObjectMapper();
 
   private static Aggregation getSubAggregationsByFunction(
       Function function, String field, int index) {
@@ -68,7 +64,15 @@ public interface ElasticSearchDynamicChartAggregatorInterface {
     return formulas;
   }
 
-  static void getDateHistogramByFormula(
+  /**
+   * Builds one aggregation per formula term and returns, in precedence order, the wrapper
+   * aggregations a categorical axis may rank itself by.
+   *
+   * <p>Only a metric-level filter yields order keys. A term's own {@code q=} narrows that term
+   * alone, so ranking by it would pick the categories satisfying one operand of the formula rather
+   * than the population the formula is evaluated over.
+   */
+  static List<String> getDateHistogramByFormula(
       String formula,
       Query filter,
       Map<String, Aggregation> aggregationsMap,
@@ -76,6 +80,8 @@ public interface ElasticSearchDynamicChartAggregatorInterface {
       List<FormulaHolder> formulas) {
     Pattern pattern = Pattern.compile(DataInsightSystemChartRepository.FORMULA_FUNC_REGEX);
     Matcher matcher = pattern.matcher(formula);
+    List<String> unnarrowed = new ArrayList<>();
+    List<String> narrowed = new ArrayList<>();
     int index = 0;
     while (matcher.find()) {
       FormulaHolder holder = new FormulaHolder();
@@ -113,14 +119,18 @@ public interface ElasticSearchDynamicChartAggregatorInterface {
         Map<String, Aggregation> subAggMap = new HashMap<>();
         subAggMap.put(field + index, subAgg);
         aggregationsMap.put(
-            "filter" + index, Aggregation.of(a -> a.filter(queryBuilder).aggregations(subAggMap)));
+            DataInsightMetricFilter.FILTER_AGG_KEY + index,
+            Aggregation.of(a -> a.filter(queryBuilder).aggregations(subAggMap)));
+        narrowed.add(DataInsightMetricFilter.FILTER_AGG_KEY + index);
         holder.setQuery(matcher.group(5));
       } else {
         if (filter != null) {
           Map<String, Aggregation> subAggMap = new HashMap<>();
           subAggMap.put(field + index, subAgg);
           aggregationsMap.put(
-              "filter" + index, Aggregation.of(a -> a.filter(filter).aggregations(subAggMap)));
+              DataInsightMetricFilter.FILTER_AGG_KEY + index,
+              Aggregation.of(a -> a.filter(filter).aggregations(subAggMap)));
+          unnarrowed.add(DataInsightMetricFilter.FILTER_AGG_KEY + index);
         } else {
           aggregationsMap.put(field + index, subAgg);
         }
@@ -128,6 +138,11 @@ public interface ElasticSearchDynamicChartAggregatorInterface {
       formulas.add(holder);
       index++;
     }
+    if (filter == null) {
+      return List.of();
+    }
+    unnarrowed.addAll(narrowed);
+    return unnarrowed;
   }
 
   private List<DataInsightCustomChartResult> processMultiAggregations(
@@ -186,7 +201,41 @@ public interface ElasticSearchDynamicChartAggregatorInterface {
     return finalList;
   }
 
-  default void populateDateHistogram(
+  /**
+   * Engine query for a filter's extracted query text, or null only when the metric declares none.
+   *
+   * <p>A filter that was declared but cannot be mapped is an error, not an absent filter. Returning
+   * null for both would leave {@link #populateDateHistogram} building the metric as an unfiltered
+   * leaf, so the chart reports a plausible number counted over every document instead of the subset
+   * the filter asked for. That is the failure the whole filter path exists to prevent, and it is
+   * silent: the request still returns 200.
+   *
+   * <p>This parses client side where the OpenSearch wrapper sends the query verbatim and lets the
+   * cluster reject it. Failing here keeps the two engines answering the same way rather than one
+   * erroring and the other quietly widening the aggregation.
+   */
+  static Query queryFromJson(String queryJson) {
+    if (queryJson == null) {
+      return null;
+    }
+    try {
+      return Query.of(q -> q.withJson(new StringReader(queryJson)));
+    } catch (RuntimeException e) {
+      throw new IllegalArgumentException(
+          "Data Insight metric filter cannot be mapped by the Elasticsearch client: " + queryJson,
+          e);
+    }
+  }
+
+  /**
+   * Builds a metric's sub-aggregations and returns the wrapper aggregations a categorical axis may
+   * rank itself by, in precedence order — empty when the metric declares no filter.
+   *
+   * <p>The keys come from the same pass that builds the wrappers, so an order path can only name an
+   * aggregation that is really in the request. Deciding separately from the chart definition would
+   * name a wrapper for a filter this client silently drops, and the engine rejects the whole search.
+   */
+  default List<String> populateDateHistogram(
       Function function,
       String formula,
       String field,
@@ -198,42 +247,23 @@ public interface ElasticSearchDynamicChartAggregatorInterface {
       throw new IllegalArgumentException(
           "Data Insight chart metric must define either a function or a formula");
     }
+    Query queryFilter = queryFromJson(DataInsightMetricFilter.queryJson(filter));
     if (formula != null) {
-      if (filter != null && !filter.equals("{}")) {
-        try {
-          JsonNode rootNode = mapper.readTree(filter);
-          JsonNode queryNode = rootNode.get("query");
-
-          Query queryFilter = Query.of(q -> q.withJson(new StringReader(queryNode.toString())));
-          getDateHistogramByFormula(formula, queryFilter, aggregationsMap, parentAggName, formulas);
-        } catch (Exception e) {
-          Log.error("Error while parsing query string so using fallback: {}", e.getMessage(), e);
-          getDateHistogramByFormula(formula, null, aggregationsMap, parentAggName, formulas);
-        }
-      } else {
-        getDateHistogramByFormula(formula, null, aggregationsMap, parentAggName, formulas);
-      }
-      return;
+      return getDateHistogramByFormula(
+          formula, queryFilter, aggregationsMap, parentAggName, formulas);
     }
 
     Aggregation subAgg = getSubAggregationsByFunction(function, field, 0);
-    if (filter != null && !filter.equals("{}")) {
-      try {
-        JsonNode rootNode = mapper.readTree(filter);
-        JsonNode queryNode = rootNode.get("query");
-
-        Query queryFilter = Query.of(q -> q.withJson(new StringReader(queryNode.toString())));
-        Map<String, Aggregation> subAggMap = new HashMap<>();
-        subAggMap.put(field + "0", subAgg);
-        aggregationsMap.put(
-            "filter", Aggregation.of(a -> a.filter(queryFilter).aggregations(subAggMap)));
-      } catch (Exception e) {
-        Log.error("Error while parsing query string so using fallback: {}", e.getMessage(), e);
-        aggregationsMap.put(field + "0", subAgg);
-      }
-    } else {
+    if (queryFilter == null) {
       aggregationsMap.put(field + "0", subAgg);
+      return List.of();
     }
+    Map<String, Aggregation> subAggMap = new HashMap<>();
+    subAggMap.put(field + "0", subAgg);
+    aggregationsMap.put(
+        DataInsightMetricFilter.FILTER_AGG_KEY,
+        Aggregation.of(a -> a.filter(queryFilter).aggregations(subAggMap)));
+    return List.of(DataInsightMetricFilter.FILTER_AGG_KEY);
   }
 
   SearchRequest prepareSearchRequest(
@@ -379,21 +409,6 @@ public interface ElasticSearchDynamicChartAggregatorInterface {
   }
 
   private void addProcessedSubResult(
-      ValueCountAggregate aggregation,
-      List<DataInsightCustomChartResult> diChartResults,
-      String key,
-      String group,
-      boolean isTimeStamp,
-      String metric) {
-    double value = aggregation.value();
-    if (!Double.isInfinite(value) && !Double.isNaN(value)) {
-      DataInsightCustomChartResult diChartResult =
-          getDIChartResult(value, key, group, isTimeStamp, metric);
-      diChartResults.add(diChartResult);
-    }
-  }
-
-  private void addProcessedSubResult(
       CardinalityAggregate aggregation,
       List<DataInsightCustomChartResult> diChartResults,
       String key,
@@ -415,8 +430,11 @@ public interface ElasticSearchDynamicChartAggregatorInterface {
       String group,
       boolean isTimeStamp,
       String metric) {
-    double value = aggregation.value();
-    if (!Double.isInfinite(value) && !Double.isNaN(value)) {
+    // Covers value_count as well: ValueCountAggregate extends this type, so both bind here.
+    // avg/min/max over a bucket the metric filter emptied return a null value, not NaN.
+    // Unboxing that throws, and the whole chart request dies with a 500.
+    Double value = aggregation.value();
+    if (value != null && !value.isInfinite() && !value.isNaN()) {
       DataInsightCustomChartResult diChartResult =
           getDIChartResult(value, key, group, isTimeStamp, metric);
       diChartResults.add(diChartResult);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchLineChartAggregator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchLineChartAggregator.java
@@ -1,13 +1,17 @@
 package org.openmetadata.service.search.elasticsearch.dataInsightAggregators;
 
+import es.co.elastic.clients.elasticsearch._types.SortOrder;
 import es.co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
 import es.co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
 import es.co.elastic.clients.elasticsearch._types.aggregations.CalendarInterval;
 import es.co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
+import es.co.elastic.clients.elasticsearch._types.aggregations.TermsAggregation;
 import es.co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import es.co.elastic.clients.elasticsearch.core.SearchRequest;
 import es.co.elastic.clients.elasticsearch.core.SearchResponse;
 import es.co.elastic.clients.json.JsonData;
+import es.co.elastic.clients.util.NamedValue;
+import es.co.elastic.clients.util.ObjectBuilder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -38,6 +42,45 @@ public class ElasticSearchLineChartAggregator
     }
   }
 
+  /**
+   * Configures the categorical axis.
+   *
+   * <p>A terms axis picks its top N by raw document count, which is neither the population a metric
+   * filters to nor the number the chart plots. {@code orderKeys} name the filter wrappers that
+   * {@code populateDateHistogram} actually built, so the axis instead ranks each category by how
+   * many documents it contributed to the metric.
+   *
+   * <p>Ranking on the wrapper's document count rather than the metric's own value is what makes
+   * this safe for every function: an empty {@code min} reads as larger than any real minimum and an
+   * empty {@code sum} is zero, so ordering by either would float the empty categories to the top. A
+   * document count is never negative, and is zero exactly when the category matched nothing, which
+   * keeps those categories in the response but last, where they cannot displace one that has data.
+   */
+  private static ObjectBuilder<TermsAggregation> termsAxis(
+      TermsAggregation.Builder builder,
+      String field,
+      String include,
+      String exclude,
+      List<String> orderKeys) {
+    TermsAggregation.Builder axis = builder.field(field).size(100);
+    if (include != null) {
+      axis = axis.include(inc -> inc.regexp(include));
+    }
+    if (exclude != null) {
+      axis = axis.exclude(exc -> exc.regexp(exclude));
+    }
+    if (!orderKeys.isEmpty()) {
+      axis = axis.order(orderKeys.stream().map(key -> NamedValue.of(key, SortOrder.Desc)).toList());
+    }
+    return axis;
+  }
+
+  /** Attaches sub-aggregations only when there are any, so an empty map is never serialized. */
+  private static ObjectBuilder<Aggregation> withSubAggregations(
+      Aggregation.Builder.ContainerBuilder container, Map<String, Aggregation> subAggregations) {
+    return subAggregations.isEmpty() ? container : container.aggregations(subAggregations);
+  }
+
   @Override
   public SearchRequest prepareSearchRequest(
       @NotNull DataInsightCustomChart diChart,
@@ -65,97 +108,51 @@ public class ElasticSearchLineChartAggregator
               ? null
               : lineChart.getExcludeXAxisField();
 
-      if (lineChart.getxAxisField() != null
-          && !lineChart.getxAxisField().equals(DataInsightSystemChartRepository.TIMESTAMP_FIELD)) {
-        Aggregation termsAgg =
-            Aggregation.of(
-                a -> {
-                  var tb = a.terms(t -> t.field(lineChart.getxAxisField()).size(100));
-                  if (finalIncludeTerms != null) {
-                    tb =
-                        a.terms(
-                            t ->
-                                t.field(lineChart.getxAxisField())
-                                    .size(100)
-                                    .include(inc -> inc.regexp(finalIncludeTerms)));
-                  }
-                  if (finalExcludeTerms != null) {
-                    tb =
-                        a.terms(
-                            t -> {
-                              var builder = t.field(lineChart.getxAxisField()).size(100);
-                              if (finalIncludeTerms != null) {
-                                builder = builder.include(inc -> inc.regexp(finalIncludeTerms));
-                              }
-                              return builder.exclude(exc -> exc.regexp(finalExcludeTerms));
-                            });
-                  }
-                  return tb;
-                });
-
-        metricAggregations.put(metricName, termsAgg);
-        startTime = end - MILLISECONDS_IN_DAY;
-
-      } else {
-        Aggregation dateHistogramAgg =
-            Aggregation.of(
-                a ->
-                    a.dateHistogram(
-                        dh ->
-                            dh.field(DataInsightSystemChartRepository.TIMESTAMP_FIELD)
-                                .calendarInterval(CalendarInterval.Day)));
-        metricAggregations.put(metricName, dateHistogramAgg);
-      }
-
       metricFormulaHolder.put(
           metricName,
           new MetricFormulaHolder(
               metric.getFormula(),
               ElasticSearchDynamicChartAggregatorInterface.getFormulaList(metric.getFormula())));
 
-      Map<String, Aggregation> subAggregations = new HashMap<>();
-      populateDateHistogram(
-          metric.getFunction(),
-          metric.getFormula(),
-          metric.getField(),
-          metric.getFilter(),
-          subAggregations,
-          metricName,
-          formulas);
+      final Map<String, Aggregation> subAggregations = new HashMap<>();
+      final List<String> orderKeys =
+          populateDateHistogram(
+              metric.getFunction(),
+              metric.getFormula(),
+              metric.getField(),
+              metric.getFilter(),
+              subAggregations,
+              metricName,
+              formulas);
 
-      Aggregation currentAgg = metricAggregations.get(metricName);
-      if (!subAggregations.isEmpty()) {
-        if (currentAgg.isTerms()) {
-          // Rebuild terms aggregation with sub-aggregations, preserving include/exclude filters
-          final String fieldName = currentAgg.terms().field();
-          final int size = currentAgg.terms().size() != null ? currentAgg.terms().size() : 100;
-          metricAggregations.put(
-              metricName,
-              Aggregation.of(
-                  a ->
-                      a.terms(
-                              t -> {
-                                var builder = t.field(fieldName).size(size);
-                                if (finalIncludeTerms != null) {
-                                  builder = builder.include(inc -> inc.regexp(finalIncludeTerms));
-                                }
-                                if (finalExcludeTerms != null) {
-                                  builder = builder.exclude(exc -> exc.regexp(finalExcludeTerms));
-                                }
-                                return builder;
-                              })
-                          .aggregations(subAggregations)));
-        } else if (currentAgg._kind().name().equals("DateHistogram")) {
-          // Rebuild date histogram aggregation with sub-aggregations
-          final String fieldName = currentAgg.dateHistogram().field();
-          final CalendarInterval interval = currentAgg.dateHistogram().calendarInterval();
-          metricAggregations.put(
-              metricName,
-              Aggregation.of(
-                  a ->
-                      a.dateHistogram(dh -> dh.field(fieldName).calendarInterval(interval))
-                          .aggregations(subAggregations)));
-        }
+      if (lineChart.getxAxisField() != null
+          && !lineChart.getxAxisField().equals(DataInsightSystemChartRepository.TIMESTAMP_FIELD)) {
+        metricAggregations.put(
+            metricName,
+            Aggregation.of(
+                a ->
+                    withSubAggregations(
+                        a.terms(
+                            t ->
+                                termsAxis(
+                                    t,
+                                    lineChart.getxAxisField(),
+                                    finalIncludeTerms,
+                                    finalExcludeTerms,
+                                    orderKeys)),
+                        subAggregations)));
+        startTime = end - MILLISECONDS_IN_DAY;
+      } else {
+        metricAggregations.put(
+            metricName,
+            Aggregation.of(
+                a ->
+                    withSubAggregations(
+                        a.dateHistogram(
+                            dh ->
+                                dh.field(DataInsightSystemChartRepository.TIMESTAMP_FIELD)
+                                    .calendarInterval(CalendarInterval.Day)),
+                        subAggregations)));
       }
 
       if (lineChart.getGroupBy() != null) {
@@ -200,7 +197,6 @@ public class ElasticSearchLineChartAggregator
     }
 
     SearchRequest.Builder searchRequestBuilder = new SearchRequest.Builder().size(0);
-
     final long finalStartTime = startTime;
     if (!live) {
       Query rangeQuery =

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchDataInsightAggregatorManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchDataInsightAggregatorManager.java
@@ -9,8 +9,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.text.WordUtils;
@@ -197,11 +199,36 @@ public class OpenSearchDataInsightAggregatorManager implements DataInsightAggreg
     return processor.process(dataInsightChartType);
   }
 
+  /**
+   * Collects the leaf field names of one entity type's index mapping into {@code fields}.
+   *
+   * <p>The seen-set is seeded from {@code fields} rather than built fresh, because a datastream
+   * resolves to backing indices and this runs once per index: a per-call set would stop
+   * deduplicating across them. Seeding costs one pass over the accumulated list per call, where
+   * scanning it per field cost a pass per leaf.
+   */
   static void getFieldNames(
       Map<String, Property> properties,
       String parent,
       List<Map<String, String>> fields,
       String entityType) {
+    Set<String> seen = new HashSet<>();
+    for (Map<String, String> field : fields) {
+      seen.add(seenKey(field.get("entityType"), field.get("name")));
+    }
+    collectFieldNames(properties, parent, fields, entityType, seen);
+  }
+
+  private static String seenKey(String entityType, String name) {
+    return entityType + ' ' + name;
+  }
+
+  private static void collectFieldNames(
+      Map<String, Property> properties,
+      String parent,
+      List<Map<String, String>> fields,
+      String entityType,
+      Set<String> seen) {
 
     if (properties == null) return;
 
@@ -229,8 +256,11 @@ public class OpenSearchDataInsightAggregatorManager implements DataInsightAggreg
       final String finalFieldName = adjustedFieldName;
 
       if (!"object".equals(type) && !"nested".equals(type)) {
-        // Deduplicate
-        if (fields.stream().noneMatch(f -> f.get("name").equals(finalFieldName))) {
+        // Deduplicate per entity type, not globally. A global dedup credits a shared field name
+        // to whichever type is iterated first, and the iteration source is a Set.of whose order is
+        // salted per JVM start: a type whose every field name was already claimed contributes
+        // nothing, and which types those are changes on restart.
+        if (seen.add(seenKey(entityType, finalFieldName))) {
           Map<String, String> fieldMap = new HashMap<>();
           fieldMap.put("name", finalFieldName);
           fieldMap.put("displayName", displayName);
@@ -245,7 +275,7 @@ public class OpenSearchDataInsightAggregatorManager implements DataInsightAggreg
       // formula's q= compiles to can reach them: every descendant of a nested field is unusable in
       // a custom chart and must not be advertised.
       if (property.isObject() && property.object().properties() != null) {
-        getFieldNames(property.object().properties(), baseFieldName, fields, entityType);
+        collectFieldNames(property.object().properties(), baseFieldName, fields, entityType, seen);
       }
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchDynamicChartAggregatorInterface.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchDynamicChartAggregatorInterface.java
@@ -1,7 +1,6 @@
 package org.openmetadata.service.search.opensearch.dataInsightAggregator;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Comparator;
@@ -10,7 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.jena.atlas.logging.Log;
 import org.jetbrains.annotations.NotNull;
 import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChart;
 import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChartResult;
@@ -18,6 +16,7 @@ import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChartResultLi
 import org.openmetadata.schema.dataInsight.custom.FormulaHolder;
 import org.openmetadata.schema.dataInsight.custom.Function;
 import org.openmetadata.service.jdbi3.DataInsightSystemChartRepository;
+import org.openmetadata.service.search.DataInsightMetricFilter;
 import org.openmetadata.service.util.DataInsightFormulaEvaluator;
 import os.org.opensearch.client.json.JsonData;
 import os.org.opensearch.client.opensearch._types.aggregations.Aggregate;
@@ -31,7 +30,6 @@ import os.org.opensearch.client.opensearch.core.SearchResponse;
 
 public interface OpenSearchDynamicChartAggregatorInterface {
   long MILLISECONDS_IN_DAY = 24L * 60 * 60 * 1000;
-  ObjectMapper mapper = new ObjectMapper();
 
   private static Aggregation getSubAggregationsByFunction(
       Function function, String field, int index) {
@@ -64,7 +62,15 @@ public interface OpenSearchDynamicChartAggregatorInterface {
     return formulas;
   }
 
-  static void getDateHistogramByFormula(
+  /**
+   * Builds one aggregation per formula term and returns, in precedence order, the wrapper
+   * aggregations a categorical axis may rank itself by.
+   *
+   * <p>Only a metric-level filter yields order keys. A term's own {@code q=} narrows that term
+   * alone, so ranking by it would pick the categories satisfying one operand of the formula rather
+   * than the population the formula is evaluated over.
+   */
+  static List<String> getDateHistogramByFormula(
       String formula,
       Query filter,
       Map<String, Aggregation> aggregations,
@@ -72,6 +78,8 @@ public interface OpenSearchDynamicChartAggregatorInterface {
       List<FormulaHolder> formulas) {
     Pattern pattern = Pattern.compile(DataInsightSystemChartRepository.FORMULA_FUNC_REGEX);
     Matcher matcher = pattern.matcher(formula);
+    List<String> unnarrowed = new ArrayList<>();
+    List<String> narrowed = new ArrayList<>();
     int index = 0;
     while (matcher.find()) {
       FormulaHolder holder = new FormulaHolder();
@@ -107,14 +115,18 @@ public interface OpenSearchDynamicChartAggregatorInterface {
         Map<String, Aggregation> subAggMap = new HashMap<>();
         subAggMap.put(field + index, subAgg);
         aggregations.put(
-            "filter" + index, Aggregation.of(a -> a.filter(queryBuilder).aggregations(subAggMap)));
+            DataInsightMetricFilter.FILTER_AGG_KEY + index,
+            Aggregation.of(a -> a.filter(queryBuilder).aggregations(subAggMap)));
+        narrowed.add(DataInsightMetricFilter.FILTER_AGG_KEY + index);
         holder.setQuery(queryString);
       } else {
         if (filter != null) {
           Map<String, Aggregation> subAggMap = new HashMap<>();
           subAggMap.put(field + index, subAgg);
           aggregations.put(
-              "filter" + index, Aggregation.of(a -> a.filter(filter).aggregations(subAggMap)));
+              DataInsightMetricFilter.FILTER_AGG_KEY + index,
+              Aggregation.of(a -> a.filter(filter).aggregations(subAggMap)));
+          unnarrowed.add(DataInsightMetricFilter.FILTER_AGG_KEY + index);
         } else {
           aggregations.put(field + index, subAgg);
         }
@@ -122,6 +134,11 @@ public interface OpenSearchDynamicChartAggregatorInterface {
       formulas.add(holder);
       index++;
     }
+    if (filter == null) {
+      return List.of();
+    }
+    unnarrowed.addAll(narrowed);
+    return unnarrowed;
   }
 
   private List<DataInsightCustomChartResult> processMultiAggregations(
@@ -180,7 +197,25 @@ public interface OpenSearchDynamicChartAggregatorInterface {
     return finalList;
   }
 
-  default void populateDateHistogram(
+  /** Engine query for a filter's extracted query text, or null when there is none. */
+  static Query queryFromJson(String queryJson) {
+    if (queryJson == null) {
+      return null;
+    }
+    String base64Query =
+        Base64.getEncoder().encodeToString(queryJson.getBytes(StandardCharsets.UTF_8));
+    return Query.of(q -> q.wrapper(w -> w.query(base64Query)));
+  }
+
+  /**
+   * Builds a metric's sub-aggregations and returns the wrapper aggregations a categorical axis may
+   * rank itself by, in precedence order — empty when the metric declares no filter.
+   *
+   * <p>The keys come from the same pass that builds the wrappers, so an order path can only name an
+   * aggregation that is really in the request. Deciding separately from the chart definition would
+   * name a wrapper for a filter this client silently drops, and the engine rejects the whole search.
+   */
+  default List<String> populateDateHistogram(
       Function function,
       String formula,
       String field,
@@ -192,45 +227,23 @@ public interface OpenSearchDynamicChartAggregatorInterface {
       throw new IllegalArgumentException(
           "Data Insight chart metric must define either a function or a formula");
     }
+    Query queryFilter = queryFromJson(DataInsightMetricFilter.queryJson(filter));
     if (formula != null) {
-      if (filter != null && !filter.equals("{}")) {
-        try {
-          JsonNode rootNode = mapper.readTree(filter);
-          JsonNode queryNode = rootNode.get("query");
-          String base64Query = Base64.getEncoder().encodeToString(queryNode.toString().getBytes());
-          Query queryFilter = Query.of(q -> q.wrapper(w -> w.query(base64Query)));
-
-          getDateHistogramByFormula(formula, queryFilter, aggregations, aggregationName, formulas);
-        } catch (Exception e) {
-          Log.error("Error while parsing query string so using fallback: {}", e.getMessage(), e);
-          getDateHistogramByFormula(formula, null, aggregations, aggregationName, formulas);
-        }
-      } else {
-        getDateHistogramByFormula(formula, null, aggregations, aggregationName, formulas);
-      }
-      return;
+      return getDateHistogramByFormula(
+          formula, queryFilter, aggregations, aggregationName, formulas);
     }
 
-    // process non formula date histogram
     Aggregation subAgg = getSubAggregationsByFunction(function, field, 0);
-    if (filter != null && !filter.equals("{}")) {
-      try {
-        JsonNode rootNode = mapper.readTree(filter);
-        JsonNode queryNode = rootNode.get("query");
-        String base64Query = Base64.getEncoder().encodeToString(queryNode.toString().getBytes());
-        Query queryFilter = Query.of(q -> q.wrapper(w -> w.query(base64Query)));
-
-        Map<String, Aggregation> subAggMap = new HashMap<>();
-        subAggMap.put(field + "0", subAgg);
-        aggregations.put(
-            "filter", Aggregation.of(a -> a.filter(queryFilter).aggregations(subAggMap)));
-      } catch (Exception e) {
-        Log.error("Error while parsing query string so using fallback: {}", e.getMessage(), e);
-        aggregations.put(field + "0", subAgg);
-      }
-    } else {
+    if (queryFilter == null) {
       aggregations.put(field + "0", subAgg);
+      return List.of();
     }
+    Map<String, Aggregation> subAggMap = new HashMap<>();
+    subAggMap.put(field + "0", subAgg);
+    aggregations.put(
+        DataInsightMetricFilter.FILTER_AGG_KEY,
+        Aggregation.of(a -> a.filter(queryFilter).aggregations(subAggMap)));
+    return List.of(DataInsightMetricFilter.FILTER_AGG_KEY);
   }
 
   SearchRequest prepareSearchRequest(
@@ -376,13 +389,14 @@ public interface OpenSearchDynamicChartAggregatorInterface {
   }
 
   private void addProcessedSubResult(
-      double value,
+      Double value,
       List<DataInsightCustomChartResult> diChartResults,
       String key,
       String group,
       boolean isTimeStamp,
       String metric) {
-    if (!Double.isInfinite(value) && !Double.isNaN(value)) {
+    // avg/min/max over a bucket the metric filter emptied return a null value, not NaN.
+    if (value != null && !value.isInfinite() && !value.isNaN()) {
       DataInsightCustomChartResult diChartResult =
           getDIChartResult(value, key, group, isTimeStamp, metric);
       diChartResults.add(diChartResult);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchLineChartAggregator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchLineChartAggregator.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.openmetadata.common.utils.CommonUtil;
 import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChart;
@@ -16,13 +15,16 @@ import org.openmetadata.schema.dataInsight.custom.LineChartMetric;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.jdbi3.DataInsightSystemChartRepository;
 import os.org.opensearch.client.json.JsonData;
+import os.org.opensearch.client.opensearch._types.SortOrder;
 import os.org.opensearch.client.opensearch._types.aggregations.Aggregate;
 import os.org.opensearch.client.opensearch._types.aggregations.Aggregation;
 import os.org.opensearch.client.opensearch._types.aggregations.CalendarInterval;
 import os.org.opensearch.client.opensearch._types.aggregations.StringTermsBucket;
+import os.org.opensearch.client.opensearch._types.aggregations.TermsAggregation;
 import os.org.opensearch.client.opensearch._types.query_dsl.Query;
 import os.org.opensearch.client.opensearch.core.SearchRequest;
 import os.org.opensearch.client.opensearch.core.SearchResponse;
+import os.org.opensearch.client.util.ObjectBuilder;
 
 public class OpenSearchLineChartAggregator implements OpenSearchDynamicChartAggregatorInterface {
   public static class MetricFormulaHolder {
@@ -35,6 +37,45 @@ public class OpenSearchLineChartAggregator implements OpenSearchDynamicChartAggr
       this.holders = holders;
       this.formula = formula;
     }
+  }
+
+  /**
+   * Configures the categorical axis.
+   *
+   * <p>A terms axis picks its top N by raw document count, which is neither the population a metric
+   * filters to nor the number the chart plots. {@code orderKeys} name the filter wrappers that
+   * {@code populateDateHistogram} actually built, so the axis instead ranks each category by how
+   * many documents it contributed to the metric.
+   *
+   * <p>Ranking on the wrapper's document count rather than the metric's own value is what makes
+   * this safe for every function: an empty {@code min} reads as larger than any real minimum and an
+   * empty {@code sum} is zero, so ordering by either would float the empty categories to the top. A
+   * document count is never negative, and is zero exactly when the category matched nothing, which
+   * keeps those categories in the response but last, where they cannot displace one that has data.
+   */
+  private static ObjectBuilder<TermsAggregation> termsAxis(
+      TermsAggregation.Builder builder,
+      String field,
+      String include,
+      String exclude,
+      List<String> orderKeys) {
+    TermsAggregation.Builder axis = builder.field(field).size(100);
+    if (include != null) {
+      axis = axis.include(inc -> inc.regexp(include));
+    }
+    if (exclude != null) {
+      axis = axis.exclude(exc -> exc.regexp(exclude));
+    }
+    if (!orderKeys.isEmpty()) {
+      axis = axis.order(orderKeys.stream().map(key -> Map.of(key, SortOrder.Desc)).toList());
+    }
+    return axis;
+  }
+
+  /** Attaches sub-aggregations only when there are any, so an empty map is never serialized. */
+  private static ObjectBuilder<Aggregation> withSubAggregations(
+      Aggregation.Builder.ContainerBuilder container, Map<String, Aggregation> subAggregations) {
+    return subAggregations.isEmpty() ? container : container.aggregations(subAggregations);
   }
 
   @Override
@@ -64,95 +105,51 @@ public class OpenSearchLineChartAggregator implements OpenSearchDynamicChartAggr
               ? null
               : lineChart.getExcludeXAxisField();
 
-      if (lineChart.getxAxisField() != null
-          && !lineChart.getxAxisField().equals(DataInsightSystemChartRepository.TIMESTAMP_FIELD)) {
-        Aggregation termsAgg =
-            Aggregation.of(
-                a -> {
-                  var tb = a.terms(t -> t.field(lineChart.getxAxisField()).size(100));
-                  if (finalIncludeTerms != null) {
-                    tb =
-                        a.terms(
-                            t ->
-                                t.field(lineChart.getxAxisField())
-                                    .size(100)
-                                    .include(inc -> inc.regexp(finalIncludeTerms)));
-                  }
-                  if (finalExcludeTerms != null) {
-                    tb =
-                        a.terms(
-                            t -> {
-                              var builder = t.field(lineChart.getxAxisField()).size(100);
-                              if (finalIncludeTerms != null) {
-                                builder = builder.include(inc -> inc.regexp(finalIncludeTerms));
-                              }
-                              return builder.exclude(exc -> exc.regexp(finalExcludeTerms));
-                            });
-                  }
-                  return tb;
-                });
-
-        metricAggregations.put(metricName, termsAgg);
-        startTime = end - MILLISECONDS_IN_DAY;
-
-      } else {
-        Aggregation dateHistogramAgg =
-            Aggregation.of(
-                a ->
-                    a.dateHistogram(
-                        dh ->
-                            dh.field(DataInsightSystemChartRepository.TIMESTAMP_FIELD)
-                                .calendarInterval(CalendarInterval.Day)));
-        metricAggregations.put(metricName, dateHistogramAgg);
-      }
-
       metricFormulaHolder.put(
           metricName,
           new MetricFormulaHolder(
               metric.getFormula(),
               OpenSearchDynamicChartAggregatorInterface.getFormulaList(metric.getFormula())));
 
-      Map<String, Aggregation> subAggregations = new HashMap<>();
-      populateDateHistogram(
-          metric.getFunction(),
-          metric.getFormula(),
-          metric.getField(),
-          metric.getFilter(),
-          subAggregations,
-          metricName,
-          formulas);
+      final Map<String, Aggregation> subAggregations = new HashMap<>();
+      final List<String> orderKeys =
+          populateDateHistogram(
+              metric.getFunction(),
+              metric.getFormula(),
+              metric.getField(),
+              metric.getFilter(),
+              subAggregations,
+              metricName,
+              formulas);
 
-      Aggregation currentAgg = metricAggregations.get(metricName);
-      if (!subAggregations.isEmpty()) {
-        if (currentAgg._kind().name().equals("Terms")) {
-          final String fieldName = currentAgg.terms().field();
-          final int size = Optional.ofNullable(currentAgg.terms().size()).orElse(100);
-          metricAggregations.put(
-              metricName,
-              Aggregation.of(
-                  a ->
-                      a.terms(
-                              t -> {
-                                var builder = t.field(fieldName).size(size);
-                                if (finalIncludeTerms != null) {
-                                  builder = builder.include(inc -> inc.regexp(finalIncludeTerms));
-                                }
-                                if (finalExcludeTerms != null) {
-                                  builder = builder.exclude(exc -> exc.regexp(finalExcludeTerms));
-                                }
-                                return builder;
-                              })
-                          .aggregations(subAggregations)));
-        } else if (currentAgg._kind().name().equals("DateHistogram")) {
-          final String fieldName = currentAgg.dateHistogram().field();
-          final CalendarInterval interval = currentAgg.dateHistogram().calendarInterval();
-          metricAggregations.put(
-              metricName,
-              Aggregation.of(
-                  a ->
-                      a.dateHistogram(dh -> dh.field(fieldName).calendarInterval(interval))
-                          .aggregations(subAggregations)));
-        }
+      if (lineChart.getxAxisField() != null
+          && !lineChart.getxAxisField().equals(DataInsightSystemChartRepository.TIMESTAMP_FIELD)) {
+        metricAggregations.put(
+            metricName,
+            Aggregation.of(
+                a ->
+                    withSubAggregations(
+                        a.terms(
+                            t ->
+                                termsAxis(
+                                    t,
+                                    lineChart.getxAxisField(),
+                                    finalIncludeTerms,
+                                    finalExcludeTerms,
+                                    orderKeys)),
+                        subAggregations)));
+        startTime = end - MILLISECONDS_IN_DAY;
+      } else {
+        metricAggregations.put(
+            metricName,
+            Aggregation.of(
+                a ->
+                    withSubAggregations(
+                        a.dateHistogram(
+                            dh ->
+                                dh.field(DataInsightSystemChartRepository.TIMESTAMP_FIELD)
+                                    .calendarInterval(CalendarInterval.Day)),
+                        subAggregations)));
       }
 
       if (lineChart.getGroupBy() != null) {
@@ -197,7 +194,6 @@ public class OpenSearchLineChartAggregator implements OpenSearchDynamicChartAggr
     }
 
     SearchRequest.Builder searchRequestBuilder = new SearchRequest.Builder().size(0);
-
     final long finalStartTime = startTime;
     if (!live) {
       Query rangeQuery =

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/DataAssetTypeCoverageTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/DataAssetTypeCoverageTest.java
@@ -1,0 +1,168 @@
+package org.openmetadata.service.apps.bundles.insights;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.dataInsight.custom.DataAssetType;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.jdbi3.DataInsightSystemChartRepository;
+import org.openmetadata.service.search.SearchClient;
+import org.openmetadata.service.search.SearchRepository;
+
+/**
+ * Data Insights covers an entity type in exactly one of two ways: the app ingests it into a
+ * datastream of its own, in which case {@code dataInsights/config.json} carries its attribute list,
+ * or a live index is aliased into the {@code di-data-assets-*} wildcard by a {@code
+ * dataInsightAliases} entry in indexMapping.json.
+ *
+ * <p>The invariant spans three files because the contract does. Nothing else in the codebase notices
+ * when a type is declared but nothing populates it, which is how {@code metric} spent five months
+ * ingested but absent from the chart field catalog.
+ */
+class DataAssetTypeCoverageTest {
+
+  private static final String CONFIG_PATH = "/dataInsights/config.json";
+  private static final String INDEX_MAPPING_PATH = "/elasticsearch/indexMapping.json";
+  private static final String COMMON_KEY = "common";
+
+  private static SearchRepository previousSearchRepository;
+
+  @BeforeAll
+  static void giveTheRepositoryASearchClient() {
+    // DataInsightSystemChartRepository resolves a SearchClient in its static initializer, so the
+    // class cannot load without one and the order assertion below would error rather than fail.
+    previousSearchRepository = Entity.getSearchRepository();
+    if (previousSearchRepository == null) {
+      SearchRepository searchRepository = mock(SearchRepository.class);
+      when(searchRepository.getSearchClient()).thenReturn(mock(SearchClient.class));
+      Entity.setSearchRepository(searchRepository);
+    }
+  }
+
+  @AfterAll
+  static void restoreTheSearchRepository() {
+    // Entity holds it in a static field and surefire reuses one JVM across every test class, so
+    // leaving the mock behind would let a later test silently observe it.
+    Entity.setSearchRepository(previousSearchRepository);
+  }
+
+  @Test
+  void everyDataAssetTypeIsEitherIngestedOrAliasedIn() {
+    Set<String> ingested = ingestedTypes();
+    Set<String> aliased = aliasedTypes();
+
+    for (DataAssetType type : DataAssetType.values()) {
+      assertTrue(
+          ingested.contains(type.value()) || aliased.contains(type.value()),
+          type.value()
+              + " is a Data Insights asset type but is neither given an attribute list in "
+              + CONFIG_PATH
+              + " nor aliased in via dataInsightAliases, so nothing would ever populate it");
+    }
+  }
+
+  @Test
+  void theCatalogTypeOrderIsTheEnumOrderNotASaltedOne() {
+    // The catalog appends records per type as it walks this set. Collectors.toUnmodifiableSet()
+    // backs onto ImmutableCollections$SetN, whose iteration order is salted per JVM start, so a
+    // consumer resolving a duplicated field name by first-record-wins would resolve it differently
+    // after a restart.
+    assertEquals(
+        Arrays.stream(DataAssetType.values()).map(DataAssetType::value).toList(),
+        List.copyOf(DataInsightSystemChartRepository.dataAssetTypes),
+        "the chart field catalog must enumerate types in a stable order");
+  }
+
+  @Test
+  void everyDataAssetTypeHasAnIndexMapping() {
+    // DataInsightsApp reads a type's IndexMapping to decide whether a live index aliases it in, and
+    // again to build the datastream's mapping. getIndexMapping is a plain map lookup, so a type
+    // with
+    // no entry here is read as "not aliased", joins the ingested set, and then NPEs inside
+    // buildMapping on a null IndexMapping. That escapes the surrounding catch, which only handles
+    // IOException, so the app install dies without naming the type. Failing here says which one.
+    Set<String> mapped = indexMappingKeys();
+
+    for (DataAssetType type : DataAssetType.values()) {
+      assertTrue(
+          mapped.contains(type.value()),
+          type.value()
+              + " is a Data Insights asset type with no entry in "
+              + INDEX_MAPPING_PATH
+              + ", so DataInsightsApp would try to ingest it and dereference a null IndexMapping");
+    }
+  }
+
+  @Test
+  void theTwoCoverageMechanismsDoNotOverlap() {
+    Set<String> overlap = new HashSet<>(ingestedTypes());
+    overlap.retainAll(aliasedTypes());
+
+    // An aliased type points at a live index. Ingesting it as well would have the app create and
+    // delete a datastream whose name that alias already occupies, i.e. aimed at live data.
+    assertTrue(overlap.isEmpty(), "types both ingested and aliased in: " + overlap);
+  }
+
+  /** Every entity type the search layer knows how to index. */
+  private static Set<String> indexMappingKeys() {
+    JsonNode indexMapping = JsonUtils.readTree(readResource(INDEX_MAPPING_PATH));
+    Set<String> keys = new HashSet<>();
+    Iterator<String> names = indexMapping.fieldNames();
+    while (names.hasNext()) {
+      keys.add(names.next());
+    }
+    return keys;
+  }
+
+  /** The types the app ingests: the keys of config.json's mappingFields other than common. */
+  private static Set<String> ingestedTypes() {
+    JsonNode mappingFields = JsonUtils.readTree(readResource(CONFIG_PATH)).get("mappingFields");
+    Set<String> types = new HashSet<>();
+    Iterator<String> keys = mappingFields.fieldNames();
+    while (keys.hasNext()) {
+      String key = keys.next();
+      if (!COMMON_KEY.equals(key)) {
+        types.add(key);
+      }
+    }
+    return types;
+  }
+
+  /** The types reaching Data Insights through an alias onto their live entity index. */
+  private static Set<String> aliasedTypes() {
+    JsonNode indexMapping = JsonUtils.readTree(readResource(INDEX_MAPPING_PATH));
+    Set<String> types = new HashSet<>();
+    Iterator<Map.Entry<String, JsonNode>> entries = indexMapping.fields();
+    while (entries.hasNext()) {
+      Map.Entry<String, JsonNode> entry = entries.next();
+      JsonNode aliases = entry.getValue().get("dataInsightAliases");
+      if (aliases != null && !aliases.isEmpty()) {
+        types.add(entry.getKey());
+      }
+    }
+    return types;
+  }
+
+  private static String readResource(String path) {
+    try (InputStream in = DataAssetTypeCoverageTest.class.getResourceAsStream(path)) {
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    } catch (Exception e) {
+      throw new IllegalStateException("could not read " + path, e);
+    }
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/search/DataInsightsSearchConfigurationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/search/DataInsightsSearchConfigurationTest.java
@@ -1,0 +1,70 @@
+package org.openmetadata.service.apps.bundles.insights.search;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.dataInsight.custom.DataAssetType;
+import org.openmetadata.schema.utils.JsonUtils;
+
+/**
+ * The keys of {@code mappingFields} are typed as {@link DataAssetType}, so a key naming something
+ * Data Insights does not cover cannot exist rather than merely being wrong. These tests pin that the
+ * shipped file still binds to that stricter shape, and that a misspelling fails at load.
+ */
+class DataInsightsSearchConfigurationTest {
+
+  @Test
+  void theShippedConfigBindsToTypedKeys() {
+    DataInsightsSearchConfiguration.MappingFields mappingFields = readShippedConfig();
+
+    assertFalse(mappingFields.getCommon().isEmpty(), "common attributes are missing");
+    assertTrue(
+        mappingFields.getByType().containsKey(DataAssetType.TABLE),
+        "table attributes should have parsed: " + mappingFields.getByType().keySet());
+    assertTrue(
+        mappingFields.getByType().containsKey(DataAssetType.METRIC),
+        "metric attributes should have parsed: " + mappingFields.getByType().keySet());
+  }
+
+  @Test
+  void anUnknownEntityTypeFailsAtLoadAndNamesTheOffendingKey() {
+    String withTypo = "{\"mappingFields\": {\"common\": [\"id\"], \"tabel\": [\"columns\"]}}";
+
+    Exception failure =
+        assertThrows(
+            Exception.class,
+            () -> JsonUtils.readOrConvertValue(withTypo, DataInsightsSearchConfiguration.class));
+
+    // Asserting the whole sentence, not just the key: Jackson's reference chain already names
+    // "tabel", so a key-only assertion passes with the guard deleted.
+    assertTrue(
+        causeChain(failure).contains("'tabel', which is not a Data Insights asset type"),
+        "the failure must say why the key is rejected, got: " + causeChain(failure));
+  }
+
+  private static DataInsightsSearchConfiguration.MappingFields readShippedConfig() {
+    String json = readResource(DataInsightsSearchInterface.DATA_INSIGHTS_SEARCH_CONFIG_PATH);
+    return JsonUtils.readOrConvertValue(json, DataInsightsSearchConfiguration.class)
+        .getMappingFields();
+  }
+
+  private static String causeChain(Throwable failure) {
+    StringBuilder messages = new StringBuilder();
+    for (Throwable cause = failure; cause != null; cause = cause.getCause()) {
+      messages.append(cause.getMessage()).append(' ');
+    }
+    return messages.toString();
+  }
+
+  private static String readResource(String path) {
+    try (InputStream in = DataInsightsSearchConfigurationTest.class.getResourceAsStream(path)) {
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    } catch (Exception e) {
+      throw new IllegalStateException("could not read " + path, e);
+    }
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/search/DataInsightsSearchInterfaceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/search/DataInsightsSearchInterfaceTest.java
@@ -1,0 +1,61 @@
+package org.openmetadata.service.apps.bundles.insights.search;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.utils.JsonUtils;
+
+/**
+ * {@code getEntityAttributeFields} decides which entity attributes reach a type's Data Insights
+ * documents. Both failure modes it has carried are silent ones: a type the config forgot would have
+ * produced documents holding only the common attributes, and returning the shared {@code common}
+ * list let each call append to the list the next call starts from.
+ */
+class DataInsightsSearchInterfaceTest {
+
+  private static final DataInsightsSearchInterface SEARCH_INTERFACE =
+      mock(DataInsightsSearchInterface.class, CALLS_REAL_METHODS);
+
+  @Test
+  void aTypeTheConfigForgotFailsAndNamesIt() {
+    DataInsightsSearchConfiguration config =
+        configFor("{\"common\": [\"id\"], \"table\": [\"columns\"]}");
+
+    IllegalStateException failure =
+        assertThrows(
+            IllegalStateException.class,
+            () -> SEARCH_INTERFACE.getEntityAttributeFields(config, "topic"));
+
+    assertTrue(failure.getMessage().contains("topic"), failure.getMessage());
+    assertTrue(
+        failure.getMessage().contains(DataInsightsSearchInterface.DATA_INSIGHTS_SEARCH_CONFIG_PATH),
+        failure.getMessage());
+  }
+
+  @Test
+  void oneTypesAttributesDoNotLeakIntoTheNext() {
+    // The workflow reuses one parsed configuration for every type in its loop, so appending to the
+    // shared common list would have each type inherit the attributes of the types before it.
+    DataInsightsSearchConfiguration config =
+        configFor("{\"common\": [\"id\"], \"table\": [\"columns\"], \"topic\": [\"service\"]}");
+
+    assertEquals(
+        List.of("id", "columns"), SEARCH_INTERFACE.getEntityAttributeFields(config, "table"));
+
+    List<String> topicFields = SEARCH_INTERFACE.getEntityAttributeFields(config, "topic");
+    assertEquals(List.of("id", "service"), topicFields);
+    assertFalse(topicFields.contains("columns"), "table's attributes leaked into topic");
+  }
+
+  private static DataInsightsSearchConfiguration configFor(String mappingFields) {
+    return JsonUtils.readOrConvertValue(
+        String.format("{\"mappingFields\": %s}", mappingFields),
+        DataInsightsSearchConfiguration.class);
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/DataInsightMetricFilterTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/DataInsightMetricFilterTest.java
@@ -1,0 +1,47 @@
+package org.openmetadata.service.search;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Both engines fall back to an unfiltered aggregation on a filter they cannot read, so this parser
+ * decides when a chart counts what it was asked for. Returning null is the safe answer everywhere:
+ * the sub-aggregation stays unfiltered, exactly as it did before the parses were shared.
+ */
+class DataInsightMetricFilterTest {
+
+  @Test
+  void theQueryNodeIsExtractedVerbatim() {
+    assertEquals(
+        "{\"term\":{\"entityType.keyword\":\"table\"}}",
+        DataInsightMetricFilter.queryJson(
+            "{\"query\":{\"term\":{\"entityType.keyword\":\"table\"}}}"));
+  }
+
+  @Test
+  void formattingDoesNotChangeTheExtractedQuery() {
+    // Re-serialized from the parsed tree, so indentation cannot split two filters that mean the
+    // same thing.
+    assertEquals(
+        DataInsightMetricFilter.queryJson("{\"query\":{\"term\":{\"a\":\"b\"}}}"),
+        DataInsightMetricFilter.queryJson("{ \"query\" : { \"term\" : { \"a\" : \"b\" } } }"));
+  }
+
+  @Test
+  void absentEmptyOrUnreadableFiltersYieldNothing() {
+    assertNull(DataInsightMetricFilter.queryJson(null));
+    assertNull(
+        DataInsightMetricFilter.queryJson("{}"), "the empty filter is an exact-string check");
+    assertNull(DataInsightMetricFilter.queryJson("{\"bool\":{}}"), "valid JSON with no query node");
+    assertNull(DataInsightMetricFilter.queryJson("{"), "unparseable");
+  }
+
+  @Test
+  void theOrderKeyPrefixCannotContainADot() {
+    // An order path splits on '.' into an aggregation and a metric sub-field, and the engine
+    // rejects the whole search when the sub-field does not exist.
+    assertEquals(-1, DataInsightMetricFilter.FILTER_AGG_KEY.indexOf('.'));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/dataInsight/CategoricalAxisSelectionTestBase.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/dataInsight/CategoricalAxisSelectionTestBase.java
@@ -1,0 +1,245 @@
+package org.openmetadata.service.search.dataInsight;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.search.SearchRepository;
+
+/**
+ * Runs the request a line chart aggregator actually builds against a real engine.
+ *
+ * <p>Every categorical-axis defect this code has carried was invisible to the unit tests, because a
+ * serialized request that looks right can still be rejected or silently mis-ordered by the engine:
+ * an order path containing a dot is an {@code invalid_path} error, a path naming an aggregation the
+ * request never built fails the whole search, and ordering by a metric value floats the categories
+ * that matched nothing to the top. Only an engine can answer those.
+ *
+ * <p>The fixture is built so that ranking is the difference between a correct chart and an empty
+ * one: {@value #NOISE_SERVICES} services hold nothing but dashboards, and only {@value
+ * #DATA_SERVICES} hold tables, each with fewer documents than any noise service. A terms axis
+ * ordered by raw document count therefore fills all {@value #AXIS_SIZE} slots with dashboard
+ * services and drops every service the chart is about.
+ */
+public abstract class CategoricalAxisSelectionTestBase {
+
+  protected static final String INDEX = "di-categorical-axis-test";
+  protected static final String X_AXIS_FIELD = "service.name.keyword";
+  protected static final String TABLE_FILTER =
+      "{\"query\":{\"term\":{\"entityType.keyword\":\"table\"}}}";
+
+  /** Services holding only dashboards. Above the axis size, so they can fill it on their own. */
+  private static final int NOISE_SERVICES = 110;
+
+  /** Services holding tables, which is what the chart counts. */
+  private static final int DATA_SERVICES = 10;
+
+  private static final int DASHBOARDS_PER_NOISE_SERVICE = 3;
+  private static final int TABLES_PER_DATA_SERVICE = 2;
+
+  /** The size both aggregators hard-code on a categorical axis. */
+  protected static final int AXIS_SIZE = 100;
+
+  protected static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final HttpClient HTTP =
+      HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+
+  /** Base URL of the running engine, e.g. {@code http://localhost:32769}. */
+  protected abstract String engineUrl();
+
+  /** The chart request under test, serialized exactly as the aggregator would send it. */
+  protected abstract String rankedRequest();
+
+  @BeforeAll
+  static void stubTheSearchRepository() {
+    // DataInsightSystemChartRepository reads the cluster alias when it names an index, and its
+    // static initializer needs a repository present before the aggregator touches it.
+    SearchRepository searchRepository = mock(SearchRepository.class);
+    lenient().when(searchRepository.getClusterAlias()).thenReturn(null);
+    Entity.setSearchRepository(searchRepository);
+  }
+
+  protected void seed() throws Exception {
+    delete(INDEX);
+    put(
+        INDEX,
+        "{\"settings\":{\"number_of_shards\":3,\"number_of_replicas\":0},"
+            + "\"mappings\":{\"properties\":{"
+            + "\"id\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\"}}},"
+            + "\"@timestamp\":{\"type\":\"date\",\"format\":\"epoch_millis\"},"
+            + "\"descriptionStatus\":{\"type\":\"keyword\"},"
+            + "\"entityType\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\"}}},"
+            + "\"service\":{\"properties\":{\"name\":{\"type\":\"text\","
+            + "\"fields\":{\"keyword\":{\"type\":\"keyword\"}}}}}}}}");
+
+    StringBuilder bulk = new StringBuilder();
+    for (int svc = 0; svc < NOISE_SERVICES; svc++) {
+      appendDocs(bulk, noiseService(svc), "dashboard", DASHBOARDS_PER_NOISE_SERVICE);
+    }
+    for (int svc = 0; svc < DATA_SERVICES; svc++) {
+      appendDocs(bulk, dataService(svc), "table", TABLES_PER_DATA_SERVICE);
+    }
+    post("_bulk?refresh=wait_for", bulk.toString());
+  }
+
+  private void appendDocs(StringBuilder bulk, String service, String entityType, int count) {
+    for (int doc = 0; doc < count; doc++) {
+      bulk.append("{\"index\":{\"_index\":\"")
+          .append(INDEX)
+          .append("\"}}\n")
+          .append("{\"id\":\"")
+          .append(service)
+          .append('-')
+          .append(entityType)
+          .append('-')
+          .append(doc)
+          .append("\",\"entityType\":\"")
+          .append(entityType)
+          .append("\",\"descriptionStatus\":\"COMPLETE\",\"@timestamp\":1,\"service\":{\"name\":\"")
+          .append(service)
+          .append("\"}}\n");
+    }
+  }
+
+  private static String noiseService(int index) {
+    return String.format("noise-%03d", index);
+  }
+
+  private static String dataService(int index) {
+    return String.format("data-%03d", index);
+  }
+
+  @Test
+  void anAxisOrderedByRawDocumentCountLosesEveryServiceTheChartIsAbout() throws Exception {
+    // The control: main's shape, and the reason ranking exists. Asserting it here is what stops
+    // the fixture quietly degenerating into one where ranking makes no difference.
+    JsonNode buckets =
+        search(
+            "{\"size\":0,\"aggregations\":{\"metric\":{\"terms\":{\"field\":\""
+                + X_AXIS_FIELD
+                + "\",\"size\":"
+                + AXIS_SIZE
+                + "}}}}");
+
+    Set<String> selected = keysOf(buckets);
+    assertEquals(AXIS_SIZE, selected.size(), "the axis is full");
+    assertTrue(
+        selected.stream().noneMatch(key -> key.startsWith("data-")),
+        "every service holding tables is displaced by a service holding none: " + selected);
+  }
+
+  @Test
+  void theRankedAxisSelectsTheServicesThatHaveDataAndStillReportsTheEmptyOnes() throws Exception {
+    JsonNode buckets = search(rankedRequest());
+    Set<String> selected = keysOf(buckets);
+
+    assertEquals(AXIS_SIZE, selected.size(), "the axis is still full");
+    for (int svc = 0; svc < DATA_SERVICES; svc++) {
+      String service = dataService(svc);
+      assertTrue(selected.contains(service), service + " must be selected: " + selected);
+      assertEquals(
+          TABLES_PER_DATA_SERVICE, metricValue(buckets, service), service + " counts its tables");
+    }
+    assertTrue(
+        selected.stream().anyMatch(key -> key.startsWith("noise-")),
+        "a service with no tables must still be reported, at zero: " + selected);
+    assertEquals(
+        0,
+        metricValue(
+            buckets,
+            selected.stream().filter(k -> k.startsWith("noise-")).findFirst().orElseThrow()),
+        "and it must report zero rather than being dropped");
+  }
+
+  @Test
+  void theRankedRequestIsNotNarrowedSoTheEmptyCategoriesSurvive() throws Exception {
+    // Narrowing the request with the metric filter would leave only the ten table services in the
+    // index the axis sees, and min_doc_count 1 would drop the other hundred entirely.
+    assertTrue(
+        MAPPER.readTree(rankedRequest()).path("query").isMissingNode(),
+        "the request must stay wide: " + rankedRequest());
+  }
+
+  /** Bucket keys in the order the engine returned them. */
+  private static Set<String> keysOf(JsonNode buckets) {
+    Set<String> keys = new LinkedHashSet<>();
+    buckets.forEach(bucket -> keys.add(bucket.path("key").asText()));
+    return keys;
+  }
+
+  /**
+   * The number the chart plots for a category: the leaf metric inside the filter wrapper, or the
+   * bare leaf when the metric carries no filter.
+   */
+  private static long metricValue(JsonNode buckets, String key) {
+    for (JsonNode bucket : buckets) {
+      if (key.equals(bucket.path("key").asText())) {
+        JsonNode wrapper = bucket.has("filter") ? bucket.get("filter") : bucket;
+        for (Iterator<String> it = wrapper.fieldNames(); it.hasNext(); ) {
+          String field = it.next();
+          if (wrapper.path(field).has("value")) {
+            return wrapper.path(field).path("value").asLong();
+          }
+        }
+      }
+    }
+    throw new AssertionError("no bucket for " + key + " in " + buckets);
+  }
+
+  private JsonNode search(String body) throws Exception {
+    JsonNode response = MAPPER.readTree(post(INDEX + "/_search", body));
+    assertEquals(0, response.path("_shards").path("failed").asInt(), "shard failures: " + response);
+    JsonNode aggregations = response.path("aggregations");
+    for (Iterator<String> it = aggregations.fieldNames(); it.hasNext(); ) {
+      JsonNode agg = aggregations.path(it.next());
+      if (agg.has("buckets")) {
+        return agg.path("buckets");
+      }
+    }
+    throw new AssertionError("no bucketed aggregation in " + response);
+  }
+
+  private String post(String path, String body) throws IOException, InterruptedException {
+    return send(
+        HttpRequest.newBuilder(URI.create(engineUrl() + "/" + path))
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(body)));
+  }
+
+  private void put(String path, String body) throws IOException, InterruptedException {
+    send(
+        HttpRequest.newBuilder(URI.create(engineUrl() + "/" + path))
+            .header("Content-Type", "application/json")
+            .PUT(HttpRequest.BodyPublishers.ofString(body)));
+  }
+
+  private void delete(String path) throws IOException, InterruptedException {
+    HTTP.send(
+        HttpRequest.newBuilder(URI.create(engineUrl() + "/" + path)).DELETE().build(),
+        HttpResponse.BodyHandlers.ofString());
+  }
+
+  private String send(HttpRequest.Builder builder) throws IOException, InterruptedException {
+    HttpResponse<String> response =
+        HTTP.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+    assertTrue(
+        response.statusCode() < 300,
+        "engine rejected the request with " + response.statusCode() + ": " + response.body());
+    return response.body();
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/dataInsight/ElasticSearchCategoricalAxisRealEngineTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/dataInsight/ElasticSearchCategoricalAxisRealEngineTest.java
@@ -1,0 +1,73 @@
+package org.openmetadata.service.search.dataInsight;
+
+import es.co.elastic.clients.elasticsearch.core.SearchRequest;
+import es.co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import jakarta.json.stream.JsonGenerator;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChart;
+import org.openmetadata.schema.dataInsight.custom.Function;
+import org.openmetadata.schema.dataInsight.custom.LineChart;
+import org.openmetadata.schema.dataInsight.custom.LineChartMetric;
+import org.openmetadata.service.search.elasticsearch.dataInsightAggregators.ElasticSearchLineChartAggregator;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers(disabledWithoutDocker = true)
+class ElasticSearchCategoricalAxisRealEngineTest extends CategoricalAxisSelectionTestBase {
+
+  @Container
+  static final GenericContainer<?> ENGINE =
+      new GenericContainer<>("docker.elastic.co/elasticsearch/elasticsearch:9.3.0")
+          .withEnv("discovery.type", "single-node")
+          .withEnv("xpack.security.enabled", "false")
+          .withEnv("ES_JAVA_OPTS", "-Xms512m -Xmx512m")
+          .withExposedPorts(9200)
+          .waitingFor(Wait.forHttp("/_cluster/health").forStatusCode(200));
+
+  private final ElasticSearchLineChartAggregator aggregator =
+      new ElasticSearchLineChartAggregator();
+
+  @BeforeEach
+  void seedFixture() throws Exception {
+    seed();
+  }
+
+  @Override
+  protected String engineUrl() {
+    return "http://" + ENGINE.getHost() + ":" + ENGINE.getMappedPort(9200);
+  }
+
+  @Override
+  protected String rankedRequest() {
+    LineChart lineChart =
+        new LineChart()
+            .withMetrics(
+                List.of(
+                    new LineChartMetric()
+                        .withName("tables")
+                        .withFunction(Function.COUNT)
+                        .withField("id.keyword")
+                        .withFilter(TABLE_FILTER)))
+            .withxAxisField(X_AXIS_FIELD);
+    SearchRequest request =
+        aggregator.prepareSearchRequest(
+            new DataInsightCustomChart().withName("tables_per_service").withChartDetails(lineChart),
+            0L,
+            System.currentTimeMillis(),
+            new ArrayList<>(),
+            new HashMap<>(),
+            true);
+    StringWriter out = new StringWriter();
+    JacksonJsonpMapper mapper = new JacksonJsonpMapper(MAPPER);
+    JsonGenerator generator = mapper.jsonProvider().createGenerator(out);
+    request.serialize(generator, mapper);
+    generator.close();
+    return out.toString();
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/dataInsight/OpenSearchCategoricalAxisRealEngineTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/dataInsight/OpenSearchCategoricalAxisRealEngineTest.java
@@ -1,0 +1,72 @@
+package org.openmetadata.service.search.dataInsight;
+
+import jakarta.json.stream.JsonGenerator;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChart;
+import org.openmetadata.schema.dataInsight.custom.Function;
+import org.openmetadata.schema.dataInsight.custom.LineChart;
+import org.openmetadata.schema.dataInsight.custom.LineChartMetric;
+import org.openmetadata.service.search.opensearch.dataInsightAggregator.OpenSearchLineChartAggregator;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import os.org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import os.org.opensearch.client.opensearch.core.SearchRequest;
+
+@Testcontainers(disabledWithoutDocker = true)
+class OpenSearchCategoricalAxisRealEngineTest extends CategoricalAxisSelectionTestBase {
+
+  @Container
+  static final GenericContainer<?> ENGINE =
+      new GenericContainer<>("opensearchproject/opensearch:3.4.0")
+          .withEnv("discovery.type", "single-node")
+          .withEnv("DISABLE_SECURITY_PLUGIN", "true")
+          .withEnv("OPENSEARCH_JAVA_OPTS", "-Xms512m -Xmx512m")
+          .withExposedPorts(9200)
+          .waitingFor(Wait.forHttp("/_cluster/health").forStatusCode(200));
+
+  private final OpenSearchLineChartAggregator aggregator = new OpenSearchLineChartAggregator();
+
+  @BeforeEach
+  void seedFixture() throws Exception {
+    seed();
+  }
+
+  @Override
+  protected String engineUrl() {
+    return "http://" + ENGINE.getHost() + ":" + ENGINE.getMappedPort(9200);
+  }
+
+  @Override
+  protected String rankedRequest() {
+    LineChart lineChart =
+        new LineChart()
+            .withMetrics(
+                List.of(
+                    new LineChartMetric()
+                        .withName("tables")
+                        .withFunction(Function.COUNT)
+                        .withField("id.keyword")
+                        .withFilter(TABLE_FILTER)))
+            .withxAxisField(X_AXIS_FIELD);
+    SearchRequest request =
+        aggregator.prepareSearchRequest(
+            new DataInsightCustomChart().withName("tables_per_service").withChartDetails(lineChart),
+            0L,
+            System.currentTimeMillis(),
+            new ArrayList<>(),
+            new HashMap<>(),
+            true);
+    StringWriter out = new StringWriter();
+    JacksonJsonpMapper mapper = new JacksonJsonpMapper(MAPPER);
+    JsonGenerator generator = mapper.jsonProvider().createGenerator(out);
+    request.serialize(generator, mapper);
+    generator.close();
+    return out.toString();
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/ElasticSearchDataInsightAggregatorManagerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/ElasticSearchDataInsightAggregatorManagerTest.java
@@ -7,6 +7,8 @@ import es.co.elastic.clients.elasticsearch._types.mapping.Property;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 class ElasticSearchDataInsightAggregatorManagerTest {
@@ -29,6 +31,54 @@ class ElasticSearchDataInsightAggregatorManagerTest {
     assertTrue(names.contains("ownerName"), "Flat ownerName twin must survive: " + names);
     assertTrue(names.contains("service.name.keyword"), "object children must survive: " + names);
     assertEquals(2, names.size(), names.toString());
+  }
+
+  @Test
+  void aSharedFieldNameIsReportedForEveryTypeThatHasIt() {
+    List<Map<String, String>> fields = new ArrayList<>();
+    ElasticSearchDataInsightAggregatorManager.getFieldNames(
+        dataAssetMapping(), "", fields, "table");
+    ElasticSearchDataInsightAggregatorManager.getFieldNames(
+        dataAssetMapping(), "", fields, "topic");
+
+    // Deduplicating on the field name alone let the first type claim every shared name, so a type
+    // whose fields were all already claimed advertised nothing at all.
+    assertEquals(
+        Set.of("table", "topic"),
+        fields.stream().map(field -> field.get("entityType")).collect(Collectors.toSet()));
+    assertEquals(
+        2,
+        fields.stream().filter(field -> "ownerName".equals(field.get("name"))).count(),
+        "a name shared by two types must be reported once for each of them");
+  }
+
+  @Test
+  void aFieldIsStillReportedOnlyOncePerType() {
+    List<Map<String, String>> fields = new ArrayList<>();
+    ElasticSearchDataInsightAggregatorManager.getFieldNames(
+        dataAssetMapping(), "", fields, "table");
+    ElasticSearchDataInsightAggregatorManager.getFieldNames(
+        dataAssetMapping(), "", fields, "table");
+
+    assertEquals(2, fields.size(), "dedup within a single type must still hold: " + fields);
+  }
+
+  @Test
+  void theCatalogDoesNotDependOnTheOrderTypesAreVisited() {
+    // The production loop iterates a Set.of, whose order is salted per JVM start, so an
+    // order-sensitive catalog reports a different set of entity types on every restart.
+    assertEquals(catalogKeys(List.of("table", "topic")), catalogKeys(List.of("topic", "table")));
+  }
+
+  private static Set<String> catalogKeys(List<String> entityTypes) {
+    List<Map<String, String>> fields = new ArrayList<>();
+    entityTypes.forEach(
+        entityType ->
+            ElasticSearchDataInsightAggregatorManager.getFieldNames(
+                dataAssetMapping(), "", fields, entityType));
+    return fields.stream()
+        .map(field -> field.get("entityType") + ":" + field.get("name"))
+        .collect(Collectors.toSet());
   }
 
   private static List<String> catalogFieldNames() {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchLineChartAggregatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchLineChartAggregatorTest.java
@@ -1,5 +1,6 @@
 package org.openmetadata.service.search.elasticsearch.dataInsightAggregators;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -11,8 +12,11 @@ import static org.mockito.Mockito.mock;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import es.co.elastic.clients.elasticsearch.core.SearchRequest;
+import es.co.elastic.clients.elasticsearch.core.SearchResponse;
+import es.co.elastic.clients.json.JsonData;
 import es.co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import jakarta.json.stream.JsonGenerator;
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -23,6 +27,8 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChart;
+import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChartResultList;
+import org.openmetadata.schema.dataInsight.custom.Function;
 import org.openmetadata.schema.dataInsight.custom.LineChart;
 import org.openmetadata.schema.dataInsight.custom.LineChartMetric;
 import org.openmetadata.service.Entity;
@@ -108,6 +114,345 @@ class ElasticSearchLineChartAggregatorTest {
     aggregations.forEach(
         groupBy -> groupBy.path("aggregations").fieldNames().forEachRemaining(metricNames::add));
     assertEquals(Set.of(OWNER_METRIC, DESCRIPTION_METRIC), metricNames);
+  }
+
+  private static final String TABLE_FILTER =
+      "{\"query\":{\"term\":{\"entityType.keyword\":\"table\"}}}";
+  private static final String DASHBOARD_FILTER =
+      "{\"query\":{\"term\":{\"entityType.keyword\":\"dashboard\"}}}";
+
+  @Test
+  void aFilteredChartNeverNarrowsItsRequest() throws Exception {
+    // Narrowing the request with the metric filter aligns selection with counting, but a terms
+    // aggregation carries min_doc_count 1: every category the filter emptied loses its bucket, and
+    // the chart can no longer say that a service holds none. Ranking the axis achieves the same
+    // alignment while leaving those categories in the response.
+    assertTrue(
+        OBJECT_MAPPER
+            .readTree(serializeToJson(prepare(filteredChart(TABLE_FILTER, TABLE_FILTER))))
+            .path("query")
+            .isMissingNode(),
+        "the live request must stay wide");
+
+    JsonNode historical =
+        OBJECT_MAPPER
+            .readTree(serializeToJson(prepareHistorical(filteredChart(TABLE_FILTER, TABLE_FILTER))))
+            .path("query");
+    assertTrue(
+        historical.has("range"), "the historical request carries the bare range: " + historical);
+  }
+
+  @Test
+  void anUnreadableFilterLeavesBothTheRequestAndTheSubAggregationUnfiltered() throws Exception {
+    // Asserting both halves together is what stops a later change narrowing the request while the
+    // sub-aggregations silently fall back, which would count one population and select from
+    // another.
+    for (String bad : new String[] {"{", "{\"bool\":{}}", "{}"}) {
+      JsonNode root = OBJECT_MAPPER.readTree(serializeToJson(prepare(filteredChart(bad, bad))));
+      assertTrue(root.path("query").isMissingNode(), "the request stays wide for filter " + bad);
+      JsonNode terms = findAggregationWithTermsField(root.path("aggregations"), X_AXIS_FIELD);
+      assertTrue(
+          terms.path("terms").path("order").isMissingNode(),
+          "nothing was wrapped, so there is nothing to rank by for filter " + bad);
+      // Naming the surviving aggregation rather than looking for an absent "filter" key: the
+      // formula path keys its wrapper "filter<index>", so a probe for the bare name can never fail.
+      Set<String> subAggregations = new HashSet<>();
+      terms.path("aggregations").fieldNames().forEachRemaining(subAggregations::add);
+      assertEquals(
+          Set.of("id.keyword0"),
+          subAggregations,
+          "the metric must fall back to one unfiltered leaf aggregation for " + bad);
+    }
+  }
+
+  @Test
+  void metricsThatDisagreeEachRankByTheirOwnWrapper() throws Exception {
+    // Every metric owns its axis, so two metrics filtering to different populations need no shared
+    // filter between them -- each ranks by the wrapper built for it.
+    JsonNode aggregations =
+        OBJECT_MAPPER
+            .readTree(serializeToJson(prepare(filteredChart(TABLE_FILTER, DASHBOARD_FILTER))))
+            .path("aggregations");
+
+    for (String metricName : new String[] {OWNER_METRIC, DESCRIPTION_METRIC}) {
+      JsonNode terms = aggregations.path(metricName);
+      assertEquals("filter0", orderKey(terms), metricName);
+      assertTrue(terms.path("aggregations").has("filter0"), metricName);
+    }
+  }
+
+  @Test
+  void aGroupedChartStillRanksItsAxis() throws Exception {
+    JsonNode terms = serviceTermsAggregation(prepare(groupedFilteredChart()));
+
+    assertEquals("filter0", orderKey(terms), "a groupBy nests the axis, it does not disable it");
+    assertTrue(terms.path("aggregations").has("filter0"));
+  }
+
+  @Test
+  void aTimestampAxisIsNeitherRankedNorNarrowed() throws Exception {
+    // A date histogram has no top-N to align. Narrowing the query would shorten the window it
+    // plots, moving the first/last delta the dashboard renders; a groupBy must not change that.
+    for (String groupBy : new String[] {null, "entityType"}) {
+      JsonNode root =
+          OBJECT_MAPPER.readTree(serializeToJson(prepareHistorical(timestampAxisChart(groupBy))));
+
+      assertTrue(
+          root.path("query").has("range"),
+          "the request must carry the bare @timestamp range, got: " + root.path("query"));
+      assertTrue(
+          root.toString().indexOf("\"order\"") < 0, "a date histogram carries no order: " + root);
+    }
+  }
+
+  @Test
+  void anEmptyBucketDoesNotKillTheResponse() throws Exception {
+    // avg over a category the metric filter matched nothing in comes back as {"value": null},
+    // not NaN, and unboxing that killed the whole request with a 500.
+    String canned =
+        "{\"took\":1,\"timed_out\":false,"
+            + "\"_shards\":{\"total\":1,\"successful\":1,\"skipped\":0,\"failed\":0},"
+            + "\"hits\":{\"total\":{\"value\":0,\"relation\":\"eq\"},\"hits\":[]},"
+            + "\"aggregations\":{\"sterms#"
+            + OWNER_METRIC
+            + "\":{\"doc_count_error_upper_bound\":0,\"sum_other_doc_count\":0,\"buckets\":["
+            + "{\"key\":\"svc-with-none\",\"doc_count\":10,"
+            + "\"filter#filter\":{\"doc_count\":0,"
+            + "\"avg#columns.dataLength0\":{\"value\":null}}}]}}}";
+
+    SearchResponse<JsonData> response =
+        SearchResponse.createSearchResponseDeserializer(JsonData._DESERIALIZER)
+            .deserialize(
+                JACKSON_JSONP_MAPPER.jsonProvider().createParser(new StringReader(canned)),
+                JACKSON_JSONP_MAPPER);
+
+    DataInsightCustomChartResultList results =
+        assertDoesNotThrow(
+            () ->
+                aggregator.processSearchResponse(
+                    avgChart(), response, new ArrayList<>(), new HashMap<>()));
+    assertTrue(results.getResults().isEmpty(), "a null metric value must be skipped, not emitted");
+  }
+
+  private static DataInsightCustomChart avgChart() {
+    LineChart lineChart =
+        new LineChart()
+            .withMetrics(
+                List.of(
+                    new LineChartMetric()
+                        .withName(OWNER_METRIC)
+                        .withFunction(Function.AVG)
+                        .withField("columns.dataLength")
+                        .withFilter(TABLE_FILTER)))
+            .withxAxisField(X_AXIS_FIELD);
+    return new DataInsightCustomChart().withName("avg_chart").withChartDetails(lineChart);
+  }
+
+  @Test
+  void aFunctionMetricRanksTheAxisAndKeepsTheEmptyCategories() throws Exception {
+    JsonNode root = OBJECT_MAPPER.readTree(serializeToJson(prepare(functionChart(Function.COUNT))));
+
+    assertTrue(
+        root.path("query").isMissingNode(),
+        "a ranked axis must not also narrow the request, or the empty categories vanish: "
+            + root.path("query"));
+
+    JsonNode terms = findAggregationWithTermsField(root.path("aggregations"), X_AXIS_FIELD);
+    String path = terms.path("terms").path("order").path(0).fieldNames().next();
+    assertEquals("filter", path, "the axis must rank by the filter wrapper's document count");
+    assertFalse(
+        terms.path("aggregations").path(path).isMissingNode(),
+        "the order path must name an aggregation the request actually builds: " + terms);
+  }
+
+  @Test
+  void everyFunctionRanksTheSameWay() throws Exception {
+    // Ranking is on the wrapper's document count, never the metric value, so no function needs
+    // special handling -- an empty min or a negative sum cannot float to the top.
+    for (Function fn :
+        List.of(Function.COUNT, Function.SUM, Function.AVG, Function.MIN, Function.MAX)) {
+      JsonNode terms =
+          findAggregationWithTermsField(
+              OBJECT_MAPPER
+                  .readTree(serializeToJson(prepare(functionChart(fn))))
+                  .path("aggregations"),
+              X_AXIS_FIELD);
+      assertEquals(
+          "desc", terms.path("terms").path("order").path(0).path("filter").asText(), fn.value());
+    }
+  }
+
+  @Test
+  void aFormulaMetricRanksByItsWrapperToo() throws Exception {
+    // A formula compiles to one wrapper per term, each named with an index and each addressable.
+    JsonNode terms = serviceTermsAggregation(prepare(filteredChart(TABLE_FILTER, TABLE_FILTER)));
+
+    assertEquals("filter0", orderKey(terms));
+    assertTrue(terms.path("aggregations").has("filter0"));
+  }
+
+  @Test
+  void theUnnarrowedTermLeadsTheOrder() throws Exception {
+    // The first term carries its own q=, which selects the numerator's population; the second
+    // carries the metric filter alone, which is the population the formula is evaluated over.
+    // Ranking must lead with the latter or the axis picks the categories that satisfy one operand.
+    JsonNode terms = serviceTermsAggregation(prepare(formulaChartWithFilter(TABLE_FILTER)));
+
+    assertEquals(
+        List.of("filter1", "filter0"), orderKeys(terms), "unnarrowed wrapper first: " + terms);
+    assertTrue(terms.path("aggregations").has("filter1"));
+    assertTrue(terms.path("aggregations").has("filter0"));
+  }
+
+  @Test
+  void aPerTermQueryAloneDoesNotRankTheAxis() throws Exception {
+    // Without a metric filter the only wrappers are the terms' own q= clauses. Ranking by one of
+    // them would select the categories satisfying a single operand -- for a ratio, the numerator --
+    // rather than the population the chart is about.
+    JsonNode root = OBJECT_MAPPER.readTree(serializeToJson(prepare(formulaChart(null, null))));
+    JsonNode terms = findAggregationWithTermsField(root.path("aggregations"), X_AXIS_FIELD);
+
+    assertTrue(root.path("query").isMissingNode());
+    assertTrue(terms.path("aggregations").has("filter0"), "the q= wrapper is still built");
+    assertTrue(terms.path("terms").path("order").isMissingNode(), "but it must not rank the axis");
+  }
+
+  @Test
+  void aFilterTheClientCannotMapFailsRatherThanCountingEveryDocument() {
+    // Jackson reads this, the typed client refuses to map it. Dropping it would leave the metric an
+    // unfiltered leaf, so the chart answers with a plausible number counted over the whole index
+    // instead of the subset the filter asked for, and still returns 200. The OpenSearch wrapper
+    // sends the query verbatim and lets the cluster reject it; this fails the same way.
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> prepare(functionChart(Function.COUNT, UNMAPPABLE)));
+
+    assertTrue(
+        thrown.getMessage().contains("cannot be mapped"),
+        "the failure must name the unmappable filter: " + thrown.getMessage());
+  }
+
+  @Test
+  void aMetricWithNoFilterStillBuildsAnUnfilteredLeaf() throws Exception {
+    // The other half of the contract: null from queryFromJson must keep meaning "none declared".
+    // Failing here too would break every chart that legitimately aggregates over everything.
+    JsonNode terms = serviceTermsAggregation(prepare(functionChart(Function.COUNT, null)));
+
+    assertEquals(
+        Set.of("columns.dataLength0"),
+        subAggregationKeys(terms),
+        "a metric that declares no filter aggregates unfiltered");
+  }
+
+  /** Order paths of a terms aggregation, in the order the request declares them. */
+  private static List<String> orderKeys(JsonNode terms) {
+    List<String> keys = new ArrayList<>();
+    terms
+        .path("terms")
+        .path("order")
+        .forEach(entry -> entry.fieldNames().forEachRemaining(keys::add));
+    return keys;
+  }
+
+  private static String orderKey(JsonNode terms) {
+    List<String> keys = orderKeys(terms);
+    assertEquals(1, keys.size(), "expected exactly one order path: " + terms);
+    return keys.get(0);
+  }
+
+  private static Set<String> subAggregationKeys(JsonNode terms) {
+    Set<String> keys = new HashSet<>();
+    terms.path("aggregations").fieldNames().forEachRemaining(keys::add);
+    return keys;
+  }
+
+  /** Readable JSON the typed client refuses to map: {@code term} has no {@code bogus_option}. */
+  private static final String UNMAPPABLE =
+      "{\"query\":{\"term\":{\"entityType.keyword\":{\"value\":\"table\",\"bogus_option\":1}}}}";
+
+  private static DataInsightCustomChart functionChart(Function function) {
+    return functionChart(function, TABLE_FILTER);
+  }
+
+  private static DataInsightCustomChart functionChart(Function function, String filter) {
+    LineChart lineChart =
+        new LineChart()
+            .withMetrics(
+                List.of(
+                    new LineChartMetric()
+                        .withName(OWNER_METRIC)
+                        .withFunction(function)
+                        .withField("columns.dataLength")
+                        .withFilter(filter)))
+            .withxAxisField(X_AXIS_FIELD);
+    return new DataInsightCustomChart().withName("fn_chart").withChartDetails(lineChart);
+  }
+
+  /** A ratio whose numerator narrows further with its own {@code q=}, under a metric filter. */
+  private static DataInsightCustomChart formulaChartWithFilter(String filter) {
+    LineChart lineChart =
+        new LineChart()
+            .withMetrics(
+                List.of(
+                    new LineChartMetric()
+                        .withName(OWNER_METRIC)
+                        .withFormula(
+                            "(count(k='id.keyword',q='descriptionStatus: COMPLETE')/count(k='id.keyword'))*100")
+                        .withFilter(filter)))
+            .withxAxisField(X_AXIS_FIELD);
+    return new DataInsightCustomChart().withName("ratio_chart").withChartDetails(lineChart);
+  }
+
+  private SearchRequest prepareHistorical(DataInsightCustomChart chart) {
+    return aggregator.prepareSearchRequest(
+        chart, 0L, END_TIME, new ArrayList<>(), new HashMap<>(), false);
+  }
+
+  private static DataInsightCustomChart filteredChart(String firstFilter, String secondFilter) {
+    LineChart lineChart =
+        new LineChart()
+            .withMetrics(
+                List.of(
+                    new LineChartMetric()
+                        .withName(OWNER_METRIC)
+                        .withFormula("count(k='id.keyword')")
+                        .withFilter(firstFilter),
+                    new LineChartMetric()
+                        .withName(DESCRIPTION_METRIC)
+                        .withFormula("count(k='id.keyword')")
+                        .withFilter(secondFilter)))
+            .withxAxisField(X_AXIS_FIELD);
+    return new DataInsightCustomChart().withName("filtered_chart").withChartDetails(lineChart);
+  }
+
+  private static DataInsightCustomChart groupedFilteredChart() {
+    LineChart lineChart =
+        new LineChart()
+            .withMetrics(
+                List.of(
+                    new LineChartMetric()
+                        .withFormula("count(k='id.keyword')")
+                        .withFilter(TABLE_FILTER)))
+            .withGroupBy("entityType")
+            .withxAxisField(X_AXIS_FIELD);
+    return new DataInsightCustomChart()
+        .withName("grouped_filtered_chart")
+        .withChartDetails(lineChart);
+  }
+
+  private static DataInsightCustomChart timestampAxisChart(String groupBy) {
+    LineChart lineChart =
+        new LineChart()
+            .withMetrics(
+                List.of(
+                    new LineChartMetric()
+                        .withFormula("count(k='id.keyword')")
+                        .withFilter(TABLE_FILTER)))
+            .withGroupBy(groupBy);
+    return new DataInsightCustomChart()
+        .withName("timestamp_axis_chart")
+        .withChartDetails(lineChart);
   }
 
   private SearchRequest prepare(DataInsightCustomChart chart) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchDataInsightAggregatorManagerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchDataInsightAggregatorManagerTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import os.org.opensearch.client.opensearch._types.mapping.Property;
 
@@ -29,6 +31,50 @@ class OpenSearchDataInsightAggregatorManagerTest {
     assertTrue(names.contains("ownerName"), "Flat ownerName twin must survive: " + names);
     assertTrue(names.contains("service.name.keyword"), "object children must survive: " + names);
     assertEquals(2, names.size(), names.toString());
+  }
+
+  @Test
+  void aSharedFieldNameIsReportedForEveryTypeThatHasIt() {
+    List<Map<String, String>> fields = new ArrayList<>();
+    OpenSearchDataInsightAggregatorManager.getFieldNames(dataAssetMapping(), "", fields, "table");
+    OpenSearchDataInsightAggregatorManager.getFieldNames(dataAssetMapping(), "", fields, "topic");
+
+    // Deduplicating on the field name alone let the first type claim every shared name, so a type
+    // whose fields were all already claimed advertised nothing at all.
+    assertEquals(
+        Set.of("table", "topic"),
+        fields.stream().map(field -> field.get("entityType")).collect(Collectors.toSet()));
+    assertEquals(
+        2,
+        fields.stream().filter(field -> "ownerName".equals(field.get("name"))).count(),
+        "a name shared by two types must be reported once for each of them");
+  }
+
+  @Test
+  void aFieldIsStillReportedOnlyOncePerType() {
+    List<Map<String, String>> fields = new ArrayList<>();
+    OpenSearchDataInsightAggregatorManager.getFieldNames(dataAssetMapping(), "", fields, "table");
+    OpenSearchDataInsightAggregatorManager.getFieldNames(dataAssetMapping(), "", fields, "table");
+
+    assertEquals(2, fields.size(), "dedup within a single type must still hold: " + fields);
+  }
+
+  @Test
+  void theCatalogDoesNotDependOnTheOrderTypesAreVisited() {
+    // The production loop iterates a Set.of, whose order is salted per JVM start, so an
+    // order-sensitive catalog reports a different set of entity types on every restart.
+    assertEquals(catalogKeys(List.of("table", "topic")), catalogKeys(List.of("topic", "table")));
+  }
+
+  private static Set<String> catalogKeys(List<String> entityTypes) {
+    List<Map<String, String>> fields = new ArrayList<>();
+    entityTypes.forEach(
+        entityType ->
+            OpenSearchDataInsightAggregatorManager.getFieldNames(
+                dataAssetMapping(), "", fields, entityType));
+    return fields.stream()
+        .map(field -> field.get("entityType") + ":" + field.get("name"))
+        .collect(Collectors.toSet());
   }
 
   private static List<String> catalogFieldNames() {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchLineChartAggregatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchLineChartAggregatorTest.java
@@ -1,5 +1,6 @@
 package org.openmetadata.service.search.opensearch.dataInsightAggregator;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -11,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.stream.JsonGenerator;
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -21,14 +23,33 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChart;
+import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChartResultList;
+import org.openmetadata.schema.dataInsight.custom.Function;
 import org.openmetadata.schema.dataInsight.custom.LineChart;
 import org.openmetadata.schema.dataInsight.custom.LineChartMetric;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.search.SearchRepository;
+import os.org.opensearch.client.json.JsonData;
 import os.org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import os.org.opensearch.client.opensearch.core.SearchRequest;
+import os.org.opensearch.client.opensearch.core.SearchResponse;
 
 class OpenSearchLineChartAggregatorTest {
+
+  private static final String TABLE_FILTER =
+      "{\"query\":{\"term\":{\"entityType.keyword\":\"table\"}}}";
+  private static final String DASHBOARD_FILTER =
+      "{\"query\":{\"term\":{\"entityType.keyword\":\"dashboard\"}}}";
+  private static final String TABLE_QUERY_TEXT = "{\"term\":{\"entityType.keyword\":\"table\"}}";
+  private static final com.fasterxml.jackson.databind.JsonNode TABLE_QUERY = tableQuery();
+
+  private static com.fasterxml.jackson.databind.JsonNode tableQuery() {
+    try {
+      return new com.fasterxml.jackson.databind.ObjectMapper().readTree(TABLE_QUERY_TEXT);
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
+  }
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final JacksonJsonpMapper JACKSON_JSONP_MAPPER =
@@ -107,6 +128,328 @@ class OpenSearchLineChartAggregatorTest {
     aggregations.forEach(
         groupBy -> groupBy.path("aggregations").fieldNames().forEachRemaining(metricNames::add));
     assertEquals(Set.of(OWNER_METRIC, DESCRIPTION_METRIC), metricNames);
+  }
+
+  @Test
+  void aFilteredChartNeverNarrowsItsRequest() throws Exception {
+    // Narrowing the request with the metric filter aligns selection with counting, but a terms
+    // aggregation carries min_doc_count 1: every category the filter emptied loses its bucket, and
+    // the chart can no longer say that a service holds none. Ranking the axis achieves the same
+    // alignment while leaving those categories in the response.
+    assertTrue(
+        OBJECT_MAPPER
+            .readTree(serializeToJson(prepare(filteredChart(TABLE_FILTER, TABLE_FILTER))))
+            .path("query")
+            .isMissingNode(),
+        "the live request must stay wide");
+
+    JsonNode historical =
+        OBJECT_MAPPER
+            .readTree(serializeToJson(prepareHistorical(filteredChart(TABLE_FILTER, TABLE_FILTER))))
+            .path("query");
+    assertTrue(
+        historical.has("range"), "the historical request carries the bare range: " + historical);
+  }
+
+  @Test
+  void anUnreadableFilterLeavesBothTheRequestAndTheSubAggregationUnfiltered() throws Exception {
+    // Asserting both halves together is what stops a later change narrowing the request while the
+    // sub-aggregations silently fall back, which would count one population and select from
+    // another.
+    for (String bad : new String[] {"{", "{\"bool\":{}}", "{}"}) {
+      JsonNode root = OBJECT_MAPPER.readTree(serializeToJson(prepare(filteredChart(bad, bad))));
+      assertTrue(root.path("query").isMissingNode(), "the request stays wide for filter " + bad);
+      JsonNode terms = findAggregationWithTermsField(root.path("aggregations"), X_AXIS_FIELD);
+      assertTrue(
+          terms.path("terms").path("order").isMissingNode(),
+          "nothing was wrapped, so there is nothing to rank by for filter " + bad);
+      // Naming the surviving aggregation rather than looking for an absent "filter" key: the
+      // formula path keys its wrapper "filter<index>", so a probe for the bare name can never fail.
+      Set<String> subAggregations = new HashSet<>();
+      terms.path("aggregations").fieldNames().forEachRemaining(subAggregations::add);
+      assertEquals(
+          Set.of("id.keyword0"),
+          subAggregations,
+          "the metric must fall back to one unfiltered leaf aggregation for " + bad);
+    }
+  }
+
+  @Test
+  void metricsThatDisagreeEachRankByTheirOwnWrapper() throws Exception {
+    // Every metric owns its axis, so two metrics filtering to different populations need no shared
+    // filter between them -- each ranks by the wrapper built for it.
+    JsonNode aggregations =
+        OBJECT_MAPPER
+            .readTree(serializeToJson(prepare(filteredChart(TABLE_FILTER, DASHBOARD_FILTER))))
+            .path("aggregations");
+
+    for (String metricName : new String[] {OWNER_METRIC, DESCRIPTION_METRIC}) {
+      JsonNode terms = aggregations.path(metricName);
+      assertEquals("filter0", orderKey(terms), metricName);
+      assertTrue(terms.path("aggregations").has("filter0"), metricName);
+    }
+  }
+
+  @Test
+  void aGroupedChartStillRanksItsAxis() throws Exception {
+    JsonNode terms = serviceTermsAggregation(prepare(groupedFilteredChart()));
+
+    assertEquals("filter0", orderKey(terms), "a groupBy nests the axis, it does not disable it");
+    assertTrue(terms.path("aggregations").has("filter0"));
+  }
+
+  @Test
+  void aTimestampAxisIsNeitherRankedNorNarrowed() throws Exception {
+    // A date histogram has no top-N to align. Narrowing the query would shorten the window it
+    // plots, moving the first/last delta the dashboard renders; a groupBy must not change that.
+    for (String groupBy : new String[] {null, "entityType"}) {
+      JsonNode root =
+          OBJECT_MAPPER.readTree(serializeToJson(prepareHistorical(timestampAxisChart(groupBy))));
+
+      assertTrue(
+          root.path("query").has("range"),
+          "the request must carry the bare @timestamp range, got: " + root.path("query"));
+      assertTrue(
+          root.toString().indexOf("\"order\"") < 0, "a date histogram carries no order: " + root);
+    }
+  }
+
+  @Test
+  void anEmptyBucketDoesNotKillTheResponse() throws Exception {
+    // avg over a category the metric filter matched nothing in comes back as {"value": null},
+    // not NaN. This engine boxes the value, so unboxing it threw a 500.
+    String canned =
+        "{\"took\":1,\"timed_out\":false,"
+            + "\"_shards\":{\"total\":1,\"successful\":1,\"skipped\":0,\"failed\":0},"
+            + "\"hits\":{\"total\":{\"value\":0,\"relation\":\"eq\"},\"hits\":[]},"
+            + "\"aggregations\":{\"sterms#"
+            + OWNER_METRIC
+            + "\":{\"doc_count_error_upper_bound\":0,\"sum_other_doc_count\":0,\"buckets\":["
+            + "{\"key\":\"svc-with-none\",\"doc_count\":10,"
+            + "\"filter#filter\":{\"doc_count\":0,"
+            + "\"avg#columns.dataLength0\":{\"value\":null}}}]}}}";
+
+    SearchResponse<JsonData> response =
+        SearchResponse.createSearchResponseDeserializer(JsonData._DESERIALIZER)
+            .deserialize(
+                JACKSON_JSONP_MAPPER.jsonProvider().createParser(new StringReader(canned)),
+                JACKSON_JSONP_MAPPER);
+
+    DataInsightCustomChartResultList results =
+        assertDoesNotThrow(
+            () ->
+                aggregator.processSearchResponse(
+                    avgChart(), response, new ArrayList<>(), new HashMap<>()));
+    assertTrue(results.getResults().isEmpty(), "a null metric value must be skipped, not emitted");
+  }
+
+  private static DataInsightCustomChart avgChart() {
+    LineChart lineChart =
+        new LineChart()
+            .withMetrics(
+                List.of(
+                    new LineChartMetric()
+                        .withName(OWNER_METRIC)
+                        .withFunction(Function.AVG)
+                        .withField("columns.dataLength")
+                        .withFilter(TABLE_FILTER)))
+            .withxAxisField(X_AXIS_FIELD);
+    return new DataInsightCustomChart().withName("avg_chart").withChartDetails(lineChart);
+  }
+
+  @Test
+  void aFunctionMetricRanksTheAxisAndKeepsTheEmptyCategories() throws Exception {
+    JsonNode root = OBJECT_MAPPER.readTree(serializeToJson(prepare(functionChart(Function.COUNT))));
+
+    assertTrue(
+        root.path("query").isMissingNode(),
+        "a ranked axis must not also narrow the request, or the empty categories vanish: "
+            + root.path("query"));
+
+    JsonNode terms = findAggregationWithTermsField(root.path("aggregations"), X_AXIS_FIELD);
+    String path = terms.path("terms").path("order").path(0).fieldNames().next();
+    assertEquals("filter", path, "the axis must rank by the filter wrapper's document count");
+    assertFalse(
+        terms.path("aggregations").path(path).isMissingNode(),
+        "the order path must name an aggregation the request actually builds: " + terms);
+  }
+
+  @Test
+  void everyFunctionRanksTheSameWay() throws Exception {
+    // Ranking is on the wrapper's document count, never the metric value, so no function needs
+    // special handling -- an empty min or a negative sum cannot float to the top.
+    for (Function fn :
+        List.of(Function.COUNT, Function.SUM, Function.AVG, Function.MIN, Function.MAX)) {
+      JsonNode terms =
+          findAggregationWithTermsField(
+              OBJECT_MAPPER
+                  .readTree(serializeToJson(prepare(functionChart(fn))))
+                  .path("aggregations"),
+              X_AXIS_FIELD);
+      assertEquals(
+          "desc", terms.path("terms").path("order").path(0).path("filter").asText(), fn.value());
+    }
+  }
+
+  @Test
+  void aFormulaMetricRanksByItsWrapperToo() throws Exception {
+    // A formula compiles to one wrapper per term, each named with an index and each addressable.
+    JsonNode terms = serviceTermsAggregation(prepare(filteredChart(TABLE_FILTER, TABLE_FILTER)));
+
+    assertEquals("filter0", orderKey(terms));
+    assertEquals(
+        TABLE_QUERY,
+        unwrap(terms.path("aggregations").path("filter0").path("filter")),
+        "the wrapper the axis ranks by must be the one carrying the metric filter");
+  }
+
+  @Test
+  void theUnnarrowedTermLeadsTheOrder() throws Exception {
+    // The first term carries its own q=, which selects the numerator's population; the second
+    // carries the metric filter alone, which is the population the formula is evaluated over.
+    // Ranking must lead with the latter or the axis picks the categories that satisfy one operand.
+    JsonNode terms = serviceTermsAggregation(prepare(formulaChartWithFilter(TABLE_FILTER)));
+
+    assertEquals(
+        List.of("filter1", "filter0"), orderKeys(terms), "unnarrowed wrapper first: " + terms);
+    assertTrue(terms.path("aggregations").has("filter1"));
+    assertTrue(terms.path("aggregations").has("filter0"));
+  }
+
+  @Test
+  void aPerTermQueryAloneDoesNotRankTheAxis() throws Exception {
+    // Without a metric filter the only wrappers are the terms' own q= clauses. Ranking by one of
+    // them would select the categories satisfying a single operand -- for a ratio, the numerator --
+    // rather than the population the chart is about.
+    JsonNode root = OBJECT_MAPPER.readTree(serializeToJson(prepare(formulaChart(null, null))));
+    JsonNode terms = findAggregationWithTermsField(root.path("aggregations"), X_AXIS_FIELD);
+
+    assertTrue(root.path("query").isMissingNode());
+    assertTrue(terms.path("aggregations").has("filter0"), "the q= wrapper is still built");
+    assertTrue(terms.path("terms").path("order").isMissingNode(), "but it must not rank the axis");
+  }
+
+  @Test
+  void aFilterOnlyTheTypedClientWouldRejectStillRanksHere() throws Exception {
+    // This engine base64-wraps the filter's bytes instead of parsing them, so a filter the
+    // ElasticSearch client drops is still sent, still wrapped, and still rankable. The divergence
+    // is intended: each engine ranks by exactly what it built, which is why the order keys come
+    // from the aggregations rather than from the chart definition.
+    JsonNode terms = serviceTermsAggregation(prepare(functionChart(Function.COUNT, UNMAPPABLE)));
+
+    assertEquals("filter", orderKey(terms));
+    assertTrue(terms.path("aggregations").has("filter"));
+  }
+
+  /** Order paths of a terms aggregation, in the order the request declares them. */
+  private static List<String> orderKeys(JsonNode terms) {
+    List<String> keys = new ArrayList<>();
+    terms
+        .path("terms")
+        .path("order")
+        .forEach(entry -> entry.fieldNames().forEachRemaining(keys::add));
+    return keys;
+  }
+
+  private static String orderKey(JsonNode terms) {
+    List<String> keys = orderKeys(terms);
+    assertEquals(1, keys.size(), "expected exactly one order path: " + terms);
+    return keys.get(0);
+  }
+
+  /** Readable JSON the ElasticSearch client refuses to map: {@code term} has no such option. */
+  private static final String UNMAPPABLE =
+      "{\"query\":{\"term\":{\"entityType.keyword\":{\"value\":\"table\",\"bogus_option\":1}}}}";
+
+  private static DataInsightCustomChart functionChart(Function function) {
+    return functionChart(function, TABLE_FILTER);
+  }
+
+  private static DataInsightCustomChart functionChart(Function function, String filter) {
+    LineChart lineChart =
+        new LineChart()
+            .withMetrics(
+                List.of(
+                    new LineChartMetric()
+                        .withName(OWNER_METRIC)
+                        .withFunction(function)
+                        .withField("columns.dataLength")
+                        .withFilter(filter)))
+            .withxAxisField(X_AXIS_FIELD);
+    return new DataInsightCustomChart().withName("fn_chart").withChartDetails(lineChart);
+  }
+
+  /** A ratio whose numerator narrows further with its own {@code q=}, under a metric filter. */
+  private static DataInsightCustomChart formulaChartWithFilter(String filter) {
+    LineChart lineChart =
+        new LineChart()
+            .withMetrics(
+                List.of(
+                    new LineChartMetric()
+                        .withName(OWNER_METRIC)
+                        .withFormula(
+                            "(count(k='id.keyword',q='descriptionStatus: COMPLETE')/count(k='id.keyword'))*100")
+                        .withFilter(filter)))
+            .withxAxisField(X_AXIS_FIELD);
+    return new DataInsightCustomChart().withName("ratio_chart").withChartDetails(lineChart);
+  }
+
+  private SearchRequest prepareHistorical(DataInsightCustomChart chart) {
+    return aggregator.prepareSearchRequest(
+        chart, 0L, END_TIME, new ArrayList<>(), new HashMap<>(), false);
+  }
+
+  private static DataInsightCustomChart filteredChart(String firstFilter, String secondFilter) {
+    LineChart lineChart =
+        new LineChart()
+            .withMetrics(
+                List.of(
+                    new LineChartMetric()
+                        .withName(OWNER_METRIC)
+                        .withFormula("count(k='id.keyword')")
+                        .withFilter(firstFilter),
+                    new LineChartMetric()
+                        .withName(DESCRIPTION_METRIC)
+                        .withFormula("count(k='id.keyword')")
+                        .withFilter(secondFilter)))
+            .withxAxisField(X_AXIS_FIELD);
+    return new DataInsightCustomChart().withName("filtered_chart").withChartDetails(lineChart);
+  }
+
+  private static DataInsightCustomChart groupedFilteredChart() {
+    LineChart lineChart =
+        new LineChart()
+            .withMetrics(
+                List.of(
+                    new LineChartMetric()
+                        .withFormula("count(k='id.keyword')")
+                        .withFilter(TABLE_FILTER)))
+            .withGroupBy("entityType")
+            .withxAxisField(X_AXIS_FIELD);
+    return new DataInsightCustomChart()
+        .withName("grouped_filtered_chart")
+        .withChartDetails(lineChart);
+  }
+
+  private static DataInsightCustomChart timestampAxisChart(String groupBy) {
+    LineChart lineChart =
+        new LineChart()
+            .withMetrics(
+                List.of(
+                    new LineChartMetric()
+                        .withFormula("count(k='id.keyword')")
+                        .withFilter(TABLE_FILTER)))
+            .withGroupBy(groupBy);
+    return new DataInsightCustomChart()
+        .withName("timestamp_axis_chart")
+        .withChartDetails(lineChart);
+  }
+
+  /** OpenSearch wraps a filter as base64, so assertions decode before comparing. */
+  private static JsonNode unwrap(JsonNode query) throws Exception {
+    JsonNode wrapper = query.path("wrapper").path("query");
+    assertFalse(wrapper.isMissingNode(), "expected a wrapper query, got: " + query);
+    return OBJECT_MAPPER.readTree(java.util.Base64.getDecoder().decode(wrapper.asText()));
   }
 
   private SearchRequest prepare(DataInsightCustomChart chart) {

--- a/openmetadata-spec/src/main/resources/json/schema/dataInsight/custom/dataAssetType.json
+++ b/openmetadata-spec/src/main/resources/json/schema/dataInsight/custom/dataAssetType.json
@@ -1,0 +1,28 @@
+{
+  "$id": "https://open-metadata.org/schema/dataInsight/custom/dataAssetType.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Data Asset Type",
+  "description": "Entity type reachable under the `di-data-assets-*` wildcard, and the single source of truth for which entity types Data Insights covers. The first sixteen are ingested by DataInsightsApp into a datastream of their own and are keyed by `dataInsights/config.json`. The last two are supplied instead by a `dataInsightAliases` entry in `indexMapping.json`, which aliases the live entity search index into the wildcard, so Data Insights reads them without ever writing them; those two must never be added to the ingestion subset.",
+  "type": "string",
+  "javaType": "org.openmetadata.schema.dataInsight.custom.DataAssetType",
+  "enum": [
+    "table",
+    "storedProcedure",
+    "databaseSchema",
+    "database",
+    "chart",
+    "dashboard",
+    "dashboardDataModel",
+    "pipeline",
+    "topic",
+    "container",
+    "searchIndex",
+    "mlmodel",
+    "dataProduct",
+    "glossaryTerm",
+    "tag",
+    "metric",
+    "testCaseResult",
+    "testCaseResolutionStatus"
+  ]
+}

--- a/openmetadata-ui/src/main/resources/ui/src/generated/dataInsight/custom/dataAssetType.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/dataInsight/custom/dataAssetType.ts
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/**
+ * Entity type reachable under the `di-data-assets-*` wildcard, and the single source of
+ * truth for which entity types Data Insights covers. The first sixteen are ingested by
+ * DataInsightsApp into a datastream of their own and are keyed by
+ * `dataInsights/config.json`. The last two are supplied instead by a `dataInsightAliases`
+ * entry in `indexMapping.json`, which aliases the live entity search index into the
+ * wildcard, so Data Insights reads them without ever writing them; those two must never be
+ * added to the ingestion subset.
+ */
+export enum DataAssetType {
+    Chart = "chart",
+    Container = "container",
+    Dashboard = "dashboard",
+    DashboardDataModel = "dashboardDataModel",
+    DataProduct = "dataProduct",
+    Database = "database",
+    DatabaseSchema = "databaseSchema",
+    GlossaryTerm = "glossaryTerm",
+    Metric = "metric",
+    Mlmodel = "mlmodel",
+    Pipeline = "pipeline",
+    SearchIndex = "searchIndex",
+    StoredProcedure = "storedProcedure",
+    Table = "table",
+    Tag = "tag",
+    TestCaseResolutionStatus = "testCaseResolutionStatus",
+    TestCaseResult = "testCaseResult",
+    Topic = "topic",
+}


### PR DESCRIPTION
Backport of #32115 to `2.0`. On `main` as `72f02a21c1`. Original issue: #31963.

Four Data Insights defects. The first three return a number that looks right and is wrong, with
nothing thrown and nothing logged; the fourth returns HTTP 500. Full analysis, measurements and the
revert-by-revert test table are in #32115.

1. **`metric` fields never reach the chart builder.** The set of entity types Data Insights covers
   was hand-written in three places. Two of them stay in sync only because a mismatch throws;
   nothing checked the third. #26260 added `metric` to those two in March, so `di-data-assets-metric`
   has been created and filled daily ever since while `metricType`, `unitOfMeasurement` and
   `granularity` have never appeared in the chart builder. Fixed by deriving all three from one
   schema enum, `dataAssetType.json`.

2. **The field catalog changed on every server restart.** `getFieldNames` deduplicated field names
   globally, so the first entity type iterated claimed a shared name permanently, and the iteration
   order came from a `Set.of`, which Java salts per JVM start. `topic` shares all 28 of its field
   names with `table`, so picking "Topic" in the field picker returned an empty list on roughly a
   coin flip. Fixed by deduplicating on `(entityType, name)` and iterating the enum in declaration
   order.

3. **Charts picked categories from data they did not count.** A terms x-axis picks its buckets first
   and counts inside them with the metric filter applied; picking ignored the filter. A "tables per
   service" chart therefore ranked services by their total document count, so a BI service with
   5,000 dashboards and 3 tables took a slot and a warehouse with 800 tables was missing entirely.
   Fixed by ordering the axis on the filter wrapper each metric is already built into, ranked by the
   wrapper's document count rather than the metric's value.

4. **An empty category returned HTTP 500.** `avg`, `min` and `max` over a bucket the metric filter
   emptied return `null`, and both aggregators unboxed that straight into a primitive. Pre-existing
   on `main` and not caused by this change; §3 is what makes it reachable, because keeping the empty
   categories is what produces the `null` buckets. Fixed with a null guard on both engines.

## What had to be adapted

One line: `import java.util.stream.Collectors;` in `DataInsightSystemChartRepository`.

On `main` that import arrived with #31759 (`NON_DATA_ASSET_ENTITY_TYPES` / `DATA_ASSET_FILTER`),
which is not on `2.0`. It was therefore an unchanged context line in the original diff rather than an
addition, the cherry-pick applied cleanly, and the compile then failed on
`Collectors.toCollection`. Putting the import back is the entire adaptation.

Nothing else diverges. Apart from #31759's block the file is identical to `main`'s, and the other 12
pre-existing files touched here are byte-identical between `2.0` and `main`'s pre-fix state, so the
rest is the merged change verbatim (25 files, +2099/-316 against the original's +2098/-316).

## Verification

Built and run from a worktree on `origin/2.0`:

```
mvn -pl openmetadata-service -am package
```

green (main and test sources), `spotless:check` clean, and the suite the original PR added:

```
mvn -pl openmetadata-service -am package -Dtest='DataAssetTypeCoverageTest,DataInsightsSearchConfigurationTest,\
DataInsightsSearchInterfaceTest,DataInsightMetricFilterTest,ElasticSearchLineChartAggregatorTest,\
OpenSearchLineChartAggregatorTest,ElasticSearchDataInsightAggregatorManagerTest,\
OpenSearchDataInsightAggregatorManagerTest,ElasticSearchCategoricalAxisRealEngineTest,\
OpenSearchCategoricalAxisRealEngineTest'

Tests run: 65, Failures: 0, Errors: 0, Skipped: 0
```

| Test | Tests run |
|---|---|
| `DataAssetTypeCoverageTest` | 4 |
| `DataInsightsSearchConfigurationTest` | 2 |
| `DataInsightsSearchInterfaceTest` | 2 |
| `DataInsightMetricFilterTest` | 4 |
| `ElasticSearchLineChartAggregatorTest` | 19 |
| `OpenSearchLineChartAggregatorTest` | 18 |
| `ElasticSearchDataInsightAggregatorManagerTest` | 5 |
| `OpenSearchDataInsightAggregatorManagerTest` | 5 |
| `ElasticSearchCategoricalAxisRealEngineTest` | 3 (17.3s, real Elasticsearch 9.3 via testcontainers) |
| `OpenSearchCategoricalAxisRealEngineTest` | 3 (13.1s, real OpenSearch 3.4 via testcontainers) |

The two real-engine classes also assert the control, i.e. `main`'s pre-fix shape picking 0 of 10
services, so a fixture that stopped discriminating would fail rather than pass quietly.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] For JSON Schema changes: `dataAssetType.json` is added, carried over from #32115 unchanged, with its generated TS type.
- [x] For UI changes: not applicable beyond the generated type above.
- [x] I have added a test that covers the exact scenario we are fixing.

_On `skip-pr-checks`: a PR whose base is not the default branch cannot create GitHub's native
`closingIssuesReferences` link, so the metadata gate has no way to see the linked issue and can never
be satisfied here. The issue is #31963, already closed by #32115._
