### PR TITLE
Fixes #32600: include samples in AI context

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/AIContextRestIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/AIContextRestIT.java
@@ -51,8 +51,10 @@ import org.openmetadata.schema.type.TableData;
 class AIContextRestIT extends McpTestBase {
 
   private static Table table;
+  private static Table ownedTable;
   private static String glossaryTermFqn;
   private static String sampleRestrictedToken;
+  private static String ownerToken;
   private static String teamName;
 
   @BeforeAll
@@ -62,6 +64,9 @@ class AIContextRestIT extends McpTestBase {
     table = createServiceDatabaseSchemaTable("aicontext_rest_" + suffix);
     addSampleData(table);
     sampleRestrictedToken = createSampleRestrictedToken(suffix);
+    ownedTable = createServiceDatabaseSchemaTable("aicontext_owned_" + suffix);
+    addSampleData(ownedTable);
+    ownerToken = createOwnerDeniedSamplesToken(suffix, ownedTable);
     glossaryTermFqn = createGlossaryTerm(suffix);
     teamName = createTeam(suffix);
   }
@@ -106,6 +111,52 @@ class AIContextRestIT extends McpTestBase {
                 .withEmail(name + "@test.openmetadata.org")
                 .withRoles(List.of(role.getId())),
             User.class);
+    return "Bearer "
+        + JwtAuthProvider.tokenFor(user.getEmail(), user.getEmail(), new String[] {}, 3600);
+  }
+
+  /**
+   * An owner-conditioned DENY of VIEW_SAMPLE_DATA, which only fires when the decision can actually
+   * see the table's owners. A ResourceContext wrapping the already-loaded table (fetched without
+   * owners) reads isOwner() as false, so the rule stays silent and the samples are handed out.
+   */
+  private static String createOwnerDeniedSamplesToken(String suffix, Table target)
+      throws Exception {
+    Rule denySamplesForOwner =
+        new Rule()
+            .withName("DenyViewSampleDataForOwner")
+            .withResources(List.of("table"))
+            .withOperations(List.of(MetadataOperation.VIEW_SAMPLE_DATA))
+            .withCondition("isOwner()")
+            .withEffect(Rule.Effect.DENY);
+    Policy policy =
+        post(
+            "policies",
+            new CreatePolicy()
+                .withName("aicontext_owner_no_samples_policy_" + suffix)
+                .withRules(List.of(denySamplesForOwner)),
+            Policy.class);
+    Role role =
+        post(
+            "roles",
+            new CreateRole()
+                .withName("aicontext_owner_no_samples_role_" + suffix)
+                .withPolicies(List.of(policy.getFullyQualifiedName())),
+            Role.class);
+    String name = "aicontext_owner_no_samples_" + suffix;
+    User user =
+        post(
+            "users",
+            new CreateUser()
+                .withName(name)
+                .withEmail(name + "@test.openmetadata.org")
+                .withRoles(List.of(role.getId())),
+            User.class);
+    patch(
+        "tables/" + target.getId(),
+        "[{\"op\":\"add\",\"path\":\"/owners\",\"value\":[{\"id\":\""
+            + user.getId()
+            + "\",\"type\":\"user\"}]}]");
     return "Bearer "
         + JwtAuthProvider.tokenFor(user.getEmail(), user.getEmail(), new String[] {}, 3600);
   }
