### PR TITLE
Backport #32512 to 1.13: resolve Confluent Cloud connector topics from the Telemetry API

### DIFF
--- a/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/client.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/client.py
@@ -14,10 +14,13 @@ Client to interact with Kafka Connect REST APIs
 
 import re
 import traceback
+from datetime import datetime, timedelta, timezone
 from typing import Iterable, List, Optional
 from urllib.parse import urlparse
 
+import requests
 from kafka_connect import KafkaConnect
+from pydantic import ValidationError
 
 from metadata.generated.schema.entity.services.connections.pipeline.kafkaConnectConnection import (
     KafkaConnectConnection,
@@ -26,6 +29,7 @@ from metadata.ingestion.source.pipeline.kafkaconnect.constants import (
     ConnectorConfigKeys,
 )
 from metadata.ingestion.source.pipeline.kafkaconnect.models import (
+    ConfluentTelemetryRow,
     KafkaConnectColumnMapping,
     KafkaConnectPipelineDetails,
     KafkaConnectTopics,
@@ -138,6 +142,43 @@ INTERNAL_TOPIC_CONFIG_KEYS = (
     "errors.deadletterqueue.topic.name",
 )
 
+# Confluent Cloud answers KIP-558 with 404, so a connector whose destination topic is
+# chosen from a row value resolves nothing from its configuration. The telemetry Data Flow
+# dataset reports which topic a producer client wrote to, and a managed connector produces
+# under a client id carrying its own connector id, which is what ties the two together.
+CONFLUENT_TELEMETRY_URL = "https://api.telemetry.confluent.cloud/v2/metrics/dataflow/query"
+
+# Named from the CLUSTER's perspective, not the client's: received_records counts records
+# the cluster received, which is what a producer wrote. The mirrored sent_records counts
+# what the cluster sent to consumers and returns no producer clients at all, so it is the
+# wrong end of the pipe for a source connector. The value itself is unused, only the
+# topic-to-client pairing matters.
+CONFLUENT_TELEMETRY_METRIC = "received_records"
+
+# Confluent retains metrics for seven days. A shorter window keeps the response small and
+# reduces how far back a since-deleted connector can appear.
+CONFLUENT_TELEMETRY_WINDOW_HOURS = 24
+
+CONFLUENT_TELEMETRY_TIMEOUT_SECONDS = 60
+
+# The documented maximum number of groups per response. Higher values are currently
+# tolerated by the service but are out of spec, and the response is paginated regardless,
+# so there is nothing to gain by asking for more than the contract allows.
+CONFLUENT_TELEMETRY_PAGE_LIMIT = 1000
+
+# A cluster busy enough to need more pages than this is not one we can usefully enumerate,
+# and an unbounded follow-the-cursor loop would hang ingestion on a malformed response.
+CONFLUENT_TELEMETRY_MAX_PAGES = 50
+
+# A managed connector's producer client is named connector-producer-<connector-id>-<task>.
+# The convention is not documented, so it is matched rather than constructed, and a client
+# id that does not match yields no attribution instead of a guess.
+CONFLUENT_PRODUCER_CLIENT_PATTERN = re.compile(r"connector-producer-(?P<connector_id>lcc-[a-z0-9]+)-\d+$")
+
+# Confluent Cloud Connect URLs end in /clusters/<kafka-cluster-id>, which is the id the
+# telemetry query filters on.
+CONFLUENT_CLUSTER_ID_PATTERN = re.compile(r"/clusters/(?P<cluster_id>lkc-[a-z0-9]+)")
+
 
 def extract_internal_topic_names(connector_config: Optional[dict]) -> set[str]:  # noqa: UP045
     """
@@ -167,6 +208,37 @@ def extract_internal_topic_names(connector_config: Optional[dict]) -> set[str]: 
             names.add(configured)
 
     return names
+
+
+def confluent_managed_internal_topic_names(connector_config: dict | None, connector_id: str) -> set[str]:
+    """
+    Bookkeeping topic names a Confluent managed connector produces, which its configuration
+    does not state.
+
+    ``extract_internal_topic_names`` covers the names configuration declares. Confluent
+    derives these two from the connector id instead, which is assigned at runtime and
+    appears in no config key, so they can only be reconstructed.
+
+    The transaction topic is produced by the connector's own client, so attribution cannot
+    separate it and excluding it by name is the only thing that does.
+
+    Schema history arrives under a separate ``<prefix>-schemahistory`` client, which never
+    matches the connector producer pattern, so attribution already removes it and this name
+    is redundant today. It is returned anyway, because the client naming is Confluent's
+    convention rather than a guarantee, and were schema history ever to move onto the
+    connector's own client it would otherwise be emitted as lineage.
+    """
+    if not isinstance(connector_config, dict):
+        return set()
+
+    prefix = connector_config.get("topic.prefix") or connector_config.get("database.server.name")
+    if not prefix:
+        return set()
+
+    return {
+        f"{prefix}.{connector_id}.transaction",
+        f"dbhistory.{prefix}.{connector_id}",
+    }
 
 
 def _to_python_replacement(replacement: str) -> str:
@@ -244,6 +316,229 @@ class KafkaConnectClient:
         self.is_confluent_cloud = parsed_url.hostname == "api.confluent.cloud"
         # None until the /topics endpoint has been probed once for this cluster
         self._topics_endpoint_supported = None
+
+        self._host_port = url
+        # The telemetry call goes through requests directly rather than the Connect client,
+        # so it has to honour this itself.
+        self._verify_ssl = ssl_verify
+        # Both telemetry lookups describe the whole cluster, not one connector, so they are
+        # resolved once and reused. Each is a single snapshot replaced wholesale rather
+        # than a cache accumulating an entry per item, and each is reduced to the
+        # connectors this cluster actually has: the raw telemetry response also carries
+        # every unrelated producer on the cluster, which is discarded at fetch time rather
+        # than retained. Size is therefore bounded by the connector count, and the client
+        # lives for a single ingestion run. None means not yet fetched.
+        self._connector_ids: dict[str, str] | None = None
+        self._telemetry_topics_by_connector_id: dict[str, set[str]] | None = None
+        # The telemetry API takes the same Confluent Cloud key as the Connect API, so no
+        # separate credential is needed. Held as a tuple because that call is made with
+        # requests directly rather than through the Connect client. Both halves have to be
+        # present: telemetry has no anonymous mode, so half a credential is worth the same
+        # as none and is better refused here than sent.
+        self._telemetry_auth: tuple[str, str] | None = None
+        auth_config = config.KafkaConnectConfig
+        if auth_config and auth_config.username and auth_config.password:
+            self._telemetry_auth = (
+                auth_config.username,
+                auth_config.password.get_secret_value(),
+            )
+
+    def _confluent_kafka_cluster_id(self) -> str | None:
+        """The Kafka cluster id the Connect URL points at, which scopes the telemetry query."""
+        if not self.is_confluent_cloud:
+            return None
+        match = CONFLUENT_CLUSTER_ID_PATTERN.search(self._host_port)
+        return match.group("cluster_id") if match else None
+
+    def _connector_id_by_name(self) -> dict[str, str]:
+        """
+        Map connector name to the Confluent connector id its producer client is named after.
+
+        `?expand=id` is served by the same Connect API already in use, so this needs no
+        extra credentials. Resolving against the live list also bounds the telemetry
+        result: a window wide enough to be useful still contains connectors deleted inside
+        it, and those must not be attributed to anything.
+        """
+        if self._connector_ids is not None:
+            return self._connector_ids
+
+        result: dict[str, str] = {}
+        try:
+            response = self.get_connectors_list(expand="id")
+            for name, block in (response or {}).items():
+                connector_id = ((block or {}).get("id") or {}).get("id")
+                if connector_id:
+                    result[name] = connector_id
+        except Exception as exc:
+            logger.debug(traceback.format_exc())
+            logger.debug("Unable to list Confluent connector ids: %s", exc)
+
+        self._connector_ids = result
+        return result
+
+    def _query_dataflow_topics_by_client(
+        self, cluster_id: str, max_pages: int = CONFLUENT_TELEMETRY_MAX_PAGES
+    ) -> dict[str, set[str]]:
+        """
+        Topics each connector producer wrote to on this cluster, from the telemetry API.
+
+        Grouping by topic and client together is what makes the result attributable. The
+        metric value is discarded: presence of the pair is the whole signal.
+
+        Only clients named like a connector producer are kept. The query is cluster wide,
+        so the response also describes every application producing to the cluster, and
+        those can never be attributed to a connector.
+
+        ``max_pages`` exists for the test-connection step, which only needs to know that
+        the API answers. Resolution needs every page, but a reachability check that walked
+        them all would spend a request per page against an endpoint that rate limits by the
+        hour, for an answer the first response already gave.
+        """
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+        start = now - timedelta(hours=CONFLUENT_TELEMETRY_WINDOW_HOURS)
+        interval = f"{start.isoformat().replace('+00:00', 'Z')}/{now.isoformat().replace('+00:00', 'Z')}"
+        payload = {
+            "aggregations": [{"metric": CONFLUENT_TELEMETRY_METRIC, "aggregations": ["SUM"]}],
+            "filter": {
+                "op": "AND",
+                "filters": [{"field": "resource.kafka.id", "op": "EQ", "value": cluster_id}],
+            },
+            "granularity": "ALL",
+            "group_by": ["metric.topic", "metric.client_id"],
+            "intervals": [interval],
+            "limit": CONFLUENT_TELEMETRY_PAGE_LIMIT,
+        }
+
+        by_client: dict[str, set[str]] = {}
+        page_token = None
+        for _ in range(max_pages):
+            response = requests.post(
+                CONFLUENT_TELEMETRY_URL,
+                json=payload,
+                params={"page_token": page_token} if page_token else None,
+                auth=self._telemetry_auth,
+                timeout=CONFLUENT_TELEMETRY_TIMEOUT_SECONDS,
+                verify=self._verify_ssl,
+            )
+            response.raise_for_status()
+            body = response.json() or {}
+
+            skipped = 0
+            for row in body.get("data") or []:
+                try:
+                    entry = ConfluentTelemetryRow.model_validate(row)
+                except ValidationError:
+                    # A row missing either half attributes nothing, and the rest of the
+                    # page is still usable, so it is dropped rather than raised. Counted
+                    # per page rather than logged per row: a response that changes shape
+                    # would otherwise emit a line per pair on the whole cluster.
+                    skipped += 1
+                    continue
+                # Discarded here rather than after the loop, because this map is held
+                # across every page: on a busy cluster the applications producing to it
+                # far outnumber the connectors, and none of them can ever be attributed.
+                if not CONFLUENT_PRODUCER_CLIENT_PATTERN.match(entry.client_id):
+                    continue
+                by_client.setdefault(entry.client_id, set()).add(entry.topic)
+
+            if skipped:
+                logger.debug(
+                    "Skipped %s unattributable Confluent telemetry rows out of %s for cluster %s",
+                    skipped,
+                    len(body.get("data") or []),
+                    cluster_id,
+                )
+
+            # A cluster with more producer/topic pairs than fit in one page returns a
+            # cursor. Stopping at the first page would drop topics silently, and a
+            # connector resolving a partial set looks indistinguishable from a complete one.
+            page_token = ((body.get("meta") or {}).get("pagination") or {}).get("next_page_token")
+            if not page_token:
+                break
+        else:
+            # Only when the full budget was asked for. A caller that deliberately reads one
+            # page has not lost anything it wanted, and warning there would report a problem
+            # during a test connection that ran exactly as intended.
+            if max_pages == CONFLUENT_TELEMETRY_MAX_PAGES:
+                logger.warning(
+                    "Stopped reading Confluent telemetry after %s pages for cluster %s, topic resolution may be incomplete",
+                    max_pages,
+                    cluster_id,
+                )
+
+        return by_client
+
+    def _telemetry_topics_for_connector_ids(self, cluster_id: str) -> dict[str, set[str]]:
+        """
+        Topics each connector produced to, keyed by connector id, fetched once per run.
+
+        The telemetry response covers every producer on the cluster, most of which belong
+        to applications that are not connectors at all, and the window outlives the
+        connectors in it, so it also carries ones deleted since. Only clients belonging to
+        a connector that currently exists are kept: a deleted connector could never be
+        attributed anyway, and retaining it would grow this with churn rather than with the
+        number of connectors the cluster has.
+        """
+        if self._telemetry_topics_by_connector_id is not None:
+            return self._telemetry_topics_by_connector_id
+
+        live_connector_ids = set(self._connector_id_by_name().values())
+        by_connector: dict[str, set[str]] = {}
+        try:
+            for client_id, client_topics in self._query_dataflow_topics_by_client(cluster_id).items():
+                match = CONFLUENT_PRODUCER_CLIENT_PATTERN.match(client_id)
+                if match and match.group("connector_id") in live_connector_ids:
+                    by_connector.setdefault(match.group("connector_id"), set()).update(client_topics)
+        except Exception as exc:
+            # Recorded as empty rather than left unset, so one failure does not become one
+            # failed call per connector. The API is rate limited per hour, and a large
+            # estate would spend that budget retrying a call that already failed.
+            logger.warning("Confluent telemetry unavailable for cluster %s, topics not enriched: %s", cluster_id, exc)
+            logger.debug(traceback.format_exc())
+
+        self._telemetry_topics_by_connector_id = by_connector
+        return by_connector
+
+    def _list_topics_from_telemetry(
+        self, connector: str, connector_config: dict | None = None
+    ) -> list[KafkaConnectTopics] | None:
+        """
+        Topics this connector actually produced to, per Confluent's telemetry.
+
+        This is the only source that knows a name chosen from row data, so it is consulted
+        before the connector's declared configuration. It reports observed activity, so a
+        connector that produced nothing in the window resolves nothing here and the
+        declared names are still used.
+
+        Returns None rather than raising: telemetry is additive, and a connector that
+        cannot be attributed with confidence must contribute no edge at all.
+        """
+        if not self.is_confluent_cloud or not self._telemetry_auth:
+            return None
+
+        cluster_id = self._confluent_kafka_cluster_id()
+        if not cluster_id:
+            return None
+
+        try:
+            connector_id = self._connector_id_by_name().get(connector)
+            if not connector_id:
+                logger.debug("No Confluent connector id for '%s', skipping telemetry lookup", connector)
+                return None
+
+            topics = set(self._telemetry_topics_for_connector_ids(cluster_id).get(connector_id) or ())
+            topics -= extract_internal_topic_names(connector_config)
+            topics -= confluent_managed_internal_topic_names(connector_config, connector_id)
+        except Exception as exc:
+            logger.debug(traceback.format_exc())
+            logger.debug("Confluent telemetry lookup failed for '%s': %s", connector, exc)
+            return None
+
+        if not topics:
+            return None
+
+        logger.info("Resolved %s topic(s) for '%s' from Confluent telemetry", len(topics), connector)
+        return [KafkaConnectTopics(name=topic) for topic in sorted(topics)]
 
     def _infer_cdc_topics_from_server_name(
         self, database_server_name: str
@@ -376,6 +671,29 @@ class KafkaConnectClient:
         except Exception as exc:
             logger.debug(traceback.format_exc())
             logger.error(f"Unable to get connector plugins  {exc}")
+
+    def check_confluent_telemetry(self) -> bool:
+        """
+        Validate that the Telemetry API answers, for the test-connection step.
+
+        Self-hosted Connect serves the topics endpoint directly and never consults
+        telemetry, so there is nothing to validate and the step reports success rather than
+        a failure the operator cannot act on.
+
+        Unlike the resolution path this raises, because a test step reports failure by
+        raising and the operator is the one who can fix the credentials.
+
+        One page is read rather than all of them. Whether the API answers and accepts the
+        credentials is settled by the first response, while walking the rest would spend a
+        request per page against an endpoint that rate limits by the hour, and would leave
+        an operator waiting on a check that has already learned its answer.
+        """
+        cluster_id = self._confluent_kafka_cluster_id()
+        if not cluster_id or not self._telemetry_auth:
+            return True
+
+        self._query_dataflow_topics_by_client(cluster_id, max_pages=1)
+        return True
 
     def get_connector_config(self, connector: str) -> Optional[dict]:
         """
@@ -601,6 +919,14 @@ class KafkaConnectClient:
             config = connector_config if connector_config is not None else self.get_connector_config(connector)
 
             topics = self._list_data_topics_from_api(connector, config)
+            if topics:
+                return topics
+
+            # Before the declared names, because both this and the runtime list describe
+            # what the connector actually did, whereas the config only describes what it
+            # was asked to do. On Confluent Cloud the runtime list is never available, so
+            # for a connector routing by row value this is the only source that can answer.
+            topics = self._list_topics_from_telemetry(connector, connector_config=config)
             if topics:
                 return topics
 

--- a/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/connection.py
@@ -53,6 +53,7 @@ def test_connection(
         "GetClusterInfo": client.get_cluster_info,
         "GetPipelines": client.get_connectors_list,
         "GetPlugins": client.get_connector_plugins,
+        "CheckConfluentTelemetry": client.check_confluent_telemetry,
     }
 
     return test_connection_steps(

--- a/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/models.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/models.py
@@ -72,6 +72,25 @@ class TopicResolutionResult(BaseModel):
     )
 
 
+class ConfluentTelemetryRow(BaseModel):
+    """
+    One topic/client pair from Confluent's telemetry Data Flow dataset.
+
+    The API returns its group_by fields under dotted names, which are not valid Python
+    identifiers, so both are read through aliases. The metric value is deliberately absent:
+    only the pairing carries meaning here, since the question is which client wrote to
+    which topic and not how much it wrote.
+
+    Both halves are required and non-empty, because a row missing either one attributes a
+    topic to no connector or a connector to no topic, and neither can become lineage.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    client_id: str = Field(..., min_length=1, alias="metric.client_id", description="Producer or consumer client id")
+    topic: str = Field(..., min_length=1, alias="metric.topic", description="Topic the client wrote to")
+
+
 class KafkaConnectColumnMapping(BaseModel):
     """Model for column-level mapping between source and target"""
 

--- a/ingestion/tests/unit/topology/pipeline/test_kafkaconnect.py
+++ b/ingestion/tests/unit/topology/pipeline/test_kafkaconnect.py
@@ -18,6 +18,8 @@ from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
 from uuid import uuid4
 
+import pytest
+
 from metadata.generated.schema.entity.data.topic import Topic
 from metadata.generated.schema.entity.services.connections.pipeline.kafkaConnectConnection import (
     KafkaConnectConnection,
@@ -2126,6 +2128,10 @@ class TestConnectorTopicsFromRuntime:
         client.client = MagicMock()
         client.is_confluent_cloud = confluent_cloud
         client._topics_endpoint_supported = None
+        # No telemetry credentials, so the Confluent telemetry lookup is skipped and these
+        # tests exercise the runtime-to-config fallback they are about.
+        client._telemetry_auth = None
+        client._host_port = ""
         return client
 
     def test_runtime_topics_preferred_over_config(self):
@@ -2663,3 +2669,461 @@ class TestForbiddenIsNotAlwaysUnsupported:
 
         assert [t.name for t in topics] == ["prod.events.orderPlaced_v1"]
         assert client.client.list_connector_topics.call_count == 2
+
+
+class TestConfluentTelemetryTopics:
+    """
+    Topics a Confluent Cloud managed connector actually produced to.
+
+    Confluent Cloud answers KIP-558 with 404, so a connector whose destination topic is
+    chosen per row resolves nothing from config. The telemetry Data Flow dataset reports
+    the topic a producer client wrote to, and a managed connector's producer client id
+    carries its connector id, which is what closes that gap.
+    """
+
+    @staticmethod
+    def _cloud_client():
+        config = MagicMock(spec=KafkaConnectConnection)
+        config.hostPort = "https://api.confluent.cloud/connect/v1/environments/env-abc/clusters/lkc-xyz"
+        config.verifySSL = True
+        auth = MagicMock()
+        auth.username = "CLOUDKEY"
+        auth.password.get_secret_value.return_value = "cloudsecret"
+        config.KafkaConnectConfig = auth
+        with patch("metadata.ingestion.source.pipeline.kafkaconnect.client.KafkaConnect"):
+            return KafkaConnectClient(config)
+
+    def test_cluster_id_comes_from_the_host_port(self):
+        """The telemetry query is scoped by Kafka cluster, and hostPort already names it."""
+        client = self._cloud_client()
+
+        assert client._confluent_kafka_cluster_id() == "lkc-xyz"
+
+    def test_self_hosted_has_no_cluster_id(self):
+        """A self-hosted Connect URL names no Kafka cluster, so there is nothing to scope by."""
+        config = MagicMock(spec=KafkaConnectConnection)
+        config.hostPort = "http://localhost:8083"
+        config.verifySSL = True
+        config.KafkaConnectConfig = None
+        with patch("metadata.ingestion.source.pipeline.kafkaconnect.client.KafkaConnect"):
+            client = KafkaConnectClient(config)
+
+        assert client._confluent_kafka_cluster_id() is None
+
+    def test_row_routed_topics_are_resolved_from_telemetry(self):
+        """
+        The case config cannot answer.
+
+        An outbox EventRouter routing by a row value publishes topic names that appear in
+        no config key. Telemetry reports them against the connector's producer client.
+        """
+        client = self._cloud_client()
+        client._connector_id_by_name = MagicMock(return_value={"outbox-wallet": "lcc-aaa111"})
+        client._query_dataflow_topics_by_client = MagicMock(
+            return_value={
+                "connector-producer-lcc-aaa111-0": {
+                    "prod.events.walletEntity_v1",
+                    "prod.events.instrument_v1",
+                },
+                "connector-producer-lcc-bbb222-0": {"prod.events.other_v1"},
+            }
+        )
+
+        topics = client._list_topics_from_telemetry("outbox-wallet")
+
+        assert sorted(t.name for t in topics) == [
+            "prod.events.instrument_v1",
+            "prod.events.walletEntity_v1",
+        ], "must return only the topics produced by this connector's own client"
+
+    def test_another_connectors_topics_are_never_claimed(self):
+        """Client ids are per connector, so a sibling's topics must not leak across."""
+        client = self._cloud_client()
+        client._connector_id_by_name = MagicMock(return_value={"outbox-wallet": "lcc-aaa111"})
+        client._query_dataflow_topics_by_client = MagicMock(
+            return_value={"connector-producer-lcc-bbb222-0": {"prod.events.other_v1"}}
+        )
+
+        assert client._list_topics_from_telemetry("outbox-wallet") is None
+
+    def test_schema_history_client_is_not_the_connector(self):
+        """
+        Confluent's managed schema history topic is named dbhistory.<prefix>.<connector-id>,
+        so its name is not derivable from config and cannot be excluded by name. It is
+        produced by a separate client, which is what makes it separable at all.
+        """
+        client = self._cloud_client()
+        client._connector_id_by_name = MagicMock(return_value={"outbox-wallet": "lcc-aaa111"})
+        client._query_dataflow_topics_by_client = MagicMock(
+            return_value={
+                "connector-producer-lcc-aaa111-0": {"prod.events.walletEntity_v1"},
+                "wallet.prod-schemahistory": {"dbhistory.wallet.prod.lcc-aaa111"},
+            }
+        )
+
+        topics = client._list_topics_from_telemetry("outbox-wallet")
+
+        assert [t.name for t in topics] == ["prod.events.walletEntity_v1"]
+
+    def test_unknown_connector_resolves_nothing(self):
+        """A connector absent from the live id map must not be matched by substring."""
+        client = self._cloud_client()
+        client._connector_id_by_name = MagicMock(return_value={})
+        client._query_dataflow_topics_by_client = MagicMock(
+            return_value={"connector-producer-lcc-aaa111-0": {"prod.events.walletEntity_v1"}}
+        )
+
+        assert client._list_topics_from_telemetry("outbox-wallet") is None
+
+    def test_telemetry_failure_is_not_fatal(self):
+        """Telemetry is additive. A failure must degrade to no enrichment, never raise."""
+        client = self._cloud_client()
+        client._connector_id_by_name = MagicMock(return_value={"outbox-wallet": "lcc-aaa111"})
+        client._query_dataflow_topics_by_client = MagicMock(side_effect=Exception("telemetry down"))
+
+        assert client._list_topics_from_telemetry("outbox-wallet") is None
+
+    def test_telemetry_runs_before_config_but_after_runtime(self):
+        """
+        Resolution order: the runtime list wins, then telemetry, then declared config.
+        Both runtime sources describe what happened, config only what was asked for.
+        """
+        client = self._cloud_client()
+        client._list_data_topics_from_api = MagicMock(return_value=None)
+        client._list_topics_from_telemetry = MagicMock(
+            return_value=[KafkaConnectTopics(name="prod.events.walletEntity_v1")]
+        )
+        client._parse_topics_from_config = MagicMock(return_value=[KafkaConnectTopics(name="declared.in.config")])
+
+        topics = client.get_connector_topics("outbox-wallet", connector_config={})
+
+        assert [t.name for t in topics] == ["prod.events.walletEntity_v1"]
+        client._parse_topics_from_config.assert_not_called()
+
+    def test_config_still_used_when_telemetry_is_silent(self):
+        """An idle connector reports no flow, so the declared names must still be used."""
+        client = self._cloud_client()
+        client._list_data_topics_from_api = MagicMock(return_value=None)
+        client._list_topics_from_telemetry = MagicMock(return_value=None)
+        client._parse_topics_from_config = MagicMock(return_value=[KafkaConnectTopics(name="declared.in.config")])
+
+        topics = client.get_connector_topics("outbox-wallet", connector_config={})
+
+        assert [t.name for t in topics] == ["declared.in.config"]
+
+    def test_check_passes_for_self_hosted(self):
+        """
+        Self-hosted Connect serves the topics endpoint and never consults telemetry, so the
+        step must not report a failure the operator has no way to act on.
+        """
+        config = MagicMock(spec=KafkaConnectConnection)
+        config.hostPort = "http://localhost:8083"
+        config.verifySSL = True
+        config.KafkaConnectConfig = None
+        with patch("metadata.ingestion.source.pipeline.kafkaconnect.client.KafkaConnect"):
+            client = KafkaConnectClient(config)
+        client._query_dataflow_topics_by_client = MagicMock()
+
+        assert client.check_confluent_telemetry() is True
+        client._query_dataflow_topics_by_client.assert_not_called()
+
+    def test_check_surfaces_the_failure_on_confluent_cloud(self):
+        """
+        The test step reports by raising, unlike the resolution path which stays silent.
+        Here the operator is the one who can fix the credentials, so they must be told.
+        """
+        client = self._cloud_client()
+        client._query_dataflow_topics_by_client = MagicMock(side_effect=Exception("401 Unauthorized"))
+
+        with pytest.raises(Exception, match="401 Unauthorized"):
+            client.check_confluent_telemetry()
+
+    def test_managed_transaction_topic_is_excluded(self):
+        """
+        Debezium's transaction metadata topic is produced by the connector's own client, so
+        client identity cannot separate it. Confluent names it <prefix>.<connector-id>.
+        transaction, which extract_internal_topic_names cannot derive from config because
+        the connector id is assigned at runtime. Emitting it would be the same class of
+        wrong edge that linking the outbox table to bookkeeping topics already was.
+        """
+        client = self._cloud_client()
+        client._connector_id_by_name = MagicMock(return_value={"outbox-wallet": "lcc-aaa111"})
+        client._query_dataflow_topics_by_client = MagicMock(
+            return_value={
+                "connector-producer-lcc-aaa111-0": {
+                    "prod.events.walletEntity_v1",
+                    "wallet.prod.lcc-aaa111.transaction",
+                }
+            }
+        )
+
+        topics = client._list_topics_from_telemetry("outbox-wallet", connector_config={"topic.prefix": "wallet.prod"})
+
+        assert [t.name for t in topics] == ["prod.events.walletEntity_v1"]
+
+    def test_configured_internal_topics_are_excluded(self):
+        """The names config does declare, such as schema history, are excluded too."""
+        client = self._cloud_client()
+        client._connector_id_by_name = MagicMock(return_value={"outbox-wallet": "lcc-aaa111"})
+        client._query_dataflow_topics_by_client = MagicMock(
+            return_value={
+                "connector-producer-lcc-aaa111-0": {
+                    "prod.events.walletEntity_v1",
+                    "schema-history.wallet.prod",
+                }
+            }
+        )
+
+        topics = client._list_topics_from_telemetry(
+            "outbox-wallet",
+            connector_config={
+                "topic.prefix": "wallet.prod",
+                "schema.history.internal.kafka.topic": "schema-history.wallet.prod",
+            },
+        )
+
+        assert [t.name for t in topics] == ["prod.events.walletEntity_v1"]
+
+    def test_a_connector_producing_only_bookkeeping_resolves_nothing(self):
+        """Bookkeeping alone is not lineage, so this must fall through to config."""
+        client = self._cloud_client()
+        client._connector_id_by_name = MagicMock(return_value={"outbox-wallet": "lcc-aaa111"})
+        client._query_dataflow_topics_by_client = MagicMock(
+            return_value={"connector-producer-lcc-aaa111-0": {"wallet.prod.lcc-aaa111.transaction"}}
+        )
+
+        assert (
+            client._list_topics_from_telemetry("outbox-wallet", connector_config={"topic.prefix": "wallet.prod"})
+            is None
+        )
+
+    def test_cluster_wide_lookups_run_once_per_ingestion(self):
+        """
+        Both lookups describe the whole cluster, not one connector, so repeating them per
+        connector is pure waste. On a four connector rig they were 43 percent of ingestion
+        time, and an estate of thirty six would repeat each thirty six times against an API
+        that rate limits per hour.
+        """
+        client = self._cloud_client()
+        client.client.list_connectors = MagicMock(
+            return_value={
+                "outbox-a": {"id": {"id": "lcc-aaa111"}},
+                "outbox-b": {"id": {"id": "lcc-bbb222"}},
+            }
+        )
+        query = MagicMock(
+            return_value={
+                "connector-producer-lcc-aaa111-0": {"prod.events.a_v1"},
+                "connector-producer-lcc-bbb222-0": {"prod.events.b_v1"},
+            }
+        )
+        client._query_dataflow_topics_by_client = query
+
+        first = client._list_topics_from_telemetry("outbox-a", connector_config={})
+        second = client._list_topics_from_telemetry("outbox-b", connector_config={})
+
+        assert [t.name for t in first] == ["prod.events.a_v1"]
+        assert [t.name for t in second] == ["prod.events.b_v1"]
+        assert query.call_count == 1, "the telemetry query is cluster wide, so once per run"
+        assert client.client.list_connectors.call_count == 1, "the connector list is cluster wide too"
+
+    @staticmethod
+    def _page(rows, next_token=None):
+        """A telemetry response page, shaped as the API returns it."""
+        page = MagicMock()
+        page.raise_for_status = MagicMock()
+        page.json = MagicMock(
+            return_value={
+                "data": rows,
+                "meta": {"pagination": {"next_page_token": next_token}} if next_token else {},
+            }
+        )
+        return page
+
+    def test_every_page_is_followed(self):
+        """
+        The API caps a query at 1000 groups and returns a cursor for the rest. Reading only
+        the first page would drop topics on a busy cluster, and a connector resolving a
+        partial topic set looks perfectly valid, which is worse than resolving nothing.
+        """
+        client = self._cloud_client()
+        pages = [
+            self._page(
+                [{"metric.client_id": "connector-producer-lcc-aaa111-0", "metric.topic": "a_v1"}],
+                next_token="TOKEN",
+            ),
+            self._page([{"metric.client_id": "connector-producer-lcc-aaa111-0", "metric.topic": "b_v1"}]),
+        ]
+        with patch(
+            "metadata.ingestion.source.pipeline.kafkaconnect.client.requests.post",
+            side_effect=pages,
+        ) as post:
+            by_client = client._query_dataflow_topics_by_client("lkc-xyz")
+
+        assert by_client == {"connector-producer-lcc-aaa111-0": {"a_v1", "b_v1"}}
+        assert post.call_count == 2
+        assert post.call_args_list[1].kwargs["params"] == {"page_token": "TOKEN"}
+
+    def test_query_stays_within_the_documented_limit(self):
+        """The API documents a maximum of 1000 groups. Above it we rely on leniency."""
+        client = self._cloud_client()
+        with patch(
+            "metadata.ingestion.source.pipeline.kafkaconnect.client.requests.post",
+            return_value=self._page([]),
+        ) as post:
+            client._query_dataflow_topics_by_client("lkc-xyz")
+
+        assert post.call_args.kwargs["json"]["limit"] <= 1000
+
+    def test_verify_ssl_is_honoured(self):
+        """A user disabling certificate verification for Connect means it for telemetry too."""
+        config = MagicMock(spec=KafkaConnectConnection)
+        config.hostPort = "https://api.confluent.cloud/connect/v1/environments/env-abc/clusters/lkc-xyz"
+        config.verifySSL = False
+        auth = MagicMock()
+        auth.username = "K"
+        auth.password.get_secret_value.return_value = "S"
+        config.KafkaConnectConfig = auth
+        with patch("metadata.ingestion.source.pipeline.kafkaconnect.client.KafkaConnect"):
+            client = KafkaConnectClient(config)
+
+        with patch(
+            "metadata.ingestion.source.pipeline.kafkaconnect.client.requests.post",
+            return_value=self._page([]),
+        ) as post:
+            client._query_dataflow_topics_by_client("lkc-xyz")
+
+        assert post.call_args.kwargs["verify"] is False
+
+    def test_a_failed_query_is_not_retried_for_every_connector(self):
+        """
+        One outage must not become one failed call per connector. The API is rate limited
+        per hour, and an estate of thirty six connectors would spend that budget retrying
+        a call that already failed.
+        """
+        client = self._cloud_client()
+        client._connector_id_by_name = MagicMock(return_value={"outbox-a": "lcc-aaa111", "outbox-b": "lcc-bbb222"})
+        query = MagicMock(side_effect=Exception("telemetry down"))
+        client._query_dataflow_topics_by_client = query
+
+        assert client._list_topics_from_telemetry("outbox-a", connector_config={}) is None
+        assert client._list_topics_from_telemetry("outbox-b", connector_config={}) is None
+        assert query.call_count == 1, "a failed cluster-wide query must not be retried per connector"
+
+    def test_only_live_connectors_are_retained(self):
+        """
+        The telemetry window outlives the connectors in it. A connector deleted earlier in
+        the window still reports the topics it produced to, and keeping those grows what is
+        retained with churn rather than with the number of connectors that exist. They can
+        never be attributed either, since resolution goes through the live connector list.
+        """
+        client = self._cloud_client()
+        client._connector_id_by_name = MagicMock(return_value={"outbox-live": "lcc-live01"})
+        client._query_dataflow_topics_by_client = MagicMock(
+            return_value={
+                "connector-producer-lcc-live01-0": {"prod.events.live_v1"},
+                "connector-producer-lcc-dead01-0": {"prod.events.deleted_v1"},
+                "connector-producer-lcc-dead02-0": {"prod.events.also_deleted_v1"},
+            }
+        )
+
+        retained = client._telemetry_topics_for_connector_ids("lkc-xyz")
+
+        assert set(retained) == {"lcc-live01"}, "a deleted connector's topics must not be retained"
+
+    def test_unattributable_rows_are_dropped_without_losing_the_page(self):
+        """
+        A row has to name both a client and a topic to mean anything: one without a client
+        attributes a topic to no connector, and one without a topic attributes a connector
+        to nothing. Neither can become lineage. An empty string counts as missing, since it
+        would otherwise reach the producer-id match as a real value.
+
+        The rest of the page still resolves, because discarding good pairs over a
+        malformed neighbour would silently shrink a connector's topic set, and a partial
+        set is indistinguishable from a complete one.
+        """
+        client = self._cloud_client()
+        rows = [
+            {"metric.client_id": "connector-producer-lcc-aaa111-0", "metric.topic": "good_v1"},
+            {"metric.topic": "orphan_v1"},
+            {"metric.client_id": "connector-producer-lcc-aaa111-0"},
+            {"metric.client_id": "", "metric.topic": "blank_client_v1"},
+            {"metric.client_id": "connector-producer-lcc-aaa111-0", "metric.topic": ""},
+            {"metric.client_id": "connector-producer-lcc-aaa111-0", "metric.topic": "also_good_v1"},
+        ]
+        with patch(
+            "metadata.ingestion.source.pipeline.kafkaconnect.client.requests.post",
+            return_value=self._page(rows),
+        ):
+            by_client = client._query_dataflow_topics_by_client("lkc-xyz")
+
+        assert by_client == {"connector-producer-lcc-aaa111-0": {"good_v1", "also_good_v1"}}
+        assert "" not in by_client, "an empty client id must not become a producer"
+
+    def test_unrelated_producers_are_dropped_before_they_accumulate(self):
+        """
+        The telemetry query is cluster wide, so the response describes every application
+        producing to the cluster, not just connectors. Those rows can never be attributed,
+        and this map is held across every page, so on a busy cluster keeping them would let
+        ordinary application traffic dominate what the connector holds in memory.
+
+        Asserted on the fetch result rather than on the attributed output, because
+        filtering later would still produce the right topics while holding the whole
+        cluster's producers to get there.
+        """
+        client = self._cloud_client()
+        rows = [
+            {"metric.client_id": "connector-producer-lcc-aaa111-0", "metric.topic": "connector_v1"},
+            {"metric.client_id": "checkout-service-prod-17", "metric.topic": "orders_v1"},
+            {"metric.client_id": "spark-streaming-job-42", "metric.topic": "events_v1"},
+            {"metric.client_id": "consumer-analytics-9", "metric.topic": "connector_v1"},
+        ]
+        with patch(
+            "metadata.ingestion.source.pipeline.kafkaconnect.client.requests.post",
+            return_value=self._page(rows),
+        ):
+            by_client = client._query_dataflow_topics_by_client("lkc-xyz")
+
+        assert by_client == {"connector-producer-lcc-aaa111-0": {"connector_v1"}}, (
+            "only connector producers may be retained from a cluster-wide response"
+        )
+
+    def test_reachability_check_reads_one_page_even_when_more_exist(self):
+        """
+        The test-connection step only has to learn whether the API answers and accepts the
+        credentials, which the first response settles. Following the cursor would spend a
+        request per page against an endpoint that rate limits by the hour, and would hold
+        an operator on a check whose answer was already known.
+
+        The first page here returns a cursor, so a caller that paged would issue a second
+        request. Asserting the call count is what distinguishes the two.
+        """
+        client = self._cloud_client()
+        with patch(
+            "metadata.ingestion.source.pipeline.kafkaconnect.client.requests.post",
+            return_value=self._page(
+                [{"metric.client_id": "connector-producer-lcc-aaa111-0", "metric.topic": "a_v1"}],
+                next_token="MORE",
+            ),
+        ) as post:
+            assert client.check_confluent_telemetry() is True
+
+        assert post.call_count == 1, "a reachability check must not walk the cursor"
+
+    def test_reachability_check_reports_failure_by_raising(self):
+        """
+        A test step reports failure by raising, so a rejected credential has to propagate
+        rather than be swallowed the way the resolution path swallows it. The operator is
+        the one who can fix it, and a step that passed regardless would say nothing.
+        """
+        client = self._cloud_client()
+        response = MagicMock()
+        response.raise_for_status = MagicMock(side_effect=Exception("401 Unauthorized"))
+        with (
+            patch(
+                "metadata.ingestion.source.pipeline.kafkaconnect.client.requests.post",
+                return_value=response,
+            ),
+            pytest.raises(Exception, match="401"),
+        ):
+            client.check_confluent_telemetry()


### PR DESCRIPTION
### Describe your changes:

Backport of #32512 to 1.13, restricted to the ingestion package.

On Confluent Cloud, `GET /connectors/{name}/topics` returns 404 for managed connectors, so the only topic names available are the ones declared in connector configuration. That cannot resolve a connector whose destination topic is chosen per row, such as a Debezium outbox `EventRouter` whose `route.topic.replacement` still interpolates `${routedByValue}`. #32205, already on this branch as `1fa364e76d6`, made those connectors resolve nothing rather than guess from the `topic.prefix` namespace, which removed incorrect lineage but left them with none.

This adds a third source to `KafkaConnectClient.get_connector_topics`, between the runtime topic list and the configured names. Confluent's Telemetry API reports which topic each producer client wrote to, and a managed connector's producer client id carries its connector id, so joining that against `GET /connectors?expand=id` gives connector to topic directly. It uses the Confluent Cloud credentials already configured for Kafka Connect, so no new connection field, and the lookup is additive throughout: a failure, an unrecognised client id, or a connector idle during the window all fall through to the configured names rather than failing ingestion.

Carries the full review history of #32512, including the paging fix, the live-connector filter, the `verifySSL` fix, dropping unrelated cluster producers at fetch time, and reading a single page for the test-connection reachability check.

#### Difference from the main PR

The main PR also adds a `CheckConfluentTelemetry` step to `openmetadata-service/src/main/resources/json/data/testConnections/pipeline/kafkaconnect.json`. That file is a server resource, so it is omitted here to keep this an ingestion-only change.

`connection.py` still registers the function in `test_fn`. That is safe on its own, because `test_connection_steps` iterates the server's step definitions and looks up `test_fn[step.name]`, so an entry with no matching definition is never invoked. The reverse order would be the unsafe one, since a defined step with no registered function raises `KeyError`. Shipping ingestion ahead of the server is therefore the correct direction, and the step activates once a server carrying the definition is deployed.

#### Backport notes

The change is purely additive against 1.13: 810 insertions, no deletions, no existing line modified. Three conflicts arose only because main had reformatted the signatures of two pre-existing methods (`_infer_cdc_topics_from_server_name`, `get_connector_config`) and moved `Iterable` to `collections.abc`. In each case 1.13's existing form was kept and only the new code was taken, so the hunks stay consistent with how #32420 was backported to this branch.

Verified on this branch against 1.13.6: 126 kafkaconnect unit tests pass, and the wider pipeline suite is unchanged at 866 passed, with 3 pre-existing `test_airflow_connection.py` failures that also fail on a clean 1.13 checkout.

#
### Type of change:

- [x] Bug fix
- [x] New feature

#
### Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
