### PR TITLE
fix(playwright): renderer-side fallback for flat single-shard downloads (backport #30523 to 2.0)

### DIFF
--- a/.github/scripts/render_playwright_summary.cjs
+++ b/.github/scripts/render_playwright_summary.cjs
@@ -210,6 +210,32 @@ async function renderPlaywrightSummary({ github, context, core }) {
 
   const shardResults = [];
   const resultsDir = 'results';
+
+  // actions/download-artifact@v5+ flattens the archive contents directly
+  // into `resultsDir` when the `pattern:` matches only ONE artifact —
+  // typical for impact-selected / spec-only PRs that plan a single
+  // chromium shard. The loops below assume the per-artifact subdirectory
+  // layout (`resultsDir/playwright-results-json-<shardId>/results.json`),
+  // so migrate the flat files into the expected subdirectory when we
+  // detect it. Multi-shard runs are untouched because they always land
+  // in the per-subdirectory layout.
+  if (
+    fs.existsSync(path.join(resultsDir, 'results.json')) &&
+    expectedShards.length === 1
+  ) {
+    const subDir = path.join(
+      resultsDir,
+      `playwright-results-json-${expectedShards[0]}`
+    );
+    fs.mkdirSync(subDir, { recursive: true });
+    for (const file of ['results.json', 'ci-status.json']) {
+      const from = path.join(resultsDir, file);
+      if (fs.existsSync(from)) {
+        fs.renameSync(from, path.join(subDir, file));
+      }
+    }
+  }
+
   if (fs.existsSync(resultsDir)) {
     for (const dir of fs.readdirSync(resultsDir).sort()) {
       const jsonPath = path.join(resultsDir, dir, 'results.json');


### PR DESCRIPTION
Backport of the renderer fix from #30523 (main commit 75aa1ced301) to `2.0`.

**Why**: on `2.0`, any PR whose Playwright plan resolves to a single shard fails `playwright-summary` with:

- `Shard chromium-01 did not upload a usable Playwright results artifact.`
- `Shard chromium-01 did not upload its execution status.`

Root cause: `actions/download-artifact` flattens the archive into `results/` when the `pattern:` matches only one artifact, so the renderer's `results/playwright-results-json-<shardId>/results.json` scan finds nothing. Observed on #32561 (run 33835819848, attempts 1–3: shard uploaded valid artifacts, summary still reported them missing).

This cherry-picks the renderer-side migration of the flat layout into the expected subdirectory — main has carried it since July; `2.0` never received it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)