### PR TITLE
Fixes #32623: keep merge-queue alert state in a repo variable, not the Actions cache

### DIFF
--- a/.github/workflows/merge-queue-health-alert.yml
+++ b/.github/workflows/merge-queue-health-alert.yml
@@ -80,16 +80,34 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      # Cache entries are immutable, so each run writes a new key and restores the most
-      # recent one by prefix. The payload is ~200 bytes; this is a state flag, not data.
-      # Scoped to the default branch, so prune-ephemeral-caches.yml (which only deletes
-      # caches on dead gh-readonly-queue refs) will not touch it.
+      # State lives in the MQ_ALERT_STATE repository variable, NOT the Actions cache.
+      #
+      # The cache was tried first and cannot hold state here. This repo runs ~2 GB over
+      # the 10 GB cache budget (measured 12.01 GB across 22 entries) and writes >5 GB
+      # of yarn/maven caches in a five-minute window, so LRU eviction is continuous.
+      # Eviction is by least-recently-used rather than size, so a 331-byte flag was
+      # evicted as readily as a 1.4 GB one and never survived the hour between runs.
+      # Every run then restored nothing, read the default "ok", and re-announced the
+      # same standing breach — an edge-triggered alert degraded into hourly spam.
+      #
+      # A repo variable is what this actually is: one small mutable value. No expiry,
+      # no quota pressure, nothing to evict. It is not secret — level, timestamp and a
+      # counter — so a plainly readable variable is appropriate; keep it that way.
       - name: Restore alert state
