### PR TITLE
Minor improvement: send Java nightly Slack notifications only on failure

### DIFF
--- a/.github/workflows/java-playwright-nightly.yml
+++ b/.github/workflows/java-playwright-nightly.yml
@@ -403,14 +403,16 @@ jobs:
           fail_on_test_failures: false
           report_paths: 'openmetadata-integration-tests/target/failsafe-reports/TEST-*.xml'
 
+      # Failures only: a green nightly is the expected case and notifying on it trains
+      # the channel to ignore the alert.
       - name: Slack notification
-        if: ${{ always() && github.event_name != 'pull_request' && env.SLACK_JAVA_PLAYWRIGHT_URL != '' }}
+        if: ${{ failure() && github.event_name != 'pull_request' && env.SLACK_JAVA_PLAYWRIGHT_URL != '' }}
         uses: slackapi/slack-github-action@v4.0.0
         with:
           webhook: ${{ env.SLACK_JAVA_PLAYWRIGHT_URL }}
           webhook-type: incoming-webhook
           payload: |
-            text: "${{ job.status == 'success' && ':white_check_mark:' || ':fire:' }} Java Playwright Nightly (${{ matrix.searchEngine }}): ${{ job.status }}\nRef: ${{ github.ref_name }}\nLogs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            text: ":fire: Java Playwright Nightly (${{ matrix.searchEngine }}): ${{ job.status }}\nRef: ${{ github.ref_name }}\nLogs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_JAVA_PLAYWRIGHT_URL: ${{ secrets.SLACK_JAVA_PLAYWRIGHT_URL }}
 
@@ -491,14 +493,16 @@ jobs:
           fail_on_test_failures: false
           report_paths: 'openmetadata-integration-tests/target/failsafe-reports/TEST-*.xml'
 
+      # Failures only: a green nightly is the expected case and notifying on it trains
+      # the channel to ignore the alert.
       - name: Slack notification
-        if: ${{ always() && github.event_name != 'pull_request' && env.SLACK_JAVA_PLAYWRIGHT_URL != '' }}
+        if: ${{ failure() && github.event_name != 'pull_request' && env.SLACK_JAVA_PLAYWRIGHT_URL != '' }}
         uses: slackapi/slack-github-action@v4.0.0
         with:
           webhook: ${{ env.SLACK_JAVA_PLAYWRIGHT_URL }}
           webhook-type: incoming-webhook
           payload: |
-            text: "${{ job.status == 'success' && ':white_check_mark:' || ':fire:' }} Java Search ITs Nightly: ${{ job.status }}\nRef: ${{ github.ref_name }}\nLogs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            text: ":fire: Java Search ITs Nightly: ${{ job.status }}\nRef: ${{ github.ref_name }}\nLogs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_JAVA_PLAYWRIGHT_URL: ${{ secrets.SLACK_JAVA_PLAYWRIGHT_URL }}
 


### PR DESCRIPTION
### Describe your changes:

Both Slack steps in `.github/workflows/java-playwright-nightly.yml` — `ui-it-nightly` (per search engine) and `search-it-nightly` — ran under `always()`, so the channel got a ping on every nightly run including green ones. A nightly success notification is the expected case; posting it trains everyone to ignore the alert. Switched both to `failure()` and dropped the now-dead `:white_check_mark:` branch from the payload.

No issue filed — trivial CI notification tweak.

#
### Type of change:
- [x] Improvement

#
### High-level design:

N/A — small change, 2 lines of condition in one workflow file.

#
### Tests:

#### Use cases covered
- Nightly `ui-it-nightly` / `search-it-nightly` job fails → Slack alert posted with `:fire:` and the run URL
- Nightly job succeeds → no Slack message
- Job cancelled or timed out → no Slack message (`failure()` is false for cancellations)
- PR-triggered run → still no Slack message (unchanged `github.event_name != 'pull_request'` guard)

#### Unit tests
Not applicable — GitHub Actions workflow condition, no application code changed. Verified the file still parses as YAML.

#### Backend integration tests
Not applicable (no backend API changes).

#### Ingestion integration tests
Not applicable (no ingestion changes).

#### Playwright (UI) tests
Not applicable (no UI changes).

#### Manual testing performed
1. `ruby -ryaml -e 'YAML.load_file(...)'` → workflow YAML valid
2. Confirmed both `Slack notification` steps now read `if: ${{ failure() && github.event_name != 'pull_request' && env.SLACK_JAVA_PLAYWRIGHT_URL != '' }}`
3. Confirmed the surrounding `always()` steps (artifact upload, test report publish, cleanup) are untouched

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)