### PR TITLE
Fixes #32582: route MSSQL table diffs through the driver that can authenticate domain accounts

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/mssql/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/connection.py
@@ -35,9 +35,13 @@ from metadata.core.connections.test_connection.network import NETWORK_ERRORS
 from metadata.generated.schema.entity.services.connections.database.mssqlConnection import (
     MssqlConnection as MssqlConnectionConfig,
 )
+from metadata.generated.schema.entity.services.connections.database.mssqlConnection import (
+    MssqlScheme,
+)
 from metadata.ingestion.connections.builders import (
     create_generic_db_connection,
     get_connection_args_common,
+    get_connection_options_dict,
     get_connection_url_common,
 )
 from metadata.ingestion.connections.connection import BaseConnection
@@ -57,6 +61,34 @@ if TYPE_CHECKING:
     from metadata.core.connections.test_connection import ChecksProvider
     from metadata.core.connections.test_connection.classifier import Matcher
     from metadata.core.connections.test_connection.records import Evidence
+
+
+DEFAULT_SQL_SERVER_PORT = 1433
+DEFAULT_ODBC_DRIVER = "ODBC Driver 18 for SQL Server"
+FREETDS_ODBC_DRIVER = "FreeTDS"
+
+
+def _odbc_driver_for_data_diff(connection: MssqlConnectionConfig) -> str:
+    """The ODBC driver whose auth capability matches `connection.scheme`.
+
+    data-diff is pyodbc-only, so a non-ODBC scheme still has to resolve to an ODBC
+    driver. Only FreeTDS splits a `DOMAIN\\user` login and negotiates NTLM;
+    msodbcsql offers it as a SQL login name, which SQL Server rejects with 18456
+    (a backslash is illegal in a SQL login, so the account can only be a Windows
+    one). pymssql is itself a FreeTDS binding, hence the mapping. pytds is
+    SQL-auth-only, so msodbcsql matches it exactly - routing it to FreeTDS would
+    let the diff authenticate more than metadata ingestion can. See issue #32582.
+
+    `connection.driver` is read only under pyodbc: it is documented as pyodbc-only
+    and otherwise sits at its schema default, so trusting it elsewhere would be a
+    no-op for exactly the configuration this resolves.
+    """
+    scheme = connection.scheme or MssqlScheme.mssql_pytds
+    if scheme.value == MssqlScheme.mssql_pyodbc.value:
+        return connection.driver or DEFAULT_ODBC_DRIVER
+    if scheme.value == MssqlScheme.mssql_pymssql.value:
+        return FREETDS_ODBC_DRIVER
+    return DEFAULT_ODBC_DRIVER
 
 
 def _mssql_number(error: BaseException) -> int | None:
@@ -199,6 +231,32 @@ class MssqlConnection(BaseConnection[MssqlConnectionConfig, Engine]):
         )
         self._on_close(engine.dispose)
         return engine
+
+    def get_connection_dict(self) -> dict:
+        """Return the connection parameters for data-diff.
+
+        Preferred over a rendered SQLAlchemy URL because it bypasses URI parsing
+        entirely: credentials reach data-diff verbatim, so usernames holding
+        reserved characters need no encode/decode round trip (see #31124/#31134),
+        and `odbc_driver` can carry the driver the URL has no room for.
+        """
+        connection = self.service_connection
+        host, _, port = (connection.hostPort or "").partition(":")
+
+        return {
+            # connectionOptions used to ride along as query params on the rendered
+            # URL and land in pyodbc's kwargs. This dict replaces that URL, so it
+            # has to carry them or extra ODBC keywords stop applying to diffs. The
+            # derived values below win: they are what makes domain auth work.
+            **(get_connection_options_dict(connection) or {}),
+            "driver": (connection.scheme or MssqlScheme.mssql_pytds).value,
+            "host": host,
+            "port": int(port) if port else DEFAULT_SQL_SERVER_PORT,
+            "user": connection.username,
+            "password": connection.password.get_secret_value() if connection.password else None,
+            "database": connection.database,
+            "odbc_driver": _odbc_driver_for_data_diff(connection),
+        }
 
     def _get_databases_statement(self) -> str:
         if self.service_connection.ingestAllDatabases:

--- a/ingestion/src/metadata/ingestion/source/database/mssql/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/connection.py
@@ -47,6 +47,9 @@ from metadata.ingestion.connections.builders import (
 from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import SourceConnectionException
 from metadata.ingestion.source.database.azuresql.connection import (
+    DEFAULT_SQL_SERVER_PORT,
+)
+from metadata.ingestion.source.database.azuresql.connection import (
     get_connection_url as get_pyodbc_connection_url,
 )
 from metadata.ingestion.source.database.mssql.queries import (
@@ -64,7 +67,6 @@ if TYPE_CHECKING:
     from metadata.core.connections.test_connection.records import Evidence
 
 
-DEFAULT_SQL_SERVER_PORT = 1433
 DEFAULT_ODBC_DRIVER = "ODBC Driver 18 for SQL Server"
 FREETDS_ODBC_DRIVER = "FreeTDS"
 
@@ -256,6 +258,17 @@ class MssqlConnection(BaseConnection[MssqlConnectionConfig, Engine]):
             )
 
         host, _, port = connection.hostPort.partition(":")
+        if port and not port.isdigit():
+            # Same reasoning as above, from the other side: `int(port)` would raise
+            # ValueError, which that fallback catches, so a typo'd port would drop
+            # the diff back onto the URL path and take the derived ODBC driver with
+            # it. Quietly defaulting to 1433 is no better - it connects somewhere
+            # the user did not ask for.
+            raise SourceConnectionException(
+                f"MSSQL hostPort {connection.hostPort!r} has a non-numeric port, so the table "
+                "diff cannot connect. Set 'Host and Port' to 'host:port', or to 'host' alone "
+                f"to use the default {DEFAULT_SQL_SERVER_PORT}."
+            )
 
         return {
             # connectionOptions used to ride along as query params on the rendered

--- a/ingestion/src/metadata/ingestion/source/database/mssql/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/connection.py
@@ -45,6 +45,7 @@ from metadata.ingestion.connections.builders import (
     get_connection_url_common,
 )
 from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.connections.test_connections import SourceConnectionException
 from metadata.ingestion.source.database.azuresql.connection import (
     get_connection_url as get_pyodbc_connection_url,
 )
@@ -241,7 +242,20 @@ class MssqlConnection(BaseConnection[MssqlConnectionConfig, Engine]):
         and `odbc_driver` can carry the driver the URL has no room for.
         """
         connection = self.service_connection
-        host, _, port = (connection.hostPort or "").partition(":")
+        if not connection.hostPort:
+            # `hostPort` is optional in the schema. Defaulting the host to "" would be
+            # worse than refusing: ODBC reads a blank server as the local machine, so
+            # the diff would quietly connect somewhere unintended. Falling back to a
+            # rendered URL cannot work either - it raises a bare TypeError - and this
+            # must stay outside (ValueError, AttributeError, NotImplementedError), or
+            # BaseTableParameter._get_service_connection_config downgrades it to that
+            # fallback and swallows the message.
+            raise SourceConnectionException(
+                "MSSQL connection has no hostPort configured, so the table diff has nothing "
+                "to connect to. Set 'Host and Port' on the service connection."
+            )
+
+        host, _, port = connection.hostPort.partition(":")
 
         return {
             # connectionOptions used to ride along as query params on the rendered

--- a/ingestion/src/metadata/ingestion/source/database/mssql/data_diff/__init__.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/data_diff/__init__.py
@@ -1,0 +1,10 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/ingestion/src/metadata/ingestion/source/database/mssql/data_diff/data_diff.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/data_diff/data_diff.py
@@ -1,0 +1,43 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""MSSQL spec for data diff"""
+
+from metadata.data_quality.validations.runtime_param_setter.base_diff_params_setter import (
+    BaseTableParameter,
+)
+from metadata.generated.schema.entity.services.databaseService import DatabaseService
+from metadata.utils import fqn
+
+
+class MssqlTableParameter(BaseTableParameter):
+    """MSSQL data_diff parameter setter.
+
+    The base get_data_diff_url obtains a connection dict from
+    MssqlConnection.get_connection_dict, which carries the *service-level*
+    database and no schema. data_diff needs the *table-specific* database and
+    schema to resolve the table path of each side of the diff, and its MsSQL
+    driver requires a schema outright.
+    """
+
+    def get_data_diff_url(
+        self,
+        db_service: DatabaseService,
+        table_fqn: str,
+        override_url: str | dict | None = None,
+    ) -> str | dict:
+        source_url = super().get_data_diff_url(db_service, table_fqn, override_url)
+        if isinstance(source_url, dict):
+            # Work on a copy to avoid mutating a dict that might be reused
+            source_url = dict(source_url)
+            _, database, schema, _ = fqn.split(table_fqn)
+            source_url["database"] = database
+            source_url["schema"] = schema
+        return source_url

--- a/ingestion/src/metadata/ingestion/source/database/mssql/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/service_spec.py
@@ -1,4 +1,7 @@
 from metadata.ingestion.source.database.mssql.connection import MssqlConnection
+from metadata.ingestion.source.database.mssql.data_diff.data_diff import (
+    MssqlTableParameter,
+)
 from metadata.ingestion.source.database.mssql.lineage import MssqlLineageSource
 from metadata.ingestion.source.database.mssql.metadata import MssqlSource
 from metadata.ingestion.source.database.mssql.usage import MssqlUsageSource
@@ -10,5 +13,6 @@ ServiceSpec = DefaultDatabaseSpec(
     lineage_source_class=MssqlLineageSource,
     usage_source_class=MssqlUsageSource,
     sampler_class=MssqlSampler,
+    data_diff=MssqlTableParameter,  # pyright: ignore[reportArgumentType]
     connection_class=MssqlConnection,  # pyright: ignore[reportArgumentType]
 )

--- a/ingestion/tests/unit/observability/data_quality/validations/runtime_param_setter/test_mssql_diff_params_setter.py
+++ b/ingestion/tests/unit/observability/data_quality/validations/runtime_param_setter/test_mssql_diff_params_setter.py
@@ -1,0 +1,215 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""MSSQL table-diff connection parameters.
+
+data-diff is pyodbc-only, so every MSSQL service - whatever SQLAlchemy scheme it
+uses for metadata ingestion - has to resolve to an ODBC driver. Only FreeTDS
+negotiates NTLM for a `DOMAIN\\user` login; msodbcsql sends it as a SQL login name
+and SQL Server answers 18456. See issue #32582.
+"""
+
+import uuid
+
+import pytest
+
+from metadata.generated.schema.entity.services.connections.connectionBasicType import (
+    ConnectionOptions,
+)
+from metadata.generated.schema.entity.services.connections.database.mssqlConnection import (
+    MssqlConnection as MssqlConnectionConfig,
+)
+from metadata.generated.schema.entity.services.connections.database.mssqlConnection import (
+    MssqlScheme,
+)
+from metadata.generated.schema.entity.services.databaseService import (
+    DatabaseConnection,
+    DatabaseService,
+    DatabaseServiceType,
+)
+from metadata.ingestion.source.database.mssql.connection import (
+    DEFAULT_ODBC_DRIVER,
+    FREETDS_ODBC_DRIVER,
+    MssqlConnection,
+    _odbc_driver_for_data_diff,
+)
+
+
+def _config(scheme: MssqlScheme, **kwargs) -> MssqlConnectionConfig:
+    return MssqlConnectionConfig(
+        scheme=scheme,
+        username="NB\\svcaccount",
+        password="secret",
+        hostPort="sqlserver.corp.local:1433",
+        database="DM_Master",
+        **kwargs,
+    )
+
+
+class TestOdbcDriverDerivation:
+    """The ODBC driver must be derived from the scheme, not read off `driver`."""
+
+    def test_pymssql_maps_to_freetds(self):
+        """pymssql is a FreeTDS binding, so FreeTDS is its ODBC equivalent.
+
+        This is the case that motivated the issue: a domain account authenticates
+        under pymssql and must keep authenticating under data-diff.
+        """
+        assert _odbc_driver_for_data_diff(_config(MssqlScheme.mssql_pymssql)) == FREETDS_ODBC_DRIVER
+
+    def test_pymssql_ignores_the_driver_field(self):
+        """`driver` is documented as pyodbc-only and defaults to msodbcsql.
+
+        Forwarding it verbatim would be a no-op for exactly the configuration that
+        is broken, so a pymssql service must ignore whatever it holds.
+        """
+        config = _config(MssqlScheme.mssql_pymssql)
+        assert config.driver == DEFAULT_ODBC_DRIVER  # schema default, never set by a pymssql user
+        assert _odbc_driver_for_data_diff(config) == FREETDS_ODBC_DRIVER
+
+    def test_pyodbc_honours_the_configured_driver(self):
+        config = _config(MssqlScheme.mssql_pyodbc, driver="FreeTDS")
+        assert _odbc_driver_for_data_diff(config) == "FreeTDS"
+
+    def test_pyodbc_falls_back_to_the_default_driver(self):
+        config = _config(MssqlScheme.mssql_pyodbc)
+        config.driver = None
+        assert _odbc_driver_for_data_diff(config) == DEFAULT_ODBC_DRIVER
+
+    def test_pytds_keeps_the_default_driver(self):
+        """pytds is SQL-auth-only, so msodbcsql matches its capability exactly.
+
+        Routing it to FreeTDS would silently widen what the diff can authenticate
+        beyond what metadata ingestion can.
+        """
+        assert _odbc_driver_for_data_diff(_config(MssqlScheme.mssql_pytds)) == DEFAULT_ODBC_DRIVER
+
+
+class TestMssqlConnectionDict:
+    def test_carries_credentials_and_derived_driver(self):
+        connection_dict = MssqlConnection(_config(MssqlScheme.mssql_pymssql)).get_connection_dict()
+
+        assert connection_dict["driver"] == MssqlScheme.mssql_pymssql.value
+        assert connection_dict["host"] == "sqlserver.corp.local"
+        assert connection_dict["port"] == 1433
+        assert connection_dict["database"] == "DM_Master"
+        assert connection_dict["odbc_driver"] == FREETDS_ODBC_DRIVER
+
+    def test_username_is_passed_through_verbatim(self):
+        """The dict path bypasses URI parsing, so the backslash needs no encoding.
+
+        This is what makes the connection dict strictly better than the rendered
+        URL that #31124 / #31134 had to patch.
+        """
+        connection_dict = MssqlConnection(_config(MssqlScheme.mssql_pymssql)).get_connection_dict()
+        assert connection_dict["user"] == "NB\\svcaccount"
+        assert connection_dict["password"] == "secret"
+
+    def test_carries_connection_options(self):
+        """connectionOptions rode along as URL query params and reached pyodbc.
+
+        The dict path replaces that URL, so it has to carry them too or extra ODBC
+        keywords (Encrypt, Authentication, ...) silently stop applying to diffs.
+        """
+        config = _config(MssqlScheme.mssql_pymssql)
+        config.connectionOptions = ConnectionOptions(root={"Encrypt": "no", "Connection Timeout": "60"})
+
+        connection_dict = MssqlConnection(config).get_connection_dict()
+
+        assert connection_dict["Encrypt"] == "no"
+        assert connection_dict["Connection Timeout"] == "60"
+
+    def test_connection_options_cannot_override_the_derived_driver(self):
+        """The derivation is authoritative - it is what makes domain auth work."""
+        config = _config(MssqlScheme.mssql_pymssql)
+        config.connectionOptions = ConnectionOptions(root={"odbc_driver": "ODBC Driver 18 for SQL Server"})
+
+        assert MssqlConnection(config).get_connection_dict()["odbc_driver"] == FREETDS_ODBC_DRIVER
+
+    def test_defaults_the_port_when_host_has_none(self):
+        config = _config(MssqlScheme.mssql_pytds)
+        config.hostPort = "sqlserver.corp.local"
+        assert MssqlConnection(config).get_connection_dict()["port"] == 1433
+
+
+class TestMssqlTableParameter:
+    """data-diff needs the *table's* database and schema, not the service's."""
+
+    @pytest.fixture
+    def db_service(self) -> DatabaseService:
+        return DatabaseService(
+            id=uuid.uuid4(),
+            name="mssql_service",
+            serviceType=DatabaseServiceType.Mssql,
+            connection=DatabaseConnection(config=_config(MssqlScheme.mssql_pymssql)),
+        )
+
+    def test_stamps_database_and_schema_without_mutating_the_service_dict(self, db_service, monkeypatch):
+        from metadata.ingestion.source.database.mssql.data_diff.data_diff import (
+            MssqlTableParameter,
+        )
+
+        service_level_dict = {
+            "driver": "mssql+pymssql",
+            "host": "sqlserver.corp.local",
+            "port": 1433,
+            "user": "NB\\svcaccount",
+            "password": "secret",
+            "database": "DM_Master",
+            "odbc_driver": FREETDS_ODBC_DRIVER,
+        }
+        param_setter = MssqlTableParameter()
+        monkeypatch.setattr(
+            param_setter,
+            "_get_service_connection_config",
+            lambda *_args, **_kwargs: service_level_dict,
+        )
+
+        first = param_setter.get_data_diff_url(db_service, "mssql_service.DM_Master.dbo.DIM_ACCOUNT")
+        second = param_setter.get_data_diff_url(db_service, "mssql_service.Other_DB.staging.DIM_ACCOUNT")
+
+        assert first["database"] == "DM_Master"
+        assert first["schema"] == "dbo"
+        assert second["database"] == "Other_DB"
+        assert second["schema"] == "staging"
+
+        # Neither call may leak into the other, or into the service-level dict.
+        assert first is not service_level_dict
+        assert first is not second
+        assert "schema" not in service_level_dict
+
+    def test_preserves_the_derived_driver_and_scheme(self, db_service, monkeypatch):
+        """The base setter strips `mssql+pymssql` to the `mssql` data-diff scheme.
+
+        `odbc_driver` must survive that untouched - it is the whole point.
+        """
+        from metadata.ingestion.source.database.mssql.data_diff.data_diff import (
+            MssqlTableParameter,
+        )
+
+        param_setter = MssqlTableParameter()
+        monkeypatch.setattr(
+            param_setter,
+            "_get_service_connection_config",
+            lambda *_args, **_kwargs: {
+                "driver": "mssql+pymssql",
+                "host": "sqlserver.corp.local",
+                "port": 1433,
+                "user": "NB\\svcaccount",
+                "database": "DM_Master",
+                "odbc_driver": FREETDS_ODBC_DRIVER,
+            },
+        )
+
+        result = param_setter.get_data_diff_url(db_service, "mssql_service.DM_Master.dbo.DIM_ACCOUNT")
+
+        assert result["driver"] == "mssql"
+        assert result["odbc_driver"] == FREETDS_ODBC_DRIVER
+        assert result["user"] == "NB\\svcaccount"

--- a/ingestion/tests/unit/observability/data_quality/validations/runtime_param_setter/test_mssql_diff_params_setter.py
+++ b/ingestion/tests/unit/observability/data_quality/validations/runtime_param_setter/test_mssql_diff_params_setter.py
@@ -20,6 +20,9 @@ import uuid
 
 import pytest
 
+from metadata.data_quality.validations.runtime_param_setter.base_diff_params_setter import (
+    BaseTableParameter,
+)
 from metadata.generated.schema.entity.services.connections.connectionBasicType import (
     ConnectionOptions,
 )
@@ -154,14 +157,31 @@ class TestMssqlConnectionDict:
         with pytest.raises(SourceConnectionException, match="hostPort"):
             MssqlConnection(config).get_connection_dict()
 
-    def test_missing_host_port_is_not_swallowed_into_a_url_fallback(self):
+    def test_non_numeric_port_fails_with_a_clear_error(self):
+        """`int(port)` on a typo'd port would raise ValueError - a swallowed one.
+
+        Defaulting to 1433 instead would be just as quiet, and would connect to a
+        port the user never asked for.
+        """
+        config = _config(MssqlScheme.mssql_pymssql)
+        config.hostPort = "sqlserver.corp.local:not-a-port"
+
+        with pytest.raises(SourceConnectionException, match="non-numeric port"):
+            MssqlConnection(config).get_connection_dict()
+
+    @pytest.mark.parametrize("host_port", [None, "sqlserver.corp.local:not-a-port"])
+    def test_bad_host_port_is_not_swallowed_into_a_url_fallback(self, host_port):
         """BaseTableParameter._get_service_connection_config catches ValueError.
 
         Raising one here would be silently downgraded to the URL path, losing both
-        this message and the derived driver, so the error must sit outside that
-        tuple.
+        the message and the derived driver, so go through that method rather than
+        `get_connection_dict` directly and prove the error actually surfaces.
         """
-        assert not issubclass(SourceConnectionException, ValueError | AttributeError | NotImplementedError)
+        config = _config(MssqlScheme.mssql_pymssql)
+        config.hostPort = host_port
+
+        with pytest.raises(SourceConnectionException):
+            BaseTableParameter._get_service_connection_config(config)
 
 
 class TestMssqlTableParameter:

--- a/ingestion/tests/unit/observability/data_quality/validations/runtime_param_setter/test_mssql_diff_params_setter.py
+++ b/ingestion/tests/unit/observability/data_quality/validations/runtime_param_setter/test_mssql_diff_params_setter.py
@@ -34,6 +34,7 @@ from metadata.generated.schema.entity.services.databaseService import (
     DatabaseService,
     DatabaseServiceType,
 )
+from metadata.ingestion.connections.test_connections import SourceConnectionException
 from metadata.ingestion.source.database.mssql.connection import (
     DEFAULT_ODBC_DRIVER,
     FREETDS_ODBC_DRIVER,
@@ -137,6 +138,30 @@ class TestMssqlConnectionDict:
         config = _config(MssqlScheme.mssql_pytds)
         config.hostPort = "sqlserver.corp.local"
         assert MssqlConnection(config).get_connection_dict()["port"] == 1433
+
+    def test_missing_host_port_fails_with_a_clear_error(self):
+        """`hostPort` is optional in the schema, so None is reachable.
+
+        An empty host is worse than no dict: ODBC treats a blank server as the
+        local machine, so the diff would connect somewhere unintended instead of
+        failing. Rendering a URL instead cannot work either - it dies with a bare
+        `TypeError: can only concatenate str (not "NoneType")`. Neither is a
+        message anyone can act on, so name the missing field.
+        """
+        config = _config(MssqlScheme.mssql_pymssql)
+        config.hostPort = None
+
+        with pytest.raises(SourceConnectionException, match="hostPort"):
+            MssqlConnection(config).get_connection_dict()
+
+    def test_missing_host_port_is_not_swallowed_into_a_url_fallback(self):
+        """BaseTableParameter._get_service_connection_config catches ValueError.
+
+        Raising one here would be silently downgraded to the URL path, losing both
+        this message and the derived driver, so the error must sit outside that
+        tuple.
+        """
+        assert not issubclass(SourceConnectionException, ValueError | AttributeError | NotImplementedError)
 
 
 class TestMssqlTableParameter:


### PR DESCRIPTION
### Describe your changes:

Fixes #32582

A table diff against a SQL Server service using a **Windows domain account**
(`DOMAIN\user`) always failed to authenticate, while metadata ingestion against
the same service with the same credentials succeeded.

A backslash is illegal in a SQL Server *SQL* login name (`Msg 15006`), so
`DOMAIN\user` can only exist as a Windows login and only authenticates over NTLM.
Which driver makes the connection decides whether that works:

| Scheme / driver | Result with `DOMAIN\user` | Domain support |
|---|---|---|
| `mssql+pytds` (OM default) | `18456` Login failed for user | ❌ plain SQL auth |
| `mssql+pyodbc` + `ODBC Driver 18` | `18456` Login failed for user | ❌ plain SQL auth |
| `mssql+pymssql` | `18452` login is from an untrusted domain | ✅ NTLM negotiated |
| `mssql+pyodbc` + `driver=FreeTDS` | `18452` login is from an untrusted domain | ✅ NTLM negotiated |

The MSSQL connector has no domain-auth code — domain-joined SQL Server works
purely because the user can pick a **FreeTDS-backed** scheme (pymssql *is* a
FreeTDS binding). data-diff is pyodbc-only and hard-codes msodbcsql18, so the
diff had no access to that lever.

I gave `MssqlConnection` a `get_connection_dict()` carrying an ODBC driver
**derived from the scheme**, mirroring the existing `AzureSQLConnection` pattern.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

**Why derive rather than forward `driver`.** `driver` is documented as
pyodbc-only and defaults to `"ODBC Driver 18 for SQL Server"`, so on a
`mssql+pymssql` service it sits at that default and is never set by the user.
Forwarding it verbatim would be a no-op for exactly the configuration that is
broken. The mapping instead answers *"which ODBC driver has the same auth
capability as the scheme metadata ingestion uses?"*:

| Service scheme | `driver` field | data-diff uses |
|---|---|---|
| `mssql+pyodbc` | user-set, meaningful | that value |
| `mssql+pymssql` | default, ignored | `FreeTDS` |
| `mssql+pytds` | default, ignored | `ODBC Driver 18` (unchanged) |

pytds deliberately stays on msodbcsql: it is SQL-auth-only, so routing it to
FreeTDS would let the diff authenticate more than metadata ingestion can.

**Why a connection dict.** It bypasses URI parsing entirely, so credentials reach
data-diff verbatim and usernames holding reserved characters need no
encode/decode round trip — retiring the fragility patched in #31124 / #31134. It
is also the only channel with room for the driver, since a URL's `driver` query
param is overwritten downstream.

**Backward compatibility.** Adding `get_connection_dict()` routes *all* MSSQL
diffs through the dict path, which would silently drop `connectionOptions` —
they used to ride along as URL query params and reach `pyodbc.connect`. They are
now carried explicitly, with derived values taking precedence.

**Rollout.** This is inert until `collate-data-diff` honors `odbc_driver`. ODBC
ignores unrecognised connection-string attributes (verified against both drivers),
so it is safe to merge ahead of that release and activates on the pin bump. The
companion fork change is written and tested:
```python
-self._args["driver"] = "{ODBC Driver 18 for SQL Server}"
+odbc_driver = kw.pop("odbc_driver", None) or DEFAULT_ODBC_DRIVER
+self._args["driver"] = "{%s}" % odbc_driver
```
A separate keyword is required because in a connection dict `driver` is already
consumed by `connect_with_dict` as the *scheme*.

**Alternative rejected.** Kerberos (`Trusted_Connection=yes` + msodbcsql) also
supports domain accounts but needs a ticket cache in the ingestion pod. FreeTDS
NTLM works with the username and password the service already holds, and FreeTDS
is already installed in the ingestion image (`tdsodbc`, `freetds-bin`).

#
### Tests:

#### Use cases covered
- MSSQL service on `mssql+pymssql` with a domain account produces a diff
  connection using FreeTDS, so the account authenticates as it does for ingestion
- MSSQL service on `mssql+pyodbc` keeps whatever driver the user configured
- MSSQL service on `mssql+pytds` is unchanged
- A username containing a backslash reaches data-diff verbatim, unencoded
- `connectionOptions` still apply to table diffs
- A diff spanning databases/schemas gets the per-table path, not the service-level one

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Files added: `ingestion/tests/unit/observability/data_quality/validations/runtime_param_setter/test_mssql_diff_params_setter.py` (12 tests)
- Full `tests/unit/observability/data_quality/` suite: **359 passed**
- `ruff check` / `ruff format` clean; `basedpyright` 0 errors on changed files

Each test was trap-verified rather than only observed green: replacing the
derivation with the naive `connection.driver` passthrough fails exactly the three
pymssql tests, and removing the `connectionOptions` merge fails exactly that test.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable — covered by unit tests; the end-to-end path needs a
  domain-joined SQL Server, which CI has no access to (see manual testing).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed

Against SQL Server 2022 in Docker, with both `msodbcsql18` and FreeTDS installed:

1. Confirmed `CREATE LOGIN [DOMAIN\user] WITH PASSWORD` fails with **Msg 15006**,
   establishing that such an account can only be a Windows login.
2. Connected with `DOMAIN\user` under each scheme and recorded the error numbers
   in the table above — **18456** (SQL auth) vs **18452** (NTLM negotiated).
3. Ran the real OM → data-diff path and confirmed the payload for a pymssql
   service: `odbc_driver: 'FreeTDS'`, `user: 'nb\svcaccount'` verbatim, `schema`
   stamped from the table FQN.
4. Ran a real `hashdiff` through the patched data-diff under **both** drivers —
   identical results (same differing row, same key), confirming FreeTDS is a
   drop-in for this dialect.
5. Confirmed an unknown `odbc_driver` attribute is tolerated by both drivers,
   which is what makes this safe to merge before the fork release.

**Not verified:** that a domain login *completes*. `18452` means the server
rejected an untrusted domain — it proves NTLM was negotiated, but only a
domain-joined instance with the real Windows login can prove the rest.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not needed — no schema change; the existing
      `driver` field is reused.
- [x] For UI changes: not applicable.
- [x] I have added tests and listed them above.

Bug fix
- [x] I have added a test that covers the exact scenario we are fixing
      (`TestOdbcDriverDerivation::test_pymssql_maps_to_freetds`, with issue #32582
      referenced in the module docstring).
