### PR TITLE
test(1.13): isolate UserMetricsResourceIT from the parallel integration suite

### DIFF
--- a/openmetadata-integration-tests/pom.xml
+++ b/openmetadata-integration-tests/pom.xml
@@ -267,6 +267,7 @@
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/TagRecognizerFeedbackIT.java</include>
+                    <include>**/UserMetricsResourceIT.java</include>
                     <include>**/WorkflowDefinitionResourceIT.java</include>
                     <include>**/AppsResourceIT.java</include>
                     <include>**/SystemResourceIT.java</include>
@@ -302,6 +303,7 @@
                   </includes>
                   <excludes>
                     <exclude>**/TagRecognizerFeedbackIT.java</exclude>
+                    <exclude>**/UserMetricsResourceIT.java</exclude>
                     <exclude>**/WorkflowDefinitionResourceIT.java</exclude>
                     <exclude>**/AppsResourceIT.java</exclude>
                     <exclude>**/SystemResourceIT.java</exclude>
@@ -360,6 +362,7 @@
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/TagRecognizerFeedbackIT.java</include>
+                    <include>**/UserMetricsResourceIT.java</include>
                     <include>**/WorkflowDefinitionResourceIT.java</include>
                     <include>**/AppsResourceIT.java</include>
                     <include>**/SystemResourceIT.java</include>
@@ -397,6 +400,7 @@
                   </includes>
                   <excludes>
                     <exclude>**/TagRecognizerFeedbackIT.java</exclude>
+                    <exclude>**/UserMetricsResourceIT.java</exclude>
                     <exclude>**/WorkflowDefinitionResourceIT.java</exclude>
                     <exclude>**/AppsResourceIT.java</exclude>
                     <exclude>**/SystemResourceIT.java</exclude>
@@ -456,6 +460,7 @@
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/TagRecognizerFeedbackIT.java</include>
+                    <include>**/UserMetricsResourceIT.java</include>
                     <include>**/WorkflowDefinitionResourceIT.java</include>
                     <include>**/AppsResourceIT.java</include>
                     <include>**/SystemResourceIT.java</include>
@@ -494,6 +499,7 @@
                   </includes>
                   <excludes>
                     <exclude>**/TagRecognizerFeedbackIT.java</exclude>
+                    <exclude>**/UserMetricsResourceIT.java</exclude>
                     <exclude>**/WorkflowDefinitionResourceIT.java</exclude>
                     <exclude>**/AppsResourceIT.java</exclude>
                     <exclude>**/SystemResourceIT.java</exclude>
@@ -553,6 +559,7 @@
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/TagRecognizerFeedbackIT.java</include>
+                    <include>**/UserMetricsResourceIT.java</include>
                     <include>**/WorkflowDefinitionResourceIT.java</include>
                     <include>**/AppsResourceIT.java</include>
                     <include>**/SystemResourceIT.java</include>
@@ -589,6 +596,7 @@
                   </includes>
                   <excludes>
                     <exclude>**/TagRecognizerFeedbackIT.java</exclude>
+                    <exclude>**/UserMetricsResourceIT.java</exclude>
                     <exclude>**/WorkflowDefinitionResourceIT.java</exclude>
                     <exclude>**/AppsResourceIT.java</exclude>
                     <exclude>**/SystemResourceIT.java</exclude>
@@ -646,6 +654,7 @@
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/TagRecognizerFeedbackIT.java</include>
+                    <include>**/UserMetricsResourceIT.java</include>
                     <include>**/WorkflowDefinitionResourceIT.java</include>
                     <include>**/AppsResourceIT.java</include>
                     <include>**/SystemResourceIT.java</include>
@@ -683,6 +692,7 @@
                   </includes>
                   <excludes>
                     <exclude>**/TagRecognizerFeedbackIT.java</exclude>
+                    <exclude>**/UserMetricsResourceIT.java</exclude>
                     <exclude>**/WorkflowDefinitionResourceIT.java</exclude>
                     <exclude>**/AppsResourceIT.java</exclude>
                     <exclude>**/SystemResourceIT.java</exclude>
@@ -740,6 +750,7 @@
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/TagRecognizerFeedbackIT.java</include>
+                    <include>**/UserMetricsResourceIT.java</include>
                     <include>**/WorkflowDefinitionResourceIT.java</include>
                     <include>**/AppsResourceIT.java</include>
                     <include>**/SystemResourceIT.java</include>
@@ -777,6 +788,7 @@
                   </includes>
                   <excludes>
                     <exclude>**/TagRecognizerFeedbackIT.java</exclude>
+                    <exclude>**/UserMetricsResourceIT.java</exclude>
                     <exclude>**/WorkflowDefinitionResourceIT.java</exclude>
                     <exclude>**/AppsResourceIT.java</exclude>
                     <exclude>**/SystemResourceIT.java</exclude>
