### PR TITLE
Fixes 28088: refresh publicKeyUrls from discovery when SSO discoveryUri changes

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
@@ -1551,6 +1551,10 @@ public class SystemRepository {
       if (securityConfig.getAuthenticationConfiguration() != null) {
         AuthenticationConfiguration authConfig = securityConfig.getAuthenticationConfiguration();
 
+        // publicKeyUrls is derived from discoveryUri for confidential clients, so refresh it first
+        // or an updated discoveryUri gets rejected against the previously stored JWKS URL.
+        syncPublicKeyUrlsFromDiscovery(authConfig);
+
         // First validate all required fields from AuthenticationConfiguration schema
         FieldError baseError = validateAuthenticationConfigurationBaseFields(authConfig);
         if (baseError != null) {
@@ -1815,10 +1819,12 @@ public class SystemRepository {
   }
 
   /**
-   * Auto-populates publicKeyUrls from OIDC discovery document for confidential clients
-   * This is called during save operation to ensure publicKeyUrls is populated before persisting
+   * Re-derives publicKeyUrls from the OIDC discovery document for confidential clients, where the
+   * field is not user-editable. Runs on every save and validate so that changing discoveryUri does
+   * not leave a stale JWKS URL behind. A discovery failure is logged and leaves the current value
+   * untouched, so a transient outage never wipes a working configuration.
    */
-  public void autoPopulatePublicKeyUrlsIfNeeded(AuthenticationConfiguration authConfig) {
+  public void syncPublicKeyUrlsFromDiscovery(AuthenticationConfiguration authConfig) {
     if (authConfig == null) {
       return;
     }
@@ -1835,30 +1841,24 @@ public class SystemRepository {
     boolean isConfidentialClient = authConfig.getClientType() == ClientType.CONFIDENTIAL;
 
     if (!isOidcProvider || !isConfidentialClient) {
-      LOG.debug("Skipping publicKeyUrls auto-population - not OIDC confidential client");
-      return;
-    }
-
-    // Skip if already populated
-    if (authConfig.getPublicKeyUrls() != null && !authConfig.getPublicKeyUrls().isEmpty()) {
-      LOG.debug("publicKeyUrls already populated, skipping auto-population");
+      LOG.debug("Skipping publicKeyUrls resolution - not OIDC confidential client");
       return;
     }
 
     OidcClientConfig oidcConfig = authConfig.getOidcConfiguration();
     if (oidcConfig == null || nullOrEmpty(oidcConfig.getDiscoveryUri())) {
-      LOG.warn("Cannot auto-populate publicKeyUrls - missing oidcConfiguration or discoveryUri");
+      LOG.warn("Cannot resolve publicKeyUrls - missing oidcConfiguration or discoveryUri");
       return;
     }
 
     try {
       OidcDiscoveryValidator discoveryValidator = new OidcDiscoveryValidator();
-      discoveryValidator.autoPopulatePublicKeyUrls(oidcConfig.getDiscoveryUri(), authConfig);
+      discoveryValidator.syncPublicKeyUrlsFromDiscovery(oidcConfig.getDiscoveryUri(), authConfig);
       LOG.info(
-          "Auto-populated publicKeyUrls from discovery document for provider: {}",
+          "Resolved publicKeyUrls from discovery document for provider: {}",
           authConfig.getProvider());
     } catch (Exception e) {
-      LOG.error("Failed to auto-populate publicKeyUrls: {}", e.getMessage(), e);
+      LOG.error("Failed to resolve publicKeyUrls from discovery: {}", e.getMessage(), e);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/SystemResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/SystemResource.java
@@ -1089,8 +1089,8 @@ public class SystemResource {
       preserveMaskedSecuritySecrets(securityConfig, originalConfig);
       AuthenticationConfiguration authConfig = securityConfig.getAuthenticationConfiguration();
 
-      // Auto-populate publicKeyUrls for OIDC confidential clients before saving
-      systemRepository.autoPopulatePublicKeyUrlsIfNeeded(authConfig);
+      // Refresh publicKeyUrls from discovery for OIDC confidential clients before saving
+      systemRepository.syncPublicKeyUrlsFromDiscovery(authConfig);
 
       // Update both configurations in a transaction
       Settings authSettings =

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/validator/OidcDiscoveryValidator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/validator/OidcDiscoveryValidator.java
@@ -348,23 +348,20 @@ public class OidcDiscoveryValidator {
   }
 
   /**
-   * Auto-populates publicKeyUrls from OIDC discovery document if not already set
+   * Re-derives publicKeyUrls from the OIDC discovery document. publicKeyUrls is a derived value for
+   * confidential clients (the UI never exposes it), so it must follow discoveryUri on every save --
+   * populating it only when empty leaves a stale JWKS URL behind when discoveryUri changes.
    *
    * @param discoveryUri The OIDC discovery URI
    * @param authConfig The authentication configuration to populate
-   * @throws Exception if discovery document cannot be fetched or parsed
+   * @throws Exception if discovery document cannot be fetched or parsed; the existing value is left
+   *     untouched in that case
    */
-  public void autoPopulatePublicKeyUrls(String discoveryUri, AuthenticationConfiguration authConfig)
-      throws Exception {
-
-    // Skip if publicKeyUrls already populated
-    if (authConfig.getPublicKeyUrls() != null && !authConfig.getPublicKeyUrls().isEmpty()) {
-      LOG.debug("publicKeyUrls already set, skipping auto-population");
-      return;
-    }
+  public void syncPublicKeyUrlsFromDiscovery(
+      String discoveryUri, AuthenticationConfiguration authConfig) throws Exception {
 
     if (nullOrEmpty(discoveryUri)) {
-      throw new IOException("Discovery URI is required for auto-populating publicKeyUrls");
+      throw new IOException("Discovery URI is required to resolve publicKeyUrls");
     }
 
     // Fetch discovery document
@@ -389,8 +386,7 @@ public class OidcDiscoveryValidator {
       throw new IOException("Discovery document contains empty 'jwks_uri' field");
     }
 
-    // Auto-populate publicKeyUrls
     authConfig.setPublicKeyUrls(List.of(jwksUri));
-    LOG.debug("Auto-populated publicKeyUrls from discovery document: {}", jwksUri);
+    LOG.debug("Resolved publicKeyUrls from discovery document: {}", jwksUri);
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/auth/validator/OidcDiscoveryValidatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/auth/validator/OidcDiscoveryValidatorTest.java
@@ -34,7 +34,7 @@ public class OidcDiscoveryValidatorTest {
   }
 
   @Test
-  void testAutoPopulatePublicKeyUrls_Success() throws Exception {
+  void testSyncPublicKeyUrls_Success() throws Exception {
     String discoveryUri = "https://accounts.google.com/.well-known/openid-configuration";
     String mockDiscoveryResponse =
         "{"
@@ -47,7 +47,7 @@ public class OidcDiscoveryValidatorTest {
           new ValidationHttpUtil.HttpResponseData(200, mockDiscoveryResponse);
       mockedHttp.when(() -> ValidationHttpUtil.safeGet(anyString())).thenReturn(mockResponse);
 
-      validator.autoPopulatePublicKeyUrls(discoveryUri, authConfig);
+      validator.syncPublicKeyUrlsFromDiscovery(discoveryUri, authConfig);
 
       assertNotNull(authConfig.getPublicKeyUrls());
       assertEquals(1, authConfig.getPublicKeyUrls().size());
@@ -57,35 +57,64 @@ public class OidcDiscoveryValidatorTest {
   }
 
   @Test
-  void testAutoPopulatePublicKeyUrls_SkipWhenAlreadyPopulated() throws Exception {
-    String discoveryUri = "https://accounts.google.com/.well-known/openid-configuration";
-    authConfig.setPublicKeyUrls(java.util.List.of("https://existing.com/keys"));
+  void testSyncPublicKeyUrls_ReplacesStaleUrlsWhenDiscoveryUriChanges() throws Exception {
+    String discoveryUri = "https://new-idp.example.com/.well-known/openid-configuration";
+    String mockDiscoveryResponse =
+        "{"
+            + "\"issuer\": \"https://new-idp.example.com\","
+            + "\"jwks_uri\": \"https://new-idp.example.com/keys\""
+            + "}";
+    authConfig.setPublicKeyUrls(java.util.List.of("https://old-idp.example.com/keys"));
 
-    validator.autoPopulatePublicKeyUrls(discoveryUri, authConfig);
+    try (MockedStatic<ValidationHttpUtil> mockedHttp = mockStatic(ValidationHttpUtil.class)) {
+      ValidationHttpUtil.HttpResponseData mockResponse =
+          new ValidationHttpUtil.HttpResponseData(200, mockDiscoveryResponse);
+      mockedHttp.when(() -> ValidationHttpUtil.safeGet(anyString())).thenReturn(mockResponse);
 
-    assertEquals(1, authConfig.getPublicKeyUrls().size());
-    assertEquals("https://existing.com/keys", authConfig.getPublicKeyUrls().get(0));
+      validator.syncPublicKeyUrlsFromDiscovery(discoveryUri, authConfig);
+
+      assertEquals(List.of("https://new-idp.example.com/keys"), authConfig.getPublicKeyUrls());
+    }
   }
 
   @Test
-  void testAutoPopulatePublicKeyUrls_NullDiscoveryUri_ThrowsIOException() {
+  void testSyncPublicKeyUrls_KeepsExistingUrlsWhenDiscoveryFetchFails() {
+    String discoveryUri = "https://new-idp.example.com/.well-known/openid-configuration";
+    authConfig.setPublicKeyUrls(java.util.List.of("https://old-idp.example.com/keys"));
+
+    try (MockedStatic<ValidationHttpUtil> mockedHttp = mockStatic(ValidationHttpUtil.class)) {
+      mockedHttp
+          .when(() -> ValidationHttpUtil.safeGet(anyString()))
+          .thenReturn(new ValidationHttpUtil.HttpResponseData(503, "Service Unavailable"));
+
+      assertThrows(
+          IOException.class,
+          () -> validator.syncPublicKeyUrlsFromDiscovery(discoveryUri, authConfig));
+
+      assertEquals(List.of("https://old-idp.example.com/keys"), authConfig.getPublicKeyUrls());
+    }
+  }
+
+  @Test
+  void testSyncPublicKeyUrls_NullDiscoveryUri_ThrowsIOException() {
     IOException exception =
         assertThrows(
-            IOException.class, () -> validator.autoPopulatePublicKeyUrls(null, authConfig));
+            IOException.class, () -> validator.syncPublicKeyUrlsFromDiscovery(null, authConfig));
 
     assertTrue(exception.getMessage().contains("Discovery URI is required"));
   }
 
   @Test
-  void testAutoPopulatePublicKeyUrls_EmptyDiscoveryUri_ThrowsIOException() {
+  void testSyncPublicKeyUrls_EmptyDiscoveryUri_ThrowsIOException() {
     IOException exception =
-        assertThrows(IOException.class, () -> validator.autoPopulatePublicKeyUrls("", authConfig));
+        assertThrows(
+            IOException.class, () -> validator.syncPublicKeyUrlsFromDiscovery("", authConfig));
 
     assertTrue(exception.getMessage().contains("Discovery URI is required"));
   }
 
   @Test
-  void testAutoPopulatePublicKeyUrls_HttpFailure_ThrowsIOException() {
+  void testSyncPublicKeyUrls_HttpFailure_ThrowsIOException() {
     String discoveryUri = "https://invalid.example.com/.well-known/openid-configuration";
 
     try (MockedStatic<ValidationHttpUtil> mockedHttp = mockStatic(ValidationHttpUtil.class)) {
@@ -96,7 +125,7 @@ public class OidcDiscoveryValidatorTest {
       IOException exception =
           assertThrows(
               IOException.class,
-              () -> validator.autoPopulatePublicKeyUrls(discoveryUri, authConfig));
+              () -> validator.syncPublicKeyUrlsFromDiscovery(discoveryUri, authConfig));
 
       assertTrue(exception.getMessage().contains("Failed to fetch discovery document"));
       assertTrue(exception.getMessage().contains("HTTP 404"));
@@ -104,7 +133,7 @@ public class OidcDiscoveryValidatorTest {
   }
 
   @Test
-  void testAutoPopulatePublicKeyUrls_MissingJwksUri_ThrowsIOException() {
+  void testSyncPublicKeyUrls_MissingJwksUri_ThrowsIOException() {
     String discoveryUri = "https://accounts.google.com/.well-known/openid-configuration";
     String mockDiscoveryResponse = "{\"issuer\": \"https://accounts.google.com\"}";
 
@@ -116,7 +145,7 @@ public class OidcDiscoveryValidatorTest {
       IOException exception =
           assertThrows(
               IOException.class,
-              () -> validator.autoPopulatePublicKeyUrls(discoveryUri, authConfig));
+              () -> validator.syncPublicKeyUrlsFromDiscovery(discoveryUri, authConfig));
 
       assertTrue(
           exception.getMessage().contains("Discovery document missing required 'jwks_uri' field"));
@@ -124,7 +153,7 @@ public class OidcDiscoveryValidatorTest {
   }
 
   @Test
-  void testAutoPopulatePublicKeyUrls_EmptyJwksUri_ThrowsIOException() {
+  void testSyncPublicKeyUrls_EmptyJwksUri_ThrowsIOException() {
     String discoveryUri = "https://accounts.google.com/.well-known/openid-configuration";
     String mockDiscoveryResponse =
         "{" + "\"issuer\": \"https://accounts.google.com\"," + "\"jwks_uri\": \"\"" + "}";
@@ -137,7 +166,7 @@ public class OidcDiscoveryValidatorTest {
       IOException exception =
           assertThrows(
               IOException.class,
-              () -> validator.autoPopulatePublicKeyUrls(discoveryUri, authConfig));
+              () -> validator.syncPublicKeyUrlsFromDiscovery(discoveryUri, authConfig));
 
       assertTrue(
           exception.getMessage().contains("Discovery document contains empty 'jwks_uri' field"));
@@ -145,7 +174,7 @@ public class OidcDiscoveryValidatorTest {
   }
 
   @Test
-  void testAutoPopulatePublicKeyUrls_Http500_ThrowsIOException() {
+  void testSyncPublicKeyUrls_Http500_ThrowsIOException() {
     String discoveryUri = "https://accounts.google.com/.well-known/openid-configuration";
 
     try (MockedStatic<ValidationHttpUtil> mockedHttp = mockStatic(ValidationHttpUtil.class)) {
@@ -156,7 +185,7 @@ public class OidcDiscoveryValidatorTest {
       IOException exception =
           assertThrows(
               IOException.class,
-              () -> validator.autoPopulatePublicKeyUrls(discoveryUri, authConfig));
+              () -> validator.syncPublicKeyUrlsFromDiscovery(discoveryUri, authConfig));
 
       assertTrue(exception.getMessage().contains("Failed to fetch discovery document"));
       assertTrue(exception.getMessage().contains("HTTP 500"));
@@ -164,7 +193,7 @@ public class OidcDiscoveryValidatorTest {
   }
 
   @Test
-  void testAutoPopulatePublicKeyUrls_InvalidJson_ThrowsException() {
+  void testSyncPublicKeyUrls_InvalidJson_ThrowsException() {
     String discoveryUri = "https://accounts.google.com/.well-known/openid-configuration";
     String mockDiscoveryResponse = "{ invalid json }";
 
@@ -174,7 +203,8 @@ public class OidcDiscoveryValidatorTest {
       mockedHttp.when(() -> ValidationHttpUtil.safeGet(anyString())).thenReturn(mockResponse);
 
       assertThrows(
-          Exception.class, () -> validator.autoPopulatePublicKeyUrls(discoveryUri, authConfig));
+          Exception.class,
+          () -> validator.syncPublicKeyUrlsFromDiscovery(discoveryUri, authConfig));
     }
   }
 


### PR DESCRIPTION
### Describe your changes:

Fixes #28088

`publicKeyUrls` is a **derived** value for OIDC confidential clients — the UI hides the field (`SSO.constant.ts`) because it is meant to come from the IdP discovery document. But the backend only ever populated it *when it was empty*: both `OidcDiscoveryValidator.autoPopulatePublicKeyUrls` and `SystemRepository.autoPopulatePublicKeyUrlsIfNeeded` returned early if a value already existed.

So when an admin edits `discoveryUri`, the previously stored JWKS URL survives, and `CustomOidcValidator.validateJwksEndpoint` rejects the save:

```
publicKeyUrls must include the JWKS URI from discovery.
Expected: <new jwks_uri> but found: [<old jwks_uri>]
```

There is a second half to the bug: the edit flow goes through `PATCH /system/security/config`, which never called the auto-population at all. Even if validation had passed, the stale JWKS URL would have been persisted and broken token verification in `JwtFilter`/`MultiUrlJwkProvider`.

**Changes**

- `OidcDiscoveryValidator.syncPublicKeyUrlsFromDiscovery` (was `autoPopulatePublicKeyUrls`) and `SystemRepository.syncPublicKeyUrlsFromDiscovery` (was `autoPopulatePublicKeyUrlsIfNeeded`) now always re-derive `publicKeyUrls` from the discovery document instead of skipping when a value is present. Renamed so the "populate only if empty" guard is not reintroduced.
- The refresh is invoked from `SystemRepository.validateSecurityConfiguration`, the shared choke point for `PATCH /system/security/config` **and** `POST /system/security/validate` (the UI's "Test configuration" button hit the identical failure). `PUT /system/security/config` already called it.
- A discovery fetch failure is still logged and leaves the current value untouched, so a transient IdP outage cannot wipe a working configuration.
- Gating is unchanged: only OIDC providers with `clientType: confidential`. Public clients keep their user-editable `publicKeyUrls`.

This fixes the sibling providers too, not just Custom OIDC — Okta, Auth0, Azure and Cognito derive their expected JWKS URL from the domain/tenant and failed identically on a domain change.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change (3 files, one shared code path).

#
### Tests:

#### Use cases covered
- Admin updates `discoveryUri` on an existing OIDC confidential SSO config and saves — `publicKeyUrls` is re-derived from the new discovery document instead of failing validation against the old JWKS URL.
- Admin clicks "Test configuration" after changing `discoveryUri` — validation passes rather than reporting a stale-JWKS error.
- The IdP discovery endpoint is unreachable during a save — the previously working `publicKeyUrls` is preserved, and the underlying discovery error is surfaced by the existing validators.
- Public-client SSO configs are unaffected — `publicKeyUrls` stays user-editable and is never overwritten.

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Files updated: `openmetadata-service/src/test/java/org/openmetadata/service/security/auth/validator/OidcDiscoveryValidatorTest.java`
  - `testSyncPublicKeyUrls_ReplacesStaleUrlsWhenDiscoveryUriChanges` — the exact scenario from #28088. Verified RED before the fix: `expected: <[https://new-idp.example.com/keys]> but was: <[https://old-idp.example.com/keys]>`.
  - `testSyncPublicKeyUrls_KeepsExistingUrlsWhenDiscoveryFetchFails` — a failed discovery fetch must not wipe the stored value.
  - The obsolete `testAutoPopulatePublicKeyUrls_SkipWhenAlreadyPopulated` was replaced, since asserting the stale value survives *is* the bug.

```
mvn -pl openmetadata-service -Dtest='org.openmetadata.service.security.auth.validator.*Test,SystemRepository*Test' test
Tests run: 204, Failures: 0, Errors: 0, Skipped: 0
```

#### Backend integration tests
- [x] Not applicable — no API endpoint or contract changes; behaviour change is inside the existing security-config validate/save path.

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Not run against a live IdP — the change is on the server-side discovery path and is covered by the unit tests above, including a RED-then-GREEN check of the reported scenario. Reviewers with a Keycloak/Okta tenant can reproduce by editing `discoveryUri` under Settings → SSO on an existing confidential OIDC config and saving.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not needed — no schema changes.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing (`testSyncPublicKeyUrls_ReplacesStaleUrlsWhenDiscoveryUriChanges`, issue #28088).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
