### PR TITLE
Fixes #32613: stop setup-uv caching into dead merge-queue scopes

### DIFF
--- a/.github/actions/setup-openmetadata-test-environment/action.yml
+++ b/.github/actions/setup-openmetadata-test-environment/action.yml
@@ -99,9 +99,26 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
+    # enable-cache is gated off for merge_group. A queue run's cache is scoped
+    # to its gh-readonly-queue ref, which GitHub deletes the moment the entry
+    # merges or is dequeued, so the entry is unreachable by every later run
+    # while still charged against the repo's 10 GB LRU budget — where it evicts
+    # the main-scoped copies runs do restore from. setup-uv's `auto` default
+    # skips non-hosted runners, tag pushes, pull_request_target, workflow_run
+    # and release, but not merge_group (upstream src/utils/inputs.ts
+    # getEnableCache).
+    #
+    # Nothing is lost by not writing: no setup-uv entry is main-scoped, so queue
+    # runs already miss and install from scratch. Measured 2026-09-04, this was
+    # 3.3 GB across 19 dead queue-ref entries — 35% of the budget — and it was
+    # evicting the assets populate-playwright-caches.yml warms 6-hourly within
+    # 15 minutes of them being written. Same reasoning as the merge_group save
+    # gates in playwright-e2e-reusable.yml; see #32613.
     - name: Install uv
       if: ${{ inputs.fast-mode != 'true' && inputs.lightweight-ingestion != 'true' }}
       uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: ${{ github.event_name != 'merge_group' }}
 
     # Cache the ingestion Python venv across runs. Key on the *resolved*
     # Python patch version (setup-python may resolve "3.10" to a different

--- a/.github/workflows/prune-ephemeral-caches.yml
+++ b/.github/workflows/prune-ephemeral-caches.yml
@@ -21,10 +21,15 @@
 # in four ~1.28 GB ingestion images on queue refs, three of them already dead.
 #
 # playwright-e2e-reusable.yml no longer saves from merge_group, which stops the
-# Playwright assets accumulating. This workflow is the backstop: third-party
-# actions (setup-uv, cache-apt-pkgs) save unconditionally and cannot be gated
-# from the workflow, and it also clears whatever was stranded before that
-# change landed.
+# Playwright assets accumulating, and setup-uv is now gated the same way (it
+# does take an `enable-cache` input — the earlier note here claiming otherwise
+# was wrong, and it cost 3.3 GB across 19 dead queue refs). This workflow is
+# the backstop for what still cannot be gated — cache-apt-pkgs has no such
+# input — and it clears whatever was stranded before those changes landed.
+#
+# Note the backstop alone cannot win: it runs every 30 minutes while the queue
+# writes continuously, so 19 setup-uv entries came back within 19 minutes of
+# run 33878696968 deleting them. Prefer gating a save over pruning it.
 #
 # SAFETY: a cache is deleted only when its ref no longer resolves. Entries
 # still in the queue keep their caches, so an in-flight run is never forced


### PR DESCRIPTION
### Describe your changes:

Fixes #32613

A `merge_group` run's cache is scoped to its `gh-readonly-queue/main/pr-N-<sha>` ref, which GitHub deletes the moment the entry merges or is dequeued. The entry is then **unreachable by every later run** but still charged against the repo's 10 GB LRU budget, where it evicts the main-scoped copies runs *do* restore from. #32605 gated the Playwright saves for exactly this reason; `setup-uv` was left behind because `prune-ephemeral-caches.yml` recorded it as ungateable.

It is not. `setup-uv` takes an `enable-cache` input, and its `auto` default skips non-hosted runners, tag pushes, `pull_request_target`, `workflow_run` and `release` — **but not `merge_group`** (upstream `src/utils/inputs.ts`, `getEnableCache`). The step passed no `with:` block at all, so it cached on every queue run.

#
### Type of change:
- [x] Improvement

#
### High-level design:

N/A — two files, one of them a comment correction.

The change is `enable-cache: ${{ github.event_name != 'merge_group' }}` on the one `astral-sh/setup-uv` step in `.github/actions/setup-openmetadata-test-environment/action.yml`. `enable-cache` is read with `core.getInput`, compared against `"auto"` and otherwise `=== "true"`, so the expression rendering `"false"` disables it correctly.

