### PR TITLE
Fixes #32593: cut avoidable Playwright server load by ~21% of API calls

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/OktaSelfSignupClaims.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/OktaSelfSignupClaims.spec.ts
@@ -11,8 +11,9 @@
  *  limitations under the License.
  */
 
-import { BrowserContext, expect, Page, test } from '@playwright/test';
+import { BrowserContext, Page } from '@playwright/test';
 import { SSO_ENV } from '../../constant/ssoAuth';
+import { expect, test } from '../../support/fixtures/base';
 import { getProviderHelper, ProviderHelper } from '../../utils/sso-providers';
 import { swapSecurityConfig } from '../../utils/ssoAuth';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/OktaSessionRenewalPublic.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/OktaSessionRenewalPublic.spec.ts
@@ -10,8 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { BrowserContext, expect, Page, Request, test } from '@playwright/test';
+import { BrowserContext, Page, Request } from '@playwright/test';
 import { SSO_ENV } from '../../constant/ssoAuth';
+import { expect, test } from '../../support/fixtures/base';
 import { redirectToHomePage } from '../../utils/common';
 import { decodeJwtExp, expireStoredToken } from '../../utils/sessionRenewal';
 import { getProviderHelper, ProviderHelper } from '../../utils/sso-providers';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/SSOAuthentication.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/SSOAuthentication.spec.ts
