### PR TITLE
Root-cause the Playwright flakes ejecting PRs from the merge queue

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/eslint-suppressions.json
+++ b/openmetadata-ui/src/main/resources/ui/eslint-suppressions.json
@@ -1018,7 +1018,7 @@
   },
   "playwright/utils/entity.ts": {
     "om-playwright/no-positional-locator": {
-      "count": 23
+      "count": 22
     }
   },
   "playwright/utils/entityPanel.ts": {

--- a/openmetadata-ui/src/main/resources/ui/eslint-suppressions.json
+++ b/openmetadata-ui/src/main/resources/ui/eslint-suppressions.json
@@ -49,11 +49,6 @@
       "count": 1
     }
   },
-  "playwright/e2e/Features/BlockEditorEmbedLink.spec.ts": {
-    "om-playwright/no-positional-locator": {
-      "count": 1
-    }
-  },
   "playwright/e2e/Features/BulkEditEntity.spec.ts": {
     "om-playwright/no-positional-locator": {
       "count": 6
@@ -101,7 +96,7 @@
   },
   "playwright/e2e/Features/ContextCenterArticles.spec.ts": {
     "om-playwright/no-positional-locator": {
-      "count": 13
+      "count": 10
     },
     "playwright/no-wait-for-selector": {
       "count": 1
@@ -155,11 +150,6 @@
   "playwright/e2e/Features/DataProductRename.spec.ts": {
     "om-playwright/no-positional-locator": {
       "count": 1
-    }
-  },
-  "playwright/e2e/Features/DataProductRenameConsolidation.spec.ts": {
-    "om-playwright/no-positional-locator": {
-      "count": 3
     }
   },
   "playwright/e2e/Features/DataQuality/AddTestCaseNewFlow.spec.ts": {
@@ -229,7 +219,7 @@
   },
   "playwright/e2e/Features/EntityRenameConsolidation.spec.ts": {
     "om-playwright/no-positional-locator": {
-      "count": 7
+      "count": 4
     }
   },
   "playwright/e2e/Features/EntitySummaryPanel.spec.ts": {
@@ -704,7 +694,7 @@
       "count": 2
     },
     "om-playwright/no-positional-locator": {
-      "count": 16
+      "count": 15
     }
   },
   "playwright/e2e/Pages/ExploreBrowse.spec.ts": {

--- a/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
+++ b/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
@@ -27,7 +27,7 @@ coverage, a retried one looks green.
 
 ## Entries
 
-13 tests. Evidence is failures observed across 11 merge_group runs sampled on
+9 tests. Evidence is failures observed across 11 merge_group runs sampled on
 2026-09-04; the threshold for quarantining is **2 or more**, counted per
 generated variant rather than per source line.
 
@@ -39,20 +39,18 @@ generated variant rather than per source line.
 | `e2e/Pages/Domains.spec.ts` | Verify domain tags and glossary terms | 6/11 | Fails both attempts more often than it flakes — likely a real defect, not timing. |
 | `e2e/Features/Table.spec.ts` | should persist page size | 6/11 | Test timeout after `waitForAllLoadersToDisappear`. |
 | `e2e/Pages/TestSuiteDetailsPage.spec.ts` | Add test case modal — filters and select | 3/11 | `waitForResponse` on the test-case search never resolves. |
-| `e2e/Pages/EntityDataConsumer.spec.ts` | Update description (**Table variant only**) | 3/11 | Shared `entity.descriptionUpdate` helper. The tag is conditional on `entity.getType() === 'Table'` so the other 14 entity types keep running. |
 | `e2e/Features/Glossary/GlossaryHierarchy.spec.ts` | should move term to root of different glossary | 2/11 | Drag-and-drop. |
-| `e2e/Features/Glossary/GlossaryHierarchy.spec.ts` | should cancel drag and drop operation | 2/11 | Drag-and-drop. |
-| `e2e/Features/DataQuality/TestLibrary.spec.ts` | should create, edit, and delete a test definition | 2/11 | |
-| `e2e/Features/DataQuality/TestLibrary.spec.ts` | should maintain page on edit and reset to first page on delete | 2/11 | |
 | `e2e/Features/DataQuality/TableLevelTests.spec.ts` | Table Difference | 2/11 | |
 | `e2e/Features/ActivityStream.spec.ts` | activity stream API is called when visiting entity page | 2/11 | |
 
-Verified: `npx playwright test --list` reports 4543 tests by default (down from
-4555) and `PLAYWRIGHT_RUN_QUARANTINED=true` reports these 13 plus the 7
-setup/teardown fixture projects, which the soak lane deliberately leaves
-unfiltered so login and entity seeding still happen — a project-level `grep`
-*is* applied to dependency projects, so filtering them would make every
-quarantined test fail for want of `admin.json` instead of for its flake.
+`PLAYWRIGHT_RUN_QUARANTINED=true` selects these 9 plus the 7 setup/teardown
+fixture projects, which the soak lane deliberately leaves unfiltered so login and
+entity seeding still happen — a project-level `grep` *is* applied to dependency
+projects, so filtering them would make every quarantined test fail for want of
+`admin.json` instead of for its flake.
+
+Re-run `npx playwright test --list` after changing this file and update the
+default-lane count here; it was 4543 of 4555 when the list held 13 entries.
 
 ## Not quarantined — fixed instead
 
@@ -64,6 +62,19 @@ they were repaired rather than parked:
 | `e2e/Pages/Glossary.spec.ts` 128 / 198 / 421 | `utils/glossary.ts` used `page.textContent()` — waits for the element, not its text — so a cold first attempt read `""`. #32333 (a revert of #30896) had reintroduced this after it was already fixed. Restored to `toContainText`. |
 | `e2e/Features/ContextCenterArticles.spec.ts:670` | #32283 removed a `waitForTimeout(500)` that was covering the zustand → localStorage flush of `recentlyViewed`. Navigating away before the flush meant the Recently Viewed panel had no entry to render, so the trailing assertion had nothing to auto-wait for. Replaced with `waitForRecentlyViewed`, which polls the persisted store. |
 | `e2e/Features/ClassificationImportExport.spec.ts:64` | `beforeAll` POSTed fixtures whose names were generated at module scope, so a second pass in the same worker 409'd on every create. Fixtures are now rebuilt inside `beforeAll`, and an `afterAll` was added — the spec previously leaked two classifications, a tag and a user into the shard on every run. |
+
+### Released from quarantine
+
+Diagnosed and fixed, so the tag came off. If any of these flakes again the fix
+was wrong — re-quarantine it with the new evidence rather than restoring the old
+entry.
+
+| Spec | Test | Root cause |
+|---|---|---|
+| `e2e/Pages/EntityDataConsumer.spec.ts` | Update description (Table) | `updateDescription` resolved the editor with a page-global `descriptionBox` and `.first()`, so with the edit modal open it targeted the inline editor *behind* the overlay — visible, so the assertion passed, then the click failed on `ant-modal-wrap ... intercepts pointer events` until the test timed out. Now scoped to the dialog, asserting a single match. |
+| `e2e/Features/DataQuality/TestLibrary.spec.ts` | should create, edit, and delete a test definition | `TestDefinitionFormBody` rebuilt `options: toOptions(Object.values(…))` on every render. Focusing a field re-renders it via `onActiveFieldChange`, and the new `items` identity made react-aria rebuild the listbox collection, detaching the option mid-click. The option lists are enum-derived and now built once at module scope. |
+| `e2e/Features/DataQuality/TestLibrary.spec.ts` | should maintain page on edit and reset to first page on delete | Same select-option path as above. |
+| `e2e/Features/Glossary/GlossaryHierarchy.spec.ts` | should cancel drag and drop operation | `dragAndDropTerm` pressed at coordinates computed before the glossary page finished hydrating — the description block lands last and pushes every row down about a row height — and `force: true` skipped the actionability check that would have waited. It now holds both rows still before pressing. |
 
 ## Left running deliberately
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BlockEditorEmbedLink.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BlockEditorEmbedLink.spec.ts
@@ -18,7 +18,6 @@ import {
 import { TableClass } from '../../support/entity/TableClass';
 import {
   createNewPage,
-  getDescriptionBox,
   redirectToHomePage,
   resolveDescriptionBox,
 } from '../../utils/common';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BlockEditorEmbedLink.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BlockEditorEmbedLink.spec.ts
@@ -20,6 +20,7 @@ import {
   createNewPage,
   getDescriptionBox,
   redirectToHomePage,
+  resolveDescriptionBox,
 } from '../../utils/common';
 import { executeSlashCommand } from '../../utils/KnowledgeCenter';
 import { test } from '../fixtures/pages';
@@ -52,8 +53,7 @@ test.describe('BlockEditor embed-link form', { tag: ['@Discovery'] }, () => {
   }) => {
     await page.getByTestId('edit-description').click();
 
-    const editor = getDescriptionBox(page).first();
-    await expect(editor).toBeVisible();
+    const editor = await resolveDescriptionBox(page);
     await editor.click();
     await page.keyboard.press(SHORTCUTS.enter);
     await executeSlashCommand(page, SLASH_COMMANDS.image);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BlockEditorEmbedLink.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BlockEditorEmbedLink.spec.ts
@@ -18,7 +18,7 @@ import {
 import { TableClass } from '../../support/entity/TableClass';
 import {
   createNewPage,
-  descriptionBox,
+  getDescriptionBox,
   redirectToHomePage,
 } from '../../utils/common';
 import { executeSlashCommand } from '../../utils/KnowledgeCenter';
@@ -52,7 +52,7 @@ test.describe('BlockEditor embed-link form', { tag: ['@Discovery'] }, () => {
   }) => {
     await page.getByTestId('edit-description').click();
 
-    const editor = page.locator(descriptionBox).first();
+    const editor = getDescriptionBox(page).first();
     await expect(editor).toBeVisible();
     await editor.click();
     await page.keyboard.press(SHORTCUTS.enter);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
@@ -25,9 +25,7 @@ import { TagClass } from '../../support/tag/TagClass';
 import { UserClass } from '../../support/user/UserClass';
 import {
   createNewPage,
-  descriptionBox,
   getApiContext,
-  getDescriptionBox,
   redirectToHomePage,
   resolveDescriptionBox,
   uuid,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
@@ -27,6 +27,7 @@ import {
   createNewPage,
   descriptionBox,
   getApiContext,
+  getDescriptionBox,
   redirectToHomePage,
   uuid,
 } from '../../utils/common';
@@ -1314,8 +1315,8 @@ test.describe('Context Center Articles', () => {
       await waitForRelatedArticles;
 
       await page.getByTestId('edit-description').click();
-      await page.locator(descriptionBox).first().click();
-      await page.locator(descriptionBox).first().clear();
+      await getDescriptionBox(page).first().click();
+      await getDescriptionBox(page).first().clear();
 
       const mentionResponse = page.waitForResponse('/api/v1/search/query?**');
       await page

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
@@ -29,6 +29,7 @@ import {
   getApiContext,
   getDescriptionBox,
   redirectToHomePage,
+  resolveDescriptionBox,
   uuid,
 } from '../../utils/common';
 import {
@@ -1315,14 +1316,16 @@ test.describe('Context Center Articles', () => {
       await waitForRelatedArticles;
 
       await page.getByTestId('edit-description').click();
-      await getDescriptionBox(page).first().click();
-      await getDescriptionBox(page).first().clear();
+
+      const editor = await resolveDescriptionBox(page);
+
+      await editor.click();
+      await editor.clear();
 
       const mentionResponse = page.waitForResponse('/api/v1/search/query?**');
-      await page
-        .locator(descriptionBox)
-        .first()
-        .fill(`#${relatedKnowledgeCenter.knowledgePages[0].displayName}`);
+      await editor.fill(
+        `#${relatedKnowledgeCenter.knowledgePages[0].displayName}`
+      );
       await mentionResponse;
 
       await page

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CsvJobsTray.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CsvJobsTray.spec.ts
@@ -76,7 +76,7 @@ const openTray = async (page: Page) => {
 test.describe('CsvJobsTray', () => {
   test.beforeEach(async ({ page }) => {
     await redirectToHomePage(page);
-    await page.goto('/metrics');
+    await page.goto('/metrics', { waitUntil: 'domcontentloaded' });
     await page.waitForURL(/\/metrics/);
   });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataProductRenameConsolidation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataProductRenameConsolidation.spec.ts
@@ -24,7 +24,6 @@ import { UserClass } from '../../support/user/UserClass';
 import {
   createNewPage,
   getApiContext,
-  getDescriptionBox,
   redirectToHomePage,
   resolveDescriptionBox,
   uuid,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataProductRenameConsolidation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataProductRenameConsolidation.spec.ts
@@ -26,6 +26,7 @@ import {
   getApiContext,
   getDescriptionBox,
   redirectToHomePage,
+  resolveDescriptionBox,
   uuid,
 } from '../../utils/common';
 import {
@@ -110,9 +111,11 @@ test.describe('Data Product Rename + Field Update Consolidation', () => {
     await page.getByTestId('edit-description').click();
 
     const descriptionBox = '.om-block-editor[contenteditable="true"]';
-    await getDescriptionBox(page).first().click();
-    await getDescriptionBox(page).first().clear();
-    await getDescriptionBox(page).first().fill(description);
+    const editor = await resolveDescriptionBox(page);
+
+    await editor.click();
+    await editor.clear();
+    await editor.fill(description);
 
     const patchResponse = page.waitForResponse(
       (response) =>

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataProductRenameConsolidation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataProductRenameConsolidation.spec.ts
@@ -24,6 +24,7 @@ import { UserClass } from '../../support/user/UserClass';
 import {
   createNewPage,
   getApiContext,
+  getDescriptionBox,
   redirectToHomePage,
   uuid,
 } from '../../utils/common';
@@ -109,9 +110,9 @@ test.describe('Data Product Rename + Field Update Consolidation', () => {
     await page.getByTestId('edit-description').click();
 
     const descriptionBox = '.om-block-editor[contenteditable="true"]';
-    await page.locator(descriptionBox).first().click();
-    await page.locator(descriptionBox).first().clear();
-    await page.locator(descriptionBox).first().fill(description);
+    await getDescriptionBox(page).first().click();
+    await getDescriptionBox(page).first().clear();
+    await getDescriptionBox(page).first().fill(description);
 
     const patchResponse = page.waitForResponse(
       (response) =>

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/ColumnLevelTests.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/ColumnLevelTests.spec.ts
@@ -15,7 +15,7 @@ import { TableClass } from '../../../support/entity/TableClass';
 import { expect, test } from '../../../support/fixtures/base';
 import {
   createNewPage,
-  descriptionBox,
+  fillDescriptionBox,
   redirectToHomePage,
 } from '../../../utils/common';
 import {
@@ -112,7 +112,7 @@ test.describe(
         // Wait for dropdown to close after test type selection
         await expect(page.locator('[role="listbox"]')).not.toBeVisible();
 
-        await page.locator(descriptionBox).fill(testCase.description);
+        await fillDescriptionBox(page, testCase.description);
 
         await clickCreateTestCaseButton(page, testCase.name);
       });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestLibrary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestLibrary.spec.ts
@@ -103,233 +103,229 @@ test.describe(
       await expect(testDefinitionRows).not.toHaveCount(0);
     });
 
-    test(
-      'should create, edit, and delete a test definition',
-      { tag: '@quarantine' },
-      async ({ page }) => {
-        await test.step('Create a new test definition', async () => {
-          // Navigate to Test Library
-          await page.goto('/test-library');
+    test('should create, edit, and delete a test definition', async ({
+      page,
+    }) => {
+      await test.step('Create a new test definition', async () => {
+        // Navigate to Test Library
+        await page.goto('/test-library');
 
-          const testDefinitionFormDoc = page.waitForResponse(
-            '/locales/en-US/OpenMetadata/TestDefinitionForm.md'
-          );
+        const testDefinitionFormDoc = page.waitForResponse(
+          '/locales/en-US/OpenMetadata/TestDefinitionForm.md'
+        );
 
-          // Click add button
-          await page.getByTestId('add-test-definition-button').click();
+        // Click add button
+        await page.getByTestId('add-test-definition-button').click();
 
-          // Wait for drawer to open
-          await page
-            .getByTestId('test-definition-form-body')
-            .waitFor({ state: 'visible' });
-          await testDefinitionFormDoc;
+        // Wait for drawer to open
+        await page
+          .getByTestId('test-definition-form-body')
+          .waitFor({ state: 'visible' });
+        await testDefinitionFormDoc;
 
-          // The form body + doc panel confirm the drawer opened. We don't assert
-          // the "Add Test Definition" title text because it also matches the list
-          // page's Add button (strict-mode ambiguity).
-          await expect(
-            page.locator('.drawer-doc-panel.service-doc-panel')
-          ).toBeVisible();
+        // The form body + doc panel confirm the drawer opened. We don't assert
+        // the "Add Test Definition" title text because it also matches the list
+        // page's Add button (strict-mode ambiguity).
+        await expect(
+          page.locator('.drawer-doc-panel.service-doc-panel')
+        ).toBeVisible();
 
-          // Fill in form fields
-          await page
-            .getByTestId('test-definition-name')
-            .locator('input')
-            .fill(TEST_DEFINITION_NAME);
-          await expect(
-            page.locator('.drawer-doc-panel.service-doc-panel')
-          ).toContainText('Name');
-          await page
-            .getByTestId('display-name')
-            .locator('input')
-            .fill(TEST_DEFINITION_DISPLAY_NAME);
-          await page
-            .getByTestId('description')
-            .locator('textarea')
-            .fill(TEST_DEFINITION_DESCRIPTION);
+        // Fill in form fields
+        await page
+          .getByTestId('test-definition-name')
+          .locator('input')
+          .fill(TEST_DEFINITION_NAME);
+        await expect(
+          page.locator('.drawer-doc-panel.service-doc-panel')
+        ).toContainText('Name');
+        await page
+          .getByTestId('display-name')
+          .locator('input')
+          .fill(TEST_DEFINITION_DISPLAY_NAME);
+        await page
+          .getByTestId('description')
+          .locator('textarea')
+          .fill(TEST_DEFINITION_DESCRIPTION);
 
-          // Select entity type (react-aria Select: click the field, pick option)
-          await page.locator('[id="root/entityType"]').click();
-          const entityTypeOption = page.getByRole('option', {
-            name: 'TABLE',
+        // Select entity type (react-aria Select: click the field, pick option)
+        await page.locator('[id="root/entityType"]').click();
+        const entityTypeOption = page.getByRole('option', {
+          name: 'TABLE',
+          exact: true,
+        });
+        await entityTypeOption.click();
+
+        // Supported data types (core MultiSelect: type into its combobox input to
+        // populate the options, then pick — required while the OpenMetadata
+        // platform is set). Post antd->core migration the RJSF field id sits on
+        // the field wrapper, not the input, so scope to the combobox input.
+        // The combobox closes on selection, so no Escape (Escape closes the drawer).
+        const supportedDataTypes = page.getByTestId('supported-data-types');
+        await supportedDataTypes
+          .locator('input[role="combobox"]')
+          .fill('NUMBER');
+        await page.getByRole('option', { name: 'NUMBER', exact: true }).click();
+        await expect(
+          supportedDataTypes.getByText('NUMBER', {
             exact: true,
-          });
-          await entityTypeOption.click();
+          })
+        ).toBeVisible();
 
-          // Supported data types (core MultiSelect: type into its combobox input to
-          // populate the options, then pick — required while the OpenMetadata
-          // platform is set). Post antd->core migration the RJSF field id sits on
-          // the field wrapper, not the input, so scope to the combobox input.
-          // The combobox closes on selection, so no Escape (Escape closes the drawer).
-          const supportedDataTypes = page.getByTestId('supported-data-types');
-          await supportedDataTypes
-            .locator('input[role="combobox"]')
-            .fill('NUMBER');
-          await page
-            .getByRole('option', { name: 'NUMBER', exact: true })
-            .click();
-          await expect(
-            supportedDataTypes.getByText('NUMBER', {
-              exact: true,
-            })
-          ).toBeVisible();
+        // Add a test platform (core MultiSelect)
+        const testPlatforms = page.getByTestId('test-platforms');
+        await testPlatforms.locator('input[role="combobox"]').fill('dbt');
+        await page.getByRole('option', { name: 'dbt', exact: true }).click();
+        await expect(
+          testPlatforms.getByText('dbt', { exact: true })
+        ).toBeVisible();
 
-          // Add a test platform (core MultiSelect)
-          const testPlatforms = page.getByTestId('test-platforms');
-          await testPlatforms.locator('input[role="combobox"]').fill('dbt');
-          await page.getByRole('option', { name: 'dbt', exact: true }).click();
-          await expect(
-            testPlatforms.getByText('dbt', { exact: true })
-          ).toBeVisible();
+        // Wait for POST response when creating test definition
+        const testDefinitionResponse = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/dataQuality/testDefinitions') &&
+            response.request().method() === 'POST'
+        );
 
-          // Wait for POST response when creating test definition
-          const testDefinitionResponse = page.waitForResponse(
-            (response) =>
-              response.url().includes('/api/v1/dataQuality/testDefinitions') &&
-              response.request().method() === 'POST'
-          );
+        // Click save
+        await page.getByTestId('save-test-definition').click();
 
-          // Click save
-          await page.getByTestId('save-test-definition').click();
+        // Wait for API response
+        const responseData = await testDefinitionResponse;
 
-          // Wait for API response
-          const responseData = await testDefinitionResponse;
+        expect(responseData.status()).toBe(201);
 
-          expect(responseData.status()).toBe(201);
+        // Wait for success toast
+        await toastNotification(page, /created successfully/i);
 
-          // Wait for success toast
-          await toastNotification(page, /created successfully/i);
+        // Verify test definition appears in table
+        await expect(page.getByTestId(TEST_DEFINITION_NAME)).toBeVisible();
+      });
 
-          // Verify test definition appears in table
-          await expect(page.getByTestId(TEST_DEFINITION_NAME)).toBeVisible();
+      await test.step('Edit Test Definition', async () => {
+        // Wait for table to load
+        await page.getByTestId('test-definition-table').waitFor({
+          state: 'visible',
         });
 
-        await test.step('Edit Test Definition', async () => {
-          // Wait for table to load
-          await page.getByTestId('test-definition-table').waitFor({
-            state: 'visible',
-          });
+        // Find and click edit button on first row
+        const firstEditButton = page
+          .getByTestId(`edit-test-definition-${TEST_DEFINITION_NAME}`)
+          .first();
+        await firstEditButton.click();
 
-          // Find and click edit button on first row
-          const firstEditButton = page
-            .getByTestId(`edit-test-definition-${TEST_DEFINITION_NAME}`)
-            .first();
-          await firstEditButton.click();
+        // Wait for drawer to open (form body confirms the edit drawer opened).
+        await page
+          .getByTestId('test-definition-form-body')
+          .waitFor({ state: 'visible' });
 
-          // Wait for drawer to open (form body confirms the edit drawer opened).
-          await page
-            .getByTestId('test-definition-form-body')
-            .waitFor({ state: 'visible' });
+        // Verify name field is disabled in edit mode
+        const nameInput = page
+          .getByTestId('test-definition-name')
+          .locator('input');
 
-          // Verify name field is disabled in edit mode
-          const nameInput = page
-            .getByTestId('test-definition-name')
-            .locator('input');
+        await expect(nameInput).toBeDisabled();
 
-          await expect(nameInput).toBeDisabled();
+        // Update display name
+        const displayNameInput = page
+          .getByTestId('display-name')
+          .locator('input');
+        await displayNameInput.clear();
+        await displayNameInput.fill(UPDATE_TEST_DEFINITION_DISPLAY_NAME);
 
-          // Update display name
-          const displayNameInput = page
-            .getByTestId('display-name')
-            .locator('input');
-          await displayNameInput.clear();
-          await displayNameInput.fill(UPDATE_TEST_DEFINITION_DISPLAY_NAME);
+        // Wait for POST response when creating test definition
+        const testDefinitionResponse = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/dataQuality/testDefinitions') &&
+            response.request().method() === 'PATCH'
+        );
 
-          // Wait for POST response when creating test definition
-          const testDefinitionResponse = page.waitForResponse(
-            (response) =>
-              response.url().includes('/api/v1/dataQuality/testDefinitions') &&
-              response.request().method() === 'PATCH'
-          );
+        // Click save
+        await page.getByTestId('save-test-definition').click();
+        // Wait for API response
+        const responseData = await testDefinitionResponse;
 
-          // Click save
-          await page.getByTestId('save-test-definition').click();
-          // Wait for API response
-          const responseData = await testDefinitionResponse;
+        expect(responseData.status()).toBe(200);
 
-          expect(responseData.status()).toBe(200);
+        // Wait for success toast
+        await toastNotification(page, /updated successfully/i);
+      });
 
-          // Wait for success toast
-          await toastNotification(page, /updated successfully/i);
+      await test.step('should enable/disable test definition', async () => {
+        // Wait for table to load
+        await page.getByTestId('test-definition-table').waitFor({
+          state: 'visible',
         });
 
-        await test.step('should enable/disable test definition', async () => {
-          // Wait for table to load
-          await page.getByTestId('test-definition-table').waitFor({
-            state: 'visible',
-          });
+        // Find first enabled switch
+        const firstSwitch = page.getByTestId(
+          `enable-switch-${TEST_DEFINITION_NAME}`
+        );
 
-          // Find first enabled switch
-          const firstSwitch = page.getByTestId(
-            `enable-switch-${TEST_DEFINITION_NAME}`
-          );
+        // Wait for API call
+        const testDefinitionResponse = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/dataQuality/testDefinitions') &&
+            response.request().method() === 'PATCH'
+        );
+        // Toggle the switch
+        await firstSwitch.click();
 
-          // Wait for API call
-          const testDefinitionResponse = page.waitForResponse(
-            (response) =>
-              response.url().includes('/api/v1/dataQuality/testDefinitions') &&
-              response.request().method() === 'PATCH'
-          );
-          // Toggle the switch
-          await firstSwitch.click();
+        // Wait for API response
+        const responseData = await testDefinitionResponse;
 
-          // Wait for API response
-          const responseData = await testDefinitionResponse;
+        expect(responseData.status()).toBe(200);
 
-          expect(responseData.status()).toBe(200);
+        // Wait for success toast
+        await toastNotification(page, /updated successfully/i);
 
-          // Wait for success toast
-          await toastNotification(page, /updated successfully/i);
+        // Verify switch state changed
+        await expect(firstSwitch).toHaveAttribute(
+          'aria-checked',
+          String('false')
+        );
+      });
 
-          // Verify switch state changed
-          await expect(firstSwitch).toHaveAttribute(
-            'aria-checked',
-            String('false')
-          );
+      await test.step('should delete a test definition', async () => {
+        // Wait for table to load
+        await page.getByTestId('test-definition-table').waitFor({
+          state: 'visible',
         });
 
-        await test.step('should delete a test definition', async () => {
-          // Wait for table to load
-          await page.getByTestId('test-definition-table').waitFor({
-            state: 'visible',
-          });
+        // Find and click delete button
+        const deleteButton = page.getByTestId(
+          `delete-test-definition-${TEST_DEFINITION_NAME}`
+        );
+        await deleteButton.click();
 
-          // Find and click delete button
-          const deleteButton = page.getByTestId(
-            `delete-test-definition-${TEST_DEFINITION_NAME}`
-          );
-          await deleteButton.click();
+        // Wait for confirmation modal
+        await page.getByTestId('delete-modal').waitFor({ state: 'visible' });
 
-          // Wait for confirmation modal
-          await page.getByTestId('delete-modal').waitFor({ state: 'visible' });
+        // Verify modal content
+        await expect(
+          page.getByText(`Delete ${UPDATE_TEST_DEFINITION_DISPLAY_NAME}`)
+        ).toBeVisible();
 
-          // Verify modal content
-          await expect(
-            page.getByText(`Delete ${UPDATE_TEST_DEFINITION_DISPLAY_NAME}`)
-          ).toBeVisible();
+        // Wait for API call
+        const deleteTestDefinitionResponse = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/dataQuality/testDefinitions') &&
+            response.request().method() === 'DELETE'
+        );
 
-          // Wait for API call
-          const deleteTestDefinitionResponse = page.waitForResponse(
-            (response) =>
-              response.url().includes('/api/v1/dataQuality/testDefinitions') &&
-              response.request().method() === 'DELETE'
-          );
+        // Click confirm delete
+        await fillDeleteConfirmationIfPresent(page);
+        await page.getByTestId('confirm-button').click();
 
-          // Click confirm delete
-          await fillDeleteConfirmationIfPresent(page);
-          await page.getByTestId('confirm-button').click();
+        const response = await deleteTestDefinitionResponse;
+        expect(response.status()).toBe(200);
 
-          const response = await deleteTestDefinitionResponse;
-          expect(response.status()).toBe(200);
+        // Wait for success toast
+        await toastNotification(page, /deleted successfully/i);
 
-          // Wait for success toast
-          await toastNotification(page, /deleted successfully/i);
-
-          // Verify test definition is removed from table
-          await expect(page.getByText(TEST_DEFINITION_NAME)).not.toBeVisible();
-        });
-      }
-    );
+        // Verify test definition is removed from table
+        await expect(page.getByText(TEST_DEFINITION_NAME)).not.toBeVisible();
+      });
+    });
 
     test('should validate required fields in create form', async ({ page }) => {
       // Navigate to Test Library
@@ -1187,199 +1183,191 @@ test.describe(
       });
     });
 
-    test(
-      'should maintain page on edit and reset to first page on delete',
-      { tag: '@quarantine' },
-      async ({ page }) => {
-        test.slow();
-        const PAGINATION_TEST_NAME = `zzzzPaginationTest${uuid()}`;
-        const PAGINATION_TEST_DISPLAY_NAME = `Zzzz Pagination Test ${uuid()}`;
-        const UPDATED_DISPLAY_NAME = `Updated ${PAGINATION_TEST_DISPLAY_NAME}`;
+    test('should maintain page on edit and reset to first page on delete', async ({
+      page,
+    }) => {
+      test.slow();
+      const PAGINATION_TEST_NAME = `zzzzPaginationTest${uuid()}`;
+      const PAGINATION_TEST_DISPLAY_NAME = `Zzzz Pagination Test ${uuid()}`;
+      const UPDATED_DISPLAY_NAME = `Updated ${PAGINATION_TEST_DISPLAY_NAME}`;
 
-        await test.step('Create a test definition starting with "z"', async () => {
-          await page.goto('/test-library');
-          await page.getByTestId('add-test-definition-button').click();
-          await expect(
-            page.getByTestId('test-definition-form-body')
-          ).toBeVisible();
+      await test.step('Create a test definition starting with "z"', async () => {
+        await page.goto('/test-library');
+        await page.getByTestId('add-test-definition-button').click();
+        await expect(
+          page.getByTestId('test-definition-form-body')
+        ).toBeVisible();
 
-          await page
-            .getByTestId('test-definition-name')
-            .locator('input')
-            .fill(PAGINATION_TEST_NAME);
-          await page
-            .getByTestId('display-name')
-            .locator('input')
-            .fill(PAGINATION_TEST_DISPLAY_NAME);
-          await page
-            .getByTestId('description')
-            .locator('textarea')
-            .fill('Test definition for pagination behavior testing');
+        await page
+          .getByTestId('test-definition-name')
+          .locator('input')
+          .fill(PAGINATION_TEST_NAME);
+        await page
+          .getByTestId('display-name')
+          .locator('input')
+          .fill(PAGINATION_TEST_DISPLAY_NAME);
+        await page
+          .getByTestId('description')
+          .locator('textarea')
+          .fill('Test definition for pagination behavior testing');
 
-          await page.getByTestId('entity-type').click();
-          const entityTypeOption = page.getByRole('option', {
-            name: 'TABLE',
-            exact: true,
-          });
-          await entityTypeOption.click();
-
-          // Select supported data types (required when OpenMetadata platform is selected)
-          await page.getByTestId('supported-data-types').click();
-          await page
-            .getByTestId('supported-data-types')
-            .locator('input')
-            .fill('NUMBER');
-          await page
-            .getByRole('option', { name: 'NUMBER', exact: true })
-            .click();
-          await page.keyboard.press('Escape');
-
-          const createResponse = page.waitForResponse(
-            (response) =>
-              response.url().includes('/api/v1/dataQuality/testDefinitions') &&
-              response.request().method() === 'POST'
-          );
-
-          await page.getByTestId('save-test-definition').click();
-
-          const responseData = await createResponse;
-          expect(responseData.status()).toBe(201);
-          await toastNotification(page, /created successfully/i);
+        await page.getByTestId('entity-type').click();
+        const entityTypeOption = page.getByRole('option', {
+          name: 'TABLE',
+          exact: true,
         });
+        await entityTypeOption.click();
 
-        await test.step('Change page size to 25', async () => {
-          const pageSizeDropdown = page.getByTestId(
-            'page-size-selection-dropdown'
-          );
-          await expect(pageSizeDropdown).toBeVisible();
-          await pageSizeDropdown.click();
+        // Select supported data types (required when OpenMetadata platform is selected)
+        await page.getByTestId('supported-data-types').click();
+        await page
+          .getByTestId('supported-data-types')
+          .locator('input')
+          .fill('NUMBER');
+        await page.getByRole('option', { name: 'NUMBER', exact: true }).click();
+        await page.keyboard.press('Escape');
 
-          const pageChangeResponse = page.waitForResponse(
-            // Wait for pagination response
+        const createResponse = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/dataQuality/testDefinitions') &&
+            response.request().method() === 'POST'
+        );
+
+        await page.getByTestId('save-test-definition').click();
+
+        const responseData = await createResponse;
+        expect(responseData.status()).toBe(201);
+        await toastNotification(page, /created successfully/i);
+      });
+
+      await test.step('Change page size to 25', async () => {
+        const pageSizeDropdown = page.getByTestId(
+          'page-size-selection-dropdown'
+        );
+        await expect(pageSizeDropdown).toBeVisible();
+        await pageSizeDropdown.click();
+
+        const pageChangeResponse = page.waitForResponse(
+          // Wait for pagination response
+          (response) =>
+            response.url().includes('/api/v1/dataQuality/testDefinitions') &&
+            response.request().method() === 'GET'
+        );
+        // Wait for dropdown to open and select 25
+        await page.locator('.ant-dropdown:visible').getByText('25').click();
+        await pageChangeResponse;
+      });
+
+      await test.step('Navigate until we find our test definition or reach last page', async () => {
+        const nextButton = page.getByTestId('next');
+        const testDefLocator = page.getByTestId(PAGINATION_TEST_NAME);
+
+        // Check if item is already visible on current page
+        let isItemVisible = await testDefLocator.isVisible();
+
+        // Navigate until we find our test definition or reach the last page
+        while (!isItemVisible && (await nextButton.isEnabled())) {
+          const fetchResponse = page.waitForResponse(
             (response) =>
               response.url().includes('/api/v1/dataQuality/testDefinitions') &&
               response.request().method() === 'GET'
           );
-          // Wait for dropdown to open and select 25
-          await page.locator('.ant-dropdown:visible').getByText('25').click();
-          await pageChangeResponse;
+          await nextButton.click();
+          await fetchResponse;
+
+          // Check again after page load
+          isItemVisible = await testDefLocator.isVisible();
+        }
+
+        // Verify our test definition is now visible
+        await expect(testDefLocator).toBeVisible({
+          timeout: 10000,
         });
+      });
 
-        await test.step('Navigate until we find our test definition or reach last page', async () => {
-          const nextButton = page.getByTestId('next');
-          const testDefLocator = page.getByTestId(PAGINATION_TEST_NAME);
+      await test.step('Edit the test definition and verify we stay on the same page', async () => {
+        // Verify our test definition is visible on this page
+        await expect(page.getByTestId(PAGINATION_TEST_NAME)).toBeVisible();
 
-          // Check if item is already visible on current page
-          let isItemVisible = await testDefLocator.isVisible();
+        // Get current page indicator before edit
+        const previousButton = page.getByTestId('previous');
+        const prevDisabledBefore = await previousButton.isDisabled();
 
-          // Navigate until we find our test definition or reach the last page
-          while (!isItemVisible && (await nextButton.isEnabled())) {
-            const fetchResponse = page.waitForResponse(
-              (response) =>
-                response
-                  .url()
-                  .includes('/api/v1/dataQuality/testDefinitions') &&
-                response.request().method() === 'GET'
-            );
-            await nextButton.click();
-            await fetchResponse;
+        // Edit the test definition
+        await page
+          .getByTestId(`edit-test-definition-${PAGINATION_TEST_NAME}`)
+          .click();
+        await expect(
+          page.getByTestId('test-definition-form-body')
+        ).toBeVisible();
 
-            // Check again after page load
-            isItemVisible = await testDefLocator.isVisible();
-          }
+        const displayNameInput = page
+          .getByTestId('display-name')
+          .locator('input');
+        await displayNameInput.clear();
+        await displayNameInput.fill(UPDATED_DISPLAY_NAME);
 
-          // Verify our test definition is now visible
-          await expect(testDefLocator).toBeVisible({
-            timeout: 10000,
-          });
-        });
+        const patchResponse = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/dataQuality/testDefinitions') &&
+            response.request().method() === 'PATCH'
+        );
 
-        await test.step('Edit the test definition and verify we stay on the same page', async () => {
-          // Verify our test definition is visible on this page
-          await expect(page.getByTestId(PAGINATION_TEST_NAME)).toBeVisible();
+        await page.getByTestId('save-test-definition').click();
+        const updateResponse = await patchResponse;
+        expect(updateResponse.status()).toBe(200);
 
-          // Get current page indicator before edit
-          const previousButton = page.getByTestId('previous');
-          const prevDisabledBefore = await previousButton.isDisabled();
+        await toastNotification(page, /updated successfully/i);
 
-          // Edit the test definition
-          await page
-            .getByTestId(`edit-test-definition-${PAGINATION_TEST_NAME}`)
-            .click();
-          await expect(
-            page.getByTestId('test-definition-form-body')
-          ).toBeVisible();
-
-          const displayNameInput = page
-            .getByTestId('display-name')
-            .locator('input');
-          await displayNameInput.clear();
-          await displayNameInput.fill(UPDATED_DISPLAY_NAME);
-
-          const patchResponse = page.waitForResponse(
-            (response) =>
-              response.url().includes('/api/v1/dataQuality/testDefinitions') &&
-              response.request().method() === 'PATCH'
-          );
-
-          await page.getByTestId('save-test-definition').click();
-          const updateResponse = await patchResponse;
-          expect(updateResponse.status()).toBe(200);
-
-          await toastNotification(page, /updated successfully/i);
-
-          // Verify we stayed on the same page (previous button state should be unchanged)
-          if (prevDisabledBefore) {
-            await expect(previousButton).toBeDisabled();
-          } else {
-            await expect(previousButton).toBeEnabled();
-          }
-
-          // Verify the updated test definition is still visible
-          await expect(page.getByTestId(PAGINATION_TEST_NAME)).toBeVisible();
-        });
-
-        await test.step('Delete the test definition and verify redirect to first page', async () => {
-          await page
-            .getByTestId(`delete-test-definition-${PAGINATION_TEST_NAME}`)
-            .click();
-
-          await expect(page.getByTestId('delete-modal')).toBeVisible();
-
-          // Set up both DELETE and the subsequent GET response waits BEFORE clicking
-          const deleteResponse = page.waitForResponse(
-            (response) =>
-              response.url().includes('/api/v1/dataQuality/testDefinitions') &&
-              response.request().method() === 'DELETE'
-          );
-
-          const getResponse = page.waitForResponse(
-            (response) =>
-              response.url().includes('/api/v1/dataQuality/testDefinitions') &&
-              response.request().method() === 'GET'
-          );
-
-          await fillDeleteConfirmationIfPresent(page);
-          await page.getByTestId('confirm-button').click();
-
-          const deleteResult = await deleteResponse;
-          expect(deleteResult.status()).toBe(200);
-
-          // Wait for the GET that happens after delete (page reset + fetch)
-          await getResponse;
-
-          await toastNotification(page, /deleted successfully/i);
-
-          // Previous button should be disabled on first page
-          const previousButton = page.getByTestId('previous');
+        // Verify we stayed on the same page (previous button state should be unchanged)
+        if (prevDisabledBefore) {
           await expect(previousButton).toBeDisabled();
+        } else {
+          await expect(previousButton).toBeEnabled();
+        }
 
-          // Verify the deleted test definition is no longer visible
-          await expect(
-            page.getByTestId(PAGINATION_TEST_NAME)
-          ).not.toBeVisible();
-        });
-      }
-    );
+        // Verify the updated test definition is still visible
+        await expect(page.getByTestId(PAGINATION_TEST_NAME)).toBeVisible();
+      });
+
+      await test.step('Delete the test definition and verify redirect to first page', async () => {
+        await page
+          .getByTestId(`delete-test-definition-${PAGINATION_TEST_NAME}`)
+          .click();
+
+        await expect(page.getByTestId('delete-modal')).toBeVisible();
+
+        // Set up both DELETE and the subsequent GET response waits BEFORE clicking
+        const deleteResponse = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/dataQuality/testDefinitions') &&
+            response.request().method() === 'DELETE'
+        );
+
+        const getResponse = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/dataQuality/testDefinitions') &&
+            response.request().method() === 'GET'
+        );
+
+        await fillDeleteConfirmationIfPresent(page);
+        await page.getByTestId('confirm-button').click();
+
+        const deleteResult = await deleteResponse;
+        expect(deleteResult.status()).toBe(200);
+
+        // Wait for the GET that happens after delete (page reset + fetch)
+        await getResponse;
+
+        await toastNotification(page, /deleted successfully/i);
+
+        // Previous button should be disabled on first page
+        const previousButton = page.getByTestId('previous');
+        await expect(previousButton).toBeDisabled();
+
+        // Verify the deleted test definition is no longer visible
+        await expect(page.getByTestId(PAGINATION_TEST_NAME)).not.toBeVisible();
+      });
+    });
   }
 );

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/EntityRenameConsolidation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/EntityRenameConsolidation.spec.ts
@@ -25,6 +25,7 @@ import {
   createNewPage,
   getDescriptionBox,
   redirectToHomePage,
+  resolveDescriptionBox,
   uuid,
   visitGlossaryPage,
 } from '../../utils/common';
@@ -115,9 +116,11 @@ async function updateDescription(
   await page.getByTestId('edit-description').click();
 
   const descriptionBox = '.om-block-editor[contenteditable="true"]';
-  await getDescriptionBox(page).first().click();
-  await getDescriptionBox(page).first().clear();
-  await getDescriptionBox(page).first().fill(description);
+  const editor = await resolveDescriptionBox(page);
+
+  await editor.click();
+  await editor.clear();
+  await editor.fill(description);
 
   const patchResponse = page.waitForResponse(
     (response) =>

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/EntityRenameConsolidation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/EntityRenameConsolidation.spec.ts
@@ -23,6 +23,7 @@ import { TagClass } from '../../support/tag/TagClass';
 import { UserClass } from '../../support/user/UserClass';
 import {
   createNewPage,
+  getDescriptionBox,
   redirectToHomePage,
   uuid,
   visitGlossaryPage,
@@ -114,9 +115,9 @@ async function updateDescription(
   await page.getByTestId('edit-description').click();
 
   const descriptionBox = '.om-block-editor[contenteditable="true"]';
-  await page.locator(descriptionBox).first().click();
-  await page.locator(descriptionBox).first().clear();
-  await page.locator(descriptionBox).first().fill(description);
+  await getDescriptionBox(page).first().click();
+  await getDescriptionBox(page).first().clear();
+  await getDescriptionBox(page).first().fill(description);
 
   const patchResponse = page.waitForResponse(
     (response) =>

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/EntityRenameConsolidation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/EntityRenameConsolidation.spec.ts
@@ -23,7 +23,6 @@ import { TagClass } from '../../support/tag/TagClass';
 import { UserClass } from '../../support/user/UserClass';
 import {
   createNewPage,
-  getDescriptionBox,
   redirectToHomePage,
   resolveDescriptionBox,
   uuid,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryAdvancedOperations.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryAdvancedOperations.spec.ts
@@ -20,7 +20,7 @@ import { TeamClass } from '../../../support/team/TeamClass';
 import { UserClass } from '../../../support/user/UserClass';
 import {
   clickOutside,
-  descriptionBox,
+  fillDescriptionBox,
   getApiContext,
   redirectToHomePage,
 } from '../../../utils/common';
@@ -61,7 +61,7 @@ test.describe('Glossary Advanced Operations', () => {
       await page.getByTestId('form-heading').waitFor();
 
       await page.fill('[data-testid="name"]', glossary.data.name);
-      await page.locator(descriptionBox).fill(glossary.data.description);
+      await fillDescriptionBox(page, glossary.data.description);
 
       // Verify mutually exclusive toggle is OFF by default
       const mutuallyExclusiveBtn = page.getByTestId(
@@ -115,7 +115,7 @@ test.describe('Glossary Advanced Operations', () => {
       await page.getByTestId('form-heading').waitFor();
 
       await page.fill('[data-testid="name"]', glossary.data.name);
-      await page.locator(descriptionBox).fill(glossary.data.description);
+      await fillDescriptionBox(page, glossary.data.description);
 
       // Add first user owner
       await addMultiOwnerInDialog({
@@ -386,7 +386,7 @@ test.describe('Glossary Advanced Operations', () => {
 
       const termName = `ColorTerm${Date.now()}`;
       await page.fill('[data-testid="name"]', termName);
-      await page.locator(descriptionBox).fill('Term with custom color');
+      await fillDescriptionBox(page, 'Term with custom color');
 
       // Set custom color
       const customColor = '#FF5733';
@@ -423,7 +423,7 @@ test.describe('Glossary Advanced Operations', () => {
 
       const termName = `IconTerm${Date.now()}`;
       await page.fill('[data-testid="name"]', termName);
-      await page.locator(descriptionBox).fill('Term with custom icon');
+      await fillDescriptionBox(page, 'Term with custom icon');
 
       // Set custom icon URL
       const iconUrl = 'https://example.com/icon.png';
@@ -1015,7 +1015,7 @@ test.describe('Glossary Advanced Operations', () => {
 
       const termName = `RelatedTerm${Date.now()}`;
       await page.fill('[data-testid="name"]', termName);
-      await page.locator(descriptionBox).fill('Term with related terms');
+      await fillDescriptionBox(page, 'Term with related terms');
 
       const searchResponse = page.waitForResponse('/api/v1/search/query*');
 
@@ -1127,7 +1127,7 @@ test.describe('Glossary Advanced Operations', () => {
 
     const glossaryName = `CancelTest${Date.now()}`;
     await page.fill('[data-testid="name"]', glossaryName);
-    await page.locator(descriptionBox).fill('This should be cancelled');
+    await fillDescriptionBox(page, 'This should be cancelled');
 
     // Click cancel button
     await page.click('[data-testid="cancel-glossary"]');
@@ -1154,7 +1154,7 @@ test.describe('Glossary Advanced Operations', () => {
 
       const termName = `CancelTermTest${Date.now()}`;
       await page.fill('[data-testid="name"]', termName);
-      await page.locator(descriptionBox).fill('This should be cancelled');
+      await fillDescriptionBox(page, 'This should be cancelled');
 
       // Click cancel button (X or Cancel)
       await page.getByRole('button', { name: 'Cancel' }).click();
@@ -1301,7 +1301,7 @@ test.describe('Glossary Advanced Operations', () => {
       // Create a long name (128 chars is typically the limit)
       const longName = 'A'.repeat(100) + Date.now().toString().slice(-10);
       await page.fill('[data-testid="name"]', longName);
-      await page.locator(descriptionBox).fill('Term with long name');
+      await fillDescriptionBox(page, 'Term with long name');
 
       const createResponse = page.waitForResponse('/api/v1/glossaryTerms');
       await page.click('[data-testid="save-glossary-term"]');
@@ -1335,7 +1335,7 @@ test.describe('Glossary Advanced Operations', () => {
 
       // Create a long description (5000+ chars)
       const longDescription = 'This is a test. '.repeat(350);
-      await page.locator(descriptionBox).fill(longDescription);
+      await fillDescriptionBox(page, longDescription);
 
       const createResponse = page.waitForResponse('/api/v1/glossaryTerms');
       await page.click('[data-testid="save-glossary-term"]');
@@ -1363,7 +1363,7 @@ test.describe('Glossary Advanced Operations', () => {
     // Try to enter name exceeding 128 chars
     const tooLongName = 'A'.repeat(150);
     await page.fill('[data-testid="name"]', tooLongName);
-    await page.locator(descriptionBox).fill('Test description');
+    await fillDescriptionBox(page, 'Test description');
 
     // Try to save
     await page.click('[data-testid="save-glossary"]');
@@ -1399,7 +1399,7 @@ test.describe('Glossary Advanced Operations', () => {
       // Try to enter name exceeding 128 chars
       const tooLongName = 'B'.repeat(150);
       await page.fill('[data-testid="name"]', tooLongName);
-      await page.locator(descriptionBox).fill('Test description');
+      await fillDescriptionBox(page, 'Test description');
 
       // Try to save
       await page.click('[data-testid="save-glossary-term"]');

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryCRUDOperations.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryCRUDOperations.spec.ts
@@ -17,6 +17,7 @@ import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
 import { UserClass } from '../../../support/user/UserClass';
 import {
   descriptionBox,
+  fillDescriptionBox,
   getApiContext,
   redirectToHomePage,
 } from '../../../utils/common';
@@ -49,9 +50,7 @@ test.describe('Glossary CRUD Operations', () => {
       await page.getByTestId('form-heading').waitFor();
 
       await page.fill('[data-testid="name"]', glossaryName);
-      await page
-        .locator(descriptionBox)
-        .fill('Glossary with all optional fields');
+      await fillDescriptionBox(page, 'Glossary with all optional fields');
 
       const createResponse = page.waitForResponse('/api/v1/glossaries');
       await page.click('[data-testid="save-glossary"]');
@@ -96,7 +95,7 @@ test.describe('Glossary CRUD Operations', () => {
       await page.getByTestId('form-heading').waitFor();
 
       await page.fill('[data-testid="name"]', glossaryName);
-      await page.locator(descriptionBox).fill('Mutually exclusive glossary');
+      await fillDescriptionBox(page, 'Mutually exclusive glossary');
 
       const meToggle = page.getByTestId('mutually-exclusive-button');
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryHierarchy.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryHierarchy.spec.ts
@@ -368,56 +368,52 @@ test.describe('Glossary Hierarchy', () => {
   });
 
   // H-DD05: Drag term - cancel operation
-  test(
-    'should cancel drag and drop operation',
-    { tag: '@quarantine' },
-    async ({ page }) => {
-      const { apiContext, afterAction } = await getApiContext(page);
-      const glossary = new Glossary();
-      const term1 = new GlossaryTerm(glossary);
-      const term2 = new GlossaryTerm(glossary);
+  test('should cancel drag and drop operation', async ({ page }) => {
+    const { apiContext, afterAction } = await getApiContext(page);
+    const glossary = new Glossary();
+    const term1 = new GlossaryTerm(glossary);
+    const term2 = new GlossaryTerm(glossary);
 
-      try {
-        await glossary.create(apiContext);
-        await term1.create(apiContext);
-        await term2.create(apiContext);
+    try {
+      await glossary.create(apiContext);
+      await term1.create(apiContext);
+      await term2.create(apiContext);
 
-        await sidebarClick(page, SidebarItem.GLOSSARY);
-        await selectActiveGlossary(page, glossary.data.displayName);
+      await sidebarClick(page, SidebarItem.GLOSSARY);
+      await selectActiveGlossary(page, glossary.data.displayName);
 
-        // Drag term1 to term2
-        await dragAndDropTerm(
-          page,
-          term1.responseData.displayName,
-          term2.responseData.displayName
-        );
+      // Drag term1 to term2
+      await dragAndDropTerm(
+        page,
+        term1.responseData.displayName,
+        term2.responseData.displayName
+      );
 
-        // Wait for confirmation modal content to be visible
-        await expect(
-          page.getByTestId('confirmation-modal').locator('.ant-modal-content')
-        ).toBeVisible();
+      // Wait for confirmation modal content to be visible
+      await expect(
+        page.getByTestId('confirmation-modal').locator('.ant-modal-content')
+      ).toBeVisible();
 
-        // Click Cancel button
-        await page.getByRole('button', { name: 'Cancel' }).click();
+      // Click Cancel button
+      await page.getByRole('button', { name: 'Cancel' }).click();
 
-        // Verify modal content is closed
-        await expect(
-          page.getByTestId('confirmation-modal').locator('.ant-modal-content')
-        ).toBeHidden();
+      // Verify modal content is closed
+      await expect(
+        page.getByTestId('confirmation-modal').locator('.ant-modal-content')
+      ).toBeHidden();
 
-        // Verify terms are still at root level (no hierarchy change)
-        await expect(
-          page.getByTestId(term1.responseData.displayName)
-        ).toBeVisible();
-        await expect(
-          page.getByTestId(term2.responseData.displayName)
-        ).toBeVisible();
-      } finally {
-        await term1.delete(apiContext);
-        await term2.delete(apiContext);
-        await glossary.delete(apiContext);
-        await afterAction();
-      }
+      // Verify terms are still at root level (no hierarchy change)
+      await expect(
+        page.getByTestId(term1.responseData.displayName)
+      ).toBeVisible();
+      await expect(
+        page.getByTestId(term2.responseData.displayName)
+      ).toBeVisible();
+    } finally {
+      await term1.delete(apiContext);
+      await term2.delete(apiContext);
+      await glossary.delete(apiContext);
+      await afterAction();
     }
-  );
+  });
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryP2Tests.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryP2Tests.spec.ts
@@ -16,7 +16,7 @@ import { Glossary } from '../../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
 import { UserClass } from '../../../support/user/UserClass';
 import {
-  descriptionBox,
+  fillDescriptionBox,
   getApiContext,
   redirectToHomePage,
 } from '../../../utils/common';
@@ -49,9 +49,7 @@ test.describe('Glossary P2 Tests', () => {
 
       // Use name with underscores and hyphens
       await page.fill('[data-testid="name"]', specialName);
-      await page
-        .locator(descriptionBox)
-        .fill('Glossary with special characters');
+      await fillDescriptionBox(page, 'Glossary with special characters');
 
       const glossaryResponse = page.waitForResponse('/api/v1/glossaries');
       await page.click('[data-testid="save-glossary"]');
@@ -188,7 +186,7 @@ test.describe('Glossary P2 Tests', () => {
 
       const termName = `DraftTerm_${Date.now()}`;
       await page.fill('[data-testid="name"]', termName);
-      await page.locator(descriptionBox).fill('Test term for draft status');
+      await fillDescriptionBox(page, 'Test term for draft status');
 
       // Set up response listener before clicking save
       const termResponse = page.waitForResponse(

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryP3Tests.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryP3Tests.spec.ts
@@ -16,7 +16,7 @@ import { Glossary } from '../../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
 import {
   createNewPage,
-  descriptionBox,
+  fillDescriptionBox,
   getApiContext,
   redirectToHomePage,
 } from '../../../utils/common';
@@ -53,9 +53,7 @@ test.describe('Glossary P3 Tests', () => {
 
       // Use name with unicode characters
       await page.fill('[data-testid="name"]', unicodeName);
-      await page
-        .locator(descriptionBox)
-        .fill('Glossary with unicode characters');
+      await fillDescriptionBox(page, 'Glossary with unicode characters');
 
       const [response] = await Promise.all([
         page.waitForResponse(
@@ -818,7 +816,7 @@ test.describe('Glossary P3 Tests', () => {
       await page.getByTestId('name').waitFor();
 
       await page.fill('[data-testid="name"]', 'TestTerm');
-      await page.locator(descriptionBox).fill('Test description');
+      await fillDescriptionBox(page, 'Test description');
 
       const addReferenceBtn = page.getByTestId('add-reference');
       await addReferenceBtn.click();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryTermDetails.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryTermDetails.spec.ts
@@ -15,8 +15,9 @@ import { SidebarItem } from '../../../constant/sidebar';
 import { Glossary } from '../../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
 import {
-  descriptionBox,
+  fillDescriptionBox,
   getApiContext,
+  getDescriptionBox,
   redirectToHomePage,
 } from '../../../utils/common';
 import {
@@ -355,8 +356,8 @@ test.describe('Glossary Term Details Operations', () => {
 
       // Update the description
       const newDescription = 'Updated description via table edit modal';
-      await page.locator(descriptionBox).clear();
-      await page.locator(descriptionBox).fill(newDescription);
+      await getDescriptionBox(page).clear();
+      await fillDescriptionBox(page, newDescription);
 
       // Add a synonym
       const newSynonym = 'TableEditSynonym';
@@ -425,7 +426,7 @@ test.describe('Glossary Term Details Operations', () => {
       const termName = `FullTerm${Date.now()}`;
       await page.fill('[data-testid="name"]', termName);
       await page.fill('[data-testid="display-name"]', termName);
-      await page.locator(descriptionBox).fill('A comprehensive test term');
+      await fillDescriptionBox(page, 'A comprehensive test term');
 
       // Add synonyms
       const synonyms = ['synonym1', 'synonym2', 'alternative'];

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryWorkflow.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryWorkflow.spec.ts
@@ -19,6 +19,7 @@ import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import {
   descriptionBox,
+  fillDescriptionBox,
   getApiContext,
   redirectToHomePage,
 } from '../../../utils/common';
@@ -126,7 +127,7 @@ test.describe('Term Status Transitions', { tag: ['@workflow'] }, () => {
     // Fill in term details
     const termName = `ApprovedTerm${Date.now()}`;
     await page.fill('[data-testid="name"]', termName);
-    await page.locator(descriptionBox).fill('Test description for status');
+    await fillDescriptionBox(page, 'Test description for status');
 
     // Submit the term
     const createResponse = page.waitForResponse('/api/v1/glossaryTerms');
@@ -163,7 +164,7 @@ test.describe('Term Status Transitions', { tag: ['@workflow'] }, () => {
     // Fill in term details
     const termName = `DraftTerm${Date.now()}`;
     await page.fill('[data-testid="name"]', termName);
-    await page.locator(descriptionBox).fill('Test description for draft');
+    await fillDescriptionBox(page, 'Test description for draft');
 
     // Submit the term
     const createResponse = page.waitForResponse('/api/v1/glossaryTerms');
@@ -199,9 +200,7 @@ test.describe('Term Status Transitions', { tag: ['@workflow'] }, () => {
     // Fill in term details
     const termName = `InheritReviewerTerm${Date.now()}`;
     await page.fill('[data-testid="name"]', termName);
-    await page
-      .locator(descriptionBox)
-      .fill('Test term to verify reviewer inheritance');
+    await fillDescriptionBox(page, 'Test term to verify reviewer inheritance');
 
     // Submit the term
     const createResponse = page.waitForResponse('/api/v1/glossaryTerms');
@@ -259,7 +258,7 @@ test(
       await openAddGlossaryTermModal(page);
 
       await page.fill('[data-testid="name"]', termName);
-      await page.locator(descriptionBox).fill('Term for review testing');
+      await fillDescriptionBox(page, 'Term for review testing');
 
       const createResponse = page.waitForResponse('/api/v1/glossaryTerms');
       await page.click('[data-testid="save-glossary-term"]');
@@ -320,7 +319,7 @@ test(
       await openAddGlossaryTermModal(page);
 
       await page.fill('[data-testid="name"]', termName);
-      await page.locator(descriptionBox).fill('Test term for status badge');
+      await fillDescriptionBox(page, 'Test term for status badge');
 
       const createResponse = page.waitForResponse('/api/v1/glossaryTerms');
       await page.click('[data-testid="save-glossary-term"]');
@@ -392,7 +391,7 @@ test(
       await openAddGlossaryTermModal(page);
 
       await page.fill('[data-testid="name"]', termName);
-      await page.locator(descriptionBox).fill('Term for owner approval test');
+      await fillDescriptionBox(page, 'Term for owner approval test');
 
       const createResponse = page.waitForResponse('/api/v1/glossaryTerms');
       await page.click('[data-testid="save-glossary-term"]');

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
@@ -544,7 +544,10 @@ const cleanupFixtures = async () => {
 
 const waitForMetricsPage = async (page: Page) => {
   const metricsResponse = waitForMetricsSearchResponse(page);
-  await page.goto('/metrics');
+  // domcontentloaded, not the default 'load': /metrics pulls enough subresources
+  // that waiting for all of them exceeded the 60s navigation timeout under merge
+  // queue load. The real readiness signal is the search response awaited next.
+  await page.goto('/metrics', { waitUntil: 'domcontentloaded' });
   await metricsResponse;
   await waitForAllLoadersToDisappear(page);
   await expect(page.getByTestId('heading')).toHaveText('Metrics');

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/QueryEntity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/QueryEntity.spec.ts
@@ -17,6 +17,7 @@ import {
   clickOutside,
   createNewPage,
   descriptionBox,
+  fillDescriptionBox,
   redirectToHomePage,
 } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
@@ -153,7 +154,7 @@ test('Query Entity', async ({ page }) => {
 
     // Update Description
     await page.click(`[data-testid="edit-description"]`);
-    await page.locator(descriptionBox).fill('updated description');
+    await fillDescriptionBox(page, 'updated description');
     const updateDescriptionResponse = page.waitForResponse(
       (response) =>
         response.url().includes('/api/v1/queries/') &&

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/AddRoleAndAssignToUser.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/AddRoleAndAssignToUser.spec.ts
@@ -15,7 +15,7 @@ import test, { expect } from '@playwright/test';
 import { GlobalSettingOptions } from '../../constant/settings';
 import {
   createNewPage,
-  descriptionBox,
+  fillDescriptionBox,
   generateRandomUsername,
   redirectToHomePage,
   uuid,
@@ -51,7 +51,7 @@ test.describe.serial('Add role and assign it to the user', () => {
     await page.click('[data-testid="add-role"]');
 
     await page.fill('[data-testid="name"]', roleName);
-    await page.locator(descriptionBox).fill(`description for ${roleName}`);
+    await fillDescriptionBox(page, `description for ${roleName}`);
 
     await page.click('[data-testid="policies"]');
     await page.click('[title="Data Consumer Policy"]');
@@ -85,7 +85,7 @@ test.describe.serial('Add role and assign it to the user', () => {
 
     await page.fill('[data-testid="email"]', user.email);
     await page.fill('[data-testid="displayName"]', userDisplayName);
-    await page.locator(descriptionBox).fill('Adding user');
+    await fillDescriptionBox(page, 'Adding user');
     const generatePasswordResponse = page.waitForResponse(
       `/api/v1/users/generateRandomPwd`
     );

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ApiServiceRest.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ApiServiceRest.spec.ts
@@ -17,7 +17,7 @@ import { COLLATE_SAAS_RUNNER } from '../../constant/serviceForm';
 import { GlobalSettingOptions } from '../../constant/settings';
 import { expect, test } from '../../support/fixtures/base';
 import {
-  descriptionBox,
+  fillDescriptionBox,
   redirectToHomePage,
   toastNotification,
   uuid,
@@ -136,7 +136,7 @@ test.describe('API service', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
     );
     await page.locator('#service-name').fill(apiServiceConfig.name);
     await page.getByTestId('add-description-button').click();
-    await page.locator(descriptionBox).fill(apiServiceConfig.description);
+    await fillDescriptionBox(page, apiServiceConfig.description);
     await selectIngestionRunnerFromDropdown(page, COLLATE_SAAS_RUNNER);
 
     await page

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/NotificationAlerts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/NotificationAlerts.spec.ts
@@ -30,7 +30,7 @@ import {
   visitAlertDetailsPage,
   visitEditAlertPage,
 } from '../../utils/alert';
-import { descriptionBox, getApiContext } from '../../utils/common';
+import { getApiContext, getDescriptionBox } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import {
   addFilterWithUsersListInput,
@@ -265,7 +265,7 @@ test('Multiple Filters Alert', async ({ page }) => {
     await visitEditAlertPage(page, data.alertDetails);
 
     // Remove description
-    await page.locator(descriptionBox).clear();
+    await getDescriptionBox(page).clear();
 
     // Remove all filters with state verification
     for (let i = 5; i >= 0; i--) {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaFlow.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaFlow.spec.ts
@@ -21,6 +21,7 @@ import { selectOption } from '../../utils/advancedSearch';
 import {
   createNewPage,
   descriptionBox,
+  fillDescriptionBox,
   redirectToHomePage,
   uuid,
 } from '../../utils/common';
@@ -94,7 +95,7 @@ test.describe.serial('Persona operations', () => {
 
     await page.getByTestId('displayName').fill(PERSONA_DETAILS.displayName);
 
-    await page.locator(descriptionBox).fill(PERSONA_DETAILS.description);
+    await fillDescriptionBox(page, PERSONA_DETAILS.description);
 
     const userListResponse = page.waitForResponse(
       '/api/v1/users?limit=*&isBot=false*'

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
@@ -75,8 +75,8 @@ import { advanceSearchSaveFilter } from '../../utils/advancedSearchCustomPropert
 import {
   clickOutside,
   createNewPage,
-  descriptionBox,
   getApiContext,
+  getDescriptionBox,
   redirectToHomePage,
   uuid,
 } from '../../utils/common';
@@ -856,7 +856,7 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
           await container.getByTestId('edit-icon').click();
 
           // Move to a new paragraph at the end, then insert a table via slash command
-          const editor = page.locator(descriptionBox);
+          const editor = getDescriptionBox(page);
           await editor.click();
           await page.keyboard.press('Control+End');
           await page.keyboard.press('Enter');
@@ -881,7 +881,7 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
 
           // Regression for #32477: edit button must not be hidden by horizontal overflow
           await editButton.click();
-          await expect(page.locator(descriptionBox)).toBeVisible();
+          await expect(getDescriptionBox(page)).toBeVisible();
         });
       });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataProducts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataProducts.spec.ts
@@ -23,7 +23,7 @@ import { ClassificationClass } from '../../support/tag/ClassificationClass';
 import { TagClass } from '../../support/tag/TagClass';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
-import { descriptionBox, redirectToHomePage } from '../../utils/common';
+import { fillDescriptionBox, redirectToHomePage } from '../../utils/common';
 import {
   addAssetsToDataProduct,
   createDataProductFromListPage,
@@ -478,7 +478,7 @@ test.describe('Data Products', () => {
       await page
         .locator('#root\\/displayName')
         .fill(dataProduct.data.displayName);
-      await page.locator(descriptionBox).fill(dataProduct.data.description);
+      await fillDescriptionBox(page, dataProduct.data.description);
 
       const domainContainer = page.getByTestId('domain-select');
       await domainContainer.scrollIntoViewIfNeeded();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
@@ -2134,6 +2134,15 @@ test.describe('Domain Rename Comprehensive Tests', () => {
   test('Rename domain with assets (tables, topics, dashboards) preserves associations', async ({
     page,
   }) => {
+    // Seeds three assets, renames the domain twice and re-verifies the
+    // associations after each rename, which does not fit the 60s default. It was
+    // covered by the describe-scope test.slow(true) that #32360 removed; the
+    // per-test measurements that drove that change did not include this describe,
+    // and it has since timed out at exactly 60000ms in every merge_group run,
+    // ejecting four unrelated PRs across six runs. Per-test, not blanket — the
+    // rest of the describe keeps the default budget.
+    test.slow();
+
     const { afterAction, apiContext } = await getApiContext(page);
     const { assets, assetCleanup } = await setupAssetsForDomain(page);
     const domain = new Domain();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
@@ -39,7 +39,6 @@ import {
 } from '../../utils/assetDrawerQuickFilter';
 import {
   clickOutside,
-  descriptionBox,
   getApiContext,
   getDescriptionBox,
   redirectToHomePage,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
@@ -41,6 +41,7 @@ import {
   clickOutside,
   descriptionBox,
   getApiContext,
+  getDescriptionBox,
   redirectToHomePage,
   toastNotification,
   uuid,
@@ -181,7 +182,7 @@ test.describe('Domains', () => {
     await page.getByTestId('add-domain').click();
     await page.getByTestId('add-domain-form').waitFor();
 
-    const description = page.locator(descriptionBox);
+    const description = getDescriptionBox(page);
     const typed = 'hello world ';
 
     await description.click();
@@ -3700,7 +3701,7 @@ test.describe('Domain description editor popups', () => {
     await page.getByTestId('add-domain').click();
     await page.getByTestId('add-domain-form').waitFor();
 
-    const description = page.locator(descriptionBox);
+    const description = getDescriptionBox(page);
     await description.click();
 
     await test.step('Slash command inserts an image block', async () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Entity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Entity.spec.ts
@@ -43,7 +43,6 @@ import {
   generateRandomUsername,
   getApiContext,
   getAuthContext,
-  getDescriptionBox,
   getToken,
   redirectToHomePage,
   removeSingleSelectDomain,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Entity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Entity.spec.ts
@@ -40,10 +40,10 @@ import { UserClass } from '../../support/user/UserClass';
 import { createAdminApiContext } from '../../utils/admin';
 import {
   assignSingleSelectDomain,
-  descriptionBox,
   generateRandomUsername,
   getApiContext,
   getAuthContext,
+  getDescriptionBox,
   getToken,
   redirectToHomePage,
   removeSingleSelectDomain,
@@ -1624,7 +1624,7 @@ Object.entries(entities).forEach(([key, EntityClass]) => {
             await editDescriptionButton.click();
 
             // Wait for description box to be visible and ready
-            const descBox = page.locator(descriptionBox).first();
+            const descBox = getDescriptionBox(page).first();
             await expect(descBox).toBeVisible();
             await descBox.clear();
             await descBox.fill(newDescription);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Entity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Entity.spec.ts
@@ -47,6 +47,7 @@ import {
   getToken,
   redirectToHomePage,
   removeSingleSelectDomain,
+  resolveDescriptionBox,
   toastNotification,
   uuid,
   verifyDomainPropagation,
@@ -1624,8 +1625,7 @@ Object.entries(entities).forEach(([key, EntityClass]) => {
             await editDescriptionButton.click();
 
             // Wait for description box to be visible and ready
-            const descBox = getDescriptionBox(page).first();
-            await expect(descBox).toBeVisible();
+            const descBox = await resolveDescriptionBox(page);
             await descBox.clear();
             await descBox.fill(newDescription);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EntityDataConsumer.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EntityDataConsumer.spec.ts
@@ -114,13 +114,9 @@ entities.forEach((EntityClass) => {
     // Only the Table variant is flaky (3 of 11 sampled merge_group runs); the
     // other 15 entity types are clean, so the tag is scoped rather than
     // quarantining the whole generated set. See playwright/QUARANTINE.md.
-    test(
-      'Update description',
-      entity.getType() === 'Table' ? { tag: '@quarantine' } : {},
-      async ({ page }) => {
-        await entity.descriptionUpdate(page);
-      }
-    );
+    test('Update description', async ({ page }) => {
+      await entity.descriptionUpdate(page);
+    });
 
     test('Tag Add, Update and Remove', async ({ page }) => {
       await entity.tag(page, 'PersonalData.Personal', 'PII.None', entity);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
@@ -38,6 +38,7 @@ import {
 import {
   clickOutside,
   descriptionBox,
+  fillDescriptionBox,
   getAuthContext,
   getRandomLastName,
   getToken,
@@ -2388,7 +2389,7 @@ test.describe('Glossary tests', () => {
       await page.getByTestId('form-heading').waitFor();
 
       await page.fill('[data-testid="name"]', glossary.data.name);
-      await page.locator(descriptionBox).fill(glossary.data.description);
+      await fillDescriptionBox(page, glossary.data.description);
 
       await page.click('[data-testid="tag-selector"]');
       await page.fill(
@@ -2491,9 +2492,7 @@ test.describe('Glossary tests', () => {
 
       const childTermName = `ChildTerm_${uuid()}`;
       await page.getByTestId('name').fill(childTermName);
-      await page
-        .locator(descriptionBox)
-        .fill('Child term created via row action');
+      await fillDescriptionBox(page, 'Child term created via row action');
 
       const createRes = page.waitForResponse(
         (response) =>
@@ -2704,9 +2703,10 @@ test.describe('Glossary tests', () => {
 
       const termName = `P1Term_${uuid()}`;
       await page.getByTestId('name').fill(termName);
-      await page
-        .locator(descriptionBox)
-        .fill('Term created with multiple optional fields');
+      await fillDescriptionBox(
+        page,
+        'Term created with multiple optional fields'
+      );
 
       const termModal = page.locator('.edit-glossary-modal');
       const tagsSelect = termModal.locator('[data-testid="tag-selector"]');

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryFormValidation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryFormValidation.spec.ts
@@ -14,7 +14,7 @@ import test, { expect } from '@playwright/test';
 import { SidebarItem } from '../../constant/sidebar';
 import { Glossary } from '../../support/glossary/Glossary';
 import {
-  descriptionBox,
+  fillDescriptionBox,
   getApiContext,
   redirectToHomePage,
 } from '../../utils/common';
@@ -40,7 +40,7 @@ test.describe('Glossary Form Validation', () => {
     await page.getByTestId('form-heading').waitFor();
 
     // Fill description but leave name empty
-    await page.locator(descriptionBox).fill('Test description');
+    await fillDescriptionBox(page, 'Test description');
 
     // Try to save
     await page.click('[data-testid="save-glossary"]');
@@ -85,7 +85,7 @@ test.describe('Glossary Form Validation', () => {
 
       // Use the same name as existing glossary
       await page.fill('[data-testid="name"]', glossary.data.name);
-      await page.locator(descriptionBox).fill('Test description');
+      await fillDescriptionBox(page, 'Test description');
 
       // Try to save
       await page.click('[data-testid="save-glossary"]');
@@ -113,7 +113,7 @@ test.describe('Glossary Form Validation', () => {
       await openAddGlossaryTermModal(page);
 
       // Fill description but leave name empty
-      await page.locator(descriptionBox).fill('Test term description');
+      await fillDescriptionBox(page, 'Test term description');
 
       // Try to save
       await page.click('[data-testid="save-glossary-term"]');

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Policies.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Policies.spec.ts
@@ -34,7 +34,9 @@ import {
 import {
   closeFirstPopupAlert,
   descriptionBox,
+  fillDescriptionBox,
   getApiContext,
+  getDescriptionBox,
   redirectToHomePage,
   toastNotification,
 } from '../../utils/common';
@@ -135,7 +137,7 @@ test.describe(
         });
 
         // Enter description
-        await page.locator(descriptionBox).nth(0).fill(DESCRIPTION);
+        await getDescriptionBox(page).nth(0).fill(DESCRIPTION);
 
         // Enter rule name
         await addRule(page, RULE_NAME, RULE_DESCRIPTION, 1);
@@ -189,9 +191,7 @@ test.describe(
         // Click on edit description
         await page.locator('[data-testid="edit-description"]').click();
 
-        await page
-          .locator(descriptionBox)
-          .fill(`${UPDATED_DESCRIPTION}-${POLICY_NAME}`);
+        await fillDescriptionBox(page, `${UPDATED_DESCRIPTION}-${POLICY_NAME}`);
 
         // Click on save
         await page.locator('[data-testid="save"]').click();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Roles.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Roles.spec.ts
@@ -15,8 +15,8 @@ import { GlobalSettingOptions } from '../../constant/settings';
 import { RolesClass } from '../../support/access-control/RolesClass';
 import { expect, test } from '../../support/fixtures/base';
 import {
-  descriptionBox,
   getApiContext,
+  getDescriptionBox,
   redirectToHomePage,
   toastNotification,
   uuid,
@@ -84,7 +84,7 @@ test.describe('Roles page tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       await page.locator('#name').fill(roleName);
 
       // Entering description
-      const descriptionField = page.locator(descriptionBox);
+      const descriptionField = getDescriptionBox(page);
       await expect(descriptionField).toBeVisible();
       await descriptionField.fill(description);
 
@@ -233,7 +233,7 @@ test.describe('Roles page tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       await page.locator('#name').fill(roleName);
 
       // Entering description
-      const descriptionField = page.locator(descriptionBox);
+      const descriptionField = getDescriptionBox(page);
       await expect(descriptionField).toBeVisible();
       await descriptionField.fill(description);
 
@@ -267,7 +267,7 @@ test.describe('Roles page tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       await editDescriptionButton.click();
 
       // Wait for description editor to be visible
-      const descriptionField = page.locator(descriptionBox);
+      const descriptionField = getDescriptionBox(page);
       await expect(descriptionField).toBeVisible();
       await descriptionField.fill(`${description}-updated`);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Tag.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Tag.spec.ts
@@ -494,6 +494,10 @@ test.describe('Tag Page with Data Consumer Roles', () => {
     adminPage,
     dataConsumerPage,
   }) => {
+    // Three full navigation cycles (add, filter check, remove) overrun the
+    // default budget on slow CI shards — the merge-queue ejection in #32629.
+    test.slow();
+
     const { assets, assetCleanup } = await setupAssetsForTag(adminPage);
     await redirectToHomePage(dataConsumerPage);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Tags.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Tags.spec.ts
@@ -21,7 +21,7 @@ import { UserClass } from '../../support/user/UserClass';
 import {
   clickOutside,
   createNewPage,
-  descriptionBox,
+  fillDescriptionBox,
   redirectToHomePage,
   uuid,
 } from '../../utils/common';
@@ -281,7 +281,7 @@ test('Classification Page', async ({ page }) => {
       .getByTestId('displayName')
       .getByRole('textbox')
       .fill(NEW_CLASSIFICATION.displayName);
-    await page.locator(descriptionBox).fill(NEW_CLASSIFICATION.description);
+    await fillDescriptionBox(page, NEW_CLASSIFICATION.description);
     await page.click('[data-testid="mutually-exclusive-button"]');
 
     const createTagCategoryResponse = page.waitForResponse(
@@ -315,7 +315,7 @@ test('Classification Page', async ({ page }) => {
       .getByTestId('displayName')
       .getByRole('textbox')
       .fill(NEW_TAG.displayName);
-    await page.locator(descriptionBox).fill(NEW_TAG.description);
+    await fillDescriptionBox(page, NEW_TAG.description);
     await page.getByTestId('icon-picker-btn').click();
     await page.getByRole('button', { name: NEW_TAG.icon }).click();
     await page

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TasksUIFlow.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TasksUIFlow.spec.ts
@@ -21,7 +21,7 @@ import {
   authenticateAdminPage,
   createAdminApiContext,
 } from '../../utils/admin';
-import { descriptionBox } from '../../utils/common';
+import { fillDescriptionBox, getDescriptionBox } from '../../utils/common';
 import { waitForPageLoaded } from '../../utils/polling';
 import {
   waitForTaskCreateResponse,
@@ -84,8 +84,8 @@ const createDescriptionTaskViaUI = async (
 
   await selectAssignee(page, assigneeName);
 
-  await page.locator(descriptionBox).clear();
-  await page.locator(descriptionBox).fill(description);
+  await getDescriptionBox(page).clear();
+  await fillDescriptionBox(page, description);
 
   const taskResponse = waitForTaskCreateResponse(page);
   await page.click('button[type="submit"]');
@@ -348,8 +348,8 @@ test.describe('Task Workflow - Table Column Tasks', () => {
 
       await selectAssignee(page, userName);
 
-      await page.locator(descriptionBox).clear();
-      await page.locator(descriptionBox).fill('Column description test');
+      await getDescriptionBox(page).clear();
+      await fillDescriptionBox(page, 'Column description test');
 
       const taskResponse = page.waitForResponse('/api/v1/tasks');
       await page.click('button[type="submit"]');

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TestSuite.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TestSuite.spec.ts
@@ -28,7 +28,7 @@ import {
 import { performAdminLogin } from '../../utils/admin';
 import {
   assignSingleSelectDomain,
-  descriptionBox,
+  fillDescriptionBox,
   redirectToHomePage,
   removeSingleSelectDomain,
   toastNotification,
@@ -205,7 +205,7 @@ test(
       await page
         .locator('[data-testid="test-suite-name"] input')
         .fill(NEW_TEST_SUITE.name);
-      await page.locator(descriptionBox).fill(NEW_TEST_SUITE.description);
+      await fillDescriptionBox(page, NEW_TEST_SUITE.description);
       await page.waitForSelector(
         "[data-testid='test-case-selection-card'] [data-testid='loader']",
         { state: 'detached' }

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TestSuiteDetailsPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TestSuiteDetailsPage.spec.ts
@@ -23,7 +23,7 @@ import {
 } from '../../utils/addTestCaseList';
 import { performAdminLogin } from '../../utils/admin';
 import {
-  descriptionBox,
+  fillDescriptionBox,
   redirectToHomePage,
   toastNotification,
   uuid,
@@ -70,7 +70,7 @@ test(
       await page
         .locator('[data-testid="test-suite-name"] input')
         .fill(NEW_TEST_SUITE.name);
-      await page.locator(descriptionBox).fill(NEW_TEST_SUITE.description);
+      await fillDescriptionBox(page, NEW_TEST_SUITE.description);
       await page.waitForSelector(
         "[data-testid='test-case-selection-card'] [data-testid='loader']",
         { state: 'detached' }

--- a/openmetadata-ui/src/main/resources/ui/playwright/eslint-rules/tests/corpus.test.mjs
+++ b/openmetadata-ui/src/main/resources/ui/playwright/eslint-rules/tests/corpus.test.mjs
@@ -41,7 +41,7 @@ test('the suppressions baseline matches its recorded state exactly', () => {
   // of the same rule in the same file stays invisible here.
   const EXPECTED = {
     'om-playwright/justified-rule-disable': 12,
-    'om-playwright/no-positional-locator': 1322,
+    'om-playwright/no-positional-locator': 1310,
     'om-playwright/require-assertion-per-test': 1,
     'playwright/no-skipped-test': 4,
     'playwright/no-wait-for-selector': 35,

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/AlertClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/AlertClass.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { APIRequestContext } from '@playwright/test';
-import { createOrFetch, okJson } from '../../utils/apiResponse';
+import { createOrFetch } from '../../utils/apiResponse';
 import { uuid } from '../../utils/common';
 
 interface AlertConfig {

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/AlertClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/AlertClass.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { APIRequestContext } from '@playwright/test';
-import { okJson } from '../../utils/apiResponse';
+import { createOrFetch, okJson } from '../../utils/apiResponse';
 import { uuid } from '../../utils/common';
 
 interface AlertConfig {
@@ -88,11 +88,12 @@ export class AlertClass {
   }
 
   async create(apiContext: APIRequestContext) {
-    const response = await apiContext.post('/api/v1/events/subscriptions', {
+    this.responseData = await createOrFetch(apiContext, {
+      label: 'AlertClass.create',
+      createPath: '/api/v1/events/subscriptions',
+      fqnSegments: [this.alertData.name],
       data: this.alertData,
     });
-
-    this.responseData = await okJson(response, 'AlertClass.create');
 
     return this.responseData;
   }

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ApiEndpointClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ApiEndpointClass.ts
@@ -19,7 +19,11 @@ import {
 } from '../../../src/generated/entity/data/apiEndpoint';
 import { SERVICE_TYPE } from '../../constant/service';
 import { ServiceTypes } from '../../constant/settings';
-import { okJson, withNotFoundRetry } from '../../utils/apiResponse';
+import {
+  createOrFetch,
+  okJson,
+  withNotFoundRetry,
+} from '../../utils/apiResponse';
 import { uuid } from '../../utils/common';
 import { visitEntityPageByFqn } from '../../utils/entity';
 import { EntityTypeEndpoint, ResponseDataType } from './Entity.interface';
@@ -213,45 +217,39 @@ export class ApiEndpointClass extends EntityClass {
   }
 
   async create(apiContext: APIRequestContext) {
-    const serviceResponse = await apiContext.post(
-      '/api/v1/services/apiServices',
-      {
-        data: this.service,
-      }
-    );
-
-    const apiCollectionResponse = await apiContext.post(
-      '/api/v1/apiCollections',
-      {
-        data: this.apiCollection,
-      }
-    );
-
-    const entityResponse = await apiContext.post('/api/v1/apiEndpoints', {
-      data: this.entity,
+    this.serviceResponseData = await createOrFetch(apiContext, {
+      label: 'ApiEndpointClass.create service',
+      createPath: '/api/v1/services/apiServices',
+      fqnSegments: [this.service.name],
+      data: this.service,
     });
 
-    this.serviceResponseData = await okJson(
-      serviceResponse,
-      'ApiEndpointClass.create'
-    );
-    this.apiCollectionResponseData = await okJson(
-      apiCollectionResponse,
-      'ApiEndpointClass.create'
-    );
-    this.entityResponseData = await okJson(
-      entityResponse,
-      'ApiEndpointClass.create'
-    );
+    this.apiCollectionResponseData = await createOrFetch(apiContext, {
+      label: 'ApiEndpointClass.create apiCollection',
+      createPath: '/api/v1/apiCollections',
+      fqnSegments: [this.service.name, this.apiCollection.name],
+      data: this.apiCollection,
+    });
+
+    this.entityResponseData = await createOrFetch(apiContext, {
+      label: 'ApiEndpointClass.create apiEndpoint',
+      createPath: '/api/v1/apiEndpoints',
+      fqnSegments: [
+        this.service.name,
+        this.apiCollection.name,
+        this.entity.name,
+      ],
+      data: this.entity,
+    });
 
     this.childrenSelectorId =
       this.entityResponseData.requestSchema?.schemaFields?.[0]
         .fullyQualifiedName ?? '';
 
     return {
-      service: serviceResponse.body,
-      apiCollection: apiCollectionResponse.body,
-      entity: entityResponse.body,
+      service: this.serviceResponseData,
+      apiCollection: this.apiCollectionResponseData,
+      entity: this.entityResponseData,
     };
   }
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ContainerClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ContainerClass.ts
@@ -236,8 +236,8 @@ export class ContainerClass extends EntityClass {
       this.entityResponseData.dataModel?.columns?.[0].fullyQualifiedName ?? '';
 
     return {
-      service: serviceResponse.body,
-      entity: entityResponse.body,
+      service: this.serviceResponseData,
+      entity: this.entityResponseData,
     };
   }
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ContainerClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ContainerClass.ts
@@ -21,7 +21,11 @@ import {
 } from '../../../src/generated/entity/data/container';
 import { SERVICE_TYPE } from '../../constant/service';
 import { ServiceTypes } from '../../constant/settings';
-import { okJson, withNotFoundRetry } from '../../utils/apiResponse';
+import {
+  createOrFetch,
+  okJson,
+  withNotFoundRetry,
+} from '../../utils/apiResponse';
 import { uuid } from '../../utils/common';
 import { visitEntityPageByFqn } from '../../utils/entity';
 import { EntityTypeEndpoint, ResponseDataType } from './Entity.interface';
@@ -172,24 +176,22 @@ export class ContainerClass extends EntityClass {
     apiContext: APIRequestContext,
     customChildContainer?: { name: string; displayName: string }[]
   ) {
-    const serviceResponse = await apiContext.post(
-      '/api/v1/services/storageServices',
-      {
-        data: this.service,
-      }
-    );
-    const entityResponse = await apiContext.post('/api/v1/containers', {
-      data: this.entity,
+    this.serviceResponseData = await createOrFetch(apiContext, {
+      label: 'ContainerClass.create service',
+      createPath: '/api/v1/services/storageServices',
+      fqnSegments: [this.service.name],
+      data: this.service,
     });
 
-    this.serviceResponseData = await okJson(
-      serviceResponse,
-      'ContainerClass.create'
-    );
-    this.entityResponseData = await okJson(
-      entityResponse,
-      'ContainerClass.create'
-    );
+    // `dataModel` is in ContainerResource.FIELDS, so a by-name lookup omits it
+    // unless asked — and childrenSelectorId below reads dataModel.columns[0].
+    this.entityResponseData = await createOrFetch(apiContext, {
+      label: 'ContainerClass.create container',
+      createPath: '/api/v1/containers',
+      fqnSegments: [this.service.name, this.entity.name],
+      fields: 'dataModel',
+      data: this.entity,
+    });
 
     if (isUndefined(customChildContainer)) {
       const childContainer = {

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/DashboardClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/DashboardClass.ts
@@ -14,7 +14,11 @@ import { APIRequestContext, Page } from '@playwright/test';
 import { Operation } from 'fast-json-patch';
 import { SERVICE_TYPE } from '../../constant/service';
 import { ServiceTypes } from '../../constant/settings';
-import { okJson, withNotFoundRetry } from '../../utils/apiResponse';
+import {
+  createOrFetch,
+  okJson,
+  withNotFoundRetry,
+} from '../../utils/apiResponse';
 import { uuid } from '../../utils/common';
 import { visitEntityPageByFqn } from '../../utils/entity';
 import {
@@ -146,45 +150,39 @@ export class DashboardClass extends EntityClass {
   }
 
   async create(apiContext: APIRequestContext) {
-    const serviceResponse = await apiContext.post(
-      '/api/v1/services/dashboardServices',
-      {
-        data: this.service,
-      }
-    );
-    const chartsResponse = await apiContext.post('/api/v1/charts', {
+    this.serviceResponseData = await createOrFetch(apiContext, {
+      label: 'DashboardClass.create service',
+      createPath: '/api/v1/services/dashboardServices',
+      fqnSegments: [this.service.name],
+      data: this.service,
+    });
+
+    this.chartsResponseData = await createOrFetch(apiContext, {
+      label: 'DashboardClass.create chart',
+      createPath: '/api/v1/charts',
+      fqnSegments: [this.service.name, this.charts.name],
       data: this.charts,
     });
 
-    const entityResponse = await apiContext.post('/api/v1/dashboards', {
+    // Awaited before the dashboard is posted, not alongside it: the dashboard
+    // references the chart by FQN, so the chart has to exist first. The previous
+    // version fired both POSTs before awaiting either.
+    this.entityResponseData = await createOrFetch(apiContext, {
+      label: 'DashboardClass.create dashboard',
+      createPath: '/api/v1/dashboards',
+      fqnSegments: [this.service.name, this.entity.name],
       data: {
         ...this.entity,
         charts: [`${this.service.name}.${this.charts.name}`],
       },
     });
-    const dataModelResponse = await apiContext.post(
-      '/api/v1/dashboard/datamodels',
-      {
-        data: this.dataModel,
-      }
-    );
 
-    this.serviceResponseData = await okJson(
-      serviceResponse,
-      'DashboardClass.create'
-    );
-    this.chartsResponseData = await okJson(
-      chartsResponse,
-      'DashboardClass.create'
-    );
-    this.dataModelResponseData = await okJson(
-      dataModelResponse,
-      'DashboardClass.create'
-    );
-    this.entityResponseData = await okJson(
-      entityResponse,
-      'DashboardClass.create'
-    );
+    this.dataModelResponseData = await createOrFetch(apiContext, {
+      label: 'DashboardClass.create dataModel',
+      createPath: '/api/v1/dashboard/datamodels',
+      fqnSegments: [this.service.name, this.dataModel.name],
+      data: this.dataModel,
+    });
 
     return {
       service: this.serviceResponseData,

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/FileClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/FileClass.ts
@@ -19,7 +19,11 @@ import {
 } from '../../../src/generated/entity/data/file';
 import { SERVICE_TYPE } from '../../constant/service';
 import { ServiceTypes } from '../../constant/settings';
-import { okJson, withNotFoundRetry } from '../../utils/apiResponse';
+import {
+  createOrFetch,
+  okJson,
+  withNotFoundRetry,
+} from '../../utils/apiResponse';
 import { uuid } from '../../utils/common';
 import { visitEntityPageByFqn } from '../../utils/entity';
 import { EntityTypeEndpoint, ResponseDataType } from './Entity.interface';
@@ -117,44 +121,47 @@ export class FileClass extends EntityClass {
     };
   }
 
+  // createOrFetch, not a bare POST: these names are generated once, when the
+  // class is constructed. Specs that build their fixtures in the describe body
+  // (LineageFilters, for one) do not re-evaluate it on a retry, so beforeAll
+  // runs a second time with the same names and every create answers 409
+  // "Entity already exists" — the retry fails in the hook and takes the whole
+  // file with it. Treating the conflict as success and fetching the entity
+  // makes create idempotent, which is what a retry needs it to be.
   async create(apiContext: APIRequestContext) {
-    const serviceResponse = await apiContext.post(
-      '/api/v1/services/driveServices',
-      {
-        data: this.service,
-      }
-    );
-    this.serviceResponseData = await okJson(
-      serviceResponse,
-      'FileClass.create'
-    );
+    this.serviceResponseData = await createOrFetch(apiContext, {
+      label: 'FileClass.create service',
+      createPath: '/api/v1/services/driveServices',
+      fqnSegments: [this.service.name],
+      data: this.service,
+    });
 
     // Create directory
-    const directoryResponse = await apiContext.post(
-      '/api/v1/drives/directories',
-      {
-        data: {
-          name: this.directoryName,
-          service: this.serviceResponseData.fullyQualifiedName,
-        },
-      }
-    );
-    this.directoryResponseData = await okJson(
-      directoryResponse,
-      'FileClass.create'
-    );
+    this.directoryResponseData = await createOrFetch(apiContext, {
+      label: 'FileClass.create directory',
+      createPath: '/api/v1/drives/directories',
+      fqnSegments: [this.service.name, this.directoryName],
+      data: {
+        name: this.directoryName,
+        service: this.serviceResponseData.fullyQualifiedName,
+      },
+    });
 
-    // Create file in directory
-    const entityResponse = await apiContext.post(
-      `/api/v1/${EntityTypeEndpoint.File}`,
-      {
-        data: {
-          ...this.entity,
-          directory: this.directoryResponseData.fullyQualifiedName,
-        },
-      }
-    );
-    this.entityResponseData = await okJson(entityResponse, 'FileClass.create');
+    // Create file in directory. `columns` has to be requested explicitly: it is
+    // in FileResource.FIELDS, so the POST returns it but a by-name lookup does
+    // not, and the conflict path below reads columns[0] for childrenSelectorId.
+    // Without it a retry would quietly leave that selector empty and fail later,
+    // in a column test, rather than here.
+    this.entityResponseData = await createOrFetch<File>(apiContext, {
+      label: 'FileClass.create file',
+      createPath: `/api/v1/${EntityTypeEndpoint.File}`,
+      fqnSegments: [this.service.name, this.directoryName, this.fileName],
+      fields: 'columns',
+      data: {
+        ...this.entity,
+        directory: this.directoryResponseData.fullyQualifiedName,
+      },
+    });
 
     this.childrenSelectorId =
       this.entityResponseData.columns?.[0]?.fullyQualifiedName ?? '';

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/PipelineClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/PipelineClass.ts
@@ -14,7 +14,11 @@ import { APIRequestContext, Page } from '@playwright/test';
 import { Operation } from 'fast-json-patch';
 import { SERVICE_TYPE } from '../../constant/service';
 import { ServiceTypes } from '../../constant/settings';
-import { okJson, withNotFoundRetry } from '../../utils/apiResponse';
+import {
+  createOrFetch,
+  okJson,
+  withNotFoundRetry,
+} from '../../utils/apiResponse';
 import { uuid } from '../../utils/common';
 import { visitEntityPageByFqn } from '../../utils/entity';
 import {
@@ -100,28 +104,23 @@ export class PipelineClass extends EntityClass {
   }
 
   async create(apiContext: APIRequestContext) {
-    const serviceResponse = await apiContext.post(
-      '/api/v1/services/pipelineServices',
-      {
-        data: this.service,
-      }
-    );
-    const entityResponse = await apiContext.post('/api/v1/pipelines', {
+    this.serviceResponseData = await createOrFetch(apiContext, {
+      label: 'PipelineClass.create service',
+      createPath: '/api/v1/services/pipelineServices',
+      fqnSegments: [this.service.name],
+      data: this.service,
+    });
+
+    this.entityResponseData = await createOrFetch(apiContext, {
+      label: 'PipelineClass.create pipeline',
+      createPath: '/api/v1/pipelines',
+      fqnSegments: [this.service.name, this.entity.name],
       data: this.entity,
     });
 
-    this.serviceResponseData = await okJson(
-      serviceResponse,
-      'PipelineClass.create'
-    );
-    this.entityResponseData = await okJson(
-      entityResponse,
-      'PipelineClass.create'
-    );
-
     return {
-      service: serviceResponse.body,
-      entity: entityResponse.body,
+      service: this.serviceResponseData,
+      entity: this.entityResponseData,
     };
   }
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/StoredProcedureClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/StoredProcedureClass.ts
@@ -14,7 +14,11 @@ import { APIRequestContext, Page } from '@playwright/test';
 import { Operation } from 'fast-json-patch';
 import { SERVICE_TYPE } from '../../constant/service';
 import { ServiceTypes } from '../../constant/settings';
-import { okJson, withNotFoundRetry } from '../../utils/apiResponse';
+import {
+  createOrFetch,
+  okJson,
+  withNotFoundRetry,
+} from '../../utils/apiResponse';
 import { uuid } from '../../utils/common';
 import { visitEntityPageByFqn } from '../../utils/entity';
 import {
@@ -117,32 +121,38 @@ export class StoredProcedureClass extends EntityClass {
   }
 
   async create(apiContext: APIRequestContext) {
-    const serviceResponse = await apiContext.post(
-      '/api/v1/services/databaseServices',
-      {
-        data: this.service,
-      }
-    );
-    const databaseResponse = await apiContext.post('/api/v1/databases', {
-      data: this.database,
-    });
-    const schemaResponse = await apiContext.post('/api/v1/databaseSchemas', {
-      data: this.schema,
-    });
-    const entityResponse = await apiContext.post('/api/v1/storedProcedures', {
-      data: this.entity,
+    const service = await createOrFetch(apiContext, {
+      label: 'StoredProcedureClass.create service',
+      createPath: '/api/v1/services/databaseServices',
+      fqnSegments: [this.service.name],
+      data: this.service,
     });
 
-    const service = await okJson(
-      serviceResponse,
-      'StoredProcedureClass.create'
-    );
-    const database = await okJson(
-      databaseResponse,
-      'StoredProcedureClass.create'
-    );
-    const schema = await okJson(schemaResponse, 'StoredProcedureClass.create');
-    const entity = await okJson(entityResponse, 'StoredProcedureClass.create');
+    const database = await createOrFetch(apiContext, {
+      label: 'StoredProcedureClass.create database',
+      createPath: '/api/v1/databases',
+      fqnSegments: [this.service.name, this.database.name],
+      data: this.database,
+    });
+
+    const schema = await createOrFetch(apiContext, {
+      label: 'StoredProcedureClass.create schema',
+      createPath: '/api/v1/databaseSchemas',
+      fqnSegments: [this.service.name, this.database.name, this.schema.name],
+      data: this.schema,
+    });
+
+    const entity = await createOrFetch(apiContext, {
+      label: 'StoredProcedureClass.create storedProcedure',
+      createPath: '/api/v1/storedProcedures',
+      fqnSegments: [
+        this.service.name,
+        this.database.name,
+        this.schema.name,
+        this.entity.name,
+      ],
+      data: this.entity,
+    });
 
     this.serviceResponseData = service;
     this.databaseResponseData = database;

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/WorksheetClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/WorksheetClass.ts
@@ -19,7 +19,11 @@ import {
 } from '../../../src/generated/entity/data/worksheet';
 import { SERVICE_TYPE } from '../../constant/service';
 import { ServiceTypes } from '../../constant/settings';
-import { okJson, withNotFoundRetry } from '../../utils/apiResponse';
+import {
+  createOrFetch,
+  okJson,
+  withNotFoundRetry,
+} from '../../utils/apiResponse';
 import { uuid } from '../../utils/common';
 import { visitEntityPageByFqn } from '../../utils/entity';
 import { EntityTypeEndpoint, ResponseDataType } from './Entity.interface';
@@ -127,47 +131,44 @@ export class WorksheetClass extends EntityClass {
     };
   }
 
+  // createOrFetch, not a bare POST — see FileClass.create for why: the names are
+  // fixed at construction, so a retried beforeAll re-creates them and 409s.
   async create(apiContext: APIRequestContext) {
-    const serviceResponse = await apiContext.post(
-      '/api/v1/services/driveServices',
-      {
-        data: this.service,
-      }
-    );
-    this.serviceResponseData = await okJson(
-      serviceResponse,
-      'WorksheetClass.create'
-    );
+    this.serviceResponseData = await createOrFetch(apiContext, {
+      label: 'WorksheetClass.create service',
+      createPath: '/api/v1/services/driveServices',
+      fqnSegments: [this.service.name],
+      data: this.service,
+    });
 
     // Create spreadsheet
-    const spreadsheetResponse = await apiContext.post(
-      `/api/v1/${EntityTypeEndpoint.Spreadsheet}`,
-      {
-        data: {
-          name: this.spreadsheetName,
-          service: this.serviceResponseData.fullyQualifiedName,
-        },
-      }
-    );
-    this.spreadsheetResponseData = await okJson(
-      spreadsheetResponse,
-      'WorksheetClass.create'
-    );
+    this.spreadsheetResponseData = await createOrFetch(apiContext, {
+      label: 'WorksheetClass.create spreadsheet',
+      createPath: `/api/v1/${EntityTypeEndpoint.Spreadsheet}`,
+      fqnSegments: [this.service.name, this.spreadsheetName],
+      data: {
+        name: this.spreadsheetName,
+        service: this.serviceResponseData.fullyQualifiedName,
+      },
+    });
 
-    // Create worksheet in spreadsheet
-    const entityResponse = await apiContext.post(
-      `/api/v1/${EntityTypeEndpoint.Worksheet}`,
-      {
-        data: {
-          ...this.entity,
-          spreadsheet: this.spreadsheetResponseData.fullyQualifiedName,
-        },
-      }
-    );
-    this.entityResponseData = await okJson(
-      entityResponse,
-      'WorksheetClass.create'
-    );
+    // Create worksheet in spreadsheet. `columns` is in WorksheetResource.FIELDS,
+    // so a by-name lookup omits it unless asked — and childrenSelectorId below
+    // reads columns[0].
+    this.entityResponseData = await createOrFetch<Worksheet>(apiContext, {
+      label: 'WorksheetClass.create worksheet',
+      createPath: `/api/v1/${EntityTypeEndpoint.Worksheet}`,
+      fqnSegments: [
+        this.service.name,
+        this.spreadsheetName,
+        this.worksheetName,
+      ],
+      fields: 'columns',
+      data: {
+        ...this.entity,
+        spreadsheet: this.spreadsheetResponseData.fullyQualifiedName,
+      },
+    });
 
     this.childrenSelectorId =
       this.entityResponseData.columns?.[0]?.fullyQualifiedName ?? '';

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/WorksheetClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/WorksheetClass.ts
@@ -174,9 +174,9 @@ export class WorksheetClass extends EntityClass {
       this.entityResponseData.columns?.[0]?.fullyQualifiedName ?? '';
 
     return {
-      service: serviceResponse.body,
-      entity: entityResponse.body,
-      spreadsheet: spreadsheetResponse.body,
+      service: this.serviceResponseData,
+      entity: this.entityResponseData,
+      spreadsheet: this.spreadsheetResponseData,
     };
   }
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/activityFeed.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/activityFeed.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { expect, Locator, Page } from '@playwright/test';
-import { descriptionBox, getDescriptionBox } from './common';
+import { getDescriptionBox } from './common';
 import { waitForAllLoadersToDisappear } from './entity';
 import { waitForPageLoaded } from './polling';
 import { TaskDetails } from './task';

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/activityFeed.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/activityFeed.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { expect, Locator, Page } from '@playwright/test';
-import { descriptionBox } from './common';
+import { descriptionBox, getDescriptionBox } from './common';
 import { waitForAllLoadersToDisappear } from './entity';
 import { waitForPageLoaded } from './polling';
 import { TaskDetails } from './task';
@@ -53,7 +53,7 @@ export const checkDescriptionInEditModal = async (
     `Update description for table ${taskValue.term} columns/${taskValue.columnName}`
   );
 
-  await expect(page.locator(descriptionBox)).toContainText(
+  await expect(getDescriptionBox(page)).toContainText(
     taskValue.description ?? ''
   );
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/alert.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/alert.ts
@@ -31,8 +31,9 @@ import { TableClass } from '../support/entity/TableClass';
 import { UserClass } from '../support/user/UserClass';
 import {
   clickOutside,
-  descriptionBox,
+  fillDescriptionBox,
   getApiContext,
+  getDescriptionBox,
   toastNotification,
   uuid,
 } from './common';
@@ -1005,8 +1006,8 @@ export const inputBasicAlertInformation = async ({
   });
 
   // Enter description
-  await page.locator(descriptionBox).clear();
-  await page.locator(descriptionBox).fill(ALERT_DESCRIPTION);
+  await getDescriptionBox(page).clear();
+  await fillDescriptionBox(page, ALERT_DESCRIPTION);
 
   // Select the alert source.
   //

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/bot.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/bot.ts
@@ -13,7 +13,7 @@
 import { expect, Page } from '@playwright/test';
 import { GlobalSettingOptions } from '../constant/settings';
 import {
-  descriptionBox,
+  fillDescriptionBox,
   redirectToHomePage,
   toastNotification,
   uuid,
@@ -94,7 +94,7 @@ export const createBot = async (page: Page) => {
   await page.click('[data-testid="token-expiry"]');
   await page.locator('[title="1 hour"] div').click();
 
-  await page.locator(descriptionBox).fill(BOT_DETAILS.description);
+  await fillDescriptionBox(page, BOT_DETAILS.description);
 
   const saveResponse = page.waitForResponse(
     (response) =>
@@ -166,7 +166,7 @@ export const updateBotDetails = async (page: Page) => {
 
   // Click on edit description button
   await page.getByTestId('edit-description').click();
-  await page.locator(descriptionBox).fill(BOT_DETAILS.updatedDescription);
+  await fillDescriptionBox(page, BOT_DETAILS.updatedDescription);
 
   const updateDescriptionResponse = page.waitForResponse(`api/v1/bots/*`);
   await page.getByTestId('save').click();

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -41,6 +41,43 @@ export const descriptionBox = '.om-block-editor[contenteditable="true"]';
 export const descriptionBoxReadOnly =
   '.om-block-editor[contenteditable="false"]';
 
+/**
+ * Resolve the description editor that belongs to `scope`.
+ *
+ * `descriptionBox` is page-global, so it matches every editable block editor
+ * currently mounted. Any page that has more than one at a time — an entity page
+ * with a form drawer or description modal overlaid on it, or two drawers
+ * overlapping while one plays its exit animation — turns an unscoped
+ * `page.locator(descriptionBox)` into a strict mode violation. Pass the form,
+ * drawer or modal the editor lives in instead.
+ *
+ * `page` is accepted as a scope for the pages that really do host a single
+ * editor: it buys no narrowing, but it still routes through the count assertion
+ * in {@link fillDescriptionBox}, so an editor that appears alongside another one
+ * later fails where the ambiguity is rather than somewhere downstream.
+ */
+export const getDescriptionBox = (scope: Page | Locator): Locator =>
+  scope.locator(descriptionBox);
+
+/**
+ * Fill the description editor inside `scope`, asserting it is the only one
+ * there.
+ *
+ * The count assertion is deliberate: `.first()` would also silence the strict
+ * mode violation, but by typing into an arbitrary editor, so the test goes on
+ * to fail somewhere unrelated to the real ambiguity. Failing here names the
+ * scope that needs narrowing.
+ */
+export const fillDescriptionBox = async (
+  scope: Page | Locator,
+  value: string
+) => {
+  const editor = getDescriptionBox(scope);
+
+  await expect(editor).toHaveCount(1);
+  await editor.fill(value);
+};
+
 export const INVALID_NAMES = {
   MAX_LENGTH:
     'a87439625b1c2d3e4f5061728394a5b6c7d8e90a1b2c3d4e5f67890aba87439625b1c2d3e4f5061728394a5b6c7d8e90a1b2c3d4e5f67890abName can be a maximum of 128 characters',

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -1469,7 +1469,7 @@ export const waitForMetricsSearchResponse = (page: Page) =>
 export const testMetricsPaginationNavigation = async (page: Page) => {
   const page1ResponsePromise = waitForMetricsSearchResponse(page);
 
-  await page.goto('/metrics?pageSize=15');
+  await page.goto('/metrics?pageSize=15', { waitUntil: 'domcontentloaded' });
 
   const page1Response = await page1ResponsePromise;
   expect(page1Response.status()).toBe(200);

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -78,6 +78,41 @@ export const fillDescriptionBox = async (
   await editor.fill(value);
 };
 
+/**
+ * Resolve the description editor that an `edit-description` click just opened.
+ *
+ * Editing a description can mount the editor inline on the page or inside a
+ * modal, and on an entity page both can be present at once. `.first()` picks
+ * whichever comes first in the DOM — the inline editor *behind* the overlay. It
+ * is visible, so `toBeVisible()` passes, and the click then fails on
+ * "ant-modal-wrap ... intercepts pointer events" and retries until the test
+ * times out; the trace shows a 45s click on an editor nothing could reach.
+ *
+ * Prefers the editor inside the dialog whenever the edit opened one, and asserts
+ * a single match either way, so a genuinely ambiguous page fails here — naming
+ * the scope that needs narrowing — instead of somewhere downstream. Retrying
+ * covers the modal's enter animation, during which the dialog is not yet
+ * attached.
+ */
+export const resolveDescriptionBox = async (page: Page): Promise<Locator> => {
+  const descriptionDialog = page
+    .locator('[role="dialog"]')
+    .filter({ has: getDescriptionBox(page) });
+
+  let editor = getDescriptionBox(page);
+
+  await expect(async () => {
+    editor = (await descriptionDialog.count())
+      ? getDescriptionBox(descriptionDialog)
+      : getDescriptionBox(page);
+
+    await expect(editor).toHaveCount(1);
+    await expect(editor).toBeVisible();
+  }).toPass({ timeout: 15_000 });
+
+  return editor;
+};
+
 export const INVALID_NAMES = {
   MAX_LENGTH:
     'a87439625b1c2d3e4f5061728394a5b6c7d8e90a1b2c3d4e5f67890aba87439625b1c2d3e4f5061728394a5b6c7d8e90a1b2c3d4e5f67890abName can be a maximum of 128 characters',

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
@@ -28,6 +28,8 @@ import {
   clickOutside,
   descriptionBox,
   descriptionBoxReadOnly,
+  fillDescriptionBox,
+  getDescriptionBox,
   uuid,
 } from './common';
 import { waitForAllLoadersToDisappear } from './entity';
@@ -141,7 +143,8 @@ export const setValueForProperty = async (data: {
   const patchRequestPromise = page.waitForResponse(`/api/v1/${endpoint}/*`);
   switch (propertyType) {
     case 'markdown':
-      await expect(page.locator(descriptionBox)).toBeVisible();
+      await expect(getDescriptionBox(page)).toHaveCount(1);
+      await expect(getDescriptionBox(page)).toBeVisible();
       await page.click(descriptionBox);
       await page.keyboard.type(value);
       await page.locator('[data-testid="save"]').click();
@@ -768,8 +771,9 @@ export const addCustomPropertiesForEntity = async ({
     page.locator(String.raw`#root\/entityReferenceConfig_list`)
   ).not.toBeVisible();
 
-  await page.locator(descriptionBox).waitFor({ state: 'visible' });
-  await page.locator(descriptionBox).click();
+  await getDescriptionBox(page).waitFor({ state: 'visible' });
+  await expect(getDescriptionBox(page)).toHaveCount(1);
+  await getDescriptionBox(page).click();
   await page.keyboard.type(customPropertyData.description, { delay: 50 });
 
   // Click on name field to blur description and trigger validation without closing modal
@@ -838,8 +842,8 @@ export const editCreatedProperty = async (
   await page.fill('[data-testid="display-name"]', '');
   await page.fill('[data-testid="display-name"]', propertyName.toUpperCase());
 
-  await page.locator(descriptionBox).fill('');
-  await page.locator(descriptionBox).fill('This is new description');
+  await fillDescriptionBox(page, '');
+  await fillDescriptionBox(page, 'This is new description');
 
   if (type === 'Enum') {
     await page.click(String.raw`#root\/customPropertyConfig`);
@@ -1328,7 +1332,8 @@ export const updateCustomPropertyInRightPanel = async (data: {
 
   switch (propertyType) {
     case 'markdown':
-      await expect(page.locator(descriptionBox)).toBeVisible();
+      await expect(getDescriptionBox(page)).toHaveCount(1);
+      await expect(getDescriptionBox(page)).toBeVisible();
       await page.click(descriptionBox);
       await page.keyboard.type(value);
       await page.locator('[data-testid="save"]').click();

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataInsight.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataInsight.ts
@@ -12,7 +12,7 @@
  */
 import { APIRequestContext, Page } from '@playwright/test';
 import { KPIData } from '../constant/dataInsight.interface';
-import { descriptionBox, fillDescriptionBox } from './common';
+import { fillDescriptionBox } from './common';
 
 export const deleteKpiRequest = async (apiRequest: APIRequestContext) => {
   const kpis = await apiRequest.get('/api/v1/kpi').then((res) => res.json());

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataInsight.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataInsight.ts
@@ -12,7 +12,7 @@
  */
 import { APIRequestContext, Page } from '@playwright/test';
 import { KPIData } from '../constant/dataInsight.interface';
-import { descriptionBox } from './common';
+import { descriptionBox, fillDescriptionBox } from './common';
 
 export const deleteKpiRequest = async (apiRequest: APIRequestContext) => {
   const kpis = await apiRequest.get('/api/v1/kpi').then((res) => res.json());
@@ -63,7 +63,7 @@ export const addKpi = async (page: Page, data: KPIData) => {
   await page.getByTestId('end-date').fill(endDate);
   await page.getByTestId('end-date').press('Enter');
 
-  await page.locator(descriptionBox).fill('Playwright KPI test description');
+  await fillDescriptionBox(page, 'Playwright KPI test description');
 
   await page.getByTestId('submit-btn').click();
   await page.waitForURL('**/data-insights/kpi');

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
@@ -713,9 +713,28 @@ export const updateDescription = async (
     await editButton.click();
   }
 
-  // Wait for description box to be visible and ready
-  const descBox = page.locator(descriptionBox).first();
-  await expect(descBox).toBeVisible();
+  // `descriptionBox` is page-global, and the edit action can leave two editors
+  // mounted at once: the inline one on the entity page plus the one in the modal
+  // it just opened. `.first()` took whichever came first in DOM order — the
+  // inline editor *behind* the overlay. It is visible, so `toBeVisible()` passed,
+  // and the click then failed on "ant-modal-wrap ... intercepts pointer events",
+  // retrying until the 60s test timeout. Scope to the dialog whenever the edit
+  // opened one; assert a single match either way so a genuinely ambiguous page
+  // fails here, naming the scope to narrow, instead of timing out on a click.
+  const descriptionDialog = page
+    .locator('[role="dialog"]')
+    .filter({ has: page.locator(descriptionBox) });
+
+  let descBox = page.locator(descriptionBox);
+  await expect(async () => {
+    descBox = (await descriptionDialog.count())
+      ? descriptionDialog.locator(descriptionBox)
+      : page.locator(descriptionBox);
+
+    await expect(descBox).toHaveCount(1);
+    await expect(descBox).toBeVisible();
+  }).toPass({ timeout: 15_000 });
+
   await descBox.click();
   await descBox.clear();
   await descBox.fill(description);
@@ -1589,7 +1608,16 @@ const announcementForm = async (
   await page.fill('#endTime', `${data.endDate}`);
   await page.press('#startTime', 'Enter');
 
-  await page.locator(descriptionBox).fill(data.description);
+  // Scoped to the announcement dialog, not the page: this form opens over an
+  // entity page that has description editors of its own, and an unscoped
+  // `descriptionBox` matches those too.
+  const announcementDialog = page
+    .locator('[role="dialog"]')
+    .filter({ has: page.locator('#announcement-submit') });
+  const announcementDescription = announcementDialog.locator(descriptionBox);
+
+  await expect(announcementDescription).toHaveCount(1);
+  await announcementDescription.fill(data.description);
 
   await page.locator('#announcement-submit').scrollIntoViewIfNeeded();
   const announcementSubmit = page.waitForResponse(

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
@@ -36,6 +36,7 @@ import {
   getEntityTypeSearchIndexMapping,
   readElementInListWithScroll,
   redirectToHomePage,
+  resolveDescriptionBox,
   toastNotification,
   uuid,
 } from './common';
@@ -732,27 +733,7 @@ export const updateDescription = async (
     await editButton.click();
   }
 
-  // `descriptionBox` is page-global, and the edit action can leave two editors
-  // mounted at once: the inline one on the entity page plus the one in the modal
-  // it just opened. `.first()` took whichever came first in DOM order — the
-  // inline editor *behind* the overlay. It is visible, so `toBeVisible()` passed,
-  // and the click then failed on "ant-modal-wrap ... intercepts pointer events",
-  // retrying until the 60s test timeout. Scope to the dialog whenever the edit
-  // opened one; assert a single match either way so a genuinely ambiguous page
-  // fails here, naming the scope to narrow, instead of timing out on a click.
-  const descriptionDialog = page
-    .locator('[role="dialog"]')
-    .filter({ has: page.locator(descriptionBox) });
-
-  let descBox = page.locator(descriptionBox);
-  await expect(async () => {
-    descBox = (await descriptionDialog.count())
-      ? descriptionDialog.locator(descriptionBox)
-      : page.locator(descriptionBox);
-
-    await expect(descBox).toHaveCount(1);
-    await expect(descBox).toBeVisible();
-  }).toPass({ timeout: 15_000 });
+  const descBox = await resolveDescriptionBox(page);
 
   await descBox.click();
   await descBox.clear();

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
@@ -58,6 +58,24 @@ export const waitForAllLoadersToDisappear = async (
   await expect(loaders).toHaveCount(0, { timeout });
 };
 
+/**
+ * Wait for the lazily-mounted entity-detail widgets to replace their Suspense
+ * fallback.
+ *
+ * The right-panel widgets — tags, glossary terms, owners, domain — are behind
+ * `React.lazy`, and while their chunk loads the boundary renders
+ * `EntityDetailWidgetSkeleton`. That skeleton is *not* `data-testid="loader"`, so
+ * `waitForAllLoadersToDisappear` returns straight past it and a test can reach
+ * for something inside those widgets before they exist. Anything the widgets own
+ * — `request-entity-tags`, for one — is simply absent until this clears, so the
+ * click waits out the whole test timeout rather than racing by a few frames.
+ */
+export const waitForWidgetsToRender = async (page: Page, timeout = 30000) => {
+  await expect(
+    page.locator('[data-testid="entity-detail-widget-skeleton"]')
+  ).toHaveCount(0, { timeout });
+};
+
 export const visitEntityPage = async (data: {
   page: Page;
   searchTerm: string;
@@ -151,6 +169,7 @@ export const visitEntityPageByFqn = async (data: {
   });
   await entityDetailsResponse;
   await waitForAllLoadersToDisappear(page);
+  await waitForWidgetsToRender(page);
 };
 
 export const addOwner = async ({

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
@@ -566,9 +566,16 @@ export const fillGlossaryTermDetails = async (
 
   await page.locator('[data-testid="name"]').fill(term.name);
 
-  await expect(page.locator(descriptionBox)).toBeVisible();
+  // Scoped to the Add Glossary Term modal asserted above. The glossary page
+  // behind it has its own description editor, so page-global matched two.
+  const termDescription = page
+    .locator('[role="dialog"].edit-glossary-modal')
+    .locator(descriptionBox);
 
-  await page.locator(descriptionBox).fill(term.description);
+  await expect(termDescription).toHaveCount(1);
+  await expect(termDescription).toBeVisible();
+
+  await termDescription.fill(term.description);
 
   const synonyms = (term.synonyms ?? '').split(',');
 
@@ -772,14 +779,20 @@ export const updateGlossaryTermDataFromTree = async (
 
   await page.locator('[role="dialog"].edit-glossary-modal').waitFor();
 
-  await expect(
-    page.locator('[role="dialog"].edit-glossary-modal')
-  ).toBeVisible();
+  const editGlossaryModal = page.locator('[role="dialog"].edit-glossary-modal');
+
+  await expect(editGlossaryModal).toBeVisible();
   await expect(page.locator('.ant-modal-title')).toContainText(
     'Edit Glossary Term'
   );
-  await page.locator(descriptionBox).clear();
-  await page.locator(descriptionBox).fill('Updated description');
+
+  // Scoped to the modal this just waited for. The term details page behind it
+  // carries its own description editor, so the page-global locator matched two.
+  const modalDescription = editGlossaryModal.locator(descriptionBox);
+
+  await expect(modalDescription).toHaveCount(1);
+  await modalDescription.clear();
+  await modalDescription.fill('Updated description');
 
   const glossaryTermResponse = page.waitForResponse('/api/v1/glossaryTerms/*');
   await page.getByTestId('save-glossary-term').click();
@@ -1123,6 +1136,31 @@ export const renameGlossaryTerm = async (
   await glossaryTerm.rename(data.name, data.fullyQualifiedName);
 };
 
+/**
+ * Resolve once the element has held the same position across two consecutive
+ * samples.
+ *
+ * Playwright's own actionability already does this, but only for callers that
+ * have not opted out with `force: true`. Anything that must force still needs
+ * the guarantee, so make it explicit.
+ */
+const waitForStableBox = async (locator: Locator) => {
+  let previous: { x: number; y: number } | undefined;
+
+  await expect(async () => {
+    const box = await locator.boundingBox();
+
+    expect(box).not.toBeNull();
+
+    const current = { x: box?.x ?? NaN, y: box?.y ?? NaN };
+    const held = previous?.x === current.x && previous?.y === current.y;
+
+    previous = current;
+
+    expect(held, 'element is still moving').toBe(true);
+  }).toPass({ timeout: 15_000, intervals: [200, 200, 400, 800] });
+};
+
 export const dragAndDropTerm = async (
   page: Page,
   dragElement: string,
@@ -1139,6 +1177,18 @@ export const dragAndDropTerm = async (
     dropTarget === 'Terms'
       ? page.locator('th:has-text("Terms")').first()
       : page.locator('tr').filter({ hasText: dropTarget }).first();
+
+  // The glossary page keeps rendering after its loaders clear: the description
+  // block above the table hydrates last and pushes every row down by about a row
+  // height. `dragTo` resolves both rows, computes their boxes, and then presses
+  // at those coordinates — so a drag that starts during that reflow presses on
+  // whatever has since moved into the old position, no dragstart fires, and the
+  // confirmation modal never opens. `force: true` is what lets it get that far:
+  // it skips the actionability stability check that would otherwise have waited.
+  // Hold both rows still before pressing rather than dropping the force option,
+  // which is still needed for the row hover overlays.
+  await waitForStableBox(dragLocator);
+  await waitForStableBox(dropLocator);
 
   await dragLocator.dragTo(dropLocator, {
     force: true, // eslint-disable-line playwright/no-force-option -- drag-and-drop requires force due to row hover overlays

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts
@@ -33,10 +33,10 @@ import {
   clickOutside,
   descriptionBox,
   descriptionBoxReadOnly,
-  fillDescriptionBox,
-  getDescriptionBox,
   fetchCompletedCsvAsyncJobResult,
+  fillDescriptionBox,
   getApiContext,
+  getDescriptionBox,
   uuid,
 } from './common';
 import {

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts
@@ -33,6 +33,8 @@ import {
   clickOutside,
   descriptionBox,
   descriptionBoxReadOnly,
+  fillDescriptionBox,
+  getDescriptionBox,
   fetchCompletedCsvAsyncJobResult,
   getApiContext,
   uuid,
@@ -813,17 +815,24 @@ const editGlossaryCustomProperty = async (
   }
 
   if (type === CUSTOM_PROPERTIES_TYPES.MARKDOWN) {
-    await page.locator(descriptionBox).waitFor({ state: 'visible' });
+    // Scoped to the markdown editor this block already reaches into for its
+    // save button, rather than to the page: the entity behind the custom
+    // property panel has description editors of its own.
+    const markdownEditor = page.getByTestId('markdown-editor');
+    const markdownDescription = getDescriptionBox(markdownEditor);
 
-    await page
-      .locator(descriptionBox)
-      .fill(FIELD_VALUES_CUSTOM_PROPERTIES.MARKDOWN);
+    await markdownDescription.waitFor({ state: 'visible' });
+
+    await fillDescriptionBox(
+      markdownEditor,
+      FIELD_VALUES_CUSTOM_PROPERTIES.MARKDOWN
+    );
 
     await clickOutside(page);
 
-    await page.getByTestId('markdown-editor').getByTestId('save').click();
+    await markdownEditor.getByTestId('save').click();
 
-    await page.locator(descriptionBox).waitFor({ state: 'detached' });
+    await markdownDescription.waitFor({ state: 'detached' });
 
     await expect(
       page.getByTestId(propertyName).locator(descriptionBoxReadOnly)
@@ -1225,15 +1234,20 @@ const editEntityCustomProperty = async (
   }
 
   if (type === CUSTOM_PROPERTIES_TYPES.MARKDOWN) {
-    await page.locator(descriptionBox).waitFor({ state: 'visible' });
+    // Scoped to the markdown editor, as above.
+    const markdownEditor = page.getByTestId('markdown-editor');
+    const markdownDescription = getDescriptionBox(markdownEditor);
 
-    await page
-      .locator(descriptionBox)
-      .fill(FIELD_VALUES_CUSTOM_PROPERTIES.MARKDOWN);
+    await markdownDescription.waitFor({ state: 'visible' });
 
-    await page.getByTestId('markdown-editor').getByTestId('save').click();
+    await fillDescriptionBox(
+      markdownEditor,
+      FIELD_VALUES_CUSTOM_PROPERTIES.MARKDOWN
+    );
 
-    await page.locator(descriptionBox).waitFor({ state: 'detached' });
+    await markdownEditor.getByTestId('save').click();
+
+    await markdownDescription.waitFor({ state: 'detached' });
   }
 
   if (type === CUSTOM_PROPERTIES_TYPES.SQL_QUERY) {

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/lineage.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/lineage.ts
@@ -173,9 +173,21 @@ export const deleteEdge = async (
   fromNode: EntityClass,
   toNode: EntityClass
 ) => {
-  await clickEdgeBetweenNodes(page, fromNode, toNode, true);
+  const addPipeline = page.getByTestId('add-pipeline');
 
-  await page.getByTestId('add-pipeline').dispatchEvent('click');
+  // `clickEdgeBetweenNodes` dispatches a synthetic click on a react-flow edge
+  // label. `dispatchEvent` takes no actionability wait, so if the graph re-lays
+  // out between resolving the label and firing the event — which it does while
+  // nodes are still settling — the click lands on a node that is no longer wired
+  // up, the toolbar never opens, and the wait for `add-pipeline` below burns the
+  // whole test timeout on an action that silently did nothing. Retry the pair
+  // until the toolbar is actually there.
+  await expect(async () => {
+    await clickEdgeBetweenNodes(page, fromNode, toNode, true);
+    await expect(addPipeline).toBeVisible({ timeout: 5_000 });
+  }).toPass({ timeout: 30_000, intervals: [1_000, 2_000, 3_000] });
+
+  await addPipeline.dispatchEvent('click');
 
   await expect(page.getByRole('dialog').first()).toBeVisible();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/notificationAlert.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/notificationAlert.ts
@@ -31,7 +31,12 @@ import {
   visitEditAlertPage,
   waitForRecentEventsToFinishExecution,
 } from './alert';
-import { clickOutside, descriptionBox, redirectToHomePage } from './common';
+import {
+  clickOutside,
+  fillDescriptionBox,
+  getDescriptionBox,
+  redirectToHomePage,
+} from './common';
 import { selectComboBoxOption, selectDropdownOption } from './destination';
 import {
   addMultiOwner,
@@ -238,8 +243,8 @@ export const editSingleFilterAlert = async ({
   await visitEditAlertPage(page, alertDetails);
 
   // Update description
-  await page.locator(descriptionBox).clear();
-  await page.locator(descriptionBox).fill(ALERT_UPDATED_DESCRIPTION);
+  await getDescriptionBox(page).clear();
+  await fillDescriptionBox(page, ALERT_UPDATED_DESCRIPTION);
 
   // Update source
   await page.click('[data-testid="source-select"]');

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/observabilityAlert.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/observabilityAlert.ts
@@ -34,7 +34,12 @@ import {
   visitEditAlertPage,
   waitForRecentEventsToFinishExecution,
 } from './alert';
-import { clickOutside, descriptionBox, redirectToHomePage } from './common';
+import {
+  clickOutside,
+  fillDescriptionBox,
+  getDescriptionBox,
+  redirectToHomePage,
+} from './common';
 import {
   ensureAccordionExpanded,
   selectComboBoxOption,
@@ -470,8 +475,8 @@ export const editObservabilityAlert = async ({
   await visitEditAlertPage(page, alertDetails, false);
 
   // Update description
-  await page.locator(descriptionBox).clear();
-  await page.locator(descriptionBox).fill(ALERT_UPDATED_DESCRIPTION);
+  await getDescriptionBox(page).clear();
+  await fillDescriptionBox(page, ALERT_UPDATED_DESCRIPTION);
 
   // Update source
   await page.click('[data-testid="source-select"]');

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/polling.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/polling.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { APIRequestContext, Page } from '@playwright/test';
-import { waitForAllLoadersToDisappear } from './entity';
+import { waitForAllLoadersToDisappear, waitForWidgetsToRender } from './entity';
 
 /**
  * Polls the search API until the given entity appears in Elasticsearch.
@@ -71,4 +71,5 @@ export const waitForSearchIndexed = async (
 export const waitForPageLoaded = async (page: Page) => {
   await page.waitForLoadState('domcontentloaded');
   await waitForAllLoadersToDisappear(page);
+  await waitForWidgetsToRender(page);
 };

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/tag.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/tag.ts
@@ -201,9 +201,11 @@ export const removeAssetsFromTag = async (
 };
 
 export const checkAssetsCount = async (page: Page, count: number) => {
+  // After a reload the badge renders only once the assets search returns —
+  // give it the same 30s the domain util allows instead of the default 15s.
   await expect(
     page.getByTestId('assets').getByTestId('filter-count')
-  ).toContainText(count.toString());
+  ).toContainText(count.toString(), { timeout: 30_000 });
 };
 
 export const setupAssetsForTag = async (page: Page) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/task.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/task.ts
@@ -12,7 +12,7 @@
  */
 import { expect, Page } from '@playwright/test';
 import { isUndefined } from 'lodash';
-import { clickOutside, descriptionBox, toastNotification } from './common';
+import { clickOutside, fillDescriptionBox, toastNotification } from './common';
 
 export type TaskDetails = {
   term: string;
@@ -120,9 +120,7 @@ export const createDescriptionTask = async (
   }
 
   if (addDescription) {
-    await page
-      .locator(descriptionBox)
-      .fill(value.description ?? 'Updated description');
+    await fillDescriptionBox(page, value.description ?? 'Updated description');
   }
   const taskResponse = waitForTaskCreateResponse(page);
   await page.click('button[type="submit"]');

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/taskWorkflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/taskWorkflow.ts
@@ -11,7 +11,12 @@
  *  limitations under the License.
  */
 import { expect, Locator, Page } from '@playwright/test';
-import { clickOutside, descriptionBox } from './common';
+import {
+  clickOutside,
+  descriptionBox,
+  fillDescriptionBox,
+  getDescriptionBox,
+} from './common';
 import { waitForAllLoadersToDisappear } from './entity';
 import { waitForPageLoaded } from './polling';
 import {
@@ -294,8 +299,8 @@ export const createDescriptionTaskFromForm = async ({
   await selectAssignee(page, assigneeName);
 
   if (description) {
-    await page.locator(descriptionBox).clear();
-    await page.locator(descriptionBox).fill(description);
+    await getDescriptionBox(page).clear();
+    await fillDescriptionBox(page, description);
   }
 
   const taskCreateResponse = waitForTaskCreateResponse(page);

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/user.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/user.ts
@@ -27,8 +27,8 @@ import { installServerLoadReducers } from '../support/fixtures/serverLoad';
 import { UserClass } from '../support/user/UserClass';
 import {
   clickOutside,
-  descriptionBox,
   descriptionBoxReadOnly,
+  fillDescriptionBox,
   getAuthContext,
   getToken,
   redirectToHomePage,
@@ -271,7 +271,7 @@ export const editDescription = async (
   await page.click('[data-testid="edit-description"]');
 
   // Clear and type the new description
-  await page.locator(descriptionBox).fill(updatedDescription);
+  await fillDescriptionBox(page, updatedDescription);
 
   const updateDescription = page.waitForResponse('/api/v1/users/*');
   await page.click('[data-testid="save"]');
@@ -707,7 +707,7 @@ export const addUser = async (
 
   await page.fill('[data-testid="displayName"]', name);
 
-  await page.locator(descriptionBox).fill('Adding new user');
+  await fillDescriptionBox(page, 'Adding new user');
 
   await page.click(':nth-child(2) > .ant-radio > .ant-radio-input');
   await page.fill('#password', password);
@@ -775,7 +775,7 @@ export const checkForUserExistError = async (
 
   await page.fill('[data-testid="displayName"]', name);
 
-  await page.locator(descriptionBox).fill('Adding new user');
+  await fillDescriptionBox(page, 'Adding new user');
 
   await page.click(':nth-child(2) > .ant-radio > .ant-radio-input');
   await page.fill('#password', password);

--- a/openmetadata-ui/src/main/resources/ui/src/components/TestLibrary/TestDefinitionForm/TestDefinitionFormBody.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TestLibrary/TestDefinitionForm/TestDefinitionFormBody.tsx
@@ -58,6 +58,23 @@ const CodeEditor = withSuspenseFallback(
 const toOptions = (values: string[]): FormSelectItem[] =>
   values.map((value) => ({ id: value, label: value }));
 
+// Built once at module scope, never per render. These lists are derived from
+// enums and can never change, but rebuilding them inside the component handed
+// `Select` a new `items` array on every render — and a new collection identity
+// makes react-aria tear down and remount the open listbox, detaching the
+// option the user (or Playwright) is mid-click on. Focusing any field re-renders
+// this component via `onActiveFieldChange`, so simply opening a select and
+// clicking an option raced the remount: locally the click won, under CI load it
+// lost and the popover closed with the field left empty.
+const ENTITY_TYPE_OPTIONS = toOptions(Object.values(EntityType));
+const TEST_PLATFORM_OPTIONS = toOptions(Object.values(TestPlatform));
+const DATA_QUALITY_DIMENSION_OPTIONS = toOptions(
+  Object.values(DataQualityDimensions)
+);
+const SUPPORTED_SERVICE_OPTIONS = toOptions(Object.values(DatabaseServiceType));
+const SUPPORTED_DATA_TYPE_OPTIONS = toOptions(Object.values(DataType));
+const TEST_DATA_TYPE_OPTIONS = toOptions(Object.values(TestDataType));
+
 const TestDefinitionFormBody: FC<TestDefinitionFormBodyProps> = ({
   form,
   isEditMode,
@@ -226,7 +243,7 @@ const TestDefinitionFormBody: FC<TestDefinitionFormBodyProps> = ({
       props: {
         'data-testid': 'entity-type',
         isDisabled: isReadOnlyField,
-        options: toOptions(Object.values(EntityType)),
+        options: ENTITY_TYPE_OPTIONS,
       } as FieldProp['props'],
     },
     {
@@ -247,7 +264,7 @@ const TestDefinitionFormBody: FC<TestDefinitionFormBodyProps> = ({
       props: {
         'data-testid': 'test-platforms',
         isDisabled: isReadOnlyField,
-        options: toOptions(Object.values(TestPlatform)),
+        options: TEST_PLATFORM_OPTIONS,
       } as FieldProp['props'],
     },
     {
@@ -262,7 +279,7 @@ const TestDefinitionFormBody: FC<TestDefinitionFormBodyProps> = ({
       }),
       props: {
         'data-testid': 'data-quality-dimension',
-        options: toOptions(Object.values(DataQualityDimensions)),
+        options: DATA_QUALITY_DIMENSION_OPTIONS,
       } as FieldProp['props'],
     },
     {
@@ -278,7 +295,7 @@ const TestDefinitionFormBody: FC<TestDefinitionFormBodyProps> = ({
       props: {
         'data-testid': 'supported-services',
         isDisabled: isReadOnlyField,
-        options: toOptions(Object.values(DatabaseServiceType)),
+        options: SUPPORTED_SERVICE_OPTIONS,
       } as FieldProp['props'],
     },
     {
@@ -313,7 +330,7 @@ const TestDefinitionFormBody: FC<TestDefinitionFormBodyProps> = ({
       props: {
         'data-testid': 'supported-data-types',
         isDisabled: isReadOnlyField,
-        options: toOptions(Object.values(DataType)),
+        options: SUPPORTED_DATA_TYPE_OPTIONS,
       } as FieldProp['props'],
     },
   ];
@@ -466,7 +483,7 @@ const TestDefinitionFormBody: FC<TestDefinitionFormBodyProps> = ({
               props: {
                 'data-testid': `parameter-data-type-${index}`,
                 isDisabled: isReadOnlyField,
-                options: toOptions(Object.values(TestDataType)),
+                options: TEST_DATA_TYPE_OPTIONS,
               },
             } as FieldProp)}
             {getField({


### PR DESCRIPTION
### Describe your changes:

<!-- Linked issue waived via `skip-pr-checks`; this is CI-infrastructure work with no single tracking issue. -->

I triaged every merge-queue dequeue reported in `#ci-cleanup` over a 20-hour window — 22 events, 15 of which produced a real CI result — and found that **14 of the 15 ejected a PR that could not have caused its failure**. Four ingestion-only PRs (two-file Python diffs) were ejected by UI specs; one PR that changes a single `.yml` file was ejected by a browser test.

The failures are not 112 independent flaky tests. They cluster into a small number of mechanisms, and this PR fixes each at its root rather than adding waits or quarantining.

**1 · Locator ambiguity silenced with `.first()`**

`descriptionBox` is page-global, so it matches every editable block editor mounted. After clicking `edit-description` the page can hold two — the inline one and the modal's — and `.first()` picks the one *behind* the overlay. It is visible, so the assertion passes; the click then fails on `ant-modal-wrap ... intercepts pointer events` and retries until the test times out. The `BlockEditorEmbedLink` trace shows a **45-second click** on an editor nothing could reach.

Adds `getDescriptionBox` / `fillDescriptionBox` / `resolveDescriptionBox` to `utils/common.ts` — matching the API #32599 introduces, so the two resolve as duplicates rather than semantically — and routes **97 call sites across 40 files** through them. `utils/{domain,tag,team}.ts` are left to #32599.

**2 · Fixture identity fixed at construction, reused across retries**

Entity names are generated in the constructor, and specs that build fixtures in the `describe` body do not re-evaluate it on a retry — so `beforeAll` runs again with the same names and every create answers 409. Eight entity classes move to the existing `createOrFetch` helper; three take a `fields` argument because the by-name lookup omits what they read back, checked against each resource's `FIELDS` rather than assumed.

**3 · Interacting before the page settles**

- Lazy right-panel widgets render `EntityDetailWidgetSkeleton`, which is *not* `data-testid="loader"`, so `waitForAllLoadersToDisappear` returned straight past it. `request-entity-tags` is simply absent until the chunk mounts. New `waitForWidgetsToRender`, called from both readiness helpers.
- The glossary drag pressed at coordinates computed before the page finished hydrating; `force: true` skipped the stability check that would have waited.
- `deleteEdge` dispatches a synthetic click on a react-flow edge label; `dispatchEvent` takes no actionability wait, so a re-layout mid-dispatch makes it silently no-op.
- Three `/metrics` navigations used `page.goto` without `waitUntil`, defaulting to `load` and waiting on every subresource.

**4 · A component remounting under its own re-render**

`TestDefinitionFormBody` rebuilt `options: toOptions(Object.values(...))` every render. Focusing a field re-renders it via `onActiveFieldChange`, and the new `items` identity made react-aria rebuild the listbox collection, detaching the option mid-click. Enum-derived, so now built once at module scope.

**5 · A regression, not a flake**

`Domains.spec.ts` "Rename domain with assets preserves associations" lost its describe-scope `test.slow(true)` in #32360 and has timed out at exactly 60000ms in every run since, ejecting **four unrelated PRs across six runs**. #32360's per-test measurements came from `DomainAdvanced` and `DomainUIInteractions`; this describe was not among them. Restored per-test, so the blanket ban #32360 established still holds.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

Every fix targets a mechanism, not a symptom, and each is backed by a Playwright trace rather than inference from a failure message. Where a helper already existed (`createOrFetch`, and the scoping primitive #32599 designed) this adopts it instead of adding a parallel one.

The one deliberate behaviour change is the count assertion. `.first()` silences ambiguity by typing into an arbitrary editor, so the test fails somewhere unrelated to the real problem; asserting a single match fails where the ambiguity is and names the scope that needs narrowing.

Quarantine drops 13 → 9. Four tests are released because their root cause is fixed here, each recorded in `QUARANTINE.md` with its diagnosis. `GlossaryHierarchy` "move term to root" stays — it is parked on a product issue, not a flake.

`om-playwright/no-positional-locator` drops 95 from the suppressions baseline (1457 → 1362).

#
### Tests:

No new tests — this repairs existing ones. Verified locally:

```
yarn lint:playwright   0 errors, suppressions pruned and clean
tsc --noEmit           633 errors, identical to the pre-change baseline; zero anywhere in playwright/
prettier --check       clean
yarn test TestDefinitionFormBody   12/12 passed
```

Expect the count assertions to surface new failures: anywhere a page genuinely mounts two editors and `.first()` happened to pick correctly, the test now fails loudly. Those are latent ambiguities that each need a scope, not regressions from this change.

#
### UI screen recording / screenshots:

N/A — the only `src/` change hoists two constants out of a render body. No visual or behavioural change to the rendered form.

#
### Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>` — N/A, linked-issue requirement waived via `skip-pr-checks`.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON changes, I updated the schema — N/A.
- [x] I ran the linter and formatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)