### PR TITLE
perf(search): stop denormalizing columns onto chunk documents

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorDocBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorDocBuilder.java
@@ -53,7 +53,7 @@ public class VectorDocBuilder {
    * embedding-reuse backfill on the next Search Reindex — without forcing a re-embed (the
    * fingerprint is deliberately left untouched, see {@link #computeFingerprintForEntity}).
    */
-  public static final int CHUNK_DOC_VERSION = 3;
+  public static final int CHUNK_DOC_VERSION = 4;
 
   /**
    * Upper bound on the denormalized {@code description} copied onto each chunk doc. The full body
@@ -305,9 +305,10 @@ public class VectorDocBuilder {
    * <ul>
    *   <li>KNN filter fields ({@code entityType}, {@code deleted}, {@code tags}/{@code domains}/
    *       {@code tier}) — the original chunk-doc contract.
-   *   <li>Lexical parity: {@code description} (capped), {@code fqnParts}, {@code synonyms} and
-   *       {@code columns.name} so the shard-fair keyword clauses match on the best-semantic chunk,
-   *       not only on chunk 0's spliced entity doc.
+   *   <li>Lexical parity: {@code description} (capped), {@code fqnParts} and {@code synonyms} so the
+   *       shard-fair keyword clauses match on every chunk, not only on chunk 0's spliced entity
+   *       doc. Column names are deliberately not denormalized here: every chunk would carry the
+   *       entity's whole column list, and {@code textToEmbed} already carries them per chunk.
    *   <li>Filter parity: {@code owners}, {@code serviceType}, {@code service}/{@code database}/
    *       {@code databaseSchema} and {@code certification} so NLQ filters on those facets no longer
    *       exclude every chunk doc.
@@ -369,12 +370,6 @@ public class VectorDocBuilder {
         && term.getSynonyms() != null
         && !term.getSynonyms().isEmpty()) {
       fields.put("synonyms", new ArrayList<>(term.getSynonyms()));
-    }
-    if (entity instanceof Table table) {
-      List<Map<String, Object>> columns = columnNameObjects(table.getColumns());
-      if (!columns.isEmpty()) {
-        fields.put("columns", columns);
-      }
     }
     if (entity instanceof Metric metric) {
       addMetricFields(fields, metric);
@@ -480,19 +475,6 @@ public class VectorDocBuilder {
       }
     }
     return owners;
-  }
-
-  private static List<Map<String, Object>> columnNameObjects(List<Column> columns) {
-    if (columns == null || columns.isEmpty()) {
-      return Collections.emptyList();
-    }
-    List<Map<String, Object>> result = new ArrayList<>(columns.size());
-    for (Column column : columns) {
-      if (column.getName() != null) {
-        result.add(Map.of("name", column.getName()));
-      }
-    }
-    return result;
   }
 
   /**

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/VectorDocBuilderChunkTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/VectorDocBuilderChunkTest.java
@@ -159,9 +159,6 @@ class VectorDocBuilderChunkTest {
       assertNotNull(doc.get("description"), "description must be denormalized onto every chunk");
       assertTrue(doc.get("fqnParts") instanceof List, "fqnParts denormalized");
       assertTrue(((List<String>) doc.get("fqnParts")).containsAll(List.of("svc", "db", "sch")));
-      List<Map<String, Object>> columns = (List<Map<String, Object>>) doc.get("columns");
-      assertNotNull(columns);
-      assertEquals("amount", columns.get(0).get("name"));
       // Filter parity so NLQ facet filters don't exclude chunk docs.
       assertEquals("Snowflake", ((Map<String, Object>) doc.get("service")).get("displayName"));
       assertEquals("db", ((Map<String, Object>) doc.get("database")).get("name"));
@@ -371,5 +368,68 @@ class VectorDocBuilderChunkTest {
             memory(MemoryVisibility.SHARED, first, second)),
         VectorDocBuilder.computeFingerprintForEntity(
             memory(MemoryVisibility.SHARED, second, first)));
+  }
+
+  /**
+   * Chunk docs must not carry the denormalized {@code columns} array. It is shared once per entity
+   * and shallow-copied onto every chunk, so a wide table stores its whole column list
+   * {@code chunkCount} times — for a field no reader projects and which downstream search excludes
+   * from {@code _source}. Asserted on every doc, since the cost is the per-chunk repetition, not
+   * the field's presence on any one of them.
+   */
+  @Test
+  void fromEntity_doesNotDenormalizeColumnsOntoChunkDocs() {
+    Table table =
+        new Table()
+            .withId(UUID.randomUUID())
+            .withName("orders")
+            .withFullyQualifiedName("svc.db.sch.orders")
+            .withDescription("revenue ".repeat(900))
+            .withColumns(
+                List.of(
+                    new Column().withName("amount").withDataType(ColumnDataType.DOUBLE),
+                    new Column().withName("country").withDataType(ColumnDataType.STRING)));
+
+    List<Map<String, Object>> docs = VectorDocBuilder.fromEntity(table, new MockEmbeddingClient());
+    assertTrue(docs.size() > 1, "long body must yield multiple chunks");
+
+    for (Map<String, Object> doc : docs) {
+      assertFalse(
+          doc.containsKey("columns"),
+          "chunk " + doc.get("chunkIndex") + " must not carry a denormalized columns array");
+    }
+  }
+
+  /**
+   * Regression pin, not a red-green slice: this behavior is unchanged, so it cannot fail before the
+   * removal above. It guards the assumption that removal depends on — with the denormalized {@code
+   * columns} array gone, {@code textToEmbed} is the only thing carrying column names on a chunk
+   * doc, and it is a scored clause in the shard-fair lexical leg. If {@code buildSemanticBodyText}
+   * ever stops emitting them, column-name recall on chunk docs dies silently.
+   *
+   * <p>Caveat this does not cover: a {@link VectorDocBuilder.BodyTextExtractor} registered for
+   * {@code "table"} would bypass the default body text entirely. That cannot be asserted here —
+   * {@code BODY_TEXT_EXTRACTORS} is a static registry with no teardown, so registering a real
+   * {@code "table"} extractor would leak into every other test in the JVM run.
+   */
+  @Test
+  void textToEmbed_carriesColumnNames_soRemovingDenormalizedColumnsKeepsRecall() {
+    Table table =
+        new Table()
+            .withId(UUID.randomUUID())
+            .withName("orders")
+            .withDescription("sales data")
+            .withColumns(
+                List.of(
+                    new Column().withName("amount").withDataType(ColumnDataType.DOUBLE),
+                    new Column().withName("country").withDataType(ColumnDataType.STRING)));
+
+    String textToEmbed =
+        (String)
+            VectorDocBuilder.fromEntity(table, new MockEmbeddingClient()).get(0).get("textToEmbed");
+
+    assertNotNull(textToEmbed);
+    assertTrue(textToEmbed.contains("amount"), "textToEmbed must carry column names");
+    assertTrue(textToEmbed.contains("country"), "textToEmbed must carry column names");
   }
 }


### PR DESCRIPTION
## What

`buildDenormalizedFields` copied a table's entire `columns` array onto **every** chunk document of
that entity. This removes it, and bumps `CHUNK_DOC_VERSION` 3 → 4 so existing chunks are recognised
as stale.

No reader projects the field — consumers select a fixed set of display fields that does not include
it, and downstream search excludes `columns` from `_source`, so it is not even returned. It only
ever cost storage and indexing, paid `chunkCount` times over on a wide table.

It also could not do what its javadoc claimed — *"so the shard-fair keyword clauses match on the
best-semantic chunk"*. Because every chunk carried every column, the `columns.name` clause matched
all chunks of an entity identically and could never single one out. `textToEmbed` already provides
that discrimination per chunk.

## Why it is safe

`textToEmbed` becomes the only lexical carrier of column names on a chunk doc. It is built from
`buildSemanticBodyText`, which emits every column for a Table. A new regression test pins that
contract, since it is now load-bearing.

Entity documents are unaffected and still carry `columns`; they sit under the same
`dataAssetEmbeddings` alias, so column-name lookup has a second route regardless.

`columnsMapping()` is deliberately **left** in `buildChunkProperties`. A field cannot be removed from
a live mapping, and mapped-but-unwritten is harmless, so the change stays purely additive and
`applyChunkMappingUpgradeIfStale`'s `PUT _mapping` stays valid.

## Migration

The version bump does **not** rewrite anything on deploy. The mapping upgrade applies on the next
write; the document backfill is lazy. Two shapes:

- **Full-coverage reindex** (every vector-indexable type) stages a new chunk generation and rewrites
  everything in one run, reusing the live generation's stored vectors when the fingerprint is
  unchanged — no re-embedding.
- **Partial reindex** keeps the chunk index in place and rewrites only the entities it touches.

Note `fetchExistingChunkVectors` swallows failures at `LOG.debug` and returns an empty map, which
silently downgrades the migration to a full re-embed. Not introduced here, but this change is the
first to depend on that path at scale — worth raising separately.

## Verified against a live cluster

Reindexed a local OpenSearch instance on sample data and diffed every chunk document before and
after:

| check | result |
|---|---|
| documents dropped | **0** (609 pre-existing docs all present) |
| field mismatches across the 609 common docs | **0**, over all 23 surviving fields |
| embeddings byte-identical | **609 / 609** — vector reuse worked |
| entities that lost column-name reachability | **0**, across 14 probed column names |
| `columns` present | 405 docs → **0**; 210,729 stored column entries → **0** |
| `docVersion` | all documents at **4** |
| chunk index size | 4.6mb → **2.3mb** |

Byte-identical embeddings are the strongest signal: vectors are deterministic over `textToEmbed`, so
they independently confirm the embedded text was untouched by the removal.

Index-share percentages are deliberately omitted — the local dataset is not representative. The
portable figure is ~11.5 bytes per stored column entry (compressed, stored + inverted).

## Test plan

Full `openmetadata-service` unit suite: **943 classes, 8610 tests, 0 failures, 0 errors**.

- `VectorDocBuilderTest`, `VectorDocBuilderChunkTest`, `OpenSearchVectorServiceTest` — including
  `chunkMappingUpgradeBody_omitsKnnVectorButAddsDenormalizedFields`, which asserts the retained
  `columns` mapping.
- New: `fromEntity_doesNotDenormalizeColumnsOntoChunkDocs` asserts the field is absent on **every**
  chunk, not just chunk 0 — the defect was per-chunk repetition.
- New: `textToEmbed_carriesColumnNames_soRemovingDenormalizedColumnsKeepsRecall` pins the recall
  contract. Documented as a pin rather than a red-green slice, since the behavior is unchanged.

Fixes #32612
