### PR TITLE
Fixes #31893: Resolve single-token OpenLineage dataset names via namespace mapping

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/OpenLineageLineageResolutionIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/OpenLineageLineageResolutionIT.java
@@ -34,7 +34,10 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.SharedResourceLocks;
 import org.openmetadata.it.util.TestNamespace;
 import org.openmetadata.it.util.TestNamespaceExtension;
 import org.openmetadata.schema.entity.data.Database;
@@ -50,6 +53,8 @@ import org.openmetadata.sdk.fluent.LineageAPI;
 import org.openmetadata.sdk.fluent.OpenLineage;
 import org.openmetadata.sdk.fluent.Tables;
 import org.openmetadata.sdk.fluent.wrappers.FluentTable;
+import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.sdk.network.RequestOptions;
 
 /**
  * Integration tests for OpenLineage → lineage resolution.
@@ -66,6 +71,7 @@ import org.openmetadata.sdk.fluent.wrappers.FluentTable;
 public class OpenLineageLineageResolutionIT {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final String OPEN_LINEAGE_SETTINGS_TYPE = "openLineageSettings";
   private static final List<Column> DEFAULT_COLUMNS =
       List.of(
           new Column().withName("id").withDataType(ColumnDataType.BIGINT),
@@ -508,9 +514,139 @@ public class OpenLineageLineageResolutionIT {
         "Edge must not attach to the same-named table in another database");
   }
 
+  @Test
+  @Order(15)
+  @ResourceLock(
+      value = SharedResourceLocks.OPEN_LINEAGE_SETTINGS,
+      mode = ResourceAccessMode.READ_WRITE)
+  void bareTokenName_resolvesViaNamespaceMapping(TestNamespace ns) throws Exception {
+    String tableName = "ol_baretoken_input_" + uniqueSuffix();
+    String outputName = "ol_baretoken_output_" + uniqueSuffix();
+    String eventNamespace = "s3://ol-baretoken-" + uniqueSuffix();
+
+    Tables.create().name(tableName).inSchema(schemaFqn).withColumns(DEFAULT_COLUMNS).execute();
+    Tables.create().name(outputName).inSchema(schemaFqn).withColumns(DEFAULT_COLUMNS).execute();
+
+    String previousSettings = readOpenLineageSettings();
+    try {
+      writeOpenLineageNamespaceMapping(eventNamespace, serviceName);
+
+      // A single undelimited token: no dots, no slashes, no symlinks facet.
+      Map<String, Object> bareInput = Map.of("namespace", eventNamespace, "name", tableName);
+
+      String response =
+          OpenLineage.event()
+              .withEventType("COMPLETE")
+              .withEventTime(Instant.now().toString())
+              .withJob(ns.prefix("bare_token_job"), ns.prefix("namespace"))
+              .withRun(UUID.randomUUID().toString())
+              .addInput(bareInput)
+              .addOutput("ecommerce_db.shopify." + outputName, serviceName)
+              .send();
+
+      JsonNode json = MAPPER.readTree(response);
+      assertEquals("success", json.get("status").asText());
+      assertTrue(
+          json.get("lineageEdgesCreated").asInt() >= 1,
+          "A bare token whose namespace maps to a service should resolve, got: " + response);
+
+      assertNotNull(
+          fetchOpenLineageEdgeDetails(tableName, outputName),
+          "Edge resolved from a bare dataset name should exist between the test tables");
+    } finally {
+      restoreOpenLineageSettings(previousSettings);
+    }
+  }
+
+  @Test
+  @Order(16)
+  void bareTokenNameWithoutMapping_createsNoEdge(TestNamespace ns) throws Exception {
+    String tableName = "ol_baretoken_unmapped_" + uniqueSuffix();
+    String outputName = "ol_baretoken_unmapped_out_" + uniqueSuffix();
+    Tables.create().name(tableName).inSchema(schemaFqn).withColumns(DEFAULT_COLUMNS).execute();
+    Tables.create().name(outputName).inSchema(schemaFqn).withColumns(DEFAULT_COLUMNS).execute();
+
+    Map<String, Object> bareInput =
+        Map.of("namespace", "s3://ol-unmapped-" + uniqueSuffix(), "name", tableName);
+
+    String response =
+        OpenLineage.event()
+            .withEventType("COMPLETE")
+            .withEventTime(Instant.now().toString())
+            .withJob(ns.prefix("bare_token_unmapped_job"), ns.prefix("namespace"))
+            .withRun(UUID.randomUUID().toString())
+            .addInput(bareInput)
+            .addOutput("ecommerce_db.shopify." + outputName, serviceName)
+            .send();
+
+    JsonNode json = MAPPER.readTree(response);
+    assertEquals("success", json.get("status").asText());
+    assertEquals(
+        0,
+        json.get("lineageEdgesCreated").asInt(),
+        "An unmapped bare token must not be matched against the whole catalog by table name");
+  }
+
   // ====================================================================================
   // Helpers
   // ====================================================================================
+
+  /**
+   * There is no reset endpoint for openLineageSettings (only searchSettings supports reset), so the
+   * test has to capture and restore the value itself. Returns null when the setting has never been
+   * persisted.
+   */
+  private static String readOpenLineageSettings() {
+    try {
+      return SdkClients.adminClient()
+          .getHttpClient()
+          .executeForString(
+              HttpMethod.GET,
+              "/v1/system/settings/" + OPEN_LINEAGE_SETTINGS_TYPE,
+              null,
+              RequestOptions.builder().build());
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  private static void writeOpenLineageNamespaceMapping(String namespace, String serviceName)
+      throws Exception {
+    Map<String, Object> configValue =
+        Map.of(
+            "autoCreateEntities",
+            false,
+            "defaultPipelineService",
+            "OpenLineage",
+            "namespaceToServiceMapping",
+            Map.of(namespace, serviceName));
+    putOpenLineageSettings(
+        Map.of("config_type", OPEN_LINEAGE_SETTINGS_TYPE, "config_value", configValue));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void restoreOpenLineageSettings(String previousSettings) throws Exception {
+    Map<String, Object> configValue = new HashMap<>();
+    if (previousSettings != null && !previousSettings.isBlank()) {
+      JsonNode previous = MAPPER.readTree(previousSettings).path("config_value");
+      if (previous.isObject()) {
+        configValue = MAPPER.convertValue(previous, Map.class);
+      }
+    }
+    configValue.remove("namespaceToServiceMapping");
+    putOpenLineageSettings(
+        Map.of("config_type", OPEN_LINEAGE_SETTINGS_TYPE, "config_value", configValue));
+  }
+
+  private static void putOpenLineageSettings(Map<String, Object> body) throws Exception {
+    SdkClients.adminClient()
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.PUT,
+            "/v1/system/settings",
+            MAPPER.writeValueAsString(body),
+            RequestOptions.builder().build());
+  }
 
   private static String uniqueSuffix() {
     return UUID.randomUUID().toString().substring(0, 8);

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/util/SharedResourceLocks.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/util/SharedResourceLocks.java
@@ -2,6 +2,7 @@ package org.openmetadata.it.util;
 
 public final class SharedResourceLocks {
   public static final String GLOSSARY_TERM_RELATION_SETTINGS = "glossaryTermRelationSettings";
+  public static final String OPEN_LINEAGE_SETTINGS = "openLineageSettings";
   public static final String SEARCH_SETTINGS = "searchSettings";
   public static final String TABLE_COLUMN_CUSTOM_PROPERTIES = "customProperties:tableColumn";
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/openlineage/OpenLineageEntityResolver.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/openlineage/OpenLineageEntityResolver.java
@@ -225,23 +225,67 @@ public class OpenLineageEntityResolver {
   private String resolveTableFqn(String namespace, String datasetName, DatasetFacets facets) {
     List<DatasetCandidate> candidates =
         OpenLineageDatasetNameNormalizer.extractCandidates(namespace, datasetName, facets);
-    String result = null;
-    if (candidates.isEmpty()) {
-      LOG.warn(
-          "No parsable table identifier for dataset {} (namespace {}). "
-              + "Expected schema.table, catalog.schema.table, a Glue table/db/table symlink, or a Hive warehouse path",
-          datasetName,
-          namespace);
-    }
     String datasourceName = extractDatasourceName(facets);
+    String result = null;
     for (DatasetCandidate candidate : candidates) {
       result = resolveCandidateFqn(candidate.namespace(), datasourceName, candidate.tableName());
       if (result != null) {
         break;
       }
     }
-    if (result == null && !candidates.isEmpty()) {
+    if (result == null) {
+      result = resolveBareTokenViaNamespaceMapping(namespace, datasetName);
+    }
+    if (result == null) {
+      logUnresolvedDataset(namespace, datasetName, candidates);
+    }
+    return result;
+  }
+
+  private void logUnresolvedDataset(
+      String namespace, String datasetName, List<DatasetCandidate> candidates) {
+    if (!candidates.isEmpty()) {
       LOG.debug("Could not resolve dataset {} using candidates {}", datasetName, candidates);
+    } else if (bareToken(datasetName) != null) {
+      LOG.warn(
+          "Dataset {} (namespace {}) carries no schema, so it can only be matched by table name. "
+              + "Map this namespace to a service via namespaceToServiceMapping to enable that lookup",
+          datasetName,
+          namespace);
+    } else {
+      LOG.warn(
+          "No parsable table identifier for dataset {} (namespace {}). "
+              + "Expected schema.table, catalog.schema.table, a Glue table/db/table symlink, or a Hive warehouse path",
+          datasetName,
+          namespace);
+    }
+  }
+
+  /**
+   * Last resort for an identifier that carries no schema at all - a single bare token, which Spark
+   * emits for relations that miss the Glue/Iceberg symlink path. A table-name-only search is only
+   * defensible when the operator has declared which service the namespace belongs to, and only when
+   * it identifies exactly one table; matching the whole catalog on a bare name would pick an
+   * arbitrary same-named table from any database.
+   */
+  private String resolveBareTokenViaNamespaceMapping(String namespace, String datasetName) {
+    String result = null;
+    String table = bareToken(datasetName);
+    String mappedService = lookupServiceFromNamespace(namespace);
+    if (table != null && mappedService != null) {
+      result = searchUniqueTableByFqnPattern(mappedService + ".%." + table);
+    }
+    return result;
+  }
+
+  /** Returns the name when it is a single undelimited token, else null. */
+  private String bareToken(String datasetName) {
+    String result = null;
+    if (!nullOrEmpty(datasetName)) {
+      String trimmed = datasetName.trim();
+      if (!trimmed.isEmpty() && !trimmed.contains(".") && !trimmed.contains("/")) {
+        result = trimmed;
+      }
     }
     return result;
   }
@@ -333,19 +377,38 @@ public class OpenLineageEntityResolver {
   }
 
   private String searchTableByFilter(String searchKey, ListFilter filter) {
+    List<Table> tables = listTables(searchKey, filter);
     String result = null;
+    if (!tables.isEmpty()) {
+      result = tables.getFirst().getFullyQualifiedName();
+      warnOnAmbiguousMatch(searchKey, result, tables);
+    }
+    return result;
+  }
+
+  /** Resolves only an unambiguous match; a multi-match is dropped rather than guessed. */
+  private String searchUniqueTableByFqnPattern(String fqnPattern) {
+    List<Table> tables = listTables(fqnPattern, new ListFilterByFqnPattern(fqnPattern));
+    String result = null;
+    if (tables.size() == 1) {
+      result = tables.getFirst().getFullyQualifiedName();
+    } else if (tables.size() > 1) {
+      LOG.warn(
+          "Bare dataset name matched {} tables for [{}], dropping the edge rather than guessing. Candidates: {}",
+          tables.size(),
+          fqnPattern,
+          describeCandidates(tables));
+    }
+    return result;
+  }
+
+  private List<Table> listTables(String searchKey, ListFilter filter) {
+    List<Table> result = List.of();
     try {
       @SuppressWarnings("unchecked")
       EntityRepository<Table> tableRepository =
           (EntityRepository<Table>) Entity.getEntityRepository(Entity.TABLE);
-
-      List<Table> tables =
-          tableRepository.listAll(tableRepository.getFields("databaseSchema"), filter);
-
-      if (!tables.isEmpty()) {
-        result = tables.getFirst().getFullyQualifiedName();
-        warnOnAmbiguousMatch(searchKey, result, tables);
-      }
+      result = tableRepository.listAll(tableRepository.getFields("databaseSchema"), filter);
     } catch (Exception e) {
       LOG.debug("Error searching for table matching {}: {}", searchKey, e.getMessage());
     }
@@ -359,19 +422,22 @@ public class OpenLineageEntityResolver {
    */
   private void warnOnAmbiguousMatch(String searchKey, String resolved, List<Table> tables) {
     if (tables.size() > 1) {
-      String competing =
-          tables.stream()
-              .limit(MAX_LOGGED_AMBIGUOUS_MATCHES)
-              .map(Table::getFullyQualifiedName)
-              .collect(Collectors.joining(", "));
       LOG.warn(
-          "Ambiguous OpenLineage table match: {} tables match [{}], resolving to [{}]. Candidates: {}{}",
+          "Ambiguous OpenLineage table match: {} tables match [{}], resolving to [{}]. Candidates: {}",
           tables.size(),
           searchKey,
           resolved,
-          competing,
-          tables.size() > MAX_LOGGED_AMBIGUOUS_MATCHES ? ", …" : "");
+          describeCandidates(tables));
     }
+  }
+
+  private String describeCandidates(List<Table> tables) {
+    String listed =
+        tables.stream()
+            .limit(MAX_LOGGED_AMBIGUOUS_MATCHES)
+            .map(Table::getFullyQualifiedName)
+            .collect(Collectors.joining(", "));
+    return tables.size() > MAX_LOGGED_AMBIGUOUS_MATCHES ? listed + ", …" : listed;
   }
 
   private String extractDatasourceName(DatasetFacets facets) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/openlineage/OpenLineageEntityResolver.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/openlineage/OpenLineageEntityResolver.java
@@ -43,6 +43,7 @@ import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.jdbi3.EntityRepository;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.openlineage.OpenLineageDatasetNameNormalizer.DatasetCandidate;
+import org.openmetadata.service.util.LikeEscape;
 
 @Slf4j
 public class OpenLineageEntityResolver {
@@ -246,19 +247,15 @@ public class OpenLineageEntityResolver {
       String namespace, String datasetName, List<DatasetCandidate> candidates) {
     if (!candidates.isEmpty()) {
       LOG.debug("Could not resolve dataset {} using candidates {}", datasetName, candidates);
-    } else if (bareToken(datasetName) != null) {
-      LOG.warn(
-          "Dataset {} (namespace {}) carries no schema, so it can only be matched by table name. "
-              + "Map this namespace to a service via namespaceToServiceMapping to enable that lookup",
-          datasetName,
-          namespace);
-    } else {
+    } else if (bareToken(datasetName) == null) {
       LOG.warn(
           "No parsable table identifier for dataset {} (namespace {}). "
               + "Expected schema.table, catalog.schema.table, a Glue table/db/table symlink, or a Hive warehouse path",
           datasetName,
           namespace);
     }
+    // A bare token is reported by resolveBareTokenViaNamespaceMapping, which knows whether the
+    // namespace was mapped - logging it again here would advise a mapping the operator may have.
   }
 
   /**
@@ -269,13 +266,56 @@ public class OpenLineageEntityResolver {
    * arbitrary same-named table from any database.
    */
   private String resolveBareTokenViaNamespaceMapping(String namespace, String datasetName) {
-    String result = null;
     String table = bareToken(datasetName);
-    String mappedService = lookupServiceFromNamespace(namespace);
-    if (table != null && mappedService != null) {
-      result = searchUniqueTableByFqnPattern(mappedService + ".%." + table);
+    if (table == null) {
+      return null;
     }
-    return result;
+    String mappedService = lookupServiceFromNamespace(namespace);
+    if (mappedService == null) {
+      LOG.warn(
+          "Dataset {} (namespace {}) carries no schema, so it can only be matched by table name. "
+              + "Map this namespace to a service via namespaceToServiceMapping to enable that lookup",
+          datasetName,
+          namespace);
+      return null;
+    }
+    return resolveBareTokenInService(namespace, datasetName, table, mappedService);
+  }
+
+  private String resolveBareTokenInService(
+      String namespace, String datasetName, String table, String mappedService) {
+    String pattern = LikeEscape.escape(mappedService) + ".%." + LikeEscape.escape(table);
+    List<Table> matches = listTables(pattern, new ListFilterByFqnPattern(pattern, true));
+    if (matches.size() == 1) {
+      return matches.getFirst().getFullyQualifiedName();
+    }
+    logUnresolvedBareToken(namespace, datasetName, table, mappedService, matches);
+    return null;
+  }
+
+  private void logUnresolvedBareToken(
+      String namespace,
+      String datasetName,
+      String table,
+      String mappedService,
+      List<Table> matches) {
+    if (matches.isEmpty()) {
+      LOG.warn(
+          "Dataset {} (namespace {}) carries no schema and no table named {} exists in service {}",
+          datasetName,
+          namespace,
+          table,
+          mappedService);
+    } else {
+      LOG.warn(
+          "Bare dataset name {} (namespace {}) matched {} tables in service {}, dropping the edge "
+              + "rather than guessing. Candidates: {}",
+          datasetName,
+          namespace,
+          matches.size(),
+          mappedService,
+          describeCandidates(matches));
+    }
   }
 
   /** Returns the name when it is a single undelimited token, else null. */
@@ -382,22 +422,6 @@ public class OpenLineageEntityResolver {
     if (!tables.isEmpty()) {
       result = tables.getFirst().getFullyQualifiedName();
       warnOnAmbiguousMatch(searchKey, result, tables);
-    }
-    return result;
-  }
-
-  /** Resolves only an unambiguous match; a multi-match is dropped rather than guessed. */
-  private String searchUniqueTableByFqnPattern(String fqnPattern) {
-    List<Table> tables = listTables(fqnPattern, new ListFilterByFqnPattern(fqnPattern));
-    String result = null;
-    if (tables.size() == 1) {
-      result = tables.getFirst().getFullyQualifiedName();
-    } else if (tables.size() > 1) {
-      LOG.warn(
-          "Bare dataset name matched {} tables for [{}], dropping the edge rather than guessing. Candidates: {}",
-          tables.size(),
-          fqnPattern,
-          describeCandidates(tables));
     }
     return result;
   }
@@ -778,15 +802,22 @@ public class OpenLineageEntityResolver {
   }
 
   private static class ListFilterByFqnPattern extends ListFilter {
+    private final boolean usesEscapedLiterals;
+
     public ListFilterByFqnPattern(String pattern) {
+      this(pattern, false);
+    }
+
+    public ListFilterByFqnPattern(String pattern, boolean usesEscapedLiterals) {
       super(Include.NON_DELETED);
+      this.usesEscapedLiterals = usesEscapedLiterals;
       addQueryParam("fqnPattern", pattern);
     }
 
     @Override
     public String getCondition(String tableName) {
       String baseCondition = super.getCondition(tableName);
-      String fqnClause = buildFqnLikeClause(tableName, "fqnPattern");
+      String fqnClause = buildFqnLikeClause(tableName, "fqnPattern", usesEscapedLiterals);
       return baseCondition + " AND " + fqnClause;
     }
   }
@@ -818,13 +849,25 @@ public class OpenLineageEntityResolver {
   }
 
   private static String buildFqnLikeClause(String tableName, String paramName) {
+    return buildFqnLikeClause(tableName, paramName, false);
+  }
+
+  /**
+   * {@code ESCAPE} is spelled with {@code !} rather than a backslash because MySQL
+   * NO_BACKSLASH_ESCAPES and Postgres standard_conforming_strings make backslash handling
+   * deployment-dependent, while {@code !} is unremarkable to both parsers.
+   */
+  private static String buildFqnLikeClause(
+      String tableName, String paramName, boolean usesEscapedLiterals) {
     String column = tableName == null ? "json" : tableName + ".json";
+    String escapeClause = usesEscapedLiterals ? " ESCAPE '!'" : "";
     if (Boolean.TRUE.equals(
         org.openmetadata.service.resources.databases.DatasourceConfig.getInstance().isMySQL())) {
       return String.format(
-          "JSON_UNQUOTE(JSON_EXTRACT(%s, '$.fullyQualifiedName')) LIKE :%s", column, paramName);
+          "JSON_UNQUOTE(JSON_EXTRACT(%s, '$.fullyQualifiedName')) LIKE :%s%s",
+          column, paramName, escapeClause);
     } else {
-      return String.format("%s->>'fullyQualifiedName' LIKE :%s", column, paramName);
+      return String.format("%s->>'fullyQualifiedName' LIKE :%s%s", column, paramName, escapeClause);
     }
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/openlineage/OpenLineageEntityResolverTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/openlineage/OpenLineageEntityResolverTest.java
@@ -2216,6 +2216,169 @@ class OpenLineageEntityResolverTest {
     }
   }
 
+  @Test
+  void resolveTable_bareTokenWithNamespaceMapping_resolvesUniqueTable() {
+    OpenLineageEntityResolver resolver =
+        new OpenLineageEntityResolver(
+            false, "openlineage", Map.of("s3://data-dev-datalake", "aws_glue_catalog_dev"));
+
+    OpenLineageInputDataset dataset =
+        new OpenLineageInputDataset()
+            .withNamespace("s3://data-dev-datalake")
+            .withName("retail_customers");
+
+    String expectedFqn = "aws_glue_catalog_dev.048372910264.data_dev_main.retail_customers";
+
+    @SuppressWarnings("unchecked")
+    EntityRepository<Table> mockTableRepo = mock(EntityRepository.class);
+    Fields mockFields = mock(Fields.class);
+
+    Table table = new Table();
+    table.setId(UUID.randomUUID());
+    table.setName("retail_customers");
+    table.setFullyQualifiedName(expectedFqn);
+
+    EntityReference expectedRef =
+        new EntityReference()
+            .withId(UUID.randomUUID())
+            .withType("table")
+            .withFullyQualifiedName(expectedFqn);
+
+    try (MockedStatic<Entity> mockedEntity = mockStatic(Entity.class)) {
+      mockedEntity.when(() -> Entity.getEntityRepository(Entity.TABLE)).thenReturn(mockTableRepo);
+      when(mockTableRepo.getFields(anyString())).thenReturn(mockFields);
+      when(mockTableRepo.listAll(any(Fields.class), any()))
+          .thenAnswer(
+              invocation -> {
+                org.openmetadata.service.jdbi3.ListFilter filter = invocation.getArgument(1);
+                String pattern = filter.getQueryParam("fqnPattern");
+                if ("aws_glue_catalog_dev.%.retail_customers".equals(pattern)) {
+                  return List.of(table);
+                }
+                return List.of();
+              });
+      mockedEntity
+          .when(
+              () ->
+                  Entity.getEntityReferenceByName(
+                      eq(Entity.TABLE), eq(expectedFqn), eq(Include.NON_DELETED)))
+          .thenReturn(expectedRef);
+
+      EntityReference result = resolver.resolveTable(dataset);
+
+      assertNotNull(
+          result,
+          "A single bare token must resolve by table name alone when its namespace maps to a "
+              + "service and exactly one table matches");
+      assertEquals(expectedFqn, result.getFullyQualifiedName());
+    }
+  }
+
+  @Test
+  void resolveTable_bareTokenAmbiguous_returnsNullAndWarns() {
+    Logger resolverLogger = (Logger) LoggerFactory.getLogger(OpenLineageEntityResolver.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    resolverLogger.addAppender(appender);
+
+    try {
+      OpenLineageEntityResolver resolver =
+          new OpenLineageEntityResolver(
+              false, "openlineage", Map.of("s3://data-dev-datalake", "aws_glue_catalog_dev"));
+
+      OpenLineageInputDataset dataset =
+          new OpenLineageInputDataset()
+              .withNamespace("s3://data-dev-datalake")
+              .withName("retail_customers");
+
+      String firstFqn = "aws_glue_catalog_dev.048372910264.data_dev_main.retail_customers";
+      String secondFqn = "aws_glue_catalog_dev.048372910264.data_dev_raw.retail_customers";
+
+      @SuppressWarnings("unchecked")
+      EntityRepository<Table> mockTableRepo = mock(EntityRepository.class);
+      Fields mockFields = mock(Fields.class);
+
+      Table first = new Table();
+      first.setId(UUID.randomUUID());
+      first.setName("retail_customers");
+      first.setFullyQualifiedName(firstFqn);
+
+      Table second = new Table();
+      second.setId(UUID.randomUUID());
+      second.setName("retail_customers");
+      second.setFullyQualifiedName(secondFqn);
+
+      try (MockedStatic<Entity> mockedEntity = mockStatic(Entity.class)) {
+        mockedEntity.when(() -> Entity.getEntityRepository(Entity.TABLE)).thenReturn(mockTableRepo);
+        when(mockTableRepo.getFields(anyString())).thenReturn(mockFields);
+        when(mockTableRepo.listAll(any(Fields.class), any())).thenReturn(List.of(first, second));
+
+        assertNull(
+            resolver.resolveTable(dataset),
+            "A bare token matching more than one table must be dropped, not guessed - picking one "
+                + "arbitrarily is the failure mode issue #31841 fixed");
+      }
+
+      String warnings =
+          appender.list.stream()
+              .filter(event -> event.getLevel() == Level.WARN)
+              .map(ILoggingEvent::getFormattedMessage)
+              .collect(java.util.stream.Collectors.joining("\n"));
+
+      assertTrue(
+          warnings.contains(firstFqn) && warnings.contains(secondFqn),
+          "Dropping an ambiguous bare token must name the competing FQNs, got: " + warnings);
+    } finally {
+      resolverLogger.detachAppender(appender);
+      appender.stop();
+    }
+  }
+
+  @Test
+  void resolveTable_bareTokenWithoutNamespaceMapping_neverSearchesCatalogWide() {
+    OpenLineageEntityResolver resolver = new OpenLineageEntityResolver(false, "openlineage");
+
+    OpenLineageInputDataset dataset =
+        new OpenLineageInputDataset()
+            .withNamespace("s3://data-dev-datalake")
+            .withName("retail_customers");
+
+    String someFqn = "some_other_service.db.schema.retail_customers";
+
+    @SuppressWarnings("unchecked")
+    EntityRepository<Table> mockTableRepo = mock(EntityRepository.class);
+    Fields mockFields = mock(Fields.class);
+
+    Table table = new Table();
+    table.setId(UUID.randomUUID());
+    table.setName("retail_customers");
+    table.setFullyQualifiedName(someFqn);
+
+    EntityReference ref =
+        new EntityReference()
+            .withId(UUID.randomUUID())
+            .withType("table")
+            .withFullyQualifiedName(someFqn);
+
+    try (MockedStatic<Entity> mockedEntity = mockStatic(Entity.class)) {
+      mockedEntity.when(() -> Entity.getEntityRepository(Entity.TABLE)).thenReturn(mockTableRepo);
+      when(mockTableRepo.getFields(anyString())).thenReturn(mockFields);
+      // Any lookup at all would match, so a non-null result proves an unscoped search ran.
+      when(mockTableRepo.listAll(any(Fields.class), any())).thenReturn(List.of(table));
+      mockedEntity
+          .when(
+              () ->
+                  Entity.getEntityReferenceByName(
+                      eq(Entity.TABLE), eq(someFqn), eq(Include.NON_DELETED)))
+          .thenReturn(ref);
+
+      assertNull(
+          resolver.resolveTable(dataset),
+          "Without a namespace-to-service mapping, a bare token must not be matched against the "
+              + "whole catalog by table name");
+    }
+  }
+
   // Helper method to test data type mapping
   // This replicates the logic in OpenLineageEntityResolver.mapDataType
   private ColumnDataType mapTestDataType(String olType) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/openlineage/OpenLineageEntityResolverTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/openlineage/OpenLineageEntityResolverTest.java
@@ -29,6 +29,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.openmetadata.schema.api.lineage.openlineage.DatasetFacets;
@@ -51,6 +53,7 @@ import org.openmetadata.schema.type.Include;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.jdbi3.EntityRepository;
+import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.util.EntityUtil.Fields;
 import org.slf4j.LoggerFactory;
 
@@ -1388,7 +1391,7 @@ class OpenLineageEntityResolverTest {
       when(mockTableRepo.listAll(any(Fields.class), any()))
           .thenAnswer(
               invocation -> {
-                org.openmetadata.service.jdbi3.ListFilter filter = invocation.getArgument(1);
+                ListFilter filter = invocation.getArgument(1);
                 // Invoke getCondition to cover lines 707-709 and 753-761
                 String condition = filter.getCondition("entity_table");
                 assertNotNull(condition);
@@ -1424,7 +1427,7 @@ class OpenLineageEntityResolverTest {
       when(mockTableRepo.listAll(any(Fields.class), any()))
           .thenAnswer(
               invocation -> {
-                org.openmetadata.service.jdbi3.ListFilter filter = invocation.getArgument(1);
+                ListFilter filter = invocation.getArgument(1);
                 // Invoke getCondition to cover lines 721-723
                 String condition = filter.getCondition("entity_table");
                 assertNotNull(condition);
@@ -1456,7 +1459,7 @@ class OpenLineageEntityResolverTest {
       when(mockContainerRepo.listAll(any(Fields.class), any()))
           .thenAnswer(
               invocation -> {
-                org.openmetadata.service.jdbi3.ListFilter filter = invocation.getArgument(1);
+                ListFilter filter = invocation.getArgument(1);
                 // Invoke getCondition to cover lines 738-749
                 String condition = filter.getCondition("container_entity");
                 assertNotNull(condition);
@@ -1487,7 +1490,7 @@ class OpenLineageEntityResolverTest {
       when(mockContainerRepo.listAll(any(Fields.class), any()))
           .thenAnswer(
               invocation -> {
-                org.openmetadata.service.jdbi3.ListFilter filter = invocation.getArgument(1);
+                ListFilter filter = invocation.getArgument(1);
                 // Call with null tableName to cover the null branch in getCondition
                 String condition = filter.getCondition(null);
                 assertNotNull(condition);
@@ -1541,7 +1544,7 @@ class OpenLineageEntityResolverTest {
       when(mockTableRepo.listAll(any(Fields.class), any()))
           .thenAnswer(
               invocation -> {
-                org.openmetadata.service.jdbi3.ListFilter filter = invocation.getArgument(1);
+                ListFilter filter = invocation.getArgument(1);
                 String suffix = filter.getQueryParam("fqnSuffix");
                 if (suffix != null && suffix.endsWith("db_refined_55586.dr_564_pdudrik_3829")) {
                   return List.of(foundTable);
@@ -1606,7 +1609,7 @@ class OpenLineageEntityResolverTest {
       when(mockTableRepo.listAll(any(Fields.class), any()))
           .thenAnswer(
               invocation -> {
-                org.openmetadata.service.jdbi3.ListFilter filter = invocation.getArgument(1);
+                ListFilter filter = invocation.getArgument(1);
                 String suffix = filter.getQueryParam("fqnSuffix");
                 if (suffix != null && suffix.endsWith("public.users")) {
                   return List.of(foundTable);
@@ -1679,7 +1682,7 @@ class OpenLineageEntityResolverTest {
       when(mockTableRepo.listAll(any(Fields.class), any()))
           .thenAnswer(
               invocation -> {
-                org.openmetadata.service.jdbi3.ListFilter filter = invocation.getArgument(1);
+                ListFilter filter = invocation.getArgument(1);
                 String suffix = filter.getQueryParam("fqnSuffix");
                 if (suffix != null && suffix.endsWith("catalog_b.sales.orders")) {
                   return List.of(rightTable);
@@ -1762,7 +1765,7 @@ class OpenLineageEntityResolverTest {
       when(mockTableRepo.listAll(any(Fields.class), any()))
           .thenAnswer(
               invocation -> {
-                org.openmetadata.service.jdbi3.ListFilter filter = invocation.getArgument(1);
+                ListFilter filter = invocation.getArgument(1);
                 String pattern = filter.getQueryParam("fqnPattern");
                 if (pattern != null && pattern.equals("databricks_svc.catalog_b.sales.orders")) {
                   return List.of(rightTable);
@@ -1833,7 +1836,7 @@ class OpenLineageEntityResolverTest {
       when(mockTableRepo.listAll(any(Fields.class), any()))
           .thenAnswer(
               invocation -> {
-                org.openmetadata.service.jdbi3.ListFilter filter = invocation.getArgument(1);
+                ListFilter filter = invocation.getArgument(1);
                 String pattern = filter.getQueryParam("fqnPattern");
                 if (pattern != null && pattern.startsWith("athena_svc")) {
                   return List.of(foundTable);
@@ -1888,7 +1891,7 @@ class OpenLineageEntityResolverTest {
       when(mockTableRepo.listAll(any(Fields.class), any()))
           .thenAnswer(
               invocation -> {
-                org.openmetadata.service.jdbi3.ListFilter filter = invocation.getArgument(1);
+                ListFilter filter = invocation.getArgument(1);
                 String suffix = filter.getQueryParam("fqnSuffix");
                 if (suffix != null && suffix.endsWith("db_refined_55586.dr_564_pdudrik_3829")) {
                   return List.of(foundTable);
@@ -1959,7 +1962,7 @@ class OpenLineageEntityResolverTest {
       when(mockSchemaRepo.listAll(any(Fields.class), any()))
           .thenAnswer(
               invocation -> {
-                org.openmetadata.service.jdbi3.ListFilter filter = invocation.getArgument(1);
+                ListFilter filter = invocation.getArgument(1);
                 String suffix = filter.getQueryParam("fqnSuffix");
                 if (suffix != null && suffix.endsWith("catalog_b.sales")) {
                   return List.of(rightSchema);
@@ -2044,7 +2047,7 @@ class OpenLineageEntityResolverTest {
       when(mockTableRepo.listAll(any(Fields.class), any()))
           .thenAnswer(
               invocation -> {
-                org.openmetadata.service.jdbi3.ListFilter filter = invocation.getArgument(1);
+                ListFilter filter = invocation.getArgument(1);
                 String suffix = filter.getQueryParam("fqnSuffix");
                 if ("%048372910264.data_dev_db_main.fact_adt_event_v2".equals(suffix)) {
                   return List.of(glueTable);
@@ -2122,7 +2125,7 @@ class OpenLineageEntityResolverTest {
       when(mockTableRepo.listAll(any(Fields.class), any()))
           .thenAnswer(
               invocation -> {
-                org.openmetadata.service.jdbi3.ListFilter filter = invocation.getArgument(1);
+                ListFilter filter = invocation.getArgument(1);
                 String suffix = filter.getQueryParam("fqnSuffix");
                 if ("%data_dev_db_main.fact_adt_event_v2".equals(suffix)) {
                   return List.of(namedDbTable);
@@ -2203,7 +2206,7 @@ class OpenLineageEntityResolverTest {
           appender.list.stream()
               .filter(event -> event.getLevel() == Level.WARN)
               .map(ILoggingEvent::getFormattedMessage)
-              .collect(java.util.stream.Collectors.joining("\n"));
+              .collect(Collectors.joining("\n"));
 
       assertTrue(
           warnings.contains(firstFqn) && warnings.contains(secondFqn),
@@ -2248,15 +2251,7 @@ class OpenLineageEntityResolverTest {
       mockedEntity.when(() -> Entity.getEntityRepository(Entity.TABLE)).thenReturn(mockTableRepo);
       when(mockTableRepo.getFields(anyString())).thenReturn(mockFields);
       when(mockTableRepo.listAll(any(Fields.class), any()))
-          .thenAnswer(
-              invocation -> {
-                org.openmetadata.service.jdbi3.ListFilter filter = invocation.getArgument(1);
-                String pattern = filter.getQueryParam("fqnPattern");
-                if ("aws_glue_catalog_dev.%.retail_customers".equals(pattern)) {
-                  return List.of(table);
-                }
-                return List.of();
-              });
+          .thenAnswer(invocation -> matchLike(List.of(table), invocation.getArgument(1)));
       mockedEntity
           .when(
               () ->
@@ -2323,7 +2318,7 @@ class OpenLineageEntityResolverTest {
           appender.list.stream()
               .filter(event -> event.getLevel() == Level.WARN)
               .map(ILoggingEvent::getFormattedMessage)
-              .collect(java.util.stream.Collectors.joining("\n"));
+              .collect(Collectors.joining("\n"));
 
       assertTrue(
           warnings.contains(firstFqn) && warnings.contains(secondFqn),
@@ -2377,6 +2372,245 @@ class OpenLineageEntityResolverTest {
           "Without a namespace-to-service mapping, a bare token must not be matched against the "
               + "whole catalog by table name");
     }
+  }
+
+  @Test
+  void resolveTable_bareTokenWithUnderscore_doesNotMatchWildcardSibling() {
+    OpenLineageEntityResolver resolver =
+        new OpenLineageEntityResolver(
+            false, "openlineage", Map.of("s3://data-dev-datalake", "aws_glue_catalog_dev"));
+
+    OpenLineageInputDataset dataset =
+        new OpenLineageInputDataset()
+            .withNamespace("s3://data-dev-datalake")
+            .withName("retail_customers");
+
+    String expectedFqn = "aws_glue_catalog_dev.048372910264.data_dev_main.retail_customers";
+    String siblingFqn = "aws_glue_catalog_dev.048372910264.data_dev_main.retail-customers";
+
+    @SuppressWarnings("unchecked")
+    EntityRepository<Table> mockTableRepo = mock(EntityRepository.class);
+    Fields mockFields = mock(Fields.class);
+
+    List<Table> catalog = List.of(tableWithFqn(expectedFqn), tableWithFqn(siblingFqn));
+
+    EntityReference expectedRef =
+        new EntityReference()
+            .withId(UUID.randomUUID())
+            .withType("table")
+            .withFullyQualifiedName(expectedFqn);
+
+    try (MockedStatic<Entity> mockedEntity = mockStatic(Entity.class)) {
+      mockedEntity.when(() -> Entity.getEntityRepository(Entity.TABLE)).thenReturn(mockTableRepo);
+      when(mockTableRepo.getFields(anyString())).thenReturn(mockFields);
+      when(mockTableRepo.listAll(any(Fields.class), any()))
+          .thenAnswer(invocation -> matchLike(catalog, invocation.getArgument(1)));
+      mockedEntity
+          .when(
+              () ->
+                  Entity.getEntityReferenceByName(
+                      eq(Entity.TABLE), eq(expectedFqn), eq(Include.NON_DELETED)))
+          .thenReturn(expectedRef);
+
+      EntityReference result = resolver.resolveTable(dataset);
+
+      assertNotNull(
+          result,
+          "Underscores in a bare table name are SQL LIKE wildcards unless escaped, so an "
+              + "unrelated sibling named retail-customers turns a unique match into an ambiguous "
+              + "one and silently drops a valid edge");
+      assertEquals(expectedFqn, result.getFullyQualifiedName());
+    }
+  }
+
+  @Test
+  void resolveTable_bareTokenAmbiguous_doesNotAdviseAddingAnExistingMapping() {
+    Logger resolverLogger = (Logger) LoggerFactory.getLogger(OpenLineageEntityResolver.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    resolverLogger.addAppender(appender);
+
+    try {
+      OpenLineageEntityResolver resolver =
+          new OpenLineageEntityResolver(
+              false, "openlineage", Map.of("s3://data-dev-datalake", "aws_glue_catalog_dev"));
+
+      OpenLineageInputDataset dataset =
+          new OpenLineageInputDataset()
+              .withNamespace("s3://data-dev-datalake")
+              .withName("customers");
+
+      @SuppressWarnings("unchecked")
+      EntityRepository<Table> mockTableRepo = mock(EntityRepository.class);
+      Fields mockFields = mock(Fields.class);
+
+      try (MockedStatic<Entity> mockedEntity = mockStatic(Entity.class)) {
+        mockedEntity.when(() -> Entity.getEntityRepository(Entity.TABLE)).thenReturn(mockTableRepo);
+        when(mockTableRepo.getFields(anyString())).thenReturn(mockFields);
+        when(mockTableRepo.listAll(any(Fields.class), any()))
+            .thenReturn(
+                List.of(
+                    tableWithFqn("aws_glue_catalog_dev.048372910264.main.customers"),
+                    tableWithFqn("aws_glue_catalog_dev.048372910264.raw.customers")));
+
+        assertNull(resolver.resolveTable(dataset));
+      }
+
+      String warnings = warnMessages(appender);
+
+      assertEquals(
+          1,
+          appender.list.stream().filter(event -> event.getLevel() == Level.WARN).count(),
+          "An ambiguous mapped lookup must emit one actionable warning");
+      assertFalse(
+          warnings.contains("namespaceToServiceMapping"),
+          "The namespace is already mapped - telling the operator to map it contradicts the "
+              + "ambiguity warning emitted moments earlier, got: "
+              + warnings);
+      assertTrue(
+          warnings.contains("aws_glue_catalog_dev"),
+          "An ambiguous bare token must name the service that was searched, got: " + warnings);
+    } finally {
+      resolverLogger.detachAppender(appender);
+      appender.stop();
+    }
+  }
+
+  @Test
+  void resolveTable_bareTokenMappedButMissing_warnsWithoutTheMappingRemedy() {
+    Logger resolverLogger = (Logger) LoggerFactory.getLogger(OpenLineageEntityResolver.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    resolverLogger.addAppender(appender);
+
+    try {
+      OpenLineageEntityResolver resolver =
+          new OpenLineageEntityResolver(
+              false, "openlineage", Map.of("s3://data-dev-datalake", "aws_glue_catalog_dev"));
+
+      OpenLineageInputDataset dataset =
+          new OpenLineageInputDataset()
+              .withNamespace("s3://data-dev-datalake")
+              .withName("customers");
+
+      @SuppressWarnings("unchecked")
+      EntityRepository<Table> mockTableRepo = mock(EntityRepository.class);
+      Fields mockFields = mock(Fields.class);
+
+      try (MockedStatic<Entity> mockedEntity = mockStatic(Entity.class)) {
+        mockedEntity.when(() -> Entity.getEntityRepository(Entity.TABLE)).thenReturn(mockTableRepo);
+        when(mockTableRepo.getFields(anyString())).thenReturn(mockFields);
+        when(mockTableRepo.listAll(any(Fields.class), any())).thenReturn(List.of());
+
+        assertNull(resolver.resolveTable(dataset));
+      }
+
+      String warnings = warnMessages(appender);
+
+      assertFalse(
+          warnings.contains("namespaceToServiceMapping"),
+          "The mapping exists and the lookup ran - the remedy hint is wrong here, got: "
+              + warnings);
+      assertTrue(
+          warnings.contains("aws_glue_catalog_dev") && warnings.contains("customers"),
+          "A mapped namespace with no matching table must report the table and service it "
+              + "searched, got: "
+              + warnings);
+    } finally {
+      resolverLogger.detachAppender(appender);
+      appender.stop();
+    }
+  }
+
+  @Test
+  void resolveTable_bareTokenWithoutMapping_advisesAddingAMapping() {
+    Logger resolverLogger = (Logger) LoggerFactory.getLogger(OpenLineageEntityResolver.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    resolverLogger.addAppender(appender);
+
+    try {
+      OpenLineageEntityResolver resolver = new OpenLineageEntityResolver(false, "openlineage");
+
+      OpenLineageInputDataset dataset =
+          new OpenLineageInputDataset()
+              .withNamespace("s3://data-dev-datalake")
+              .withName("customers");
+
+      @SuppressWarnings("unchecked")
+      EntityRepository<Table> mockTableRepo = mock(EntityRepository.class);
+      Fields mockFields = mock(Fields.class);
+
+      try (MockedStatic<Entity> mockedEntity = mockStatic(Entity.class)) {
+        mockedEntity.when(() -> Entity.getEntityRepository(Entity.TABLE)).thenReturn(mockTableRepo);
+        when(mockTableRepo.getFields(anyString())).thenReturn(mockFields);
+        when(mockTableRepo.listAll(any(Fields.class), any())).thenReturn(List.of());
+
+        assertNull(resolver.resolveTable(dataset));
+      }
+
+      assertTrue(
+          warnMessages(appender).contains("namespaceToServiceMapping"),
+          "An unmapped bare token is only resolvable once the operator declares the namespace, so "
+              + "that remedy must stay in the log");
+    } finally {
+      resolverLogger.detachAppender(appender);
+      appender.stop();
+    }
+  }
+
+  private static Table tableWithFqn(String fqn) {
+    Table table = new Table();
+    table.setId(UUID.randomUUID());
+    table.setName(fqn.substring(fqn.lastIndexOf('.') + 1));
+    table.setFullyQualifiedName(fqn);
+    return table;
+  }
+
+  private static String warnMessages(ListAppender<ILoggingEvent> appender) {
+    return appender.list.stream()
+        .filter(event -> event.getLevel() == Level.WARN)
+        .map(ILoggingEvent::getFormattedMessage)
+        .collect(Collectors.joining("\n"));
+  }
+
+  /**
+   * Applies the SQL LIKE semantics the resolver relies on, so a test can tell an escaped literal
+   * from an accidental wildcard. Mirrors the {@code ESCAPE '!'} clause the resolver emits.
+   */
+  private static List<Table> matchLike(List<Table> catalog, ListFilter filter) {
+    String pattern = filter.getQueryParam("fqnPattern");
+    if (pattern == null) {
+      pattern = filter.getQueryParam("fqnSuffix");
+    }
+    if (pattern == null) {
+      return List.of();
+    }
+    boolean usesBangEscape = filter.getCondition("entity_table").contains(" ESCAPE '!'");
+    String regex = likePatternToRegex(pattern, usesBangEscape);
+    return catalog.stream()
+        .filter(table -> table.getFullyQualifiedName().matches(regex))
+        .collect(Collectors.toList());
+  }
+
+  private static String likePatternToRegex(String pattern, boolean usesBangEscape) {
+    StringBuilder regex = new StringBuilder();
+    boolean escaped = false;
+    for (char c : pattern.toCharArray()) {
+      if (escaped) {
+        regex.append(Pattern.quote(String.valueOf(c)));
+        escaped = false;
+      } else if (usesBangEscape && c == '!') {
+        escaped = true;
+      } else if (c == '%') {
+        regex.append(".*");
+      } else if (c == '_') {
+        regex.append('.');
+      } else {
+        regex.append(Pattern.quote(String.valueOf(c)));
+      }
+    }
+    return regex.toString();
   }
 
   // Helper method to test data type mapping


### PR DESCRIPTION
### Describe your changes:

Fixes #31893

> **#32385 has landed** (commit `095c09f` on `main`), so this PR is now rebased onto `main` and targets `main` directly; the diff contains only the bare-token change.

Spark emits a bare, undelimited dataset name (no `.`, no `/`, no `symlinks` facet) for relations that miss the Glue/Iceberg symlink code path. No candidate parses from such a name, so `resolveTableFqn` gave up before issuing any lookup and the edge was silently dropped even when exactly one matching table existed. I added a table-name-only fallback, but deliberately **narrower than the issue requests** — see the design note below, since that's the main review decision here.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

The issue asks for an unconditional `%.<table>` suffix search accepting `tables.getFirst()`. I did not implement that: a bare table name matches every same-named table in every service, database and schema in the catalog, and `listAll` orders by `(name, id)` — so with more than one match the pick is effectively by UUID. That is precisely the arbitrary-resolution failure mode #31841 / #32385 fixes, and applying it here would reintroduce it one layer up.

Instead the fallback is gated twice:
1. **The namespace must map to a service** via the existing `namespaceToServiceMapping` setting. An operator declaring "events from this namespace belong to service X" is what makes a name-only match defensible, and it bounds the search to `service.%.<table>`.
2. **The match must be unique.** `searchUniqueTableByFqnPattern` resolves only on exactly one hit; a multi-match logs the competing FQNs and drops the edge rather than guessing.

An unmapped bare token therefore still resolves nothing — but it now emits a warning naming the remedy ("map this namespace to a service via namespaceToServiceMapping") instead of the misleading "no parsable table identifier", which addresses the issue's actual complaint that these gaps are silent. `resolveTableFqn` was also restructured so the failure log fires only when resolution genuinely failed, rather than warning up-front and then succeeding.

Two notes on the issue's repro data, for the record: the sample dataset name (`retail_customers_staging`) and the sample table FQN (`…data_dev_main.retail_customers`) are different names, so a name-only search would not have matched that specific pair either way; and `OpenLineageMapper` already falls back to `resolveContainer` for storage namespaces, so the edge is only fully dropped when no matching Container exists either.

#
### Tests:

#### Use cases covered
- A bare dataset name whose namespace maps to a service, matching exactly one table → edge resolves.
- The same bare name matching two tables in different schemas → no edge, warning names both FQNs.
- A bare name whose namespace is **not** mapped → no edge, even though a same-named table exists elsewhere in the catalog.

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- File updated: `openmetadata-service/src/test/java/org/openmetadata/service/openlineage/OpenLineageEntityResolverTest.java`
- 3 tests added: `resolveTable_bareTokenWithNamespaceMapping_resolvesUniqueTable`, `resolveTable_bareTokenAmbiguous_returnsNullAndWarns`, `resolveTable_bareTokenWithoutNamespaceMapping_neverSearchesCatalogWide`. The first two fail before the change; the third is a guard that must stay green — it mocks the repository so that *any* lookup would match, so a non-null result would prove an unscoped search ran.
- `mvn test -pl openmetadata-service -Dtest='OpenLineage*Test'` → 121 tests, 0 failures.

#### Backend integration tests
- [x] I added integration tests in `openmetadata-integration-tests/`.
- File updated: `openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/OpenLineageLineageResolutionIT.java`
- `bareTokenName_resolvesViaNamespaceMapping` sets `namespaceToServiceMapping` through `/v1/system/settings`, posts a bare-token event, and asserts the edge; `bareTokenNameWithoutMapping_createsNoEdge` asserts `lineageEdgesCreated == 0` without a mapping. These are the only tests that exercise the real SQL `LIKE` behaviour of the `service.%.<table>` pattern, which the unit tests mock away.
- The settings mutation is captured and restored in a `finally` (there is no reset endpoint for `openLineageSettings` — only `searchSettings` supports reset) and guarded by a new `SharedResourceLocks.OPEN_LINEAGE_SETTINGS` lock.
- Compiles; not executed here (needs a live stack).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
None — server-side resolution path, covered by the unit tests above including two that fail before the change. Reproducing by hand needs a Spark job emitting an unqualified relation name plus a configured namespace mapping.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable — no schema changes (`namespaceToServiceMapping` already exists in `openLineageSettings.json`).
- [x] For UI changes: not applicable — no UI changes.
- [x] I have added tests (unit / integration as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing (`resolveTable_bareTokenWithNamespaceMapping_resolvesUniqueTable`, issue #31893).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
