### PR TITLE
Fixes #32610: let a slow Playwright shard finish instead of killing it

### DIFF
--- a/.github/scripts/evaluate_playwright_performance.py
+++ b/.github/scripts/evaluate_playwright_performance.py
@@ -152,10 +152,16 @@ BUDGET_TARGET_DETAILS: dict[str, dict[str, Any]] = {
     },
     # The planner packs shards to a 19-minute predicted budget
     # (COMMON_SHARD_BUDGET_MS in build_playwright_shards.py); 1500 s is that
-    # promise plus tail headroom. The hang-protection `timeout … 30m` wrapper
-    # in playwright-e2e-reusable.yml sits well above this on purpose: a shard
-    # between 25 and 30 minutes breaches the budget (signal) but still
-    # finishes, uploads results, and keeps the run green if tests passed.
+    # promise plus tail headroom. The hang-protection `timeout … 60m` wrapper
+    # in playwright-e2e-reusable.yml sits far above this on purpose: a shard
+    # over 25 minutes breaches the budget (signal) but still finishes, uploads
+    # results, and keeps the run green if tests passed. These two targets are
+    # the "this shard is too slow" alert — they annotate the run and upsert the
+    # tracked issue "Playwright CI over time budget". The wrapper is not an
+    # alert and must never be used as one: killing a slow shard destroys its
+    # blob report, so its tests read as never-executed and the merge-queue
+    # batch is ejected with no record of what passed (2026-09-04: 584 of 4464
+    # tests lost, 0 test failures, 27 batches ejected).
     "executionAtMostTwentyFiveMinutes": {
         "label": "Maximum shard execution",
         "phase_field": "executionSeconds",

--- a/.github/workflows/playwright-e2e-reusable.yml
+++ b/.github/workflows/playwright-e2e-reusable.yml
@@ -1242,7 +1242,7 @@ jobs:
     needs:
       [build, cache-keys, detect-changes, plan-playwright, prepare-playwright-fixture]
     runs-on: ubuntu-latest
-    # Budget breakdown: up to 30 min playwright hang-protection wrapper on
+    # Budget breakdown: up to 60 min playwright hang-protection wrapper on
     # the test step + ~5-8 min for setup (env, node, browser, bundle verify)
     # and teardown/artifact upload. The job clock must clear the inner
     # wrapper plus setup/teardown so a slow-but-finishing shard is never
@@ -1254,7 +1254,7 @@ jobs:
     # since `PW_ENVIRONMENT_SECONDS` was recorded before that step ran so the
     # 5-min env blocking gate couldn't fire. Keep those inner timeouts in
     # sync when adjusting this outer ceiling.
-    timeout-minutes: 40
+    timeout-minutes: 75
     # `warm_caches_only` runs the pipeline for its cache side effects alone;
     # the shards are what makes it expensive and they prove nothing on a commit
     # the merge queue already tested.
@@ -1550,13 +1550,35 @@ jobs:
           # ~19 min predicted; the 1500 s execution BUDGET is evaluated (and
           # signalled, never enforced) by evaluate_playwright_performance.py.
           # This wrapper exists solely so a truly wedged playwright process
-          # cannot hold the job until the 40-min job clock. It must stay well
-          # above the budget: at the old 25m it killed chromium-12 five
-          # seconds after its last test PASSED (run 32500973433 — one wedged
-          # retry teardown ate 9 min), destroying the results artifact and
-          # ejecting a green PR.
+          # cannot hold the job until the job clock.
+          #
+          # A shard that is merely SLOW must finish, not be killed. `timeout`
+          # SIGTERMs playwright before it writes its blob report, so the whole
+          # shard reports zero results, the coverage check flags every test on
+          # it as missing, and the batch is ejected — with no record of which
+          # tests passed. That has now happened twice for the same reason:
+          # run 32500973433 killed chromium-12 five seconds after its last
+          # test PASSED (one wedged retry teardown ate 9 min), and on
+          # 2026-09-04 runs 33862281607 and 33869395948 each lost the same
+          # 584 of 4464 planned tests (13.1%) to three shards clipped at
+          # exactly 1800 s while reporting 0 test failures. 27 consecutive
+          # merge_group batches were ejected and nothing merged for ~4 h.
+          #
+          # Raising 25m -> 30m was the previous response and did not hold,
+          # because the ceiling has to clear the actual tail and not the
+          # predicted one: under merge-queue contention the measured
+          # actual/predicted ratio reached 1.52 aggregate (median 1.59 per
+          # test) against 0.99 on an uncontended run of the SAME baseline. At
+          # a 19-min pack that tail needs ~29 min, i.e. the old wall sat
+          # inside the distribution it was meant to bound. 60m tolerates a
+          # 3.1x tail, so only a genuinely wedged process reaches it.
+          #
+          # Slow shards are not silent: exceeding the 1500 s budget already
+          # annotates the run and upserts the tracked issue "Playwright CI
+          # over time budget" via the `Signal Playwright budget breaches`
+          # step. Alert there, do not kill here.
           set +e
-          timeout --signal=TERM --kill-after=30s 30m \
+          timeout --signal=TERM --kill-after=30s 60m \
             npx playwright test "${project_args[@]}" "${files[@]}"
           test_exit=$?
           set -e


### PR DESCRIPTION
### Describe your changes:

Fixes #32610

The test step wraps Playwright in `timeout --signal=TERM --kill-after=30s 30m`. Playwright writes its blob report **at the end of a run**, so when that fires it SIGTERMs the process before anything is written and the shard uploads no results — the artifact is 341 bytes, just `ci-status.json`. `verify_playwright_coverage.py` then flags every test on that shard as missing, `render_playwright_summary.cjs:249` turns the failed step into an infrastructure issue, `core.setFailed` fails `playwright-summary`, and `ALLGREEN` ejects the batch — three PRs at a time at `maximumEntriesToMerge: 3`. **The tests that did run are never recorded, so there is nothing to show they passed.**

Two runs on 2026-09-04, both ejected:

| run | tests | failed | flake | dead shards | missing |
|---|---|---|---|---|---|
| [33862281607](https://github.com/open-metadata/OpenMetadata/actions/runs/33862281607) | 3881 | **0** | 0.23% | 17, 18, 19 | 584 / 4464 |
| [33869395948](https://github.com/open-metadata/OpenMetadata/actions/runs/33869395948) | 3881 | **0** | 0.26% | 17, 18, 19 | 584 / 4464 |

The missing sets are **byte-identical** — same 584 ids, jaccard 1.00. Shard packing is deterministic, so the same shards get the same content and are clipped at exactly 1800 s every time; the blind spot is the same 13.1% of the suite, not a random 13%. 27 consecutive `merge_group` batches were ejected and nothing merged for ~4 hours.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

**Raise the wall so a slow shard finishes and reports; keep the alert where it already is.**

- `timeout … 30m` → `60m`. Tolerates a 3.1x tail against the planner's 19-minute pack, so only a genuinely wedged process reaches it.
- `playwright-ci` `timeout-minutes: 40` → `75`. Load-bearing, not cosmetic: leaving it at 40 would just move the kill to the job clock and lose the results the same way. 60m wrapper + ~5-8 min setup + ~4 min upload needs the headroom (observed: `executionSeconds: 1801` → `elapsedBeforeUploadSeconds: 2050`).

**Why 30m was the wrong number, not just a small number.** Raising it 25m → 30m was the previous response to this exact failure — the comment above the wrapper records run 32500973433, where it killed `chromium-12` five seconds after its last test passed. That didn't hold because the ceiling has to clear the *actual* tail, not the predicted one. Measured per test against the **same** checked-in `timing-baseline.json` (`sourceRunId` 32744092683, 2026-08-24):

| run | tests | median actual/predicted | aggregate |
|---|---|---|---|
| [33857297197](https://github.com/open-metadata/OpenMetadata/actions/runs/33857297197) — `All Playwright budget targets met` | 4465 | **1.04** | **0.991** |
| [33869395948](https://github.com/open-metadata/OpenMetadata/actions/runs/33869395948) — 3 shards killed | 3881 | 1.59 | 1.518 |

Worth being explicit since it was the leading hypothesis: **the baseline is not stale.** It predicted the suite to within 1% four hours before the ejections, only 1.3% of its entries are dead titles, and 3.8% of current tests are untimed. The 1.59x belongs to the contended runs, not to the data — so refreshing the baseline would have been the wrong fix, and refreshing it *from* a contended run would have made things worse: ×1.52 asks for ~34 chromium shards against `COMMON_MAX_SHARDS = 28`, so it would clamp, over-provision permanently, and add the very concurrency that causes the 1.52x.

**Alternative rejected: tolerate the missing tests.** I first wrote a `--max-missing-percent` on the coverage verifier so a starved shard warns instead of gating. It unblocks, but it merges on 87% of the suite and — because the missing set is deterministic — silently retires the *same* 584 tests indefinitely behind a green check. That is the #32588 pattern (retries laundering failures into invisible green) through a different door. Discarded in favour of letting the shard finish.

**Slow shards stay visible.** `executionAtMostTwentyFiveMinutes` (1500 s) and `shardsAtMostThirtyMinutesBeforeUpload` (1800 s) are already non-blocking BUDGET targets that annotate the run and upsert the tracked issue "Playwright CI over time budget". Those are the "this shard is too slow" alert. The wrapper never was one, and the comment in `evaluate_playwright_performance.py` now says so.

Also relevant but out of scope here: `maximumEntriesToBuild` was 5, and ejection-driven re-queues had 22 `merge_group` Playwright fleets live simultaneously (~770 jobs, each standing up its own Postgres + OpenSearch + OM server). Reduced to 2 separately. That reduces the tail; this PR stops the tail from destroying results.

Follow-ups are enumerated on #32610 — the main one being `globalTimeout` in `playwright.config.ts`, which is currently unset and is what would let an over-budget shard degrade to "green but incomplete" with a usable `missingTestIds` list instead of a 341-byte artifact.

#
### Tests:

#### Use cases covered
- A shard that needs more than 30 minutes runs to completion, writes its blob, and reports its passes instead of being SIGTERMed into a 341-byte artifact.
- A shard over 25 min still breaches the budget targets, annotates the run, and upserts the tracked issue — without gating.
- A genuinely wedged process is still killed, at 60 min, before the 75-min job clock.

#### Unit tests
Not applicable — no product code. Existing coverage for the touched script:

```
$ python3 -m pytest .github/scripts/tests/ -q
139 passed in 4.09s
```

#### Backend integration tests
Not applicable — no backend changes.

#### Ingestion integration tests
Not applicable — no ingestion changes.

#### Playwright (UI) tests
Not applicable — no test or product change; this is Playwright CI configuration. The change is exercised by the next `merge_group` run of the full suite.

#### Manual testing performed
CI-only change, verified against the workflow and the recorded artifacts rather than a local stack:

1. Traced the failure end to end: `##[error]Process completed with exit code 124` (124 = `timeout`) on `chromium-17/18/19`, each with `executionSeconds` 1800/1801 against a 1500 s budget, and `playwright-results-json-chromium-{17,18,19}` at 341-342 bytes versus ~25 KB for shards that finished.
2. Confirmed the gate chain by finding the failing step — `Render consolidated job summary and gate on results` — and the message `Playwright coverage mismatch: 584 missing, 0 unexpected, 0 duplicate plans, and 0 duplicate executions`. Note `Verify Playwright timing coverage` is `continue-on-error: true`, so the gate is downstream in the renderer, not in the verifier step.
3. Downloaded `playwright-coverage.json` from both ejections and diffed `missingTestIds`: 584 each, intersection 584, jaccard 1.00.
4. Computed the ratio tables above from `playwright-timing-history.json` (per-test `durationMs` + `retryDurationMs`) against `percentile_75` of the baseline's `durationMs` for the same `(file, title)` — the same key the planner uses.
5. Established it was not the PR under test and not this change: all five runs in the 11:44 batch failed, `chromium-19` died in 5 of 5 across four branches, and every control had 3-4 *real* test failures where the ejected PR had 0.
6. Checked the arithmetic on the new job clock against observed phases (`environmentSeconds: 219`, `executionSeconds: 1801`, `elapsedBeforeUploadSeconds: 2050`).
7. Validated both workflows parse and the new values are live:
   ```
   playwright-e2e-reusable.yml OK jobs= 10
   playwright-postgresql-e2e.yml OK jobs= 3
   playwright-ci timeout-minutes = 75
   1581:  timeout --signal=TERM --kill-after=30s 60m \
   ```
8. `python3 -m py_compile .github/scripts/evaluate_playwright_performance.py` and the full script test suite (139 passed).

#
### UI screen recording / screenshots:

Not applicable — CI configuration only, no UI change.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas — the wrapper comment records why 30m failed, the measured tail ratios, and that the budget targets rather than the wrapper are the alert.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing — as far as this admits one. The defect is a timeout constant in a GitHub Actions job; reproducing it in a test would mean running a 30-minute shard under runner contention. The regression evidence is the recorded artifacts cited above, and the run ids are in the code comment so the next person to consider lowering this number finds the two incidents first.

> **Note for the reviewer:** this needs to bypass the merge queue. The queue is the thing it fixes — it has ejected 27 consecutive batches and merged nothing for ~4 hours, so this PR cannot land through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)