**Why gate rather than prune.** `prune-ephemeral-caches.yml` already deletes these — it filters by ref prefix, so `setup-uv` is in scope, and it is working. It just cannot win: it runs every 30 minutes while five concurrent queue entries each write three Python versions. Run 33878696968 deleted them at 13:33 and 19 entries were back by 13:52. Its header is corrected to record that, and to retract the claim that the action cannot be gated.

**Alternative rejected: warm a main-scoped `setup-uv` entry instead.** That would give queue runs a real hit rather than just stopping the waste, and is worth doing separately, but it does not fix this: the eviction pressure is what stops any warmed entry surviving, so the gate has to come first.

**Not addressed, deliberately.** `cache-apt-pkgs` genuinely has no equivalent input, and at 41 MB it is noise — the prune header now scopes its "cannot be gated" claim to it alone. The 1190 MB of `buildkit-blob` and 700 MB of `node-cache` sit on `refs/pull/*` scopes the prune does not cover; separate problem, separate change.

#
### Tests:

#### Use cases covered
- A `merge_group` run no longer writes a `setup-uv` cache entry it can never read back.
- `pull_request`, `push` and `schedule` runs keep the cache behaviour they have today.
- The 6-hourly `populate-playwright-caches.yml` warm can survive long enough for a queue entry to restore from it.

#### Unit tests
Not applicable — no product code. The change is one GitHub Actions input expression.

Verified instead against upstream behaviour and measured repo state:

| check | result |
|---|---|
| `enable-cache` input exists in `astral-sh/setup-uv@v7` | yes — `action.yml:35`, default `auto` |
| how it is parsed | `core.getInput("enable-cache")`, `=== "auto"` branch, else `=== "true"` — so `"false"` disables |
| does `auto` already exclude `merge_group`? | **no** — excludes only non-hosted runners, tag push, `pull_request_target`, `workflow_run`, `release` |
| `yaml.safe_load` on both changed files | parses |
| main-scoped `setup-uv` entries before this change | **0** — so no queue run loses a hit it currently gets |

#### Backend integration tests
Not applicable — no backend changes.

#### Ingestion integration tests
Not applicable — no ingestion source changes. The composite action this touches *is* used by the ingestion test jobs, so those jobs exercise it on this PR: a `pull_request` run keeps `enable-cache` on, and the queue run for this PR will exercise the gated path.

#### Playwright (UI) tests
Not applicable — no UI changes.

#### Manual testing performed
Measured with the Actions cache API rather than by hand in the UI:

1. `gh api repos/open-metadata/OpenMetadata/actions/cache/usage` → `active_caches=26, size=9.28 GB` against the 10 GB cap.
2. Grouped every entry by key family and ref scope:

   ```
   3279 MB  19 entries  queue-ref  setup-uv      <- 35% of the budget
   1250 MB   3 entries  pr-ref     Linux-maven
   1206 MB   1 entries  main       yarn-pkg-cache
   1190 MB   7 entries  pr-ref     buildkit-blob
    878 MB   2 entries  main       codeql
    700 MB   1 entries  pr-ref     node-cache
   ```

   All 19 `setup-uv` entries on `gh-readonly-queue/*`; none main-scoped.
3. Confirmed the eviction end to end. Warm run 33876071256 finished 13:37 and its `build` job logged saves for `playwright-distribution-v2-*`, `ui-dist-v1-Linux-pw-e2e-bundle-*` and `Linux-maven-*`. At 13:52 the first two were **0 entries repo-wide**, and the 1287 MB `playwright-ingestion-image-v2-*` and 53 MB `playwright-golden-fixture-v2-*` were gone from main scope too.
4. Read prune run 33878696968 (13:33): it correctly deleted ~28 dead entries including two 1005 MB `Linux-maven` and several 406 MB `setup-uv`, then 19 `setup-uv` entries reappeared within 19 minutes.
5. Read the upstream `getEnableCache` source to confirm `merge_group` is not in the `auto` exclusion list.

**How to confirm this worked after merge:** compare `active_caches_size_in_bytes` before/after a few queue entries, and check that the `playwright-distribution-v2-*` / `ui-dist-v1-*` keys written by the 6-hourly warm are still present when the next `merge_group` run asks for them. Expect the `setup-uv` queue-ref families to stop appearing.

#
### UI screen recording / screenshots:

Not applicable — no UI changes.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Improvement -->
- [x] I have added tests around the new logic — not applicable in the unit-test sense; the verification table above is the evidence, and CI on this PR exercises both the gated and ungated paths.
- [x] For connector/ingestion changes: not applicable.