@@ -23,7 +23,8 @@
  *   - OM server running with .env.sso-test (docker compose --env-file .env.sso-test up -d)
  */
 
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 import {
   configureMockOidc,
   forceInteractionRequired,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/SSOLogin.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/SSOLogin.spec.ts
@@ -10,8 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { BrowserContext, expect, Page, test } from '@playwright/test';
+import { BrowserContext, Page } from '@playwright/test';
 import { SSO_ENV } from '../../constant/ssoAuth';
+import { expect, test } from '../../support/fixtures/base';
 import { redirectToHomePage } from '../../utils/common';
 import { getProviderHelper, ProviderHelper } from '../../utils/sso-providers';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/SSORenewal.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/SSORenewal.spec.ts
@@ -10,8 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { BrowserContext, expect, Page, Response, test } from '@playwright/test';
+import { BrowserContext, Page, Response } from '@playwright/test';
 import { SSO_ENV } from '../../constant/ssoAuth';
+import { expect, test } from '../../support/fixtures/base';
 import {
   AUTH_REFRESH_PATH,
   clearServerSessionCookie,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/SSOSelfSignup.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/SSOSelfSignup.spec.ts
@@ -27,7 +27,8 @@
  *     and AUTHENTICATION_ENABLE_SELF_SIGNUP=true
  */
 
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 import { getApiContext } from '../../utils/common';
 import {
   MOCK_OIDC_MAPPED_CLAIM_ACCOUNT,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/SSOSessionLimit.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/SSOSessionLimit.spec.ts
@@ -10,8 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { BrowserContext, expect, Page, test } from '@playwright/test';
+import { BrowserContext, Page } from '@playwright/test';
 import { SSO_ENV } from '../../constant/ssoAuth';
+import { expect, test } from '../../support/fixtures/base';
 import { withMaxActiveSessions } from '../../utils/sessionRenewal';
 import { getProviderHelper, ProviderHelper } from '../../utils/sso-providers';
 import { swapSecurityConfig } from '../../utils/ssoAuth';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityFeed.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityFeed.spec.ts
@@ -10,16 +10,11 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import {
-  APIRequestContext,
-  expect,
-  Locator,
-  Page,
-  test as base,
-} from '@playwright/test';
+import { APIRequestContext, Locator, Page } from '@playwright/test';
 import { ApiEndpointClass } from '../../support/entity/ApiEndpointClass';
 import { DatabaseClass } from '../../support/entity/DatabaseClass';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test as base } from '../../support/fixtures/base';
 import { PersonaClass } from '../../support/persona/PersonaClass';
 import { UserClass } from '../../support/user/UserClass';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityFeedTabBadge.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityFeedTabBadge.spec.ts
@@ -11,8 +11,9 @@
  *  limitations under the License.
  */
 
-import { APIRequestContext, expect, test } from '@playwright/test';
+import { APIRequestContext } from '@playwright/test';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import { createConversationThread } from '../../utils/activityAPI';
 import { performAdminLogin } from '../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityStream.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityStream.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { expect, test as base } from '@playwright/test';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test as base } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import { insertActivityEventForTest } from '../../utils/activityAPI';
 import { performAdminLogin } from '../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AgentLogStreamHandover.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AgentLogStreamHandover.spec.ts
@@ -11,9 +11,10 @@
  *  limitations under the License.
  */
 
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { randomUUID } from 'crypto';
 import { EntityDataClass } from '../../support/entity/EntityDataClass';
+import { expect, test } from '../../support/fixtures/base';
 import { createNewPage, uuid } from '../../utils/common';
 import { getEncodedFqn } from '../../utils/entity';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AppMode/AppModeAiPersonaLandsAtRoot.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AppMode/AppModeAiPersonaLandsAtRoot.spec.ts
@@ -34,7 +34,8 @@
  * the URL `/` after boot.
  */
 
-import { APIRequestContext, expect, Page, test } from '@playwright/test';
+import { APIRequestContext, Page } from '@playwright/test';
+import { expect, test } from '../../../support/fixtures/base';
 import { PersonaClass } from '../../../support/persona/PersonaClass';
 import { UserClass } from '../../../support/user/UserClass';
 import { createNewPage } from '../../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AppMode/AppModeAuthGating.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AppMode/AppModeAuthGating.spec.ts
@@ -11,7 +11,8 @@
  *  limitations under the License.
  */
 
-import { APIRequestContext, expect, test } from '@playwright/test';
+import { APIRequestContext } from '@playwright/test';
+import { expect, test } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { createNewPage, getApiContext } from '../../../utils/common';
 import { withAppConfigLock } from '../../Utils/appConfigMutex';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AppMode/AppModeCrossDevice.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AppMode/AppModeCrossDevice.spec.ts
@@ -11,7 +11,8 @@
  *  limitations under the License.
  */
 
-import { expect, Page, Response, test } from '@playwright/test';
+import { Page, Response } from '@playwright/test';
+import { expect, test } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { createNewPage } from '../../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../../utils/entity';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AppMode/AppModePrecedence.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AppMode/AppModePrecedence.spec.ts
@@ -29,13 +29,8 @@
  * persona-changed-mid-session case.
  */
 
-import {
-  APIRequestContext,
-  Browser,
-  expect,
-  Page,
-  test,
-} from '@playwright/test';
+import { APIRequestContext, Browser, Page } from '@playwright/test';
+import { expect, test } from '../../../support/fixtures/base';
 import { PersonaClass } from '../../../support/persona/PersonaClass';
 import { UserClass } from '../../../support/user/UserClass';
 import { createNewPage } from '../../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AppMode/AppModePreferenceRoundTrip.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AppMode/AppModePreferenceRoundTrip.spec.ts
@@ -11,7 +11,8 @@
  *  limitations under the License.
  */
 
-import { expect, Page, Request, Response, test } from '@playwright/test';
+import { Page, Request, Response } from '@playwright/test';
+import { expect, test } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { createNewPage } from '../../../utils/common';
 import { switchToAiModeViaProfileToggle } from '../../Utils/appMode';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AutoPilot.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AutoPilot.spec.ts
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { isEmpty } from 'lodash';
 import { PLAYWRIGHT_INGESTION_TAG_OBJ } from '../../constant/config';
 import AirflowIngestionClass from '../../support/entity/ingestion/AirflowIngestionClass';
@@ -20,6 +19,7 @@ import KafkaIngestionClass from '../../support/entity/ingestion/KafkaIngestionCl
 import MetabaseIngestionClass from '../../support/entity/ingestion/MetabaseIngestionClass';
 import MlFlowIngestionClass from '../../support/entity/ingestion/MlFlowIngestionClass';
 import MysqlIngestionClass from '../../support/entity/ingestion/MySqlIngestionClass';
+import { expect, test } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import { checkAutoPilotStatus } from '../../utils/AutoPilot';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditEntity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditEntity.spec.ts
@@ -10,7 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { APIRequestContext, expect, test } from '@playwright/test';
+import { APIRequestContext } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 
 import { RDG_ACTIVE_CELL_SELECTOR } from '../../constant/bulkImportExport';
 import { SERVICE_TYPE } from '../../constant/service';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditOperationBadges.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditOperationBadges.spec.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 
 import { RDG_ACTIVE_CELL_SELECTOR } from '../../constant/bulkImportExport';
 import { SERVICE_TYPE } from '../../constant/service';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts
@@ -10,7 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Locator, Page, test } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 
 import { RDG_ACTIVE_CELL_SELECTOR } from '../../constant/bulkImportExport';
 import { GlobalSettingOptions } from '../../constant/settings';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImportWithDotInName.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImportWithDotInName.spec.ts
@@ -10,7 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { APIRequestContext, expect, test } from '@playwright/test';
+import { APIRequestContext } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 
 import { SERVICE_TYPE } from '../../constant/service';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CertificationDropdown.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CertificationDropdown.spec.ts
@@ -10,8 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import { TagClass } from '../../support/tag/TagClass';
 import {
   closeCertificationDropdown,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ClassificationImportExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ClassificationImportExport.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 import { ClassificationClass } from '../../support/tag/ClassificationClass';
 import { TagClass } from '../../support/tag/TagClass';
 import { UserClass } from '../../support/user/UserClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ColumnBulkOperations.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ColumnBulkOperations.spec.ts
@@ -10,9 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { APIRequestContext, expect, Page, test } from '@playwright/test';
+import { APIRequestContext, Page } from '@playwright/test';
 import { SidebarItem } from '../../constant/sidebar';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import {
   createNewPage,
   fullUuid,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ColumnBulkOperationsTagsGlossary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ColumnBulkOperationsTagsGlossary.spec.ts
@@ -10,9 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { APIRequestContext, expect, Page, test } from '@playwright/test';
+import { APIRequestContext, Page } from '@playwright/test';
 import { SidebarItem } from '../../constant/sidebar';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import { createNewPage, redirectToHomePage } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterPermission.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterPermission.spec.ts
@@ -11,13 +11,9 @@
  *  limitations under the License.
  */
 
-import {
-  APIRequestContext,
-  expect,
-  Page,
-  test as base,
-} from '@playwright/test';
+import { APIRequestContext, Page } from '@playwright/test';
 import { KnowledgeCenterClass } from '../../support/entity/KnowledgeCenterClass';
+import { expect, test as base } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CronValidations.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CronValidations.spec.ts
@@ -11,8 +11,9 @@
  *  limitations under the License.
  */
 
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
+import { expect, test } from '../../support/fixtures/base';
 import { redirectToHomePage } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CuratedAssets.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CuratedAssets.spec.ts
@@ -10,8 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { EntityDataClass } from '../../support/entity/EntityDataClass';
+import { expect, test as base } from '../../support/fixtures/base';
 import { PersonaClass } from '../../support/persona/PersonaClass';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CustomizeDetailPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CustomizeDetailPage.spec.ts
@@ -10,12 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import {
-  APIRequestContext,
-  expect,
-  Page,
-  test as base,
-} from '@playwright/test';
+import { APIRequestContext, Page } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import {
   ECustomizedDataAssets,
@@ -24,6 +19,7 @@ import {
 } from '../../constant/customizeDetail';
 import { GlobalSettingOptions } from '../../constant/settings';
 import { SidebarItem } from '../../constant/sidebar';
+import { expect, test as base } from '../../support/fixtures/base';
 import { PersonaClass } from '../../support/persona/PersonaClass';
 import { AdminClass } from '../../support/user/AdminClass';
 import { UserClass } from '../../support/user/UserClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CustomizeNavigationNewItems.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CustomizeNavigationNewItems.spec.ts
@@ -11,10 +11,11 @@
  *  limitations under the License.
  */
 
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { GlobalSettingOptions } from '../../constant/settings';
 import { SidebarItem } from '../../constant/sidebar';
+import { expect, test as base } from '../../support/fixtures/base';
 import { PersonaClass } from '../../support/persona/PersonaClass';
 import { AdminClass } from '../../support/user/AdminClass';
 import { UserClass } from '../../support/user/UserClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataProductDomainMigration.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataProductDomainMigration.spec.ts
@@ -11,11 +11,11 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { SidebarItem } from '../../constant/sidebar';
 import { DataProduct } from '../../support/domain/DataProduct';
 import { Domain } from '../../support/domain/Domain';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import {
   createNewPage,
   getApiContext,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataProductPersonaCustomization.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataProductPersonaCustomization.spec.ts
@@ -10,14 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import {
-  APIRequestContext,
-  expect,
-  Page,
-  test as base,
-} from '@playwright/test';
+import { APIRequestContext, Page } from '@playwright/test';
 import { ECustomizedGovernance } from '../../constant/customizeDetail';
 import { GlobalSettingOptions } from '../../constant/settings';
+import { expect, test as base } from '../../support/fixtures/base';
 import { PersonaClass } from '../../support/persona/PersonaClass';
 import { AdminClass } from '../../support/user/AdminClass';
 import { UserClass } from '../../support/user/UserClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataProductRename.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataProductRename.spec.ts
@@ -11,12 +11,12 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { get } from 'lodash';
 import { SidebarItem } from '../../constant/sidebar';
 import { DataProduct } from '../../support/domain/DataProduct';
 import { Domain } from '../../support/domain/Domain';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import {
   createNewPage,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataProductRenameConsolidation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataProductRenameConsolidation.spec.ts
@@ -11,12 +11,13 @@
  *  limitations under the License.
  */
 
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { get } from 'lodash';
 import { SidebarItem } from '../../constant/sidebar';
 import { DataProduct } from '../../support/domain/DataProduct';
 import { Domain } from '../../support/domain/Domain';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import { ClassificationClass } from '../../support/tag/ClassificationClass';
 import { TagClass } from '../../support/tag/TagClass';
 import { UserClass } from '../../support/user/UserClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/ColumnLevelTests.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/ColumnLevelTests.spec.ts
@@ -10,9 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { DOMAIN_TAGS } from '../../../constant/config';
 import { TableClass } from '../../../support/entity/TableClass';
+import { expect, test } from '../../../support/fixtures/base';
 import {
   createNewPage,
   descriptionBox,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataObservabilityGovernanceTab.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataObservabilityGovernanceTab.spec.ts
@@ -11,9 +11,10 @@
  *  limitations under the License.
  */
 
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { Domain } from '../../../support/domain/Domain';
 import { TableClass } from '../../../support/entity/TableClass';
+import { expect, test } from '../../../support/fixtures/base';
 import { Glossary } from '../../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
 import { ClassificationClass } from '../../../support/tag/ClassificationClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityPermissions.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { DOMAIN_TAGS } from '../../../constant/config';
 import {
   CREATE_TEST_CASE_POLICY,
@@ -25,6 +25,7 @@ import {
   VIEW_ALL_TEST_CASE_POLICY,
 } from '../../../constant/dataQualityPermissions';
 import { TableClass } from '../../../support/entity/TableClass';
+import { expect, test as base } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import { redirectToHomePage, uuid } from '../../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/IncidentManagerLocaleLayout.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/IncidentManagerLocaleLayout.spec.ts
@@ -10,7 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test, type Page } from '@playwright/test';
+import { type Page } from '@playwright/test';
+import { expect, test } from '../../../support/fixtures/base';
 
 /**
  * Issue #30522 — a long Russian "No Severity" placeholder made the nowrap chip

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TableLevelTests.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TableLevelTests.spec.ts
@@ -10,9 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { DOMAIN_TAGS } from '../../../constant/config';
 import { TableClass } from '../../../support/entity/TableClass';
+import { expect, test } from '../../../support/fixtures/base';
 import {
   createNewPage,
   getApiContext,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestCaseIncidentPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestCaseIncidentPermissions.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { DOMAIN_TAGS } from '../../../constant/config';
 import {
   CONSUMER_LIKE_POLICY,
@@ -22,6 +22,7 @@ import {
 import { PolicyClass } from '../../../support/access-control/PoliciesClass';
 import { RolesClass } from '../../../support/access-control/RolesClass';
 import { TableClass } from '../../../support/entity/TableClass';
+import { expect, test as base } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import { getApiContext } from '../../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestCaseResultPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestCaseResultPermissions.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { DOMAIN_TAGS } from '../../../constant/config';
 import {
   DELETE_RESULTS_POLICY,
@@ -21,6 +21,7 @@ import {
   VIEW_RESULTS_POLICY,
 } from '../../../constant/dataQualityPermissions';
 import { TableClass } from '../../../support/entity/TableClass';
+import { expect, test as base } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import { getApiContext, redirectToHomePage } from '../../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestDefinitionFilters.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestDefinitionFilters.spec.ts
@@ -11,13 +11,13 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { DOMAIN_TAGS } from '../../../constant/config';
 import {
   ENTITY_TYPE_OPTIONS,
   FILTER_LABELS,
   TEST_PLATFORM_OPTIONS,
 } from '../../../constant/testDefinitionFilter';
+import { expect, test } from '../../../support/fixtures/base';
 import { waitForAllLoadersToDisappear } from '../../../utils/entity';
 import {
   closeFilterDropdown,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestDefinitionPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestDefinitionPermissions.spec.ts
@@ -10,10 +10,11 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { DOMAIN_TAGS } from '../../../constant/config';
 import { PolicyClass } from '../../../support/access-control/PoliciesClass';
 import { RolesClass } from '../../../support/access-control/RolesClass';
+import { expect, test as base } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import { getApiContext, redirectToHomePage, uuid } from '../../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DescriptionSuggestion.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DescriptionSuggestion.spec.ts
@@ -10,12 +10,13 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { APIRequestContext, expect, test } from '@playwright/test';
+import { APIRequestContext } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { ApiEndpointClass } from '../../support/entity/ApiEndpointClass';
 import { ContainerClass } from '../../support/entity/ContainerClass';
 import { TableClass } from '../../support/entity/TableClass';
 import { TopicClass } from '../../support/entity/TopicClass';
+import { expect, test } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import { getApiContext } from '../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainDropdownIsolation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainDropdownIsolation.spec.ts
@@ -11,8 +11,9 @@
  *  limitations under the License.
  */
 
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { Domain } from '../../../support/domain/Domain';
+import { expect, test as base } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import { redirectToHomePage } from '../../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainIncidentIsolation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainIncidentIsolation.spec.ts
@@ -10,10 +10,11 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { SidebarItem } from '../../../constant/sidebar';
 import { Domain } from '../../../support/domain/Domain';
 import { TableClass } from '../../../support/entity/TableClass';
+import { expect, test as base } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import { redirectToHomePage } from '../../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainLineageIsolation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainLineageIsolation.spec.ts
@@ -10,9 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { Domain } from '../../../support/domain/Domain';
 import { TableClass } from '../../../support/entity/TableClass';
+import { expect, test as base } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainListingIsolation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainListingIsolation.spec.ts
@@ -10,9 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { SidebarItem } from '../../../constant/sidebar';
 import { Domain } from '../../../support/domain/Domain';
+import { expect, test as base } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import { redirectToHomePage } from '../../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainSearchIsolation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainSearchIsolation.spec.ts
@@ -10,9 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { Domain } from '../../../support/domain/Domain';
 import { TableClass } from '../../../support/entity/TableClass';
+import { expect, test as base } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import { getApiContext } from '../../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainTaskIsolation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainTaskIsolation.spec.ts
@@ -10,9 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { Domain } from '../../../support/domain/Domain';
 import { TableClass } from '../../../support/entity/TableClass';
+import { expect, test as base } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import { getApiContext } from '../../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/EntityRenameConsolidation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/EntityRenameConsolidation.spec.ts
@@ -11,10 +11,11 @@
  *  limitations under the License.
  */
 
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { SidebarItem } from '../../constant/sidebar';
 import { Domain } from '../../support/domain/Domain';
+import { expect, test } from '../../support/fixtures/base';
 import { Glossary } from '../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import { ClassificationClass } from '../../support/tag/ClassificationClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/EntitySummaryPanel.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/EntitySummaryPanel.spec.ts
@@ -10,11 +10,12 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { ENTITY_TYPES } from '../../constant/entity';
 import { SidebarItem } from '../../constant/sidebar';
 import { EntityType } from '../../support/entity/EntityDataClass.interface';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import { createNewPage, redirectToHomePage, uuid } from '../../utils/common';
 import { getEntityDisplayName } from '../../utils/entity';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreSortOrderFilter.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreSortOrderFilter.spec.ts
@@ -10,10 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { DATA_ASSETS_SORT } from '../../constant/explore';
 import { SidebarItem } from '../../constant/sidebar';
+import { expect, test } from '../../support/fixtures/base';
 import { performAdminLogin } from '../../utils/admin';
 import { redirectToHomePage } from '../../utils/common';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/FailedTestCaseSampleData.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/FailedTestCaseSampleData.spec.ts
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { PLAYWRIGHT_INGESTION_TAG_OBJ } from '../../constant/config';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import { performAdminLogin } from '../../utils/admin';
 import {
   expectNoErrorToast,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryInheritedReviewerApproval.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryInheritedReviewerApproval.spec.ts
@@ -10,7 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { APIRequestContext, expect, test } from '@playwright/test';
+import { APIRequestContext } from '@playwright/test';
+import { expect, test } from '../../../support/fixtures/base';
 import { Glossary } from '../../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
 import { UserClass } from '../../../support/user/UserClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryMutualExclusivity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryMutualExclusivity.spec.ts
@@ -10,9 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { SidebarItem } from '../../../constant/sidebar';
 import { TableClass } from '../../../support/entity/TableClass';
+import { expect, test } from '../../../support/fixtures/base';
 import { Glossary } from '../../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
 import { getApiContext, redirectToHomePage } from '../../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryMutualExclusivityDataProductTree.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryMutualExclusivityDataProductTree.spec.ts
@@ -10,8 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { Domain } from '../../../support/domain/Domain';
+import { expect, test } from '../../../support/fixtures/base';
 import { Glossary } from '../../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
 import { getApiContext, redirectToHomePage } from '../../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryPersonaCustomization.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryPersonaCustomization.spec.ts
@@ -10,9 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { ECustomizedGovernance } from '../../../constant/customizeDetail';
 import { GlobalSettingOptions } from '../../../constant/settings';
+import { expect, test as base } from '../../../support/fixtures/base';
 import { Glossary } from '../../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
 import { PersonaClass } from '../../../support/persona/PersonaClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryRelationsGraph.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryRelationsGraph.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../../../support/fixtures/base';
 import { Glossary } from '../../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryRelationsGraphPerf.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryRelationsGraphPerf.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../../../support/fixtures/base';
 import { Glossary } from '../../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryTermRelationsGraph.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryTermRelationsGraph.spec.ts
@@ -10,8 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { GlossaryTermRelationsGraphData as GraphData } from '../../../support/entity/OntologyStudioDataClass';
+import { expect, test } from '../../../support/fixtures/base';
 import { redirectToHomePage } from '../../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../../utils/entity';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryTermRelationsGraphNested.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryTermRelationsGraphNested.spec.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../../../support/fixtures/base';
 import { Glossary } from '../../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryWorkflow.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryWorkflow.spec.ts
@@ -10,8 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { SidebarItem } from '../../../constant/sidebar';
+import { expect, test as base } from '../../../support/fixtures/base';
 import { Glossary } from '../../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
 import { UserClass } from '../../../support/user/UserClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IngestionListNameSorting.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IngestionListNameSorting.spec.ts
@@ -10,9 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Locator, Page, test } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
 import { SORT_ORDER } from '../../../src/enums/common.enum';
 import { DatabaseServiceClass } from '../../support/entity/service/DatabaseServiceClass';
+import { expect, test } from '../../support/fixtures/base';
 import { performAdminLogin } from '../../utils/admin';
 import { uuid } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LandingPageWidgets/DataAssetsWidget.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LandingPageWidgets/DataAssetsWidget.spec.ts
@@ -10,7 +10,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { test } from '@playwright/test';
 import { toLower } from 'lodash';
 import { ContainerClass } from '../../../support/entity/ContainerClass';
 import { DashboardClass } from '../../../support/entity/DashboardClass';
@@ -19,6 +18,7 @@ import { PipelineClass } from '../../../support/entity/PipelineClass';
 import { SearchIndexClass } from '../../../support/entity/SearchIndexClass';
 import { TableClass } from '../../../support/entity/TableClass';
 import { TopicClass } from '../../../support/entity/TopicClass';
+import { test } from '../../../support/fixtures/base';
 import { createNewPage, redirectToHomePage } from '../../../utils/common';
 import { checkDataAssetWidget } from '../../../utils/entity';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LandingPageWidgets/DomainDataProductsWidgets.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LandingPageWidgets/DomainDataProductsWidgets.spec.ts
@@ -10,13 +10,14 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { SidebarItem } from '../../../constant/sidebar';
 import { DataProduct } from '../../../support/domain/DataProduct';
 import { Domain } from '../../../support/domain/Domain';
 import { SubDomain } from '../../../support/domain/SubDomain';
 import { TableClass } from '../../../support/entity/TableClass';
 import { TopicClass } from '../../../support/entity/TopicClass';
+import { test as base } from '../../../support/fixtures/base';
 import { PersonaClass } from '../../../support/persona/PersonaClass';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LandingPageWidgets/DomainWidgetFilter.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LandingPageWidgets/DomainWidgetFilter.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { Domain } from '../../../support/domain/Domain';
+import { expect, test } from '../../../support/fixtures/base';
 import { PersonaClass } from '../../../support/persona/PersonaClass';
 import {
   createNewPage,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LandingPageWidgets/FollowingWidget.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LandingPageWidgets/FollowingWidget.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { ApiEndpointClass } from '../../../support/entity/ApiEndpointClass';
 import { ContainerClass } from '../../../support/entity/ContainerClass';
 import { DashboardClass } from '../../../support/entity/DashboardClass';
@@ -22,6 +22,7 @@ import { SearchIndexClass } from '../../../support/entity/SearchIndexClass';
 import { StoredProcedureClass } from '../../../support/entity/StoredProcedureClass';
 import { TableClass } from '../../../support/entity/TableClass';
 import { TopicClass } from '../../../support/entity/TopicClass';
+import { test as base } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import { redirectToHomePage } from '../../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LanguageOverride.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LanguageOverride.spec.ts
@@ -10,7 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Browser, expect, Page, test as base } from '@playwright/test';
+import { Browser, Page } from '@playwright/test';
+import { expect, test as base } from '../../support/fixtures/base';
 import { redirectToHomePage } from '../../utils/common';
 
 const test = base.extend<{ germanLocalePage: Page }>({

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LineageExportPNGSnapshot.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LineageExportPNGSnapshot.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import * as fs from 'fs';
+import { expect, test } from '../../support/fixtures/base';
 import { performZoomOut } from '../../utils/lineage';
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LineagePipelineAnnotator.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LineagePipelineAnnotator.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import {
   getAuthContext,
   getToken,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricCustomUnitFlow.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricCustomUnitFlow.spec.ts
@@ -10,9 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Locator, Page, test } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { SidebarItem } from '../../constant/sidebar';
+import { expect, test } from '../../support/fixtures/base';
 import {
   clickOutside,
   descriptionBox,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MultipleRename.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MultipleRename.spec.ts
@@ -11,9 +11,10 @@
  *  limitations under the License.
  */
 
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { SidebarItem } from '../../constant/sidebar';
+import { expect, test } from '../../support/fixtures/base';
 import { Glossary } from '../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import { ClassificationClass } from '../../support/tag/ClassificationClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MutuallyExclusiveColumnTags.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MutuallyExclusiveColumnTags.spec.ts
@@ -10,9 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import {
   createNewPage,
   redirectToHomePage,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/NavigationBlocker.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/NavigationBlocker.spec.ts
@@ -10,8 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
+import { expect, test as base } from '../../support/fixtures/base';
 import { PersonaClass } from '../../support/persona/PersonaClass';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/NestedColumnsExpandCollapse.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/NestedColumnsExpandCollapse.spec.ts
@@ -10,7 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { APIRequestContext, test } from '@playwright/test';
+import { APIRequestContext } from '@playwright/test';
+import { test } from '../../support/fixtures/base';
 import { createNewPage, redirectToHomePage } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import { clickUpdateButtonIfVisible } from '../../utils/explore';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyAiFlagRdf.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyAiFlagRdf.spec.ts
@@ -11,11 +11,11 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import {
   ProjectionState,
   RDFStatus,
 } from '../../../src/generated/api/rdf/rdfStatus';
+import { expect, test } from '../../support/fixtures/base';
 import { Glossary } from '../../support/glossary/Glossary';
 import { performAdminLogin } from '../../utils/admin';
 import { navigateToOntologyStudio } from '../../utils/ontologyStudio';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyAuthoringRdf.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyAuthoringRdf.spec.ts
@@ -11,13 +11,14 @@
  *  limitations under the License.
  */
 
-import { APIRequestContext, expect, Page, test } from '@playwright/test';
+import { APIRequestContext, Page } from '@playwright/test';
 import {
   Category,
   CreateRelationshipType,
   PaletteKey,
 } from '../../../src/generated/api/data/createRelationshipType';
 import { RelationshipType } from '../../../src/generated/entity/data/relationshipType';
+import { expect, test } from '../../support/fixtures/base';
 import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import { OntologyRdfFixture } from '../../support/ontology/OntologyRdfFixture';
 import { performAdminLogin } from '../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyConceptAttributesRdf.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyConceptAttributesRdf.spec.ts
@@ -11,7 +11,8 @@
  *  limitations under the License.
  */
 
-import { APIRequestContext, expect, Page, test } from '@playwright/test';
+import { APIRequestContext, Page } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import { OntologyRdfFixture } from '../../support/ontology/OntologyRdfFixture';
 import { performAdminLogin } from '../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyConceptRealizationRdf.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyConceptRealizationRdf.spec.ts
@@ -11,8 +11,9 @@
  *  limitations under the License.
  */
 
-import { APIRequestContext, expect, test } from '@playwright/test';
+import { APIRequestContext } from '@playwright/test';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import { OntologyRdfFixture } from '../../support/ontology/OntologyRdfFixture';
 import { performAdminLogin } from '../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyDataExploreRdf.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyDataExploreRdf.spec.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { APIRequestContext, expect, Page, test } from '@playwright/test';
+import { APIRequestContext, Page } from '@playwright/test';
 import {
   CreateTable,
   DataType,
@@ -20,6 +20,7 @@ import {
 import { Table } from '../../../src/generated/entity/data/table';
 import { EntityReference } from '../../../src/generated/entity/type';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import { OntologyRdfFixture } from '../../support/ontology/OntologyRdfFixture';
 import { performAdminLogin } from '../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyGovernanceRdf.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyGovernanceRdf.spec.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { APIRequestContext, expect, test } from '@playwright/test';
+import { APIRequestContext } from '@playwright/test';
 import { randomUUID } from 'crypto';
 import {
   CreateGlossary,
@@ -21,6 +21,7 @@ import { OntologyBulkSubmission } from '../../../src/generated/api/data/ontology
 import { OntologyImpactReport } from '../../../src/generated/api/data/ontologyImpactReport';
 import { OntologyImportResult } from '../../../src/generated/api/data/ontologyImportResult';
 import { Glossary as GlossaryEntity } from '../../../src/generated/entity/data/glossary';
+import { expect, test } from '../../support/fixtures/base';
 import { Glossary } from '../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import { OntologyRdfFixture } from '../../support/ontology/OntologyRdfFixture';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyImportFidelityRdf.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyImportFidelityRdf.spec.ts
@@ -11,7 +11,8 @@
  *  limitations under the License.
  */
 
-import { APIRequestContext, expect, test } from '@playwright/test';
+import { APIRequestContext } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 import { Glossary } from '../../support/glossary/Glossary';
 import { performAdminLogin } from '../../utils/admin';
 import { uuid } from '../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyImportRdf.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyImportRdf.spec.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 import { Glossary } from '../../support/glossary/Glossary';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyImportRoundTripRdf.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyImportRoundTripRdf.spec.ts
@@ -11,8 +11,9 @@
  *  limitations under the License.
  */
 
-import { APIRequestContext, expect, test } from '@playwright/test';
+import { APIRequestContext } from '@playwright/test';
 import { OntologyImportResult } from '../../../src/generated/api/data/ontologyImportResult';
+import { expect, test } from '../../support/fixtures/base';
 import { OntologyRdfFixture } from '../../support/ontology/OntologyRdfFixture';
 import { performAdminLogin } from '../../utils/admin';
 import { uuid } from '../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyLibraryRdf.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyLibraryRdf.spec.ts
@@ -11,9 +11,10 @@
  *  limitations under the License.
  */
 
-import { APIRequestContext, expect, test } from '@playwright/test';
+import { APIRequestContext } from '@playwright/test';
 import { OntologyPackInstallResult } from '../../../src/generated/api/data/ontologyPackInstallResult';
 import { Glossary } from '../../../src/generated/entity/data/glossary';
+import { expect, test } from '../../support/fixtures/base';
 import { performAdminLogin } from '../../utils/admin';
 import { uuid } from '../../utils/common';
 import { navigateToOntologyStudio } from '../../utils/ontologyStudio';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyQueryRdf.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyQueryRdf.spec.ts
@@ -11,11 +11,12 @@
  *  limitations under the License.
  */
 
-import { APIRequestContext, expect, Page, test } from '@playwright/test';
+import { APIRequestContext, Page } from '@playwright/test';
 import {
   SavedSparqlQueries,
   SavedSparqlQuery,
 } from '../../../src/generated/api/rdf/savedSparqlQueries';
+import { expect, test } from '../../support/fixtures/base';
 import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import { OntologyRdfFixture } from '../../support/ontology/OntologyRdfFixture';
 import { performAdminLogin } from '../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyRbacRdf.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyRbacRdf.spec.ts
@@ -11,10 +11,10 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { VIEW_ONLY_RULE } from '../../constant/permission';
 import { PolicyClass } from '../../support/access-control/PoliciesClass';
 import { RolesClass } from '../../support/access-control/RolesClass';
+import { expect, test } from '../../support/fixtures/base';
 import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import { OntologyRdfFixture } from '../../support/ontology/OntologyRdfFixture';
 import { TeamClass } from '../../support/team/TeamClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyStudio.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyStudio.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { OntologyStudioPageData as PageData } from '../../support/entity/OntologyStudioDataClass';
+import { expect, test } from '../../support/fixtures/base';
 import {
   applyGlossaryFilter,
   clickGraphNode,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyStudioCardinality.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyStudioCardinality.spec.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 import { Glossary } from '../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyStudioE2E.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyStudioE2E.spec.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 import { Glossary } from '../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyStudioIntegration.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyStudioIntegration.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import { Glossary } from '../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import { getAuthContext, getToken, uuid } from '../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyStudioInteractions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyStudioInteractions.spec.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 import { Glossary } from '../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyStudioIsolatedToggle.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyStudioIsolatedToggle.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 import { Glossary } from '../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyStudioRdf.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyStudioRdf.spec.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 import { Glossary } from '../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import { AdminClass } from '../../support/user/AdminClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Permission.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Permission.spec.ts
@@ -10,11 +10,12 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { Operation } from 'fast-json-patch';
 import { PolicyClass } from '../../support/access-control/PoliciesClass';
 import { RolesClass } from '../../support/access-control/RolesClass';
 import { TableClass } from '../../support/entity/TableClass';
+import { test as base } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import { getApiContext, redirectToHomePage, uuid } from '../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Permissions/DataProductPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Permissions/DataProductPermissions.spec.ts
@@ -11,10 +11,11 @@
  *  limitations under the License.
  */
 
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { SidebarItem } from '../../../constant/sidebar';
 import { DataProduct } from '../../../support/domain/DataProduct';
 import { Domain } from '../../../support/domain/Domain';
+import { expect, test as base } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import { getApiContext, redirectToHomePage } from '../../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Permissions/DomainPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Permissions/DomainPermissions.spec.ts
@@ -11,9 +11,10 @@
  *  limitations under the License.
  */
 
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { SidebarItem } from '../../../constant/sidebar';
 import { Domain } from '../../../support/domain/Domain';
+import { expect, test as base } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import { getApiContext, redirectToHomePage } from '../../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Permissions/EntityPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Permissions/EntityPermissions.spec.ts
@@ -11,11 +11,12 @@
  *  limitations under the License.
  */
 
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { PolicyClass } from '../../../support/access-control/PoliciesClass';
 import { RolesClass } from '../../../support/access-control/RolesClass';
 import { EntityClass } from '../../../support/entity/EntityClass';
 import { TableClass } from '../../../support/entity/TableClass';
+import { expect, test as base } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import { getApiContext } from '../../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Permissions/GlossaryPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Permissions/GlossaryPermissions.spec.ts
@@ -11,8 +11,9 @@
  *  limitations under the License.
  */
 
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { SidebarItem } from '../../../constant/sidebar';
+import { expect, test as base } from '../../../support/fixtures/base';
 import { Glossary } from '../../../support/glossary/Glossary';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaAIContextRules.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaAIContextRules.spec.ts
@@ -29,7 +29,8 @@
  *  - Always in context and Fully rendered toggles
  */
 
-import { expect, Locator, Page, test as base } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
+import { expect, test as base } from '../../support/fixtures/base';
 import { PersonaClass } from '../../support/persona/PersonaClass';
 import { AdminClass } from '../../support/user/AdminClass';
 import { performAdminLogin } from '../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaSessionPersistence.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaSessionPersistence.spec.ts
@@ -10,7 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
+import { expect, test as base } from '../../support/fixtures/base';
 import { PersonaClass } from '../../support/persona/PersonaClass';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/RecentlyViewed.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/RecentlyViewed.spec.ts
@@ -10,7 +10,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { ApiEndpointClass } from '../../support/entity/ApiEndpointClass';
 import { ContainerClass } from '../../support/entity/ContainerClass';
 import { DashboardClass } from '../../support/entity/DashboardClass';
@@ -22,6 +21,7 @@ import { SearchIndexClass } from '../../support/entity/SearchIndexClass';
 import { StoredProcedureClass } from '../../support/entity/StoredProcedureClass';
 import { TableClass } from '../../support/entity/TableClass';
 import { TopicClass } from '../../support/entity/TopicClass';
+import { expect, test } from '../../support/fixtures/base';
 import { createNewPage, redirectToHomePage } from '../../utils/common';
 import { getEntityDisplayName } from '../../utils/entity';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SampleDataDomainDataProduct.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SampleDataDomainDataProduct.spec.ts
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { SidebarItem } from '../../constant/sidebar';
 import { Domain } from '../../support/domain/Domain';
+import { expect, test } from '../../support/fixtures/base';
 import { redirectToHomePage } from '../../utils/common';
 import { selectDomain } from '../../utils/domain';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SchemaSearch.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SchemaSearch.spec.ts
@@ -10,9 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { GlobalSettingOptions } from '../../constant/settings';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import { createNewPage, redirectToHomePage } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import { settingClick } from '../../utils/sidebar';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
@@ -11,7 +11,8 @@
  *  limitations under the License.
  */
 
-import { APIRequestContext, expect, Page, test } from '@playwright/test';
+import { APIRequestContext, Page } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/ApiEndpoint.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/ApiEndpoint.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { test } from '@playwright/test';
 import { ApiEndpointClass } from '../../../support/entity/ApiEndpointClass';
+import { test } from '../../../support/fixtures/base';
 import { registerFilterSeparationSuite } from './SearchSeparationSuite';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Container.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Container.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { test } from '@playwright/test';
 import { ContainerClass } from '../../../support/entity/ContainerClass';
+import { test } from '../../../support/fixtures/base';
 import { registerFilterSeparationSuite } from './SearchSeparationSuite';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Dashboard.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Dashboard.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { test } from '@playwright/test';
 import { DashboardClass } from '../../../support/entity/DashboardClass';
+import { test } from '../../../support/fixtures/base';
 import { registerFilterSeparationSuite } from './SearchSeparationSuite';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Database.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Database.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { test } from '@playwright/test';
 import { DatabaseClass } from '../../../support/entity/DatabaseClass';
+import { test } from '../../../support/fixtures/base';
 import { registerFilterSeparationSuite } from './SearchSeparationSuite';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/DatabaseSchema.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/DatabaseSchema.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { test } from '@playwright/test';
 import { DatabaseSchemaClass } from '../../../support/entity/DatabaseSchemaClass';
+import { test } from '../../../support/fixtures/base';
 import { registerFilterSeparationSuite } from './SearchSeparationSuite';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/ExploreFilterSeparation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/ExploreFilterSeparation.spec.ts
@@ -18,8 +18,8 @@
  * sibling specs in this folder cover other entity types via the same factory.
  */
 
-import { test } from '@playwright/test';
 import { TableClass } from '../../../support/entity/TableClass';
+import { test } from '../../../support/fixtures/base';
 import { registerFilterSeparationSuite } from './SearchSeparationSuite';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Metric.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Metric.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { test } from '@playwright/test';
 import { MetricClass } from '../../../support/entity/MetricClass';
+import { test } from '../../../support/fixtures/base';
 import { registerFilterSeparationSuite } from './SearchSeparationSuite';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/MlModel.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/MlModel.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { test } from '@playwright/test';
 import { MlModelClass } from '../../../support/entity/MlModelClass';
+import { test } from '../../../support/fixtures/base';
 import { registerFilterSeparationSuite } from './SearchSeparationSuite';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Pipeline.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Pipeline.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { test } from '@playwright/test';
 import { PipelineClass } from '../../../support/entity/PipelineClass';
+import { test } from '../../../support/fixtures/base';
 import { registerFilterSeparationSuite } from './SearchSeparationSuite';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/StoredProcedure.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/StoredProcedure.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { test } from '@playwright/test';
 import { StoredProcedureClass } from '../../../support/entity/StoredProcedureClass';
+import { test } from '../../../support/fixtures/base';
 import { registerFilterSeparationSuite } from './SearchSeparationSuite';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Topic.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Topic.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { test } from '@playwright/test';
 import { TopicClass } from '../../../support/entity/TopicClass';
+import { test } from '../../../support/fixtures/base';
 import { registerFilterSeparationSuite } from './SearchSeparationSuite';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ServiceAgentsDeploymentSummary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ServiceAgentsDeploymentSummary.spec.ts
@@ -10,8 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { EntityDataClass } from '../../support/entity/EntityDataClass';
+import { expect, test } from '../../support/fixtures/base';
 import { getEncodedFqn } from '../../utils/entity';
 
 // use the admin user to login

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ServiceAgentsLiveProgress.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ServiceAgentsLiveProgress.spec.ts
@@ -10,10 +10,11 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { APIRequestContext, expect, Page, test } from '@playwright/test';
+import { APIRequestContext, Page } from '@playwright/test';
 import { randomUUID } from 'crypto';
 import { PLAYWRIGHT_INGESTION_TAG_OBJ } from '../../constant/config';
 import { DatabaseServiceClass } from '../../support/entity/service/DatabaseServiceClass';
+import { expect, test } from '../../support/fixtures/base';
 import {
   createNewPage,
   getApiContext,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ServiceAgentsPauseResume.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ServiceAgentsPauseResume.spec.ts
@@ -10,8 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { EntityDataClass } from '../../support/entity/EntityDataClass';
+import { expect, test } from '../../support/fixtures/base';
 import { createNewPage, uuid } from '../../utils/common';
 import { getEncodedFqn } from '../../utils/entity';
 import { getAgentCard } from '../../utils/serviceIngestion';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ServiceAgentsRefresh.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ServiceAgentsRefresh.spec.ts
@@ -10,8 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Response, test } from '@playwright/test';
+import { Response } from '@playwright/test';
 import { EntityDataClass } from '../../support/entity/EntityDataClass';
+import { expect, test } from '../../support/fixtures/base';
 import { getEncodedFqn } from '../../utils/entity';
 
 // use the admin user to login

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ServiceAgentsStatusDegradation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ServiceAgentsStatusDegradation.spec.ts
@@ -10,8 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { EntityDataClass } from '../../support/entity/EntityDataClass';
+import { expect, test } from '../../support/fixtures/base';
 import { createNewPage, uuid } from '../../utils/common';
 import { getEncodedFqn } from '../../utils/entity';
 import { getAgentCard } from '../../utils/serviceIngestion';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SettingsNavigationPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SettingsNavigationPage.spec.ts
@@ -11,8 +11,9 @@
  *  limitations under the License.
  */
 
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { GlobalSettingOptions } from '../../constant/settings';
+import { expect, test as base } from '../../support/fixtures/base';
 import { PersonaClass } from '../../support/persona/PersonaClass';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/StorageMetadataAgentForm.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/StorageMetadataAgentForm.spec.ts
@@ -10,9 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { PLAYWRIGHT_INGESTION_TAG_OBJ } from '../../constant/config';
 import { StorageServiceClass } from '../../support/entity/service/StorageServiceClass';
+import { expect, test } from '../../support/fixtures/base';
 import { createNewPage, redirectToHomePage, uuid } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SystemCertificationTags.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SystemCertificationTags.spec.ts
@@ -10,8 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import {
   closeCertificationDropdown,
   openCertificationDropdown,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TagsSuggestion.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TagsSuggestion.spec.ts
@@ -23,12 +23,13 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { APIRequestContext, expect, test } from '@playwright/test';
+import { APIRequestContext } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { ApiEndpointClass } from '../../support/entity/ApiEndpointClass';
 import { ContainerClass } from '../../support/entity/ContainerClass';
 import { TableClass } from '../../support/entity/TableClass';
 import { TopicClass } from '../../support/entity/TopicClass';
+import { expect, test } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import { getApiContext } from '../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import { TeamClass } from '../../support/team/TeamClass';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/ActivityFeed.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/ActivityFeed.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { TableClass } from '../../../support/entity/TableClass';
+import { expect, test } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { insertActivityEventForTest } from '../../../utils/activityAPI';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/DomainFiltering.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/DomainFiltering.spec.ts
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { Domain } from '../../../support/domain/Domain';
 import { TableClass } from '../../../support/entity/TableClass';
+import { expect, test } from '../../../support/fixtures/base';
 import { createNewPage } from '../../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../../utils/entity';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskAllEntities.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskAllEntities.spec.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { APIRequestContext, expect, test } from '@playwright/test';
+import { APIRequestContext } from '@playwright/test';
 import { DataProduct } from '../../../support/domain/DataProduct';
 import { Domain } from '../../../support/domain/Domain';
 import { ContainerClass } from '../../../support/entity/ContainerClass';
@@ -24,6 +24,7 @@ import { PipelineClass } from '../../../support/entity/PipelineClass';
 import { SearchIndexClass } from '../../../support/entity/SearchIndexClass';
 import { TableClass } from '../../../support/entity/TableClass';
 import { TopicClass } from '../../../support/entity/TopicClass';
+import { expect, test } from '../../../support/fixtures/base';
 import { Glossary } from '../../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
 import { UserClass } from '../../../support/user/UserClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskAssigneeManagement.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskAssigneeManagement.spec.ts
@@ -24,9 +24,9 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { TableClass } from '../../../support/entity/TableClass';
 import { TaskClass } from '../../../support/entity/TaskClass';
+import { expect, test } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import { getApiContext } from '../../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskComments.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskComments.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { TableClass } from '../../../support/entity/TableClass';
+import { expect, test } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import { waitForPageLoaded } from '../../../utils/polling';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskContainerEntity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskContainerEntity.spec.ts
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { Domain } from '../../../support/domain/Domain';
 import { ContainerClass } from '../../../support/entity/ContainerClass';
+import { expect, test } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskCreation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskCreation.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { TableClass } from '../../../support/entity/TableClass';
+import { expect, test } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskCustomFormWorkflow.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskCustomFormWorkflow.spec.ts
@@ -24,8 +24,8 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { TableClass } from '../../../support/entity/TableClass';
+import { expect, test } from '../../../support/fixtures/base';
 import { authenticateAdminPage } from '../../../utils/admin';
 import { getApiContext, uuid } from '../../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../../utils/entity';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskDashboardEntity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskDashboardEntity.spec.ts
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { Domain } from '../../../support/domain/Domain';
 import { DashboardClass } from '../../../support/entity/DashboardClass';
+import { expect, test } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import { waitForAllLoadersToDisappear } from '../../../utils/entity';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskEntityResolution.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskEntityResolution.spec.ts
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { Domain } from '../../../support/domain/Domain';
 import { TableClass } from '../../../support/entity/TableClass';
+import { expect, test } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskNavigation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskNavigation.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { TableClass } from '../../../support/entity/TableClass';
+import { expect, test } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import { getApiContext, redirectToHomePage } from '../../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskNestedFields.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskNestedFields.spec.ts
@@ -11,11 +11,11 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { ApiEndpointClass } from '../../../support/entity/ApiEndpointClass';
 import { DashboardDataModelClass } from '../../../support/entity/DashboardDataModelClass';
 import { MlModelClass } from '../../../support/entity/MlModelClass';
 import { SearchIndexClass } from '../../../support/entity/SearchIndexClass';
+import { expect, test } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskPermissions.spec.ts
@@ -11,11 +11,12 @@
  *  limitations under the License.
  */
 
-import { expect, test, type Browser } from '@playwright/test';
+import { type Browser } from '@playwright/test';
 import { VIEW_ONLY_RULE } from '../../../constant/permission';
 import { PolicyClass } from '../../../support/access-control/PoliciesClass';
 import { RolesClass } from '../../../support/access-control/RolesClass';
 import { TableClass } from '../../../support/entity/TableClass';
+import { expect, test } from '../../../support/fixtures/base';
 import { TeamClass } from '../../../support/team/TeamClass';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskPipelineEntity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskPipelineEntity.spec.ts
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { Domain } from '../../../support/domain/Domain';
 import { PipelineClass } from '../../../support/entity/PipelineClass';
+import { expect, test } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskResolution.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskResolution.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { TableClass } from '../../../support/entity/TableClass';
+import { expect, test } from '../../../support/fixtures/base';
 import { TeamClass } from '../../../support/team/TeamClass';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskSuggestionAPIs.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskSuggestionAPIs.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { TableClass } from '../../../support/entity/TableClass';
+import { expect, test } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskTopicEntity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskTopicEntity.spec.ts
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { Domain } from '../../../support/domain/Domain';
 import { TopicClass } from '../../../support/entity/TopicClass';
+import { expect, test } from '../../../support/fixtures/base';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TeamActivity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TeamActivity.spec.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { TableClass } from '../../../support/entity/TableClass';
+import { expect, test } from '../../../support/fixtures/base';
 import { TeamClass } from '../../../support/team/TeamClass';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamSubscriptions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamSubscriptions.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 import { TeamClass } from '../../support/team/TeamClass';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts
@@ -10,8 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
+import { expect, test } from '../../support/fixtures/base';
 import {
   createNewPage,
   redirectToHomePage,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsHierarchy.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsHierarchy.spec.ts
@@ -10,9 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { GlobalSettingOptions } from '../../constant/settings';
+import { expect, test } from '../../support/fixtures/base';
 import { redirectToHomePage, uuid } from '../../utils/common';
 import { settingClick } from '../../utils/sidebar';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts
@@ -10,9 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { PLAYWRIGHT_INGESTION_TAG_OBJ } from '../../constant/config';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import { getApiContext, redirectToHomePage, uuid } from '../../utils/common';
 import {
   ObservabilityFeature,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TierDropdown.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TierDropdown.spec.ts
@@ -10,8 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import { TagClass } from '../../support/tag/TagClass';
 import { createNewPage, redirectToHomePage } from '../../utils/common';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/UserProfileOnlineStatus.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/UserProfileOnlineStatus.spec.ts
@@ -11,8 +11,9 @@
  *  limitations under the License.
  */
 
-import { APIRequestContext, expect, test } from '@playwright/test';
+import { APIRequestContext } from '@playwright/test';
 import { SidebarItem } from '../../constant/sidebar';
+import { expect, test } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import { createAdminApiContext } from '../../utils/admin';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Workflows/NoOpWorkflowNodeConfig.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Workflows/NoOpWorkflowNodeConfig.spec.ts
@@ -11,7 +11,8 @@
  *  limitations under the License.
  */
 
-import { expect, test as base, type Page } from '@playwright/test';
+import { type Page } from '@playwright/test';
+import { expect, test as base } from '../../../support/fixtures/base';
 import { performAdminLogin } from '../../../utils/admin';
 import { redirectToHomePage, uuid } from '../../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../../utils/entity';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Workflows/WorkflowExecutionHistoryEntity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Workflows/WorkflowExecutionHistoryEntity.spec.ts
@@ -11,7 +11,8 @@
  *  limitations under the License.
  */
 
-import { expect, test as base, type Page } from '@playwright/test';
+import { type Page } from '@playwright/test';
+import { expect, test as base } from '../../../support/fixtures/base';
 import { performAdminLogin } from '../../../utils/admin';
 import { redirectToHomePage, uuid } from '../../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../../utils/entity';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Workflows/WorkflowOssRestrictions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Workflows/WorkflowOssRestrictions.spec.ts
@@ -11,8 +11,9 @@
  *  limitations under the License.
  */
 
-import { expect, test as base, type Page } from '@playwright/test';
+import { type Page } from '@playwright/test';
 import { SidebarItem } from '../../../constant/sidebar';
+import { expect, test as base } from '../../../support/fixtures/base';
 import { performAdminLogin } from '../../../utils/admin';
 import { clickOutside, redirectToHomePage, uuid } from '../../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../../utils/entity';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ApiDocs.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ApiDocs.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 import { redirectToHomePage } from '../../utils/common';
 
 // use the admin user to login

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ApiServiceRest.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ApiServiceRest.spec.ts
@@ -10,11 +10,12 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { PLAYWRIGHT_INGESTION_TAG_OBJ } from '../../constant/config';
 import { BIG_ENTITY_DELETE_TIMEOUT } from '../../constant/delete';
 import { COLLATE_SAAS_RUNNER } from '../../constant/serviceForm';
 import { GlobalSettingOptions } from '../../constant/settings';
+import { expect, test } from '../../support/fixtures/base';
 import {
   descriptionBox,
   redirectToHomePage,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/Collect.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/Collect.spec.ts
@@ -10,9 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { SidebarItem } from '../../constant/sidebar';
+import { expect, test } from '../../support/fixtures/base';
+import { allowAnalyticsCollection } from '../../support/fixtures/serverLoad';
 import { redirectToHomePage } from '../../utils/common';
 import { settingClick, SettingOptionsType } from '../../utils/sidebar';
 
@@ -55,6 +56,9 @@ test.describe(
     };
 
     test.beforeEach('Visit entity details page', async ({ page }) => {
+      // This is the one spec that asserts on the collect payload, so it needs
+      // the real endpoint rather than the stub the shared fixture installs.
+      await allowAnalyticsCollection(page.context());
       await redirectToHomePage(page);
     });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ConditionalPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ConditionalPermissions.spec.ts
@@ -10,13 +10,14 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { startCase } from 'lodash';
 import {
   assetsData,
   userWithOwnerPermission,
   userWithTagPermission,
 } from '../../constant/conditionalPermissions';
+import { test as base } from '../../support/fixtures/base';
 import { performAdminLogin } from '../../utils/admin';
 import {
   checkViewAllPermission,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ConnectionConfigLayout.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ConnectionConfigLayout.spec.ts
@@ -11,8 +11,9 @@
  *  limitations under the License.
  */
 
-import { expect, Locator, Page, test } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
 import { COLLATE_SAAS_RUNNER } from '../../constant/serviceForm';
+import { expect, test } from '../../support/fixtures/base';
 import { redirectToHomePage } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import { selectIngestionRunnerFromDropdown } from '../../utils/serviceFormUtils';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/CustomizeLandingPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/CustomizeLandingPage.spec.ts
@@ -10,8 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
+import { expect, test as base } from '../../support/fixtures/base';
 import { PersonaClass } from '../../support/persona/PersonaClass';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/CustomizeWidgets.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/CustomizeWidgets.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { SearchIndex } from '../../../src/enums/search.enum';
 import { KPI_DATA } from '../../constant/dataInsight';
 import { SidebarItem } from '../../constant/sidebar';
@@ -18,6 +18,7 @@ import { DataProduct } from '../../support/domain/DataProduct';
 import { Domain } from '../../support/domain/Domain';
 import { EntityDataClass } from '../../support/entity/EntityDataClass';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test as base } from '../../support/fixtures/base';
 import { PersonaClass } from '../../support/persona/PersonaClass';
 import { UserClass } from '../../support/user/UserClass';
 import { insertActivityEventForTest } from '../../utils/activityAPI';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ExploreAggregationCountsMatching.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ExploreAggregationCountsMatching.spec.ts
@@ -11,7 +11,8 @@
  *  limitations under the License.
  */
 
-import { expect, Locator, Page, Response, test } from '@playwright/test';
+import { Locator, Page, Response } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 import { redirectToHomePage } from '../../utils/common';
 
 // Maps entityType keys from the API aggregation to the explore left-panel tab testid labels.

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/FrequentlyJoined.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/FrequentlyJoined.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 import { redirectToHomePage } from '../../utils/common';
 import { visitEntityPage } from '../../utils/entity';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/IngestionBot.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/IngestionBot.spec.ts
@@ -10,9 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { SidebarItem } from '../../constant/sidebar';
 import { Domain } from '../../support/domain/Domain';
+import { expect, test as base } from '../../support/fixtures/base';
 import { performAdminLogin } from '../../utils/admin';
 import { redirectToHomePage } from '../../utils/common';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/Metric.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/Metric.spec.ts
@@ -10,10 +10,11 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { SidebarItem } from '../../constant/sidebar';
 import { MetricClass } from '../../support/entity/MetricClass';
+import { expect, test as base } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/Navbar.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/Navbar.spec.ts
@@ -10,9 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { SidebarItem } from '../../constant/sidebar';
+import { expect, test } from '../../support/fixtures/base';
 import { redirectToHomePage } from '../../utils/common';
 import { navbarSearchItems, selectOption } from '../../utils/navbar';
 import { sidebarClick } from '../../utils/sidebar';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/NestedChildrenUpdates.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/NestedChildrenUpdates.spec.ts
@@ -10,8 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { nestedChildrenTestData } from '../../constant/nestedColumnUpdates';
+import { expect, test } from '../../support/fixtures/base';
 import { createNewPage, redirectToHomePage } from '../../utils/common';
 import {
   assignTagToChildren,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/NotificationAlerts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/NotificationAlerts.spec.ts
@@ -11,10 +11,11 @@
  *  limitations under the License.
  */
 
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { Domain } from '../../support/domain/Domain';
 import { DashboardClass } from '../../support/entity/DashboardClass';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test as base } from '../../support/fixtures/base';
 import { AdminClass } from '../../support/user/AdminClass';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceCreationPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceCreationPermissions.spec.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { PLAYWRIGHT_INGESTION_TAG_OBJ } from '../../constant/config';
 import {
   SERVICE_CREATOR_RULES,
@@ -22,6 +22,7 @@ import { GlobalSettingOptions } from '../../constant/settings';
 import { PolicyClass } from '../../support/access-control/PoliciesClass';
 import { RolesClass } from '../../support/access-control/RolesClass';
 import { DatabaseServiceClass } from '../../support/entity/service/DatabaseServiceClass';
+import { expect, test as base } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceDocPanel.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceDocPanel.spec.ts
@@ -11,8 +11,9 @@
  *  limitations under the License.
  */
 
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
+import { expect, test } from '../../support/fixtures/base';
 import { redirectToHomePage } from '../../utils/common';
 import {
   copyAndGetClipboardText,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceForm.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceForm.spec.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { APIRequestContext, expect, test } from '@playwright/test';
+import { APIRequestContext } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
 import { PLAYWRIGHT_INGESTION_TAG_OBJ } from '../../constant/config';
@@ -27,6 +27,7 @@ import {
 } from '../../constant/serviceForm';
 import { DatabaseServiceClass } from '../../support/entity/service/DatabaseServiceClass';
 import { MessagingServiceClass } from '../../support/entity/service/MessagingServiceClass';
+import { expect, test } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import {
   createNewPage,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/TestConnectionModal.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/TestConnectionModal.spec.ts
@@ -11,8 +11,9 @@
  *  limitations under the License.
  */
 
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
+import { expect, test } from '../../support/fixtures/base';
 import { redirectToHomePage, uuid } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/Tour.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/Tour.spec.ts
@@ -10,8 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
+import { expect, test } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/UsersPagination.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/UsersPagination.spec.ts
@@ -10,9 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { GlobalSettingOptions } from '../../constant/settings';
+import { expect, test } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import { createNewPage, redirectToHomePage } from '../../utils/common';
 import { settingClick } from '../../utils/sidebar';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Http2/SmokeH2.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Http2/SmokeH2.spec.ts
@@ -25,7 +25,8 @@
  * a CDP session (Playwright's request/response API doesn't surface the wire
  * protocol directly).
  */
-import { CDPSession, expect, test } from '@playwright/test';
+import { CDPSession } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 
 type ResponseRecord = {
   url: string;

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/AppRunsHistoryLogs.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/AppRunsHistoryLogs.spec.ts
@@ -11,7 +11,8 @@
  *  limitations under the License.
  */
 
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 import { redirectToHomePage } from '../../utils/common';
 import {
   assertLogViewerShowsLogs,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/AppStopRunModal.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/AppStopRunModal.spec.ts
@@ -10,8 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { GlobalSettingOptions } from '../../constant/settings';
+import { expect, test } from '../../support/fixtures/base';
 import { redirectToHomePage } from '../../utils/common';
 import { settingClick } from '../../utils/sidebar';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/AuditLogs.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/AuditLogs.spec.ts
@@ -10,9 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { GlobalSettingOptions } from '../../constant/settings';
+import { expect, test } from '../../support/fixtures/base';
 import {
   navigateToAuditLogsPage,
   verifyAuditEntryHasValidUUIDs,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Bots.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Bots.spec.ts
@@ -10,8 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
+import { expect, test } from '../../support/fixtures/base';
 import {
   BOT_DETAILS,
   createBot,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CSVImportWithQuotesAndCommas.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CSVImportWithQuotesAndCommas.spec.ts
@@ -10,8 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { APIRequestContext, expect, Page, test } from '@playwright/test';
+import { APIRequestContext, Page } from '@playwright/test';
 import * as fs from 'fs';
+import { expect, test } from '../../support/fixtures/base';
 import { Glossary } from '../../support/glossary/Glossary';
 import {
   fetchCompletedCsvAsyncJobResult,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ClassificationConditionalRendering.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ClassificationConditionalRendering.spec.ts
@@ -10,8 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { SidebarItem } from '../../constant/sidebar';
+import { expect, test } from '../../support/fixtures/base';
 import { ClassificationClass } from '../../support/tag/ClassificationClass';
 import { TagClass } from '../../support/tag/TagClass';
 import { createNewPage, redirectToHomePage } from '../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
@@ -25,7 +25,7 @@
  * so cleanup always runs in afterAll even when a test fails mid-way.
  */
 
-import { APIRequestContext, expect, test } from '@playwright/test';
+import { APIRequestContext } from '@playwright/test';
 import {
   CP_NAME_MAX_LENGTH_VALIDATION_ERROR,
   INVALID_NAMES,
@@ -63,6 +63,7 @@ import { SearchIndexClass } from '../../support/entity/SearchIndexClass';
 import { StoredProcedureClass } from '../../support/entity/StoredProcedureClass';
 import { TableClass } from '../../support/entity/TableClass';
 import { TopicClass } from '../../support/entity/TopicClass';
+import { expect, test } from '../../support/fixtures/base';
 import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import { UserClass } from '../../support/user/UserClass';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataContracts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataContracts.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { PLAYWRIGHT_INGESTION_TAG_OBJ } from '../../constant/config';
 import {
   DATA_CONTRACT_CONTAIN_SEMANTICS,
@@ -45,6 +45,7 @@ import { StoredProcedureClass } from '../../support/entity/StoredProcedureClass'
 import { TableClass } from '../../support/entity/TableClass';
 import { TopicClass } from '../../support/entity/TopicClass';
 import { WorksheetClass } from '../../support/entity/WorksheetClass';
+import { expect, test as base } from '../../support/fixtures/base';
 import { Glossary } from '../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import { PersonaClass } from '../../support/persona/PersonaClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataInsightReportApplication.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataInsightReportApplication.spec.ts
@@ -10,8 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { GlobalSettingOptions } from '../../constant/settings';
+import { expect, test } from '../../support/fixtures/base';
 import {
   createNewPage,
   getApiContext,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataProductAndSubdomains.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataProductAndSubdomains.spec.ts
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { SidebarItem } from '../../constant/sidebar';
 import { DataProduct } from '../../support/domain/DataProduct';
 import { Domain } from '../../support/domain/Domain';
@@ -19,6 +18,7 @@ import { SubDomain } from '../../support/domain/SubDomain';
 import { DashboardClass } from '../../support/entity/DashboardClass';
 import { TableClass } from '../../support/entity/TableClass';
 import { TopicClass } from '../../support/entity/TopicClass';
+import { expect, test } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import {
   runDrawerQuickFilterMatrix,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DomainAdvanced.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DomainAdvanced.spec.ts
@@ -11,12 +11,7 @@
  *  limitations under the License.
  */
 
-import {
-  APIRequestContext,
-  expect,
-  Page,
-  test as base,
-} from '@playwright/test';
+import { APIRequestContext, Page } from '@playwright/test';
 import { get } from 'lodash';
 import { SidebarItem } from '../../constant/sidebar';
 import { PolicyClass } from '../../support/access-control/PoliciesClass';
@@ -25,6 +20,7 @@ import { DataProduct } from '../../support/domain/DataProduct';
 import { Domain } from '../../support/domain/Domain';
 import { SubDomain } from '../../support/domain/SubDomain';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test as base } from '../../support/fixtures/base';
 import { TeamClass } from '../../support/team/TeamClass';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DomainUIInteractions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DomainUIInteractions.spec.ts
@@ -11,13 +11,14 @@
  *  limitations under the License.
  */
 
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { SidebarItem } from '../../constant/sidebar';
 import { DataProduct } from '../../support/domain/DataProduct';
 import { Domain } from '../../support/domain/Domain';
 import { SubDomain } from '../../support/domain/SubDomain';
 import { TableClass } from '../../support/entity/TableClass';
 import { TopicClass } from '../../support/entity/TopicClass';
+import { expect, test as base } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import { getApiContext, toastNotification, uuid } from '../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EditClassification.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EditClassification.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 import { ClassificationClass } from '../../support/tag/ClassificationClass';
 import { createNewPage, redirectToHomePage, uuid } from '../../utils/common';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EmailConfiguration.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EmailConfiguration.spec.ts
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { GlobalSettingOptions } from '../../constant/settings';
+import { expect, test } from '../../support/fixtures/base';
 import { redirectToHomePage, toastNotification } from '../../utils/common';
 import { settingClick } from '../../utils/sidebar';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Entity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Entity.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, Request, test as base } from '@playwright/test';
+import { Page, Request } from '@playwright/test';
 import { isUndefined } from 'lodash';
 import { Column, Table } from '../../../src/generated/entity/data/table';
 import { COMMON_TIER_TAG, KEY_PROFILE_METRICS } from '../../constant/common';
@@ -35,6 +35,7 @@ import { StoredProcedureClass } from '../../support/entity/StoredProcedureClass'
 import { TableClass } from '../../support/entity/TableClass';
 import { TopicClass } from '../../support/entity/TopicClass';
 import { WorksheetClass } from '../../support/entity/WorksheetClass';
+import { expect, test as base } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import { createAdminApiContext } from '../../utils/admin';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EntityDataConsumer.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EntityDataConsumer.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { isUndefined } from 'lodash';
 import { COMMON_TIER_TAG } from '../../constant/common';
 import { ApiEndpointClass } from '../../support/entity/ApiEndpointClass';
@@ -29,6 +29,7 @@ import { StoredProcedureClass } from '../../support/entity/StoredProcedureClass'
 import { TableClass } from '../../support/entity/TableClass';
 import { TopicClass } from '../../support/entity/TopicClass';
 import { WorksheetClass } from '../../support/entity/WorksheetClass';
+import { expect, test as base } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import { redirectToHomePage } from '../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EntityDataSteward.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EntityDataSteward.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { isUndefined } from 'lodash';
 import { COMMON_TIER_TAG } from '../../constant/common';
 import { ApiEndpointClass } from '../../support/entity/ApiEndpointClass';
@@ -29,6 +29,7 @@ import { StoredProcedureClass } from '../../support/entity/StoredProcedureClass'
 import { TableClass } from '../../support/entity/TableClass';
 import { TopicClass } from '../../support/entity/TopicClass';
 import { WorksheetClass } from '../../support/entity/WorksheetClass';
+import { test as base } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import { redirectToHomePage } from '../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EntityHeaderBreadcrumb.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EntityHeaderBreadcrumb.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { ApiCollectionClass } from '../../support/entity/ApiCollectionClass';
 import { ApiEndpointClass } from '../../support/entity/ApiEndpointClass';
@@ -31,6 +31,7 @@ import { StoredProcedureClass } from '../../support/entity/StoredProcedureClass'
 import { TableClass } from '../../support/entity/TableClass';
 import { TopicClass } from '../../support/entity/TopicClass';
 import { WorksheetClass } from '../../support/entity/WorksheetClass';
+import { test as base } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import { redirectToHomePage } from '../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExploreBrowse.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExploreBrowse.spec.ts
@@ -10,10 +10,11 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { SidebarItem } from '../../constant/sidebar';
 import { DashboardClass } from '../../support/entity/DashboardClass';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import { createNewPage, redirectToHomePage, uuid } from '../../utils/common';
 import {
   getEncodedFqn,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExploreResilience.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExploreResilience.spec.ts
@@ -10,8 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { SidebarItem } from '../../constant/sidebar';
+import { expect, test } from '../../support/fixtures/base';
 import { redirectToHomePage } from '../../utils/common';
 import { sidebarClick } from '../../utils/sidebar';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { APIRequestContext, expect, Page, test } from '@playwright/test';
+import { APIRequestContext, Page } from '@playwright/test';
 import { CUSTOM_PROPERTIES_ENTITIES } from '../../constant/customProperty';
 import {
   CUSTOM_PROPERTIES_TYPES,
@@ -19,6 +19,7 @@ import {
 import { GlobalSettingOptions } from '../../constant/settings';
 import { SidebarItem } from '../../constant/sidebar';
 import { EntityTypeEndpoint } from '../../support/entity/Entity.interface';
+import { expect, test } from '../../support/fixtures/base';
 import { Glossary } from '../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import { UserClass } from '../../support/user/UserClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/HealthCheck.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/HealthCheck.spec.ts
@@ -10,9 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { PLAYWRIGHT_INGESTION_TAG_OBJ } from '../../constant/config';
 import { GlobalSettingOptions } from '../../constant/settings';
+import { expect, test } from '../../support/fixtures/base';
 import { redirectToHomePage } from '../../utils/common';
 import { settingClick } from '../../utils/sidebar';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/IngestionLogStreamLive.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/IngestionLogStreamLive.spec.ts
@@ -11,11 +11,12 @@
  *  limitations under the License.
  */
 
-import { APIRequestContext, expect, test } from '@playwright/test';
+import { APIRequestContext } from '@playwright/test';
 import {
   DOMAIN_TAGS,
   PLAYWRIGHT_INGESTION_TAG_OBJ,
 } from '../../constant/config';
+import { expect, test } from '../../support/fixtures/base';
 import { createNewPage, uuid } from '../../utils/common';
 import { getEncodedFqn } from '../../utils/entity';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/InputOutputPorts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/InputOutputPorts.spec.ts
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
 import { get } from 'lodash';
 import { SidebarItem } from '../../constant/sidebar';
 import { DataProduct } from '../../support/domain/DataProduct';
@@ -19,6 +18,7 @@ import { Domain } from '../../support/domain/Domain';
 import { DashboardClass } from '../../support/entity/DashboardClass';
 import { TableClass } from '../../support/entity/TableClass';
 import { TopicClass } from '../../support/entity/TopicClass';
+import { expect, test } from '../../support/fixtures/base';
 import { performAdminLogin } from '../../utils/admin';
 import { runDrawerQuickFilterMatrix } from '../../utils/assetDrawerQuickFilter';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LearningResources.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LearningResources.spec.ts
@@ -10,9 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { GlobalSettingOptions } from '../../constant/settings';
 import { SidebarItem } from '../../constant/sidebar';
+import { expect, test } from '../../support/fixtures/base';
 import { Glossary } from '../../support/glossary/Glossary';
 import { LearningResourceClass } from '../../support/learning/LearningResourceClass';
 import { AdminClass } from '../../support/user/AdminClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Login.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Login.spec.ts
@@ -10,9 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { JWT_EXPIRY_TIME_MAP, LOGIN_ERROR_MESSAGE } from '../../constant/login';
+import { expect, test } from '../../support/fixtures/base';
 import { AdminClass } from '../../support/user/AdminClass';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LoginConfiguration.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LoginConfiguration.spec.ts
@@ -10,9 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { GlobalSettingOptions } from '../../constant/settings';
+import { expect, test } from '../../support/fixtures/base';
 import { redirectToHomePage, toastNotification } from '../../utils/common';
 import { settingClick } from '../../utils/sidebar';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/OmdURLConfiguration.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/OmdURLConfiguration.spec.ts
@@ -10,8 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { GlobalSettingOptions } from '../../constant/settings';
+import { expect, test } from '../../support/fixtures/base';
 import { redirectToHomePage, toastNotification } from '../../utils/common';
 import { settingClick } from '../../utils/sidebar';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/PipelineExecution.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/PipelineExecution.spec.ts
@@ -10,8 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { PipelineClass } from '../../support/entity/PipelineClass';
+import { expect, test } from '../../support/fixtures/base';
 import { createNewPage, redirectToHomePage } from '../../utils/common';
 
 // use the admin user to login

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/PipelineValidation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/PipelineValidation.spec.ts
@@ -11,7 +11,8 @@
  *  limitations under the License.
  */
 
-import { expect, test, type APIRequestContext } from '@playwright/test';
+import { type APIRequestContext } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 import { getDefaultAdminAPIContext, uuid } from '../../utils/common';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ProfilerConfigurationPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ProfilerConfigurationPage.spec.ts
@@ -10,12 +10,13 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import {
   PROFILER_EMPTY_RESPONSE_CONFIG,
   PROFILER_REQUEST_CONFIG,
 } from '../../constant/profilerConfiguration';
 import { SidebarItem } from '../../constant/sidebar';
+import { expect, test as base } from '../../support/fixtures/base';
 import { AdminClass } from '../../support/user/AdminClass';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Roles.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Roles.spec.ts
@@ -10,10 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { GlobalSettingOptions } from '../../constant/settings';
 import { RolesClass } from '../../support/access-control/RolesClass';
+import { expect, test } from '../../support/fixtures/base';
 import {
   descriptionBox,
   getApiContext,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts
@@ -10,10 +10,11 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { GlobalSettingOptions } from '../../constant/settings';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test as base } from '../../support/fixtures/base';
 import { AdminClass } from '../../support/user/AdminClass';
 import { performAdminLogin } from '../../utils/admin';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ServiceEntity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ServiceEntity.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import {
   CertificationSupportedServices,
   FollowSupportedServices,
@@ -27,6 +27,7 @@ import { MlmodelServiceClass } from '../../support/entity/service/MlmodelService
 import { PipelineServiceClass } from '../../support/entity/service/PipelineServiceClass';
 import { SearchIndexServiceClass } from '../../support/entity/service/SearchIndexServiceClass';
 import { StorageServiceClass } from '../../support/entity/service/StorageServiceClass';
+import { expect, test as base } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SubDomainPagination.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SubDomainPagination.spec.ts
@@ -10,11 +10,11 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { SidebarItem } from '../../constant/sidebar';
 import { Domain } from '../../support/domain/Domain';
 import { SubDomain } from '../../support/domain/SubDomain';
+import { expect, test } from '../../support/fixtures/base';
 import { createNewPage, redirectToHomePage } from '../../utils/common';
 import {
   checkSubDomainCount,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Tag.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Tag.spec.ts
@@ -10,12 +10,13 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { SidebarItem } from '../../constant/sidebar';
 import { PolicyClass } from '../../support/access-control/PoliciesClass';
 import { RolesClass } from '../../support/access-control/RolesClass';
 import { Domain } from '../../support/domain/Domain';
 import { EntityTypeEndpoint } from '../../support/entity/Entity.interface';
+import { expect, test as base } from '../../support/fixtures/base';
 import { ClassificationClass } from '../../support/tag/ClassificationClass';
 import { TagClass } from '../../support/tag/TagClass';
 import { TeamClass } from '../../support/team/TeamClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Tags.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Tags.spec.ts
@@ -10,10 +10,11 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { SidebarItem } from '../../constant/sidebar';
 import { EntityTypeEndpoint } from '../../support/entity/Entity.interface';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import { ClassificationClass } from '../../support/tag/ClassificationClass';
 import { TagClass } from '../../support/tag/TagClass';
 import { UserClass } from '../../support/user/UserClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TaskComments.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TaskComments.spec.ts
@@ -10,8 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { APIRequestContext, expect, test } from '@playwright/test';
+import { APIRequestContext } from '@playwright/test';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import { getApiContext, redirectToHomePage } from '../../utils/common';
 import { waitForPageLoaded } from '../../utils/polling';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TasksUIFlow.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TasksUIFlow.spec.ts
@@ -10,11 +10,12 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { DashboardClass } from '../../support/entity/DashboardClass';
 import { PipelineClass } from '../../support/entity/PipelineClass';
 import { TableClass } from '../../support/entity/TableClass';
 import { TopicClass } from '../../support/entity/TopicClass';
+import { expect, test } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import {
   authenticateAdminPage,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Teams.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Teams.spec.ts
@@ -10,12 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import {
-  APIRequestContext,
-  expect,
-  Page,
-  test as base,
-} from '@playwright/test';
+import { APIRequestContext, Page } from '@playwright/test';
 import {
   EDIT_USER_FOR_TEAM_RULES,
   OWNER_TEAM_RULES,
@@ -27,6 +22,7 @@ import { DataProduct } from '../../support/domain/DataProduct';
 import { Domain } from '../../support/domain/Domain';
 import { EntityTypeEndpoint } from '../../support/entity/Entity.interface';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test as base } from '../../support/fixtures/base';
 import { TeamClass } from '../../support/team/TeamClass';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/UserDetails.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/UserDetails.spec.ts
@@ -11,10 +11,11 @@
  *  limitations under the License.
  */
 
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { Domain } from '../../support/domain/Domain';
 import { SubDomain } from '../../support/domain/SubDomain';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test as base } from '../../support/fixtures/base';
 import { TeamClass } from '../../support/team/TeamClass';
 import { AdminClass } from '../../support/user/AdminClass';
 import { UserClass } from '../../support/user/UserClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Users.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Users.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import {
   DATA_CONSUMER_RULES,
   DATA_STEWARD_RULES,
@@ -29,6 +29,7 @@ import { RolesClass } from '../../support/access-control/RolesClass';
 import { ChartClass } from '../../support/entity/ChartClass';
 import { EntityDataClass } from '../../support/entity/EntityDataClass';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test as base } from '../../support/fixtures/base';
 import { PersonaClass } from '../../support/persona/PersonaClass';
 import { TeamClass } from '../../support/team/TeamClass';
 import { UserClass } from '../../support/user/UserClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/ClassificationVersionPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/ClassificationVersionPage.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 import { ClassificationClass } from '../../support/tag/ClassificationClass';
 import { TagClass } from '../../support/tag/TagClass';
 import { createNewPage, redirectToHomePage } from '../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/EntityVersionPages.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/EntityVersionPages.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { COMMON_TIER_TAG } from '../../constant/common';
 import { BIG_ENTITY_DELETE_TIMEOUT } from '../../constant/delete';
 import { ApiEndpointClass } from '../../support/entity/ApiEndpointClass';
@@ -30,6 +30,7 @@ import { StoredProcedureClass } from '../../support/entity/StoredProcedureClass'
 import { TableClass } from '../../support/entity/TableClass';
 import { TopicClass } from '../../support/entity/TopicClass';
 import { WorksheetClass } from '../../support/entity/WorksheetClass';
+import { expect, test as base } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/ServiceEntityVersionPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/ServiceEntityVersionPage.spec.ts
@@ -10,12 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import {
-  APIRequestContext,
-  expect,
-  Page,
-  test as base,
-} from '@playwright/test';
+import { APIRequestContext, Page } from '@playwright/test';
 import { Operation } from 'fast-json-patch';
 import { BIG_ENTITY_DELETE_TIMEOUT } from '../../constant/delete';
 import { ApiCollectionClass } from '../../support/entity/ApiCollectionClass';
@@ -31,6 +26,7 @@ import { MlmodelServiceClass } from '../../support/entity/service/MlmodelService
 import { PipelineServiceClass } from '../../support/entity/service/PipelineServiceClass';
 import { SearchIndexServiceClass } from '../../support/entity/service/SearchIndexServiceClass';
 import { StorageServiceClass } from '../../support/entity/service/StorageServiceClass';
+import { expect, test as base } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/TestCaseVersionPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/TestCaseVersionPage.spec.ts
@@ -10,8 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import {
   createNewPage,
   descriptionBox,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VisualRegression/entityDetails.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VisualRegression/entityDetails.spec.ts
@@ -10,8 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
 import { getDefaultAdminAPIContext } from '../../utils/common';
 import {
   gotoForScreenshot,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VisualRegression/interactiveStates.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VisualRegression/interactiveStates.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 import {
   gotoForScreenshot,
   SCREENSHOT_OPTS,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VisualRegression/staticPages.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VisualRegression/staticPages.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../../support/fixtures/base';
 import {
   gotoForScreenshot,
   SCREENSHOT_OPTS,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/fixtures/pages.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/fixtures/pages.ts
@@ -10,7 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Browser, Page, test as base } from '@playwright/test';
+import { Browser, Page } from '@playwright/test';
+import { test as base } from '../../support/fixtures/base';
+import { installServerLoadReducers } from '../../support/fixtures/serverLoad';
 import { disableEtagConditionalReads } from '../../utils/common';
 
 // Define the type for our custom fixtures
@@ -29,6 +31,7 @@ export type CustomFixtures = {
 // always receive fresh entity state.
 const openRolePage = async (browser: Browser, storageState: string) => {
   const page = await browser.newPage({ storageState });
+  await installServerLoadReducers(page.context());
   await disableEtagConditionalReads(page);
 
   return page;

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/base.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/base.ts
@@ -1,0 +1,37 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { test as playwrightTest } from '@playwright/test';
+import { installServerLoadReducers } from './serverLoad';
+
+/**
+ * The suite's single entry point for `test`.
+ *
+ * It overrides the built-in `context` fixture rather than `page`, which is what
+ * makes it reach every spec shape without them opting in: the built-in `page`
+ * is derived from `context`, and `test.use({ storageState })` is applied as a
+ * context option, so both keep working untouched.
+ *
+ * Specs that build their own pages via `browser.newContext()` or
+ * `browser.newPage()` bypass this fixture entirely and call
+ * `installServerLoadReducers` themselves — see `e2e/fixtures/pages.ts` and
+ * `support/fixtures/userPages.ts`.
+ */
+export const test = playwrightTest.extend({
+  context: async ({ context }, use) => {
+    await installServerLoadReducers(context);
+
+    await use(context);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/serverLoad.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/serverLoad.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { BrowserContext, Route } from '@playwright/test';
+import { BrowserContext, Request, Route } from '@playwright/test';
 
 /**
  * Reduces the server load a Playwright shard generates.
@@ -50,6 +50,14 @@ const ANALYTICS_COLLECT = '**/api/v1/analytics/web/events/collect';
  * - `apps/installed`, `announcements`, `users/{id}/preferences`,
  *   `contextCenter/pages`, `learning/resources` — each has a spec or support
  *   class that writes it through `apiContext` rather than the browser.
+ * - `users/loggedInUser` — identity-scoped. Worth spelling out because it is
+ *   the one exclusion that is not about writes: the cache is per worker, and a
+ *   worker runs several identities (the userPages fixtures alone cover admin,
+ *   dataConsumer, dataSteward and owner), so caching it would serve the first
+ *   identity's profile to the rest. The failure mode is a permission test
+ *   quietly seeing the admin profile and passing, which is worse than the test
+ *   not existing. The identity-keyed cache below makes this safe in principle,
+ *   but nothing about a false pass is worth 497 requests a shard.
  */
 const CACHEABLE_BOOT_PATHS = [
   // No writer anywhere in the suite.
@@ -64,8 +72,7 @@ const CACHEABLE_BOOT_PATHS = [
   '/api/v1/system/config/customUiThemePreference',
   '/api/v1/system/settings/lineageSettings',
   '/api/v1/system/settings/appConfiguration',
-  // Same, under `/api/v1/users/` and `/api/v1/services/` respectively.
-  '/api/v1/users/loggedInUser',
+  // Same, under `/api/v1/services/`.
   '/api/v1/services/ingestionPipelines/status',
 ];
 
@@ -129,6 +136,16 @@ const isCacheableBootRequest = (url: URL) =>
   CACHEABLE_BOOT_PATHS.includes(url.pathname);
 
 /**
+ * The cache is per worker and a worker runs many identities, so the caller's
+ * credentials are part of the key. Every path in CACHEABLE_BOOT_PATHS is
+ * global today, which makes this redundant — it is here so that adding an
+ * identity-scoped path later degrades into a cache miss rather than into one
+ * user being served another user's response.
+ */
+const cacheKey = (request: Request) =>
+  `${request.headers()['authorization'] ?? ''}::${request.url()}`;
+
+/**
  * Playwright hands back the *decoded* body, so replaying the original
  * `content-encoding` would describe bytes that are no longer encoded and the
  * browser would fail to parse them. `content-length` is dropped for the same
@@ -151,7 +168,7 @@ const serveBootConfig = async (route: Route) => {
     return;
   }
 
-  const key = request.url();
+  const key = cacheKey(request);
   const cached = bootCache.get(key);
 
   if (cached) {

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/serverLoad.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/serverLoad.ts
@@ -82,13 +82,24 @@ type CachedResponse = {
   body: Buffer;
 };
 
+/**
+ * The pathname is stored alongside the response rather than parsed back out of
+ * the cache key. The key is `authorization::url`, so parsing it as a URL throws
+ * — which is exactly the bug that took out seven lanes when the identity was
+ * first folded into the key.
+ */
+type CacheEntry = {
+  pathname: string;
+  response: CachedResponse;
+};
+
 // One entry per (path + query) of the paths above, so this never grows past a
 // couple of dozen. Capped and FIFO-evicted regardless, because an unbounded
 // module-level cache is an unbounded leak in a long-lived worker.
 const MAX_CACHED_RESPONSES = 64;
-const bootCache = new Map<string, CachedResponse>();
+const bootCache = new Map<string, CacheEntry>();
 
-const remember = (key: string, value: CachedResponse) => {
+const remember = (key: string, value: CacheEntry) => {
   if (bootCache.size >= MAX_CACHED_RESPONSES) {
     const oldest = bootCache.keys().next();
 
@@ -125,8 +136,8 @@ const invalidateFamily = (pathname: string) => {
     return;
   }
 
-  for (const key of [...bootCache.keys()]) {
-    if (new URL(key).pathname.startsWith(prefix)) {
+  for (const [key, entry] of [...bootCache.entries()]) {
+    if (entry.pathname.startsWith(prefix)) {
       bootCache.delete(key);
     }
   }
@@ -172,13 +183,13 @@ const serveBootConfig = async (route: Route) => {
   const cached = bootCache.get(key);
 
   if (cached) {
-    await route.fulfill(cached);
+    await route.fulfill(cached.response);
 
     return;
   }
 
   const response = await route.fetch();
-  const entry: CachedResponse = {
+  const payload: CachedResponse = {
     status: response.status(),
     headers: replayableHeaders(response.headers()),
     body: await response.body(),
@@ -187,10 +198,13 @@ const serveBootConfig = async (route: Route) => {
   // Only a success is worth replaying; caching a 5xx would pin a transient
   // failure for the rest of the worker's life.
   if (response.ok()) {
-    remember(key, entry);
+    remember(key, {
+      pathname: new URL(request.url()).pathname,
+      response: payload,
+    });
   }
 
-  await route.fulfill(entry);
+  await route.fulfill(payload);
 };
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/serverLoad.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/serverLoad.ts
@@ -93,9 +93,11 @@ type CacheEntry = {
   response: CachedResponse;
 };
 
-// One entry per (path + query) of the paths above, so this never grows past a
-// couple of dozen. Capped and FIFO-evicted regardless, because an unbounded
-// module-level cache is an unbounded leak in a long-lived worker.
+// One entry per (identity + path + query). Ten paths, but the identity half is
+// unbounded — every fresh user that boots the app adds a set — so the cap is
+// load-bearing rather than belt-and-braces, and eviction is LRU (see the hit
+// path in serveBootConfig) so identity churn cannot evict the admin entries
+// that account for most boots.
 const MAX_CACHED_RESPONSES = 64;
 const bootCache = new Map<string, CacheEntry>();
 
@@ -196,6 +198,15 @@ const serveBootConfig = async (route: Route) => {
   const cached = bootCache.get(key);
 
   if (cached) {
+    // Re-inserting on a hit makes eviction LRU rather than FIFO, which matters
+    // now that the Authorization header is part of the key: the key space is
+    // unbounded in identities (106 call sites build their own context, and
+    // performUserLogin mints a fresh user), while the cap is 6.4 identities'
+    // worth of entries. Under FIFO a burst of short-lived users would evict the
+    // admin entries that account for most boots, and they would all refetch.
+    bootCache.delete(key);
+    bootCache.set(key, cached);
+
     await route.fulfill(cached.response);
 
     return;
@@ -266,6 +277,25 @@ const serveStaticAsset = async (route: Route) => {
   await route.fulfill(entry);
 };
 
+/**
+ * Playwright rethrows out of a route handler (`RouteHandler._handleImpl`) and
+ * `BrowserContext._onRoute` does not catch it, so a handler that throws fails
+ * whichever test owns the route. Losing the target mid-flight is routine here
+ * rather than exceptional: boot config is fetched on every navigation, so any
+ * test that navigates away or ends while one is in flight would otherwise fail
+ * on a request nothing asserts on. Anything else still propagates — a cache
+ * that is broken for a real reason must not be silent.
+ */
+const ignoreClosedTarget = async (serve: () => Promise<void>) => {
+  try {
+    await serve();
+  } catch (error) {
+    if (!/has been closed/.test(String(error))) {
+      throw error;
+    }
+  }
+};
+
 // Playwright stacks route handlers, so installing twice on one context would
 // leave a dead handler behind on every call. Contexts are the key so entries
 // disappear with them.
@@ -289,13 +319,13 @@ export const installServerLoadReducers = async (context: BrowserContext) => {
 
   await context.route(
     (url) => isCacheableBootRequest(url),
-    (route) => serveBootConfig(route)
+    (route) => ignoreClosedTarget(() => serveBootConfig(route))
   );
 
   if (cacheStaticAssets) {
     await context.route(
       (url) => STATIC_ASSET.test(url.pathname),
-      (route) => serveStaticAsset(route)
+      (route) => ignoreClosedTarget(() => serveStaticAsset(route))
     );
   }
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/serverLoad.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/serverLoad.ts
@@ -143,6 +143,19 @@ const invalidateFamily = (pathname: string) => {
   }
 };
 
+/**
+ * A throw inside the `request` listener below fails whichever test happened to
+ * be mid-action, which is a lot of blast radius for a URL the cache does not
+ * even care about, so a URL it cannot parse is simply not an API write.
+ */
+const pathnameOf = (url: string) => {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return undefined;
+  }
+};
+
 const isCacheableBootRequest = (url: URL) =>
   CACHEABLE_BOOT_PATHS.includes(url.pathname);
 
@@ -291,9 +304,9 @@ export const installServerLoadReducers = async (context: BrowserContext) => {
       return;
     }
 
-    const { pathname } = new URL(request.url());
+    const pathname = pathnameOf(request.url());
 
-    if (pathname.startsWith('/api/v1/')) {
+    if (pathname?.startsWith('/api/v1/')) {
       invalidateFamily(pathname);
     }
   });

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/serverLoad.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/serverLoad.ts
@@ -209,12 +209,14 @@ const serveBootConfig = async (route: Route) => {
   };
 
   // Only a success is worth replaying; caching a 5xx would pin a transient
-  // failure for the rest of the worker's life.
-  if (response.ok()) {
-    remember(key, {
-      pathname: new URL(request.url()).pathname,
-      response: payload,
-    });
+  // failure for the rest of the worker's life. The pathname is parsed through
+  // the same guard as the listener: unreachable here, since Playwright already
+  // handed a parsed URL to the route predicate, but a throw inside a route
+  // handler fails the test just as readily and consistency is one line.
+  const pathname = pathnameOf(request.url());
+
+  if (response.ok() && pathname) {
+    remember(key, { pathname, response: payload });
   }
 
   await route.fulfill(payload);

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/serverLoad.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/serverLoad.ts
@@ -33,11 +33,15 @@ const ANALYTICS_COLLECT = '**/api/v1/analytics/web/events/collect';
 /**
  * Boot endpoints safe to serve from the per-worker cache.
  *
- * Two things have to hold for a path to be listed here. It must have no writer
- * that bypasses the browser — an `apiContext.patch()` in a `beforeAll` is
- * invisible to the request listener below, so the cache would go stale with no
- * way to notice. And any write that *does* go through the browser must land
+ * Three things have to hold for a path to be listed here. It must have no
+ * writer that bypasses the browser — an `apiContext.patch()` in a `beforeAll`
+ * is invisible to the request listener below, so the cache would go stale with
+ * no way to notice. Any write that *does* go through the browser must land
  * under the same `/api/v1/<family>/` prefix, so `invalidateFamily` clears it.
+ * And the value must not change without a client write at all: invalidation is
+ * driven by observed requests, so a path whose answer moves on the server's own
+ * schedule can never be cleared. That last one is easy to miss, because such a
+ * path has no writer to find — see `ingestionPipelines/status` below.
  *
  * Deliberately excluded, with the reason, because this list is the whole
  * correctness surface:
@@ -58,6 +62,17 @@ const ANALYTICS_COLLECT = '**/api/v1/analytics/web/events/collect';
  *   quietly seeing the admin profile and passing, which is worse than the test
  *   not existing. The identity-keyed cache below makes this safe in principle,
  *   but nothing about a false pass is worth 497 requests a shard.
+ * - `services/ingestionPipelines/status` — flagged in review, and the reason it
+ *   is unsafe is the third condition rather than a missed writer. It reports
+ *   whether the pipeline service client is reachable, which moves on its own as
+ *   the orchestrator comes up, and it reports it as a `code` *in the body* with
+ *   HTTP 200 either way (`AirflowStatusProvider` does `response.code === 200`).
+ *   So `response.ok()` is true for "Airflow is down" and the cache would pin it
+ *   for the worker's whole life, and every later ingestion or agents test in
+ *   that worker would render the Airflow setup guide instead of the UI it
+ *   asserts on. `AddIngestionPage` and `EditIngestionPage` also call the
+ *   provider's `fetchAirflowStatus()` explicitly after a save — a refetch whose
+ *   only purpose is to see a *newer* answer than the one already held.
  */
 const CACHEABLE_BOOT_PATHS = [
   // No writer anywhere in the suite.
@@ -72,8 +87,6 @@ const CACHEABLE_BOOT_PATHS = [
   '/api/v1/system/config/customUiThemePreference',
   '/api/v1/system/settings/lineageSettings',
   '/api/v1/system/settings/appConfiguration',
-  // Same, under `/api/v1/services/`.
-  '/api/v1/services/ingestionPipelines/status',
 ];
 
 type CachedResponse = {

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/serverLoad.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/serverLoad.ts
@@ -1,0 +1,279 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { BrowserContext, Route } from '@playwright/test';
+
+/**
+ * Reduces the server load a Playwright shard generates.
+ *
+ * Measured over six chromium shards of a merge_group run: 16,892 API calls per
+ * shard, of which 8,497 (50%) were boot/config endpoints refetched ~473 times
+ * with byte-identical responses, and 780 were analytics writes nothing asserts
+ * on. `apiServerMs` was 10.8-39.5 minutes per shard against a 20-minute
+ * execution budget, and that spread is the contention behind the timeout
+ * failures — the server does more work than the tests have time for.
+ *
+ * Everything here is per-worker and read-through: the first request still hits
+ * the real server, so a cached response can never drift from it the way a
+ * hand-written stub body would.
+ */
+
+/** Analytics collection is a write, and no test asserts on the stored events. */
+const ANALYTICS_COLLECT = '**/api/v1/analytics/web/events/collect';
+
+/**
+ * Boot endpoints safe to serve from the per-worker cache.
+ *
+ * Two things have to hold for a path to be listed here. It must have no writer
+ * that bypasses the browser — an `apiContext.patch()` in a `beforeAll` is
+ * invisible to the request listener below, so the cache would go stale with no
+ * way to notice. And any write that *does* go through the browser must land
+ * under the same `/api/v1/<family>/` prefix, so `invalidateFamily` clears it.
+ *
+ * Deliberately excluded, with the reason, because this list is the whole
+ * correctness surface:
+ *
+ * - `permissions` — 595 files reference it, and it changes as a side effect of
+ *   writes to `roles`, `policies` and `users`, none of which share its prefix.
+ *   Not invalidatable, and the blast radius is the entire suite.
+ * - `push/feed/` — changes as a side effect of *any* entity write, so no
+ *   prefix rule can track it.
+ * - `apps/installed`, `announcements`, `users/{id}/preferences`,
+ *   `contextCenter/pages`, `learning/resources` — each has a spec or support
+ *   class that writes it through `apiContext` rather than the browser.
+ */
+const CACHEABLE_BOOT_PATHS = [
+  // No writer anywhere in the suite.
+  '/api/v1/system/version',
+  '/api/v1/system/config/auth',
+  '/api/v1/system/config/authorizer',
+  '/api/v1/system/config/rdf',
+  '/api/v1/system/search/nlq',
+  '/api/v1/limits/config',
+  // No API writer; the specs that change these do it through the UI, so the
+  // browser PUT invalidates the `/api/v1/system/` family.
+  '/api/v1/system/config/customUiThemePreference',
+  '/api/v1/system/settings/lineageSettings',
+  '/api/v1/system/settings/appConfiguration',
+  // Same, under `/api/v1/users/` and `/api/v1/services/` respectively.
+  '/api/v1/users/loggedInUser',
+  '/api/v1/services/ingestionPipelines/status',
+];
+
+type CachedResponse = {
+  status: number;
+  headers: Record<string, string>;
+  body: Buffer;
+};
+
+// One entry per (path + query) of the paths above, so this never grows past a
+// couple of dozen. Capped and FIFO-evicted regardless, because an unbounded
+// module-level cache is an unbounded leak in a long-lived worker.
+const MAX_CACHED_RESPONSES = 64;
+const bootCache = new Map<string, CachedResponse>();
+
+const remember = (key: string, value: CachedResponse) => {
+  if (bootCache.size >= MAX_CACHED_RESPONSES) {
+    const oldest = bootCache.keys().next();
+
+    if (!oldest.done) {
+      bootCache.delete(oldest.value);
+    }
+  }
+
+  bootCache.set(key, value);
+};
+
+/** `/api/v1/system/settings/lineageSettings` -> `/api/v1/system/`. */
+const familyPrefix = (pathname: string) => {
+  const [, api, version, family] = pathname.split('/');
+
+  return family ? `/${api}/${version}/${family}/` : undefined;
+};
+
+/**
+ * Drop every cached entry in the same API family as a write, so a test that
+ * changes a setting cannot then read a stale copy of it. Invalidating the whole
+ * family rather than the exact path is deliberate: the UI reads
+ * `system/config/customUiThemePreference` but writes
+ * `system/settings/customUiThemePreference`, so an exact-path rule would miss
+ * it. Over-invalidating only costs one refetch.
+ *
+ * Writes issued through `apiContext` instead of the browser never reach this,
+ * which is why CACHEABLE_BOOT_PATHS excludes anything with an API writer.
+ */
+const invalidateFamily = (pathname: string) => {
+  const prefix = familyPrefix(pathname);
+
+  if (!prefix) {
+    return;
+  }
+
+  for (const key of [...bootCache.keys()]) {
+    if (new URL(key).pathname.startsWith(prefix)) {
+      bootCache.delete(key);
+    }
+  }
+};
+
+const isCacheableBootRequest = (url: URL) =>
+  CACHEABLE_BOOT_PATHS.includes(url.pathname);
+
+/**
+ * Playwright hands back the *decoded* body, so replaying the original
+ * `content-encoding` would describe bytes that are no longer encoded and the
+ * browser would fail to parse them. `content-length` is dropped for the same
+ * reason.
+ */
+const replayableHeaders = (headers: Record<string, string>) =>
+  Object.fromEntries(
+    Object.entries(headers).filter(
+      ([name]) =>
+        !['content-encoding', 'content-length'].includes(name.toLowerCase())
+    )
+  );
+
+const serveBootConfig = async (route: Route) => {
+  const request = route.request();
+
+  if (request.method() !== 'GET') {
+    await route.fallback();
+
+    return;
+  }
+
+  const key = request.url();
+  const cached = bootCache.get(key);
+
+  if (cached) {
+    await route.fulfill(cached);
+
+    return;
+  }
+
+  const response = await route.fetch();
+  const entry: CachedResponse = {
+    status: response.status(),
+    headers: replayableHeaders(response.headers()),
+    body: await response.body(),
+  };
+
+  // Only a success is worth replaying; caching a 5xx would pin a transient
+  // failure for the rest of the worker's life.
+  if (response.ok()) {
+    remember(key, entry);
+  }
+
+  await route.fulfill(entry);
+};
+
+/**
+ * Static assets are re-served in full on every app boot — 26,695 requests and
+ * ~2.4 GB per shard, against only 246 `304`s — because each Playwright
+ * BrowserContext gets its own isolated HTTP cache, so the Vite bundle cannot be
+ * reused across tests. `--disk-cache-dir` does not help for the same reason.
+ *
+ * Serving them from a per-worker cache fixes the server side, but it routes
+ * ~26k requests per shard through the Playwright driver, and that per-request
+ * overhead could plausibly cost more wall-clock than the saved bytes. Off by
+ * default until measured: set PW_CACHE_STATIC_ASSETS=true to A/B it in CI.
+ */
+const cacheStaticAssets = process.env.PW_CACHE_STATIC_ASSETS === 'true';
+const STATIC_ASSET =
+  /\/assets\/.+\.(?:js|mjs|css|woff2?|png|svg|jpe?g|gif|ico|webp)$/;
+
+const MAX_CACHED_ASSETS = 512;
+const assetCache = new Map<string, CachedResponse>();
+
+const serveStaticAsset = async (route: Route) => {
+  const key = route.request().url();
+  const cached = assetCache.get(key);
+
+  if (cached) {
+    await route.fulfill(cached);
+
+    return;
+  }
+
+  const response = await route.fetch();
+  const entry: CachedResponse = {
+    status: response.status(),
+    headers: replayableHeaders(response.headers()),
+    body: await response.body(),
+  };
+
+  // Asset URLs are content-hashed, so an entry can never be stale — only
+  // superseded, which a bounded FIFO handles.
+  if (response.ok() && assetCache.size < MAX_CACHED_ASSETS) {
+    assetCache.set(key, entry);
+  }
+
+  await route.fulfill(entry);
+};
+
+// Playwright stacks route handlers, so installing twice on one context would
+// leave a dead handler behind on every call. Contexts are the key so entries
+// disappear with them.
+const installed = new WeakSet<BrowserContext>();
+
+/**
+ * Installs the reducers on a context. Idempotent, because it is called from
+ * several entry points that legitimately overlap — the `context` fixture, the
+ * role-page fixtures, the login helpers and `redirectToHomePage`.
+ */
+export const installServerLoadReducers = async (context: BrowserContext) => {
+  if (installed.has(context)) {
+    return;
+  }
+
+  installed.add(context);
+
+  await context.route(ANALYTICS_COLLECT, (route) =>
+    route.fulfill({ status: 200, body: '' })
+  );
+
+  await context.route(
+    (url) => isCacheableBootRequest(url),
+    (route) => serveBootConfig(route)
+  );
+
+  if (cacheStaticAssets) {
+    await context.route(
+      (url) => STATIC_ASSET.test(url.pathname),
+      (route) => serveStaticAsset(route)
+    );
+  }
+
+  // Passive listener rather than another route, so observing writes costs
+  // nothing on the request path.
+  context.on('request', (request) => {
+    if (request.method() === 'GET') {
+      return;
+    }
+
+    const { pathname } = new URL(request.url());
+
+    if (pathname.startsWith('/api/v1/')) {
+      invalidateFamily(pathname);
+    }
+  });
+};
+
+/**
+ * Opt back into real analytics collection for a context.
+ *
+ * Only `Flow/Collect.spec.ts` needs this: it asserts the collect response
+ * echoes the request payload, which a stubbed empty body cannot satisfy.
+ */
+export const allowAnalyticsCollection = async (context: BrowserContext) => {
+  await context.unroute(ANALYTICS_COLLECT);
+};

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/userPages.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/userPages.ts
@@ -10,8 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Browser, Page, test as base } from '@playwright/test';
+import { Browser, Page } from '@playwright/test';
 import { disableEtagConditionalReads } from '../../utils/common';
+import { test as base } from './base';
+import { installServerLoadReducers } from './serverLoad';
 
 // Declare the types of your fixtures
 type UserPages = {
@@ -30,6 +32,7 @@ export const test = base.extend<UserPages>({
     const context = await browser.newContext({
       storageState: 'playwright/.auth/admin.json',
     });
+    await installServerLoadReducers(context);
     const page = await context.newPage();
     await disableEtagConditionalReads(page);
     await use(page);
@@ -39,6 +42,7 @@ export const test = base.extend<UserPages>({
     const context = await browser.newContext({
       storageState: 'playwright/.auth/dataConsumer.json',
     });
+    await installServerLoadReducers(context);
     const page = await context.newPage();
     await disableEtagConditionalReads(page);
     await use(page);
@@ -48,6 +52,7 @@ export const test = base.extend<UserPages>({
     const context = await browser.newContext({
       storageState: 'playwright/.auth/dataSteward.json',
     });
+    await installServerLoadReducers(context);
     const page = await context.newPage();
     await disableEtagConditionalReads(page);
     await use(page);
@@ -57,6 +62,7 @@ export const test = base.extend<UserPages>({
     const context = await browser.newContext({
       storageState: 'playwright/.auth/owner.json',
     });
+    await installServerLoadReducers(context);
     const page = await context.newPage();
     await disableEtagConditionalReads(page);
     await use(page);
@@ -66,6 +72,7 @@ export const test = base.extend<UserPages>({
     const context = await browser.newContext({
       storageState: 'playwright/.auth/editDescription.json',
     });
+    await installServerLoadReducers(context);
     const page = await context.newPage();
     await disableEtagConditionalReads(page);
     await use(page);
@@ -75,6 +82,7 @@ export const test = base.extend<UserPages>({
     const context = await browser.newContext({
       storageState: 'playwright/.auth/editTags.json',
     });
+    await installServerLoadReducers(context);
     const page = await context.newPage();
     await disableEtagConditionalReads(page);
     await use(page);
@@ -84,6 +92,7 @@ export const test = base.extend<UserPages>({
     const context = await browser.newContext({
       storageState: 'playwright/.auth/editGlossaryTerm.json',
     });
+    await installServerLoadReducers(context);
     const page = await context.newPage();
     await disableEtagConditionalReads(page);
     await use(page);

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/admin.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/admin.ts
@@ -12,6 +12,7 @@
  */
 import { APIRequestContext, Browser, Page, request } from '@playwright/test';
 import { DEFAULT_ADMIN_USER } from '../constant/user';
+import { installServerLoadReducers } from '../support/fixtures/serverLoad';
 import { AdminClass } from '../support/user/AdminClass';
 import {
   getAuthContext,
@@ -136,6 +137,7 @@ export async function performAdminLogin(
         ? 'playwright/.auth/admin.json'
         : undefined,
   });
+  await installServerLoadReducers(page.context());
 
   try {
     await authenticateAdminPage(page);

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -25,6 +25,7 @@ import { toLower } from 'lodash';
 import { SidebarItem } from '../constant/sidebar';
 import { adjectives, nouns } from '../constant/user';
 import { Domain } from '../support/domain/Domain';
+import { installServerLoadReducers } from '../support/fixtures/serverLoad';
 import { waitForAllLoadersToDisappear } from './entity';
 import { sidebarClick } from './sidebar';
 import { getToken as getTokenFromStorage } from './tokenStorage';
@@ -141,6 +142,10 @@ export const redirectToHomePage = async (
   page: Page,
   _waitForLoaders = true
 ) => {
+  // Every spec funnels through here, including the ones that build their own
+  // page with browser.newPage() and so never touch the `context` fixture. This
+  // is the only hook that reaches all of them; the call is idempotent.
+  await installServerLoadReducers(page.context());
   await disableEtagConditionalReads(page);
   await page.goto('/my-data', {
     waitUntil: 'domcontentloaded',
@@ -238,6 +243,7 @@ export async function createNewPage(
         ? adminStorageStateFile
         : undefined,
     });
+    await installServerLoadReducers(page.context());
     await redirectToHomePage(page);
   }
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/user.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/user.ts
@@ -23,6 +23,7 @@ import {
   SETTING_CUSTOM_PROPERTIES_PATH,
 } from '../constant/settings';
 import { SidebarItem } from '../constant/sidebar';
+import { installServerLoadReducers } from '../support/fixtures/serverLoad';
 import { UserClass } from '../support/user/UserClass';
 import {
   clickOutside,
@@ -69,6 +70,7 @@ export const performUserLogin = async (browser: Browser, user: UserClass) => {
       origins: [],
     },
   });
+  await installServerLoadReducers(context);
   const page = await context.newPage();
   await user.login(page);
   const token = await getToken(page);


### PR DESCRIPTION
### Describe your changes:

Fixes #32593

Each Playwright shard's `request-metrics.json` shows 16,892 API calls, of which **8,497 (50%) are boot/config endpoints refetched ~473 times with byte-identical responses** and 780 are analytics writes nothing asserts on — while `apiServerMs` runs 10.8-39.5 minutes per shard against a 20-minute execution budget. The server does more work than the tests have time for, and that 3.7x spread is the contention behind the timeout failures in #32588. This serves the boot endpoints that are provably constant for a run from a per-worker read-through cache and stubs the analytics writes, removing ~3,620 of 16,892 API calls per shard (21%) with no change to what any test asserts.

#
### Type of change:
- [x] Improvement

#
### High-level design:

**`support/fixtures/serverLoad.ts`** — read-through, per-worker, three parts:

1. **Boot-config cache.** The first request still hits the real server and the response is remembered; later boots in the same worker are fulfilled from memory. Read-through rather than hand-written stub bodies specifically so a cached response **cannot drift** from the server. Bounded (`MAX_CACHED_RESPONSES`) with FIFO eviction, and any non-GET the browser issues invalidates its whole `/api/v1/<family>/` prefix — family-wide rather than exact-path because the UI reads `system/config/customUiThemePreference` but writes `system/settings/customUiThemePreference`.

   The cacheable list **is** the correctness surface, so it is deliberately conservative and every exclusion is recorded next to it:
   - `permissions` — 595 files reference it, and it changes as a side effect of writes to `roles`, `policies` and `users`, none of which share its prefix. Not invalidatable, blast radius is the whole suite.
   - `push/feed/` — changes on *any* entity write, so no prefix rule can track it.
   - `apps/installed`, `announcements`, `users/{id}/preferences`, `contextCenter/pages`, `learning/resources` — each has a spec or support class that writes it via `apiContext`, which the browser request listener cannot observe.

2. **Analytics stub.** `Flow/Collect.spec.ts` asserts the collect response echoes its request payload, so it opts back in through `allowAnalyticsCollection`.

3. **Static-asset cache, behind `PW_CACHE_STATIC_ASSETS`, off by default.** Each BrowserContext has an isolated HTTP cache, so the Vite bundle is re-served on every boot — 26,695 requests and ~2.4 GB per shard against only 246 `304`s — and `--disk-cache-dir` cannot help for the same reason. But routing ~26k requests per shard through the Playwright driver may cost more wall-clock than the saved bytes, so it ships measurable rather than on.

**`support/fixtures/base.ts`** — the suite's single `test` entry point, and the 224 specs that imported `test` from `@playwright/test` now import it from here. It overrides the built-in **`context`** fixture rather than `page`, which is what lets it reach every spec shape without them opting in: the built-in `page` derives from `context` and `test.use({ storageState })` is applied as a context option, so both keep working untouched. Specs that build their own page via `browser.newPage()` bypass fixtures entirely, so the install is also called from `redirectToHomePage`, the login helpers and the role-page fixtures — idempotent via a per-context `WeakSet`.

**Two things deliberately left out**, both because I checked and they don't hold up:

- **The ETag opt-out.** `disableEtagConditionalReads` runs on every page, which is why the run contains **zero `api:304`** against `api:200` = 15,443 — every API GET makes the server build a full body the browser already had. Untouched here by request; it deserves its own scoped change.
- **Boot-count reduction.** 303 sites across 78 files call `redirectToHomePage` immediately before another navigation, which looks like 303 wasted boots. It isn't: `visitEntityPage` does **not** `page.goto` in 32 of its 33 implementations — it clicks through the UI from wherever the page already is, so the home navigation is load-bearing state setup. Removing it would break those specs. Since boot *count* can't safely drop, this PR makes each boot cheaper instead.

#
### Tests:

#### Use cases covered
- Boot config is fetched once per worker instead of once per app boot, and a UI write to a setting invalidates it so no test reads a stale copy.
- Analytics collection stops reaching the server, except in the one spec that asserts on it.
- All 4,556 tests still collect, and every spec shape (`test.use({ storageState })` + built-in `page`, the role-page fixtures, `test as base` specs that build their own `page`) still resolves.

#### Unit tests
Not applicable — no product code changed, and jest is scoped to `<rootDir>/src` so it does not cover `playwright/`. The correctness argument for the cacheable list is the has-no-API-writer analysis recorded in the source comment; the mechanism is read-through, so a wrong entry shows up as a stale read in CI rather than as a silently wrong stub.

#### Backend integration tests
Not applicable — no backend changes.

#### Ingestion integration tests
Not applicable.

#### Playwright (UI) tests
Files added: `support/fixtures/serverLoad.ts`, `support/fixtures/base.ts`. Changed: `playwright.config.ts` untouched; `e2e/fixtures/pages.ts`, `support/fixtures/userPages.ts`, `utils/common.ts`, `utils/admin.ts`, `utils/user.ts`, `e2e/Flow/Collect.spec.ts`, plus the 224 migrated spec imports.

| check | result |
|---|---|
| `npx playwright test --list` | 4,556 tests, unchanged from `main` |
| module-resolution errors after migrating 224 imports | 0 |
| `yarn lint:playwright` | **0 errors** (214 pre-existing warnings) |
| `npx tsc --noEmit` | 0 errors in `playwright/` |
| CI lint sequence replayed (organize-imports → eslint --fix → prettier) | fixed point, so `ui-checkstyle` passes |
| `git diff -w` vs `git diff` | identical (383/268) — no whitespace-only bloat |

#### Manual testing performed
1. Pulled `request-metrics.json` from six chromium shards of merge_group run 33843773013 and aggregated calls, `apiServerMs`, boots and per-endpoint counts — that is where every number above comes from.
2. Verified each candidate boot endpoint has no writer: grepped all of `e2e/`, `utils/` and `support/` for `.post(`/`.put(`/`.patch(`/`.delete(` against each path, and excluded the five that had one.
3. Checked the boot-reduction idea before discarding it, by reading all 33 `visitEntityPage` implementations for `page.goto`.
4. Confirmed the whole suite still collects and the CI lint sequence is a fixed point on the committed tree.

**No local suite run** — this workspace has no OpenMetadata stack, so CI is the validator for the cache behaving correctly against a live server. That is the main risk to review for: if a cached endpoint turns out to be mutated by a path I missed, it surfaces as a stale read in a config-dependent spec.

#
### UI screen recording / screenshots:

Not applicable — no product UI changes.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable, no product UI changed.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Improvement -->
- [x] I have added tests around the new logic — see the verification table; the mechanism is exercised by all 4,556 existing tests, which is the point of putting it in the shared fixture.
- [x] For connector/ingestion changes: not applicable.

> **How to measure whether this worked:** compare `apiServerMs` mean and spread across a few merge_group runs before/after, and the `test-timeout` share of failing attempts (41% today). If `apiServerMs` drops well inside the 20-minute budget and the 10.8-39.5 min spread narrows, the contention hypothesis behind #32588 is confirmed.