### PR TITLE
Backport #32181 to 2.0: stop pipeline alerts firing for historical and re-ingested executions

### DIFF
--- a/bootstrap/sql/migrations/native/2.0.2/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/2.0.2/mysql/schemaChanges.sql
@@ -1,0 +1,10 @@
+-- Pipeline alert starting watermark - OpenMetadata 2.0.2
+
+-- Alerts must not fire for pipeline executions that finished before the alert existed (#31782).
+-- Stamp the alerting watermark on subscriptions that already have a consumer offset; subscriptions
+-- without one are stamped when that row is first created. '$.timestamp' is deliberately untouched:
+-- change_event_consumers derives a NOT NULL generated column from it.
+UPDATE change_event_consumers
+SET json = JSON_SET(json, '$.startingTimestamp', CAST(UNIX_TIMESTAMP(NOW(3)) * 1000 AS UNSIGNED))
+WHERE extension = 'eventSubscription.Offset'
+  AND JSON_EXTRACT(json, '$.startingTimestamp') IS NULL;

--- a/bootstrap/sql/migrations/native/2.0.2/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/2.0.2/postgres/schemaChanges.sql
@@ -1,0 +1,13 @@
+-- Pipeline alert starting watermark - OpenMetadata 2.0.2
+
+-- Alerts must not fire for pipeline executions that finished before the alert existed (#31782).
+-- Stamp the alerting watermark on subscriptions that already have a consumer offset; subscriptions
+-- without one are stamped when that row is first created. 'timestamp' is deliberately untouched:
+-- change_event_consumers derives a NOT NULL generated column from it.
+UPDATE change_event_consumers
+SET json = jsonb_set(
+    json,
+    '{startingTimestamp}',
+    to_jsonb((EXTRACT(EPOCH FROM now()) * 1000)::bigint))
+WHERE extension = 'eventSubscription.Offset'
+  AND json ->> 'startingTimestamp' IS NULL;

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AlertsRuleEvaluatorDeletedEntityIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AlertsRuleEvaluatorDeletedEntityIT.java
@@ -151,7 +151,7 @@ public class AlertsRuleEvaluatorDeletedEntityIT {
 
     Map<ChangeEvent, Set<UUID>> delivered =
         AlertUtil.getFilteredEvents(
-            subscriptionFilteringOnDomain(domain.getFullyQualifiedName()), batch);
+            subscriptionFilteringOnDomain(domain.getFullyQualifiedName()), batch, null);
 
     assertTrue(
         delivered.containsKey(liveEvent),

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/changeEvent/AbstractEventConsumer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/changeEvent/AbstractEventConsumer.java
@@ -73,6 +73,7 @@ public abstract class AbstractEventConsumer
   private long pendingGapSince;
   private boolean gapStateChanged;
   private long startingOffset = -1;
+  private Long startingTimestamp;
 
   private AlertMetrics alertMetrics;
 
@@ -118,6 +119,7 @@ public abstract class AbstractEventConsumer
       EventSubscriptionOffset eventSubscriptionOffset = loadInitialOffset(context);
       this.offset = eventSubscriptionOffset.getCurrentOffset();
       this.startingOffset = eventSubscriptionOffset.getStartingOffset();
+      this.startingTimestamp = eventSubscriptionOffset.getStartingTimestamp();
       this.lastReadOffset = this.offset;
       this.pendingGapSince = loadPendingGapSince();
       this.gapStateChanged = false;
@@ -251,7 +253,8 @@ public abstract class AbstractEventConsumer
     if (events.isEmpty()) {
       return;
     }
-    Map<ChangeEvent, Set<UUID>> filteredEvents = getFilteredEvents(eventSubscription, events);
+    Map<ChangeEvent, Set<UUID>> filteredEvents =
+        getFilteredEvents(eventSubscription, events, startingTimestamp);
     RecipientResolver resolver = new RecipientResolver();
     int successDeliveries = 0;
     int failedDeliveries = 0;
@@ -352,6 +355,7 @@ public abstract class AbstractEventConsumer
         new EventSubscriptionOffset()
             .withCurrentOffset(offset)
             .withStartingOffset(startingOffset)
+            .withStartingTimestamp(startingTimestamp)
             .withTimestamp(currentTime);
 
     Entity.getCollectionDAO()

--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/scheduled/EventSubscriptionScheduler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/scheduled/EventSubscriptionScheduler.java
@@ -367,7 +367,14 @@ public class EventSubscriptionScheduler {
   public long getRelevantUnprocessedEvents(UUID subscriptionId) {
     // Fetch subscription ONCE before the loop to avoid N+1 query problem
     // Previously, getEventSubscription was called for each event in the stream
-    FilteringRules filteringRules = getEventSubscription(subscriptionId).getFilteringRules();
+    EventSubscription subscription = getEventSubscription(subscriptionId);
+    FilteringRules filteringRules = subscription.getFilteringRules();
+    Long startingTimestamp =
+        AlertUtil.alertingWatermark(
+            subscription,
+            getEventSubscriptionOffset(subscriptionId)
+                .map(EventSubscriptionOffset::getStartingTimestamp)
+                .orElse(null));
 
     long offset =
         getEventSubscriptionOffset(subscriptionId)
@@ -378,7 +385,9 @@ public class EventSubscriptionScheduler {
         .map(
             eventJson -> {
               ChangeEvent event = JsonUtils.readValue(eventJson, ChangeEvent.class);
-              return AlertUtil.checkIfChangeEventIsAllowed(event, filteringRules) ? event : null;
+              return AlertUtil.checkIfChangeEventIsAllowed(event, filteringRules, startingTimestamp)
+                  ? event
+                  : null;
             })
         .filter(Objects::nonNull)
         .count();
@@ -459,7 +468,14 @@ public class EventSubscriptionScheduler {
   public List<ChangeEvent> getRelevantUnprocessedEvents(
       UUID subscriptionId, int limit, int paginationOffset) {
     // Fetch subscription ONCE before the loop to avoid N+1 query problem
-    FilteringRules filteringRules = getEventSubscription(subscriptionId).getFilteringRules();
+    EventSubscription subscription = getEventSubscription(subscriptionId);
+    FilteringRules filteringRules = subscription.getFilteringRules();
+    Long startingTimestamp =
+        AlertUtil.alertingWatermark(
+            subscription,
+            getEventSubscriptionOffset(subscriptionId)
+                .map(EventSubscriptionOffset::getStartingTimestamp)
+                .orElse(null));
 
     long offset =
         getEventSubscriptionOffset(subscriptionId)
@@ -473,7 +489,9 @@ public class EventSubscriptionScheduler {
         .map(
             eventJson -> {
               ChangeEvent event = JsonUtils.readValue(eventJson, ChangeEvent.class);
-              return AlertUtil.checkIfChangeEventIsAllowed(event, filteringRules) ? event : null;
+              return AlertUtil.checkIfChangeEventIsAllowed(event, filteringRules, startingTimestamp)
+                  ? event
+                  : null;
             })
         .filter(Objects::nonNull)
         .toList();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertUtil.java
@@ -29,13 +29,17 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.common.utils.CommonUtil;
 import org.openmetadata.schema.api.events.AlertFilteringInput;
 import org.openmetadata.schema.api.events.CreateEventSubscription;
+import org.openmetadata.schema.entity.data.PipelineStatus;
 import org.openmetadata.schema.entity.events.Argument;
 import org.openmetadata.schema.entity.events.ArgumentsInput;
 import org.openmetadata.schema.entity.events.EventFilterRule;
@@ -47,6 +51,8 @@ import org.openmetadata.schema.entity.events.SubscriptionStatus;
 import org.openmetadata.schema.entity.events.TestDestinationStatus;
 import org.openmetadata.schema.entity.feed.Thread;
 import org.openmetadata.schema.type.ChangeEvent;
+import org.openmetadata.schema.type.FieldChange;
+import org.openmetadata.schema.type.Status;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.CatalogExceptionMessage;
@@ -59,6 +65,8 @@ public final class AlertUtil {
   // Bounded + thread-safe — also evaluated from EventSubscriptionScheduler parallel streams.
   private static final Cache<String, Expression> COMPILED_CONDITIONS =
       Caffeine.newBuilder().maximumSize(1000).build();
+
+  private static final String FIELD_PIPELINE_STATUS = "pipelineStatus";
 
   private AlertUtil() {}
 
@@ -242,16 +250,41 @@ public final class AlertUtil {
   }
 
   public static Map<ChangeEvent, Set<UUID>> getFilteredEvents(
-      EventSubscription eventSubscription, Map<ChangeEvent, Set<UUID>> events) {
+      EventSubscription eventSubscription,
+      Map<ChangeEvent, Set<UUID>> events,
+      Long startingTimestamp) {
+    Long watermark = alertingWatermark(eventSubscription, startingTimestamp);
     return events.entrySet().stream()
         .filter(
             entry ->
-                checkIfChangeEventIsAllowed(entry.getKey(), eventSubscription.getFilteringRules()))
+                checkIfChangeEventIsAllowed(
+                    entry.getKey(), eventSubscription.getFilteringRules(), watermark))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  /**
+   * Only notification and observability subscriptions suppress historical executions. Custom and
+   * governance-workflow consumers drive integrations that may legitimately need the full stream.
+   */
+  public static Long alertingWatermark(
+      EventSubscription eventSubscription, Long startingTimestamp) {
+    CreateEventSubscription.AlertType alertType = eventSubscription.getAlertType();
+    boolean alerting =
+        alertType == CreateEventSubscription.AlertType.NOTIFICATION
+            || alertType == CreateEventSubscription.AlertType.OBSERVABILITY;
+    return alerting ? startingTimestamp : null;
   }
 
   public static boolean checkIfChangeEventIsAllowed(
       ChangeEvent event, FilteringRules filteringRules) {
+    return checkIfChangeEventIsAllowed(event, filteringRules, null);
+  }
+
+  public static boolean checkIfChangeEventIsAllowed(
+      ChangeEvent event, FilteringRules filteringRules, Long startingTimestamp) {
+    if (isStalePipelineExecution(event, startingTimestamp)) {
+      return false;
+    }
     boolean triggerChangeEvent = AlertUtil.shouldTriggerAlert(event, filteringRules);
 
     if (triggerChangeEvent) {
@@ -275,17 +308,80 @@ public final class AlertUtil {
             .eventSubscriptionDAO()
             .getSubscriberExtension(eventSubscriptionId.toString(), OFFSET_EXTENSION);
     if (json != null) {
-      EventSubscriptionOffset offsetFromDb =
-          JsonUtils.readValue(json, EventSubscriptionOffset.class);
-      startingOffset = offsetFromDb.getStartingOffset();
-      currentOffset = offsetFromDb.getCurrentOffset();
-    } else {
-      currentOffset = Entity.getCollectionDAO().changeEventDAO().getLatestOffset();
-      startingOffset = currentOffset;
+      return JsonUtils.readValue(json, EventSubscriptionOffset.class);
     }
-    return new EventSubscriptionOffset()
-        .withCurrentOffset(currentOffset)
-        .withStartingOffset(startingOffset);
+    currentOffset = Entity.getCollectionDAO().changeEventDAO().getLatestOffset();
+    startingOffset = currentOffset;
+    long now = System.currentTimeMillis();
+    EventSubscriptionOffset offset =
+        new EventSubscriptionOffset()
+            .withCurrentOffset(currentOffset)
+            .withStartingOffset(startingOffset)
+            .withStartingTimestamp(now)
+            .withTimestamp(now);
+    // Persisted here rather than at the first commit. Until a row exists every server restart and
+    // every subscription edit re-derives this, which would drift the watermark forward and silently
+    // suppress executions that failed after the alert was created.
+    Entity.getCollectionDAO()
+        .eventSubscriptionDAO()
+        .upsertSubscriberExtension(
+            eventSubscriptionId.toString(),
+            OFFSET_EXTENSION,
+            "eventSubscriptionOffset",
+            JsonUtils.pojoToJson(offset));
+    return offset;
+  }
+
+  /**
+   * True when a pipeline execution finished before this subscription started alerting. Anything we
+   * cannot place in time is delivered: a suppression rule that cannot decide must not suppress.
+   */
+  public static boolean isStalePipelineExecution(ChangeEvent event, Long startingTimestamp) {
+    if (startingTimestamp == null
+        || event == null
+        || !Entity.PIPELINE.equals(event.getEntityType())
+        || event.getChangeDescription() == null) {
+      return false;
+    }
+    for (FieldChange fieldChange : listOrEmpty(event.getChangeDescription().getFieldsUpdated())) {
+      if (!FIELD_PIPELINE_STATUS.equals(fieldChange.getName())
+          || fieldChange.getNewValue() == null) {
+        continue;
+      }
+      PipelineStatus status;
+      try {
+        status = JsonUtils.convertValue(fieldChange.getNewValue(), PipelineStatus.class);
+      } catch (Exception ex) {
+        // This filter runs on every pipeline event in the batch, including subscriptions with no
+        // pipelineStatus rule, so a throw here would drop the whole delivery batch.
+        LOG.warn("Could not read pipelineStatus for the staleness check, delivering", ex);
+        return false;
+      }
+      OptionalLong executedAt = effectiveExecutionTime(status);
+      return executedAt.isPresent() && executedAt.getAsLong() < startingTimestamp;
+    }
+    return false;
+  }
+
+  /**
+   * Wall-clock time the execution finished. {@code PipelineStatus.timestamp} is deliberately not a
+   * fallback: it is the per-execution unique key, and connectors fill it with anything stable, from
+   * Airflow's logical date to the ingestion clock.
+   */
+  static OptionalLong effectiveExecutionTime(PipelineStatus status) {
+    if (status.getEndTime() != null) {
+      return OptionalLong.of(status.getEndTime());
+    }
+    OptionalLong taskEnd = maxTaskTime(status, Status::getEndTime);
+    return taskEnd.isPresent() ? taskEnd : maxTaskTime(status, Status::getStartTime);
+  }
+
+  private static OptionalLong maxTaskTime(PipelineStatus status, Function<Status, Long> extractor) {
+    return listOrEmpty(status.getTaskStatus()).stream()
+        .map(extractor)
+        .filter(Objects::nonNull)
+        .mapToLong(Long::longValue)
+        .max();
   }
 
   public static FilteringRules validateAndBuildFilteringConditions(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -13182,7 +13182,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
     }
   }
 
-  private Optional<String> buildChangeEventJsonForBulkOperation(
+  Optional<String> buildChangeEventJsonForBulkOperation(
       T entity, EventType eventType, String userName) {
     return buildChangeEventJsonForBulkOperation(entity, eventType, userName, false);
   }
@@ -13221,7 +13221,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
     }
   }
 
-  private void insertChangeEventsBatch(List<String> changeEvents) {
+  void insertChangeEventsBatch(List<String> changeEvents) {
     if (changeEvents == null || changeEvents.isEmpty()) {
       return;
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EventSubscriptionRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EventSubscriptionRepository.java
@@ -178,6 +178,7 @@ public class EventSubscriptionRepository extends EntityRepository<EventSubscript
         new EventSubscriptionOffset()
             .withCurrentOffset(latestOffset)
             .withStartingOffset(latestOffset)
+            .withStartingTimestamp(currentTime)
             .withTimestamp(currentTime);
 
     Entity.getCollectionDAO()

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/PipelineRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/PipelineRepository.java
@@ -41,12 +41,15 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Triple;
+import org.jdbi.v3.core.statement.PreparedBatch;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.api.feed.ResolveTask;
@@ -329,15 +332,20 @@ public class PipelineRepository extends EntityRepository<Pipeline> {
     pipeline.setService(getContainer(pipeline.getId()));
 
     // validate all the Tasks
-    for (Status taskStatus : pipelineStatus.getTaskStatus()) {
+    for (Status taskStatus : listOrEmpty(pipelineStatus.getTaskStatus())) {
       validateTask(pipeline, taskStatus.getName());
     }
 
-    // Pipeline status is from the pipeline execution. There is no gurantee that it is unique as it
-    // is unrelated to workflow execution. We should bring back the old behavior for this one.
-    String storedPipelineStatus =
-        getExtensionAtTimestamp(fqn, PIPELINE_STATUS_EXTENSION, pipelineStatus.getTimestamp());
-    if (storedPipelineStatus != null) {
+    StatusChange statusChange =
+        resolveStatusChange(pipeline.getFullyQualifiedName(), pipelineStatus);
+    if (statusChange.outcome() == StatusOutcome.UNCHANGED) {
+      // A re-sent identical status writes nothing: every ES call here forces a segment refresh, and
+      // ENTITY_NO_CHANGE keeps ChangeEventHandler from emitting an event the alert would fire on.
+      return new RestUtil.PutResponse<>(
+          Response.Status.OK, pipeline.withPipelineStatus(pipelineStatus), ENTITY_NO_CHANGE);
+    }
+
+    if (statusChange.outcome() == StatusOutcome.UPDATED) {
       daoCollection
           .entityExtensionTimeSeriesDao()
           .update(
@@ -355,7 +363,7 @@ public class PipelineRepository extends EntityRepository<Pipeline> {
 
     ChangeDescription change =
         addPipelineStatusChangeDescription(
-            pipeline.getVersion(), pipelineStatus, storedPipelineStatus);
+            pipeline.getVersion(), pipelineStatus, statusChange.previous());
     pipeline.setPipelineStatus(pipelineStatus);
     pipeline.setChangeDescription(change);
     pipeline.setIncrementalChangeDescription(change);
@@ -387,58 +395,169 @@ public class PipelineRepository extends EntityRepository<Pipeline> {
   }
 
   public RestUtil.PutResponse<?> addBulkPipelineStatus(
-      String fqn, List<PipelineStatus> pipelineStatuses) {
+      String fqn, List<PipelineStatus> pipelineStatuses, String updatedBy) {
     Pipeline pipeline = daoCollection.pipelineDAO().findEntityByName(fqn);
     pipeline.setService(getContainer(pipeline.getId()));
 
-    if (pipelineStatuses == null || pipelineStatuses.isEmpty()) {
+    // Postgres ON CONFLICT rejects duplicate keys within one statement, so collapse them first.
+    List<PipelineStatus> incoming = dedupeByTimestamp(pipelineStatuses);
+    if (incoming.isEmpty()) {
       return new RestUtil.PutResponse<>(Response.Status.OK, pipeline, ENTITY_NO_CHANGE);
     }
+    validateTasks(pipeline, incoming);
 
+    Map<Long, PipelineStatus> stored = loadStoredStatuses(pipeline, incoming);
+    List<PipelineStatus> written = new ArrayList<>();
+    List<String> changeEvents = new ArrayList<>();
+
+    // incoming is ordered oldest first, so change events are emitted chronologically.
+    for (PipelineStatus status : incoming) {
+      StatusChange statusChange = resolveStatusChange(stored.get(status.getTimestamp()), status);
+      if (statusChange.outcome() == StatusOutcome.UNCHANGED) {
+        continue;
+      }
+      written.add(status);
+      buildStatusChangeEvent(pipeline, status, statusChange.previous(), updatedBy)
+          .ifPresent(changeEvents::add);
+    }
+
+    PipelineStatus latestStatus = incoming.getLast();
+    boolean latestChanged =
+        !written.isEmpty() && written.getLast().getTimestamp().equals(latestStatus.getTimestamp());
+
+    if (!written.isEmpty()) {
+      bulkUpsertPipelineStatuses(pipeline.getFullyQualifiedName(), written);
+      searchRepository.bulkIndexPipelineExecutions(pipeline, written);
+      if (RdfUpdater.isEnabled()) {
+        written.forEach(status -> storePipelineExecutionInRdf(pipeline, status));
+      }
+    }
+
+    pipeline.setPipelineStatus(latestStatus);
+    if (latestChanged) {
+      refreshPipelineIndexes(pipeline);
+    }
+
+    // This endpoint emits one change event per status, which the response filter cannot do, so the
+    // repository owns emission and ENTITY_NO_CHANGE stops the filter adding a duplicate.
+    insertChangeEventsInChunks(changeEvents);
+
+    return new RestUtil.PutResponse<>(
+        Response.Status.OK, pipeline.withPipelineStatus(latestStatus), ENTITY_NO_CHANGE);
+  }
+
+  private static List<PipelineStatus> dedupeByTimestamp(List<PipelineStatus> pipelineStatuses) {
+    Map<Long, PipelineStatus> byTimestamp = new LinkedHashMap<>();
+    for (PipelineStatus status : listOrEmpty(pipelineStatuses)) {
+      byTimestamp.put(status.getTimestamp(), status);
+    }
+    return byTimestamp.values().stream()
+        .sorted(Comparator.comparing(PipelineStatus::getTimestamp))
+        .toList();
+  }
+
+  private void validateTasks(Pipeline pipeline, List<PipelineStatus> statuses) {
     Set<String> validatedTasks = new HashSet<>();
-    for (PipelineStatus pipelineStatus : pipelineStatuses) {
-      for (Status taskStatus : listOrEmpty(pipelineStatus.getTaskStatus())) {
+    for (PipelineStatus status : statuses) {
+      for (Status taskStatus : listOrEmpty(status.getTaskStatus())) {
         if (validatedTasks.add(taskStatus.getName())) {
           validateTask(pipeline, taskStatus.getName());
         }
       }
     }
+  }
 
-    PipelineStatus latestStatus = null;
-    for (PipelineStatus pipelineStatus : pipelineStatuses) {
-      if (latestStatus == null || pipelineStatus.getTimestamp() > latestStatus.getTimestamp()) {
-        latestStatus = pipelineStatus;
-      }
+  private Map<Long, PipelineStatus> loadStoredStatuses(
+      Pipeline pipeline, List<PipelineStatus> incoming) {
+    long from = incoming.getFirst().getTimestamp();
+    long to = incoming.getLast().getTimestamp();
+    Map<Long, PipelineStatus> stored = new HashMap<>();
+    for (String json :
+        getResultsFromAndToTimestamps(
+            pipeline.getFullyQualifiedName(), PIPELINE_STATUS_EXTENSION, from, to)) {
+      PipelineStatus status = JsonUtils.readValue(json, PipelineStatus.class);
+      stored.put(status.getTimestamp(), status);
     }
+    return stored;
+  }
 
-    bulkUpsertPipelineStatuses(pipeline.getFullyQualifiedName(), pipelineStatuses);
-
-    searchRepository.bulkIndexPipelineExecutions(pipeline, pipelineStatuses);
-
-    if (RdfUpdater.isEnabled() && latestStatus != null) {
-      storePipelineExecutionInRdf(pipeline, latestStatus);
-    }
-
-    pipeline.setPipelineStatus(latestStatus);
+  private Optional<String> buildStatusChangeEvent(
+      Pipeline pipeline, PipelineStatus status, PipelineStatus previous, String updatedBy) {
     ChangeDescription change =
-        addPipelineStatusChangeDescription(pipeline.getVersion(), latestStatus, null);
-    pipeline.setChangeDescription(change);
-    pipeline.setIncrementalChangeDescription(change);
+        addPipelineStatusChangeDescription(pipeline.getVersion(), status, previous);
+    Pipeline snapshot = JsonUtils.deepCopy(pipeline, Pipeline.class);
+    snapshot.setPipelineStatus(status);
+    snapshot.setChangeDescription(change);
+    snapshot.setIncrementalChangeDescription(change);
+    // Wall-clock, not status.getTimestamp(): /v1/events filters on ChangeEvent.timestamp.
+    snapshot.setUpdatedAt(System.currentTimeMillis());
+    return buildChangeEventJsonForBulkOperation(snapshot, ENTITY_UPDATED, updatedBy);
+  }
 
+  private void insertChangeEventsInChunks(List<String> changeEvents) {
+    for (int i = 0; i < changeEvents.size(); i += CHANGE_EVENT_CHUNK_SIZE) {
+      insertChangeEventsBatch(
+          changeEvents.subList(i, Math.min(i + CHANGE_EVENT_CHUNK_SIZE, changeEvents.size())));
+    }
+  }
+
+  private void refreshPipelineIndexes(Pipeline pipeline) {
     try {
       searchRepository.updateEntityIndex(pipeline);
+      searchRepository
+          .getSearchClient()
+          .reindexAcrossIndices(
+              "upstreamLineage.pipeline.fullyQualifiedName", pipeline.getEntityReference());
     } catch (Exception e) {
       LOG.error("Failed to update pipeline entity index in Elasticsearch", e);
     }
+  }
 
-    return new RestUtil.PutResponse<>(
-        Response.Status.OK,
-        pipeline.withPipelineStatus(latestStatus).withUpdatedAt(System.currentTimeMillis()),
-        ENTITY_UPDATED);
+  enum StatusOutcome {
+    UNCHANGED,
+    CREATED,
+    UPDATED
+  }
+
+  record StatusChange(StatusOutcome outcome, PipelineStatus previous) {}
+
+  private static final int CHANGE_EVENT_CHUNK_SIZE = 100;
+
+  private static final Comparator<Status> BY_TASK_NAME =
+      Comparator.comparing(Status::getName, Comparator.nullsFirst(String::compareTo));
+
+  private StatusChange resolveStatusChange(String pipelineFqn, PipelineStatus incoming) {
+    String storedJson =
+        getExtensionAtTimestamp(pipelineFqn, PIPELINE_STATUS_EXTENSION, incoming.getTimestamp());
+    return resolveStatusChange(
+        storedJson == null ? null : JsonUtils.readValue(storedJson, PipelineStatus.class),
+        incoming);
+  }
+
+  private StatusChange resolveStatusChange(PipelineStatus stored, PipelineStatus incoming) {
+    if (stored == null) {
+      return new StatusChange(StatusOutcome.CREATED, null);
+    }
+    return new StatusChange(
+        isSameStatus(stored, incoming) ? StatusOutcome.UNCHANGED : StatusOutcome.UPDATED, stored);
+  }
+
+  static boolean isSameStatus(PipelineStatus stored, PipelineStatus incoming) {
+    return canonicalize(stored).equals(canonicalize(incoming));
+  }
+
+  // Round-trips through JSON so an explicit null collapses onto the schema default, and orders
+  // taskStatus by name because connectors do not guarantee a stable order across ingestions.
+  private static PipelineStatus canonicalize(PipelineStatus status) {
+    PipelineStatus copy = JsonUtils.readValue(JsonUtils.pojoToJson(status), PipelineStatus.class);
+    if (copy.getTaskStatus() != null) {
+      copy.setTaskStatus(copy.getTaskStatus().stream().sorted(BY_TASK_NAME).toList());
+    }
+    return copy;
   }
 
   private ChangeDescription addPipelineStatusChangeDescription(
-      Double version, Object newValue, Object oldValue) {
+      Double version, PipelineStatus newValue, PipelineStatus oldValue) {
     FieldChange fieldChange =
         new FieldChange().withName("pipelineStatus").withNewValue(newValue).withOldValue(oldValue);
     ChangeDescription change = new ChangeDescription().withPreviousVersion(version);
@@ -461,9 +580,9 @@ public class PipelineRepository extends EntityRepository<Pipeline> {
               + "ON CONFLICT (entityFQNHash, extension, timestamp) DO UPDATE SET json = EXCLUDED.json";
     }
     Entity.getJdbi()
-        .useHandle(
+        .useTransaction(
             handle -> {
-              var batch = handle.prepareBatch(sql);
+              PreparedBatch batch = handle.prepareBatch(sql);
               for (PipelineStatus pipelineStatus : pipelineStatuses) {
                 batch
                     .bind("entityFQNHash", entityFQNHash)
@@ -493,7 +612,8 @@ public class PipelineRepository extends EntityRepository<Pipeline> {
     String docId = PipelineExecutionIndex.getDocumentId(pipeline, pipelineStatus);
     String docJson = JsonUtils.pojoToJson(doc);
     String indexName =
-        Entity.getSearchRepository().getIndexOrAliasName("pipeline_status_search_index");
+        searchRepository.routeToStagedIfActive(
+            searchRepository.getIndexOrAliasName("pipeline_status_search_index"));
 
     searchRepository.getSearchClient().createEntity(indexName, docId, docJson);
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
@@ -3636,7 +3636,8 @@ public class TableRepository extends EntityRepository<Table> {
 
     // Use getIndexOrAliasName to get the correct index name with prefix
     String indexName =
-        Entity.getSearchRepository().getIndexOrAliasName("pipeline_status_search_index");
+        searchRepository.routeToStagedIfActive(
+            searchRepository.getIndexOrAliasName("pipeline_status_search_index"));
     searchRepository.getSearchClient().createEntity(indexName, docId, docJson);
 
     LOG.debug(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/pipelines/PipelineResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/pipelines/PipelineResource.java
@@ -577,7 +577,9 @@ public class PipelineResource extends EntityResource<Pipeline, PipelineRepositor
     OperationContext operationContext =
         new OperationContext(entityType, MetadataOperation.EDIT_STATUS);
     authorizer.authorize(securityContext, operationContext, getResourceContextByName(fqn));
-    return repository.addBulkPipelineStatus(fqn, pipelineStatuses).toResponse();
+    return repository
+        .addBulkPipelineStatus(fqn, pipelineStatuses, securityContext.getUserPrincipal().getName())
+        .toResponse();
   }
 
   @GET

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/changeEvent/AbstractEventConsumerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/changeEvent/AbstractEventConsumerTest.java
@@ -473,7 +473,7 @@ class AbstractEventConsumerTest {
     Map<ChangeEvent, Set<UUID>> events = Map.of(event, Set.of(webhookId, emailId));
 
     try (MockedStatic<AlertUtil> alertUtil = mockStatic(AlertUtil.class)) {
-      alertUtil.when(() -> AlertUtil.getFilteredEvents(any(), any())).thenReturn(events);
+      alertUtil.when(() -> AlertUtil.getFilteredEvents(any(), any(), any())).thenReturn(events);
       consumer.publishEvents(events);
     }
 
@@ -540,7 +540,7 @@ class AbstractEventConsumerTest {
             mockConstruction(
                 RecipientResolver.class,
                 (mock, ctx) -> when(mock.resolveRecipients(any(), anyList())).thenReturn(union))) {
-      alertUtil.when(() -> AlertUtil.getFilteredEvents(any(), any())).thenReturn(events);
+      alertUtil.when(() -> AlertUtil.getFilteredEvents(any(), any(), any())).thenReturn(events);
 
       consumer.publishEvents(events);
 
@@ -579,7 +579,7 @@ class AbstractEventConsumerTest {
                 RecipientResolver.class,
                 (mock, ctx) ->
                     when(mock.resolveRecipients(any(), anyList())).thenReturn(Set.of()))) {
-      alertUtil.when(() -> AlertUtil.getFilteredEvents(any(), any())).thenReturn(events);
+      alertUtil.when(() -> AlertUtil.getFilteredEvents(any(), any(), any())).thenReturn(events);
       consumer.publishEvents(events);
     }
 
@@ -605,7 +605,7 @@ class AbstractEventConsumerTest {
     try (MockedStatic<AlertUtil> alertUtil = mockStatic(AlertUtil.class);
         MockedConstruction<RecipientResolver> resolverCtor =
             mockConstruction(RecipientResolver.class)) {
-      alertUtil.when(() -> AlertUtil.getFilteredEvents(any(), any())).thenReturn(events);
+      alertUtil.when(() -> AlertUtil.getFilteredEvents(any(), any(), any())).thenReturn(events);
       consumer.publishEvents(events);
 
       RecipientResolver resolver = resolverCtor.constructed().getFirst();
@@ -637,7 +637,7 @@ class AbstractEventConsumerTest {
     try (MockedStatic<AlertUtil> alertUtil = mockStatic(AlertUtil.class);
         MockedConstruction<RecipientResolver> resolverCtor =
             mockConstruction(RecipientResolver.class)) {
-      alertUtil.when(() -> AlertUtil.getFilteredEvents(any(), any())).thenReturn(events);
+      alertUtil.when(() -> AlertUtil.getFilteredEvents(any(), any(), any())).thenReturn(events);
       consumer.publishEvents(events);
     }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/events/subscription/StalePipelineExecutionTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/events/subscription/StalePipelineExecutionTest.java
@@ -1,0 +1,179 @@
+package org.openmetadata.service.events.subscription;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.api.events.CreateEventSubscription;
+import org.openmetadata.schema.entity.data.PipelineStatus;
+import org.openmetadata.schema.entity.events.ArgumentsInput;
+import org.openmetadata.schema.entity.events.EventFilterRule;
+import org.openmetadata.schema.entity.events.EventSubscription;
+import org.openmetadata.schema.entity.events.FilteringRules;
+import org.openmetadata.schema.type.ChangeDescription;
+import org.openmetadata.schema.type.ChangeEvent;
+import org.openmetadata.schema.type.EventType;
+import org.openmetadata.schema.type.FieldChange;
+import org.openmetadata.schema.type.Status;
+import org.openmetadata.schema.type.StatusType;
+import org.openmetadata.service.Entity;
+
+/**
+ * The historical-execution cut-off for #31782. Every case here is a way the rule could either
+ * silence a real failure or fail to silence a backfilled one.
+ */
+class StalePipelineExecutionTest {
+
+  private static final long WATERMARK = 1_700_000_000_000L;
+  private static final long HOUR = 3_600_000L;
+
+  private static ChangeEvent pipelineStatusEvent(PipelineStatus status) {
+    return new ChangeEvent()
+        .withId(UUID.randomUUID())
+        .withEventType(EventType.ENTITY_UPDATED)
+        .withEntityType(Entity.PIPELINE)
+        .withChangeDescription(
+            new ChangeDescription()
+                .withFieldsUpdated(
+                    List.of(new FieldChange().withName("pipelineStatus").withNewValue(status)))
+                .withFieldsAdded(Collections.emptyList()));
+  }
+
+  private static PipelineStatus status(Long timestamp, Long taskEnd) {
+    return new PipelineStatus()
+        .withTimestamp(timestamp)
+        .withExecutionStatus(StatusType.Failed)
+        .withTaskStatus(
+            List.of(
+                new Status()
+                    .withName("t1")
+                    .withExecutionStatus(StatusType.Failed)
+                    .withEndTime(taskEnd)));
+  }
+
+  @Test
+  @DisplayName("an execution that finished before the alert existed is stale")
+  void oldExecutionIsStale() {
+    ChangeEvent event =
+        pipelineStatusEvent(status(WATERMARK - 40 * 24 * HOUR, WATERMARK - 40 * 24 * HOUR));
+    assertTrue(AlertUtil.isStalePipelineExecution(event, WATERMARK));
+  }
+
+  @Test
+  @DisplayName("a daily DAG's stale logical date must not silence a run that just failed")
+  void logicalDateOlderThanWatermarkButTaskFinishedNow() {
+    // Airflow's logical_date is the data-interval start, so a run executing today carries
+    // yesterday's timestamp. Judging on timestamp would black out alerting for a full interval.
+    ChangeEvent event = pipelineStatusEvent(status(WATERMARK - 24 * HOUR, WATERMARK + 2 * HOUR));
+    assertFalse(AlertUtil.isStalePipelineExecution(event, WATERMARK));
+  }
+
+  @Test
+  @DisplayName("top-level endTime wins over task times")
+  void topLevelEndTimeIsPreferred() {
+    PipelineStatus status = status(WATERMARK - 24 * HOUR, WATERMARK - 24 * HOUR);
+    status.setEndTime(WATERMARK + HOUR);
+    assertFalse(AlertUtil.isStalePipelineExecution(pipelineStatusEvent(status), WATERMARK));
+  }
+
+  @Test
+  @DisplayName("no wall clock at all fails open rather than silencing")
+  void missingWallClocksFailOpen() {
+    PipelineStatus status =
+        new PipelineStatus()
+            .withTimestamp(WATERMARK - 40 * 24 * HOUR)
+            .withExecutionStatus(StatusType.Failed)
+            .withTaskStatus(Collections.emptyList());
+    assertFalse(AlertUtil.isStalePipelineExecution(pipelineStatusEvent(status), WATERMARK));
+  }
+
+  @Test
+  @DisplayName("a null watermark delivers everything, so upgrades do not silently suppress")
+  void nullWatermarkDeliversEverything() {
+    ChangeEvent event =
+        pipelineStatusEvent(status(WATERMARK - 40 * 24 * HOUR, WATERMARK - 40 * 24 * HOUR));
+    assertFalse(AlertUtil.isStalePipelineExecution(event, null));
+  }
+
+  @Test
+  @DisplayName("non-pipeline events are untouched")
+  void nonPipelineEventsAreUntouched() {
+    ChangeEvent event =
+        pipelineStatusEvent(status(WATERMARK - 40 * 24 * HOUR, WATERMARK - 40 * 24 * HOUR))
+            .withEntityType(Entity.TABLE);
+    assertFalse(AlertUtil.isStalePipelineExecution(event, WATERMARK));
+  }
+
+  @Test
+  @DisplayName("only notification and observability subscriptions suppress history")
+  void watermarkAppliesOnlyToAlertingSubscriptions() {
+    assertTrue(
+        AlertUtil.alertingWatermark(
+                subscription(CreateEventSubscription.AlertType.OBSERVABILITY), WATERMARK)
+            != null);
+    assertTrue(
+        AlertUtil.alertingWatermark(
+                subscription(CreateEventSubscription.AlertType.NOTIFICATION), WATERMARK)
+            != null);
+    assertFalse(
+        AlertUtil.alertingWatermark(
+                subscription(CreateEventSubscription.AlertType.CUSTOM), WATERMARK)
+            != null);
+    assertFalse(
+        AlertUtil.alertingWatermark(
+                subscription(CreateEventSubscription.AlertType.GOVERNANCE_WORKFLOW_CHANGE_EVENT),
+                WATERMARK)
+            != null);
+  }
+
+  private static EventSubscription subscription(CreateEventSubscription.AlertType alertType) {
+    return new EventSubscription().withId(UUID.randomUUID()).withAlertType(alertType);
+  }
+
+  @Test
+  @DisplayName("an EXCLUDE rule must still drop a stale execution rather than deliver it")
+  void staleEventIsDroppedUnderAnExcludeRule() {
+    // The cut-off deliberately sits outside the rule engine. EXCLUDE rules compile to !(condition),
+    // so moving this check into matchPipelineState would make such an alert fire on exactly the
+    // backfilled executions it is meant to suppress.
+    ChangeEvent stale =
+        pipelineStatusEvent(status(WATERMARK - 40 * 24 * HOUR, WATERMARK - 40 * 24 * HOUR));
+    EventFilterRule rule =
+        new EventFilterRule()
+            .withName("trigger")
+            .withEffect(ArgumentsInput.Effect.EXCLUDE)
+            .withCondition("matchPipelineState({'Failed'})")
+            .withPrefixCondition(ArgumentsInput.PrefixCondition.AND);
+    FilteringRules rules =
+        new FilteringRules()
+            .withResources(List.of("pipeline"))
+            .withRules(Collections.emptyList())
+            .withActions(List.of(rule));
+
+    assertFalse(AlertUtil.checkIfChangeEventIsAllowed(stale, rules, WATERMARK));
+  }
+
+  @Test
+  @DisplayName("an unreadable pipelineStatus payload is delivered, not thrown out of the batch")
+  void unreadablePayloadIsDelivered() {
+    ChangeEvent event =
+        new ChangeEvent()
+            .withId(UUID.randomUUID())
+            .withEventType(EventType.ENTITY_UPDATED)
+            .withEntityType(Entity.PIPELINE)
+            .withChangeDescription(
+                new ChangeDescription()
+                    .withFieldsUpdated(
+                        List.of(
+                            new FieldChange()
+                                .withName("pipelineStatus")
+                                .withNewValue("not a pipeline status")))
+                    .withFieldsAdded(Collections.emptyList()));
+
+    assertFalse(AlertUtil.isStalePipelineExecution(event, WATERMARK));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/PipelineStatusComparisonTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/PipelineStatusComparisonTest.java
@@ -1,0 +1,73 @@
+package org.openmetadata.service.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.entity.data.PipelineStatus;
+import org.openmetadata.schema.type.Status;
+import org.openmetadata.schema.type.StatusType;
+
+/**
+ * Guards the equality check behind ENTITY_NO_CHANGE for pipeline status writes. A false "changed"
+ * here re-opens the alert storm of #31782, so each case below is a way a re-sent but identical
+ * status can look different on the wire.
+ */
+class PipelineStatusComparisonTest {
+
+  private static final long TS = 1785063454240L;
+
+  private static Status task(String name, StatusType status, Long endTime) {
+    return new Status().withName(name).withExecutionStatus(status).withEndTime(endTime);
+  }
+
+  private static PipelineStatus status(List<Status> tasks) {
+    return new PipelineStatus()
+        .withTimestamp(TS)
+        .withExecutionId("run_1")
+        .withExecutionStatus(StatusType.Failed)
+        .withTaskStatus(tasks);
+  }
+
+  @Test
+  @DisplayName("reordered taskStatus compares equal: connectors do not guarantee a stable order")
+  void reorderedTasksAreEqual() {
+    PipelineStatus stored =
+        status(List.of(task("a", StatusType.Failed, 5L), task("b", StatusType.Successful, 6L)));
+    PipelineStatus incoming =
+        status(List.of(task("b", StatusType.Successful, 6L), task("a", StatusType.Failed, 5L)));
+    assertTrue(PipelineRepository.isSameStatus(stored, incoming));
+  }
+
+  @Test
+  @DisplayName("explicit null inputs collapses onto the schema default")
+  void explicitNullInputsEqualsDefault() {
+    PipelineStatus incoming = status(List.of(task("a", StatusType.Failed, 5L)));
+    incoming.setInputs(null);
+    incoming.setOutputs(null);
+    assertTrue(
+        PipelineRepository.isSameStatus(
+            status(List.of(task("a", StatusType.Failed, 5L))), incoming));
+  }
+
+  @Test
+  @DisplayName("a changed executionStatus is a real change")
+  void differentExecutionStatusIsAChange() {
+    PipelineStatus incoming = status(List.of(task("a", StatusType.Failed, 5L)));
+    incoming.setExecutionStatus(StatusType.Successful);
+    assertFalse(
+        PipelineRepository.isSameStatus(
+            status(List.of(task("a", StatusType.Failed, 5L))), incoming));
+  }
+
+  @Test
+  @DisplayName("a task gaining an endTime is a real change")
+  void taskEndTimeAppearingIsAChange() {
+    assertFalse(
+        PipelineRepository.isSameStatus(
+            status(List.of(task("a", StatusType.Failed, null))),
+            status(List.of(task("a", StatusType.Failed, 5L)))));
+  }
+}

--- a/openmetadata-spec/src/main/resources/json/schema/entity/data/pipeline.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/data/pipeline.json
@@ -172,7 +172,7 @@
       "type": "object",
       "properties": {
         "timestamp": {
-          "description": "Timestamp where the job was executed.",
+          "description": "Unique key identifying this execution within the pipeline's status history. Connector defined and NOT a reliable wall clock: sources fill it with whatever is stable per run, from a scheduler's logical date to the ingestion time. For when the execution actually ran, use `endTime` or the per-task `startTime`/`endTime`.",
           "$ref": "../../type/basic.json#/definitions/timestamp"
         },
         "executionStatus": {
@@ -192,7 +192,7 @@
           "type": "string"
         },
         "endTime": {
-          "description": "Execution end time",
+          "description": "Wall clock time the execution finished. With the per-task `startTime`/`endTime` this is what alerting reads to decide whether an execution predates a subscription.",
           "$ref": "../../type/basic.json#/definitions/timestamp"
         },
         "version": {

--- a/openmetadata-spec/src/main/resources/json/schema/events/eventSubscriptionOffset.json
+++ b/openmetadata-spec/src/main/resources/json/schema/events/eventSubscriptionOffset.json
@@ -19,6 +19,10 @@
     "timestamp": {
       "description": "Update time of the job status.",
       "$ref": "../type/basic.json#/definitions/timestamp"
+    },
+    "startingTimestamp": {
+      "description": "Point in time from which this subscription started alerting. Executions that finished before it are treated as historical and are not delivered.",
+      "$ref": "../type/basic.json#/definitions/timestamp"
     }
   },
   "required": ["startingOffset", "currentOffset"],

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/data/pipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/data/pipeline.ts
@@ -577,7 +577,8 @@ export interface AccessDetails {
  */
 export interface PipelineStatus {
     /**
-     * Execution end time
+     * Wall clock time the execution finished. With the per-task `startTime`/`endTime` this is
+     * what alerting reads to decide whether an execution predates a subscription.
      */
     endTime?: number;
     /**
@@ -617,7 +618,10 @@ export interface PipelineStatus {
      */
     taskStatus?: TaskStatus[];
     /**
-     * Timestamp where the job was executed.
+     * Unique key identifying this execution within the pipeline's status history. Connector
+     * defined and NOT a reliable wall clock: sources fill it with whatever is stable per run,
+     * from a scheduler's logical date to the ingestion time. For when the execution actually
+     * ran, use `endTime` or the per-task `startTime`/`endTime`.
      */
     timestamp: number;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/events/eventSubscriptionOffset.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/events/eventSubscriptionOffset.ts
@@ -24,6 +24,11 @@ export interface EventSubscriptionOffset {
      */
     startingOffset: number;
     /**
+     * Point in time from which this subscription started alerting. Executions that finished
+     * before it are treated as historical and are not delivered.
+     */
+    startingTimestamp?: number;
+    /**
      * Update time of the job status.
      */
     timestamp?: number;

--- a/skills/standards/source_types/pipeline.md
+++ b/skills/standards/source_types/pipeline.md
@@ -56,17 +56,27 @@ OMetaPipelineStatus(
     pipeline_fqn=pipeline_fqn,
     pipeline_status=PipelineStatus(
         executionStatus=StatusType.Successful,
-        timestamp=Timestamp(execution["start_time"]),
+        timestamp=Timestamp(execution["run_id_or_logical_date"]),
+        endTime=Timestamp(execution["finished_at"]),
         taskStatus=[
             TaskStatus(
                 name=task["name"],
                 executionStatus=StatusType.Successful,
+                startTime=Timestamp(task["started_at"]),
+                endTime=Timestamp(task["finished_at"]),
             )
             for task in execution.get("tasks", [])
         ],
     ),
 )
 ```
+
+`timestamp` is the **unique key** for an execution, not a clock. It only has to be stable per run so
+re-ingesting the same run updates one row instead of creating another.
+
+Populate a real wall clock separately, in `endTime` or in the per-task `startTime`/`endTime`.
+Alerting uses it to tell a run that just failed from one backfilled out of the source's history; a
+connector that supplies neither has its executions delivered unfiltered.
 
 ## Schema Properties
 - `hostPort` (required)


### PR DESCRIPTION
### Describe your changes:

Backport of #32181 (`Fixes #31782`) to `2.0`.

An alert on `Pipeline` filtered to `Failed` is unusable on this branch: the metadata agent re-sends
the same `numberOfStatus` runs every cycle and each re-send emitted a change event, so one old
failure re-notifies forever; and the first ingestion after an alert is created emits a change event
per historical run, so enabling an alert produces a backfill burst. `PUT /status/bulk` additionally
emitted a single change event describing only the newest status, so a failure that was not the
newest run in a batch never alerted at all.

Full analysis, diagrams and manual-test tables are in #32181.

**Why this is a manual PR.** #32181 did carry `To release`, and the release cherry-pick workflow ran
for both release branches
([run 33819745878](https://github.com/open-metadata/OpenMetadata/actions/runs/33819745878)). On
`2.0` the pick applied cleanly, but its direct push was rejected:

```
! [remote rejected]       2.0 -> 2.0 (push declined due to repository rule violations)
```

so the workflow asked for a manual cherry-pick. This is it. The companion `1.13` backport is
#32590.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

One commit: `git cherry-pick -x 3969ba38a7cb2188bdafc2d7ba5f10a2795c47e3`, **zero conflicts**,
diffstat identical to the original (21 files, +607/-67).

A clean apply is not by itself proof the pick is correct on a release branch, so this was verified
rather than eyeballed: every file the commit touches was diffed against `main`'s post-fix version.
All of the PR's own content is present, and the only differences are pre-existing `2.0` divergence
that this change never touches:

| File | `main`-only content this branch does not have |
|---|---|
| `PipelineRepository` | the `getTaskWorkflow` / `TaskDescriptionWorkflow` / `TaskTagWorkflow` block |
| `AlertUtil` | the `Conversation` alert path (`CONVERSATION` resource vs `THREAD`) |
| `AbstractEventConsumer` | `AccessControlDAOs.ChangeEventDAO` vs `CollectionDAO.ChangeEventDAO` import |

`EventSubscriptionScheduler`, `EntityRepository`, `EventSubscriptionRepository`, `TableRepository`,
`PipelineResource`, both JSON schemas, both generated TS files and the connector doc are
byte-identical to `main`. Every symbol the new code depends on already exists here:
`routeToStagedIfActive`, `bulkIndexPipelineExecutions`, `getResultsFromAndToTimestamps`,
`upsertSubscriberExtension`, and `buildChangeEventJsonForBulkOperation` /
`insertChangeEventsBatch` (the latter two arrived with the #32350 backport, #32535).

**Migration folder stays `2.0.2`.** That is this branch's in-flight `pom` version and the next
unreleased folder here: `2.0.1-release` shipped 2026-09-02 and the folders on `2.0` stop at `2.0.1`.
Appending to an already-released folder would silently skip clusters that have executed `2.0.1`,
because `MigrationWorkflow.getReprocessingVersions` only reprocesses the max executed version per
release train. The statement is idempotent (`WHERE ... startingTimestamp IS NULL`) and does not
touch `$.timestamp`, which `change_event_consumers` derives a `NOT NULL` generated column from.

#
### Tests:

#### Unit tests

`mvn -pl openmetadata-service -am package -Dtest='StalePipelineExecutionTest,PipelineStatusComparisonTest,AlertUtilTest,AbstractEventConsumerTest,SearchRepositoryBehaviorTest'`
run on this branch: **208 run, 0 failures, 0 errors.**

| Suite | Tests |
|---|---|
| `StalePipelineExecutionTest` (new) | 9 |
| `PipelineStatusComparisonTest` (new) | 4 |
| `AlertUtilTest` | 38 |
| `AbstractEventConsumerTest` | 30 |
| `SearchRepositoryBehaviorTest` | 127 |

The two new suites carry the same 9 and 4 cases they have on `main`. `openmetadata-service` also
compiles clean end to end (`-am package -DskipTests`, main *and* test sources), which is the check
that catches a release-branch pick that applies without conflict but leans on a symbol only `main`
has.

#### Backend integration tests

Not applicable: no new REST endpoints. `AlertsRuleEvaluatorDeletedEntityIT` (the one IT the original
PR touched, to pass `null` to the widened `getFilteredEvents`) exists on this branch and is carried
over unchanged.

#### Ingestion integration tests

Not applicable: no connector changes.

#### Playwright (UI) tests

Not applicable: the only UI diff is regenerated types under `generated/`.

#### Manual testing performed

Covered on `main` in #32181 (backfill, identical re-send, stale `logical_date`, bulk batches, and
the migration against live MySQL and Postgres 15). Nothing in the backport diverges from what was
tested there.

#### Note on CI

`Validate PR Metadata` cannot pass on a release-branch PR: `Fixes #N` only creates GitHub's native
`closingIssuesReferences` when the PR targets the **default** branch, and the workflow's body regex
only accepts cross-repo forms. Bypassed with the documented `skip-pr-checks` label. The linked issue
is #31782, tracked on Shipping via #32181.

`maven-collate-ci` is red on every base-`2.0` OSS PR and is not caused by this change: the collate
dispatch does a bare `cd OpenMetadata && git checkout "$INPUT_SHA"` with no prior fetch, so the
submodule clone never has the PR head object. Same on merged base-`2.0` PRs #32509 and #32424.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR is linked to a GitHub issue: backport of #32181, `Fixes #31782`.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.
