### PR TITLE
Fixes #32617: scope Playwright route interception to the cached paths

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/serverLoad.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/serverLoad.ts
@@ -364,8 +364,11 @@ export const installServerLoadReducers = async (context: BrowserContext) => {
 
   installed.add(context);
 
+  // Guarded like the two below: analytics beacons are fired on navigation and
+  // unload, so a `fulfill` here is more likely than either of them to land on a
+  // page that is already going away.
   await context.route(ANALYTICS_COLLECT, (route) =>
-    route.fulfill({ status: 200, body: '' })
+    ignoreClosedTarget(() => route.fulfill({ status: 200, body: '' }))
   );
 
   await context.route(CACHEABLE_BOOT_PATTERN, (route) =>

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/serverLoad.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/serverLoad.ts
@@ -171,8 +171,41 @@ const pathnameOf = (url: string) => {
   }
 };
 
-const isCacheableBootRequest = (url: URL) =>
-  CACHEABLE_BOOT_PATHS.includes(url.pathname);
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * The matcher has to be a RegExp rather than the obvious
+ * `(url) => CACHEABLE_BOOT_PATHS.includes(url.pathname)`, because Playwright
+ * cannot push a predicate into the browser:
+ *
+ * ```js
+ * // playwright-core/lib/client/network.js
+ * static prepareInterceptionPatterns(handlers) {
+ *   ...
+ *   if (isString(handler.url))      patterns.push({ glob: handler.url });
+ *   else if (isRegExp(handler.url)) patterns.push({ regexSource: ..., regexFlags: ... });
+ *   else                            all = true;
+ *   if (all) return [{ glob: '**\/*' }];
+ * }
+ * ```
+ *
+ * One predicate handler sets `all`, and the whole context then intercepts
+ * every request. Measured on merge_group runs of #32594, that cost the suite
+ * ~7% wall-clock and +15.6 GB of asset traffic: ~29k requests a shard
+ * round-tripped through the Node driver instead of ~8.5k, and intercepted
+ * requests miss the browser's HTTP cache (`static:304` 4,151 -> 2,239 while
+ * `static:200` rose 22.3k). A RegExp is forwarded as `regexSource`, so the
+ * browser pauses only these paths.
+ *
+ * Matched against the full URL, since that is what `urlMatches` tests a RegExp
+ * against. `[^?#]*` cannot cross a `?`, so a path that appears inside a query
+ * string is not mistaken for the path itself, and the trailing `(?:[?#]|$)`
+ * keeps `/system/config/auth` from matching `/system/config/authorizer`.
+ */
+const CACHEABLE_BOOT_PATTERN = new RegExp(
+  `^[^?#]*(?:${CACHEABLE_BOOT_PATHS.map(escapeRegExp).join('|')})(?:[?#]|$)`
+);
 
 /**
  * The cache is per worker and a worker runs many identities, so the caller's
@@ -254,12 +287,17 @@ const serveBootConfig = async (route: Route) => {
  *
  * Serving them from a per-worker cache fixes the server side, but it routes
  * ~26k requests per shard through the Playwright driver, and that per-request
- * overhead could plausibly cost more wall-clock than the saved bytes. Off by
- * default until measured: set PW_CACHE_STATIC_ASSETS=true to A/B it in CI.
+ * overhead could plausibly cost more wall-clock than the saved bytes. The
+ * merge_group measurement behind CACHEABLE_BOOT_PATTERN says it does: the same
+ * ~29k requests a shard, intercepted only so a predicate could reject them,
+ * cost ~7% wall-clock. So this stays off by default and now has a reason
+ * rather than a caveat. Set PW_CACHE_STATIC_ASSETS=true to A/B it in CI.
  */
 const cacheStaticAssets = process.env.PW_CACHE_STATIC_ASSETS === 'true';
+// Same full-URL form as CACHEABLE_BOOT_PATTERN, so it can be handed to
+// `context.route` directly instead of through a predicate.
 const STATIC_ASSET =
