### PR TITLE
test(playwright): stabilise the top-5 merge-group flakes at their cause

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/eslint-suppressions.json
+++ b/openmetadata-ui/src/main/resources/ui/eslint-suppressions.json
@@ -1029,7 +1029,7 @@
   },
   "playwright/e2e/Pages/UserDetails.spec.ts": {
     "om-playwright/no-positional-locator": {
-      "count": 6
+      "count": 5
     }
   },
   "playwright/e2e/Pages/Users.spec.ts": {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AdvancedSearchSuggestions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AdvancedSearchSuggestions.spec.ts
@@ -82,10 +82,16 @@ test.describe('Advanced Search Suggestions', () => {
       // the helper matches the typed-value aggregate specifically so the wait
       // cannot resolve early on the dropdown-open request.
       await expect(async () => {
+        // .catch at construction: the exact dropped-aggregate case this fix
+        // targets leaves the underlying waitForResponse pending, so it will
+        // reject with a Playwright timeout ~30s later once the 5s fallback
+        // timer has already won the race. Without the catch, every toPass
+        // attempt orphans a fresh promise and Playwright surfaces them as
+        // unhandled rejections that can fail the test.
         const aggregateResponse = waitForAggregation(page, {
           field: field.fieldName,
           value: searchText,
-        });
+        }).catch(() => undefined);
         await dropdownInput.fill('');
         await dropdownInput.fill(searchText);
         await Promise.race([

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AdvancedSearchSuggestions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AdvancedSearchSuggestions.spec.ts
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 
+import { expect } from '@playwright/test';
 import { toLower } from 'lodash';
 import { ADVANCED_SEARCH_SUGGESTION_FIELDS } from '../../constant/advancedSearch';
 import { SidebarItem } from '../../constant/sidebar';
@@ -21,11 +22,8 @@ import {
   showAdvancedSearchDialog,
 } from '../../utils/advancedSearch';
 import { redirectToHomePage } from '../../utils/common';
-import {
-  escapeESReservedCharacters,
-  getEncodedFqn,
-  waitForAllLoadersToDisappear,
-} from '../../utils/entity';
+import { waitForAllLoadersToDisappear } from '../../utils/entity';
+import { waitForAggregation } from '../../utils/searchAggregation';
 import { sidebarClick } from '../../utils/sidebar';
 import { test } from '../fixtures/pages';
 
@@ -73,23 +71,29 @@ test.describe('Advanced Search Suggestions', () => {
         getFieldsSuggestionSearchText(field.label, testData.fieldSearchData)
       );
 
-      const aggregateRes2 = page.waitForResponse(
-        `/api/v1/search/aggregate?*${getEncodedFqn(
-          escapeESReservedCharacters(searchText)
-        )}*`
-      );
+      const suggestionOption = page
+        .locator('[role="listbox"]:visible [role="option"]')
+        .filter({ hasText: searchText });
 
-      await dropdownInput.fill(searchText);
-
-      await aggregateRes2;
-
-      await test
-        .expect(
-          page
-            .locator('[role="listbox"]:visible [role="option"]')
-            .filter({ hasText: searchText })
-        )
-        .not.toHaveCount(0);
+      // The ComboBox popover re-mounts under load and the isMounting gate can
+      // drop the aggregate request — the listbox then opens empty. Retry the
+      // fill until at least one matching option renders; each attempt re-arms
+      // waitForAggregation so we don't block forever on a dropped request, and
+      // the helper matches the typed-value aggregate specifically so the wait
+      // cannot resolve early on the dropdown-open request.
+      await expect(async () => {
+        const aggregateResponse = waitForAggregation(page, {
+          field: field.fieldName,
+          value: searchText,
+        });
+        await dropdownInput.fill('');
+        await dropdownInput.fill(searchText);
+        await Promise.race([
+          aggregateResponse,
+          new Promise((resolve) => setTimeout(resolve, 5_000)),
+        ]);
+        await expect(suggestionOption).not.toHaveCount(0, { timeout: 5_000 });
+      }).toPass({ timeout: 30_000, intervals: [500, 1_000, 2_000] });
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
@@ -651,7 +651,22 @@ const expectVisibleAfterHorizontalScroll = async (
   page: Page,
   locator: Locator
 ) => {
-  for (const scrollLeft of [0, 400, 800, 1200, 1600, 2000, 2400]) {
+  const grid = page.locator('.bulk-edit-grid-shell .rdg');
+  const maxScrollLeft = await grid.evaluate(
+    (el) => el.scrollWidth - el.clientWidth
+  );
+
+  // React Data Grid virtualises columns, so a cell is only in the DOM when its
+  // column overlaps the viewport. Step across the whole scroll range in ~250px
+  // increments so we cannot skip past a column between samples.
+  const step = 250;
+  const positions: number[] = [];
+  for (let x = 0; x < maxScrollLeft; x += step) {
+    positions.push(x);
+  }
+  positions.push(Math.max(0, maxScrollLeft));
+
+  for (const scrollLeft of positions) {
     await scrollBulkEditGridTo(page, scrollLeft);
 
     if (await locator.isVisible().catch(() => false)) {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Table.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Table.spec.ts
@@ -260,12 +260,23 @@ test.describe('Table pagination sorting search scenarios ', () => {
     await pageSizeDropdown.scrollIntoViewIfNeeded();
     await expect(pageSizeDropdown).toBeVisible();
     await expect(pageSizeDropdown).toBeEnabled();
-    await pageSizeDropdown.click();
 
-    const pageSizeOption = page
-      .locator('.ant-dropdown:not(.ant-dropdown-hidden)')
-      .getByRole('menuitem', { name: '15 / Page' });
-    await expect(pageSizeOption).toBeVisible();
+    // NextPrevious wraps the button in an Ant Dropdown with the default hover
+    // trigger, so a bare click only fires preventDefault. Hover + click-fallback
+    // + retry — a re-render that nudges the footer out from under the pointer
+    // otherwise leaves the menu closed for good.
+    const pageSizeMenu = page.getByRole('menu').filter({ hasText: '/ Page' });
+    const pageSizeOption = pageSizeMenu.getByRole('menuitem', {
+      name: '15 / Page',
+    });
+    await expect(async () => {
+      await pageSizeDropdown.hover();
+      if (!(await pageSizeMenu.isVisible())) {
+        await pageSizeDropdown.click();
+      }
+      await expect(pageSizeMenu).toBeVisible({ timeout: 2_000 });
+    }).toPass({ timeout: 15_000, intervals: [500, 1_000, 2_000] });
+
     await pageSizeOption.click();
     await waitForAllLoadersToDisappear(page);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataContractInheritance.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataContractInheritance.spec.ts
@@ -1169,15 +1169,20 @@ test.describe('Data Contract Inheritance', () => {
     });
 
     await test.step('Verify asset shows inherited contract', async () => {
-      await tableForRemoveAssetTest.visitEntityPage(page);
-      await openContractTab(page);
-
-      await waitForAllLoadersToDisappear(page);
-
-      // Verify the inherited contract is displayed
-      await expect(page.getByTestId('contract-title')).toContainText(
-        DP_CONTRACT_DETAILS.name
-      );
+      // Contract inheritance propagates asynchronously after the /assets/add
+      // response returns — the search index and the entity's dataProducts field
+      // update on separate event-bus consumers. Reload until the inherited
+      // contract surfaces rather than asserting once and burning 300s on a
+      // stale first paint (which was cascading the whole shard).
+      await expect(async () => {
+        await tableForRemoveAssetTest.visitEntityPage(page);
+        await openContractTab(page);
+        await waitForAllLoadersToDisappear(page);
+        await expect(page.getByTestId('contract-title')).toContainText(
+          DP_CONTRACT_DETAILS.name,
+          { timeout: 5_000 }
+        );
+      }).toPass({ timeout: 30_000, intervals: [2_000, 3_000, 5_000] });
 
       // Verify the inherited icon is shown
       await expect(

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/UserDetails.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/UserDetails.spec.ts
@@ -232,9 +232,13 @@ test.describe('User with different Roles', () => {
       state: 'visible',
     });
 
+    // The team title exists twice on the page — once as the selected chip in the
+    // TreeSelect input, once as the option inside the dropdown. `.nth(1)` matched
+    // the option by DOM order but raced with the dropdown re-rendering after the
+    // hierarchy load. Scope to the dropdown so the option is unambiguous.
     await adminPage
+      .locator('.ant-tree-select-dropdown')
       .locator('[title="' + team.responseData.displayName + '"]')
-      .nth(1)
       .click();
 
     const userProfileResponse = adminPage.waitForResponse((response) =>

--- a/openmetadata-ui/src/main/resources/ui/playwright/eslint-rules/tests/corpus.test.mjs
+++ b/openmetadata-ui/src/main/resources/ui/playwright/eslint-rules/tests/corpus.test.mjs
@@ -42,7 +42,7 @@ test('the suppressions baseline matches its recorded state exactly', () => {
   const EXPECTED = {
     'om-playwright/justified-rule-disable': 12,
     'om-playwright/no-blanket-test-slow': 83,
-    'om-playwright/no-positional-locator': 1324,
+    'om-playwright/no-positional-locator': 1323,
     'om-playwright/require-assertion-per-test': 1,
     'playwright/no-skipped-test': 4,
     'playwright/no-wait-for-selector': 35,


### PR DESCRIPTION
## Describe your changes

Fixes five Playwright specs that accounted for **every hard failure** across the last 20 merge-queue runs — the same failures kept ejecting green PRs and blocking the queue. Each fix removes the specific race at its cause; no `test.slow`, no `waitForTimeout`, no papering over with an inflated retry.

Failure counts across a 20-run sample of `merge_group` Playwright runs:

| Spec | Hard-failure hits | Root cause |
|---|---:|---|
| `Pages/UserDetails.spec.ts:126` inherited-domain after team removal | **9** | positional `.nth(1)` on `[title=…]` — the team title exists twice (chip + tree option); the second match races with the tree-select re-render |
| `Features/MetricBulkImportExportEdit.spec.ts:1285` bulk-edit renders complex fields | **9** | hard-coded scroll positions `[0, 400, …, 2400]` skip past the nested-glossary column between samples — RDG virtualises columns so it's never in the DOM at any checkpoint |
| `Features/Table.spec.ts:252` should persist page size | **3** | `NextPrevious` wraps its button in an Ant `Dropdown` with the default hover trigger, so a bare `.click()` only fires `preventDefault` — the menu never opens |
| `Features/AdvancedSearchSuggestions.spec.ts:51` Database field | recurring | ComboBox popover re-mounts under load and the `isMounting` gate drops the aggregate; the listbox opens empty. `[role="listbox"]:visible [role="option"]` polls 18× against 0 elements |
| `Pages/DataContractInheritance.spec.ts` "Remove Asset" test | 8 in one shard | contract inheritance propagates async after `/assets/add`; first assertion times out at 300 s, cascading the other 7 tests in the file with "Target page/context/browser has been closed" |

### 1. `Features/Table.spec.ts:252` — Ant Dropdown hover-open

Same pattern as the second half of #32506. Hover-first, click-fallback wrapped in `toPass`, and locate the menu by `role="menu"` instead of `.ant-dropdown` (better through the antd → core-components migration).

### 2. `Pages/UserDetails.spec.ts:238`

Scoped the title lookup to `.ant-tree-select-dropdown` so the dropdown option is unambiguous — Playwright's auto-retry handles the tree re-render once the locator matches exactly one element. Pruned one now-stale `om-playwright/no-positional-locator` suppression (6 → 5) via `yarn lint:playwright:suppressions`.

### 3. `Features/AdvancedSearchSuggestions.spec.ts:92`

Switched from an endpoint-URL `waitForResponse` to `waitForAggregation({ field, value })` — the helper matches the typed-value aggregate specifically, so it can't resolve early on the dropdown-open request. Wrapped the fill + assert in `toPass`: each attempt re-arms the wait, so a dropped aggregate no longer wastes 15 s on an empty listbox.

### 4. `Features/MetricBulkImportExportEdit.spec.ts` — `expectVisibleAfterHorizontalScroll`

Replaced the hard-coded step list with `scrollWidth - clientWidth` computed from the grid and iterate in 250 px steps. No column can be skipped between samples.

### 5. `Pages/DataContractInheritance.spec.ts:1153` — "Verify asset shows inherited contract"

Wrapped the first assertion in `toPass` with a full revisit + reopen. Contract inheritance flows through separate event-bus consumers (search index + entity `dataProducts`), so the first paint sometimes lands before propagation. **Fixing the first failure drains the whole cascade** — the other seven tests in the file were dying with "context closed" because the 300 s hang exhausted the shard budget, not because of their own bugs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

Test-only change; no product code touched.

- `yarn lint:playwright` — 0 errors on touched files (7 pre-existing warnings on untouched lines).
- `yarn tsc:playwright` — 0 errors on touched files.
- `yarn lint:playwright:suppressions` — re-baselined; one stale entry pruned.
- `select_playwright_tests.py --event-name pull_request` picks up all 5 specs as `directChangedSpecs` — PR CI runs them under targeted mode alongside the smoke suite; `merge_group` re-runs them in the full plan.

Stress-testing note: `retries: 1` catches transient failures as *flaky* rather than *failed*, so a green PR run + green merge-queue run is the natural non-flakiness signal. If any of the five fixed tests reappears in the failed/flaky lists after this lands, the fix isn't sufficient and needs a follow-up.

## Not addressed in this PR

- `MetricBulkImportExportEdit` may still have a **product-side hydration bug** — the finer-grained scroll should surface the cell if it's rendered at all. If a green scroll sweep still hits `element(s) not found`, that points at the bulk-edit grid, not the test.
- `DataContractInheritance` propagation latency is masked, not fixed. Worth a follow-up look at the event-bus consumer that updates the asset's `dataProducts` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)