### PR TITLE
Fixes #32761: serve the history-by-timestamp page when an entity in the window is hard-deleted mid-request

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseResourceIT.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -1804,7 +1805,17 @@ public class DatabaseResourceIT extends BaseEntityIT<Database, CreateDatabase> {
     assertTrue(data.isArray(), "Data should be an array");
     assertTrue(data.size() > 0, "Should have at least one version in the time range");
 
+    // The window is server-wide, so only this test's own versions are asserted on: a database
+    // another test is hard-deleting at the same moment is legitimately mid-teardown.
+    List<JsonNode> ownVersions = new ArrayList<>();
     for (JsonNode entityNode : data) {
+      if (database.getId().toString().equals(entityNode.path("id").asText())) {
+        ownVersions.add(entityNode);
+      }
+    }
+    assertEquals(2, ownVersions.size(), "Both versions of the test database must be listed");
+
+    for (JsonNode entityNode : ownVersions) {
       assertTrue(
           entityNode.has("service") && !entityNode.get("service").isNull(),
           "Each database version must include the required 'service' field, but got: "

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -2870,11 +2870,63 @@ public abstract class EntityRepository<T extends EntityInterface> {
     if (page.isBackward()) {
       Collections.reverse(entities);
     }
-    setFieldsInBulk(putFields, entities);
-    hydrateHistoryEntities(entities);
+    entities = hydrateHistoryPage(entities);
 
     int total = getVersionCountCached(tableName, startTs, endTs, entityType);
     return historyPageResult(entities, page, hasMoreInCurrentDirection, total);
+  }
+
+  /**
+   * The version rows are read without a lock, so an entity in the page can be hard-deleted by a
+   * concurrent request before it is hydrated: its relationships and referenced entities vanish
+   * first, then its versions and its own row. Hydration must not turn that into a 404 for the
+   * whole page, and the page must not list an entity that no longer exists.
+   */
+  private List<T> hydrateHistoryPage(List<T> entities) {
+    List<T> hydrated;
+    try {
+      hydrateHistoryBatch(entities);
+      hydrated = entities;
+    } catch (EntityNotFoundException e) {
+      hydrated = hydrateHistoryEntitiesOneByOne(entities);
+    }
+    return dropVanishedHistoryEntities(hydrated);
+  }
+
+  private void hydrateHistoryBatch(List<T> entities) {
+    setFieldsInBulk(putFields, entities);
+    hydrateHistoryEntities(entities);
+  }
+
+  private List<T> hydrateHistoryEntitiesOneByOne(List<T> entities) {
+    List<T> hydrated = new ArrayList<>(entities.size());
+    for (T entity : entities) {
+      try {
+        hydrateHistoryBatch(new ArrayList<>(List.of(entity)));
+        hydrated.add(entity);
+      } catch (EntityNotFoundException e) {
+        LOG.debug(
+            "Skipping history of {} {} deleted mid-request: {}",
+            entityType,
+            entity.getId(),
+            e.getMessage());
+      }
+    }
+    return hydrated;
+  }
+
+  private List<T> dropVanishedHistoryEntities(List<T> entities) {
+    if (entities.isEmpty()) {
+      return entities;
+    }
+    List<UUID> ids = entities.stream().map(EntityInterface::getId).distinct().toList();
+    Set<UUID> existing =
+        dao.findReferencesByIds(ids, ALL).stream()
+            .map(EntityReference::getId)
+            .collect(Collectors.toSet());
+    return entities.stream()
+        .filter(entity -> existing.contains(entity.getId()))
+        .collect(Collectors.toCollection(ArrayList::new));
   }
 
   private ResultList<T> historyPageResult(

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/EntityRepositoryHistoryPageTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/EntityRepositoryHistoryPageTest.java
@@ -1,0 +1,213 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.entity.data.Pipeline;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.Include;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.schema.utils.ResultList;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.exception.EntityNotFoundException;
+import org.openmetadata.service.util.EntityUtil.Fields;
+import org.openmetadata.service.util.EntityUtil.RelationIncludes;
+
+/**
+ * {@link EntityRepository#listEntityHistoryByTimestamp} reads version rows without a lock, so an
+ * entity in the page can be hard-deleted by a concurrent request before the page is hydrated.
+ * These tests pin the contract for that window: the page is still served, and it lists only
+ * entities that still exist.
+ */
+class EntityRepositoryHistoryPageTest {
+
+  // Distinct windows per test keep the repository's static version-count cache from crossing over.
+  private static final AtomicLong WINDOW = new AtomicLong(1_000_000L);
+
+  private CollectionDAO daoCollection;
+  private CollectionDAO.EntityExtensionDAO extensionDAO;
+  private CollectionDAO.PipelineDAO pipelineDAO;
+
+  /** Hydration stub: batches that contain a vanished id fail like a strict reference lookup. */
+  private static class HistoryPipelineRepo extends EntityRepository<Pipeline> {
+    final Set<UUID> vanishedDuringHydration = new HashSet<>();
+    int bulkHydrations = 0;
+
+    HistoryPipelineRepo(CollectionDAO.PipelineDAO dao) {
+      super("pipelines", Entity.PIPELINE, Pipeline.class, dao, "", "");
+    }
+
+    @Override
+    public void setFieldsInBulk(Fields fields, List<Pipeline> entities) {
+      bulkHydrations++;
+      for (Pipeline entity : entities) {
+        if (vanishedDuringHydration.contains(entity.getId())) {
+          throw new EntityNotFoundException(
+              "pipeline instance for " + entity.getId() + " not found");
+        }
+      }
+    }
+
+    @Override
+    protected void setFields(Pipeline entity, Fields fields, RelationIncludes includes) {}
+
+    @Override
+    protected void clearFields(Pipeline entity, Fields fields) {}
+
+    @Override
+    protected void prepare(Pipeline entity, boolean update) {}
+
+    @Override
+    protected void storeEntity(Pipeline entity, boolean update) {}
+
+    @Override
+    protected void storeRelationships(Pipeline entity) {}
+  }
+
+  @BeforeEach
+  void setUp() {
+    daoCollection = mock(CollectionDAO.class);
+    extensionDAO = mock(CollectionDAO.EntityExtensionDAO.class);
+    pipelineDAO = mock(CollectionDAO.PipelineDAO.class);
+    when(daoCollection.entityExtensionDAO()).thenReturn(extensionDAO);
+    when(daoCollection.relationshipDAO())
+        .thenReturn(mock(CollectionDAO.EntityRelationshipDAO.class));
+    when(pipelineDAO.getTableName()).thenReturn("pipeline_entity");
+    Entity.setCollectionDAO(daoCollection);
+  }
+
+  @AfterEach
+  void tearDown() {
+    Entity.setCollectionDAO(null);
+  }
+
+  @Test
+  void historyPage_isServedWhenAnEntityVanishesDuringHydration() {
+    HistoryPipelineRepo repo = new HistoryPipelineRepo(pipelineDAO);
+    Pipeline survivor = version(30L);
+    Pipeline vanished = version(20L);
+    Pipeline older = version(10L);
+    long startTs = WINDOW.getAndAdd(100L);
+    stubVersionRows(startTs, List.of(survivor, vanished, older));
+    stubExistingRows(List.of(survivor, older));
+    repo.vanishedDuringHydration.add(vanished.getId());
+
+    ResultList<Pipeline> page =
+        repo.listEntityHistoryByTimestamp(startTs, startTs + 99L, null, null, 10);
+
+    assertEquals(List.of(survivor.getId(), older.getId()), ids(page));
+    assertEquals(4, repo.bulkHydrations, "one failed batch, then one hydration per row");
+    assertEquals(3, page.getPaging().getTotal());
+    assertNull(page.getPaging().getAfter());
+  }
+
+  @Test
+  void historyPage_dropsAnEntityWhoseRowVanishedAfterHydration() {
+    HistoryPipelineRepo repo = new HistoryPipelineRepo(pipelineDAO);
+    Pipeline survivor = version(30L);
+    Pipeline vanished = version(20L);
+    long startTs = WINDOW.getAndAdd(100L);
+    stubVersionRows(startTs, List.of(survivor, vanished));
+    stubExistingRows(List.of(survivor));
+
+    ResultList<Pipeline> page =
+        repo.listEntityHistoryByTimestamp(startTs, startTs + 99L, null, null, 10);
+
+    assertEquals(List.of(survivor.getId()), ids(page));
+    assertEquals(1, repo.bulkHydrations, "a healthy batch is hydrated exactly once");
+  }
+
+  @Test
+  void historyPage_pagesFromTheLastSurvivingRow() {
+    HistoryPipelineRepo repo = new HistoryPipelineRepo(pipelineDAO);
+    Pipeline first = version(30L);
+    Pipeline last = version(20L);
+    Pipeline beyondPage = version(10L);
+    long startTs = WINDOW.getAndAdd(100L);
+    stubVersionRows(startTs, List.of(first, last, beyondPage));
+    stubExistingRows(List.of(first, last));
+
+    ResultList<Pipeline> page =
+        repo.listEntityHistoryByTimestamp(startTs, startTs + 99L, null, null, 2);
+
+    assertEquals(List.of(first.getId(), last.getId()), ids(page));
+    assertEquals(
+        last.getUpdatedAt() + ":" + last.getId(), decodeCursor(page.getPaging().getAfter()));
+  }
+
+  private static Pipeline version(long updatedAt) {
+    return new Pipeline()
+        .withId(UUID.randomUUID())
+        .withName("p" + updatedAt)
+        .withUpdatedAt(updatedAt)
+        .withUpdatedBy("admin")
+        .withVersion(0.1);
+  }
+
+  private void stubVersionRows(long startTs, List<Pipeline> rows) {
+    List<String> jsons = rows.stream().map(JsonUtils::pojoToJson).toList();
+    when(extensionDAO.getEntityHistoryByTimestampRange(
+            anyString(),
+            eq(startTs),
+            anyLong(),
+            anyString(),
+            anyString(),
+            anyString(),
+            any(),
+            any(),
+            anyInt()))
+        .thenReturn(jsons);
+    when(extensionDAO.getEntityHistoryByTimestampRangeCount(
+            anyString(), eq(startTs), anyLong(), anyString()))
+        .thenReturn(rows.size());
+  }
+
+  private void stubExistingRows(List<Pipeline> rows) {
+    List<EntityReference> refs =
+        rows.stream()
+            .map(row -> new EntityReference().withId(row.getId()).withType(Entity.PIPELINE))
+            .toList();
+    when(pipelineDAO.findReferencesByIds(anyList(), eq(Include.ALL))).thenReturn(refs);
+  }
+
+  private static String decodeCursor(String cursor) {
+    return new String(Base64.getDecoder().decode(cursor), StandardCharsets.UTF_8);
+  }
+
+  private static List<UUID> ids(ResultList<Pipeline> page) {
+    List<UUID> ids = new ArrayList<>();
+    page.getData().forEach(row -> ids.add(row.getId()));
+    return ids;
+  }
+}


### PR DESCRIPTION
### Describe your changes:

`EntityRepository.listEntityHistoryByTimestamp` reads a page of version rows and then hydrates them with `setFieldsInBulk` and `hydrateHistoryEntities`. Nothing is locked in between, and a hard delete removes an entity's relationships first, then its versions, then its row (`cleanup`). When any entity in the window is being hard-deleted by a concurrent request (a recursive service delete cascading through databases and schemas, for instance), hydration can no longer resolve what a snapshot points at, and one vanished row failed the **whole page** with `404 database instance for <id> not found` or `Entity not found: glossaryTerm <id>`.

That is the standing flake of `BaseEntityIT$ListEntityHistoryByTimestampPaginationTest` in the `parallel` and `multi-node` lanes on `main`, `2.0` and every `1.13` backport: the window is server-wide, so the walking test cannot avoid other namespaces' entities. In one run the 404'd database belonged to `TableResourceIT.test_sdkCRUDOperations` while other tests' `DELETE /services/databaseServices/async/<id>?hardDelete=true&recursive=true` cleanup ran in the same second.

**Fix (`EntityRepository`):** the page is hydrated through `hydrateHistoryPage`:
- the batch hydration runs as before; if it throws `EntityNotFoundException`, the page is re-hydrated one entity at a time and the entities that fail are dropped (with a debug log), so a vanished neighbour no longer fails the read;
- after hydration, one batched `findReferencesByIds` drops any entity whose row no longer exists, so a page never lists an entity that was hard-deleted while the request ran. Soft-deleted entities keep their history (`Include.ALL`).

Paging cursors are derived from the surviving rows, so a walk simply continues after the last row that still exists. The version total is the cached window count and is unchanged.

**Test scoping (`DatabaseResourceIT.test_listEntityHistoryByTimestamp_returnsServiceField`):** the same race also produces a version whose `service` is `null` for the few milliseconds between relationship and row deletion of *another* test's database, which this assertion used to trip on (seen in the merge queue for #32458). The assertion now applies to the test's own two versions, which are the ones it can reason about.

#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests around the new logic.
- [x] I have tested that my changes work locally.

#
### Testing
New `EntityRepositoryHistoryPageTest` (Mockito, same shape as `EntityRepositoryRestoreTest`) pins the contract:
- a batch that fails with `EntityNotFoundException` is retried per entity and only the vanished entity is dropped (one failed batch, then one hydration per row);
- an entity whose row vanished after a clean hydration is dropped by the existence check, and a healthy batch is hydrated exactly once;
- the `after` cursor is built from the last surviving row.

Results (`mvn -pl openmetadata-integration-tests -am package -Dtest=EntityRepositoryHistoryPageTest`): `Tests run: 3, Failures: 0, Errors: 0`, and the integration-tests module compiles with the scoped assertion.

Control run with `EntityRepository` reverted to `origin/main`: `Tests run: 3, Failures: 1, Errors: 1`. The vanished-entity test errors with `EntityNotFound pipeline instance for <id> not found` (the 404 this PR removes) and the dropped-row test still lists the deleted entity; only the cursor test passes either way.
