### PR TITLE
Fixes #32477: keep edit icon visible when custom property value overflows

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -25,13 +25,6 @@ dotenv.config();
 export default defineConfig({
   testDir: './playwright/e2e',
   outputDir: './playwright/output/test-results',
-  // Omit {projectName} and {platform} from snapshot filenames so a single
-  // reference image works on both macOS dev machines and Linux CI runners.
-  // Edge lines in the lineage PNG are pure bezier geometry (no text/fonts)
-  // and render identically across platforms; the threshold in toMatchSnapshot
-  // absorbs any minor anti-aliasing differences in the node-card text areas.
-  snapshotPathTemplate:
-    '{testDir}/{testFileDir}/__snapshots__/{testFileName}-snapshots/{arg}{ext}',
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
@@ -96,28 +89,7 @@ export default defineConfig({
         '**/DataAssetRulesDisabled.spec.ts',
         '**/SystemCertificationTags.spec.ts',
         '**/SearchRBAC.spec.ts',
-        // Toggles the global enableAccessControl search setting in beforeAll/afterAll —
-        // same reason SearchRBAC.spec.ts is isolated below; runs in the SearchRBAC
-        // project instead so it never races other chromium tests on that setting.
-        '**/DomainIncidentIsolation.spec.ts',
-        '**/SSOLogin.spec.ts',
-        // Runs in its own post-chromium project to prevent IntakeForm.spec.ts's
-        // per-test beforeEach (which deletes all intake forms) from racing against
-        // the domain intake form this spec creates in beforeAll.
-        '**/IntakeFormCustomPropertyFields.spec.ts',
-        // IntakeForm.spec.ts sets required intake-form fields that cause other
-        // chromium tests (e.g. DomainDataProductsWidgets) to fail with 400 when
-        // they create domains or data products. Isolate it post-chromium so those
-        // parallel tests never see active required fields.
-        '**/IntakeForm.spec.ts',
       ],
-    },
-    {
-      name: 'sso-auth',
-      testMatch: ['**/SSOLogin.spec.ts', '**/SSORenewal.spec.ts'],
-      use: { ...devices['Desktop Chrome'] },
-      fullyParallel: false,
-      workers: 1,
     },
     {
       name: 'entity-data-teardown',
@@ -164,34 +136,11 @@ export default defineConfig({
       fullyParallel: true,
     },
     {
-      // Also runs DomainIncidentIsolation.spec.ts (1.13 backport of the #31740 domain-RBAC
-      // fix) — it toggles the same global enableAccessControl setting in beforeAll/afterAll,
-      // so it needs the same isolation from chromium. workers:1 serializes the two spec
-      // files against each other too (a second file here would otherwise be free to run
-      // on a separate worker and race the same setting within this one project).
       name: 'SearchRBAC',
-      testMatch: [
-        '**/SearchRBAC.spec.ts',
-        '**/DomainIncidentIsolation.spec.ts',
-      ],
+      testMatch: '**/SearchRBAC.spec.ts',
       dependencies: ['DataAssetRulesDisabled'],
       use: { ...devices['Desktop Chrome'] },
       teardown: 'entity-data-teardown',
-      workers: 1,
-    },
-    // Compatibility shim for PR workflows that still pass --project=DomainIsolation.
-    // The DomainIsolation E2E suite is not backported to 1.13, so this project intentionally
-    // matches no tests while allowing the workflow argument to resolve.
-    {
-      name: 'DomainIsolation',
-      testMatch: [],
-    },
-    // Compatibility shim for PR workflows that still pass --project=search-nightly.
-    // The dedicated search nightly suite is not backported to 1.13, so this project
-    // intentionally matches no tests while allowing the workflow argument to resolve.
-    {
-      name: 'search-nightly',
-      testMatch: [],
     },
     // System Certification Tags tests modify global shared state (system tags like Gold, Silver, Bronze)
     // They must run in isolation after the main chromium project to avoid flakiness
@@ -200,44 +149,6 @@ export default defineConfig({
       testMatch: '**/SystemCertificationTags.spec.ts',
       use: { ...devices['Desktop Chrome'] },
       dependencies: ['setup', 'chromium'],
-      fullyParallel: false,
-    },
-    // IntakeFormCustomPropertyFields creates a domain intake form in beforeAll
-    // and relies on it persisting across its serial tests. IntakeForm.spec.ts
-    // has a per-test beforeEach that deletes ALL intake forms, so the two specs
-    // race if they run concurrently.
-    //
-    // We deliberately do NOT declare the chromium project as a dependency here:
-    // forcing the entire chromium suite to run before this single file is huge
-    // wasted work (blows the CI job timeout, and no one wants to wait 40+ min
-    // locally either). Instead, run this project by itself with
-    // `--project=IntakeFormCustomPropertyFields` — or with `--project=IntakeForm`,
-    // which pulls this in as its dep.
-    //
-    // DO NOT run `--project=chromium --project=IntakeFormCustomPropertyFields`
-    // (or the full suite with no filter) concurrently — it will race with
-    // chromium tests that create domains/data-products and fail with 400s.
-    {
-      name: 'IntakeFormCustomPropertyFields',
-      testMatch: '**/IntakeFormCustomPropertyFields.spec.ts',
-      use: { ...devices['Desktop Chrome'] },
-      dependencies: ['setup'],
-      fullyParallel: false,
-    },
-    // IntakeForm.spec.ts has a per-test beforeEach that deletes ALL intake forms.
-    // While active, its required fields also break parallel chromium tests that
-    // create domains or data products (400 errors).
-    //
-    // Same rule as IntakeFormCustomPropertyFields above — the chromium project
-    // is NOT declared as a dep. Run only `--project=IntakeForm` (which chains
-    // IntakeFormCustomPropertyFields via its dep) on a dedicated shard.
-    //
-    // DO NOT run this project concurrently with the chromium project.
-    {
-      name: 'IntakeForm',
-      testMatch: '**/IntakeForm.spec.ts',
-      use: { ...devices['Desktop Chrome'] },
-      dependencies: ['setup', 'IntakeFormCustomPropertyFields'],
       fullyParallel: false,
     },
   ],

--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -25,6 +25,13 @@ dotenv.config();
 export default defineConfig({
   testDir: './playwright/e2e',
   outputDir: './playwright/output/test-results',
+  // Omit {projectName} and {platform} from snapshot filenames so a single
+  // reference image works on both macOS dev machines and Linux CI runners.
+  // Edge lines in the lineage PNG are pure bezier geometry (no text/fonts)
+  // and render identically across platforms; the threshold in toMatchSnapshot
+  // absorbs any minor anti-aliasing differences in the node-card text areas.
+  snapshotPathTemplate:
+    '{testDir}/{testFileDir}/__snapshots__/{testFileName}-snapshots/{arg}{ext}',
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
@@ -89,7 +96,28 @@ export default defineConfig({
         '**/DataAssetRulesDisabled.spec.ts',
         '**/SystemCertificationTags.spec.ts',
         '**/SearchRBAC.spec.ts',
+        // Toggles the global enableAccessControl search setting in beforeAll/afterAll —
+        // same reason SearchRBAC.spec.ts is isolated below; runs in the SearchRBAC
+        // project instead so it never races other chromium tests on that setting.
+        '**/DomainIncidentIsolation.spec.ts',
+        '**/SSOLogin.spec.ts',
+        // Runs in its own post-chromium project to prevent IntakeForm.spec.ts's
+        // per-test beforeEach (which deletes all intake forms) from racing against
+        // the domain intake form this spec creates in beforeAll.
+        '**/IntakeFormCustomPropertyFields.spec.ts',
+        // IntakeForm.spec.ts sets required intake-form fields that cause other
+        // chromium tests (e.g. DomainDataProductsWidgets) to fail with 400 when
+        // they create domains or data products. Isolate it post-chromium so those
+        // parallel tests never see active required fields.
+        '**/IntakeForm.spec.ts',
       ],
+    },
+    {
+      name: 'sso-auth',
+      testMatch: ['**/SSOLogin.spec.ts', '**/SSORenewal.spec.ts'],
+      use: { ...devices['Desktop Chrome'] },
+      fullyParallel: false,
+      workers: 1,
     },
     {
       name: 'entity-data-teardown',
@@ -136,11 +164,34 @@ export default defineConfig({
       fullyParallel: true,
     },
     {
+      // Also runs DomainIncidentIsolation.spec.ts (1.13 backport of the #31740 domain-RBAC
+      // fix) — it toggles the same global enableAccessControl setting in beforeAll/afterAll,
+      // so it needs the same isolation from chromium. workers:1 serializes the two spec
+      // files against each other too (a second file here would otherwise be free to run
+      // on a separate worker and race the same setting within this one project).
       name: 'SearchRBAC',
-      testMatch: '**/SearchRBAC.spec.ts',
+      testMatch: [
+        '**/SearchRBAC.spec.ts',
+        '**/DomainIncidentIsolation.spec.ts',
+      ],
       dependencies: ['DataAssetRulesDisabled'],
       use: { ...devices['Desktop Chrome'] },
       teardown: 'entity-data-teardown',
+      workers: 1,
+    },
+    // Compatibility shim for PR workflows that still pass --project=DomainIsolation.
+    // The DomainIsolation E2E suite is not backported to 1.13, so this project intentionally
+    // matches no tests while allowing the workflow argument to resolve.
+    {
+      name: 'DomainIsolation',
+      testMatch: [],
+    },
+    // Compatibility shim for PR workflows that still pass --project=search-nightly.
+    // The dedicated search nightly suite is not backported to 1.13, so this project
+    // intentionally matches no tests while allowing the workflow argument to resolve.
+    {
+      name: 'search-nightly',
+      testMatch: [],
     },
     // System Certification Tags tests modify global shared state (system tags like Gold, Silver, Bronze)
     // They must run in isolation after the main chromium project to avoid flakiness
@@ -149,6 +200,44 @@ export default defineConfig({
       testMatch: '**/SystemCertificationTags.spec.ts',
       use: { ...devices['Desktop Chrome'] },
       dependencies: ['setup', 'chromium'],
+      fullyParallel: false,
+    },
+    // IntakeFormCustomPropertyFields creates a domain intake form in beforeAll
+    // and relies on it persisting across its serial tests. IntakeForm.spec.ts
+    // has a per-test beforeEach that deletes ALL intake forms, so the two specs
+    // race if they run concurrently.
+    //
+    // We deliberately do NOT declare the chromium project as a dependency here:
+    // forcing the entire chromium suite to run before this single file is huge
+    // wasted work (blows the CI job timeout, and no one wants to wait 40+ min
+    // locally either). Instead, run this project by itself with
+    // `--project=IntakeFormCustomPropertyFields` — or with `--project=IntakeForm`,
+    // which pulls this in as its dep.
+    //
+    // DO NOT run `--project=chromium --project=IntakeFormCustomPropertyFields`
+    // (or the full suite with no filter) concurrently — it will race with
+    // chromium tests that create domains/data-products and fail with 400s.
+    {
+      name: 'IntakeFormCustomPropertyFields',
+      testMatch: '**/IntakeFormCustomPropertyFields.spec.ts',
+      use: { ...devices['Desktop Chrome'] },
+      dependencies: ['setup'],
+      fullyParallel: false,
+    },
+    // IntakeForm.spec.ts has a per-test beforeEach that deletes ALL intake forms.
+    // While active, its required fields also break parallel chromium tests that
+    // create domains or data products (400 errors).
+    //
+    // Same rule as IntakeFormCustomPropertyFields above — the chromium project
+    // is NOT declared as a dep. Run only `--project=IntakeForm` (which chains
+    // IntakeFormCustomPropertyFields via its dep) on a dedicated shard.
+    //
+    // DO NOT run this project concurrently with the chromium project.
+    {
+      name: 'IntakeForm',
+      testMatch: '**/IntakeForm.spec.ts',
+      use: { ...devices['Desktop Chrome'] },
+      dependencies: ['setup', 'IntakeFormCustomPropertyFields'],
       fullyParallel: false,
     },
   ],

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
@@ -82,6 +82,7 @@ import {
 import {
   addCustomPropertiesForEntity,
   createCustomPropertyForEntity,
+  createTable,
   CustomProperty,
   CustomPropertyTypeByName,
   deleteCreatedProperty,
@@ -106,7 +107,6 @@ import {
 } from '../../utils/entity';
 import { getEntityFqn } from '../../utils/entityPanel';
 import { navigateToExploreAndSelectEntity } from '../../utils/explore';
-import { createTable } from '../../utils/customProperty';
 import {
   openMatchingFieldsPanel,
   setSliderValue,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
@@ -833,10 +833,9 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
         });
       });
 
-      test('markdown edit button visible and clickable when value contains a table (regression #32477)', async ({
+      test('markdown edit button visible and clickable when value contains a table', async ({
         page,
       }) => {
-        test.slow();
         const propertyName =
           mainEntity.customPropertyValue[CustomPropertyTypeByName.MARKDOWN]
             .property.name;

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
@@ -74,10 +74,12 @@ import { advanceSearchSaveFilter } from '../../utils/advancedSearchCustomPropert
 import {
   clickOutside,
   createNewPage,
+  descriptionBox,
   getApiContext,
   redirectToHomePage,
   uuid,
 } from '../../utils/common';
+import { createTable } from '../../utils/KnowledgeCenter';
 import {
   addCustomPropertiesForEntity,
   createCustomPropertyForEntity,
@@ -828,6 +830,56 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
           await expect(
             container.getByTestId(`toggle-${propertyName}`)
           ).not.toBeVisible();
+        });
+      });
+
+      test('markdown edit button visible and clickable when value contains a table (regression #32477)', async ({
+        page,
+      }) => {
+        test.slow();
+        const propertyName =
+          mainEntity.customPropertyValue[CustomPropertyTypeByName.MARKDOWN]
+            .property.name;
+
+        await test.step('Insert a TipTap table into the markdown property value', async () => {
+          await redirectToHomePage(page);
+          await mainEntity.visitEntityPage(page);
+          await waitForAllLoadersToDisappear(page);
+          await page.getByTestId('custom_properties').click();
+
+          const container = page.locator(
+            `[data-testid="custom-property-${propertyName}-card"]`
+          );
+          await container.getByTestId('edit-icon').scrollIntoViewIfNeeded();
+          await container.getByTestId('edit-icon').click();
+
+          // Move to a new paragraph at the end, then insert a table via slash command
+          const editor = page.locator(descriptionBox);
+          await editor.click();
+          await page.keyboard.press('Control+End');
+          await page.keyboard.press('Enter');
+          await createTable(page);
+
+          const patchResponse = page.waitForResponse(
+            `/api/v1/${entity.entityApiType}/*`
+          );
+          await page.locator('[data-testid="save"]').click();
+          expect((await patchResponse).status()).toBe(200);
+          await waitForAllLoadersToDisappear(page);
+        });
+
+        await test.step('Edit button visible and clickable with wide table in markdown value', async () => {
+          const container = page.locator(
+            `[data-testid="custom-property-${propertyName}-card"]`
+          );
+          const editButton = container.getByTestId('edit-icon');
+          await editButton.scrollIntoViewIfNeeded();
+          await expect(editButton).toBeVisible();
+          await expect(editButton).toBeEnabled();
+
+          // Regression for #32477: edit button must not be hidden by horizontal overflow
+          await editButton.click();
+          await expect(page.locator(descriptionBox)).toBeVisible();
         });
       });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
@@ -79,7 +79,6 @@ import {
   redirectToHomePage,
   uuid,
 } from '../../utils/common';
-import { createTable } from '../../utils/KnowledgeCenter';
 import {
   addCustomPropertiesForEntity,
   createCustomPropertyForEntity,
@@ -107,6 +106,7 @@ import {
 } from '../../utils/entity';
 import { getEntityFqn } from '../../utils/entityPanel';
 import { navigateToExploreAndSelectEntity } from '../../utils/explore';
+import { createTable } from '../../utils/KnowledgeCenter';
 import {
   openMatchingFieldsPanel,
   setSliderValue,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
@@ -106,7 +106,7 @@ import {
 } from '../../utils/entity';
 import { getEntityFqn } from '../../utils/entityPanel';
 import { navigateToExploreAndSelectEntity } from '../../utils/explore';
-import { createTable } from '../../utils/KnowledgeCenter';
+import { createTable } from '../../utils/customProperty';
 import {
   openMatchingFieldsPanel,
   setSliderValue,

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
@@ -1543,3 +1543,8 @@ export const updateCustomPropertyInRightPanel = async (data: {
     await expect(container.getByTestId('no-data')).not.toBeVisible();
   }
 };
+
+export const createTable = async (page: Page) => {
+  await page.keyboard.type('/table');
+  await page.getByRole('option', { name: /table/i }).first().click();
+};

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
@@ -1546,5 +1546,5 @@ export const updateCustomPropertyInRightPanel = async (data: {
 
 export const createTable = async (page: Page) => {
   await page.keyboard.type('/table');
-  await page.getByRole('option', { name: /table/i }).first().click();
+  await page.locator('#editor-commands-viewport').getByText('Table').first().click();
 };

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
@@ -1546,5 +1546,9 @@ export const updateCustomPropertyInRightPanel = async (data: {
 
 export const createTable = async (page: Page) => {
   await page.keyboard.type('/table');
-  await page.locator('#editor-commands-viewport').getByText('Table').first().click();
+  await page
+    .locator('#editor-commands-viewport')
+    .getByText('Table')
+    .first()
+    .click();
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/PropertyValue.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/PropertyValue.test.tsx
@@ -497,4 +497,27 @@ describe('Test PropertyValue Component', () => {
       await screen.findByTestId('entity-reference-select')
     ).toBeInTheDocument();
   });
+
+  it('Should render edit icon alongside toggle when markdown property overflows', async () => {
+    // Regression test for #32477: edit icon must not be hidden inside the overflow container
+    const extension = { yNumber: 'some markdown value' };
+    const propertyType = {
+      ...mockData.property.propertyType,
+      name: 'markdown',
+    };
+    render(
+      <PropertyValue
+        {...mockData}
+        extension={extension}
+        property={{ ...mockData.property, propertyType: propertyType }}
+      />
+    );
+
+    // Both edit icon and expand toggle should be accessible when content overflows
+    const editIcon = await screen.findByTestId('edit-icon');
+    const toggleBtn = await screen.findByTestId(`toggle-${mockData.property.name}`);
+
+    expect(editIcon).toBeInTheDocument();
+    expect(toggleBtn).toBeInTheDocument();
+  });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/PropertyValue.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/PropertyValue.test.tsx
@@ -515,7 +515,9 @@ describe('Test PropertyValue Component', () => {
 
     // Both edit icon and expand toggle should be accessible when content overflows
     const editIcon = await screen.findByTestId('edit-icon');
-    const toggleBtn = await screen.findByTestId(`toggle-${mockData.property.name}`);
+    const toggleBtn = await screen.findByTestId(
+      `toggle-${mockData.property.name}`
+    );
 
     expect(editIcon).toBeInTheDocument();
     expect(toggleBtn).toBeInTheDocument();

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/PropertyValue.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/PropertyValue.tsx
@@ -1197,45 +1197,49 @@ export const PropertyValue: FC<PropertyValueProps> = ({
                 : '32px',
           }}>
           {showInput ? getPropertyInput() : getValueElement()}
-          {hasEditPermissions && !showInput && (
-            <Tooltip
-              placement="left"
-              title={t('label.edit-entity', {
-                entity: getEntityName(property),
-              })}>
+        </div>
+        {!showInput && (hasEditPermissions || isOverflowing) && (
+          <div className="d-flex items-center gap-1 flex-shrink-0">
+            {hasEditPermissions && (
+              <Tooltip
+                placement="left"
+                title={t('label.edit-entity', {
+                  entity: getEntityName(property),
+                })}>
+                <Icon
+                  component={EditIconComponent}
+                  data-testid={`edit-icon${
+                    isRenderedInRightPanel ? '-right-panel' : ''
+                  }`}
+                  style={{ color: DE_ACTIVE_COLOR, ...ICON_DIMENSION }}
+                  tabIndex={0}
+                  onClick={onShowInput}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      onShowInput();
+                    }
+                  }}
+                />
+              </Tooltip>
+            )}
+            {isOverflowing && (
               <Icon
-                component={EditIconComponent}
-                data-testid={`edit-icon${
-                  isRenderedInRightPanel ? '-right-panel' : ''
-                }`}
+                className={classNames('custom-property-value-toggle-btn', {
+                  active: isExpanded,
+                })}
+                component={ArrowIconComponent}
+                data-testid={`toggle-${propertyName}`}
                 style={{ color: DE_ACTIVE_COLOR, ...ICON_DIMENSION }}
                 tabIndex={0}
-                onClick={onShowInput}
+                onClick={toggleExpand}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') {
-                    onShowInput();
+                    toggleExpand();
                   }
                 }}
               />
-            </Tooltip>
-          )}
-        </div>
-        {isOverflowing && !showInput && (
-          <Icon
-            className={classNames('custom-property-value-toggle-btn', {
-              active: isExpanded,
-            })}
-            component={ArrowIconComponent}
-            data-testid={`toggle-${propertyName}`}
-            style={{ color: DE_ACTIVE_COLOR, ...ICON_DIMENSION }}
-            tabIndex={0}
-            onClick={toggleExpand}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                toggleExpand();
-              }
-            }}
-          />
+            )}
+          </div>
         )}
       </div>
     </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/property-value.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/property-value.less
@@ -124,11 +124,9 @@
 }
 
 .value-container {
-  width: 100%;
+  flex: 1;
+  min-width: 0;
   overflow: hidden;
-  display: flex;
-  align-items: center;
-  gap: @size-md;
 }
 
 .custom-property-scrollable-container {


### PR DESCRIPTION
## Description

Backport of #32550 to the `1.13` release branch.

Fixes #32477: A Markdown custom property containing a TipTap table was causing the edit icon to overflow and become invisible/unclickable.

**Fix**: Moves the edit icon outside `.value-container` so it is never clipped by `overflow: hidden`. Groups it with the expand/collapse toggle as `flex-shrink-0` siblings, with `.value-container` updated to `flex: 1; min-width: 0`.

Includes Jest unit tests and Playwright E2E regression tests.

## Cherry-picked commits

- `63adddaf` — Main fix
- `fa33cf5e` — lint fix
- `984176a6` — addressed gitar comment