-        uses: actions/cache/restore@v6
-        with:
-          path: .merge-queue-state
-          key: merge-queue-alert-state-${{ github.run_id }}
-          restore-keys: merge-queue-alert-state-
+        shell: bash
+        env:
+          STATE_JSON: ${{ vars.MQ_ALERT_STATE }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$(dirname "$STATE_FILE")"
+          if [ -z "${STATE_JSON:-}" ]; then
+            # The script reads a missing file as "ok", so a first run (or a cleared
+            # variable) re-announces a standing breach rather than going silent.
+            echo "MQ_ALERT_STATE unset — treating the queue as previously healthy."
+            exit 0
+          fi
+          printf '%s' "$STATE_JSON" > "$STATE_FILE"
+          echo "Restored state: $STATE_JSON"
 
       - name: Evaluate queue health
         id: check
@@ -104,21 +122,9 @@ jobs:
             --degraded-hours "$DEGRADED_HOURS" \
             --severe-hours "$SEVERE_HOURS"
 
-      # Cache keys are immutable, so every save mints a new entry — 24/day if done
-      # unconditionally. The level is unchanged on almost every run, so the script
-      # reports whether the state actually moved and the save is gated on that,
-      # per prune-ephemeral-caches.yml: "prefer gating a save over pruning it".
-      #
-      # Skipping the write cannot lose the state: the restore above counts as an
-      # access, so the surviving entry never reaches the 7-day unaccessed eviction.
-      # A run that advances the recovery streak DOES change state, so it still saves.
-      - name: Save alert state
-        if: ${{ steps.check.outputs.state_changed == 'true' }}
-        uses: actions/cache/save@v6
-        with:
-          path: .merge-queue-state
-          key: merge-queue-alert-state-${{ github.run_id }}
-
+      # Delivery runs BEFORE persistence on purpose. A failed variable write must not
+      # swallow the alert it was about to record — the worst case then is a duplicate
+      # next hour plus a red run, not silence.
       - name: "Post to Slack"
         if: ${{ steps.check.outputs.post == 'true' && env.DRY_RUN != 'true' }}
         continue-on-error: true
@@ -129,3 +135,23 @@ jobs:
           # Keep on — the action discards Slack API errors by default.
           errors: true
           payload-file-path: ${{ env.SLACK_FILE }}
+
+      # Gated on the state actually moving, which a variable makes safe: it never
+      # expires, so skipping a write cannot lose it. That is ~2 API writes a week
+      # instead of 24 a day.
+      #
+      # COLLATE_PAT rather than github.token: writing a repository variable needs
+      # `administration: write`, which is not one of the keys a workflow `permissions:`
+      # block can grant, so GITHUB_TOKEN cannot do it at any permission level. The PAT
+      # is scoped to this step alone and is never exposed to the Python process.
+      - name: Save alert state
+        if: ${{ steps.check.outputs.state_changed == 'true' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.COLLATE_PAT }}
+        run: |
+          set -euo pipefail
+          gh variable set MQ_ALERT_STATE \
+            --repo "$GITHUB_REPOSITORY" \
+            --body "$(cat "$STATE_FILE")"
+          echo "Stored state: $(cat "$STATE_FILE")"


### PR DESCRIPTION
Fixes #32623

### Describe your changes:

The hourly alert posted `degraded` **every hour** instead of once per incident. Every run logged:

```
Cache not found for input keys: merge-queue-alert-state-33934469878, merge-queue-alert-state-
```

so it restored nothing, read the default `ok`, and re-announced the same standing breach. Edge-triggering was working correctly — it never had prior state to compare against.

### Root cause

The Actions cache cannot hold state in this repo. Measured live:

```
active caches: 12.01 GB against a 10 GB budget, 22 entries

00:57  42MB    cache-apt-pkgs
00:54  0MB     merge-queue-alert-state-33934469878   <- ours
00:53  1421MB  Linux-node-yarn
00:53  782MB   Linux-maven
00:52  1421MB  Linux-node-yarn
```

Over 5 GB written in a five-minute window while 2 GB over budget, so LRU eviction runs continuously. **Eviction is by least-recently-used, not by size** — the 331-byte flag is evicted as readily as a 1.4 GB one, and never survived the hour between runs. Only the newest entry was ever present; the `Save alert state` step succeeded on all three runs.

The original design assumed an hourly restore would keep the entry alive, since restoring counts as an access. That holds only when the eviction window exceeds the run interval. Here it is far shorter.

### Fix

State moves to the **`MQ_ALERT_STATE` repository variable** — which is what it actually is: one small mutable value. No expiry, no quota pressure, nothing to evict. It holds a level, a timestamp and a counter, so a plainly readable variable is appropriate.

- **Restore** — reads `vars.MQ_ALERT_STATE`. Unset means "previously healthy", so a first run (or a cleared variable) re-announces a standing breach rather than going silent.
- **Write** — needs `administration: write`, which a workflow `permissions:` block cannot grant, so `GITHUB_TOKEN` cannot do it at any permission level. `COLLATE_PAT` is used instead, scoped to that single step and never exposed to the Python process.
- **Gated on `state_changed`** — safe now that the store cannot lapse. ~2 API writes a week rather than 24 a day.
- **Delivery moved before persistence** — a failed variable write must not swallow the alert it was about to record. Worst case is a duplicate next hour plus a red run, not silence.

`actions: read` is dropped again; nothing lists artifacts any more.

### Type of change:
- [x] Bug fix

### Tests:

#### Use cases covered
- An ongoing incident posts once, not once per hour
- An unset variable defaults to healthy and re-announces rather than going silent

#### Unit tests
- [ ] No automated tests (consistent with the rest of this feature). Verification below.

#### Manual testing performed
1. Wrote a repo variable with a real state payload via `gh variable set` and read it back byte-identical through both `gh variable list` and the REST API — confirms the PAT-shaped write path and that JSON survives round-trip unescaped.
2. Ran the **exact restore-step shell** against that variable, then the alert script, with the queue genuinely `degraded`:
   ```
   Restored: {"level": "degraded", "since": "...", "below_streak": 0}
   | previous level | degraded |
   | transition     | none     |
   outputs: post=false level=degraded state_changed=false
   slack payload written? no
   ```
   That is the bug reproduced as fixed — a second observation of the same level produces no post.
3. Verified the unset-variable branch exits 0 and defaults to healthy.
4. Test variable deleted afterwards; `gh variable list` confirms no residue.
5. YAML validated; `permissions` is `{contents: read, pull-requests: read}`; no `actions/cache` or artifact reference remains.

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.

### Notes for reviewers

**`COLLATE_PAT` needs `repo` scope** (classic) or `administration: write` (fine-grained) for the variable write. If it lacks that, the `Save alert state` step fails loudly — a red run and duplicate alerts, not silence.

Until this merges the channel keeps getting hourly alerts. Setting `MQ_ALERT_DRY_RUN=true` silences posting immediately without reverting anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7XdWwEx1UD5CjP5p1a5eE
