### PR TITLE
refactor(ui): remove dangerouslySetInnerHTML from SearchDropdown label

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.tsx
@@ -21,6 +21,8 @@ import {
   ValueSource,
 } from '@react-awesome-query-builder/antd';
 import { Button, Checkbox, MenuProps, Radio, Space, Typography } from 'antd';
+import DOMPurify from 'dompurify';
+import parse from 'html-react-parser';
 import { isArray, isEmpty } from 'lodash';
 import React from 'react';
 import { ReactComponent as IconDeleteColored } from '../assets/svg/ic-delete-colored.svg';
@@ -130,11 +132,11 @@ export const generateSearchDropdownLabel = (
             ellipsis
             className="dropdown-option-label"
             title={option.label}>
-            <span
-              dangerouslySetInnerHTML={{
-                __html: getSearchLabel(option.label, searchKey),
-              }}
-            />
+            <span>
+              {parse(
+                DOMPurify.sanitize(getSearchLabel(option.label, searchKey))
+              )}
+            </span>
           </Typography.Text>
           {option.description && (
             <Typography.Text


### PR DESCRIPTION
### Describe your changes:

Render the search-dropdown option label via `html-react-parser` on a `DOMPurify.sanitize`d string instead of setting `innerHTML` directly, so the highlighted `<mark>` output is inserted through React nodes rather than a raw HTML string. Backport of the same hunk in #32087 to `1.13`.

#
### Type of change:
- [x] Improvement

#
### Tests:

#### Manual testing performed
- Opened Explore page → clicked several quick filter dropdowns (Service, Owner, Tag, Column) → labels render identically to before, `<mark>` highlight still applied when the search input matches.