### PR TITLE
Fixes 32584: lower no-positional-locator suppressions baseline to 1322

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/eslint-rules/tests/corpus.test.mjs
+++ b/openmetadata-ui/src/main/resources/ui/playwright/eslint-rules/tests/corpus.test.mjs
@@ -42,7 +42,7 @@ test('the suppressions baseline matches its recorded state exactly', () => {
   const EXPECTED = {
     'om-playwright/justified-rule-disable': 12,
     'om-playwright/no-blanket-test-slow': 83,
-    'om-playwright/no-positional-locator': 1323,
+    'om-playwright/no-positional-locator': 1322,
     'om-playwright/require-assertion-per-test': 1,
     'playwright/no-skipped-test': 4,
     'playwright/no-wait-for-selector': 35,


### PR DESCRIPTION
### Describe your changes:

Fixes #32584

`main` currently fails its own Playwright guardrail check. This lowers the recorded `no-positional-locator` suppressions baseline from **1323** to **1322** so it matches `eslint-suppressions.json`, which is already at 1322.

```diff
   const EXPECTED = {
     'om-playwright/justified-rule-disable': 12,
     'om-playwright/no-blanket-test-slow': 83,
-    'om-playwright/no-positional-locator': 1323,
+    'om-playwright/no-positional-locator': 1322,
     'om-playwright/require-assertion-per-test': 1,
     'playwright/no-skipped-test': 4,
     'playwright/no-wait-for-selector': 35,
   };
```

One line, one file. No production code, no Playwright specs, no suppressions data.

#
## Root cause analysis

### Symptom

`ui-checkstyle` fails in the merge queue. The job is an aggregator over 9 results; the failing one is `lint_playwright_result`. That step is `continue-on-error`, so it reports `conclusion: success` in the step list while its **outcome** is failure — which makes the real cause easy to miss.

Inside the step, ESLint is clean and the guardrail suite is not:

```
##[error]0 ESLint error(s) under playwright/, or a failing guardrail check.
# tests 114 · # pass 113 · # fail 1

not ok 27 - the suppressions baseline matches its recorded state exactly
    +   'om-playwright/no-positional-locator': 1322,
    -   'om-playwright/no-positional-locator': 1323,
```

`corpus.test.mjs` sums `entry.count` across `eslint-suppressions.json` and compares the per-rule totals to a hardcoded `EXPECTED`. The data file says 1322, the recorded literal says 1323.

### It is `main`, not any open PR

Verified on a clean checkout of `origin/main` at `2fb1cb523a`:

```
$ node --test playwright/eslint-rules/tests/corpus.test.mjs
not ok 1 - the suppressions baseline matches its recorded state exactly
# pass 1 · # fail 1
```

Measured at each relevant ref:

| ref | json sum | recorded | |
|---|---|---|---|
| `origin/main` | 1322 | 1323 | ❌ mismatch |
| #32348 branch | 1323 | 1323 | ✅ |
| #32348 merge-base | 1323 | 1323 | ✅ |
| queue base `6e20c8f0` | 1322 | 1323 | ❌ inherits main |
| queue head `a2062355` | 1322 | 1323 | ❌ inherits main |

#32348 changes **zero** Playwright files and touches neither `eslint-suppressions.json` nor `corpus.test.mjs`.

### Why it looked selective

The Playwright lint step is gated on a trigger path list:

```
playwright/**/*.{ts,tsx,js,jsx,mjs,cjs,mts,cts}
playwright/**/*.md
playwright/eslint-rules/**
playwright.config.ts
eslint.config.mjs
eslint-suppressions.json
eslint-rules/**
scripts/generate-playwright-rule-table.mjs
package.json
```

PRs touching none of these skip the step entirely and never evaluate the corpus test — which is why most of the merge queue is green and this sat unnoticed. The ESLint rule-promotion PRs (#32348, #32364, #32381) all edit `eslint.config.mjs`, so they are currently the only ones exercising the gate, and all three fail on it.

### How `main` broke — a semantic merge conflict

Two independently-correct PRs:

| | PR | commit | pruned entry | json sum | recorded |
|---|---|---|---|---|---|
| merge-base `9a73f6c1e0` | — | — | — | 1324 | 1324 |
| **A** | #32078 consolidate destination form | `2edf277d65` (Sep 2) | entry at line ~1242, `count 3 → 2` | 1323 | 1323 |
| **B** | #32576 stabilise merge-group flakes | `4db5ca000e` (Sep 3) | `UserDetails.spec.ts`, `count 6 → 5` | 1323 | 1323 |
| | **merge result** | | | **1322** | **1323** |

#32576 branched from `9a73f6c1e0`, before #32078 landed. The two then:

- pruned **different** entries of `eslint-suppressions.json` → git applied **both** reductions: 1324 − 1 − 1 = **1322**
- made the **identical** `1324 → 1323` edit to `corpus.test.mjs` → git saw no conflict and kept a single **1323**

The additive data file counted two burn-downs; the hand-maintained mirror counted one.

Neither PR is at fault. #32078 was green, and #32576's head at `2596a70eda` is a consistent **1323/1323** — I checked it directly. The inconsistency exists only in the merge result, so no reviewer of either diff could have seen it.

### Why lower rather than raise

The test's own comment states the rule:

> *Lower a number when you fix violations and commit the pruned `eslint-suppressions.json` with it; raising one is almost always wrong.*

`eslint-suppressions.json` is already at 1322 because two real violations were genuinely fixed. This records a burn-down that already happened; it does not relax the gate. The ratchet still only moves down: **1335 → 1328 → 1324 → 1323 → 1322**.

Pushing the JSON back up to 1323 would mean re-suppressing a fixed violation, which is the direction the test explicitly calls wrong.

### Follow-up (not in this PR)

This will recur — any two concurrent burn-down PRs pruning different entries reproduce it, with no mistake by either author. Tracked in #32584. Options: derive `EXPECTED` from the JSON at test time, or have `yarn lint:playwright:suppressions` rewrite both files together so they cannot drift.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — one-line change.

#
### Tests:

#### Use cases covered
- `ui-checkstyle` passes on `main` again.
- PRs touching `eslint.config.mjs` / `playwright/**` are unblocked in the merge queue.

#### Unit tests
This change *is* to a test's recorded baseline. Verified with the exact commands CI runs, in `openmetadata-ui/src/main/resources/ui`:

```
$ yarn test:eslint-rules
# tests 114 · # pass 114 · # fail 0          (was 113 / 1 before)

$ node scripts/generate-playwright-rule-table.mjs --check
rc=0

$ yarn lint:playwright -f json
eslint errors: 0   warnings: 214             (no stale-suppression notice on stderr)
```

Before the change, on the same clean `main` checkout, `corpus.test.mjs` was `# pass 1 · # fail 1`.

#### Backend integration tests
Not applicable — no backend changes.

#### Ingestion integration tests
Not applicable — no ingestion changes.

#### Playwright (UI) tests
Not applicable — no Playwright specs added or changed; this only corrects a recorded count.

#### Manual testing performed
1. Created a clean worktree at `origin/main` (`2fb1cb523a`) and ran `node --test playwright/eslint-rules/tests/corpus.test.mjs` → **fail**.
2. Applied the one-line change → **pass**.
3. Ran the three CI commands above → all green.
4. Reverted and re-confirmed the failure to rule out a dirty worktree.

#
### UI screen recording / screenshots:

Not applicable — no UI changes.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR is linked to a GitHub issue via `Fixes #32584` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