-  /\/assets\/.+\.(?:js|mjs|css|woff2?|png|svg|jpe?g|gif|ico|webp)$/;
+  /^[^?#]*\/assets\/[^?#]+\.(?:js|mjs|css|woff2?|png|svg|jpe?g|gif|ico|webp)(?:[?#]|$)/;
 
 const MAX_CACHED_ASSETS = 512;
 const assetCache = new Map<string, CachedResponse>();
@@ -330,15 +368,13 @@ export const installServerLoadReducers = async (context: BrowserContext) => {
     route.fulfill({ status: 200, body: '' })
   );
 
-  await context.route(
-    (url) => isCacheableBootRequest(url),
-    (route) => ignoreClosedTarget(() => serveBootConfig(route))
+  await context.route(CACHEABLE_BOOT_PATTERN, (route) =>
+    ignoreClosedTarget(() => serveBootConfig(route))
   );
 
   if (cacheStaticAssets) {
-    await context.route(
-      (url) => STATIC_ASSET.test(url.pathname),
-      (route) => ignoreClosedTarget(() => serveStaticAsset(route))
+    await context.route(STATIC_ASSET, (route) =>
+      ignoreClosedTarget(() => serveStaticAsset(route))
     );
   }
 


### PR DESCRIPTION
### Describe your changes:

Fixes #32617

#32594 cut Playwright API calls by 21.3%, and the merge-queue measurement confirms that part: 407,362 -> 320,606 per suite run with work held constant (uiScenarios -0.2%, appBoots -0.0%). But it also made the suite **7% slower**, because the boot-config cache is installed with a predicate matcher and Playwright cannot push a predicate into the browser — one predicate handler switches the whole context to intercepting `**/*`. ~29k requests a shard round-trip through the Node driver only to be rejected, and intercepted requests miss the browser's HTTP cache. This scopes the interception to the paths the cache actually serves, so the API saving stops being paid for in wall-clock.

Follows #32594, now merged (`90e9a784`); this branch is rebased onto it and the diff is the one file below.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

`playwright-core/lib/client/network.js` (1.57.0):

```js
static prepareInterceptionPatterns(handlers) {
  const patterns = [];
  let all = false;
  for (const handler of handlers) {
    if (isString(handler.url))      patterns.push({ glob: handler.url });
    else if (isRegExp(handler.url)) patterns.push({ regexSource: ..., regexFlags: ... });
    else                            all = true;
  }
  if (all) return [{ glob: "**/*" }];
  return patterns;
}
```

A string or RegExp is forwarded to the browser and pre-filters there; anything else sets `all`. `urlMatch.js:99-102` shows a RegExp is tested against the **full URL**, not the pathname, which is the only behavioural difference to account for.

`isCacheableBootRequest` was exact-pathname membership over a 10-entry list, so it maps to a RegExp derived from that same list — `CACHEABLE_BOOT_PATHS` stays the single source of truth, and adding a path still only means editing the list:

```ts
const CACHEABLE_BOOT_PATTERN = new RegExp(
  `^[^?#]*(?:${CACHEABLE_BOOT_PATHS.map(escapeRegExp).join('|')})(?:[?#]|$)`
);
```

Two guards matter now that matching is against a whole URL rather than a parsed pathname:

- `^[^?#]*` cannot cross a `?`, so `/api/v1/tables?fields=/api/v1/system/version` is not mistaken for `/api/v1/system/version`. The old code got this for free by reading `url.pathname`.
- the trailing `(?:[?#]|$)` keeps `/system/config/auth` from matching `/system/config/authorizer` — both are in the list, and a bare alternation would have the shorter one win.

`STATIC_ASSET` gets the same treatment so the `PW_CACHE_STATIC_ASSETS` branch can pass it to `context.route` directly instead of wrapping it in `(url) => STATIC_ASSET.test(url.pathname)`. It was `/\/assets\/.+\.(?:js|…)$/`, unanchored with a greedy `.+`, which as a full-URL pattern would match `/x?q=/assets/a.js`; it is now anchored with the same `^[^?#]*` and `[^?#]+`.

Behaviour is otherwise unchanged: matching is method-agnostic either way, `serveBootConfig` still falls back on non-GET, and a query string never affected `url.pathname`, so the set of matched requests is the same.

The static-asset comment said the driver overhead "could plausibly cost more wall-clock than the saved bytes". It does, and the comment now says so with the number instead of hedging.

#
### Tests:

#### Use cases covered
- The same requests are intercepted as before, including the `auth` / `authorizer` prefix pair and paths carrying a query string.
- A cacheable path appearing inside a query string is not intercepted — a new failure mode introduced by matching full URLs, guarded explicitly.
- Assets are still matched under `PW_CACHE_STATIC_ASSETS=true`, and `/app-worker.js` and `/assets/a.json` still are not.

#### Unit tests
Not applicable, for the same structural reason as #32594: jest is `roots: ['<rootDir>/src']` and Playwright's `testDir` is `./playwright/e2e`, so `playwright/support/` has no CI-run test home. The one that exists — `yarn test:eslint-rules`, which does run in `ui-checkstyle` — is globbed to `playwright/eslint-rules/tests/**`, and putting a matcher test there to borrow its runner would be the wrong directory.

Verified instead against a 21-case URL matrix over the real `CACHEABLE_BOOT_PATHS`, all passing:

| URL | expected | 
|---|---|
| `/api/v1/system/version` | match |
| `/api/v1/system/config/auth` | match |
| `/api/v1/system/config/authorizer` | match |
| `/api/v1/system/config/auth?x=1` | match |
| `/api/v1/system/config/auth#f` | match |
| `/api/v1/system/config/authX` | no match |
| `/api/v1/system/versionable` | no match |
| `/api/v1/tables?fields=/api/v1/system/version` | no match |
| `/api/v1/permissions` | no match |
| `/api/v1/system/settings/customUiThemePreference` | no match (only `config/` is cached) |
| `/assets/Foo-abc123.js`, `.css`, `.woff2`, `.woff`, `.webp`, `a.js?v=2` | match |
| `/app-worker.js`, `/assets/a.json`, `/x?q=/assets/a.js` | no match |

CI is also a check on this: the matcher under-matching shows up as `apiRequests` returning toward ~407k in `request-metrics.json`, and over-matching shows up as a stale config read failing a spec.

#### Backend integration tests
Not applicable — no backend changes.

#### Ingestion integration tests
Not applicable.

#### Playwright (UI) tests
No spec changes. One file touched: `playwright/support/fixtures/serverLoad.ts`.

| check | result |
|---|---|
| `tsc --noEmit -p playwright/tsconfig.json` | 0 errors in `serverLoad.ts` (166 project errors, unchanged from main) |
| CI lint sequence replayed (organize-imports -> eslint --fix -> prettier) | fixed point, 0 eslint errors |
| `prettier --check` | clean |

#### Manual testing performed
1. Aggregated `request-metrics.json` and `shard-phases.json` across all shards of ten complete merge_group runs — five containing `serverLoad.ts` and five not, four minutes apart on the same runners — which is where every number in #32617 comes from.
2. Ruled out retries as the cause of the +7% by comparing per-run `results-json` artifacts: the changed run had fewer retries and fewer failures with the same pass count.
3. Confirmed the mechanism in the installed `playwright-core@1.57.0` rather than from the docs, at `prepareInterceptionPatterns` and `urlMatches`.
4. Ran the 21-case URL matrix above against the pattern built from the real list.

**Not re-measured after the fix** — that needs a merge_group run of this branch, and it is the thing to check before considering #32617 closed. The removed overhead should recover the +7%; whether the -21.3% API saving then shows up as a net *win* is a separate question, since it was only worth ~12.5 s of server time per shard.

#
### UI screen recording / screenshots:

Not applicable — no product UI changes.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

