### PR TITLE
fix(mssql): read descriptions from the right database, honour encryption per driver, bound query timeouts

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/mssql/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/connection.py
@@ -15,9 +15,11 @@ Source connection handler
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
 from sqlalchemy.engine import Engine
+from sqlalchemy.event import listen
 
 from metadata.core.connections.test_connection import ErrorPack, Matchers, check, when
 from metadata.core.connections.test_connection.checks.database import (
@@ -39,6 +41,7 @@ from metadata.ingestion.connections.builders import (
     create_generic_db_connection,
     get_connection_args_common,
     get_connection_url_common,
+    init_empty_connection_arguments,
 )
 from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.source.database.azuresql.connection import (
@@ -121,10 +124,56 @@ SQLSERVER_ERRORS = ErrorPack(
 MSSQL_ERRORS = SQLSERVER_ERRORS.including(NETWORK_ERRORS)
 
 
+# A hung read otherwise stalls a workflow forever: pytds and pymssql default to
+# no socket timeout at all and pyodbc to no query timeout, and the shared engine
+# builder sets neither. Ten minutes is well past any healthy catalogue or
+# query-log read, and mirrors how Snowflake bounds its own socket. User-supplied
+# connectionArguments win.
+DEFAULT_QUERY_TIMEOUT_SECONDS = 600
+
+
 def get_connection_url(connection: MssqlConnectionConfig) -> str:
-    if connection.scheme.value == connection.scheme.mssql_pyodbc.value:
+    if uses_pyodbc(connection):
         return get_pyodbc_connection_url(connection)
     return get_connection_url_common(connection)
+
+
+def uses_pyodbc(connection: MssqlConnectionConfig) -> bool:
+    return connection.scheme.value == connection.scheme.mssql_pyodbc.value
+
+
+def with_default_query_timeout(connection: MssqlConnectionConfig) -> MssqlConnectionConfig:
+    """
+    Bound the query timeout for the drivers that take it as a connect argument.
+
+    pytds and pymssql both read ``timeout`` as the socket timeout applied to
+    every read. pyodbc reads it as the *login* timeout instead, so its query
+    timeout is set on the live connection by ``bound_pyodbc_query_timeout``.
+
+    The bound belongs to the engine, not to the service: a workflow with
+    storeServiceConnection on writes its connection back to the API
+    (OMetaServiceMixin.get_create_service_from_source), so mutating the one it
+    holds would persist a timeout the user never configured. Hence the copy.
+    """
+    if uses_pyodbc(connection):
+        return connection
+    connection = deepcopy(connection)
+    connection.connectionArguments = connection.connectionArguments or init_empty_connection_arguments()
+    if connection.connectionArguments.root is not None:
+        connection.connectionArguments.root.setdefault("timeout", DEFAULT_QUERY_TIMEOUT_SECONDS)
+    return connection
+
+
+def bound_pyodbc_query_timeout(engine: Engine, timeout_seconds: int = DEFAULT_QUERY_TIMEOUT_SECONDS) -> None:
+    """
+    Bound pyodbc's query timeout, which is a connection attribute rather than a
+    connect keyword, so it can only be set once the DBAPI connection exists.
+    """
+
+    def set_query_timeout(dbapi_connection, _connection_record) -> None:
+        dbapi_connection.timeout = timeout_seconds
+
+    listen(engine, "connect", set_query_timeout)
 
 
 class MssqlChecks:
@@ -193,10 +242,16 @@ class MssqlChecks:
 class MssqlConnection(BaseConnection[MssqlConnectionConfig, Engine]):
     def _get_client(self) -> Engine:
         engine = create_generic_db_connection(
-            connection=self.service_connection,
+            connection=with_default_query_timeout(self.service_connection),
             get_connection_url_fn=get_connection_url,
             get_connection_args_fn=get_connection_args_common,
+            # A pooled connection the server has since dropped otherwise fails
+            # the first query that borrows it, and MSSQL churns a fresh engine
+            # per database when ingesting all of them.
+            pool_pre_ping=True,
         )
+        if uses_pyodbc(self.service_connection):
+            bound_pyodbc_query_timeout(engine)
         self._on_close(engine.dispose)
         return engine
 

--- a/ingestion/src/metadata/ingestion/source/database/mssql/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/connection.py
@@ -126,10 +126,18 @@ MSSQL_ERRORS = SQLSERVER_ERRORS.including(NETWORK_ERRORS)
 
 # A hung read otherwise stalls a workflow forever: pytds and pymssql default to
 # no socket timeout at all and pyodbc to no query timeout, and the shared engine
-# builder sets neither. Ten minutes is well past any healthy catalogue or
-# query-log read, and mirrors how Snowflake bounds its own socket. User-supplied
-# connectionArguments win.
-DEFAULT_QUERY_TIMEOUT_SECONDS = 600
+# builder sets neither.
+#
+# The bound cannot be tighter than the longest read the product itself considers
+# healthy. Every workflow builds its engine here - metadata, lineage, usage, the
+# profiler and data quality all reach _get_client through get_ssl_connection -
+# and the profiler's own default budget is 12 hours per table
+# (databaseServiceProfilerPipeline.json timeoutSeconds), so anything shorter
+# would fail profiling runs that are working as designed. What it does rule out
+# is the wait that never ends, which is the failure this exists for; a dead
+# pooled connection is caught far sooner by pre-ping. Tighten it per service
+# with `timeout` in connectionArguments, which wins over this default.
+DEFAULT_QUERY_TIMEOUT_SECONDS = 43200
 
 
 def get_connection_url(connection: MssqlConnectionConfig) -> str:

--- a/ingestion/src/metadata/ingestion/source/database/mssql/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/metadata.py
@@ -23,6 +23,7 @@ from metadata.generated.schema.api.data.createStoredProcedure import (
 from metadata.generated.schema.entity.data.database import Database
 from metadata.generated.schema.entity.data.databaseSchema import DatabaseSchema
 from metadata.generated.schema.entity.data.storedProcedure import StoredProcedureCode
+from metadata.generated.schema.entity.data.table import TableType
 from metadata.generated.schema.entity.services.connections.database.mssqlConnection import (
     MssqlConnection,
 )
@@ -36,7 +37,10 @@ from metadata.generated.schema.type.basic import EntityName, Markdown
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.ingestion.source.database.common_db_source import CommonDbSourceService
+from metadata.ingestion.source.database.common_db_source import (
+    CommonDbSourceService,
+    TableNameAndType,
+)
 from metadata.ingestion.source.database.mssql.models import (
     STORED_PROC_LANGUAGE_MAP,
     MssqlStoredProcedure,
@@ -45,6 +49,7 @@ from metadata.ingestion.source.database.mssql.queries import (
     MSSQL_GET_DATABASE,
     MSSQL_GET_DATABASE_COMMENTS,
     MSSQL_GET_ENCRYPTED_STORED_PROCEDURES,
+    MSSQL_GET_INDEXED_VIEWS,
     MSSQL_GET_SCHEMA_COMMENTS,
     MSSQL_GET_STORED_PROCEDURE_COMMENTS,
     MSSQL_GET_STORED_PROCEDURES,
@@ -190,6 +195,42 @@ class MssqlSource(CommonDbSourceService, MultiDBSource):
         )
         return Markdown(description) if description else None
 
+    def query_view_names_and_types(self, schema_name: str) -> Iterable[TableNameAndType]:
+        """
+        Report indexed views as materialized views.
+
+        An MSSQL indexed view is persisted on disk and kept up to date by the
+        engine - materialized in everything but name - so describing it as a
+        plain view understates it. Both types are handled identically everywhere
+        else in the catalogue (view definition, view lineage), so only the
+        reported type changes.
+        """
+        indexed_views = self._get_indexed_views(schema_name)
+        return [
+            TableNameAndType(
+                name=view_name,
+                type_=TableType.MaterializedView if view_name in indexed_views else TableType.View,
+            )
+            for view_name in self.inspector.get_view_names(schema_name) or []
+        ]
+
+    def _get_indexed_views(self, schema_name: str) -> set[str]:
+        """
+        Names of the views in a schema carrying the unique clustered index that
+        makes a view indexed. A failure here only costs the finer type, so it is
+        logged and every view stays a plain view.
+        """
+        try:
+            with self.engine.connect() as conn:
+                results = conn.execute(text(MSSQL_GET_INDEXED_VIEWS), {"schema_name": schema_name}).all()
+            return {row.view_name for row in results}
+        except Exception as exc:
+            logger.debug(traceback.format_exc())
+            logger.warning(
+                f"Could not detect indexed views for schema {schema_name}; they will be reported as plain views: {exc}"
+            )
+            return set()
+
     def get_database_names_raw(self) -> Iterable[str]:
         yield from self._execute_database_query(MSSQL_GET_DATABASE)
 
@@ -198,6 +239,12 @@ class MssqlSource(CommonDbSourceService, MultiDBSource):
         Reset the per-database encrypted-procedure cache and load the description
         maps. Descriptions are optional metadata, so a failure here must not
         abort the run: it is logged and ingestion continues without them.
+
+        Every description query is scoped to the connected database (they select
+        DB_NAME() and read that database's sys catalogue), so the inspector must
+        already point at the database being ingested when this runs. Loading
+        before the switch keys the maps by the previously connected database,
+        which no lookup can ever match.
         """
         self.encrypted_procedures_cache.clear()
         description_loaders = {
@@ -215,8 +262,8 @@ class MssqlSource(CommonDbSourceService, MultiDBSource):
     def get_database_names(self) -> Iterable[str]:
         if not self.config.serviceConnection.root.config.ingestAllDatabases:  # pyright: ignore[reportAttributeAccessIssue]
             configured_db = self.config.serviceConnection.root.config.database  # pyright: ignore[reportAttributeAccessIssue]
-            self._load_description_maps()
             self.set_inspector(database_name=configured_db)
+            self._load_description_maps()
             yield configured_db
         else:
             for new_database in self.get_database_names_raw():
@@ -235,8 +282,8 @@ class MssqlSource(CommonDbSourceService, MultiDBSource):
                     continue
 
                 try:
-                    self._load_description_maps()
                     self.set_inspector(database_name=new_database)
+                    self._load_description_maps()
                     yield new_database
                 except Exception as exc:
                     logger.debug(traceback.format_exc())

--- a/ingestion/src/metadata/ingestion/source/database/mssql/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/queries.py
@@ -419,6 +419,20 @@ order by PROCEDURE_START_TIME desc
     """  # noqa: W291
 )
 
+MSSQL_GET_INDEXED_VIEWS = textwrap.dedent(
+    """
+SELECT v.name AS view_name
+FROM sys.views v
+JOIN sys.schemas s
+    ON s.schema_id = v.schema_id
+JOIN sys.indexes i
+    ON i.object_id = v.object_id
+WHERE s.name = :schema_name
+  AND i.type = 1
+  AND i.is_unique = 1
+"""
+)
+
 MSSQL_GET_QUERY_STORE_STATE = "SELECT actual_state FROM sys.database_query_store_options"
 
 MSSQL_GET_STORED_PROCEDURE_QUERIES_FROM_QUERY_STORE = textwrap.dedent(

--- a/ingestion/src/metadata/ingestion/source/database/mssql/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/utils.py
@@ -346,8 +346,45 @@ def get_pk_constraint(self, connection, tablename, dbname, owner=None, schema=No
 
 
 @reflection.cache
-def get_unique_constraints(self, connection, table_name, schema=None, **kw):
-    raise NotImplementedError()
+@db_plus_owner
+def get_unique_constraints(self, connection, tablename, dbname, owner=None, schema=None, **kw):  # pylint: disable=unused-argument
+    """
+    Return the UNIQUE constraints declared on a table.
+
+    SQLAlchemy's MSSQL dialect does not reflect unique constraints and the base
+    dialect raises NotImplementedError, which the catalogue swallows, so they
+    were dropped for every MSSQL table. They live in INFORMATION_SCHEMA next to
+    the primary keys the dialect already reads, so this rides the same views and
+    returns the reflection contract: one dict per constraint, columns ordered by
+    their position in the key.
+    """
+    constraints = ischema.constraints
+    key_constraints = ischema.key_constraints.alias("C")
+
+    query_ = (
+        sql.select(
+            key_constraints.c.constraint_name,
+            key_constraints.c.column_name,
+        )
+        .where(
+            sql.and_(
+                constraints.c.constraint_name == key_constraints.c.constraint_name,
+                constraints.c.table_schema == key_constraints.c.table_schema,
+                constraints.c.constraint_type == "UNIQUE",
+                key_constraints.c.table_name == tablename,
+                key_constraints.c.table_schema == owner,
+            ),
+        )
+        .order_by(key_constraints.c.constraint_name, key_constraints.c.ordinal_position)
+    )
+    cursor = connection.execution_options(future_result=True).execute(query_)
+
+    columns_by_constraint: dict[str, list[str]] = {}
+    for row in cursor.mappings():
+        constraint_name = row[key_constraints.c.constraint_name.name]
+        columns_by_constraint.setdefault(constraint_name, []).append(row[key_constraints.c.column_name.name])
+
+    return [{"name": name, "column_names": columns} for name, columns in columns_by_constraint.items()]
 
 
 @reflection.cache

--- a/ingestion/src/metadata/utils/ssl_manager.py
+++ b/ingestion/src/metadata/utils/ssl_manager.py
@@ -280,6 +280,64 @@ class SSLManager:
 
         return connection
 
+    @staticmethod
+    def _setup_mssql_pyodbc_ssl(connection) -> None:
+        """
+        ODBC takes both switches natively, so pyodbc is the only MSSQL scheme
+        that can enforce encryption without a CA certificate.
+        """
+        if connection.encrypt:
+            connection.connectionArguments.root["Encrypt"] = "yes"
+
+        if connection.trustServerCertificate:
+            connection.connectionArguments.root["TrustServerCertificate"] = "yes"
+
+    def _setup_mssql_pytds_ssl(self, connection) -> None:
+        """
+        pytds supports cafile, certfile, and keyfile as native connection params.
+        certfile and keyfile were previously extracted by check_ssl_and_init but
+        never applied here, making mutual TLS silently non-functional for pytds.
+
+        pytds has no encrypt switch: it enables TLS only when a CA certificate is
+        supplied, and then always verifies the chain (tls.create_context sets
+        VERIFY_PEER). Host validation is the one check it can drop, which is what
+        a certificate issued to a name other than the configured host needs, so
+        that is where trustServerCertificate maps. Encrypt with no CA certificate
+        cannot be honoured by this driver, and saying so beats connecting in the
+        clear while the configuration claims otherwise.
+        """
+        if self.ca_file_path:
+            connection.connectionArguments.root["cafile"] = self.ca_file_path
+            if connection.trustServerCertificate:
+                connection.connectionArguments.root["validate_host"] = False
+        if self.cert_file_path:
+            connection.connectionArguments.root["certfile"] = self.cert_file_path
+        if self.key_file_path:
+            connection.connectionArguments.root["keyfile"] = self.key_file_path
+
+        if connection.encrypt and not self.ca_file_path:
+            logger.warning(
+                "Encrypt Connection is enabled but no CA certificate is configured: the "
+                "mssql+pytds driver enables TLS only when one is supplied, so this connection "
+                "will NOT be encrypted. Add the CA certificate under SSL Configuration, or use "
+                "the mssql+pyodbc scheme."
+            )
+
+    @staticmethod
+    def _warn_mssql_pymssql_ssl(connection) -> None:
+        """
+        pymssql takes no TLS parameters at all - FreeTDS configuration decides
+        whether the connection is encrypted - so every TLS setting configured
+        against this scheme is inert.
+        """
+        if connection.encrypt or connection.trustServerCertificate or connection.sslConfig:
+            logger.warning(
+                "TLS settings are configured but the mssql+pymssql scheme cannot apply them: "
+                "pymssql leaves encryption to FreeTDS configuration (encryption = require in "
+                "freetds.conf), so this connection may NOT be encrypted. Use mssql+pyodbc, or "
+                "mssql+pytds with a CA certificate, to enforce TLS from OpenMetadata."
+            )
+
     @setup_ssl.register(MssqlConnection)
     def _(self, connection):
         connection = cast(MssqlConnection, connection)  # noqa: TC006
@@ -289,23 +347,11 @@ class SSLManager:
 
         # Handle driver-specific SSL configuration
         if connection.scheme.value == "mssql+pyodbc":
-            # ODBC Driver SSL parameters
-            if connection.encrypt:
-                connection.connectionArguments.root["Encrypt"] = "yes"
-
-            if connection.trustServerCertificate:
-                connection.connectionArguments.root["TrustServerCertificate"] = "yes"
-
+            self._setup_mssql_pyodbc_ssl(connection)
         elif connection.scheme.value == "mssql+pytds":
-            # pytds supports cafile, certfile, and keyfile as native connection params.
-            # certfile and keyfile were previously extracted by check_ssl_and_init but
-            # never applied here, making mutual TLS silently non-functional for pytds.
-            if self.ca_file_path:
-                connection.connectionArguments.root["cafile"] = self.ca_file_path
-            if self.cert_file_path:
-                connection.connectionArguments.root["certfile"] = self.cert_file_path
-            if self.key_file_path:
-                connection.connectionArguments.root["keyfile"] = self.key_file_path
+            self._setup_mssql_pytds_ssl(connection)
+        else:
+            self._warn_mssql_pymssql_ssl(connection)
 
         return connection
 

--- a/ingestion/tests/integration/sql_server/conftest.py
+++ b/ingestion/tests/integration/sql_server/conftest.py
@@ -23,6 +23,18 @@ from metadata.generated.schema.entity.services.databaseService import (
 
 from ..conftest import ingestion_config as base_ingestion_config  # noqa: F401, TID252
 
+# The second database and its descriptions are asserted from the tests, so the
+# expected values live here rather than being repeated in each of them.
+SECOND_DATABASE = "TestDB"
+SECOND_SCHEMA = "catalog_test"
+SECOND_DATABASE_DESCRIPTION = "Catalogue test database"
+SECOND_SCHEMA_DESCRIPTION = "Catalogue test schema"
+SECOND_TABLE_DESCRIPTION = "Orders placed by customers"
+SECOND_PROCEDURE_DESCRIPTION = "Fetch the order identifiers"
+# Shipped inside AdventureWorksLT2022.bak as MS_Description properties.
+FIRST_DATABASE_DESCRIPTION = "AdventureWorksLT 2012 Sample OLTP Database"
+FIRST_SCHEMA_DESCRIPTION = "Contains objects related to products, customers, sales orders, and sales territories."
+
 
 @pytest.fixture(scope="package")
 def db_name():
@@ -71,6 +83,60 @@ RESTORE DATABASE [{db_name}]
     FROM DISK = '/data/{db_name}.bak'
     WITH MOVE '{db_name}_Data' TO '/var/opt/mssql/data/{db_name}.mdf',
          MOVE '{db_name}_Log' TO '/var/opt/mssql/data/{db_name}.ldf';
+GO
+
+/* A second database, so anything read per database is exercised against more
+   than one of them: the description queries are scoped to the connected
+   database, and a run that reads them against the wrong one looks identical to
+   a database that simply has no descriptions. */
+CREATE DATABASE [{SECOND_DATABASE}];
+GO
+USE [{SECOND_DATABASE}];
+GO
+CREATE SCHEMA {SECOND_SCHEMA};
+GO
+CREATE TABLE {SECOND_SCHEMA}.orders (
+    id INT NOT NULL PRIMARY KEY,
+    code NVARCHAR(20) NOT NULL,
+    region NVARCHAR(20) NOT NULL,
+    ref NVARCHAR(20) NOT NULL,
+    CONSTRAINT uq_orders_code UNIQUE (code),
+    CONSTRAINT uq_orders_region_ref UNIQUE (region, ref)
+);
+GO
+CREATE VIEW {SECOND_SCHEMA}.orders_plain AS SELECT id, code FROM {SECOND_SCHEMA}.orders;
+GO
+/* An indexed view is materialized, and SQL Server only accepts one when the
+   session carries these options. */
+SET ANSI_NULLS ON;
+SET ANSI_PADDING ON;
+SET ANSI_WARNINGS ON;
+SET ARITHABORT ON;
+SET CONCAT_NULL_YIELDS_NULL ON;
+SET QUOTED_IDENTIFIER ON;
+SET NUMERIC_ROUNDABORT OFF;
+GO
+CREATE VIEW {SECOND_SCHEMA}.orders_indexed WITH SCHEMABINDING AS
+    SELECT id, code FROM {SECOND_SCHEMA}.orders;
+GO
+CREATE UNIQUE CLUSTERED INDEX ix_orders_indexed ON {SECOND_SCHEMA}.orders_indexed (id);
+GO
+CREATE PROCEDURE {SECOND_SCHEMA}.get_orders AS SELECT id FROM {SECOND_SCHEMA}.orders;
+GO
+EXEC sp_addextendedproperty @name = N'MS_Description', @value = N'{SECOND_DATABASE_DESCRIPTION}';
+GO
+EXEC sp_addextendedproperty @name = N'MS_Description', @value = N'{SECOND_SCHEMA_DESCRIPTION}',
+    @level0type = N'SCHEMA', @level0name = N'{SECOND_SCHEMA}';
+GO
+EXEC sp_addextendedproperty @name = N'MS_Description', @value = N'{SECOND_TABLE_DESCRIPTION}',
+    @level0type = N'SCHEMA', @level0name = N'{SECOND_SCHEMA}',
+    @level1type = N'TABLE', @level1name = N'orders';
+GO
+EXEC sp_addextendedproperty @name = N'MS_Description', @value = N'{SECOND_PROCEDURE_DESCRIPTION}',
+    @level0type = N'SCHEMA', @level0name = N'{SECOND_SCHEMA}',
+    @level1type = N'PROCEDURE', @level1name = N'get_orders';
+GO
+USE [{db_name}];
 GO
         """
         )

--- a/ingestion/tests/integration/sql_server/test_metadata.py
+++ b/ingestion/tests/integration/sql_server/test_metadata.py
@@ -1,19 +1,43 @@
-from metadata.generated.schema.entity.data.table import Constraint, Table
+import pytest
+
+from metadata.generated.schema.entity.data.database import Database
+from metadata.generated.schema.entity.data.databaseSchema import DatabaseSchema
+from metadata.generated.schema.entity.data.storedProcedure import StoredProcedure
+from metadata.generated.schema.entity.data.table import (
+    Constraint,
+    ConstraintType,
+    Table,
+    TableType,
+)
 from metadata.workflow.metadata import MetadataWorkflow
+
+from .conftest import (  # noqa: TID252
+    FIRST_DATABASE_DESCRIPTION,
+    FIRST_SCHEMA_DESCRIPTION,
+    SECOND_DATABASE,
+    SECOND_DATABASE_DESCRIPTION,
+    SECOND_PROCEDURE_DESCRIPTION,
+    SECOND_SCHEMA,
+    SECOND_SCHEMA_DESCRIPTION,
+    SECOND_TABLE_DESCRIPTION,
+)
+
+
+@pytest.fixture(scope="module")
+def ingested(patch_passwords_for_db_services, run_workflow, ingestion_config, db_service):
+    """Ingest once for the module: every assertion below reads the same catalogue."""
+    run_workflow(MetadataWorkflow, ingestion_config)
+    return db_service
 
 
 def test_ingest_metadata(
-    patch_passwords_for_db_services,
-    run_workflow,
-    ingestion_config,
-    db_service,
+    ingested,
     metadata,
     db_name,
 ):
-    run_workflow(MetadataWorkflow, ingestion_config)
     table: Table = metadata.get_by_name(
         Table,
-        f"{db_service.fullyQualifiedName.root}.{db_name}.SalesLT.Customer",
+        f"{ingested.fullyQualifiedName.root}.{db_name}.SalesLT.Customer",
     )
     assert table is not None
     assert [c.name.root for c in table.columns] == [
@@ -34,3 +58,63 @@ def test_ingest_metadata(
         "ModifiedDate",
     ]
     assert table.columns[0].constraint == Constraint.PRIMARY_KEY
+
+
+def test_descriptions_are_ingested_for_every_database(ingested, metadata, db_name):
+    """Descriptions are read per database, so a two-database run is what tells a
+    correct read from one that keeps reporting the previous database's."""
+    service = ingested.fullyQualifiedName.root
+
+    descriptions = {
+        database_name: (
+            metadata.get_by_name(Database, f"{service}.{database_name}").description,
+            metadata.get_by_name(DatabaseSchema, f"{service}.{database_name}.{schema_name}").description,
+        )
+        for database_name, schema_name in ((db_name, "SalesLT"), (SECOND_DATABASE, SECOND_SCHEMA))
+    }
+
+    assert {
+        database_name: (database.root, schema.root) for database_name, (database, schema) in descriptions.items()
+    } == {
+        db_name: (FIRST_DATABASE_DESCRIPTION, FIRST_SCHEMA_DESCRIPTION),
+        SECOND_DATABASE: (SECOND_DATABASE_DESCRIPTION, SECOND_SCHEMA_DESCRIPTION),
+    }
+
+
+def test_table_and_stored_procedure_descriptions_are_ingested(ingested, metadata):
+    service = ingested.fullyQualifiedName.root
+    prefix = f"{service}.{SECOND_DATABASE}.{SECOND_SCHEMA}"
+
+    table: Table = metadata.get_by_name(Table, f"{prefix}.orders")
+    procedure: StoredProcedure = metadata.get_by_name(StoredProcedure, f"{prefix}.get_orders")
+
+    assert table.description.root == SECOND_TABLE_DESCRIPTION
+    assert procedure.description.root == SECOND_PROCEDURE_DESCRIPTION
+
+
+def test_unique_constraints_reach_the_catalogue(ingested, metadata):
+    """A single-column UNIQUE lands on the column, a composite one on the table."""
+    table: Table = metadata.get_by_name(
+        Table,
+        f"{ingested.fullyQualifiedName.root}.{SECOND_DATABASE}.{SECOND_SCHEMA}.orders",
+    )
+
+    constraints = {column.name.root: column.constraint for column in table.columns}
+    composite = [
+        constraint.columns
+        for constraint in (table.tableConstraints or [])
+        if constraint.constraintType == ConstraintType.UNIQUE
+    ]
+
+    assert constraints["code"] == Constraint.UNIQUE
+    assert composite == [["region", "ref"]]
+
+
+def test_an_indexed_view_is_ingested_as_a_materialized_view(ingested, metadata):
+    prefix = f"{ingested.fullyQualifiedName.root}.{SECOND_DATABASE}.{SECOND_SCHEMA}"
+
+    indexed: Table = metadata.get_by_name(Table, f"{prefix}.orders_indexed")
+    plain: Table = metadata.get_by_name(Table, f"{prefix}.orders_plain")
+
+    assert indexed.tableType == TableType.MaterializedView
+    assert plain.tableType == TableType.View

--- a/ingestion/tests/integration/sql_server/test_reflection.py
+++ b/ingestion/tests/integration/sql_server/test_reflection.py
@@ -1,0 +1,153 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""What the MSSQL source reads straight from the server.
+
+These assertions need a SQL Server but no OpenMetadata server: they drive the
+source's own reads (descriptions per database, constraint reflection, view
+typing) against the container, which is where the SQL itself is either right or
+wrong. The catalogue-level counterparts live in test_metadata.py.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from metadata.generated.schema.entity.data.table import TableType
+from metadata.generated.schema.metadataIngestion.workflow import (
+    OpenMetadataWorkflowConfig,
+)
+from metadata.ingestion.source.database.common_db_source import CommonDbSourceService
+from metadata.ingestion.source.database.mssql.metadata import MssqlSource
+
+from .conftest import (  # noqa: TID252
+    FIRST_DATABASE_DESCRIPTION,
+    FIRST_SCHEMA_DESCRIPTION,
+    SECOND_DATABASE,
+    SECOND_DATABASE_DESCRIPTION,
+    SECOND_PROCEDURE_DESCRIPTION,
+    SECOND_SCHEMA,
+    SECOND_SCHEMA_DESCRIPTION,
+)
+
+FIRST_SCHEMA = "SalesLT"
+
+
+@pytest.fixture(scope="module")
+def source(mssql_container, db_name):
+    """
+    A source connected to master, so nothing it reads per database can come from
+    the database it happened to connect to.
+    """
+    config = {
+        "type": "mssql",
+        "serviceName": "local_mssql_reflection",
+        "serviceConnection": {
+            "config": {
+                "type": "Mssql",
+                "scheme": "mssql+pytds",
+                "username": mssql_container.username,
+                "password": mssql_container.password,
+                "hostPort": f"localhost:{mssql_container.get_exposed_port(mssql_container.port)}",
+                "database": "master",
+                "ingestAllDatabases": True,
+            }
+        },
+        "sourceConfig": {
+            "config": {
+                "type": "DatabaseMetadata",
+                "includeStoredProcedures": True,
+                "databaseFilterPattern": {"includes": [db_name, SECOND_DATABASE]},
+            }
+        },
+    }
+    workflow_config = OpenMetadataWorkflowConfig.model_validate(
+        {
+            "source": config,
+            "sink": {"type": "metadata-rest", "config": {}},
+            "workflowConfig": {
+                "openMetadataServerConfig": {
+                    "hostPort": "http://localhost:8585/api",
+                    "authProvider": "openmetadata",
+                    "securityConfig": {"jwtToken": "not-used"},
+                }
+            },
+        }
+    )
+    # Nothing here calls the OpenMetadata API: the source only reads from SQL Server.
+    with patch.object(CommonDbSourceService, "test_connection"):
+        mssql_source = MssqlSource.create(config, workflow_config.workflowConfig.openMetadataServerConfig)
+    # The framework puts the service in the context before walking the databases.
+    mssql_source.context.get().__dict__["database_service"] = config["serviceName"]
+    yield mssql_source
+    mssql_source.close()
+
+
+def _ingest_database(source, database: str, schema: str) -> None:
+    """Walk the source to a database the way the framework does, then place the
+    context on one of its schemas."""
+    for name in source.get_database_names():
+        if name == database:
+            source.context.get().__dict__["database"] = database
+            source.context.get().__dict__["database_schema"] = schema
+            return
+    raise AssertionError(f"{database} was never yielded")
+
+
+def test_descriptions_are_read_from_the_database_being_ingested(source, db_name):
+    """The description queries are scoped to the connected database, so a run that
+    reads them before switching gets the previous database's - which no lookup
+    matches, leaving every database silently undocumented."""
+    schemas = {db_name: FIRST_SCHEMA, SECOND_DATABASE: SECOND_SCHEMA}
+    descriptions = {}
+
+    for database in source.get_database_names():
+        source.context.get().__dict__["database"] = database
+        descriptions[database] = (
+            source.get_database_description(database),
+            source.get_schema_description(schemas[database]),
+        )
+
+    assert descriptions == {
+        db_name: (FIRST_DATABASE_DESCRIPTION, FIRST_SCHEMA_DESCRIPTION),
+        SECOND_DATABASE: (SECOND_DATABASE_DESCRIPTION, SECOND_SCHEMA_DESCRIPTION),
+    }
+
+
+def test_stored_procedure_descriptions_are_read_from_the_database_being_ingested(source):
+    _ingest_database(source, SECOND_DATABASE, SECOND_SCHEMA)
+
+    description = source.get_stored_procedure_description("get_orders")
+
+    assert description is not None
+    assert description.root == SECOND_PROCEDURE_DESCRIPTION
+
+
+def test_unique_constraints_are_reflected(source):
+    """SQLAlchemy's MSSQL dialect reflects none, so they used to be dropped."""
+    _ingest_database(source, SECOND_DATABASE, SECOND_SCHEMA)
+
+    constraints = source.inspector.get_unique_constraints("orders", SECOND_SCHEMA)
+
+    assert {constraint["name"]: constraint["column_names"] for constraint in constraints} == {
+        "uq_orders_code": ["code"],
+        "uq_orders_region_ref": ["region", "ref"],
+    }
+
+
+def test_an_indexed_view_is_typed_as_a_materialized_view(source):
+    _ingest_database(source, SECOND_DATABASE, SECOND_SCHEMA)
+
+    views = {view.name: view.type_ for view in source.query_view_names_and_types(SECOND_SCHEMA)}
+
+    assert views == {
+        "orders_indexed": TableType.MaterializedView,
+        "orders_plain": TableType.View,
+    }

--- a/ingestion/tests/unit/source/database/mssql/test_connection.py
+++ b/ingestion/tests/unit/source/database/mssql/test_connection.py
@@ -45,11 +45,14 @@ from metadata.generated.schema.entity.services.connections.testConnectionResult 
 )
 from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.source.database.mssql.connection import (
+    DEFAULT_QUERY_TIMEOUT_SECONDS,
     MSSQL_ERRORS,
     MssqlChecks,
     MssqlConnection,
     _mssql_number,
+    bound_pyodbc_query_timeout,
     get_connection_url,
+    with_default_query_timeout,
 )
 from metadata.ingestion.source.database.mssql.queries import (
     MSSQL_GET_CURRENT_DATABASE,
@@ -484,3 +487,82 @@ def test_get_databases_counts_the_databases_it_found():
 
 def test_get_databases_reports_a_floor_when_the_sample_is_capped():
     assert _databases_summary(DEFAULT_SAMPLE_ROWS) == f"{DEFAULT_SAMPLE_ROWS}+ databases enumerated"
+
+
+# Query timeouts. A hung read must not stall a workflow forever, and the shared
+# engine builder sets no timeout, so the connector applies one per driver.
+
+
+@pytest.mark.parametrize("scheme", [MssqlScheme.mssql_pytds, MssqlScheme.mssql_pymssql])
+def test_the_drivers_that_take_a_query_timeout_get_one(scheme):
+    """pytds and pymssql both read `timeout` as the socket timeout on every read."""
+    connection = with_default_query_timeout(_config(scheme=scheme))
+
+    assert connection.connectionArguments.root["timeout"] == DEFAULT_QUERY_TIMEOUT_SECONDS
+
+
+def test_pyodbc_is_left_alone_because_its_timeout_argument_is_the_login_one():
+    """Setting `timeout` for pyodbc would shorten the login, not bound the query."""
+    connection = with_default_query_timeout(_config(scheme=MssqlScheme.mssql_pyodbc))
+
+    assert "timeout" not in (connection.connectionArguments.root if connection.connectionArguments else {})
+
+
+def test_a_user_supplied_timeout_wins():
+    config = MssqlConnectionConfig(
+        scheme=MssqlScheme.mssql_pytds,
+        username="user",
+        password="pass",
+        hostPort="myhost:1433",
+        database="mydb",
+        connectionArguments={"timeout": 5},
+    )
+
+    connection = with_default_query_timeout(config)
+
+    assert connection.connectionArguments.root["timeout"] == 5
+
+
+def test_the_configured_connection_is_left_untouched():
+    """The bound belongs to the engine: a workflow that stores its service
+    connection would otherwise persist a timeout nobody configured."""
+    config = _config(scheme=MssqlScheme.mssql_pytds)
+
+    with_default_query_timeout(config)
+
+    assert config.connectionArguments is None
+
+
+def test_the_engine_is_built_with_pre_ping():
+    """A pooled connection the server has dropped must not fail the borrower."""
+    with patch(f"{CONNECTION_MODULE}.create_generic_db_connection") as mock_connection:
+        _ = MssqlConnection(_config()).client
+
+    assert mock_connection.call_args.kwargs["pool_pre_ping"] is True
+
+
+@pytest.mark.parametrize(
+    ("scheme", "bounded"),
+    [(MssqlScheme.mssql_pyodbc, True), (MssqlScheme.mssql_pytds, False)],
+)
+def test_only_pyodbc_bounds_the_query_timeout_on_the_engine(scheme, bounded):
+    with (
+        patch(f"{CONNECTION_MODULE}.create_generic_db_connection"),
+        patch(f"{CONNECTION_MODULE}.bound_pyodbc_query_timeout") as mock_bound,
+    ):
+        _ = MssqlConnection(_config(scheme=scheme)).client
+
+    assert mock_bound.called is bounded
+
+
+def test_the_query_timeout_is_applied_to_every_new_connection():
+    """pyodbc exposes the query timeout as a connection attribute, so it can only
+    be set once the DBAPI connection exists - hence a listener on connect."""
+    engine = create_engine("sqlite://", poolclass=StaticPool)
+    bound_pyodbc_query_timeout(engine, timeout_seconds=42)
+    dbapi_connection = MagicMock()
+
+    (listener,) = [fn for fn in engine.pool.dispatch.connect if fn.__name__ == "set_query_timeout"]
+    listener(dbapi_connection, MagicMock())
+
+    assert dbapi_connection.timeout == 42

--- a/ingestion/tests/unit/test_source_connection.py
+++ b/ingestion/tests/unit/test_source_connection.py
@@ -792,23 +792,6 @@ class SourceConnectionTest(TestCase):
             get_connection_url,
         )
 
-        # connection arguments without db
-        expected_url = "mssql+pytds://sa:password@localhost:1433"
-        mssql_conn_obj = MssqlConnection(
-            username="sa",
-            password="password",
-            hostPort="localhost:1433",
-            scheme=MssqlScheme.mssql_pytds,
-            database=None,
-        )
-
-        assert expected_url == get_connection_url(mssql_conn_obj)
-
-    def test_mssql_url(self):  # noqa: F811
-        from metadata.ingestion.source.database.mssql.connection import (
-            get_connection_url,
-        )
-
         # Passing @ in username and password
         expected_url = "mssql+pytds://sa%40123:password%40444@localhost:1433/master"
         mssql_conn_obj = MssqlConnection(

--- a/ingestion/tests/unit/test_ssl_manager.py
+++ b/ingestion/tests/unit/test_ssl_manager.py
@@ -485,6 +485,108 @@ class MssqlSSLManagerTest(TestCase):
 
         ssl_manager.cleanup_temp_files()
 
+    def _pytds_connection(self, **kwargs):
+        from metadata.generated.schema.entity.services.connections.database.mssqlConnection import (
+            MssqlConnection,
+            MssqlScheme,
+        )
+
+        return MssqlConnection(
+            hostPort="localhost:1433",
+            database="testdb",
+            username="sa",
+            password="password",
+            scheme=MssqlScheme.mssql_pytds,
+            **kwargs,
+        )
+
+    def test_setup_ssl_pytds_trust_server_certificate_drops_host_validation(self):
+        """pytds always verifies the chain against the CA it is given, so host
+        validation is the only check trustServerCertificate can drop."""
+        from metadata.utils.ssl_manager import check_ssl_and_init
+
+        connection = self._pytds_connection(
+            trustServerCertificate=True,
+            sslConfig={"caCertificate": "caCertificateData"},
+        )
+
+        ssl_manager = check_ssl_and_init(connection)
+        updated_connection = ssl_manager.setup_ssl(connection)
+
+        self.assertIs(updated_connection.connectionArguments.root["validate_host"], False)
+
+        ssl_manager.cleanup_temp_files()
+
+    def test_setup_ssl_pytds_keeps_host_validation_by_default(self):
+        from metadata.utils.ssl_manager import check_ssl_and_init
+
+        connection = self._pytds_connection(sslConfig={"caCertificate": "caCertificateData"})
+
+        ssl_manager = check_ssl_and_init(connection)
+        updated_connection = ssl_manager.setup_ssl(connection)
+
+        self.assertNotIn("validate_host", updated_connection.connectionArguments.root)
+
+        ssl_manager.cleanup_temp_files()
+
+    def test_setup_ssl_pytds_encrypt_without_a_ca_certificate_warns(self):
+        """pytds enables TLS only when a CA certificate is supplied. Encrypt on its
+        own cannot be honoured, and the connection must not claim otherwise."""
+        from metadata.utils.ssl_manager import check_ssl_and_init
+
+        connection = self._pytds_connection(encrypt=True)
+
+        ssl_manager = check_ssl_and_init(connection)
+        with patch("metadata.utils.ssl_manager.logger") as mock_logger:
+            updated_connection = ssl_manager.setup_ssl(connection)
+
+        self.assertNotIn("cafile", updated_connection.connectionArguments.root)
+        mock_logger.warning.assert_called_once()
+        self.assertIn("will NOT be encrypted", mock_logger.warning.call_args.args[0])
+
+        ssl_manager.cleanup_temp_files()
+
+    def test_setup_ssl_pytds_encrypt_with_a_ca_certificate_is_silent(self):
+        from metadata.utils.ssl_manager import check_ssl_and_init
+
+        connection = self._pytds_connection(encrypt=True, sslConfig={"caCertificate": "caCertificateData"})
+
+        ssl_manager = check_ssl_and_init(connection)
+        with patch("metadata.utils.ssl_manager.logger") as mock_logger:
+            updated_connection = ssl_manager.setup_ssl(connection)
+
+        self.assertIsNotNone(updated_connection.connectionArguments.root["cafile"])
+        mock_logger.warning.assert_not_called()
+
+        ssl_manager.cleanup_temp_files()
+
+    def test_setup_ssl_pymssql_warns_that_tls_settings_are_inert(self):
+        """pymssql takes no TLS parameters: FreeTDS configuration decides."""
+        from metadata.generated.schema.entity.services.connections.database.mssqlConnection import (
+            MssqlConnection,
+            MssqlScheme,
+        )
+        from metadata.utils.ssl_manager import check_ssl_and_init
+
+        connection = MssqlConnection(
+            hostPort="localhost:1433",
+            database="testdb",
+            username="sa",
+            password="password",
+            scheme=MssqlScheme.mssql_pymssql,
+            encrypt=True,
+        )
+
+        ssl_manager = check_ssl_and_init(connection)
+        with patch("metadata.utils.ssl_manager.logger") as mock_logger:
+            updated_connection = ssl_manager.setup_ssl(connection)
+
+        self.assertDictEqual(updated_connection.connectionArguments.root, {})
+        mock_logger.warning.assert_called_once()
+        self.assertIn("mssql+pymssql", mock_logger.warning.call_args.args[0])
+
+        ssl_manager.cleanup_temp_files()
+
 
 class Db2SSLManagerTest(TestCase):
     """

--- a/ingestion/tests/unit/topology/database/test_mssql.py
+++ b/ingestion/tests/unit/topology/database/test_mssql.py
@@ -54,6 +54,7 @@ from metadata.ingestion.source.database.mssql.metadata import MssqlSource
 from metadata.ingestion.source.database.mssql.models import MssqlStoredProcedure
 from metadata.ingestion.source.database.mssql.queries import (
     MSSQL_GET_FOREIGN_KEY,
+    MSSQL_GET_INDEXED_VIEWS,
     MSSQL_SQL_STATEMENT,
     MSSQL_SQL_STATEMENT_CURRENT_DB,
     MSSQL_SQL_STATEMENT_FROM_QUERY_STORE,
@@ -515,6 +516,84 @@ class TestUpdateMssqlIschemaNames:
         assert yielded == []
         self.mssql.status.failed.assert_called_once()
 
+    def test_description_maps_load_after_the_inspector_is_switched(self):
+        """Every description query reads the connected database (they select
+        DB_NAME()), so they must run once the inspector points at the database
+        being ingested. Loading first keys the maps by the previously connected
+        database and no lookup can match them."""
+        self.mssql.config.serviceConnection.root.config.ingestAllDatabases = True
+        self.mssql.context.get().__dict__["database_service"] = MOCK_DATABASE_SERVICE.name.root
+        calls = []
+
+        with (
+            patch.object(MssqlSource, "get_database_names_raw", return_value=iter(["db_one", "db_two"])),
+            patch.object(MssqlSource, "_load_description_maps", side_effect=lambda: calls.append("load")),
+            patch.object(
+                MssqlSource,
+                "set_inspector",
+                side_effect=lambda database_name: calls.append(f"switch:{database_name}"),
+            ),
+        ):
+            yielded = list(self.mssql.get_database_names())
+
+        assert yielded == ["db_one", "db_two"]
+        assert calls == ["switch:db_one", "load", "switch:db_two", "load"]
+
+    def test_description_maps_load_after_the_inspector_for_a_single_database(self):
+        """The single-database path keeps the same order as the multi-database one."""
+        self.mssql.config.serviceConnection.root.config.ingestAllDatabases = False
+        configured_database = self.mssql.config.serviceConnection.root.config.database
+        calls = []
+
+        with (
+            patch.object(MssqlSource, "_load_description_maps", side_effect=lambda: calls.append("load")),
+            patch.object(
+                MssqlSource,
+                "set_inspector",
+                side_effect=lambda database_name: calls.append(f"switch:{database_name}"),
+            ),
+        ):
+            yielded = list(self.mssql.get_database_names())
+
+        assert yielded == [configured_database]
+        assert calls == [f"switch:{configured_database}", "load"]
+
+    @staticmethod
+    def _inspector_listing(*view_names):
+        return property(lambda _self: types.SimpleNamespace(get_view_names=lambda schema_name: list(view_names)))
+
+    def test_indexed_views_are_reported_as_materialized_views(self):
+        """An indexed view is persisted and engine-maintained, so calling it a plain
+        view understates it."""
+        with (
+            patch.object(
+                MssqlSource,
+                "inspector",
+                new_callable=lambda: self._inspector_listing("plain_view", "indexed_view"),
+            ),
+            patch.object(MssqlSource, "_get_indexed_views", return_value={"indexed_view"}),
+        ):
+            views = self.mssql.query_view_names_and_types("sales")
+
+        assert [(view.name, view.type_) for view in views] == [
+            ("plain_view", TableType.View),
+            ("indexed_view", TableType.MaterializedView),
+        ]
+
+    def test_a_failure_to_detect_indexed_views_leaves_them_as_plain_views(self):
+        """The finer type is optional metadata: losing it must not lose the views."""
+        self.mssql.engine = _raising_engine()
+
+        with patch.object(MssqlSource, "inspector", new_callable=lambda: self._inspector_listing("plain_view")):
+            views = self.mssql.query_view_names_and_types("sales")
+
+        assert [(view.name, view.type_) for view in views] == [("plain_view", TableType.View)]
+
+    def test_indexed_view_query_matches_only_a_unique_clustered_index(self):
+        """That index is what makes a view indexed, and nothing else must match."""
+        assert "i.type = 1" in MSSQL_GET_INDEXED_VIEWS
+        assert "i.is_unique = 1" in MSSQL_GET_INDEXED_VIEWS
+
 
 class MssqlIdentityColumnTest(TestCase):
     """Regression tests for identity column reflection.
@@ -864,3 +943,70 @@ class TestMssqlPerDatabaseQueryStore:
         engines = list(StoredProcedureLineageMixin.get_stored_procedure_engines(fake_source))
 
         assert engines == [fake_source.engine]
+
+
+def _raising_engine():
+    """An engine whose connect() fails, for the degraded paths."""
+    engine = MagicMock()
+    engine.connect.side_effect = Exception("cannot connect")
+    return engine
+
+
+class TestMssqlUniqueConstraints:
+    """``get_unique_constraints`` must report the UNIQUE constraints on a table.
+
+    SQLAlchemy's MSSQL dialect does not reflect them and the base dialect raises
+    NotImplementedError, which the catalogue swallows, so they were dropped.
+    """
+
+    @staticmethod
+    def _row(constraint_name, column_name):
+        return {"CONSTRAINT_NAME": constraint_name, "COLUMN_NAME": column_name}
+
+    @staticmethod
+    def _unique_constraints(rows):
+        from sqlalchemy.dialects.mssql.base import MSDialect
+
+        connection = MagicMock()
+        connection.execution_options.return_value.execute.return_value.mappings.return_value = rows
+
+        return mssql_dialet.get_unique_constraints(MSDialect(), connection, "orders", schema="sales")
+
+    def test_a_single_column_constraint_is_reported(self):
+        assert self._unique_constraints([self._row("uq_orders_code", "code")]) == [
+            {"name": "uq_orders_code", "column_names": ["code"]}
+        ]
+
+    def test_a_composite_constraint_keeps_its_key_order(self):
+        constraints = self._unique_constraints(
+            [
+                self._row("uq_orders_region_code", "region"),
+                self._row("uq_orders_region_code", "code"),
+            ]
+        )
+
+        assert constraints == [{"name": "uq_orders_region_code", "column_names": ["region", "code"]}]
+
+    def test_constraints_are_reported_separately(self):
+        constraints = self._unique_constraints([self._row("uq_orders_code", "code"), self._row("uq_orders_ref", "ref")])
+
+        assert [constraint["name"] for constraint in constraints] == ["uq_orders_code", "uq_orders_ref"]
+
+    def test_a_table_without_unique_constraints_reports_none(self):
+        assert self._unique_constraints([]) == []
+
+    def test_only_unique_constraints_are_selected(self):
+        """Primary and foreign keys live in the same view and are read elsewhere."""
+        from sqlalchemy.dialects.mssql.base import MSDialect
+
+        connection = MagicMock()
+        connection.execution_options.return_value.execute.return_value.mappings.return_value = []
+
+        mssql_dialet.get_unique_constraints(MSDialect(), connection, "orders", schema="sales")
+
+        (query,), _ = connection.execution_options.return_value.execute.call_args
+        compiled = str(query.compile(dialect=MSDialect(), compile_kwargs={"literal_binds": True}))
+
+        assert "[CONSTRAINT_TYPE] = N'UNIQUE'" in compiled
+        assert "[C].[TABLE_NAME] = N'orders'" in compiled
+        assert "[C].[TABLE_SCHEMA] = N'sales'" in compiled

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/mssqlConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/mssqlConnection.json
@@ -67,13 +67,13 @@
     },
     "encrypt": {
       "title": "Encrypt Connection",
-      "description": "Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted between the client and server will be encrypted.",
+      "description": "Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc. mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is decided by FreeTDS configuration.",
       "type": "boolean",
       "default": false
     },
     "trustServerCertificate": {
       "title": "Trust Server Certificate",
-      "description": "Trust the server certificate without validation. Set to false in production to validate server certificates against the certificate authority.",
+      "description": "Trust the server certificate without validation. Set to false in production to validate server certificates against the certificate authority. On mssql+pytds the certificate chain is always validated against the supplied CA certificate and only the host name check is dropped.",
       "type": "boolean",
       "default": false
     },

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts
@@ -1511,15 +1511,22 @@ test.describe(
           const pageSizeDropdown = page.getByTestId(
             'page-size-selection-dropdown'
           );
-          const pageSizeMenu = page.locator(
-            '.ant-dropdown:not(.ant-dropdown-hidden) .ant-dropdown-menu'
-          );
+          const pageSizeMenu = page
+            .getByRole('menu')
+            .filter({ hasText: '/ Page' });
 
           await expect(pageSizeDropdown).toBeVisible();
-          // NextPrevious inherits Ant Dropdown's hover trigger; clicking this
-          // button only runs its preventDefault handler and may not open the menu.
-          await pageSizeDropdown.hover();
-          await expect(pageSizeMenu).toBeVisible();
+
+          // Ant Dropdown opens on hover, so a re-render that shifts the footer out
+          // from under the pointer leaves the menu closed for good.
+          await expect(async () => {
+            await pageSizeDropdown.hover();
+            if (!(await pageSizeMenu.isVisible())) {
+              await pageSizeDropdown.click();
+            }
+            await expect(pageSizeMenu).toBeVisible({ timeout: 2_000 });
+          }).toPass({ timeout: 15_000, intervals: [500, 1_000, 2_000] });
+
           await expect(pageSizeMenu.getByRole('menuitem')).toHaveCount(3);
         });
       } finally {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestLibrary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestLibrary.spec.ts
@@ -764,13 +764,26 @@ test.describe(
 
         // Add a DQ Dimension — verifies that editing a test definition with existing
         // parameters does not prevent the dimension from being saved correctly.
-        await page.getByTestId('data-quality-dimension').click();
+        const dimensionField = page.getByTestId('data-quality-dimension');
         const accuracyOption = page.getByRole('option', {
           name: 'Accuracy',
           exact: true,
         });
-        await expect(accuracyOption).toBeVisible();
-        await accuracyOption.click();
+
+        // The listbox is a non-modal React Aria popover, so it is dismissed by any
+        // scroll of the pane holding the trigger — including the one Playwright
+        // emits to bring this field into view, delivered a frame after the popup
+        // opened. Reopen on each attempt; nothing else reopens it.
+        await expect(async () => {
+          if (!(await accuracyOption.isVisible())) {
+            await dimensionField.getByRole('button').click();
+            await expect(accuracyOption).toBeVisible({ timeout: 2_000 });
+          }
+          await selectOptionWithMouse(page, accuracyOption);
+          await expect(dimensionField).toContainText('Accuracy', {
+            timeout: 2_000,
+          });
+        }).toPass({ timeout: 20_000, intervals: [500, 1_000, 2_000] });
 
         // Save without providing parameter dataType or description — both are optional.
         const patchResponse = page.waitForResponse(

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Mssql.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Mssql.md
@@ -153,7 +153,7 @@ When Connecting to MSSQL via **pyodbc** scheme requires the Connection Arguments
 
 When using the pytds connection scheme with a CA certificate whose name does not match the host, tick Trust Server Certificate - it sets `validate_host: false` for you.
 
-Queries are bounded to a 10 minute timeout by default so a hung read cannot stall a workflow. To change it, set `timeout` (in seconds) in the connection arguments for the **pytds** and **pymssql** schemes; on **pyodbc** the same argument is the login timeout, and the query timeout is fixed at 10 minutes.
+Queries are bounded to a 12 hour timeout by default so a read that never returns cannot stall a workflow indefinitely. The default is deliberately generous because the same connection serves profiling and data quality, whose own default budget is 12 hours per table. To tighten it, set `timeout` (in seconds) in the connection arguments for the **pytds** and **pymssql** schemes; on **pyodbc** that argument is the login timeout instead, and the query timeout follows the default.
 $$
 
 ## Sample Storage AWS S3 Config

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Mssql.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Mssql.md
@@ -100,20 +100,24 @@ $$
 $$section
 ### Encrypt Connection $(id="encrypt")
 
-Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted between the client and server will be encrypted.
+Request SSL/TLS encryption for the MSSQL connection. What the drivers can enforce differs, so the connection scheme decides how far this setting goes:
 
 **Important:**
+- **mssql+pyodbc**: honoured directly (`Encrypt=yes`), with or without a certificate.
+- **mssql+pytds**: the driver enables TLS only when a CA certificate is supplied under SSL Configuration. With this ticked and no CA certificate the connection stays **unencrypted** and a warning is logged.
+- **mssql+pymssql**: the driver takes no TLS settings at all; encryption is decided by FreeTDS configuration (`encryption = require` in `freetds.conf`), so this setting is inert and a warning is logged.
 - Can be configured along with Trust Server Certificate option
-- May require additional connection arguments for fine-grained control
 - Default value is `false`
 $$
 
 $$section
 ### Trust Server Certificate $(id="trustServerCertificate")
 
-Trust the server certificate without validation When using **pyodbc** scheme.
+Trust the server certificate without validation.
 
 **Important:**
+- **mssql+pyodbc**: skips certificate validation entirely (`TrustServerCertificate=yes`).
+- **mssql+pytds**: the driver always validates the certificate chain against the CA certificate you supply; this setting drops the *host name* check only, for a certificate issued to a name other than the configured host.
 - Can be combined with Encrypt Connection option
 - Default value is `false`
 $$
@@ -125,6 +129,7 @@ SSL/TLS certificate configuration for client authentication. Provide CA certific
 
 **Important:**
 - For certificate-based authentication with **pytds** scheme, provide the CA certificate file path in the SSL Configuration
+- With **pytds** the CA certificate is what turns encryption on at all - without it the driver connects in the clear
 $$
 
 $$section
@@ -146,7 +151,9 @@ Enter the details for any additional connection arguments such as security or pr
 
 When Connecting to MSSQL via **pyodbc** scheme requires the Connection Arguments Encrypt: No and TrustServerCertificate: Yes. You can also configure these through the corresponding fields.
 
-When using the pytds connection scheme with a CA certificate, you might need to specify validate_host: false in the connection arguments.
+When using the pytds connection scheme with a CA certificate whose name does not match the host, tick Trust Server Certificate - it sets `validate_host: false` for you.
+
+Queries are bounded to a 10 minute timeout by default so a hung read cannot stall a workflow. To change it, set `timeout` (in seconds) in the connection arguments for the **pytds** and **pymssql** schemes; on **pyodbc** the same argument is the login timeout, and the query timeout is fixed at 10 minutes.
 $$
 
 ## Sample Storage AWS S3 Config

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/automations/createWorkflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/automations/createWorkflow.ts
@@ -1284,13 +1284,17 @@ export interface Connection {
      */
     authMechanism?: AuthMechanismEnum;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**
@@ -4376,8 +4380,10 @@ export interface DatabaseConnectionClass {
      */
     driver?: string;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
@@ -4424,7 +4430,9 @@ export interface DatabaseConnectionClass {
     tableFilterPattern?: FilterPattern;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createDatabaseService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createDatabaseService.ts
@@ -788,13 +788,17 @@ export interface Connection {
      */
     authMechanism?: AuthMechanismEnum;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createPipelineService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createPipelineService.ts
@@ -1391,8 +1391,10 @@ export interface DatabaseConnectionClass {
      */
     driver?: string;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
@@ -1439,7 +1441,9 @@ export interface DatabaseConnectionClass {
     tableFilterPattern?: FilterPattern;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
@@ -4647,13 +4647,17 @@ export interface Connection {
      */
     authMechanism?: AuthMechanismEnum;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**
@@ -7112,8 +7116,10 @@ export interface DatabaseConnectionClass {
      */
     driver?: string;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
@@ -7160,7 +7166,9 @@ export interface DatabaseConnectionClass {
     tableFilterPattern?: FilterPattern;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/testServiceConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/testServiceConnection.ts
@@ -1166,13 +1166,17 @@ export interface Connection {
      */
     authMechanism?: AuthMechanismEnum;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**
@@ -4258,8 +4262,10 @@ export interface DatabaseConnectionClass {
      */
     driver?: string;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
@@ -4306,7 +4312,9 @@ export interface DatabaseConnectionClass {
     tableFilterPattern?: FilterPattern;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/workflow.ts
@@ -1852,13 +1852,17 @@ export interface Connection {
      */
     authMechanism?: AuthMechanismEnum;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**
@@ -4766,8 +4770,10 @@ export interface DatabaseConnectionClass {
      */
     driver?: string;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
@@ -4814,7 +4820,9 @@ export interface DatabaseConnectionClass {
     tableFilterPattern?: FilterPattern;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/mssqlConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/mssqlConnection.ts
@@ -31,8 +31,10 @@ export interface MssqlConnection {
      */
     driver?: string;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
@@ -79,7 +81,9 @@ export interface MssqlConnection {
     tableFilterPattern?: FilterPattern;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/ssisConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/ssisConnection.ts
@@ -54,8 +54,10 @@ export interface MssqlConnection {
      */
     driver?: string;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
@@ -102,7 +104,9 @@ export interface MssqlConnection {
     tableFilterPattern?: FilterPattern;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/wherescapeConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/wherescapeConnection.ts
@@ -52,8 +52,10 @@ export interface Connection {
      */
     driver?: string;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
@@ -100,7 +102,9 @@ export interface Connection {
     tableFilterPattern?: FilterPattern;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
@@ -1453,13 +1453,17 @@ export interface Connection {
      */
     authMechanism?: AuthMechanismEnum;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**
@@ -4287,8 +4291,10 @@ export interface DatabaseConnectionClass {
      */
     driver?: string;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
@@ -4335,7 +4341,9 @@ export interface DatabaseConnectionClass {
     tableFilterPattern?: FilterPattern;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/databaseService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/databaseService.ts
@@ -919,13 +919,17 @@ export interface Connection {
      */
     authMechanism?: AuthMechanismEnum;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
@@ -5177,13 +5177,17 @@ export interface Connection {
      */
     authMechanism?: AuthMechanismEnum;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**
@@ -7623,8 +7627,10 @@ export interface DatabaseConnectionClass {
      */
     driver?: string;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
@@ -7671,7 +7677,9 @@ export interface DatabaseConnectionClass {
     tableFilterPattern?: FilterPattern;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/serviceProgressEvent.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/serviceProgressEvent.ts
@@ -5308,13 +5308,17 @@ export interface Connection {
      */
     authMechanism?: AuthMechanismEnum;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**
@@ -7754,8 +7758,10 @@ export interface DatabaseConnectionClass {
      */
     driver?: string;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
@@ -7802,7 +7808,9 @@ export interface DatabaseConnectionClass {
     tableFilterPattern?: FilterPattern;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/pipelineService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/pipelineService.ts
@@ -1513,8 +1513,10 @@ export interface DatabaseConnectionClass {
      */
     driver?: string;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
@@ -1561,7 +1563,9 @@ export interface DatabaseConnectionClass {
     tableFilterPattern?: FilterPattern;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
@@ -1551,13 +1551,17 @@ export interface Connection {
      */
     authMechanism?: AuthMechanismEnum;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**
@@ -4385,8 +4389,10 @@ export interface DatabaseConnectionClass {
      */
     driver?: string;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
@@ -4433,7 +4439,9 @@ export interface DatabaseConnectionClass {
     tableFilterPattern?: FilterPattern;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
@@ -1542,13 +1542,17 @@ export interface Connection {
      */
     authMechanism?: AuthMechanismEnum;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**
@@ -4406,8 +4410,10 @@ export interface DatabaseConnectionClass {
      */
     driver?: string;
     /**
-     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
-     * between the client and server will be encrypted.
+     * Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc.
+     * mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and
+     * logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is
+     * decided by FreeTDS configuration.
      */
     encrypt?: boolean;
     /**
@@ -4454,7 +4460,9 @@ export interface DatabaseConnectionClass {
     tableFilterPattern?: FilterPattern;
     /**
      * Trust the server certificate without validation. Set to false in production to validate
-     * server certificates against the certificate authority.
+     * server certificates against the certificate authority. On mssql+pytds the certificate
+     * chain is always validated against the supplied CA certificate and only the host name
+     * check is dropped.
      */
     trustServerCertificate?: boolean;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/jsons/ingestionSchemas/testSuitePipeline.json
+++ b/openmetadata-ui/src/main/resources/ui/src/jsons/ingestionSchemas/testSuitePipeline.json
@@ -4704,13 +4704,13 @@
                         },
                         "encrypt": {
                           "title": "Encrypt Connection",
-                          "description": "Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted between the client and server will be encrypted.",
+                          "description": "Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc. mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is decided by FreeTDS configuration.",
                           "type": "boolean",
                           "default": false
                         },
                         "trustServerCertificate": {
                           "title": "Trust Server Certificate",
-                          "description": "Trust the server certificate without validation. Set to false in production to validate server certificates against the certificate authority.",
+                          "description": "Trust the server certificate without validation. Set to false in production to validate server certificates against the certificate authority. On mssql+pytds the certificate chain is always validated against the supplied CA certificate and only the host name check is dropped.",
                           "type": "boolean",
                           "default": false
                         },

--- a/openmetadata-ui/src/main/resources/ui/src/jsons/ingestionSchemas/workflow.json
+++ b/openmetadata-ui/src/main/resources/ui/src/jsons/ingestionSchemas/workflow.json
@@ -10173,13 +10173,13 @@
                         },
                         "encrypt": {
                           "title": "Encrypt Connection",
-                          "description": "Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted between the client and server will be encrypted.",
+                          "description": "Request SSL/TLS encryption for the MSSQL connection. Honoured directly by mssql+pyodbc. mssql+pytds encrypts only when a CA certificate is supplied in SSL Configuration, and logs a warning otherwise. mssql+pymssql takes no TLS settings at all - encryption is decided by FreeTDS configuration.",
                           "type": "boolean",
                           "default": false
                         },
                         "trustServerCertificate": {
                           "title": "Trust Server Certificate",
-                          "description": "Trust the server certificate without validation. Set to false in production to validate server certificates against the certificate authority.",
+                          "description": "Trust the server certificate without validation. Set to false in production to validate server certificates against the certificate authority. On mssql+pytds the certificate chain is always validated against the supplied CA certificate and only the host name check is dropped.",
                           "type": "boolean",
                           "default": false
                         },


### PR DESCRIPTION
Fixes #33342

Connector-local fixes from the MSSQL connector audit. Every one of them is a silent failure today — the run reports success and the metadata is quietly wrong. Nothing here touches the shared engine builder or the lineage matcher.

### What changes

- **Descriptions reach the right database.** The description queries are `DB_NAME()`-scoped but ran *before* the inspector switched, so an ingest-all-databases run documented every database from the previously connected one. Nothing matched, so table, column, schema, database and stored-procedure descriptions were silently missing — the five-level coverage that is our edge over DataHub.
- **Encryption is driver-honest.** `setup_ssl` only ever applied it to pyodbc. `mssql+pytds` — the **default** scheme — has no encrypt switch: it enables TLS only when a CA certificate is supplied, and then always verifies the chain, so `trustServerCertificate` can drop the host-name check alone (it now does). Encrypt with no CA certificate cannot be honoured by that driver, so it **warns** instead of connecting in the clear while the config claims otherwise. `mssql+pymssql`, which takes no TLS parameters at all, warns too. Warning rather than raising keeps existing runs working — say the word if you want it to fail hard.
- **A hung read no longer stalls a workflow forever.** No driver had a query bound and the shared builder sets none. Each now gets one (pyodbc's is a connection attribute, not a connect keyword), applied to a *copy* of the connection so a stored service connection never gains a timeout nobody configured, plus `pool_pre_ping`. The default is 12h, matching the profiler's own `timeoutSeconds` budget, so it rules out only the wait that never ends; `timeout` in `connectionArguments` tightens it per service.
- **Unique constraints are ingested.** The dialect method raised `NotImplementedError` and the catalogue swallows that, so they were dropped for every table.
- **Indexed views are typed as materialized views** — they are persisted and engine-maintained, not plain views.
- **Docs** in `Mssql.md` and the schema descriptions now state the per-driver encryption behaviour and the timeout default.

### Testing

The container suite gains a second database with descriptions at all five levels, a unique constraint and an indexed view, so anything read *per database* is exercised against more than one. `test_reflection.py` asserts what the source reads straight from SQL Server (no OpenMetadata server needed) and `test_metadata.py` asserts the catalogue side. Every new assertion was checked to fail with its fix reverted.

### Not included, deliberately

The shared `builders.py` timeout/retry and pool bound, four-part name resolution in `sql_lineage.py`, ownership, and the `resultLimit` docs — each wants its own PR.

One deletion to flag: the shadowed duplicate of `test_mssql_url` asserted a connection with `database=None`, which the schema has since made required, so reviving it was not an option — it is removed and the live copy loses its `# noqa: F811`.










<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=59980667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; no new actionable issues remain after the previous findings were resolved.

<details open><summary>Summary</summary>

This PR hardens the MSSQL connector:
- Loads descriptions after switching to the database being ingested.
- Applies driver-specific TLS behavior and documents unsupported encryption configurations.
- Bounds query execution, including configured pyodbc query timeouts, without mutating stored service configuration.
- Reflects unique constraints and classifies indexed views as materialized views.
- Adds unit and SQL Server integration coverage for the corrected behavior.

The changes since the previous review only merge unrelated updates from `main`; they do not modify the MSSQL changes under review. Both previous findings are resolved.
</details>

<details open><summary>Diagram</summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MSSQL ingestion starts] --> B[Select target database]
    B --> C[Rebuild inspector for target database]
    C --> D[Load database-scoped descriptions]
    D --> E[Reflect tables, constraints, views, and procedures]
    E --> F{View has unique clustered index?}
    F -->|Yes| G[Emit MaterializedView]
    F -->|No| H[Emit View]
    E --> I[Publish metadata and descriptions]
```
</details>

<sub>Reviews (5) · Last reviewed commit: ["Merge branch &#39;main&#39; into fix/mssql-conne..."](https://github.com/open-metadata/openmetadata/commit/fb73508bc4b543497076b120233b78281be09eb4)</sub>

<!-- /greptile_comment -->