### PR TITLE
Fixes #32588: fix 5 masked Playwright failures, quarantine 13 flakes

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -58,6 +58,53 @@ const dedicatedStateTestIgnore = hasDedicatedIngestionLane
       '**/*AfterReindex.spec.ts',
     ]
   : [];
+// Tests tagged @quarantine are known-flaky and must not run in any lane, so a
+// flake cannot eject a PR from the merge queue while it is still being
+// diagnosed. Each entry is listed with its evidence in
+// playwright/QUARANTINE.md and is expected to be fixed and untagged, not to
+// live there. PLAYWRIGHT_RUN_QUARANTINED=true flips this to run *only* the
+// quarantined set, for a soak lane that tracks whether they are still failing.
+//
+// This has to be applied per project, not at the top level: Playwright replaces
+// (never merges) a top-level grepInvert with a project's own, and the chromium
+// project already sets one to route @basic/@ingestion/@data-insight into their
+// dedicated lanes — so a top-level grepInvert is silently dropped for the very
+// project that runs most of the suite.
+const QUARANTINE_TAG = /@quarantine/;
+const runQuarantinedOnly = Boolean(process.env.PLAYWRIGHT_RUN_QUARANTINED);
+const asRegExpList = (value?: RegExp | RegExp[]) =>
+  value === undefined ? [] : Array.isArray(value) ? value : [value];
+
+const andQuarantine = (base: RegExp) =>
+  new RegExp(
+    `(?=.*(?:${base.source}))(?=.*(?:${QUARANTINE_TAG.source}))`,
+    [...new Set(`${base.flags}${QUARANTINE_TAG.flags}`)].join('')
+  );
+
+const applyQuarantine = <
+  T extends { grep?: RegExp | RegExp[]; grepInvert?: RegExp | RegExp[] }
+>(
+  projects: T[]
+): T[] =>
+  projects.map((project) => ({
+    ...project,
+    // grepInvert is OR-matched, so appending the tag is enough to exclude it.
+    // grep is OR-matched too, which is the wrong operator for the soak lane —
+    // replacing the project's lane-routing grep would let it pick up
+    // quarantined tests belonging to other lanes, so each alternative is
+    // AND-ed with the tag via lookaheads instead (same trick as combineGrep).
+    ...(runQuarantinedOnly
+      ? {
+          grep:
+            project.grep === undefined
+              ? QUARANTINE_TAG
+              : asRegExpList(project.grep).map(andQuarantine),
+        }
+      : {
+          grepInvert: [...asRegExpList(project.grepInvert), QUARANTINE_TAG],
+        }),
+  }));
+
 const combineGrep = (base?: RegExp) => {
   if (!base) {
     return shardGrep;
@@ -164,7 +211,7 @@ export default defineConfig({
   },
 
   /* Configure projects for major browsers */
-  projects: [
+  projects: applyQuarantine([
     {
       name: 'bundle-smoke',
       testMatch: '**/bundle.smoke.ts',
@@ -437,7 +484,7 @@ export default defineConfig({
       fullyParallel: true,
       teardown: entityTeardown,
     },
-  ],
+  ]),
 
   // Increase timeout for the test
   timeout: 60000,

--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -81,29 +81,56 @@ const andQuarantine = (base: RegExp) =>
     [...new Set(`${base.flags}${QUARANTINE_TAG.flags}`)].join('')
   );
 
+// Fixture projects hold no @quarantine tests, so the soak lane must leave their
+// grep alone. A project-level grep *is* applied to dependency projects (unlike
+// a CLI --grep, which Playwright exempts them from), so grepping them would
+// select zero tests and skip login and entity seeding entirely — every
+// quarantined test would then fail for want of admin.json rather than for the
+// flake being diagnosed, and `--list` cannot catch it because it neither runs
+// setup nor lists dependency projects.
+// Matched by file convention plus dataInsightApp.ts, which seeds the Data
+// Insight app without following it. Deliberately keyed on testMatch and not on
+// "is a dependency of something": chromium and DataAssetRulesEnabled are also
+// dependencies, but they carry real tests and must still be filtered.
+const FIXTURE_TEST_MATCH = /(?:\.(?:setup|teardown)\.ts|dataInsightApp\.ts)$/;
+const isFixtureProject = (project: { testMatch?: unknown }) =>
+  typeof project.testMatch === 'string' &&
+  FIXTURE_TEST_MATCH.test(project.testMatch);
+
 const applyQuarantine = <
-  T extends { grep?: RegExp | RegExp[]; grepInvert?: RegExp | RegExp[] }
+  T extends {
+    grep?: RegExp | RegExp[];
+    grepInvert?: RegExp | RegExp[];
+    testMatch?: unknown;
+  }
 >(
   projects: T[]
 ): T[] =>
-  projects.map((project) => ({
-    ...project,
+  projects.map((project) => {
     // grepInvert is OR-matched, so appending the tag is enough to exclude it.
+    if (!runQuarantinedOnly) {
+      return {
+        ...project,
+        grepInvert: [...asRegExpList(project.grepInvert), QUARANTINE_TAG],
+      };
+    }
+
+    if (isFixtureProject(project)) {
+      return { ...project };
+    }
+
     // grep is OR-matched too, which is the wrong operator for the soak lane —
     // replacing the project's lane-routing grep would let it pick up
     // quarantined tests belonging to other lanes, so each alternative is
     // AND-ed with the tag via lookaheads instead (same trick as combineGrep).
-    ...(runQuarantinedOnly
-      ? {
-          grep:
-            project.grep === undefined
-              ? QUARANTINE_TAG
-              : asRegExpList(project.grep).map(andQuarantine),
-        }
-      : {
-          grepInvert: [...asRegExpList(project.grepInvert), QUARANTINE_TAG],
-        }),
-  }));
+    return {
+      ...project,
+      grep:
+        project.grep === undefined
+          ? QUARANTINE_TAG
+          : asRegExpList(project.grep).map(andQuarantine),
+    };
+  });
 
 const combineGrep = (base?: RegExp) => {
   if (!base) {

--- a/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
+++ b/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
@@ -48,7 +48,11 @@ generated variant rather than per source line.
 | `e2e/Features/ActivityStream.spec.ts` | activity stream API is called when visiting entity page | 2/11 | |
 
 Verified: `npx playwright test --list` reports 4543 tests by default (down from
-4555) and `PLAYWRIGHT_RUN_QUARANTINED=true` reports exactly these 13.
+4555) and `PLAYWRIGHT_RUN_QUARANTINED=true` reports these 13 plus the 7
+setup/teardown fixture projects, which the soak lane deliberately leaves
+unfiltered so login and entity seeding still happen — a project-level `grep`
+*is* applied to dependency projects, so filtering them would make every
+quarantined test fail for want of `admin.json` instead of for its flake.
 
 ## Not quarantined — fixed instead
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
+++ b/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
@@ -1,0 +1,86 @@
+# Playwright quarantine
+
+Tests tagged `@quarantine` are excluded from every lane by
+`grepInvert` in `playwright.config.ts`. Quarantine is a **holding pen, not a
+resting place**: each entry below is a bug with an owner, and the fix is to
+diagnose it and delete the tag — not to leave it here.
+
+Run only the quarantined set to check whether an entry is still failing:
+
+```bash
+PLAYWRIGHT_RUN_QUARANTINED=true npx playwright test
+```
+
+## Why quarantine instead of retries
+
+`retries: 1` was converting first-attempt failures into `status: "flaky"`, so
+the shard exited 0 and the required `playwright-summary` check went green. Over
+11 sampled merge_group runs (4487 tests each) that hid ~15 first-attempt
+failures per run, ~1 of which also lost its retry and ejected a PR from the
+merge queue. The flake-rate budget in
+`.github/scripts/evaluate_playwright_performance.py` could not catch it: it is a
+*budget* target (advisory by design), and 0.5% of 4487 tests is 22 tests, so
+the failures were inside budget the whole time.
+
+Quarantine makes the cost visible — a skipped test is obviously missing
+coverage, a retried one looks green.
+
+## Entries
+
+13 tests. Evidence is failures observed across 11 merge_group runs sampled on
+2026-09-04; the threshold for quarantining is **2 or more**, counted per
+generated variant rather than per source line.
+
+| Spec | Test | Seen | Symptom |
+|---|---|---|---|
+| `e2e/Pages/Lineage/LineageInteraction.spec.ts` | Verify node panel opens on click | 11/11 | `clickLineageNode` → `entity-header-display-name` never visible (15s). The topic node is not in the graph the `beforeEach` renders. |
+| `e2e/Pages/ExplorePageRightPanel_KnowledgeCenter.spec.ts` | Should remove user owner for knowledgeCenter | 11/11 | `entity-summary-panel-container` → owner chip not found (10s). Regressed around #31853, which removed the welcome-banner dismiss helpers. |
+| `e2e/Features/PersonaAIContextRules.spec.ts` | knowledge entity type forces Fully rendered on and disables it | 7/11 | Test timeout. |
+| `e2e/Pages/Domains.spec.ts` | Verify domain tags and glossary terms | 6/11 | Fails both attempts more often than it flakes — likely a real defect, not timing. |
+| `e2e/Features/Table.spec.ts` | should persist page size | 6/11 | Test timeout after `waitForAllLoadersToDisappear`. |
+| `e2e/Pages/TestSuiteDetailsPage.spec.ts` | Add test case modal — filters and select | 3/11 | `waitForResponse` on the test-case search never resolves. |
+| `e2e/Pages/EntityDataConsumer.spec.ts` | Update description (**Table variant only**) | 3/11 | Shared `entity.descriptionUpdate` helper. The tag is conditional on `entity.getType() === 'Table'` so the other 14 entity types keep running. |
+| `e2e/Features/Glossary/GlossaryHierarchy.spec.ts` | should move term to root of different glossary | 2/11 | Drag-and-drop. |
+| `e2e/Features/Glossary/GlossaryHierarchy.spec.ts` | should cancel drag and drop operation | 2/11 | Drag-and-drop. |
+| `e2e/Features/DataQuality/TestLibrary.spec.ts` | should create, edit, and delete a test definition | 2/11 | |
+| `e2e/Features/DataQuality/TestLibrary.spec.ts` | should maintain page on edit and reset to first page on delete | 2/11 | |
+| `e2e/Features/DataQuality/TableLevelTests.spec.ts` | Table Difference | 2/11 | |
+| `e2e/Features/ActivityStream.spec.ts` | activity stream API is called when visiting entity page | 2/11 | |
+
+Verified: `npx playwright test --list` reports 4543 tests by default (down from
+4555) and `PLAYWRIGHT_RUN_QUARANTINED=true` reports exactly these 13.
+
+## Not quarantined — fixed instead
+
+These were failing their first attempt in ~every run and are root-caused, so
+they were repaired rather than parked:
+
+| Spec | Root cause |
+|---|---|
+| `e2e/Pages/Glossary.spec.ts` 128 / 198 / 421 | `utils/glossary.ts` used `page.textContent()` — waits for the element, not its text — so a cold first attempt read `""`. #32333 (a revert of #30896) had reintroduced this after it was already fixed. Restored to `toContainText`. |
+| `e2e/Features/ContextCenterArticles.spec.ts:670` | #32283 removed a `waitForTimeout(500)` that was covering the zustand → localStorage flush of `recentlyViewed`. Navigating away before the flush meant the Recently Viewed panel had no entry to render, so the trailing assertion had nothing to auto-wait for. Replaced with `waitForRecentlyViewed`, which polls the persisted store. |
+| `e2e/Features/ClassificationImportExport.spec.ts:64` | `beforeAll` POSTed fixtures whose names were generated at module scope, so a second pass in the same worker 409'd on every create. Fixtures are now rebuilt inside `beforeAll`, and an `afterAll` was added — the spec previously leaked two classifications, a tag and a user into the shard on every run. |
+
+## Left running deliberately
+
+**Single-observation tests.** 50 further tests failed exactly once across the 11
+sampled runs. One observation is not evidence of a flake, and quarantining them
+would drop real coverage for noise.
+
+**Two specs that looked worse than they are.**
+`e2e/Pages/CustomProperties.spec.ts` and
+`e2e/Features/RestoreEntityInheritedFields.spec.ts` each showed 2 failures at
+the source line, but those were *different generated variants* (`database` +
+`tableColumn`, and `Topic` + `MlModel`) — one observation each. Tagging the
+shared line would have quarantined 28 and 12 test instances respectively to
+chase two single failures, so they stay in.
+
+That distinction is the reason the threshold is counted per variant: a tag on a
+`describe`-loop body is not a scalpel.
+
+**What should catch the rest.** A per-test flake ledger that fails a PR when a
+test flakes that does not flake on `main` — snapshot the flaking set from
+merge_group runs into a baseline file (the same shape as
+`.github/playwright/timing-baseline.json`, refreshed by the same job) and gate
+on new entries. That closes the hole these 13 came through; quarantine only
+stops them costing merge-queue time today.

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityStream.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityStream.spec.ts
@@ -227,35 +227,37 @@ test.describe('Activity Stream on Entity Pages', () => {
     await expect(countBadge).toHaveText(/^[1-9]\d*$/, { timeout: 30_000 });
   });
 
-  test('activity stream API is called when visiting entity page', async ({
-    page,
-  }) => {
-    const activityApiPromise = page
-      .waitForResponse(
-        (response) =>
-          response.url().includes('/api/v1/activity') &&
-          response.status() === 200,
-        { timeout: 10000 }
-      )
-      .catch(() => null);
+  test(
+    'activity stream API is called when visiting entity page',
+    { tag: '@quarantine' },
+    async ({ page }) => {
+      const activityApiPromise = page
+        .waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/activity') &&
+            response.status() === 200,
+          { timeout: 10000 }
+        )
+        .catch(() => null);
 
-    await testTable.visitEntityPage(page);
-    await waitForAllLoadersToDisappear(page);
+      await testTable.visitEntityPage(page);
+      await waitForAllLoadersToDisappear(page);
 
-    const activityFeedTab = page.getByRole('tab', {
-      name: 'Activity Feeds & Tasks',
-    });
-    await activityFeedTab.click();
+      const activityFeedTab = page.getByRole('tab', {
+        name: 'Activity Feeds & Tasks',
+      });
+      await activityFeedTab.click();
 
-    const response = await activityApiPromise;
+      const response = await activityApiPromise;
 
-    if (response) {
-      const responseBody = await response.json();
+      if (response) {
+        const responseBody = await response.json();
 
-      expect(responseBody).toHaveProperty('data');
-      expect(Array.isArray(responseBody.data)).toBe(true);
+        expect(responseBody).toHaveProperty('data');
+        expect(Array.isArray(responseBody.data)).toBe(true);
+      }
     }
-  });
+  );
 
   test('activity feed left panel shows All and Tasks options', async ({
     page,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ClassificationImportExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ClassificationImportExport.spec.ts
@@ -20,13 +20,22 @@ import { performUserLogin } from '../../utils/user';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 
-const userClassification = new ClassificationClass();
-const systemClassification = new ClassificationClass({ provider: 'system' });
-const userTag = new TagClass({ classification: userClassification.data.name });
-const exportUser = new UserClass(undefined, true);
+let userClassification = new ClassificationClass();
+let systemClassification = new ClassificationClass({ provider: 'system' });
+let userTag = new TagClass({ classification: userClassification.data.name });
+let exportUser = new UserClass(undefined, true);
 
 test.describe('Classification Import Export', { tag: '@import-export' }, () => {
   test.beforeAll('Setup classifications and a tag', async ({ browser }) => {
+    // beforeAll runs once per worker, and a worker restart re-enters it with the
+    // module scope still warm — so the second pass POSTs the names the first
+    // pass already created and every create 409s. Rebuilding the fixtures here
+    // means each pass owns a fresh set of names.
+    userClassification = new ClassificationClass();
+    systemClassification = new ClassificationClass({ provider: 'system' });
+    userTag = new TagClass({ classification: userClassification.data.name });
+    exportUser = new UserClass(undefined, true);
+
     const { apiContext, afterAction } = await createNewPage(browser);
     await userClassification.create(apiContext);
     await systemClassification.create(apiContext);
@@ -113,4 +122,45 @@ test.describe('Classification Import Export', { tag: '@import-export' }, () => {
       page.getByText('Drag & Drop or Browse CSV file here')
     ).toBeVisible();
   });
+
+  // Without this the spec leaked two classifications, a tag and a user into the
+  // shard on every run; they then show up in every other spec's listings.
+  // Deletes are individually tolerant so a fixture that never got created (a
+  // failed beforeAll) cannot turn the run red from teardown.
+  test.afterAll(
+    'Remove the classifications, tag and user',
+    async ({ browser }) => {
+      const { apiContext, afterAction } = await createNewPage(browser);
+
+      const remove = async (
+        created: boolean,
+        deletion: () => Promise<unknown>
+      ) => {
+        if (!created) {
+          return;
+        }
+
+        try {
+          await deletion();
+        } catch {
+          // Teardown must not turn a green run red.
+        }
+      };
+
+      await remove(Boolean(userTag.responseData?.id), () =>
+        userTag.delete(apiContext)
+      );
+      await remove(Boolean(userClassification.responseData?.id), () =>
+        userClassification.delete(apiContext)
+      );
+      await remove(Boolean(systemClassification.responseData?.id), () =>
+        systemClassification.delete(apiContext)
+      );
+      await remove(Boolean(exportUser.responseData?.id), () =>
+        exportUser.delete(apiContext)
+      );
+
+      await afterAction();
+    }
+  );
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
@@ -52,6 +52,7 @@ import {
   verifyArticleSearch,
   waitForArticleInFollows,
   waitForDraftPersisted,
+  waitForRecentlyViewed,
 } from '../../utils/ContextCenterUtil';
 import {
   addMultiOwner,
@@ -688,6 +689,10 @@ test.describe('Context Center Articles', () => {
       url.pathname.includes('/context-center/articles/')
     );
     await waitForAllLoadersToDisappear(page);
+    await waitForRecentlyViewed(
+      page,
+      articleEntity.responseData.displayName as string
+    );
 
     await navigateToArticles(page);
     const rightPanel = page.getByTestId('knowledge-center-right-panel');

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TableLevelTests.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TableLevelTests.spec.ts
@@ -622,7 +622,7 @@ test.describe(
      * 2. Open Test Case form, select type `tableDiff`, pick Table 2 and its key columns; define Table 1 key/use columns and threshold.
      * 3. Submit and verify in Data Quality tab; then edit to add additional key/use columns; delete at the end.
      */
-    test('Table Difference', async ({ page }) => {
+    test('Table Difference', { tag: '@quarantine' }, async ({ page }) => {
       await redirectToHomePage(page);
       const { apiContext } = await getApiContext(page);
       table1 = new TableClass(undefined, undefined, service);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestLibrary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestLibrary.spec.ts
@@ -103,229 +103,233 @@ test.describe(
       await expect(testDefinitionRows).not.toHaveCount(0);
     });
 
-    test('should create, edit, and delete a test definition', async ({
-      page,
-    }) => {
-      await test.step('Create a new test definition', async () => {
-        // Navigate to Test Library
-        await page.goto('/test-library');
+    test(
+      'should create, edit, and delete a test definition',
+      { tag: '@quarantine' },
+      async ({ page }) => {
+        await test.step('Create a new test definition', async () => {
+          // Navigate to Test Library
+          await page.goto('/test-library');
 
-        const testDefinitionFormDoc = page.waitForResponse(
-          '/locales/en-US/OpenMetadata/TestDefinitionForm.md'
-        );
+          const testDefinitionFormDoc = page.waitForResponse(
+            '/locales/en-US/OpenMetadata/TestDefinitionForm.md'
+          );
 
-        // Click add button
-        await page.getByTestId('add-test-definition-button').click();
+          // Click add button
+          await page.getByTestId('add-test-definition-button').click();
 
-        // Wait for drawer to open
-        await page
-          .getByTestId('test-definition-form-body')
-          .waitFor({ state: 'visible' });
-        await testDefinitionFormDoc;
+          // Wait for drawer to open
+          await page
+            .getByTestId('test-definition-form-body')
+            .waitFor({ state: 'visible' });
+          await testDefinitionFormDoc;
 
-        // The form body + doc panel confirm the drawer opened. We don't assert
-        // the "Add Test Definition" title text because it also matches the list
-        // page's Add button (strict-mode ambiguity).
-        await expect(
-          page.locator('.drawer-doc-panel.service-doc-panel')
-        ).toBeVisible();
+          // The form body + doc panel confirm the drawer opened. We don't assert
+          // the "Add Test Definition" title text because it also matches the list
+          // page's Add button (strict-mode ambiguity).
+          await expect(
+            page.locator('.drawer-doc-panel.service-doc-panel')
+          ).toBeVisible();
 
-        // Fill in form fields
-        await page
-          .getByTestId('test-definition-name')
-          .locator('input')
-          .fill(TEST_DEFINITION_NAME);
-        await expect(
-          page.locator('.drawer-doc-panel.service-doc-panel')
-        ).toContainText('Name');
-        await page
-          .getByTestId('display-name')
-          .locator('input')
-          .fill(TEST_DEFINITION_DISPLAY_NAME);
-        await page
-          .getByTestId('description')
-          .locator('textarea')
-          .fill(TEST_DEFINITION_DESCRIPTION);
+          // Fill in form fields
+          await page
+            .getByTestId('test-definition-name')
+            .locator('input')
+            .fill(TEST_DEFINITION_NAME);
+          await expect(
+            page.locator('.drawer-doc-panel.service-doc-panel')
+          ).toContainText('Name');
+          await page
+            .getByTestId('display-name')
+            .locator('input')
+            .fill(TEST_DEFINITION_DISPLAY_NAME);
+          await page
+            .getByTestId('description')
+            .locator('textarea')
+            .fill(TEST_DEFINITION_DESCRIPTION);
 
-        // Select entity type (react-aria Select: click the field, pick option)
-        await page.locator('[id="root/entityType"]').click();
-        const entityTypeOption = page.getByRole('option', {
-          name: 'TABLE',
-          exact: true,
-        });
-        await entityTypeOption.click();
-
-        // Supported data types (core MultiSelect: type into its combobox input to
-        // populate the options, then pick — required while the OpenMetadata
-        // platform is set). Post antd->core migration the RJSF field id sits on
-        // the field wrapper, not the input, so scope to the combobox input.
-        // The combobox closes on selection, so no Escape (Escape closes the drawer).
-        const supportedDataTypes = page.getByTestId('supported-data-types');
-        await supportedDataTypes
-          .locator('input[role="combobox"]')
-          .fill('NUMBER');
-        await page.getByRole('option', { name: 'NUMBER', exact: true }).click();
-        await expect(
-          supportedDataTypes.getByText('NUMBER', {
+          // Select entity type (react-aria Select: click the field, pick option)
+          await page.locator('[id="root/entityType"]').click();
+          const entityTypeOption = page.getByRole('option', {
+            name: 'TABLE',
             exact: true,
-          })
-        ).toBeVisible();
+          });
+          await entityTypeOption.click();
 
-        // Add a test platform (core MultiSelect)
-        const testPlatforms = page.getByTestId('test-platforms');
-        await testPlatforms.locator('input[role="combobox"]').fill('dbt');
-        await page.getByRole('option', { name: 'dbt', exact: true }).click();
-        await expect(
-          testPlatforms.getByText('dbt', { exact: true })
-        ).toBeVisible();
+          // Supported data types (core MultiSelect: type into its combobox input to
+          // populate the options, then pick — required while the OpenMetadata
+          // platform is set). Post antd->core migration the RJSF field id sits on
+          // the field wrapper, not the input, so scope to the combobox input.
+          // The combobox closes on selection, so no Escape (Escape closes the drawer).
+          const supportedDataTypes = page.getByTestId('supported-data-types');
+          await supportedDataTypes
+            .locator('input[role="combobox"]')
+            .fill('NUMBER');
+          await page
+            .getByRole('option', { name: 'NUMBER', exact: true })
+            .click();
+          await expect(
+            supportedDataTypes.getByText('NUMBER', {
+              exact: true,
+            })
+          ).toBeVisible();
 
-        // Wait for POST response when creating test definition
-        const testDefinitionResponse = page.waitForResponse(
-          (response) =>
-            response.url().includes('/api/v1/dataQuality/testDefinitions') &&
-            response.request().method() === 'POST'
-        );
+          // Add a test platform (core MultiSelect)
+          const testPlatforms = page.getByTestId('test-platforms');
+          await testPlatforms.locator('input[role="combobox"]').fill('dbt');
+          await page.getByRole('option', { name: 'dbt', exact: true }).click();
+          await expect(
+            testPlatforms.getByText('dbt', { exact: true })
+          ).toBeVisible();
 
-        // Click save
-        await page.getByTestId('save-test-definition').click();
+          // Wait for POST response when creating test definition
+          const testDefinitionResponse = page.waitForResponse(
+            (response) =>
+              response.url().includes('/api/v1/dataQuality/testDefinitions') &&
+              response.request().method() === 'POST'
+          );
 
-        // Wait for API response
-        const responseData = await testDefinitionResponse;
+          // Click save
+          await page.getByTestId('save-test-definition').click();
 
-        expect(responseData.status()).toBe(201);
+          // Wait for API response
+          const responseData = await testDefinitionResponse;
 
-        // Wait for success toast
-        await toastNotification(page, /created successfully/i);
+          expect(responseData.status()).toBe(201);
 
-        // Verify test definition appears in table
-        await expect(page.getByTestId(TEST_DEFINITION_NAME)).toBeVisible();
-      });
+          // Wait for success toast
+          await toastNotification(page, /created successfully/i);
 
-      await test.step('Edit Test Definition', async () => {
-        // Wait for table to load
-        await page.getByTestId('test-definition-table').waitFor({
-          state: 'visible',
+          // Verify test definition appears in table
+          await expect(page.getByTestId(TEST_DEFINITION_NAME)).toBeVisible();
         });
 
-        // Find and click edit button on first row
-        const firstEditButton = page
-          .getByTestId(`edit-test-definition-${TEST_DEFINITION_NAME}`)
-          .first();
-        await firstEditButton.click();
+        await test.step('Edit Test Definition', async () => {
+          // Wait for table to load
+          await page.getByTestId('test-definition-table').waitFor({
+            state: 'visible',
+          });
 
-        // Wait for drawer to open (form body confirms the edit drawer opened).
-        await page
-          .getByTestId('test-definition-form-body')
-          .waitFor({ state: 'visible' });
+          // Find and click edit button on first row
+          const firstEditButton = page
+            .getByTestId(`edit-test-definition-${TEST_DEFINITION_NAME}`)
+            .first();
+          await firstEditButton.click();
 
-        // Verify name field is disabled in edit mode
-        const nameInput = page
-          .getByTestId('test-definition-name')
-          .locator('input');
+          // Wait for drawer to open (form body confirms the edit drawer opened).
+          await page
+            .getByTestId('test-definition-form-body')
+            .waitFor({ state: 'visible' });
 
-        await expect(nameInput).toBeDisabled();
+          // Verify name field is disabled in edit mode
+          const nameInput = page
+            .getByTestId('test-definition-name')
+            .locator('input');
 
-        // Update display name
-        const displayNameInput = page
-          .getByTestId('display-name')
-          .locator('input');
-        await displayNameInput.clear();
-        await displayNameInput.fill(UPDATE_TEST_DEFINITION_DISPLAY_NAME);
+          await expect(nameInput).toBeDisabled();
 
-        // Wait for POST response when creating test definition
-        const testDefinitionResponse = page.waitForResponse(
-          (response) =>
-            response.url().includes('/api/v1/dataQuality/testDefinitions') &&
-            response.request().method() === 'PATCH'
-        );
+          // Update display name
+          const displayNameInput = page
+            .getByTestId('display-name')
+            .locator('input');
+          await displayNameInput.clear();
+          await displayNameInput.fill(UPDATE_TEST_DEFINITION_DISPLAY_NAME);
 
-        // Click save
-        await page.getByTestId('save-test-definition').click();
-        // Wait for API response
-        const responseData = await testDefinitionResponse;
+          // Wait for POST response when creating test definition
+          const testDefinitionResponse = page.waitForResponse(
+            (response) =>
+              response.url().includes('/api/v1/dataQuality/testDefinitions') &&
+              response.request().method() === 'PATCH'
+          );
 
-        expect(responseData.status()).toBe(200);
+          // Click save
+          await page.getByTestId('save-test-definition').click();
+          // Wait for API response
+          const responseData = await testDefinitionResponse;
 
-        // Wait for success toast
-        await toastNotification(page, /updated successfully/i);
-      });
+          expect(responseData.status()).toBe(200);
 
-      await test.step('should enable/disable test definition', async () => {
-        // Wait for table to load
-        await page.getByTestId('test-definition-table').waitFor({
-          state: 'visible',
+          // Wait for success toast
+          await toastNotification(page, /updated successfully/i);
         });
 
-        // Find first enabled switch
-        const firstSwitch = page.getByTestId(
-          `enable-switch-${TEST_DEFINITION_NAME}`
-        );
+        await test.step('should enable/disable test definition', async () => {
+          // Wait for table to load
+          await page.getByTestId('test-definition-table').waitFor({
+            state: 'visible',
+          });
 
-        // Wait for API call
-        const testDefinitionResponse = page.waitForResponse(
-          (response) =>
-            response.url().includes('/api/v1/dataQuality/testDefinitions') &&
-            response.request().method() === 'PATCH'
-        );
-        // Toggle the switch
-        await firstSwitch.click();
+          // Find first enabled switch
+          const firstSwitch = page.getByTestId(
+            `enable-switch-${TEST_DEFINITION_NAME}`
+          );
 
-        // Wait for API response
-        const responseData = await testDefinitionResponse;
+          // Wait for API call
+          const testDefinitionResponse = page.waitForResponse(
+            (response) =>
+              response.url().includes('/api/v1/dataQuality/testDefinitions') &&
+              response.request().method() === 'PATCH'
+          );
+          // Toggle the switch
+          await firstSwitch.click();
 
-        expect(responseData.status()).toBe(200);
+          // Wait for API response
+          const responseData = await testDefinitionResponse;
 
-        // Wait for success toast
-        await toastNotification(page, /updated successfully/i);
+          expect(responseData.status()).toBe(200);
 
-        // Verify switch state changed
-        await expect(firstSwitch).toHaveAttribute(
-          'aria-checked',
-          String('false')
-        );
-      });
+          // Wait for success toast
+          await toastNotification(page, /updated successfully/i);
 
-      await test.step('should delete a test definition', async () => {
-        // Wait for table to load
-        await page.getByTestId('test-definition-table').waitFor({
-          state: 'visible',
+          // Verify switch state changed
+          await expect(firstSwitch).toHaveAttribute(
+            'aria-checked',
+            String('false')
+          );
         });
 
-        // Find and click delete button
-        const deleteButton = page.getByTestId(
-          `delete-test-definition-${TEST_DEFINITION_NAME}`
-        );
-        await deleteButton.click();
+        await test.step('should delete a test definition', async () => {
+          // Wait for table to load
+          await page.getByTestId('test-definition-table').waitFor({
+            state: 'visible',
+          });
 
-        // Wait for confirmation modal
-        await page.getByTestId('delete-modal').waitFor({ state: 'visible' });
+          // Find and click delete button
+          const deleteButton = page.getByTestId(
+            `delete-test-definition-${TEST_DEFINITION_NAME}`
+          );
+          await deleteButton.click();
 
-        // Verify modal content
-        await expect(
-          page.getByText(`Delete ${UPDATE_TEST_DEFINITION_DISPLAY_NAME}`)
-        ).toBeVisible();
+          // Wait for confirmation modal
+          await page.getByTestId('delete-modal').waitFor({ state: 'visible' });
 
-        // Wait for API call
-        const deleteTestDefinitionResponse = page.waitForResponse(
-          (response) =>
-            response.url().includes('/api/v1/dataQuality/testDefinitions') &&
-            response.request().method() === 'DELETE'
-        );
+          // Verify modal content
+          await expect(
+            page.getByText(`Delete ${UPDATE_TEST_DEFINITION_DISPLAY_NAME}`)
+          ).toBeVisible();
 
-        // Click confirm delete
-        await fillDeleteConfirmationIfPresent(page);
-        await page.getByTestId('confirm-button').click();
+          // Wait for API call
+          const deleteTestDefinitionResponse = page.waitForResponse(
+            (response) =>
+              response.url().includes('/api/v1/dataQuality/testDefinitions') &&
+              response.request().method() === 'DELETE'
+          );
 
-        const response = await deleteTestDefinitionResponse;
-        expect(response.status()).toBe(200);
+          // Click confirm delete
+          await fillDeleteConfirmationIfPresent(page);
+          await page.getByTestId('confirm-button').click();
 
-        // Wait for success toast
-        await toastNotification(page, /deleted successfully/i);
+          const response = await deleteTestDefinitionResponse;
+          expect(response.status()).toBe(200);
 
-        // Verify test definition is removed from table
-        await expect(page.getByText(TEST_DEFINITION_NAME)).not.toBeVisible();
-      });
-    });
+          // Wait for success toast
+          await toastNotification(page, /deleted successfully/i);
+
+          // Verify test definition is removed from table
+          await expect(page.getByText(TEST_DEFINITION_NAME)).not.toBeVisible();
+        });
+      }
+    );
 
     test('should validate required fields in create form', async ({ page }) => {
       // Navigate to Test Library
@@ -1183,191 +1187,199 @@ test.describe(
       });
     });
 
-    test('should maintain page on edit and reset to first page on delete', async ({
-      page,
-    }) => {
-      test.slow();
-      const PAGINATION_TEST_NAME = `zzzzPaginationTest${uuid()}`;
-      const PAGINATION_TEST_DISPLAY_NAME = `Zzzz Pagination Test ${uuid()}`;
-      const UPDATED_DISPLAY_NAME = `Updated ${PAGINATION_TEST_DISPLAY_NAME}`;
+    test(
+      'should maintain page on edit and reset to first page on delete',
+      { tag: '@quarantine' },
+      async ({ page }) => {
+        test.slow();
+        const PAGINATION_TEST_NAME = `zzzzPaginationTest${uuid()}`;
+        const PAGINATION_TEST_DISPLAY_NAME = `Zzzz Pagination Test ${uuid()}`;
+        const UPDATED_DISPLAY_NAME = `Updated ${PAGINATION_TEST_DISPLAY_NAME}`;
 
-      await test.step('Create a test definition starting with "z"', async () => {
-        await page.goto('/test-library');
-        await page.getByTestId('add-test-definition-button').click();
-        await expect(
-          page.getByTestId('test-definition-form-body')
-        ).toBeVisible();
+        await test.step('Create a test definition starting with "z"', async () => {
+          await page.goto('/test-library');
+          await page.getByTestId('add-test-definition-button').click();
+          await expect(
+            page.getByTestId('test-definition-form-body')
+          ).toBeVisible();
 
-        await page
-          .getByTestId('test-definition-name')
-          .locator('input')
-          .fill(PAGINATION_TEST_NAME);
-        await page
-          .getByTestId('display-name')
-          .locator('input')
-          .fill(PAGINATION_TEST_DISPLAY_NAME);
-        await page
-          .getByTestId('description')
-          .locator('textarea')
-          .fill('Test definition for pagination behavior testing');
+          await page
+            .getByTestId('test-definition-name')
+            .locator('input')
+            .fill(PAGINATION_TEST_NAME);
+          await page
+            .getByTestId('display-name')
+            .locator('input')
+            .fill(PAGINATION_TEST_DISPLAY_NAME);
+          await page
+            .getByTestId('description')
+            .locator('textarea')
+            .fill('Test definition for pagination behavior testing');
 
-        await page.getByTestId('entity-type').click();
-        const entityTypeOption = page.getByRole('option', {
-          name: 'TABLE',
-          exact: true,
+          await page.getByTestId('entity-type').click();
+          const entityTypeOption = page.getByRole('option', {
+            name: 'TABLE',
+            exact: true,
+          });
+          await entityTypeOption.click();
+
+          // Select supported data types (required when OpenMetadata platform is selected)
+          await page.getByTestId('supported-data-types').click();
+          await page
+            .getByTestId('supported-data-types')
+            .locator('input')
+            .fill('NUMBER');
+          await page
+            .getByRole('option', { name: 'NUMBER', exact: true })
+            .click();
+          await page.keyboard.press('Escape');
+
+          const createResponse = page.waitForResponse(
+            (response) =>
+              response.url().includes('/api/v1/dataQuality/testDefinitions') &&
+              response.request().method() === 'POST'
+          );
+
+          await page.getByTestId('save-test-definition').click();
+
+          const responseData = await createResponse;
+          expect(responseData.status()).toBe(201);
+          await toastNotification(page, /created successfully/i);
         });
-        await entityTypeOption.click();
 
-        // Select supported data types (required when OpenMetadata platform is selected)
-        await page.getByTestId('supported-data-types').click();
-        await page
-          .getByTestId('supported-data-types')
-          .locator('input')
-          .fill('NUMBER');
-        await page.getByRole('option', { name: 'NUMBER', exact: true }).click();
-        await page.keyboard.press('Escape');
+        await test.step('Change page size to 25', async () => {
+          const pageSizeDropdown = page.getByTestId(
+            'page-size-selection-dropdown'
+          );
+          await expect(pageSizeDropdown).toBeVisible();
+          await pageSizeDropdown.click();
 
-        const createResponse = page.waitForResponse(
-          (response) =>
-            response.url().includes('/api/v1/dataQuality/testDefinitions') &&
-            response.request().method() === 'POST'
-        );
-
-        await page.getByTestId('save-test-definition').click();
-
-        const responseData = await createResponse;
-        expect(responseData.status()).toBe(201);
-        await toastNotification(page, /created successfully/i);
-      });
-
-      await test.step('Change page size to 25', async () => {
-        const pageSizeDropdown = page.getByTestId(
-          'page-size-selection-dropdown'
-        );
-        await expect(pageSizeDropdown).toBeVisible();
-        await pageSizeDropdown.click();
-
-        const pageChangeResponse = page.waitForResponse(
-          // Wait for pagination response
-          (response) =>
-            response.url().includes('/api/v1/dataQuality/testDefinitions') &&
-            response.request().method() === 'GET'
-        );
-        // Wait for dropdown to open and select 25
-        await page.locator('.ant-dropdown:visible').getByText('25').click();
-        await pageChangeResponse;
-      });
-
-      await test.step('Navigate until we find our test definition or reach last page', async () => {
-        const nextButton = page.getByTestId('next');
-        const testDefLocator = page.getByTestId(PAGINATION_TEST_NAME);
-
-        // Check if item is already visible on current page
-        let isItemVisible = await testDefLocator.isVisible();
-
-        // Navigate until we find our test definition or reach the last page
-        while (!isItemVisible && (await nextButton.isEnabled())) {
-          const fetchResponse = page.waitForResponse(
+          const pageChangeResponse = page.waitForResponse(
+            // Wait for pagination response
             (response) =>
               response.url().includes('/api/v1/dataQuality/testDefinitions') &&
               response.request().method() === 'GET'
           );
-          await nextButton.click();
-          await fetchResponse;
-
-          // Check again after page load
-          isItemVisible = await testDefLocator.isVisible();
-        }
-
-        // Verify our test definition is now visible
-        await expect(testDefLocator).toBeVisible({
-          timeout: 10000,
+          // Wait for dropdown to open and select 25
+          await page.locator('.ant-dropdown:visible').getByText('25').click();
+          await pageChangeResponse;
         });
-      });
 
-      await test.step('Edit the test definition and verify we stay on the same page', async () => {
-        // Verify our test definition is visible on this page
-        await expect(page.getByTestId(PAGINATION_TEST_NAME)).toBeVisible();
+        await test.step('Navigate until we find our test definition or reach last page', async () => {
+          const nextButton = page.getByTestId('next');
+          const testDefLocator = page.getByTestId(PAGINATION_TEST_NAME);
 
-        // Get current page indicator before edit
-        const previousButton = page.getByTestId('previous');
-        const prevDisabledBefore = await previousButton.isDisabled();
+          // Check if item is already visible on current page
+          let isItemVisible = await testDefLocator.isVisible();
 
-        // Edit the test definition
-        await page
-          .getByTestId(`edit-test-definition-${PAGINATION_TEST_NAME}`)
-          .click();
-        await expect(
-          page.getByTestId('test-definition-form-body')
-        ).toBeVisible();
+          // Navigate until we find our test definition or reach the last page
+          while (!isItemVisible && (await nextButton.isEnabled())) {
+            const fetchResponse = page.waitForResponse(
+              (response) =>
+                response
+                  .url()
+                  .includes('/api/v1/dataQuality/testDefinitions') &&
+                response.request().method() === 'GET'
+            );
+            await nextButton.click();
+            await fetchResponse;
 
-        const displayNameInput = page
-          .getByTestId('display-name')
-          .locator('input');
-        await displayNameInput.clear();
-        await displayNameInput.fill(UPDATED_DISPLAY_NAME);
+            // Check again after page load
+            isItemVisible = await testDefLocator.isVisible();
+          }
 
-        const patchResponse = page.waitForResponse(
-          (response) =>
-            response.url().includes('/api/v1/dataQuality/testDefinitions') &&
-            response.request().method() === 'PATCH'
-        );
+          // Verify our test definition is now visible
+          await expect(testDefLocator).toBeVisible({
+            timeout: 10000,
+          });
+        });
 
-        await page.getByTestId('save-test-definition').click();
-        const updateResponse = await patchResponse;
-        expect(updateResponse.status()).toBe(200);
+        await test.step('Edit the test definition and verify we stay on the same page', async () => {
+          // Verify our test definition is visible on this page
+          await expect(page.getByTestId(PAGINATION_TEST_NAME)).toBeVisible();
 
-        await toastNotification(page, /updated successfully/i);
+          // Get current page indicator before edit
+          const previousButton = page.getByTestId('previous');
+          const prevDisabledBefore = await previousButton.isDisabled();
 
-        // Verify we stayed on the same page (previous button state should be unchanged)
-        if (prevDisabledBefore) {
+          // Edit the test definition
+          await page
+            .getByTestId(`edit-test-definition-${PAGINATION_TEST_NAME}`)
+            .click();
+          await expect(
+            page.getByTestId('test-definition-form-body')
+          ).toBeVisible();
+
+          const displayNameInput = page
+            .getByTestId('display-name')
+            .locator('input');
+          await displayNameInput.clear();
+          await displayNameInput.fill(UPDATED_DISPLAY_NAME);
+
+          const patchResponse = page.waitForResponse(
+            (response) =>
+              response.url().includes('/api/v1/dataQuality/testDefinitions') &&
+              response.request().method() === 'PATCH'
+          );
+
+          await page.getByTestId('save-test-definition').click();
+          const updateResponse = await patchResponse;
+          expect(updateResponse.status()).toBe(200);
+
+          await toastNotification(page, /updated successfully/i);
+
+          // Verify we stayed on the same page (previous button state should be unchanged)
+          if (prevDisabledBefore) {
+            await expect(previousButton).toBeDisabled();
+          } else {
+            await expect(previousButton).toBeEnabled();
+          }
+
+          // Verify the updated test definition is still visible
+          await expect(page.getByTestId(PAGINATION_TEST_NAME)).toBeVisible();
+        });
+
+        await test.step('Delete the test definition and verify redirect to first page', async () => {
+          await page
+            .getByTestId(`delete-test-definition-${PAGINATION_TEST_NAME}`)
+            .click();
+
+          await expect(page.getByTestId('delete-modal')).toBeVisible();
+
+          // Set up both DELETE and the subsequent GET response waits BEFORE clicking
+          const deleteResponse = page.waitForResponse(
+            (response) =>
+              response.url().includes('/api/v1/dataQuality/testDefinitions') &&
+              response.request().method() === 'DELETE'
+          );
+
+          const getResponse = page.waitForResponse(
+            (response) =>
+              response.url().includes('/api/v1/dataQuality/testDefinitions') &&
+              response.request().method() === 'GET'
+          );
+
+          await fillDeleteConfirmationIfPresent(page);
+          await page.getByTestId('confirm-button').click();
+
+          const deleteResult = await deleteResponse;
+          expect(deleteResult.status()).toBe(200);
+
+          // Wait for the GET that happens after delete (page reset + fetch)
+          await getResponse;
+
+          await toastNotification(page, /deleted successfully/i);
+
+          // Previous button should be disabled on first page
+          const previousButton = page.getByTestId('previous');
           await expect(previousButton).toBeDisabled();
-        } else {
-          await expect(previousButton).toBeEnabled();
-        }
 
-        // Verify the updated test definition is still visible
-        await expect(page.getByTestId(PAGINATION_TEST_NAME)).toBeVisible();
-      });
-
-      await test.step('Delete the test definition and verify redirect to first page', async () => {
-        await page
-          .getByTestId(`delete-test-definition-${PAGINATION_TEST_NAME}`)
-          .click();
-
-        await expect(page.getByTestId('delete-modal')).toBeVisible();
-
-        // Set up both DELETE and the subsequent GET response waits BEFORE clicking
-        const deleteResponse = page.waitForResponse(
-          (response) =>
-            response.url().includes('/api/v1/dataQuality/testDefinitions') &&
-            response.request().method() === 'DELETE'
-        );
-
-        const getResponse = page.waitForResponse(
-          (response) =>
-            response.url().includes('/api/v1/dataQuality/testDefinitions') &&
-            response.request().method() === 'GET'
-        );
-
-        await fillDeleteConfirmationIfPresent(page);
-        await page.getByTestId('confirm-button').click();
-
-        const deleteResult = await deleteResponse;
-        expect(deleteResult.status()).toBe(200);
-
-        // Wait for the GET that happens after delete (page reset + fetch)
-        await getResponse;
-
-        await toastNotification(page, /deleted successfully/i);
-
-        // Previous button should be disabled on first page
-        const previousButton = page.getByTestId('previous');
-        await expect(previousButton).toBeDisabled();
-
-        // Verify the deleted test definition is no longer visible
-        await expect(page.getByTestId(PAGINATION_TEST_NAME)).not.toBeVisible();
-      });
-    });
+          // Verify the deleted test definition is no longer visible
+          await expect(
+            page.getByTestId(PAGINATION_TEST_NAME)
+          ).not.toBeVisible();
+        });
+      }
+    );
   }
 );

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryHierarchy.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryHierarchy.spec.ts
@@ -137,42 +137,46 @@ test.describe('Glossary Hierarchy', () => {
 
   // H-M04: Move term to root of different glossary
   // Skipped due to known issue: https://github.com/open-metadata/OpenMetadata/pull/24794
-  test('should move term to root of different glossary', async ({ page }) => {
-    const { apiContext, afterAction } = await getApiContext(page);
-    const glossary1 = new Glossary();
-    const glossary2 = new Glossary();
-    const term1 = new GlossaryTerm(glossary1);
-    const term2 = new GlossaryTerm(glossary2);
+  test(
+    'should move term to root of different glossary',
+    { tag: '@quarantine' },
+    async ({ page }) => {
+      const { apiContext, afterAction } = await getApiContext(page);
+      const glossary1 = new Glossary();
+      const glossary2 = new Glossary();
+      const term1 = new GlossaryTerm(glossary1);
+      const term2 = new GlossaryTerm(glossary2);
 
-    try {
-      await glossary1.create(apiContext);
-      await glossary2.create(apiContext);
-      await term1.create(apiContext);
-      await term2.create(apiContext);
+      try {
+        await glossary1.create(apiContext);
+        await glossary2.create(apiContext);
+        await term1.create(apiContext);
+        await term2.create(apiContext);
 
-      await sidebarClick(page, SidebarItem.GLOSSARY);
-      await selectActiveGlossary(page, glossary1.data.displayName);
-      await selectActiveGlossaryTerm(page, term1.data.displayName);
-      await changeTermHierarchyFromModal(
-        page,
-        term2.responseData.displayName,
-        glossary2.responseData.fullyQualifiedName
-      );
+        await sidebarClick(page, SidebarItem.GLOSSARY);
+        await selectActiveGlossary(page, glossary1.data.displayName);
+        await selectActiveGlossaryTerm(page, term1.data.displayName);
+        await changeTermHierarchyFromModal(
+          page,
+          term2.responseData.displayName,
+          glossary2.responseData.fullyQualifiedName
+        );
 
-      // Verify term is now in glossary2
-      await redirectToHomePage(page);
-      await sidebarClick(page, SidebarItem.GLOSSARY);
-      await selectActiveGlossary(page, glossary2.data.displayName);
+        // Verify term is now in glossary2
+        await redirectToHomePage(page);
+        await sidebarClick(page, SidebarItem.GLOSSARY);
+        await selectActiveGlossary(page, glossary2.data.displayName);
 
-      await expect(
-        page.getByTestId(term1.responseData.displayName)
-      ).toBeVisible();
-    } finally {
-      await glossary1.delete(apiContext);
-      await glossary2.delete(apiContext);
-      await afterAction();
+        await expect(
+          page.getByTestId(term1.responseData.displayName)
+        ).toBeVisible();
+      } finally {
+        await glossary1.delete(apiContext);
+        await glossary2.delete(apiContext);
+        await afterAction();
+      }
     }
-  });
+  );
 
   // H-M05: Move term with children to different glossary
   // Skipped due to known issue: https://github.com/open-metadata/OpenMetadata/pull/24794
@@ -364,52 +368,56 @@ test.describe('Glossary Hierarchy', () => {
   });
 
   // H-DD05: Drag term - cancel operation
-  test('should cancel drag and drop operation', async ({ page }) => {
-    const { apiContext, afterAction } = await getApiContext(page);
-    const glossary = new Glossary();
-    const term1 = new GlossaryTerm(glossary);
-    const term2 = new GlossaryTerm(glossary);
+  test(
+    'should cancel drag and drop operation',
+    { tag: '@quarantine' },
+    async ({ page }) => {
+      const { apiContext, afterAction } = await getApiContext(page);
+      const glossary = new Glossary();
+      const term1 = new GlossaryTerm(glossary);
+      const term2 = new GlossaryTerm(glossary);
 
-    try {
-      await glossary.create(apiContext);
-      await term1.create(apiContext);
-      await term2.create(apiContext);
+      try {
+        await glossary.create(apiContext);
+        await term1.create(apiContext);
+        await term2.create(apiContext);
 
-      await sidebarClick(page, SidebarItem.GLOSSARY);
-      await selectActiveGlossary(page, glossary.data.displayName);
+        await sidebarClick(page, SidebarItem.GLOSSARY);
+        await selectActiveGlossary(page, glossary.data.displayName);
 
-      // Drag term1 to term2
-      await dragAndDropTerm(
-        page,
-        term1.responseData.displayName,
-        term2.responseData.displayName
-      );
+        // Drag term1 to term2
+        await dragAndDropTerm(
+          page,
+          term1.responseData.displayName,
+          term2.responseData.displayName
+        );
 
-      // Wait for confirmation modal content to be visible
-      await expect(
-        page.getByTestId('confirmation-modal').locator('.ant-modal-content')
-      ).toBeVisible();
+        // Wait for confirmation modal content to be visible
+        await expect(
+          page.getByTestId('confirmation-modal').locator('.ant-modal-content')
+        ).toBeVisible();
 
-      // Click Cancel button
-      await page.getByRole('button', { name: 'Cancel' }).click();
+        // Click Cancel button
+        await page.getByRole('button', { name: 'Cancel' }).click();
 
-      // Verify modal content is closed
-      await expect(
-        page.getByTestId('confirmation-modal').locator('.ant-modal-content')
-      ).toBeHidden();
+        // Verify modal content is closed
+        await expect(
+          page.getByTestId('confirmation-modal').locator('.ant-modal-content')
+        ).toBeHidden();
 
-      // Verify terms are still at root level (no hierarchy change)
-      await expect(
-        page.getByTestId(term1.responseData.displayName)
-      ).toBeVisible();
-      await expect(
-        page.getByTestId(term2.responseData.displayName)
-      ).toBeVisible();
-    } finally {
-      await term1.delete(apiContext);
-      await term2.delete(apiContext);
-      await glossary.delete(apiContext);
-      await afterAction();
+        // Verify terms are still at root level (no hierarchy change)
+        await expect(
+          page.getByTestId(term1.responseData.displayName)
+        ).toBeVisible();
+        await expect(
+          page.getByTestId(term2.responseData.displayName)
+        ).toBeVisible();
+      } finally {
+        await term1.delete(apiContext);
+        await term2.delete(apiContext);
+        await glossary.delete(apiContext);
+        await afterAction();
+      }
     }
-  });
+  );
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaAIContextRules.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaAIContextRules.spec.ts
@@ -425,33 +425,35 @@ test.describe.serial('Persona AI Context — Rule Builder', () => {
       await page.keyboard.press('Escape');
     });
 
-    test('knowledge entity type forces Fully rendered on and disables it', async ({
-      adminPage: page,
-    }) => {
-      await navigateToAIContextTab(page);
-      await openAddRuleDrawer(page);
+    test(
+      'knowledge entity type forces Fully rendered on and disables it',
+      { tag: '@quarantine' },
+      async ({ adminPage: page }) => {
+        await navigateToAIContextTab(page);
+        await openAddRuleDrawer(page);
 
-      await test.step('switch to a knowledge entity type', async () => {
-        await page.getByTestId('context-rule-entity-type').click();
-        await page
-          .getByRole('listbox')
-          .getByText(/knowledge/i)
-          .first()
-          .click();
-      });
+        await test.step('switch to a knowledge entity type', async () => {
+          await page.getByTestId('context-rule-entity-type').click();
+          await page
+            .getByRole('listbox')
+            .getByText(/knowledge/i)
+            .first()
+            .click();
+        });
 
-      await test.step('Fully rendered switch must be checked and disabled', async () => {
-        const fullyRenderedSwitch = page
-          .getByTestId('context-rule-fully-rendered')
-          .getByRole('switch')
-          .first();
-        // toBeChecked() reads the checkbox `checked` property — react-aria Switch
-        // does not always set the aria-checked attribute, so attribute checks fail
-        await expect(fullyRenderedSwitch).toBeChecked();
-        await expect(fullyRenderedSwitch).toBeDisabled();
-      });
+        await test.step('Fully rendered switch must be checked and disabled', async () => {
+          const fullyRenderedSwitch = page
+            .getByTestId('context-rule-fully-rendered')
+            .getByRole('switch')
+            .first();
+          // toBeChecked() reads the checkbox `checked` property — react-aria Switch
+          // does not always set the aria-checked attribute, so attribute checks fail
+          await expect(fullyRenderedSwitch).toBeChecked();
+          await expect(fullyRenderedSwitch).toBeDisabled();
+        });
 
-      await page.keyboard.press('Escape');
-    });
+        await page.keyboard.press('Escape');
+      }
+    );
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Table.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Table.spec.ts
@@ -249,56 +249,60 @@ test.describe('Table pagination sorting search scenarios ', () => {
     );
   });
 
-  test('should persist page size', async ({ dataConsumerPage: page }) => {
-    await page.goto('/databaseSchema/sample_data.ecommerce_db.shopify');
+  test(
+    'should persist page size',
+    { tag: '@quarantine' },
+    async ({ dataConsumerPage: page }) => {
+      await page.goto('/databaseSchema/sample_data.ecommerce_db.shopify');
 
-    await waitForAllLoadersToDisappear(page);
+      await waitForAllLoadersToDisappear(page);
 
-    await expect(page.getByTestId('databaseSchema-tables')).toBeVisible();
+      await expect(page.getByTestId('databaseSchema-tables')).toBeVisible();
 
-    const pageSizeDropdown = page.getByTestId('page-size-selection-dropdown');
-    await pageSizeDropdown.scrollIntoViewIfNeeded();
-    await expect(pageSizeDropdown).toBeVisible();
-    await expect(pageSizeDropdown).toBeEnabled();
+      const pageSizeDropdown = page.getByTestId('page-size-selection-dropdown');
+      await pageSizeDropdown.scrollIntoViewIfNeeded();
+      await expect(pageSizeDropdown).toBeVisible();
+      await expect(pageSizeDropdown).toBeEnabled();
 
-    // NextPrevious wraps the button in an Ant Dropdown with the default hover
-    // trigger, so a bare click only fires preventDefault. Hover + click-fallback
-    // + retry — a re-render that nudges the footer out from under the pointer
-    // otherwise leaves the menu closed for good.
-    const pageSizeMenu = page.getByRole('menu').filter({ hasText: '/ Page' });
-    const pageSizeOption = pageSizeMenu.getByRole('menuitem', {
-      name: '15 / Page',
-    });
-    await expect(async () => {
-      await pageSizeDropdown.hover();
-      if (!(await pageSizeMenu.isVisible())) {
-        await pageSizeDropdown.click();
-      }
-      await expect(pageSizeMenu).toBeVisible({ timeout: 2_000 });
-    }).toPass({ timeout: 15_000, intervals: [500, 1_000, 2_000] });
+      // NextPrevious wraps the button in an Ant Dropdown with the default hover
+      // trigger, so a bare click only fires preventDefault. Hover + click-fallback
+      // + retry — a re-render that nudges the footer out from under the pointer
+      // otherwise leaves the menu closed for good.
+      const pageSizeMenu = page.getByRole('menu').filter({ hasText: '/ Page' });
+      const pageSizeOption = pageSizeMenu.getByRole('menuitem', {
+        name: '15 / Page',
+      });
+      await expect(async () => {
+        await pageSizeDropdown.hover();
+        if (!(await pageSizeMenu.isVisible())) {
+          await pageSizeDropdown.click();
+        }
+        await expect(pageSizeMenu).toBeVisible({ timeout: 2_000 });
+      }).toPass({ timeout: 15_000, intervals: [500, 1_000, 2_000] });
 
-    await pageSizeOption.click();
-    await waitForAllLoadersToDisappear(page);
+      await pageSizeOption.click();
+      await waitForAllLoadersToDisappear(page);
 
-    const linkInColumn = getFirstRowColumnLink(page);
-    const entityApiResponse = page.waitForResponse(
-      '/api/v1/permissions/table/name/*'
-    );
-    await linkInColumn.click();
+      const linkInColumn = getFirstRowColumnLink(page);
+      const entityApiResponse = page.waitForResponse(
+        '/api/v1/permissions/table/name/*'
+      );
+      await linkInColumn.click();
 
-    await entityApiResponse;
-    await waitForAllLoadersToDisappear(page);
+      await entityApiResponse;
+      await waitForAllLoadersToDisappear(page);
 
-    await page.goBack();
-    await waitForAllLoadersToDisappear(page);
-    await page
-      .getByTestId('page-size-selection-dropdown')
-      .scrollIntoViewIfNeeded();
+      await page.goBack();
+      await waitForAllLoadersToDisappear(page);
+      await page
+        .getByTestId('page-size-selection-dropdown')
+        .scrollIntoViewIfNeeded();
 
-    await expect(page.getByTestId('page-size-selection-dropdown')).toHaveText(
-      '15 / Page'
-    );
-  });
+      await expect(page.getByTestId('page-size-selection-dropdown')).toHaveText(
+        '15 / Page'
+      );
+    }
+  );
 });
 
 test.describe('Table & Data Model columns table pagination', () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
@@ -1164,38 +1164,42 @@ test.describe('Domains', () => {
     }
   });
 
-  test('Verify domain tags and glossary terms', async ({ page }) => {
-    const { afterAction, apiContext } = await getApiContext(page);
-    const domain = new Domain();
-    try {
-      await domain.create(apiContext);
-      await page.reload();
-      await sidebarClick(page, SidebarItem.DOMAIN);
-      await waitForAllLoadersToDisappear(page);
-      await selectDomain(page, domain.data);
-      await waitForAllLoadersToDisappear(page);
+  test(
+    'Verify domain tags and glossary terms',
+    { tag: '@quarantine' },
+    async ({ page }) => {
+      const { afterAction, apiContext } = await getApiContext(page);
+      const domain = new Domain();
+      try {
+        await domain.create(apiContext);
+        await page.reload();
+        await sidebarClick(page, SidebarItem.DOMAIN);
+        await waitForAllLoadersToDisappear(page);
+        await selectDomain(page, domain.data);
+        await waitForAllLoadersToDisappear(page);
 
-      await addTagsAndGlossaryToDomain(page, {
-        tagFqn: tag.responseData.fullyQualifiedName,
-        glossaryTermFqn: glossaryTerm.responseData.fullyQualifiedName,
-      });
+        await addTagsAndGlossaryToDomain(page, {
+          tagFqn: tag.responseData.fullyQualifiedName,
+          glossaryTermFqn: glossaryTerm.responseData.fullyQualifiedName,
+        });
 
-      await redirectToHomePage(page);
-      await sidebarClick(page, SidebarItem.DOMAIN);
-      await waitForAllLoadersToDisappear(page);
-      await selectDomain(page, domain.data);
+        await redirectToHomePage(page);
+        await sidebarClick(page, SidebarItem.DOMAIN);
+        await waitForAllLoadersToDisappear(page);
+        await selectDomain(page, domain.data);
 
-      // Verify tag is visible
-      await expect(
-        page.locator(
-          `[data-testid="tag-${tag.responseData.fullyQualifiedName}"]`
-        )
-      ).toBeVisible();
-    } finally {
-      await domain.delete(apiContext);
-      await afterAction();
+        // Verify tag is visible
+        await expect(
+          page.locator(
+            `[data-testid="tag-${tag.responseData.fullyQualifiedName}"]`
+          )
+        ).toBeVisible();
+      } finally {
+        await domain.delete(apiContext);
+        await afterAction();
+      }
     }
-  });
+  );
 
   test('Create domain with tags using TagSuggestion', async ({ page }) => {
     const { afterAction, apiContext } = await getApiContext(page);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EntityDataConsumer.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EntityDataConsumer.spec.ts
@@ -110,9 +110,16 @@ entities.forEach((EntityClass) => {
       await entity.tier(page, COMMON_TIER_TAG[0].name, COMMON_TIER_TAG[3].name);
     });
 
-    test('Update description', async ({ page }) => {
-      await entity.descriptionUpdate(page);
-    });
+    // Only the Table variant is flaky (3 of 11 sampled merge_group runs); the
+    // other 15 entity types are clean, so the tag is scoped rather than
+    // quarantining the whole generated set. See playwright/QUARANTINE.md.
+    test(
+      'Update description',
+      entity.getType() === 'Table' ? { tag: '@quarantine' } : {},
+      async ({ page }) => {
+        await entity.descriptionUpdate(page);
+      }
+    );
 
     test('Tag Add, Update and Remove', async ({ page }) => {
       await entity.tag(page, 'PersonalData.Personal', 'PII.None', entity);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExplorePageRightPanel_KnowledgeCenter.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExplorePageRightPanel_KnowledgeCenter.spec.ts
@@ -293,37 +293,37 @@ test.describe('Knowledge Center Right Panel Test Suite', () => {
         ).not.toBeVisible();
       });
 
-      test('Should remove user owner for knowledgeCenter', async ({
-        adminPage,
-        rightPanel,
-        overview,
-      }) => {
-        await navigateToKCEntity(
-          adminPage,
-          getEntityDisplayName(knowledgeCenter.responseData)
-        );
-        await rightPanel.waitForPanelLoaded();
-        rightPanel.setEntityConfigByType('knowledgeCenter');
+      test(
+        'Should remove user owner for knowledgeCenter',
+        { tag: '@quarantine' },
+        async ({ adminPage, rightPanel, overview }) => {
+          await navigateToKCEntity(
+            adminPage,
+            getEntityDisplayName(knowledgeCenter.responseData)
+          );
+          await rightPanel.waitForPanelLoaded();
+          rightPanel.setEntityConfigByType('knowledgeCenter');
 
-        await addOwnerInKCPanel(adminPage, user1.getUserDisplayName());
-        await expectOwnerInPanel(
-          adminPage,
-          getEntityDisplayName(knowledgeCenter.responseData),
-          user1.getUserDisplayName()
-        );
+          await addOwnerInKCPanel(adminPage, user1.getUserDisplayName());
+          await expectOwnerInPanel(
+            adminPage,
+            getEntityDisplayName(knowledgeCenter.responseData),
+            user1.getUserDisplayName()
+          );
 
-        await overview.removeOwner([user1.getUserDisplayName()], 'Users');
-        await waitForAllLoadersToDisappear(adminPage);
+          await overview.removeOwner([user1.getUserDisplayName()], 'Users');
+          await waitForAllLoadersToDisappear(adminPage);
 
-        await navigateToKCEntity(
-          adminPage,
-          getEntityDisplayName(knowledgeCenter.responseData)
-        );
-        const ownerElement = adminPage
-          .locator('.owners-section')
-          .getByText(user1.getUserDisplayName());
-        await expect(ownerElement).not.toBeVisible();
-      });
+          await navigateToKCEntity(
+            adminPage,
+            getEntityDisplayName(knowledgeCenter.responseData)
+          );
+          const ownerElement = adminPage
+            .locator('.owners-section')
+            .getByText(user1.getUserDisplayName());
+          await expect(ownerElement).not.toBeVisible();
+        }
+      );
     });
 
     test.describe('Overview panel - Deleted entity verification', () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageInteraction.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageInteraction.spec.ts
@@ -362,23 +362,31 @@ test.describe('Lineage Interactions', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       await fitToScreen(page);
     });
 
-    test('Verify node panel opens on click', async ({ page }) => {
-      const topicFqn = get(topic, 'entityResponseData.fullyQualifiedName', '');
+    test(
+      'Verify node panel opens on click',
+      { tag: '@quarantine' },
+      async ({ page }) => {
+        const topicFqn = get(
+          topic,
+          'entityResponseData.fullyQualifiedName',
+          ''
+        );
 
-      await clickLineageNode(page, topicFqn);
+        await clickLineageNode(page, topicFqn);
 
-      await expect(page.locator('[role="dialog"]')).toBeVisible();
+        await expect(page.locator('[role="dialog"]')).toBeVisible();
 
-      await expect(
-        page
-          .getByTestId('entity-summary-panel-container')
-          .getByTestId('entity-header-title')
-      ).toHaveText(topic.entityResponseData.displayName ?? '');
+        await expect(
+          page
+            .getByTestId('entity-summary-panel-container')
+            .getByTestId('entity-header-title')
+        ).toHaveText(topic.entityResponseData.displayName ?? '');
 
-      await page.getByLabel('Close').first().click();
+        await page.getByLabel('Close').first().click();
 
-      await expect(page.locator('[role="dialog"]')).not.toBeVisible();
-    });
+        await expect(page.locator('[role="dialog"]')).not.toBeVisible();
+      }
+    );
 
     test('Verify node full path is present as breadcrumb in lineage node', async ({
       page,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TestSuiteDetailsPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TestSuiteDetailsPage.spec.ts
@@ -50,7 +50,7 @@ test.beforeEach(async ({ page }) => {
 
 test(
   'Add test case modal on Test Suite details page - filters and select',
-  PLAYWRIGHT_INGESTION_TAG_OBJ,
+  { tag: [PLAYWRIGHT_INGESTION_TAG_OBJ.tag, '@quarantine'] },
   async ({ page }) => {
     test.slow();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/ContextCenterUtil.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/ContextCenterUtil.ts
@@ -207,10 +207,16 @@ export const navigateToDashboard = async (page: Page) => {
  * article, so the panel assertion has nothing to auto-wait for and only passes
  * once a retry warms the cache. Waiting on the persisted entry is the real
  * signal, so no fixed delay is needed.
+ *
+ * The Knowledge Center panel reads `recentlyViewedQuickLinks`, which is a
+ * different slice from the landing page's generic `recentlyViewed` — see
+ * `addToKnowledgeCenterRecentViewed` in `src/utils/KnowledgePageUtils.tsx`.
+ * The match mirrors `getLink` in that file, which builds the panel's test id
+ * from `displayName || fullyQualifiedName`.
  */
 export const readRecentlyViewed = async (
   page: Page
-): Promise<{ displayName?: string; fqn?: string }[]> => {
+): Promise<{ displayName?: string; fullyQualifiedName?: string }[]> => {
   const raw = await page.evaluate(
     (key: string) => localStorage.getItem(key),
     'user-preferences-store'
@@ -225,13 +231,18 @@ export const readRecentlyViewed = async (
       state?: {
         preferences?: Record<
           string,
-          { recentlyViewed?: { displayName?: string; fqn?: string }[] }
+          {
+            recentlyViewedQuickLinks?: {
+              displayName?: string;
+              fullyQualifiedName?: string;
+            }[];
+          }
         >;
       };
     };
 
     return Object.values(parsed?.state?.preferences ?? {}).flatMap(
-      (slice) => slice?.recentlyViewed ?? []
+      (slice) => slice?.recentlyViewedQuickLinks ?? []
     );
   } catch {
     return [];
@@ -247,7 +258,10 @@ export const waitForRecentlyViewed = async (
       async () => {
         const entries = await readRecentlyViewed(page);
 
-        return entries.some((entry) => entry?.displayName === displayName);
+        return entries.some(
+          (entry) =>
+            (entry?.displayName || entry?.fullyQualifiedName) === displayName
+        );
       },
       {
         message: `Wait for "${displayName}" to be persisted into recentlyViewed`,

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/ContextCenterUtil.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/ContextCenterUtil.ts
@@ -199,6 +199,65 @@ export const navigateToDashboard = async (page: Page) => {
   await section.waitFor({ state: 'visible' });
 };
 
+/**
+ * Recently-viewed is client-only state: the article detail page pushes it into
+ * the zustand `user-preferences-store` slice in localStorage, and that write
+ * lands after the render that triggered it. Navigating away before it flushes
+ * means the Recently Viewed panel renders from a store that never saw the
+ * article, so the panel assertion has nothing to auto-wait for and only passes
+ * once a retry warms the cache. Waiting on the persisted entry is the real
+ * signal, so no fixed delay is needed.
+ */
+export const readRecentlyViewed = async (
+  page: Page
+): Promise<{ displayName?: string; fqn?: string }[]> => {
+  const raw = await page.evaluate(
+    (key: string) => localStorage.getItem(key),
+    'user-preferences-store'
+  );
+
+  if (!raw) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as {
+      state?: {
+        preferences?: Record<
+          string,
+          { recentlyViewed?: { displayName?: string; fqn?: string }[] }
+        >;
+      };
+    };
+
+    return Object.values(parsed?.state?.preferences ?? {}).flatMap(
+      (slice) => slice?.recentlyViewed ?? []
+    );
+  } catch {
+    return [];
+  }
+};
+
+export const waitForRecentlyViewed = async (
+  page: Page,
+  displayName: string
+) => {
+  await expect
+    .poll(
+      async () => {
+        const entries = await readRecentlyViewed(page);
+
+        return entries.some((entry) => entry?.displayName === displayName);
+      },
+      {
+        message: `Wait for "${displayName}" to be persisted into recentlyViewed`,
+        timeout: 15_000,
+        intervals: [50, 100, 200, 500],
+      }
+    )
+    .toBe(true);
+};
+
 export const navigateToArticles = async (page: Page) => {
   await page.goto(ARTICLES_URL);
   await page

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
@@ -462,11 +462,13 @@ export const verifyGlossaryDetails = async (
 
   await checkName(page, glossaryDetails.name);
 
-  const viewerContainerText = await page.textContent(
-    '[data-testid="viewer-container"]'
+  // The description viewer mounts before the rich-text content hydrates, so
+  // page.textContent() — which waits for the element but not for its text —
+  // reads "" on a cold first attempt and only passes once a retry warms the
+  // bundle. toContainText polls, so it survives the hydration gap.
+  await expect(page.getByTestId('viewer-container')).toContainText(
+    glossaryDetails.description
   );
-
-  expect(viewerContainerText).toContain(glossaryDetails.description);
 
   // Owner
   if (glossaryDetails.owners.length > 0) {


### PR DESCRIPTION
### Describe your changes:

Fixes #32588

Sampling 11 merge_group Playwright runs showed ~15 first-attempt failures per run, ~94% of them rescued by `retries: 1` and therefore invisible — the shard exits 0 and the required `playwright-summary` check goes green. Seven tests were failing their first attempt in essentially *every* run: not flaky, deterministic and permanently masked. I fixed the 5 with a confident root cause and quarantined the 13 tests with 2+ observations behind a `@quarantine` tag, so a known flake can no longer eject a PR from the merge queue while it is being diagnosed.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

**Fixes (root-caused, not parked).**

- `playwright/utils/glossary.ts` used `page.textContent()`, which waits for the element but not for its text, so the lazily-hydrated description viewer read `""` on a cold attempt. This is #31384 — fixed by #30896 and reintroduced by `c22ea387d6` (#32333), a 327-file revert that also reverted 13 unrelated `playwright/` files. Restored to `toContainText`. Fixes `Pages/Glossary.spec.ts` 128 / 198 / 421 (11/11 first-attempt failures each).
- `ContextCenterArticles.spec.ts:670` lost a `waitForTimeout(500)` in #32283 that was covering the zustand → localStorage flush of `recentlyViewed`. The trailing assertion the removal relied on has no signal to wait for, because that state is client-side. Added `waitForRecentlyViewed`, which polls the persisted entry — same shape as the existing `waitForDraftPersisted` in the same file. (#32283 was otherwise sound: it removed 26 `waitForTimeout` and added 20 `expect.poll` + 4 assertions. This was the one removal with no replacement.)
- `ClassificationImportExport.spec.ts` generated fixture names at module scope, so a second `beforeAll` pass in the same worker recreated them and every create 409'd. Fixtures are now built inside `beforeAll`. Also added the missing `afterAll` — the spec was leaking two classifications, a tag and a user into the shard on *every* run, which pollutes other specs' listings.

**Quarantine mechanism.** `applyQuarantine()` in `playwright.config.ts` maps over the projects array rather than setting a top-level `grepInvert`. That is load-bearing: Playwright *replaces* (never merges) a top-level `grepInvert` with a project's own, and `chromium` already sets one for lane routing — so the top-level form is silently dropped for the project that runs most of the suite. My first attempt looked correct and excluded zero tests; `--list` caught it.

Evidence is counted **per generated variant, not per source line**. `CustomProperties.spec.ts` and `RestoreEntityInheritedFields.spec.ts` each showed two failures at one line, but in different loop variants — one observation each — so tagging the shared line would have quarantined 28 and 12 instances to chase two singletons. They stay in. `EntityDataConsumer.spec.ts` is scoped to its `Table` variant only.

**Alternative rejected: a flake ledger / baseline.** It institutionalises the flakiness it tracks. **Also rejected: `retries: 0` now.** The flake set does not converge — each additional run reveals ~5 previously-unseen flaky tests, still linear at run 11 (15.1 → 40.3 → 72.0 cumulative), 54 of 72 seen exactly once, Chao1 lower bound ≥315 tests. The 0.34% per-test rate is identical on PRs (3.5/942) and in the queue (15.2/4487), so it is a property of path length, not of the tests. Quarantining to zero is unbounded; the real fix is suite shape and is filed for follow-up on #32588.

#
### Tests:

#### Use cases covered
- A cold-cache first attempt renders a glossary description and the assertion survives the lazy editor chunk resolving.
- Viewing an article then navigating back shows it in the Recently Viewed panel, without depending on a fixed delay.
- `ClassificationImportExport` sets up cleanly when `beforeAll` runs a second time in the same worker, and leaves no entities behind.
- Tests tagged `@quarantine` do not run in any lane; `PLAYWRIGHT_RUN_QUARANTINED=true` runs only those.

#### Unit tests
Not applicable — no product code changed; this PR is entirely test-suite and Playwright config.

#### Backend integration tests
Not applicable — no backend API changes.

#### Ingestion integration tests
Not applicable — no ingestion changes.

#### Playwright (UI) tests
Files updated: `playwright.config.ts`, `playwright/utils/glossary.ts`, `playwright/utils/ContextCenterUtil.ts`, `playwright/QUARANTINE.md` (new), and 13 specs.

| check | result |
|---|---|
| `npx playwright test --list` | 4543 tests (was 4555) |
| `PLAYWRIGHT_RUN_QUARANTINED=true … --list` | exactly the 13 |
| per-test leak check, all 13 | 0 leaks in the default run; `EntityDataConsumer` keeps its other 14 variants |
| `yarn lint:playwright` | **0 errors** (214 pre-existing warnings) |
| `npx tsc --noEmit` | 0 errors in changed files (604 pre-existing repo-wide, all i18next/`ReactNode`) |
| CI lint sequence replayed (organize-imports → eslint --fix → prettier) | fixed point, so `ui-checkstyle` passes |

#### Manual testing performed
1. Reproduced from CI evidence rather than a local stack: downloaded per-shard `results.json` for 11 merge_group runs and 11 pull_request runs and aggregated first-attempt failures, attempt indices, durations and error text (script in the issue thread).
2. Confirmed each of the 5 fixes against its recorded failure: attempt index 0 in 10-11 of 11 runs, passing on attempt 1.
3. Verified the quarantine both ways with `npx playwright test --list`, then re-verified after the final format pass since prettier shifts line numbers.
4. Verified the CI lint sequence is a fixed point on the committed tree by snapshotting, replaying it, and diffing.

#
### UI screen recording / screenshots:

Not applicable — no product UI changes.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable, no product UI changed.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing. The three Glossary tests, `ContextCenterArticles.spec.ts:670` and `ClassificationImportExport.spec.ts` are themselves the regression tests — each failed its first attempt in 10-11 of 11 sampled runs before this change. #31384 is referenced in `QUARANTINE.md` for the glossary regression.

> **Review tip:** use `git diff -w`. The real change is 261/51 lines; the raw 889/593 is ~90% prettier re-indentation, because adding a `{ tag: '@quarantine' }` argument reflows each test body.