### PR TITLE
Fix #32698: [Detail Bug] Customize UI: Table "Add new widget" modal shows duplicate Articles tab and React duplicate-key

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableClassBase.ts
@@ -3,7 +3,9 @@
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -301,13 +303,6 @@ class TableClassBase {
         },
       },
       CUSTOM_PROPERTIES_WIDGET,
-      {
-        fullyQualifiedName: DetailPageWidgetKeys.KNOWLEDGE_ARTICLE,
-        name: i18n.t('label.article-plural'),
-        data: {
-          gridSizes: ['large'] as GridSizes[],
-        },
-      },
       KNOWLEDGE_ARTICLE_WIDGET,
     ];
   }


### PR DESCRIPTION
Fixed duplicate Knowledge Article widget in TableClassBase.getCommonWidgetList by removing the redundant inline widget object and keeping only the imported KNOWLEDGE_ARTICLE_WIDGET constant. This eliminates duplicate tabs and React duplicate-key warnings in the "Add new widget" modal.

PR Title: /claim #32698 Fix: remove duplicate Knowledge Article widget in TableClassBase.getCommonWidgetList

PR Body:
Closes #32698

Summary of changes:
- Removed redundant inline Knowledge Article widget object from getCommonWidgetList in TableClassBase.ts so KNOWLEDGE_ARTICLE_WIDGET is included only once.

Verification:
- Manually inspected openmetadata-ui/src/main/resources/ui/src/utils/TableClassBase.ts to ensure the list now contains a single KNOWLEDGE_ARTICLE_WIDGET entry.

Notes:
- This is a small cosmetic fix that prevents duplicate tabs and React duplicate-key warnings in the "Add new widget" modal for Table customization.


Closes #32698

<!-- greptile_comment -->

<!-- greptile_summary -->

<details open><summary>Greptile Summary</summary>

This PR currently reformats the Apache license header but does not implement its stated widget-list correction.
- Adds two blank comment lines around the license URL.
- Leaves the duplicate Knowledge Article widget behavior unchanged.
</details>


<details open><summary>Confidence Score: 4/5</summary>

This PR should not merge as the fix for #32698 because it does not change the widget list and leaves the reported UI defect unresolved.

The sole changed file contains only license-header formatting, so the duplicate Knowledge Article entry, tab, and React key warning are unaffected.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/src/utils/TableClassBase.ts
</details>


<details open><summary>Important Files Changed</summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/utils/TableClassBase.ts | Only license-header whitespace changes; the intended duplicate-widget removal is absent. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into monexa/issue-32..."](https://github.com/open-metadata/openmetadata/commit/e7e40379864ff3a57fba3c21f91911046a5b3364) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60902139)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->