@@ -174,6 +225,22 @@ class AIContextRestIT extends McpTestBase {
         getResponse(
             "tables/name/" + table.getFullyQualifiedName() + "/context?format=json",
             sampleRestrictedToken);
+
+    assertThat(response.statusCode()).isEqualTo(200);
+    JsonNode context = OBJECT_MAPPER.readTree(response.body());
+    JsonNode sampleData = context.at("/assetContext/table/sampleData");
+    assertThat(sampleData.isMissingNode() || sampleData.isNull()).isTrue();
+  }
+
+  @Test
+  void tableContext_omitsSamplesForOwnerConditionedDeny() throws Exception {
+    assertThat(getResponse("tables/" + ownedTable.getId() + "/sampleData", ownerToken).statusCode())
+        .isEqualTo(403);
+
+    HttpResponse<String> response =
+        getResponse(
+            "tables/name/" + ownedTable.getFullyQualifiedName() + "/context?format=json",
+            ownerToken);
 
     assertThat(response.statusCode()).isEqualTo(200);
     JsonNode context = OBJECT_MAPPER.readTree(response.body());

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/AIContextRestIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/AIContextRestIT.java
@@ -16,17 +16,29 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.openmetadata.it.auth.JwtAuthProvider;
 import org.openmetadata.schema.api.data.CreateGlossary;
 import org.openmetadata.schema.api.data.CreateGlossaryTerm;
+import org.openmetadata.schema.api.policies.CreatePolicy;
+import org.openmetadata.schema.api.teams.CreateRole;
 import org.openmetadata.schema.api.teams.CreateTeam;
+import org.openmetadata.schema.api.teams.CreateUser;
 import org.openmetadata.schema.entity.data.Glossary;
 import org.openmetadata.schema.entity.data.GlossaryTerm;
 import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.entity.policies.Policy;
+import org.openmetadata.schema.entity.policies.accessControl.Rule;
+import org.openmetadata.schema.entity.teams.Role;
 import org.openmetadata.schema.entity.teams.Team;
+import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.type.MetadataOperation;
+import org.openmetadata.schema.type.TableData;
 
 /**
  * End-to-end test for the per-entity AI Context REST endpoint added to the {@code EntityResource}
@@ -40,6 +52,7 @@ class AIContextRestIT extends McpTestBase {
 
   private static Table table;
   private static String glossaryTermFqn;
+  private static String sampleRestrictedToken;
   private static String teamName;
 
   @BeforeAll
@@ -47,8 +60,54 @@ class AIContextRestIT extends McpTestBase {
     initAuth();
     String suffix = UUID.randomUUID().toString().substring(0, 8);
     table = createServiceDatabaseSchemaTable("aicontext_rest_" + suffix);
+    addSampleData(table);
+    sampleRestrictedToken = createSampleRestrictedToken(suffix);
     glossaryTermFqn = createGlossaryTerm(suffix);
     teamName = createTeam(suffix);
+  }
+
+  private static void addSampleData(Table target) throws Exception {
+    List<List<Object>> rows = new ArrayList<>();
+    for (int index = 0; index < 12; index++) {
+      rows.add(List.of(index, "name-" + index, "2026-09-04T00:00:00Z"));
+    }
+    TableData sampleData =
+        new TableData().withColumns(List.of("id", "name", "created_at")).withRows(rows);
+    put("tables/" + target.getId() + "/sampleData", sampleData, Table.class);
+  }
+
+  private static String createSampleRestrictedToken(String suffix) throws Exception {
+    Rule denySamples =
+        new Rule()
+            .withName("DenyViewSampleData")
+            .withResources(List.of("table"))
+            .withOperations(List.of(MetadataOperation.VIEW_SAMPLE_DATA))
+            .withEffect(Rule.Effect.DENY);
+    Policy policy =
+        post(
+            "policies",
+            new CreatePolicy()
+                .withName("aicontext_no_samples_policy_" + suffix)
+                .withRules(List.of(denySamples)),
+            Policy.class);
+    Role role =
+        post(
+            "roles",
+            new CreateRole()
+                .withName("aicontext_no_samples_role_" + suffix)
+                .withPolicies(List.of(policy.getFullyQualifiedName())),
+            Role.class);
+    String name = "aicontext_no_samples_" + suffix;
+    User user =
+        post(
+            "users",
+            new CreateUser()
+                .withName(name)
+                .withEmail(name + "@test.openmetadata.org")
+                .withRoles(List.of(role.getId())),
+            User.class);
+    return "Bearer "
+        + JwtAuthProvider.tokenFor(user.getEmail(), user.getEmail(), new String[] {}, 3600);
   }
 
   private static String createGlossaryTerm(String suffix) throws Exception {
@@ -103,6 +162,23 @@ class AIContextRestIT extends McpTestBase {
     assertThat(context.get("entityType").asText()).isEqualTo("table");
     assertThat(context.get("fullyQualifiedName").asText()).isEqualTo(table.getFullyQualifiedName());
     assertThat(context.has("assetContext")).isTrue();
+    JsonNode sampleData = context.at("/assetContext/table/sampleData");
+    assertThat(sampleData.get("columns").size()).isEqualTo(3);
+    assertThat(sampleData.get("rows").size()).isEqualTo(10);
+    assertThat(sampleData.get("rows").get(9).get(1).asText()).isEqualTo("name-9");
+  }
+
+  @Test
+  void tableContext_omitsSamplesWithoutViewSampleDataPermission() throws Exception {
+    HttpResponse<String> response =
+        getResponse(
+            "tables/name/" + table.getFullyQualifiedName() + "/context?format=json",
+            sampleRestrictedToken);
+
+    assertThat(response.statusCode()).isEqualTo(200);
+    JsonNode context = OBJECT_MAPPER.readTree(response.body());
+    JsonNode sampleData = context.at("/assetContext/table/sampleData");
+    assertThat(sampleData.isMissingNode() || sampleData.isNull()).isTrue();
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AIContextBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AIContextBuilder.java
@@ -54,6 +54,7 @@ import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.PartitionColumnDetails;
 import org.openmetadata.schema.type.Relationship;
 import org.openmetadata.schema.type.TableConstraint;
+import org.openmetadata.schema.type.TableData;
 import org.openmetadata.schema.type.TableJoins;
 import org.openmetadata.schema.type.TablePartition;
 import org.openmetadata.schema.type.TableProfile;
@@ -99,6 +100,7 @@ public class AIContextBuilder {
   private static final int MAX_KNOWLEDGE_ITEMS = 50;
   private static final int MAX_ARTICLES = 20;
   private static final int MAX_JOIN_HINTS = 25;
+  static final int MAX_SAMPLE_ROWS = 10;
   static final int MAX_COLUMN_MAPPINGS_PER_EDGE = 25;
 
   /** Upper bound on the model SQL inlined into a table's data-model context, in characters. */
@@ -866,15 +868,50 @@ public class AIContextBuilder {
     return item;
   }
 
-  private static AssetContext buildAssetContext(EntityInterface entity) {
+  private AssetContext buildAssetContext(EntityInterface entity) {
     AssetContext context = new AssetContext();
     if (entity instanceof Table table) {
-      context.withTable(buildTableContext(table));
+      context.withTable(buildTableContext(table).withSampleData(resolveSampleData(table)));
     }
     if (entity instanceof Metric metric) {
       context.withGeneric(buildMetricContext(metric));
     }
     return context;
+  }
+
+  private TableData resolveSampleData(Table table) {
+    if (authorizer == null || securityContext == null) {
+      return null;
+    }
+    TableRepository repository = (TableRepository) Entity.getEntityRepository(Entity.TABLE);
+    ResourceContext<Table> resourceContext = new ResourceContext<>(Entity.TABLE, table, repository);
+    try {
+      authorizer.authorize(
+          securityContext,
+          new OperationContext(Entity.TABLE, MetadataOperation.VIEW_SAMPLE_DATA),
+          resourceContext);
+      boolean canViewPii = authorizer.authorizePII(securityContext, resourceContext.getOwners());
+      return boundedSampleData(repository.getSampleData(table.getId(), canViewPii).getSampleData());
+    } catch (AuthorizationException e) {
+      LOG.debug("AIContext: sample data omitted for {}: permission denied", fqn);
+    } catch (RuntimeException e) {
+      LOG.warn("AIContext: failed to load sample data for {}: {}", fqn, e.getMessage());
+    }
+    return null;
+  }
+
+  static TableData boundedSampleData(TableData sampleData) {
+    if (sampleData == null) {
+      return null;
+    }
+    List<String> columns =
+        sampleData.getColumns() == null ? null : new ArrayList<>(sampleData.getColumns());
+    List<List<Object>> rows =
+        listOrEmpty(sampleData.getRows()).stream()
+            .limit(MAX_SAMPLE_ROWS)
+            .<List<Object>>map(row -> row == null ? null : new ArrayList<>(row))
+            .toList();
+    return new TableData().withColumns(columns).withRows(rows);
   }
 
   /**

--- a/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AIContextBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AIContextBuilder.java
@@ -884,7 +884,12 @@ public class AIContextBuilder {
       return null;
     }
     TableRepository repository = (TableRepository) Entity.getEntityRepository(Entity.TABLE);
-    ResourceContext<Table> resourceContext = new ResourceContext<>(Entity.TABLE, table, repository);
+    // Resolved by id rather than wrapping the already-loaded table: the pre-resolved constructor
+    // never runs resolveEntity(), so owners and domains would be absent (TABLE_FIELDS does not ask
+    // for them) and every owner- or domain-conditioned rule would misfire — including the PII
+    // decision below, which would mask an owner's own sample data.
+    ResourceContext<Table> resourceContext =
+        new ResourceContext<>(Entity.TABLE, table.getId(), null);
     try {
       authorizer.authorize(
           securityContext,

--- a/openmetadata-service/src/test/java/org/openmetadata/service/aicontext/AIContextBuilderTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/aicontext/AIContextBuilderTest.java
@@ -44,6 +44,7 @@ import org.openmetadata.schema.type.JoinedWith;
 import org.openmetadata.schema.type.LineageDetails;
 import org.openmetadata.schema.type.PartitionColumnDetails;
 import org.openmetadata.schema.type.TableConstraint;
+import org.openmetadata.schema.type.TableData;
 import org.openmetadata.schema.type.TableJoins;
 import org.openmetadata.schema.type.TablePartition;
 import org.openmetadata.schema.type.TableProfile;
@@ -624,5 +625,22 @@ class AIContextBuilderTest {
     assertEquals(1, context.getForeignKeys().size());
     assertEquals(1, context.getFrequentJoins().size());
     assertEquals(List.of("created_at"), context.getPartitionColumns());
+  }
+
+  @Test
+  void boundedSampleData_keepsColumnsAndOnlyFirstTenRows() {
+    List<List<Object>> rows = new ArrayList<>();
+    for (int index = 0; index < 12; index++) {
+      rows.add(new ArrayList<>(List.of(index, "value-" + index)));
+    }
+    TableData source = new TableData().withColumns(List.of("id", "value")).withRows(rows);
+
+    TableData bounded = AIContextBuilder.boundedSampleData(source);
+
+    assertEquals(List.of("id", "value"), bounded.getColumns());
+    assertEquals(10, bounded.getRows().size());
+    assertEquals(List.of(9, "value-9"), bounded.getRows().get(9));
+    rows.get(0).set(1, "mutated");
+    assertEquals("value-0", bounded.getRows().get(0).get(1));
   }
 }

--- a/openmetadata-spec/src/main/resources/json/schema/type/aiContext.json
+++ b/openmetadata-spec/src/main/resources/json/schema/type/aiContext.json
@@ -156,6 +156,10 @@
                 "dataModel": {
                     "description": "The dbt/DDL model that produces this table (type, path, and defining SQL), when available.",
                     "$ref": "#/definitions/tableDataModel"
+                },
+                "sampleData": {
+                    "description": "A permission-filtered preview of stored sample data, masked when the caller lacks PII access. The AI context returns at most 10 rows.",
+                    "$ref": "../entity/data/table.json#/definitions/tableData"
                 }
             },
             "additionalProperties": false

--- a/openmetadata-ui/src/main/resources/ui/src/generated/type/aiContext.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/type/aiContext.ts
@@ -257,6 +257,11 @@ export interface TableContext {
      */
     primaryKey?: string[];
     /**
+     * A permission-filtered preview of stored sample data, masked when the caller lacks PII
+     * access. The AI context returns at most 10 rows.
+     */
+    sampleData?: TableData;
+    /**
      * DDL for tables and views, when available.
      */
     schemaDefinition?: string;
@@ -327,6 +332,23 @@ export interface JoinHint {
      * Fully qualified name of the column this column is frequently joined with.
      */
     joinedWith?: string;
+}
+
+/**
+ * A permission-filtered preview of stored sample data, masked when the caller lacks PII
+ * access. The AI context returns at most 10 rows.
+ *
+ * This schema defines the type to capture rows of sample data for a table.
+ */
+export interface TableData {
+    /**
+     * List of local column names (not fully qualified column names) of the table.
+     */
+    columns?: string[];
+    /**
+     * Data for multiple rows of the table.
+     */
+    rows?: Array<any[]>;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/type/personaContext.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/type/personaContext.ts
@@ -355,6 +355,11 @@ export interface TableContext {
      */
     primaryKey?: string[];
     /**
+     * A permission-filtered preview of stored sample data, masked when the caller lacks PII
+     * access. The AI context returns at most 10 rows.
+     */
+    sampleData?: TableData;
+    /**
      * DDL for tables and views, when available.
      */
     schemaDefinition?: string;
@@ -425,6 +430,23 @@ export interface JoinHint {
      * Fully qualified name of the column this column is frequently joined with.
      */
     joinedWith?: string;
+}
+
+/**
+ * A permission-filtered preview of stored sample data, masked when the caller lacks PII
+ * access. The AI context returns at most 10 rows.
+ *
+ * This schema defines the type to capture rows of sample data for a table.
+ */
+export interface TableData {
+    /**
+     * List of local column names (not fully qualified column names) of the table.
+     */
+    columns?: string[];
+    /**
+     * Data for multiple rows of the table.
+     */
+    rows?: Array<any[]>;
 }
 
 /**


### PR DESCRIPTION
### Describe your changes:

Fixes #32600

Adds stored table samples to the structured per-entity AI context so SQL agents can inspect representative value shapes without first querying the warehouse.

The endpoint returns at most 10 rows, reuses the existing `ViewSampleData` authorization, and applies the same PII masking as `GET /tables/{id}/sampleData`. If the caller cannot view samples—or stored data cannot be loaded—the rest of `/context` still succeeds without sample rows.

Companion consumer: open-metadata/ai-platform#982.

#
### Type of change:

- [x] Improvement

#
### High-level design:

- Adds the optional typed `sampleData` field to `assetContext.table` in `aiContext.json` and regenerates dependent TypeScript models.
- Loads samples through `TableRepository.getSampleData(..., canViewPii)` after the same `ViewSampleData` and PII authorization checks used by `TableResource`.
- Defensively copies the payload and caps it at 10 rows before adding it to the context response.
- No migration is needed: this is an optional additive response field backed by the existing table sample-data extension; no persisted format changes.
- The default Markdown rendering is unchanged. The AI consumer reads the structured `?format=json` representation.

#
### Tests:

#### Use cases covered

- An authorized caller receives columns and only the first 10 of 12 stored rows.
- A caller with explicit `deny ViewSampleData` still receives the context response, without sample rows.
- The bounded copy is independent from the repository payload.

#### Unit tests

- [x] Updated `AIContextBuilderTest`; 35 tests passed.

#### Backend integration tests

- [x] Updated `AIContextRestIT`; 7 tests passed against the HTTP endpoint.

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Not applicable (generated types only; no UI behavior changes).

#### Manual testing performed

- `mvn -pl openmetadata-spec -am install -DskipTests`
- `mvn test -pl openmetadata-service -Dtest=AIContextBuilderTest -DfailIfNoTests=false`
- `mvn test -pl openmetadata-integration-tests -Dtest=AIContextRestIT -DfailIfNoTests=false`
- `mvn spotless:check`

#
### UI screen recording / screenshots:

Not applicable; there are no UI behavior changes.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [x] For UI changes: not applicable; generated types only.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

#### Improvement

- [x] I have added tests around the new logic.
- [x] For connector/ingestion changes: not applicable.