@@ -848,6 +860,7 @@
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/TagRecognizerFeedbackIT.java</include>
+                    <include>**/UserMetricsResourceIT.java</include>
                     <include>**/WorkflowDefinitionResourceIT.java</include>
                     <include>**/AppsResourceIT.java</include>
                     <include>**/SystemResourceIT.java</include>
@@ -887,6 +900,7 @@
                   </includes>
                   <excludes>
                     <exclude>**/TagRecognizerFeedbackIT.java</exclude>
+                    <exclude>**/UserMetricsResourceIT.java</exclude>
                     <exclude>**/WorkflowDefinitionResourceIT.java</exclude>
                     <exclude>**/AppsResourceIT.java</exclude>
                     <exclude>**/SystemResourceIT.java</exclude>
@@ -947,6 +961,7 @@
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/TagRecognizerFeedbackIT.java</include>
+                    <include>**/UserMetricsResourceIT.java</include>
                     <include>**/WorkflowDefinitionResourceIT.java</include>
                     <include>**/AppsResourceIT.java</include>
                     <include>**/SystemResourceIT.java</include>
@@ -985,6 +1000,7 @@
                   </includes>
                   <excludes>
                     <exclude>**/TagRecognizerFeedbackIT.java</exclude>
+                    <exclude>**/UserMetricsResourceIT.java</exclude>
                     <exclude>**/WorkflowDefinitionResourceIT.java</exclude>
                     <exclude>**/AppsResourceIT.java</exclude>
                     <exclude>**/SystemResourceIT.java</exclude>


### PR DESCRIPTION
### Describe your changes:

`UserMetricsResourceIT.testUserMetricsWithRealActivity` fails intermittently on `1.13` because it
runs inside the parallel integration suite while asserting on a **server-global** counter.

The test reads `total_users`, creates 3 users, re-reads, and asserts
`updatedTotalUsers >= initialTotalUsers + 3`. Any test running concurrently that hard-deletes users
between the two reads pushes the count back down and the assertion fails. The test's own comment
already documents the hazard:

> Polling would only widen the window in which a parallel lane can hard-delete users and push the
> count back down.

Observed on #32590 ([job](https://github.com/open-metadata/OpenMetadata/actions/runs/33850732856/job/100953518099)),
`12768 tests run, 1 failed`:

```
UserMetricsResourceIT.java:229 | Metrics should include every user created and kept alive by
this test ==> expected: <true> but was: <false>
```

That PR touches no file under `openmetadata-integration-tests/`, and the same lane passed on the
other two database/search combinations of the same commit, so this is branch-level flakiness rather
than anything a given PR introduced.

**`main` and `2.0` already isolate this class; `1.13` never got that change.** Both carry the eight
`<include>`/`<exclude>` pairs for `UserMetricsResourceIT`, and `main` additionally lists it in
`integrationTests.globalStateTests`. On `1.13` there were zero references. Both branches received it
in `b16f585789`, the same upstream commit that hardened `SecurityConfigurationManagerTest`; only
that half was backported.

`1.13` is exposed because the lane machinery is main-only. `integrationTests.lane` and the
`integration-lane-*` profiles do not exist in this branch's `openmetadata-integration-tests/pom.xml`,
so `-DintegrationTests.lane=global-state` is inert and every lane runs the full suite. On the run
above the `global-state` and `parallel` lanes each executed the identical 12768 tests.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

`1.13` still uses the older `sequential-tests` / `parallel-tests` execution pair rather than main's
lane profiles, so this applies the equivalent in that shape: add `UserMetricsResourceIT` to the
`sequential-tests` includes and to the `parallel-tests` excludes, in all 8 profiles that have the
split (`mysql-elasticsearch`, `postgres-opensearch`, `postgres-os-redis`, `postgres-elasticsearch`,
`mysql-opensearch`, `mysql-elasticsearch-redis`, `cache-tests`, `postgres-rdf-tests`).

The class is inserted immediately after `TagRecognizerFeedbackIT` in both blocks, matching the
ordering `main` and `2.0` use. 16 added lines, no deletions, no production code.

This works because `1.13` runs `forkCount=1, reuseForks=true` and the two failsafe executions run in
sequence within the `integration-test` phase. `sequential-tests` sets
`junit.jupiter.execution.parallel.enabled=false`, so nothing else executes between the test's
baseline read and its second read of `total_users`.

**Verification**

- `help:effective-pom` confirms the merged configuration in every profile: the class is present in
  `sequential-tests` includes and in `parallel-tests` excludes (16/16 checks).
- `mvn -pl :openmetadata-integration-tests validate` passes under both `-Pcache-tests` and
  `-Pmysql-elasticsearch`.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
