### PR TITLE
ci(ui): stage public/jsons/ in schema-drift auto-commit

### DIFF
--- a/.github/workflows/typescript-type-generation.yml
+++ b/.github/workflows/typescript-type-generation.yml
@@ -8,6 +8,7 @@ on:
       - 'openmetadata-spec/src/main/resources/json/schema/**'
       - 'openmetadata-ui/src/main/resources/ui/src/generated/**'
       - 'openmetadata-ui/src/main/resources/ui/src/jsons/**'
+      - 'openmetadata-ui/src/main/resources/ui/public/jsons/**'
       - 'openmetadata-ui/src/main/resources/ui/parseSchemas.js'
   workflow_dispatch:
     inputs:
@@ -167,7 +168,8 @@ jobs:
         continue-on-error: true
         run: |
           git add openmetadata-ui/src/main/resources/ui/src/generated/ \
-                  openmetadata-ui/src/main/resources/ui/src/jsons/
+                  openmetadata-ui/src/main/resources/ui/src/jsons/ \
+                  openmetadata-ui/src/main/resources/ui/public/jsons/
           git diff --cached --quiet
 
       - name: Configure Git
@@ -198,8 +200,8 @@ jobs:
             ## ✅ Generated Sources Auto-Updated
 
             The generated TypeScript types (`src/generated/`) and dereferenced JSON
-            schemas (`src/jsons/`) have been automatically updated based on JSON schema
-            changes in this PR.
+            schemas (`src/jsons/`, `public/jsons/`) have been automatically updated
+            based on JSON schema changes in this PR.
 
       - name: Create PR comment for fork repository
         if: steps.git-check.outcome != 'success' && steps.check-fork.outputs.is_fork == 'true' && (github.event_name == 'pull_request_target' || github.event.inputs.pr_number != '')
@@ -218,7 +220,7 @@ jobs:
             cd openmetadata-ui/src/main/resources/ui
             ./json2ts-generate-all.sh -l true
             yarn parse-schema
-            git add src/generated/ src/jsons/
+            git add src/generated/ src/jsons/ public/jsons/
             git commit -m "Update generated TypeScript types and dereferenced schemas"
             git push
             ```


### PR DESCRIPTION
## Summary

Follow-up to #32384 (Rolldown migration). `parseSchemas.js` now writes connection schemas to `public/jsons/connectionSchemas/` instead of `src/jsons/connectionSchemas/`, but `.github/workflows/typescript-type-generation.yml` still only stages `src/jsons/`. The result is a silent-failure mode: a schema change in `openmetadata-spec/` triggers the workflow, `yarn parse-schema` regenerates the connection schemas into `public/jsons/`, `git add src/generated/ src/jsons/` picks up nothing new there, `git diff --cached --quiet` succeeds, and the auto-commit is skipped — shipping stale connection schemas in the UI.

Changes:
- Add `public/jsons/**` to the `paths:` trigger so a hand-edit to a generated connection schema also fires this workflow.
- Add `public/jsons/` to the `git add` in the *Check for changes* step so regenerated connection schemas actually get staged and committed.
- Update the fork-PR help comment to mirror the new `git add` line so external contributors regenerate the same set of paths.
- Update the auto-update PR comment body to reference both `src/jsons/` and `public/jsons/`.

## Test plan

- [ ] Verify the workflow file parses (YAML lint).
- [ ] Once merged, next schema-drift trigger on a `openmetadata-spec/` change should stage both `src/generated/` and `public/jsons/` in the auto-commit.
- [ ] Fork-PR flow: the help comment `git add` line matches what a contributor needs to run.

Note: this workflow uses `pull_request_target`, so it runs the base-ref version of itself — this fix only takes effect after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)