### PR TITLE
Backport #32306 to 2.0: keep Oracle CHAR length semantics in the reflected column type

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/oracle/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/oracle/queries.py
@@ -331,6 +331,7 @@ ORACLE_GET_COLUMNS = textwrap.dedent(
             col.data_default,
             com.comments,
             col.virtual_column,
+            col.char_used,
             {identity_cols}
         FROM {prefix}_TAB_COLS{dblink} col
         LEFT JOIN {prefix}_COL_COMMENTS{dblink} com

--- a/ingestion/src/metadata/ingestion/source/database/oracle/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/oracle/utils.py
@@ -46,6 +46,13 @@ from metadata.utils.sqlalchemy_utils import (
 
 logger = ingestion_logger()
 
+# ALL_TAB_COLS.CHAR_USED is 'C' when a column was declared with character length
+# semantics (VARCHAR2(10 CHAR)) and 'B' for byte semantics (VARCHAR2(10 BYTE), the
+# default). Oracle only renders the qualifier for VARCHAR2 and CHAR: NVARCHAR2 and
+# NCHAR are always character based and are never displayed with it.
+CHAR_SEMANTICS_FLAG = "C"
+CHAR_SEMANTICS_TYPES = ("VARCHAR2", "CHAR")
+
 
 def get_table_prefix_from_connection(service_connection) -> str:
     return "DBA" if getattr(service_connection, "useDBATable", True) else "ALL"
@@ -193,7 +200,9 @@ def _fetch_view_definition_by_name(connection, prefix, owner, name, object_type)
     )
 
 
-def _get_col_type(self, coltype, precision, scale, length, colname):  # pylint: disable=too-many-branches
+def _get_col_type(  # pylint: disable=too-many-branches
+    self, coltype, precision, scale, length, colname, char_used=None
+):
     raw_type = coltype
     if coltype == "NUMBER":
         if precision is None and scale == 0:
@@ -210,9 +219,10 @@ def _get_col_type(self, coltype, precision, scale, length, colname):  # pylint: 
         # TODO: support "precision" here as "binary_precision"
         coltype = FLOAT()
     elif coltype in ("VARCHAR2", "NVARCHAR2", "CHAR", "NCHAR"):
+        char_semantics = char_used == CHAR_SEMANTICS_FLAG and coltype in CHAR_SEMANTICS_TYPES
         coltype = self.ischema_names.get(coltype)(length)
         if length:
-            raw_type += f"({length})"
+            raw_type += f"({length} CHAR)" if char_semantics else f"({length})"
     elif "WITH TIME ZONE" in coltype or "TIMESTAMP" in coltype:
         coltype = TIMESTAMP(timezone=True)
     elif "INTERVAL" in coltype:
@@ -307,10 +317,11 @@ def get_columns(self, connection, table_name, schema=None, **kw):  # noqa: C901
         default = row[6]
         comment = row[7]
         generated = row[8]
-        default_on_nul = row[9]
-        identity_options = row[10]
+        char_used = row[9]
+        default_on_nul = row[10]
+        identity_options = row[11]
 
-        coltype, raw_coltype = self._get_col_type(coltype, precision, scale, length, colname)
+        coltype, raw_coltype = self._get_col_type(coltype, precision, scale, length, colname, char_used)
 
         computed = None
         if generated == "YES":

--- a/ingestion/tests/unit/topology/database/test_oracle_char_semantics.py
+++ b/ingestion/tests/unit/topology/database/test_oracle_char_semantics.py
@@ -1,0 +1,150 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Oracle reflection keeps the CHAR/BYTE length semantics in the displayed type."""
+
+from importlib import import_module
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.dialects.oracle.base import OracleDialect
+
+
+def _column_row(
+    name,
+    data_type,
+    length=None,
+    char_used=None,
+    precision=None,
+    scale=None,
+    default_on_null=None,
+    identity_options=None,
+):
+    """A row shaped like ORACLE_GET_COLUMNS returns it."""
+    return (
+        name,
+        data_type,
+        length,
+        precision,
+        scale,
+        "Y",
+        None,
+        None,
+        "NO",
+        char_used,
+        default_on_null,
+        identity_options,
+    )
+
+
+# The shape ALL_TAB_COLS.IDENTITY_OPTIONS actually has on a 19c identity column.
+IDENTITY_OPTIONS = (
+    "ALWAYS,START WITH: 1, INCREMENT BY: 1, MAX_VALUE: 9999999999999999999999999999, "
+    "MIN_VALUE: 1, CYCLE_FLAG: N, CACHE_SIZE: 20, ORDER_FLAG: N, SCALE_FLAG: N, "
+    "EXTEND_FLAG: N, SESSION_FLAG: N, KEEP_VALUE: N"
+)
+
+
+def _dialect(server_version) -> OracleDialect:
+    import_module("metadata.ingestion.source.database.oracle.metadata")
+    dialect = OracleDialect()
+    dialect.table_prefix = "DBA"  # type: ignore[attr-defined]
+    dialect.server_version_info = server_version
+    return dialect
+
+
+def _reflect(rows, server_version=(19, 0)):
+    dialect = _dialect(server_version)
+    connection = MagicMock()
+    connection.execute.return_value = rows
+    columns = dialect.get_columns(connection, "my_table", schema="my_schema")
+    executed = str(connection.execute.call_args.args[0])
+    return columns, executed
+
+
+@pytest.mark.parametrize(
+    ("data_type", "length", "char_used", "expected"),
+    [
+        # https://github.com/open-metadata/OpenMetadata/issues/18576
+        ("VARCHAR2", 10, "C", "VARCHAR2(10 CHAR)"),
+        ("VARCHAR2", 10, "B", "VARCHAR2(10)"),
+        ("CHAR", 5, "C", "CHAR(5 CHAR)"),
+        ("CHAR", 5, "B", "CHAR(5)"),
+        # NVARCHAR2/NCHAR are always character based; Oracle never shows the qualifier
+        ("NVARCHAR2", 20, "C", "NVARCHAR2(20)"),
+        ("NCHAR", 4, "C", "NCHAR(4)"),
+        # a NULL CHAR_USED (older catalogs, non-string columns) must not add a suffix
+        ("VARCHAR2", 10, None, "VARCHAR2(10)"),
+    ],
+)
+@pytest.mark.parametrize("server_version", [(11, 2), (19, 0)])
+def test_char_semantics_are_kept_in_the_displayed_type(data_type, length, char_used, expected, server_version):
+    columns, _ = _reflect(
+        [_column_row("my_column", data_type, length=length, char_used=char_used)],
+        server_version=server_version,
+    )
+
+    assert columns[0]["system_data_type"] == expected
+
+
+def test_char_used_is_selected_from_the_catalog():
+    _, executed = _reflect([_column_row("my_column", "VARCHAR2", length=10, char_used="C")])
+
+    assert "col.char_used" in executed
+
+
+def test_non_string_types_are_unaffected():
+    columns, _ = _reflect(
+        [
+            _column_row("amount", "NUMBER", precision=10, scale=2),
+            _column_row("created_at", "TIMESTAMP(6)"),
+        ]
+    )
+
+    assert [column["system_data_type"] for column in columns] == ["NUMBER(10,2)", "TIMESTAMP(6)"]
+
+
+def test_identity_columns_are_still_read_from_the_right_position():
+    """CHAR_USED was inserted ahead of the identity columns in the select list."""
+    columns, _ = _reflect(
+        [
+            _column_row(
+                "id",
+                "NUMBER",
+                precision=10,
+                scale=0,
+                default_on_null="NO",
+                identity_options=IDENTITY_OPTIONS,
+            )
+        ]
+    )
+
+    assert columns[0]["identity"] == {
+        "always": True,
+        "on_null": False,
+        "start": 1,
+        "increment": 1,
+        "maxvalue": 9999999999999999999999999999,
+        "minvalue": 1,
+        "cycle": False,
+        "cache": 20,
+        "order": False,
+    }
+
+
+def test_columns_still_line_up_before_12c():
+    """Pre-12c the identity columns are NULL literals, so CHAR_USED shifts them too."""
+    columns, _ = _reflect(
+        [_column_row("my_column", "VARCHAR2", length=10, char_used="C")],
+        server_version=(11, 2),
+    )
+
+    assert columns[0]["system_data_type"] == "VARCHAR2(10 CHAR)"
+    assert "identity" not in columns[0]


### PR DESCRIPTION
### Describe your changes:

Fixes #18576

Backport of #32306 to `2.0`.

`VARCHAR2(10 CHAR)` and `VARCHAR2(10 BYTE)` were both surfaced as `VARCHAR2(10)`, so the two are indistinguishable in OpenMetadata even though the length semantics differ — which matters on a multi-byte character set.

The Oracle column reflection never read `ALL_TAB_COLS.CHAR_USED`, the only place the declared semantics survive: `CHAR_LENGTH` holds the same declared number under both. `ORACLE_GET_COLUMNS` now selects `CHAR_USED`, and `_get_col_type` appends the qualifier when it is `'C'`.

| Declared | `dataTypeDisplay` before | after |
|---|---|---|
| `VARCHAR2(10 CHAR)` | `VARCHAR2(10)` | `VARCHAR2(10 CHAR)` |
| `VARCHAR2(10 BYTE)` | `VARCHAR2(10)` | `VARCHAR2(10)` |
| `CHAR(5 CHAR)` | `CHAR(5)` | `CHAR(5 CHAR)` |
| `NVARCHAR2(20)` | `NVARCHAR2(20)` | `NVARCHAR2(20)` |

Two points worth a reviewer's attention, both unchanged from the forward-fix:

- **The qualifier is limited to `VARCHAR2` and `CHAR`.** `NVARCHAR2`/`NCHAR` also report `CHAR_USED = 'C'` because they are always character based, but Oracle never renders them with it.
- **`CHAR_USED` is selected ahead of the identity columns**, so `get_columns` reads `default_on_null` and `identity_options` one position further along (`row[9]/[10]` → `row[10]/[11]`). This is the riskiest line in the diff; the tests cover it on both the 12c+ path (a real `IDENTITY_OPTIONS` string) and the pre-12c path (where `identity_cols` is a pair of `NULL` literals).

Cherry-picked clean, no conflicts.

**Rollout note.** This changes `dataTypeDisplay` for existing columns: on the next ingestion run every `VARCHAR2(n CHAR)` column flips from `VARCHAR2(n)` to `VARCHAR2(n CHAR)`. The new value is the correct one, but it does mean table version bumps and change events across Oracle services on first re-ingest. Nothing else about the entity changes.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- An Oracle column declared `VARCHAR2(n CHAR)` is displayed as `VARCHAR2(n CHAR)`
- An Oracle column declared `VARCHAR2(n BYTE)` / `VARCHAR2(n)` is displayed as `VARCHAR2(n)`
- `NVARCHAR2` / `NCHAR` columns are unchanged despite reporting character semantics
- Identity and non-string columns still reflect correctly after the select-list change, on both Oracle 11g and 19c

#### Unit tests
- [x] Carried over with the backport: `ingestion/tests/unit/topology/database/test_oracle_char_semantics.py`

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable — covered by unit tests against the reflection query; an integration test would need a live Oracle instance with both column semantics.

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed

Ran the Oracle suites against **this branch** — `test_oracle_char_semantics.py`, `test_oracle.py`, `test_oracle_constraint_reflection.py` and `tests/unit/source/database/oracle/`: **47 passed**. `make py_format_check` clean.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR is linked to the original issue (#18576) and forward-fix (#32306) above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.
- [x] I have added tests and listed them above.

