### PR TITLE
Fixes #32598: scope the Playwright description-editor locator to its container

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -154,7 +154,7 @@ export default defineConfig({
     ignoreHTTPSErrors: isH2Mode,
 
     /* Collect trace and video on every failure (not just retries) for debugging */
-    trace: 'on-first-retry',
+    trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
 
     /* Add navigation timeout to prevent infinite hangs on networkidle waits.

--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -154,7 +154,7 @@ export default defineConfig({
     ignoreHTTPSErrors: isH2Mode,
 
     /* Collect trace and video on every failure (not just retries) for debugging */
-    trace: 'retain-on-failure',
+    trace: 'on-first-retry',
     screenshot: 'only-on-failure',
 
     /* Add navigation timeout to prevent infinite hangs on networkidle waits.

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -40,6 +40,35 @@ export const descriptionBox = '.om-block-editor[contenteditable="true"]';
 export const descriptionBoxReadOnly =
   '.om-block-editor[contenteditable="false"]';
 
+/**
+ * Resolve the description editor that belongs to `scope`.
+ *
+ * `descriptionBox` is page-global, so it matches every editable block editor
+ * currently mounted. Any page that has more than one at a time — an entity page
+ * with a form drawer or description modal overlaid on it, or two drawers
+ * overlapping while one plays its exit animation — turns an unscoped
+ * `page.locator(descriptionBox)` into a strict mode violation. Pass the form,
+ * drawer or modal the editor lives in instead.
+ */
+export const getDescriptionBox = (scope: Locator): Locator =>
+  scope.locator(descriptionBox);
+
+/**
+ * Fill the description editor inside `scope`, asserting it is the only one
+ * there.
+ *
+ * The count assertion is deliberate: `.first()` would also silence the strict
+ * mode violation, but by typing into an arbitrary editor, so the test goes on
+ * to fail somewhere unrelated to the real ambiguity. Failing here names the
+ * scope that needs narrowing.
+ */
+export const fillDescriptionBox = async (scope: Locator, value: string) => {
+  const editor = getDescriptionBox(scope);
+
+  await expect(editor).toHaveCount(1);
+  await editor.fill(value);
+};
+
 export const INVALID_NAMES = {
   MAX_LENGTH:
     'a87439625b1c2d3e4f5061728394a5b6c7d8e90a1b2c3d4e5f67890aba87439625b1c2d3e4f5061728394a5b6c7d8e90a1b2c3d4e5f67890abName can be a maximum of 128 characters',

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
@@ -36,7 +36,7 @@ import { UserClass } from '../support/user/UserClass';
 import {
   clickOutside,
   closeFirstPopupAlert,
-  descriptionBox,
+  fillDescriptionBox,
   getApiContext,
   INVALID_NAMES,
   NAME_MAX_LENGTH_VALIDATION_ERROR,
@@ -582,13 +582,25 @@ export const verifyAssetsInDomain = async (
   }
 };
 
+/**
+ * Fill the fields AddDomainForm shares between domains, subdomains and data
+ * products.
+ *
+ * Everything is resolved through the `add-domain-form` container rather than
+ * off `page`: DomainDetails mounts the data product drawer and the subdomain
+ * drawer as siblings, so a page-global `#root/name` or `descriptionBox` can see
+ * a second copy of this very form and strict mode violate (merge queue run
+ * 33847455975 ejected #32465 that way).
+ */
 export const fillCommonFormItems = async (
   page: Page,
   entity: Domain['data'] | DataProduct['data'] | SubDomain['data']
 ) => {
-  await page.locator('#root\\/name').fill(entity.name);
-  await page.locator('#root\\/displayName').fill(entity.displayName);
-  await page.locator(descriptionBox).fill(entity.description);
+  const form = page.getByTestId('add-domain-form');
+
+  await form.locator('#root\\/name').fill(entity.name);
+  await form.locator('#root\\/displayName').fill(entity.displayName);
+  await fillDescriptionBox(form, entity.description);
   if (!isEmpty(entity.owners) && !isUndefined(entity.owners)) {
     await addOwner({
       page,

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/tag.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/tag.ts
@@ -25,6 +25,7 @@ import {
   descriptionBox,
   descriptionBoxReadOnly,
   getApiContext,
+  getDescriptionBox,
   NAME_MIN_MAX_LENGTH_VALIDATION_ERROR,
   NAME_VALIDATION_ERROR,
   redirectToHomePage,
@@ -397,10 +398,15 @@ export const editTagPageDescription = async (page: Page, tag: TagClass) => {
   await expect(page.getByTestId('edit-description')).toBeVisible();
   await page.getByTestId('edit-description').click();
 
-  await expect(page.getByRole('dialog')).toBeVisible();
+  const descriptionModal = page.getByRole('dialog');
 
-  await page.locator(descriptionBox).clear();
-  await page.locator(descriptionBox).fill(updatedDescription);
+  await expect(descriptionModal).toBeVisible();
+
+  const editor = getDescriptionBox(descriptionModal);
+
+  await expect(editor).toHaveCount(1);
+  await editor.clear();
+  await editor.fill(updatedDescription);
 
   const editDescription = page.waitForResponse(
     (response) =>

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
@@ -20,6 +20,7 @@ import { UserClass } from '../support/user/UserClass';
 import {
   assignDomain,
   descriptionBox,
+  fillDescriptionBox,
   redirectToHomePage,
   uuid,
 } from './common';
@@ -231,9 +232,11 @@ export const createTeam = async (
     ...overrides,
   };
 
-  await page.locator('[role="dialog"].ant-modal').waitFor();
+  const teamModal = page.locator('[role="dialog"].ant-modal');
 
-  await expect(page.locator('[role="dialog"].ant-modal')).toBeVisible();
+  await teamModal.waitFor();
+
+  await expect(teamModal).toBeVisible();
 
   await page.fill('[data-testid="name"]', teamData.name);
   await page.fill('[data-testid="display-name"]', teamData.displayName);
@@ -243,8 +246,7 @@ export const createTeam = async (
     await page.getByTestId('isJoinable-switch-button').click();
   }
 
-  await page.locator(descriptionBox).isVisible();
-  await page.locator(descriptionBox).fill(teamData.description);
+  await fillDescriptionBox(teamModal, teamData.description);
 
   const createTeamResponse = page.waitForResponse(
     (response) =>


### PR DESCRIPTION
### Describe your changes:

Fixes #32598

`playwright/utils/common.ts` exports the description editor as a **page-global** selector:

```ts
export const descriptionBox = '.om-block-editor[contenteditable="true"]';
```

It matches *every* editable block editor mounted at that instant, so `page.locator(descriptionBox)` is only correct while exactly one exists. Any page holding two — an entity page with a form drawer or a description modal over it, or two drawers overlapping while one plays its react-aria exit animation — turns the call into a Playwright strict mode violation, and the test fails outright rather than flaking.

That is what ejected #32465 from the merge queue in run [33847455975](https://github.com/open-metadata/OpenMetadata/actions/runs/33847455975). Shard `chromium-05`, `1 failed, 1 flaky, 175 passed`; `Pages/Domains.spec.ts:492 › Domains › Follow/unfollow subdomain and create nested sub domain` failed **both** attempts, so `retries: 1` could not launder it into `status: "flaky"`:

```
Error: locator.fill: Error: strict mode violation:
locator('.om-block-editor[contenteditable="true"]') resolved to 2 elements:
    1) ... aka locator('.tiptap').first()
    2) ... aka locator('div:nth-child(2) > .tiptap')
```

Not a `main` regression — four of five runs in that 07:09 batch were green, #32465 is backend/MCP and cannot mount a TipTap editor, and the test failed in 0 of 22 sampled runs. It was a single observation with no root cause, which is why #32591 neither fixed nor quarantined it.

**This PR fixes the class, not that one instance.** The specific second editor is not recoverable: `playwright.config.ts` has `trace: 'on-first-retry'`, so attempt 0 produced no trace and attempt 1 failed a different way (a 180s `waitForResponse` timeout at `Domains.spec.ts:508`). An earlier revision of this PR flipped that to `retain-on-failure`; it is **no longer part of this PR** — see the note at the end of the design section.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

**1. A scoped resolver, with an assertion instead of `.first()`** — `utils/common.ts`

```ts
export const getDescriptionBox = (scope: Locator): Locator =>
  scope.locator(descriptionBox);

export const fillDescriptionBox = async (scope: Locator, value: string) => {
  const editor = getDescriptionBox(scope);

  await expect(editor).toHaveCount(1);
  await editor.fill(value);
};
```

The `toHaveCount(1)` is the point. `.first()` also silences a strict mode violation, but by typing into an arbitrary editor — so the test proceeds against the wrong form and fails somewhere unrelated to the real ambiguity. Failing here names the scope that needs narrowing. `main` already has **15** call sites papered over with `.first()`/`.nth(0)`, which is the same bug silenced per-site rather than at the definition.

**2. `fillCommonFormItems` resolves every field through `add-domain-form`** — `utils/domain.ts`

This is the demonstrated failure. Note it scopes `#root/name` and `#root/displayName` too, not just the editor: `AddDomainForm` renders all three inside `data-testid="add-domain-form"` (`AddDomainForm.component.tsx:1043`), and duplicate `id` attributes across two mounted copies of the same form make the ids page-global for exactly the same reason. The helper's own caller `fillDomainForm` was already scoping `domainType` to that container — the container was in hand and this function reached past it.

The page really can hold two: `DomainDetails.component.tsx` renders `AddDomainForm` twice — the data-product drawer (:446, mounted :1157) and the subdomain drawer (:619, mounted :1201) — each a `useFormDrawerWithHook` → `SlideoutMenu` → react-aria `ModalOverlay`. `slideout-menu.tsx` has an `isExiting` branch with `tw:duration-500 tw:animate-out`, so a *closing* overlay stays mounted ~500ms; opening one while another exits puts both editors in the DOM. Scoping to the testid therefore narrows "any editor on the page" → "an `AddDomainForm` drawer", and the count assertion turns the residual two-drawer case into a failure that names the container instead of an opaque strict-mode surprise. Called out because the reviewer should know this container is not *provably* unique.

**3. Two call sites where the container was already in hand and already asserted unique**

- `utils/team.ts` `createTeam` — the function already does `waitFor()` + `expect(...).toBeVisible()` on `[role="dialog"].ant-modal`, which proves uniqueness at that point, then reached past it to `page` for the editor. Now hoisted to a `teamModal` const and reused. Also drops `await page.locator(descriptionBox).isVisible()` — the boolean was discarded, so it was a no-op that waited for nothing; `fillDescriptionBox`'s assertion is a real wait.
- `utils/tag.ts` `editTagPageDescription` — same pattern with `page.getByRole('dialog')`, already asserted visible on the line above. (`edit-description` opens `ModalWithMarkdownEditor` via `EntityDescription/Description.tsx`.)

**Removed from this PR: the `trace: 'retain-on-failure'` change to `playwright.config.ts`.**

It was in an earlier revision (commit `f013af49`) and has been reverted in `e5218015`. `retain-on-failure` records a full trace on attempt 0 for *every* test, not only on retry, and the cost is not marginal. On merge-queue run [33886823198](https://github.com/open-metadata/OpenMetadata/actions/runs/33886823198), shard `global-state-01`, measured against green run [33881093952](https://github.com/open-metadata/OpenMetadata/actions/runs/33881093952) on the same shard and the same base:

| step | green | with the trace change | ratio |
|---|---|---|---|
| Setup Openmetadata Test Environment | 108s | 96s | 0.89 |
| Install dependencies | 33s | 31s | 0.94 |
| **Run Playwright tests** | **255s** | **496s** | **1.95** |

Every environment step was equal or faster, so the runner was not slower — only the test step was. Subtracting the two 60s timeouts gives 1.47x, and each of the 11 comparable tests was individually 1.4–1.7x slower (9.6→14.1s, 7.8→12.2s, 11.3→16.7s, …). Aggregate across the 18 completed shards in that run: 13696s → 17142s.

That is what ejected this PR from the merge queue. `Pages/SearchSettings.spec.ts:492` — 8.9s in the green run — hit the 60s test timeout on both attempts: `setSliderValue` never moved `field-weight-slider` off its default weight of 1 (confirmed from the attempt-0 `error-context.md` a11y snapshot), so the form never went dirty and `save-btn` stayed `disabled`. Unrelated to the locator work, but the slowdown is what pushed it over.

The diagnostic value is real; it belongs behind a `workflow_dispatch` input rather than in a config change that gates the merge queue for every PR. The `sso-auth` project keeps its own `retain-on-failure` override, unchanged.

**Deliberately out of scope: the remaining ~125 unscoped call sites.** Each needs its container identified by reading the corresponding UI component, and 15 currently rely on `.first()` where the page may genuinely hold two editors — swapping those for a strict assertion can turn green tests red. A blind sweep of `playwright/` is the exact shape of `c22ea387d6` (#32333), the 327-file revert that reintroduced #31384 by reverting 13 unrelated `playwright/` files. The new helpers make each remaining site a one-line migration when it next misbehaves. Also left alone, but worth a follow-up: 5 spec files locally redeclare `const descriptionBox = '.om-block-editor[contenteditable="true"]'`, shadowing the shared export, and `Domains.spec.ts:1270` passes a third argument to the two-parameter `fillDomainForm` — invisible because nothing type-checks `playwright/` (see below).

#
### Tests:

#### Use cases covered
- Creating a subdomain from a domain page that also has the data-product drawer mounted fills the *open* drawer's form, and fails naming `add-domain-form` if two are mounted, instead of a strict mode violation on the whole page.
- Creating a data product (from the domain page and from the list page) and a domain from the marketplace widgets go through the same scoped helper.
- Creating a team fills the editor inside the add-team modal.
- Editing a tag's description fills the editor inside the description modal.

#### Unit tests
Not applicable — no product code changed. This PR is entirely Playwright helper functions.

#### Backend integration tests
Not applicable — no backend API changes.

#### Ingestion integration tests
Not applicable — no ingestion changes.

#### Playwright (UI) tests
Files updated: `playwright/utils/common.ts`, `playwright/utils/domain.ts`, `playwright/utils/tag.ts`, `playwright/utils/team.ts`. No new spec — the fix is in shared helpers already exercised by the existing specs (`Pages/Domains.spec.ts`, `Pages/DataProducts.spec.ts`, `Pages/DataMarketplace.spec.ts`, `Pages/Teams.spec.ts`, `Pages/Tags.spec.ts`), and the failure it fixes is a locator-resolution error rather than product behaviour, so there is nothing a new spec could assert that the assertion inside `fillDescriptionBox` does not.

| check | result |
|---|---|
| `playwright test --list --reporter=list` | **4556 tests in 381 files** — identical to the clean-tree baseline, which I measured by reverting the four files, re-listing, then re-applying and confirming each file byte-identical |
| `prettier --config ./.prettierrc.yaml --ignore-path ./.prettierignore --check` on the 4 files | `All matched files use Prettier code style!` |
| `eslint --no-error-on-unmatched-pattern` (CI's `lint:base`) on the 4 files | exit 0, no errors or warnings |
| `pre-commit run --from-ref HEAD~1 --to-ref HEAD` | `Prettier (UI)` Passed, `Apache-2.0 license header (UI)` Passed, remainder skipped (no files) |

On `tsc`: `tsconfig.json` is `"include": ["src"]`, so **nothing under `playwright/` is type-checked**, by this PR or by CI. Pointing a temporary strict config at `include: ["playwright"]` yields 166 pre-existing errors on clean `main` (95× TS2345, 31× TS6133, 24× TS2322), so the total is not a usable gate. Scoped to the changed files: zero in `common.ts`, `domain.ts` and `team.ts`; the five in `tag.ts` are at lines 120-163, whereas the only edit to that file is at 398+. No TS6133 in any of the four, which is what proves the import swap left no unused binding.

#### Manual testing performed
No local stack — the failure is a CI-only merge-queue event and the change is test-harness code, so it was root-caused from CI artifacts and verified by reading the components involved:

1. Pulled run 33847455975's `chromium-05` shard artifacts; confirmed attempt 0 is the strict mode violation at `utils/domain.ts:591` and attempt 1 is a distinct `waitForResponse` timeout at `Domains.spec.ts:508`, i.e. both attempts failed and the retry could not mask it.
2. Confirmed from the retry-1 trace snapshot (`after@call@90`) that the domain page mounts 13 `om-block-editor` nodes, all `contenteditable="false"` — so the editable ones can only come from a drawer or modal.
3. Traced the container for every migrated site in the product source before scoping to it, rather than assuming a testid: `add-domain-form` on the `HookForm` wrapping name/displayName/description (`AddDomainForm.component.tsx:1043-1085`); `AddTeamForm.tsx:151-254` for the antd team modal; `ModalWithMarkdownEditor.tsx:60-100` reached from `EntityDescription/Description.tsx` for the tag description modal. Cross-checked the last one against the two call sites already using `[data-testid="markdown-editor"] ${descriptionBox}` (`utils/importUtils.ts:352`, `Flow/Metric.spec.ts:160`).
4. Followed `useFormDrawerWithHook` → `useCompositeDrawer` → `useDrawer` → `SlideoutMenu` to establish that the overlay is `isOpen`-gated but has a 500ms `isExiting` window, which is what makes two simultaneous `AddDomainForm` mounts reachable and is why the count assertion is there rather than a bare scope.
5. Re-ran the test list on a reverted tree and on the change to confirm no test was added, removed or renamed.

#
### UI screen recording / screenshots:

Not applicable — no product UI changed, only Playwright test helper functions.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas — both new helpers carry a doc comment explaining why the scope is required and why the assertion is not `.first()`, and `fillCommonFormItems` records the two-drawer situation and the run that surfaced it.
- [x] For JSON Schema changes: not applicable, no schema changes.
- [x] For UI changes: not applicable, no product UI changes.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing — as far as the scenario admits one. `expect(editor).toHaveCount(1)` inside `fillDescriptionBox` **is** the regression check: it is the assertion that the failing selector implicitly made and lost. A conventional regression spec would have to mount two editable editors at once on purpose, which on this page means driving a drawer's 500ms exit animation to overlap the next drawer's entry — a race, i.e. precisely the flake this PR removes. `Pages/Domains.spec.ts:492` remains the natural end-to-end cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

