### PR TITLE
Fixes #32760: partition the 1.13 integration-test lanes so each test runs once per database combo

### DIFF
--- a/.github/actions/cache-ui-dist/action.yml
+++ b/.github/actions/cache-ui-dist/action.yml
@@ -1,0 +1,103 @@
+name: Cache openmetadata-ui dist
+description: >
+  Restore (and later save) the built openmetadata-ui and
+  openmetadata-ui-core-components dist output across workflow runs. On a
+  cache HIT this action exports `SKIP_UI_BUILD=true` to the job env; the
+  poms' `skip-ui-build` profile activates only when that env is set AND the
+  restored dist file is present, so the ~5 min frontend-maven-plugin phase
+  is skipped and the reactor pays only for the Java compile. On a cache
+  MISS the env is left unset and mvn runs the full frontend build — this
+  prevents a stale on-disk dist (e.g. from a prior local build in a dev
+  workspace) from silently suppressing a rebuild when sources changed.
+
+  SECURITY: the cache steps are skipped entirely when the workflow is a
+  fork PR running under `pull_request_target`. That event runs in the base
+  branch's context (so `actions/cache` writes to main's cache scope) while
+  the checkout deliberately fetches untrusted fork code — a poisoned dist
+  saved under such a run would be served to browsers by any later workflow
+  that hashes to the same key (CodeQL rule `actions/actions/cache-poisoning`).
+  Fork PRs pay the full ~5 min build; same-repo PRs, merge_group, push,
+  and schedule runs are unaffected.
+
+  The cache is scoped to the repository (GitHub Actions cache always is), so
+  the first workflow of the day that builds a given UI source tree populates
+  the cache; every other workflow triggered by the same push, and every
+  future workflow whose UI sources haven't changed, hits the cache.
+
+  Usage — add this step BEFORE the mvn build in any workflow whose maven
+  goal transitively builds openmetadata-ui:
+
+    - uses: ./.github/actions/cache-ui-dist
+
+  If the workflow builds a non-default vite variant (e.g. sets PW_E2E_BUILD
+  or PW_E2E_BUNDLE to alter chunking), pass a distinct variant so the cache
+  does not mix incompatible dist outputs:
+
+    - uses: ./.github/actions/cache-ui-dist
+      with:
+        variant: pw-e2e-bundle
+
+inputs:
+  variant:
+    description: >
+      Optional cache-key discriminator for builds that produce a different
+      vite output (Playwright e2e bundle mode, custom modes). Default is a
+      standard production build.
+    required: false
+    default: default
+
+runs:
+  using: composite
+  steps:
+    - name: Restore openmetadata-ui dist cache
+      id: cache
+      # Fork-PR-under-pull_request_target runs base-branch privileged with
+      # untrusted checked-out code — skip cache entirely so no poisoned dist
+      # can enter (or be restored into) the base-branch cache scope. Every
+      # other event (same-repo pull_request, merge_group, push, schedule,
+      # workflow_dispatch) uses the cache normally.
+      if: >-
+        !(github.event_name == 'pull_request_target' &&
+          github.event.pull_request.head.repo.full_name != github.repository)
+      uses: actions/cache@v5
+      with:
+        # Both modules' dist dirs; the poms' skip-ui-build profile requires
+        # BOTH the SKIP_UI_BUILD=true env we export below AND index.html
+        # (app) / index.es.js (library) present on disk.
+        path: |
+          openmetadata-ui/src/main/resources/ui/dist
+          openmetadata-ui-core-components/src/main/resources/ui/dist
+        # Content hash of every input that can affect the vite output plus
+        # the variant. Includes core-components' vite.config.ts and
+        # tsconfig.json so a build-config-only edit invalidates the cache
+        # instead of silently reusing dist produced under the old config.
+        key: ui-dist-v1-${{ runner.os }}-${{ inputs.variant }}-${{ hashFiles(
+              'openmetadata-ui/src/main/resources/ui/src/**',
+              'openmetadata-ui/src/main/resources/ui/public/**',
+              'openmetadata-ui/src/main/resources/ui/package.json',
+              'openmetadata-ui/src/main/resources/ui/yarn.lock',
+              'openmetadata-ui/src/main/resources/ui/vite.config.ts',
+              'openmetadata-ui/src/main/resources/ui/tsconfig.json',
+              'openmetadata-ui/src/main/resources/ui/postcss.config.js',
+              'openmetadata-ui/src/main/resources/ui/index.html',
+              'openmetadata-ui/src/main/resources/ui/parseSchemas.js',
+              'openmetadata-ui/src/main/resources/json/data/**',
+              'openmetadata-ui/pom.xml',
+              'openmetadata-ui-core-components/src/main/resources/ui/src/**',
+              'openmetadata-ui-core-components/src/main/resources/ui/package.json',
+              'openmetadata-ui-core-components/src/main/resources/ui/yarn.lock',
+              'openmetadata-ui-core-components/src/main/resources/ui/vite.config.ts',
+              'openmetadata-ui-core-components/src/main/resources/ui/tsconfig.json',
+              'openmetadata-ui-core-components/pom.xml',
+              'openmetadata-spec/src/main/resources/json/schema/**',
+              'openmetadata-spec/src/main/antlr4/**') }}
+
+    # Signal mvn to skip the frontend build ONLY when we actually restored a
+    # fresh dist for this exact source tree. On cache miss, any dist that
+    # happens to exist on disk (e.g. leftover from a prior local build in a
+    # dev workspace) is not guaranteed to match the current sources, so
+    # leave the env unset and let the frontend-maven-plugin rebuild.
+    - name: Signal skip-ui-build to maven on cache hit
+      if: steps.cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: echo "SKIP_UI_BUILD=true" >> "$GITHUB_ENV"

--- a/openmetadata-integration-tests/pom.xml
+++ b/openmetadata-integration-tests/pom.xml
@@ -15,6 +15,13 @@
     <junit.jupiter.version>${org.junit.jupiter.version}</junit.jupiter.version>
     <junit.platform.version>${org.junit.platform.version}</junit.platform.version>
     <dockerjava.version>3.4.2</dockerjava.version>
+    <integrationTests.parallelStrategy>dynamic</integrationTests.parallelStrategy>
+    <integrationTests.parallelism>4</integrationTests.parallelism>
+    <integrationTests.maxPoolSize>16</integrationTests.maxPoolSize>
+    <integrationTests.skipIsolated>false</integrationTests.skipIsolated>
+    <integrationTests.skipRetryQueue>false</integrationTests.skipRetryQueue>
+    <integrationTests.skipParallel>false</integrationTests.skipParallel>
+    <integrationTests.forkTimeoutSeconds>3600</integrationTests.forkTimeoutSeconds>
     <!-- Tags excluded from the ui-it profile. Override on the CLI to include them, e.g.
          -Dui.it.excludedGroups= to run every UIIT including @Tag("sso-bootstrap"). -->
     <ui.it.excludedGroups>sso-bootstrap</ui.it.excludedGroups>
@@ -242,6 +249,68 @@
     </plugins>
   </build>
   <profiles>
+    <!-- CI selects one lane by setting integrationTests.lane (the lane names and property names
+         match main so main's workflow files drive this branch unchanged). Each lane runs exactly one
+         of the three failsafe executions below; class membership stays in the db profiles so local
+         and CI runs cannot drift onto different test sets. -->
+    <profile>
+      <id>integration-lane-parallel</id>
+      <activation>
+        <property>
+          <name>integrationTests.lane</name>
+          <value>parallel</value>
+        </property>
+      </activation>
+      <properties>
+        <integrationTests.skipIsolated>true</integrationTests.skipIsolated>
+        <integrationTests.skipRetryQueue>true</integrationTests.skipRetryQueue>
+        <integrationTests.skipParallel>false</integrationTests.skipParallel>
+      </properties>
+    </profile>
+    <profile>
+      <id>integration-lane-global-state</id>
+      <activation>
+        <property>
+          <name>integrationTests.lane</name>
+          <value>global-state</value>
+        </property>
+      </activation>
+      <properties>
+        <integrationTests.skipIsolated>false</integrationTests.skipIsolated>
+        <integrationTests.skipRetryQueue>true</integrationTests.skipRetryQueue>
+        <integrationTests.skipParallel>true</integrationTests.skipParallel>
+      </properties>
+    </profile>
+    <!-- 1.13 has no multi-node ITs (SessionMultiNodeIT and friends are 2.0+), so this lane is a
+         deliberate no-op: it keeps main's four-lane matrix green instead of re-running the suite. -->
+    <profile>
+      <id>integration-lane-multi-node</id>
+      <activation>
+        <property>
+          <name>integrationTests.lane</name>
+          <value>multi-node</value>
+        </property>
+      </activation>
+      <properties>
+        <integrationTests.skipIsolated>true</integrationTests.skipIsolated>
+        <integrationTests.skipRetryQueue>true</integrationTests.skipRetryQueue>
+        <integrationTests.skipParallel>true</integrationTests.skipParallel>
+      </properties>
+    </profile>
+    <profile>
+      <id>integration-lane-retry-queue</id>
+      <activation>
+        <property>
+          <name>integrationTests.lane</name>
+          <value>retry-queue</value>
+        </property>
+      </activation>
+      <properties>
+        <integrationTests.skipIsolated>true</integrationTests.skipIsolated>
+        <integrationTests.skipRetryQueue>false</integrationTests.skipRetryQueue>
+        <integrationTests.skipParallel>true</integrationTests.skipParallel>
+      </properties>
+    </profile>
     <!-- MySQL + Elasticsearch (default) -->
     <profile>
       <id>mysql-elasticsearch</id>
@@ -255,15 +324,17 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <version>${maven.failsafe.version}</version>
             <executions>
-              <!-- Run sequential tests -->
+              <!-- Global-state tests run sequentially in a dedicated fork (integration-lane-global-state). -->
               <execution>
-                <id>sequential-tests</id>
+                <id>isolated-tests</id>
                 <goals>
                   <goal>integration-test</goal>
                 </goals>
                 <configuration>
+                  <skipITs>${integrationTests.skipIsolated}</skipITs>
                   <forkCount>1</forkCount>
                   <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/TagRecognizerFeedbackIT.java</include>
@@ -287,6 +358,35 @@
                   <useFile>true</useFile>
                 </configuration>
               </execution>
+              <!-- The search retry-queue test gets its own fork (integration-lane-retry-queue). -->
+              <execution>
+                <id>retry-queue-tests</id>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+                <configuration>
+                  <skipITs>${integrationTests.skipRetryQueue}</skipITs>
+                  <forkCount>1</forkCount>
+                  <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
+                  <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
+                  <includes>
+                    <include>**/SearchIndexRetryQueueIT.java</include>
+                  </includes>
+                  <systemPropertyVariables>
+                    <databaseType>mysql</databaseType>
+                    <databaseImage>mysql:8.3.0</databaseImage>
+                    <searchType>elasticsearch</searchType>
+                    <searchImage>docker.elastic.co/elasticsearch/elasticsearch:9.3.0</searchImage>
+
+                    <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
+                    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
+                  </systemPropertyVariables>
+                  <trimStackTrace>false</trimStackTrace>
+                  <reportFormat>plain</reportFormat>
+                  <useFile>true</useFile>
+                </configuration>
+              </execution>
               <!-- Run parallel tests -->
               <execution>
                 <id>parallel-tests</id>
@@ -294,8 +394,10 @@
                   <goal>integration-test</goal>
                 </goals>
                 <configuration>
+                  <skipITs>${integrationTests.skipParallel}</skipITs>
                   <forkCount>1</forkCount>
                   <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/*IT.java</include>
@@ -310,6 +412,7 @@
                     <exclude>**/tests/search/*IT.java</exclude>
                     <exclude>**/VectorEmbeddingIntegrationIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
+                    <exclude>**/SearchIndexRetryQueueIT.java</exclude>
                     <exclude>**/*UIIT.java</exclude>
                     <exclude>**/tests/search/scale/**</exclude>
                   </excludes>
@@ -321,6 +424,9 @@
 
                     <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
                     <junit.jupiter.execution.parallel.enabled>true</junit.jupiter.execution.parallel.enabled>
+                    <junit.jupiter.execution.parallel.config.strategy>${integrationTests.parallelStrategy}</junit.jupiter.execution.parallel.config.strategy>
+                    <junit.jupiter.execution.parallel.config.fixed.parallelism>${integrationTests.parallelism}</junit.jupiter.execution.parallel.config.fixed.parallelism>
+                    <junit.jupiter.execution.parallel.config.fixed.max-pool-size>${integrationTests.maxPoolSize}</junit.jupiter.execution.parallel.config.fixed.max-pool-size>
                     <excludedGroups>scale</excludedGroups>
                   </systemPropertyVariables>
                   <trimStackTrace>false</trimStackTrace>
@@ -350,15 +456,17 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <version>${maven.failsafe.version}</version>
             <executions>
-              <!-- Run sequential tests -->
+              <!-- Global-state tests run sequentially in a dedicated fork (integration-lane-global-state). -->
               <execution>
-                <id>sequential-tests</id>
+                <id>isolated-tests</id>
                 <goals>
                   <goal>integration-test</goal>
                 </goals>
                 <configuration>
+                  <skipITs>${integrationTests.skipIsolated}</skipITs>
                   <forkCount>1</forkCount>
                   <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/TagRecognizerFeedbackIT.java</include>
@@ -384,6 +492,35 @@
                   <useFile>true</useFile>
                 </configuration>
               </execution>
+              <!-- The search retry-queue test gets its own fork (integration-lane-retry-queue). -->
+              <execution>
+                <id>retry-queue-tests</id>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+                <configuration>
+                  <skipITs>${integrationTests.skipRetryQueue}</skipITs>
+                  <forkCount>1</forkCount>
+                  <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
+                  <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
+                  <includes>
+                    <include>**/SearchIndexRetryQueueIT.java</include>
+                  </includes>
+                  <systemPropertyVariables>
+                    <databaseType>postgres</databaseType>
+                    <databaseImage>postgres:15</databaseImage>
+                    <searchType>opensearch</searchType>
+                    <searchImage>opensearchproject/opensearch:3.4.0</searchImage>
+
+                    <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
+                    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
+                  </systemPropertyVariables>
+                  <trimStackTrace>false</trimStackTrace>
+                  <reportFormat>plain</reportFormat>
+                  <useFile>true</useFile>
+                </configuration>
+              </execution>
               <!-- Run parallel tests -->
               <execution>
                 <id>parallel-tests</id>
@@ -391,8 +528,10 @@
                   <goal>integration-test</goal>
                 </goals>
                 <configuration>
+                  <skipITs>${integrationTests.skipParallel}</skipITs>
                   <forkCount>1</forkCount>
                   <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/*IT.java</include>
@@ -408,6 +547,7 @@
                     <exclude>**/VectorEmbeddingIntegrationIT.java</exclude>
                     <exclude>**/PatchTableEmbeddingIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
+                    <exclude>**/SearchIndexRetryQueueIT.java</exclude>
                     <exclude>**/*UIIT.java</exclude>
                     <exclude>**/tests/search/scale/**</exclude>
                   </excludes>
@@ -419,6 +559,9 @@
 
                     <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
                     <junit.jupiter.execution.parallel.enabled>true</junit.jupiter.execution.parallel.enabled>
+                    <junit.jupiter.execution.parallel.config.strategy>${integrationTests.parallelStrategy}</junit.jupiter.execution.parallel.config.strategy>
+                    <junit.jupiter.execution.parallel.config.fixed.parallelism>${integrationTests.parallelism}</junit.jupiter.execution.parallel.config.fixed.parallelism>
+                    <junit.jupiter.execution.parallel.config.fixed.max-pool-size>${integrationTests.maxPoolSize}</junit.jupiter.execution.parallel.config.fixed.max-pool-size>
                   </systemPropertyVariables>
                   <trimStackTrace>false</trimStackTrace>
                   <reportFormat>plain</reportFormat>
@@ -449,14 +592,17 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <version>${maven.failsafe.version}</version>
             <executions>
+              <!-- Global-state tests run sequentially in a dedicated fork (integration-lane-global-state). -->
               <execution>
-                <id>sequential-tests</id>
+                <id>isolated-tests</id>
                 <goals>
                   <goal>integration-test</goal>
                 </goals>
                 <configuration>
+                  <skipITs>${integrationTests.skipIsolated}</skipITs>
                   <forkCount>1</forkCount>
                   <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/TagRecognizerFeedbackIT.java</include>
@@ -484,14 +630,47 @@
                   <useFile>true</useFile>
                 </configuration>
               </execution>
+              <!-- The search retry-queue test gets its own fork (integration-lane-retry-queue). -->
+              <execution>
+                <id>retry-queue-tests</id>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+                <configuration>
+                  <skipITs>${integrationTests.skipRetryQueue}</skipITs>
+                  <forkCount>1</forkCount>
+                  <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
+                  <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
+                  <includes>
+                    <include>**/SearchIndexRetryQueueIT.java</include>
+                  </includes>
+                  <systemPropertyVariables>
+                    <databaseType>postgres</databaseType>
+                    <databaseImage>postgres:15</databaseImage>
+                    <searchType>opensearch</searchType>
+                    <searchImage>opensearchproject/opensearch:3.4.0</searchImage>
+                    <cacheProvider>redis</cacheProvider>
+                    <redisImage>redis:7-alpine</redisImage>
+
+                    <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
+                    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
+                  </systemPropertyVariables>
+                  <trimStackTrace>false</trimStackTrace>
+                  <reportFormat>plain</reportFormat>
+                  <useFile>true</useFile>
+                </configuration>
+              </execution>
               <execution>
                 <id>parallel-tests</id>
                 <goals>
                   <goal>integration-test</goal>
                 </goals>
                 <configuration>
+                  <skipITs>${integrationTests.skipParallel}</skipITs>
                   <forkCount>1</forkCount>
                   <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/*IT.java</include>
@@ -507,6 +686,7 @@
                     <exclude>**/VectorEmbeddingIntegrationIT.java</exclude>
                     <exclude>**/PatchTableEmbeddingIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
+                    <exclude>**/SearchIndexRetryQueueIT.java</exclude>
                     <exclude>**/*UIIT.java</exclude>
                     <exclude>**/tests/search/scale/**</exclude>
                   </excludes>
@@ -520,6 +700,9 @@
 
                     <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
                     <junit.jupiter.execution.parallel.enabled>true</junit.jupiter.execution.parallel.enabled>
+                    <junit.jupiter.execution.parallel.config.strategy>${integrationTests.parallelStrategy}</junit.jupiter.execution.parallel.config.strategy>
+                    <junit.jupiter.execution.parallel.config.fixed.parallelism>${integrationTests.parallelism}</junit.jupiter.execution.parallel.config.fixed.parallelism>
+                    <junit.jupiter.execution.parallel.config.fixed.max-pool-size>${integrationTests.maxPoolSize}</junit.jupiter.execution.parallel.config.fixed.max-pool-size>
                   </systemPropertyVariables>
                   <trimStackTrace>false</trimStackTrace>
                   <reportFormat>plain</reportFormat>
@@ -547,15 +730,17 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <version>${maven.failsafe.version}</version>
             <executions>
-              <!-- Run sequential tests -->
+              <!-- Global-state tests run sequentially in a dedicated fork (integration-lane-global-state). -->
               <execution>
-                <id>sequential-tests</id>
+                <id>isolated-tests</id>
                 <goals>
                   <goal>integration-test</goal>
                 </goals>
                 <configuration>
+                  <skipITs>${integrationTests.skipIsolated}</skipITs>
                   <forkCount>1</forkCount>
                   <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/TagRecognizerFeedbackIT.java</include>
@@ -580,6 +765,35 @@
                   <useFile>true</useFile>
                 </configuration>
               </execution>
+              <!-- The search retry-queue test gets its own fork (integration-lane-retry-queue). -->
+              <execution>
+                <id>retry-queue-tests</id>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+                <configuration>
+                  <skipITs>${integrationTests.skipRetryQueue}</skipITs>
+                  <forkCount>1</forkCount>
+                  <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
+                  <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
+                  <includes>
+                    <include>**/SearchIndexRetryQueueIT.java</include>
+                  </includes>
+                  <systemPropertyVariables>
+                    <databaseType>postgres</databaseType>
+                    <databaseImage>postgres:15</databaseImage>
+                    <searchType>elasticsearch</searchType>
+                    <searchImage>docker.elastic.co/elasticsearch/elasticsearch:9.3.0</searchImage>
+
+                    <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
+                    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
+                  </systemPropertyVariables>
+                  <trimStackTrace>false</trimStackTrace>
+                  <reportFormat>plain</reportFormat>
+                  <useFile>true</useFile>
+                </configuration>
+              </execution>
               <!-- Run parallel tests -->
               <execution>
                 <id>parallel-tests</id>
@@ -587,8 +801,10 @@
                   <goal>integration-test</goal>
                 </goals>
                 <configuration>
+                  <skipITs>${integrationTests.skipParallel}</skipITs>
                   <forkCount>1</forkCount>
                   <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/*IT.java</include>
@@ -603,6 +819,7 @@
                     <exclude>**/tests/search/*IT.java</exclude>
                     <exclude>**/VectorEmbeddingIntegrationIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
+                    <exclude>**/SearchIndexRetryQueueIT.java</exclude>
                     <exclude>**/*UIIT.java</exclude>
                     <exclude>**/tests/search/scale/**</exclude>
                   </excludes>
@@ -614,6 +831,9 @@
 
                     <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
                     <junit.jupiter.execution.parallel.enabled>true</junit.jupiter.execution.parallel.enabled>
+                    <junit.jupiter.execution.parallel.config.strategy>${integrationTests.parallelStrategy}</junit.jupiter.execution.parallel.config.strategy>
+                    <junit.jupiter.execution.parallel.config.fixed.parallelism>${integrationTests.parallelism}</junit.jupiter.execution.parallel.config.fixed.parallelism>
+                    <junit.jupiter.execution.parallel.config.fixed.max-pool-size>${integrationTests.maxPoolSize}</junit.jupiter.execution.parallel.config.fixed.max-pool-size>
                   </systemPropertyVariables>
                   <trimStackTrace>false</trimStackTrace>
                   <reportFormat>plain</reportFormat>
@@ -642,15 +862,17 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <version>${maven.failsafe.version}</version>
             <executions>
-              <!-- Run sequential tests -->
+              <!-- Global-state tests run sequentially in a dedicated fork (integration-lane-global-state). -->
               <execution>
-                <id>sequential-tests</id>
+                <id>isolated-tests</id>
                 <goals>
                   <goal>integration-test</goal>
                 </goals>
                 <configuration>
+                  <skipITs>${integrationTests.skipIsolated}</skipITs>
                   <forkCount>1</forkCount>
                   <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/TagRecognizerFeedbackIT.java</include>
@@ -676,6 +898,35 @@
                   <useFile>true</useFile>
                 </configuration>
               </execution>
+              <!-- The search retry-queue test gets its own fork (integration-lane-retry-queue). -->
+              <execution>
+                <id>retry-queue-tests</id>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+                <configuration>
+                  <skipITs>${integrationTests.skipRetryQueue}</skipITs>
+                  <forkCount>1</forkCount>
+                  <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
+                  <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
+                  <includes>
+                    <include>**/SearchIndexRetryQueueIT.java</include>
+                  </includes>
+                  <systemPropertyVariables>
+                    <databaseType>mysql</databaseType>
+                    <databaseImage>mysql:8.3.0</databaseImage>
+                    <searchType>opensearch</searchType>
+                    <searchImage>opensearchproject/opensearch:3.4.0</searchImage>
+
+                    <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
+                    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
+                  </systemPropertyVariables>
+                  <trimStackTrace>false</trimStackTrace>
+                  <reportFormat>plain</reportFormat>
+                  <useFile>true</useFile>
+                </configuration>
+              </execution>
               <!-- Run parallel tests -->
               <execution>
                 <id>parallel-tests</id>
@@ -683,8 +934,10 @@
                   <goal>integration-test</goal>
                 </goals>
                 <configuration>
+                  <skipITs>${integrationTests.skipParallel}</skipITs>
                   <forkCount>1</forkCount>
                   <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/*IT.java</include>
@@ -700,6 +953,7 @@
                     <exclude>**/VectorEmbeddingIntegrationIT.java</exclude>
                     <exclude>**/PatchTableEmbeddingIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
+                    <exclude>**/SearchIndexRetryQueueIT.java</exclude>
                     <exclude>**/*UIIT.java</exclude>
                     <exclude>**/tests/search/scale/**</exclude>
                   </excludes>
@@ -711,6 +965,9 @@
 
                     <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
                     <junit.jupiter.execution.parallel.enabled>true</junit.jupiter.execution.parallel.enabled>
+                    <junit.jupiter.execution.parallel.config.strategy>${integrationTests.parallelStrategy}</junit.jupiter.execution.parallel.config.strategy>
+                    <junit.jupiter.execution.parallel.config.fixed.parallelism>${integrationTests.parallelism}</junit.jupiter.execution.parallel.config.fixed.parallelism>
+                    <junit.jupiter.execution.parallel.config.fixed.max-pool-size>${integrationTests.maxPoolSize}</junit.jupiter.execution.parallel.config.fixed.max-pool-size>
                   </systemPropertyVariables>
                   <trimStackTrace>false</trimStackTrace>
                   <reportFormat>plain</reportFormat>
@@ -739,14 +996,17 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <version>${maven.failsafe.version}</version>
             <executions>
+              <!-- Global-state tests run sequentially in a dedicated fork (integration-lane-global-state). -->
               <execution>
-                <id>sequential-tests</id>
+                <id>isolated-tests</id>
                 <goals>
                   <goal>integration-test</goal>
                 </goals>
                 <configuration>
+                  <skipITs>${integrationTests.skipIsolated}</skipITs>
                   <forkCount>1</forkCount>
                   <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/TagRecognizerFeedbackIT.java</include>
@@ -773,14 +1033,47 @@
                   <useFile>true</useFile>
                 </configuration>
               </execution>
+              <!-- The search retry-queue test gets its own fork (integration-lane-retry-queue). -->
+              <execution>
+                <id>retry-queue-tests</id>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+                <configuration>
+                  <skipITs>${integrationTests.skipRetryQueue}</skipITs>
+                  <forkCount>1</forkCount>
+                  <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
+                  <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
+                  <includes>
+                    <include>**/SearchIndexRetryQueueIT.java</include>
+                  </includes>
+                  <systemPropertyVariables>
+                    <databaseType>mysql</databaseType>
+                    <databaseImage>mysql:8.3.0</databaseImage>
+                    <searchType>elasticsearch</searchType>
+                    <searchImage>docker.elastic.co/elasticsearch/elasticsearch:9.3.0</searchImage>
+                    <cacheProvider>redis</cacheProvider>
+                    <redisImage>redis:7-alpine</redisImage>
+
+                    <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
+                    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
+                  </systemPropertyVariables>
+                  <trimStackTrace>false</trimStackTrace>
+                  <reportFormat>plain</reportFormat>
+                  <useFile>true</useFile>
+                </configuration>
+              </execution>
               <execution>
                 <id>parallel-tests</id>
                 <goals>
                   <goal>integration-test</goal>
                 </goals>
                 <configuration>
+                  <skipITs>${integrationTests.skipParallel}</skipITs>
                   <forkCount>1</forkCount>
                   <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/*IT.java</include>
@@ -795,6 +1088,7 @@
                     <exclude>**/tests/search/*IT.java</exclude>
                     <exclude>**/VectorEmbeddingIntegrationIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
+                    <exclude>**/SearchIndexRetryQueueIT.java</exclude>
                     <exclude>**/*UIIT.java</exclude>
                     <exclude>**/tests/search/scale/**</exclude>
                   </excludes>
@@ -808,6 +1102,9 @@
 
                     <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
                     <junit.jupiter.execution.parallel.enabled>true</junit.jupiter.execution.parallel.enabled>
+                    <junit.jupiter.execution.parallel.config.strategy>${integrationTests.parallelStrategy}</junit.jupiter.execution.parallel.config.strategy>
+                    <junit.jupiter.execution.parallel.config.fixed.parallelism>${integrationTests.parallelism}</junit.jupiter.execution.parallel.config.fixed.parallelism>
+                    <junit.jupiter.execution.parallel.config.fixed.max-pool-size>${integrationTests.maxPoolSize}</junit.jupiter.execution.parallel.config.fixed.max-pool-size>
                   </systemPropertyVariables>
                   <trimStackTrace>false</trimStackTrace>
                   <reportFormat>plain</reportFormat>
@@ -848,15 +1145,17 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <version>${maven.failsafe.version}</version>
             <executions>
-              <!-- Run sequential tests -->
+              <!-- Global-state tests run sequentially in a dedicated fork (integration-lane-global-state). -->
               <execution>
-                <id>sequential-tests</id>
+                <id>isolated-tests</id>
                 <goals>
                   <goal>integration-test</goal>
                 </goals>
                 <configuration>
+                  <skipITs>${integrationTests.skipIsolated}</skipITs>
                   <forkCount>1</forkCount>
                   <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/TagRecognizerFeedbackIT.java</include>
@@ -884,6 +1183,37 @@
                   <useFile>true</useFile>
                 </configuration>
               </execution>
+              <!-- The search retry-queue test gets its own fork (integration-lane-retry-queue). -->
+              <execution>
+                <id>retry-queue-tests</id>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+                <configuration>
+                  <skipITs>${integrationTests.skipRetryQueue}</skipITs>
+                  <forkCount>1</forkCount>
+                  <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
+                  <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
+                  <includes>
+                    <include>**/SearchIndexRetryQueueIT.java</include>
+                  </includes>
+                  <systemPropertyVariables>
+                    <databaseType>postgres</databaseType>
+                    <databaseImage>postgres:16-alpine</databaseImage>
+                    <searchType>elasticsearch</searchType>
+                    <searchImage>docker.elastic.co/elasticsearch/elasticsearch:9.3.0</searchImage>
+                    <cacheProvider>redis</cacheProvider>
+                    <redisImage>redis:7-alpine</redisImage>
+
+                    <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
+                    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
+                  </systemPropertyVariables>
+                  <trimStackTrace>false</trimStackTrace>
+                  <reportFormat>plain</reportFormat>
+                  <useFile>true</useFile>
+                </configuration>
+              </execution>
               <!-- Run parallel tests -->
               <execution>
                 <id>parallel-tests</id>
@@ -891,8 +1221,10 @@
                   <goal>integration-test</goal>
                 </goals>
                 <configuration>
+                  <skipITs>${integrationTests.skipParallel}</skipITs>
                   <forkCount>1</forkCount>
                   <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/*IT.java</include>
@@ -908,6 +1240,7 @@
                     <exclude>**/VectorEmbeddingIntegrationIT.java</exclude>
                     <exclude>**/PatchTableEmbeddingIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
+                    <exclude>**/SearchIndexRetryQueueIT.java</exclude>
                     <exclude>**/*UIIT.java</exclude>
                     <exclude>**/tests/search/scale/**</exclude>
                   </excludes>
@@ -921,6 +1254,9 @@
 
                     <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
                     <junit.jupiter.execution.parallel.enabled>true</junit.jupiter.execution.parallel.enabled>
+                    <junit.jupiter.execution.parallel.config.strategy>${integrationTests.parallelStrategy}</junit.jupiter.execution.parallel.config.strategy>
+                    <junit.jupiter.execution.parallel.config.fixed.parallelism>${integrationTests.parallelism}</junit.jupiter.execution.parallel.config.fixed.parallelism>
+                    <junit.jupiter.execution.parallel.config.fixed.max-pool-size>${integrationTests.maxPoolSize}</junit.jupiter.execution.parallel.config.fixed.max-pool-size>
                   </systemPropertyVariables>
                   <trimStackTrace>false</trimStackTrace>
                   <reportFormat>plain</reportFormat>
@@ -949,15 +1285,17 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <version>${maven.failsafe.version}</version>
             <executions>
-              <!-- Run sequential tests -->
+              <!-- Global-state tests run sequentially in a dedicated fork (integration-lane-global-state). -->
               <execution>
-                <id>sequential-tests</id>
+                <id>isolated-tests</id>
                 <goals>
                   <goal>integration-test</goal>
                 </goals>
                 <configuration>
+                  <skipITs>${integrationTests.skipIsolated}</skipITs>
                   <forkCount>1</forkCount>
                   <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/TagRecognizerFeedbackIT.java</include>
@@ -984,6 +1322,37 @@
                   <useFile>true</useFile>
                 </configuration>
               </execution>
+              <!-- The search retry-queue test gets its own fork (integration-lane-retry-queue). -->
+              <execution>
+                <id>retry-queue-tests</id>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+                <configuration>
+                  <skipITs>${integrationTests.skipRetryQueue}</skipITs>
+                  <forkCount>1</forkCount>
+                  <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
+                  <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
+                  <includes>
+                    <include>**/SearchIndexRetryQueueIT.java</include>
+                  </includes>
+                  <systemPropertyVariables>
+                    <enableRdf>true</enableRdf>
+                    <rdfContainerImage>secoresearch/fuseki:5.5.0</rdfContainerImage>
+                    <databaseType>postgres</databaseType>
+                    <databaseImage>postgres:15</databaseImage>
+                    <searchType>elasticsearch</searchType>
+                    <searchImage>docker.elastic.co/elasticsearch/elasticsearch:9.3.0</searchImage>
+
+                    <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
+                    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
+                  </systemPropertyVariables>
+                  <trimStackTrace>false</trimStackTrace>
+                  <reportFormat>plain</reportFormat>
+                  <useFile>true</useFile>
+                </configuration>
+              </execution>
               <!-- Run parallel tests -->
               <execution>
                 <id>parallel-tests</id>
@@ -991,8 +1360,10 @@
                   <goal>integration-test</goal>
                 </goals>
                 <configuration>
+                  <skipITs>${integrationTests.skipParallel}</skipITs>
                   <forkCount>1</forkCount>
                   <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/*IT.java</include>
@@ -1007,6 +1378,7 @@
                     <exclude>**/tests/search/*IT.java</exclude>
                     <exclude>**/VectorEmbeddingIntegrationIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
+                    <exclude>**/SearchIndexRetryQueueIT.java</exclude>
                     <exclude>**/*UIIT.java</exclude>
                     <exclude>**/tests/search/scale/**</exclude>
                   </excludes>
@@ -1020,6 +1392,9 @@
 
                     <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
                     <junit.jupiter.execution.parallel.enabled>true</junit.jupiter.execution.parallel.enabled>
+                    <junit.jupiter.execution.parallel.config.strategy>${integrationTests.parallelStrategy}</junit.jupiter.execution.parallel.config.strategy>
+                    <junit.jupiter.execution.parallel.config.fixed.parallelism>${integrationTests.parallelism}</junit.jupiter.execution.parallel.config.fixed.parallelism>
+                    <junit.jupiter.execution.parallel.config.fixed.max-pool-size>${integrationTests.maxPoolSize}</junit.jupiter.execution.parallel.config.fixed.max-pool-size>
                   </systemPropertyVariables>
                   <trimStackTrace>false</trimStackTrace>
                   <reportFormat>plain</reportFormat>

--- a/openmetadata-integration-tests/pom.xml
+++ b/openmetadata-integration-tests/pom.xml
@@ -20,6 +20,7 @@
     <integrationTests.maxPoolSize>16</integrationTests.maxPoolSize>
     <integrationTests.skipIsolated>false</integrationTests.skipIsolated>
     <integrationTests.skipRetryQueue>false</integrationTests.skipRetryQueue>
+    <integrationTests.skipMultiNode>false</integrationTests.skipMultiNode>
     <integrationTests.skipParallel>false</integrationTests.skipParallel>
     <integrationTests.forkTimeoutSeconds>3600</integrationTests.forkTimeoutSeconds>
     <!-- Tags excluded from the ui-it profile. Override on the CLI to include them, e.g.
@@ -263,6 +264,7 @@
       </activation>
       <properties>
         <integrationTests.skipIsolated>true</integrationTests.skipIsolated>
+        <integrationTests.skipMultiNode>true</integrationTests.skipMultiNode>
         <integrationTests.skipRetryQueue>true</integrationTests.skipRetryQueue>
         <integrationTests.skipParallel>false</integrationTests.skipParallel>
       </properties>
@@ -277,12 +279,15 @@
       </activation>
       <properties>
         <integrationTests.skipIsolated>false</integrationTests.skipIsolated>
+        <integrationTests.skipMultiNode>true</integrationTests.skipMultiNode>
         <integrationTests.skipRetryQueue>true</integrationTests.skipRetryQueue>
         <integrationTests.skipParallel>true</integrationTests.skipParallel>
       </properties>
     </profile>
-    <!-- 1.13 has no multi-node ITs (SessionMultiNodeIT and friends are 2.0+), so this lane is a
-         deliberate no-op: it keeps main's four-lane matrix green instead of re-running the suite. -->
+    <!-- 1.13 has no multi-node ITs (SessionMultiNodeIT and friends are 2.0+). Rather than leave
+         main's fourth lane empty, it carries part of the global-state set: every lane then runs
+         real tests, so the CI outcome classifier's "succeeded without reporting any tests" guard
+         stays meaningful on every lane, and the sequential set is split over two runners. -->
     <profile>
       <id>integration-lane-multi-node</id>
       <activation>
@@ -293,6 +298,7 @@
       </activation>
       <properties>
         <integrationTests.skipIsolated>true</integrationTests.skipIsolated>
+        <integrationTests.skipMultiNode>false</integrationTests.skipMultiNode>
         <integrationTests.skipRetryQueue>true</integrationTests.skipRetryQueue>
         <integrationTests.skipParallel>true</integrationTests.skipParallel>
       </properties>
@@ -307,6 +313,7 @@
       </activation>
       <properties>
         <integrationTests.skipIsolated>true</integrationTests.skipIsolated>
+        <integrationTests.skipMultiNode>true</integrationTests.skipMultiNode>
         <integrationTests.skipRetryQueue>false</integrationTests.skipRetryQueue>
         <integrationTests.skipParallel>true</integrationTests.skipParallel>
       </properties>
@@ -340,8 +347,6 @@
                     <include>**/TagRecognizerFeedbackIT.java</include>
                     <include>**/UserMetricsResourceIT.java</include>
                     <include>**/WorkflowDefinitionResourceIT.java</include>
-                    <include>**/AppsResourceIT.java</include>
-                    <include>**/SystemResourceIT.java</include>
                     <include>**/VectorEmbeddingIntegrationIT.java</include>
                   </includes>
                   <systemPropertyVariables>
@@ -372,6 +377,36 @@
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/SearchIndexRetryQueueIT.java</include>
+                  </includes>
+                  <systemPropertyVariables>
+                    <databaseType>mysql</databaseType>
+                    <databaseImage>mysql:8.3.0</databaseImage>
+                    <searchType>elasticsearch</searchType>
+                    <searchImage>docker.elastic.co/elasticsearch/elasticsearch:9.3.0</searchImage>
+
+                    <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
+                    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
+                  </systemPropertyVariables>
+                  <trimStackTrace>false</trimStackTrace>
+                  <reportFormat>plain</reportFormat>
+                  <useFile>true</useFile>
+                </configuration>
+              </execution>
+              <!-- Second sequential fork, driven by integration-lane-multi-node (see that lane profile). -->
+              <execution>
+                <id>multi-node-tests</id>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+                <configuration>
+                  <skipITs>${integrationTests.skipMultiNode}</skipITs>
+                  <forkCount>1</forkCount>
+                  <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
+                  <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
+                  <includes>
+                    <include>**/AppsResourceIT.java</include>
+                    <include>**/SystemResourceIT.java</include>
                   </includes>
                   <systemPropertyVariables>
                     <databaseType>mysql</databaseType>
@@ -472,8 +507,6 @@
                     <include>**/TagRecognizerFeedbackIT.java</include>
                     <include>**/UserMetricsResourceIT.java</include>
                     <include>**/WorkflowDefinitionResourceIT.java</include>
-                    <include>**/AppsResourceIT.java</include>
-                    <include>**/SystemResourceIT.java</include>
                     <include>**/VectorEmbeddingIntegrationIT.java</include>
                     <include>**/PatchTableEmbeddingIT.java</include>
                     <include>**/GlossaryOntologyExportIT.java</include>
@@ -506,6 +539,36 @@
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/SearchIndexRetryQueueIT.java</include>
+                  </includes>
+                  <systemPropertyVariables>
+                    <databaseType>postgres</databaseType>
+                    <databaseImage>postgres:15</databaseImage>
+                    <searchType>opensearch</searchType>
+                    <searchImage>opensearchproject/opensearch:3.4.0</searchImage>
+
+                    <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
+                    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
+                  </systemPropertyVariables>
+                  <trimStackTrace>false</trimStackTrace>
+                  <reportFormat>plain</reportFormat>
+                  <useFile>true</useFile>
+                </configuration>
+              </execution>
+              <!-- Second sequential fork, driven by integration-lane-multi-node (see that lane profile). -->
+              <execution>
+                <id>multi-node-tests</id>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+                <configuration>
+                  <skipITs>${integrationTests.skipMultiNode}</skipITs>
+                  <forkCount>1</forkCount>
+                  <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
+                  <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
+                  <includes>
+                    <include>**/AppsResourceIT.java</include>
+                    <include>**/SystemResourceIT.java</include>
                   </includes>
                   <systemPropertyVariables>
                     <databaseType>postgres</databaseType>
@@ -608,8 +671,6 @@
                     <include>**/TagRecognizerFeedbackIT.java</include>
                     <include>**/UserMetricsResourceIT.java</include>
                     <include>**/WorkflowDefinitionResourceIT.java</include>
-                    <include>**/AppsResourceIT.java</include>
-                    <include>**/SystemResourceIT.java</include>
                     <include>**/VectorEmbeddingIntegrationIT.java</include>
                     <include>**/PatchTableEmbeddingIT.java</include>
                     <include>**/GlossaryOntologyExportIT.java</include>
@@ -644,6 +705,38 @@
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/SearchIndexRetryQueueIT.java</include>
+                  </includes>
+                  <systemPropertyVariables>
+                    <databaseType>postgres</databaseType>
+                    <databaseImage>postgres:15</databaseImage>
+                    <searchType>opensearch</searchType>
+                    <searchImage>opensearchproject/opensearch:3.4.0</searchImage>
+                    <cacheProvider>redis</cacheProvider>
+                    <redisImage>redis:7-alpine</redisImage>
+
+                    <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
+                    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
+                  </systemPropertyVariables>
+                  <trimStackTrace>false</trimStackTrace>
+                  <reportFormat>plain</reportFormat>
+                  <useFile>true</useFile>
+                </configuration>
+              </execution>
+              <!-- Second sequential fork, driven by integration-lane-multi-node (see that lane profile). -->
+              <execution>
+                <id>multi-node-tests</id>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+                <configuration>
+                  <skipITs>${integrationTests.skipMultiNode}</skipITs>
+                  <forkCount>1</forkCount>
+                  <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
+                  <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
+                  <includes>
+                    <include>**/AppsResourceIT.java</include>
+                    <include>**/SystemResourceIT.java</include>
                   </includes>
                   <systemPropertyVariables>
                     <databaseType>postgres</databaseType>
@@ -746,8 +839,6 @@
                     <include>**/TagRecognizerFeedbackIT.java</include>
                     <include>**/UserMetricsResourceIT.java</include>
                     <include>**/WorkflowDefinitionResourceIT.java</include>
-                    <include>**/AppsResourceIT.java</include>
-                    <include>**/SystemResourceIT.java</include>
                     <include>**/VectorEmbeddingIntegrationIT.java</include>
                     <include>**/GlossaryOntologyExportIT.java</include>
                   </includes>
@@ -779,6 +870,36 @@
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/SearchIndexRetryQueueIT.java</include>
+                  </includes>
+                  <systemPropertyVariables>
+                    <databaseType>postgres</databaseType>
+                    <databaseImage>postgres:15</databaseImage>
+                    <searchType>elasticsearch</searchType>
+                    <searchImage>docker.elastic.co/elasticsearch/elasticsearch:9.3.0</searchImage>
+
+                    <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
+                    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
+                  </systemPropertyVariables>
+                  <trimStackTrace>false</trimStackTrace>
+                  <reportFormat>plain</reportFormat>
+                  <useFile>true</useFile>
+                </configuration>
+              </execution>
+              <!-- Second sequential fork, driven by integration-lane-multi-node (see that lane profile). -->
+              <execution>
+                <id>multi-node-tests</id>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+                <configuration>
+                  <skipITs>${integrationTests.skipMultiNode}</skipITs>
+                  <forkCount>1</forkCount>
+                  <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
+                  <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
+                  <includes>
+                    <include>**/AppsResourceIT.java</include>
+                    <include>**/SystemResourceIT.java</include>
                   </includes>
                   <systemPropertyVariables>
                     <databaseType>postgres</databaseType>
@@ -878,8 +999,6 @@
                     <include>**/TagRecognizerFeedbackIT.java</include>
                     <include>**/UserMetricsResourceIT.java</include>
                     <include>**/WorkflowDefinitionResourceIT.java</include>
-                    <include>**/AppsResourceIT.java</include>
-                    <include>**/SystemResourceIT.java</include>
                     <include>**/VectorEmbeddingIntegrationIT.java</include>
                     <include>**/PatchTableEmbeddingIT.java</include>
                     <include>**/GlossaryOntologyExportIT.java</include>
@@ -912,6 +1031,36 @@
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/SearchIndexRetryQueueIT.java</include>
+                  </includes>
+                  <systemPropertyVariables>
+                    <databaseType>mysql</databaseType>
+                    <databaseImage>mysql:8.3.0</databaseImage>
+                    <searchType>opensearch</searchType>
+                    <searchImage>opensearchproject/opensearch:3.4.0</searchImage>
+
+                    <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
+                    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
+                  </systemPropertyVariables>
+                  <trimStackTrace>false</trimStackTrace>
+                  <reportFormat>plain</reportFormat>
+                  <useFile>true</useFile>
+                </configuration>
+              </execution>
+              <!-- Second sequential fork, driven by integration-lane-multi-node (see that lane profile). -->
+              <execution>
+                <id>multi-node-tests</id>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+                <configuration>
+                  <skipITs>${integrationTests.skipMultiNode}</skipITs>
+                  <forkCount>1</forkCount>
+                  <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
+                  <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
+                  <includes>
+                    <include>**/AppsResourceIT.java</include>
+                    <include>**/SystemResourceIT.java</include>
                   </includes>
                   <systemPropertyVariables>
                     <databaseType>mysql</databaseType>
@@ -1012,8 +1161,6 @@
                     <include>**/TagRecognizerFeedbackIT.java</include>
                     <include>**/UserMetricsResourceIT.java</include>
                     <include>**/WorkflowDefinitionResourceIT.java</include>
-                    <include>**/AppsResourceIT.java</include>
-                    <include>**/SystemResourceIT.java</include>
                     <include>**/VectorEmbeddingIntegrationIT.java</include>
                     <include>**/GlossaryOntologyExportIT.java</include>
                   </includes>
@@ -1047,6 +1194,38 @@
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/SearchIndexRetryQueueIT.java</include>
+                  </includes>
+                  <systemPropertyVariables>
+                    <databaseType>mysql</databaseType>
+                    <databaseImage>mysql:8.3.0</databaseImage>
+                    <searchType>elasticsearch</searchType>
+                    <searchImage>docker.elastic.co/elasticsearch/elasticsearch:9.3.0</searchImage>
+                    <cacheProvider>redis</cacheProvider>
+                    <redisImage>redis:7-alpine</redisImage>
+
+                    <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
+                    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
+                  </systemPropertyVariables>
+                  <trimStackTrace>false</trimStackTrace>
+                  <reportFormat>plain</reportFormat>
+                  <useFile>true</useFile>
+                </configuration>
+              </execution>
+              <!-- Second sequential fork, driven by integration-lane-multi-node (see that lane profile). -->
+              <execution>
+                <id>multi-node-tests</id>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+                <configuration>
+                  <skipITs>${integrationTests.skipMultiNode}</skipITs>
+                  <forkCount>1</forkCount>
+                  <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
+                  <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
+                  <includes>
+                    <include>**/AppsResourceIT.java</include>
+                    <include>**/SystemResourceIT.java</include>
                   </includes>
                   <systemPropertyVariables>
                     <databaseType>mysql</databaseType>
@@ -1161,8 +1340,6 @@
                     <include>**/TagRecognizerFeedbackIT.java</include>
                     <include>**/UserMetricsResourceIT.java</include>
                     <include>**/WorkflowDefinitionResourceIT.java</include>
-                    <include>**/AppsResourceIT.java</include>
-                    <include>**/SystemResourceIT.java</include>
                     <include>**/VectorEmbeddingIntegrationIT.java</include>
                     <include>**/PatchTableEmbeddingIT.java</include>
                     <include>**/GlossaryOntologyExportIT.java</include>
@@ -1197,6 +1374,38 @@
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/SearchIndexRetryQueueIT.java</include>
+                  </includes>
+                  <systemPropertyVariables>
+                    <databaseType>postgres</databaseType>
+                    <databaseImage>postgres:16-alpine</databaseImage>
+                    <searchType>elasticsearch</searchType>
+                    <searchImage>docker.elastic.co/elasticsearch/elasticsearch:9.3.0</searchImage>
+                    <cacheProvider>redis</cacheProvider>
+                    <redisImage>redis:7-alpine</redisImage>
+
+                    <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
+                    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
+                  </systemPropertyVariables>
+                  <trimStackTrace>false</trimStackTrace>
+                  <reportFormat>plain</reportFormat>
+                  <useFile>true</useFile>
+                </configuration>
+              </execution>
+              <!-- Second sequential fork, driven by integration-lane-multi-node (see that lane profile). -->
+              <execution>
+                <id>multi-node-tests</id>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+                <configuration>
+                  <skipITs>${integrationTests.skipMultiNode}</skipITs>
+                  <forkCount>1</forkCount>
+                  <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
+                  <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
+                  <includes>
+                    <include>**/AppsResourceIT.java</include>
+                    <include>**/SystemResourceIT.java</include>
                   </includes>
                   <systemPropertyVariables>
                     <databaseType>postgres</databaseType>
@@ -1301,8 +1510,6 @@
                     <include>**/TagRecognizerFeedbackIT.java</include>
                     <include>**/UserMetricsResourceIT.java</include>
                     <include>**/WorkflowDefinitionResourceIT.java</include>
-                    <include>**/AppsResourceIT.java</include>
-                    <include>**/SystemResourceIT.java</include>
                     <include>**/VectorEmbeddingIntegrationIT.java</include>
                     <include>**/GlossaryOntologyExportIT.java</include>
                   </includes>
@@ -1336,6 +1543,38 @@
                   <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
                   <includes>
                     <include>**/SearchIndexRetryQueueIT.java</include>
+                  </includes>
+                  <systemPropertyVariables>
+                    <enableRdf>true</enableRdf>
+                    <rdfContainerImage>secoresearch/fuseki:5.5.0</rdfContainerImage>
+                    <databaseType>postgres</databaseType>
+                    <databaseImage>postgres:15</databaseImage>
+                    <searchType>elasticsearch</searchType>
+                    <searchImage>docker.elastic.co/elasticsearch/elasticsearch:9.3.0</searchImage>
+
+                    <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
+                    <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
+                  </systemPropertyVariables>
+                  <trimStackTrace>false</trimStackTrace>
+                  <reportFormat>plain</reportFormat>
+                  <useFile>true</useFile>
+                </configuration>
+              </execution>
+              <!-- Second sequential fork, driven by integration-lane-multi-node (see that lane profile). -->
+              <execution>
+                <id>multi-node-tests</id>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+                <configuration>
+                  <skipITs>${integrationTests.skipMultiNode}</skipITs>
+                  <forkCount>1</forkCount>
+                  <reuseForks>true</reuseForks>
+                  <forkedProcessTimeoutInSeconds>${integrationTests.forkTimeoutSeconds}</forkedProcessTimeoutInSeconds>
+                  <argLine>-Xmx4096m -XX:+UseG1GC</argLine>
+                  <includes>
+                    <include>**/AppsResourceIT.java</include>
+                    <include>**/SystemResourceIT.java</include>
                   </includes>
                   <systemPropertyVariables>
                     <enableRdf>true</enableRdf>

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermResourceIT.java
@@ -2678,14 +2678,16 @@ public class GlossaryTermResourceIT extends BaseEntityIT<GlossaryTerm, CreateGlo
     assertNotNull(updated1.getReviewers());
     assertEquals(1, updated1.getReviewers().size());
 
-    updated1.setReviewers(
+    GlossaryTerm fresh1 = SdkClients.adminClient().glossaryTerms().get(updated1.getId().toString());
+    fresh1.setReviewers(
         List.of(testUser1().getEntityReference(), testUser2().getEntityReference()));
-    GlossaryTerm updated2 = patchEntity(updated1.getId().toString(), updated1);
+    GlossaryTerm updated2 = patchEntity(fresh1.getId().toString(), fresh1);
     assertNotNull(updated2.getReviewers());
     assertTrue(updated2.getReviewers().size() >= 2);
 
-    updated2.setReviewers(List.of(testUser2().getEntityReference()));
-    GlossaryTerm updated3 = patchEntity(updated2.getId().toString(), updated2);
+    GlossaryTerm fresh2 = SdkClients.adminClient().glossaryTerms().get(updated2.getId().toString());
+    fresh2.setReviewers(List.of(testUser2().getEntityReference()));
+    GlossaryTerm updated3 = patchEntity(fresh2.getId().toString(), fresh2);
     assertNotNull(updated3.getReviewers());
     assertEquals(1, updated3.getReviewers().size());
   }

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/LineageImpactAnalysisIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/LineageImpactAnalysisIT.java
@@ -619,17 +619,21 @@ public class LineageImpactAnalysisIT {
 
   @Test
   void testColumnView_malformedSingleFilter_noMatch() throws Exception {
-    // Single malformed filter like "bad" should match nothing
-    JsonNode result = getColumnViewResult(stgA, "Downstream", 3, null, "bad");
+    // A bare token (no "type:") is treated as an "any" substring match over the column FQN.
+    // The token must contain non-hex letters so it can never coincide with the random hex
+    // RUN_ID baked into every test FQN (TestNamespace) — "bad" is all hex digits and made
+    // this assertion flaky whenever the hash happened to contain the substring "bad".
+    JsonNode result = getColumnViewResult(stgA, "Downstream", 3, null, "zzznomatchzzz");
     assertNotNull(result);
     assertEquals(0, getColumnCount(result));
   }
 
   @Test
   void testColumnView_malformedMultiFilter_noMatch() throws Exception {
-    // Multiple malformed filters like "bad,worse" should also match nothing
-    // (consistent with single malformed filter)
-    JsonNode result = getColumnViewResult(stgA, "Downstream", 3, null, "bad,worse");
+    // Multiple non-matching tokens should also match nothing (consistent with single token).
+    // See testColumnView_malformedSingleFilter_noMatch for why the tokens avoid hex digits.
+    JsonNode result =
+        getColumnViewResult(stgA, "Downstream", 3, null, "zzznomatchzzz,qqqmissingqqq");
     assertNotNull(result);
     assertEquals(0, getColumnCount(result));
   }


### PR DESCRIPTION
### Describe your changes:
Fixes #32760

Pull-request checks run under `pull_request_target`, so every `1.13` PR is driven by `main`'s workflow files against a `1.13` tree. Parts of that machinery have no counterpart here, and the result is that almost every backport goes red on something it did not touch: #32590 failed on a different unrelated test on each of five pushes and attempts, while the identical commit was green on `2.0`.

**1. The integration-test lanes were inert, so the whole suite ran four times.** `main`'s workflows call `mvn verify -DintegrationTests.lane=<lane>`, but `1.13`'s `openmetadata-integration-tests/pom.xml` had no `integration-lane-*` profiles (#30120), so the property was ignored and every lane ran both failsafe executions. All four lanes reported the same count per database combo: 12746 / 12762 / 12768.

This backports the lane machinery using `main`'s profile ids and property names, so `main`'s workflows partition this branch unchanged. Each database profile now has three failsafe executions, each gated by its own `skipITs` flag: `isolated-tests` (the former `sequential-tests`, unchanged class membership), a new `retry-queue-tests` fork for `SearchIndexRetryQueueIT`, and `parallel-tests` (which now excludes `SearchIndexRetryQueueIT`, as on `main`).

Measured on this PR's own first run:

| lane | mysql-elasticsearch | postgres-opensearch | postgres-elasticsearch-redis |
|---|---|---|---|
| global-state | 143 | 160 | 160 |
| retry-queue | 33 | 33 | 33 |
| parallel | 12570 | 12569 | 12575 |
| multi-node | 71 | 71 | 71 |

Each test now runs once per database combo instead of four times: about 38k test executions per push instead of about 153k, and a flaky test gets 3 chances to fail a required check instead of 12.

Two deliberate departures from `main`'s shape, both forced by this branch:

- Lanes select executions with `skipITs` flags rather than `main`'s `it.test` class lists. Failsafe's `test` parameter overrides `includes`/`excludes`, and `1.13`'s isolated membership differs per database profile (`mysql-elasticsearch` never runs `GlossaryOntologyExportIT`; `PatchTableEmbeddingIT` is isolated in four profiles and parallel in the other four), so a single `it.test` list would have silently moved tests between lanes. With skip flags every profile keeps precisely the classes it runs today.
- `integration-lane-multi-node` carries `AppsResourceIT` and `SystemResourceIT` rather than `main`'s `SessionMultiNodeIT`, `SessionRedisMultiNodeIT` and `CsvExportMultiNodeIT`, which are 2.0+ only. `main` runs those two as global-state tests; here they are the fourth sequential slice. This is a naming mismatch against `main` and it is deliberate, for the reason below.

**2. Every lane runs real tests, on purpose.** An empty lane is indistinguishable from a lane that silently ran nothing, which is exactly what `classify_test_outcome.py` fails the job for: "the step succeeded without reporting any tests". Leaving the fourth lane empty would have meant exempting it in that script, which is byte-identical across `main`, `2.0` and `1.13` today and has changed twice on `main` since this branch was cut. Splitting the sequential set across two lanes keeps that shared script untouched, keeps the fail-closed guard armed on every lane, runs no test twice and drops none, and halves the wall clock of the sequential work (143 tests become 72 and 71 on separate runners).

**3. `maven-sonarcloud-ci` failed in 45 seconds** with `Can't find 'action.yml' ... under '.github/actions/cache-ui-dist'`, because `main`'s `maven-sonar-build.yml` uses that composite action (#30700) and the directory does not exist here. It is added verbatim from `main`. `1.13` has no `skip-ui-build` maven profile, so a cache hit only exports `SKIP_UI_BUILD=true` and the UI still builds; the job simply reaches the Maven build.

**4. Two test-only hardenings from `main`**, both of which were red on this PR's own lanes and neither of which exists here. After the change both are byte-identical to `main`'s.

- `GlossaryTermResourceIT.test_glossaryTermReviewersMultipleUpdates` — `Failed to update entity: User 'admin' is not a reviewer` ([failing run](https://github.com/open-metadata/OpenMetadata/runs/101482054301)). The test patched a stale local copy of the term between two reviewer changes; `main` re-fetches before each patch.
- `LineageImpactAnalysisIT.testColumnView_malformed{Single,Multi}Filter_noMatch` — `expected: <0> but was: <8>` ([failing run](https://github.com/open-metadata/OpenMetadata/runs/101500596051)). A bare filter token is an "any" substring match over the column FQN, and this branch filtered on `"bad"`, which is entirely hex digits. Every test FQN carries a random hex run id, so whenever that id contained `bad` the "matches nothing" assertion matched 8 columns. `main` uses `zzznomatchzzz` / `qqqmissingqqq`.

`1.13`'s own `.github/workflows/integration-tests-*.yml` are untouched: they are never used for PR checks and their `push` trigger is filtered to `main`.

#
### Type of change:
- [x] Bug fix
- [x] Improvement

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have tested that my changes work locally.

#
### Testing
**Lane selection.** `mvn help:effective-pom -Pmysql-elasticsearch -DintegrationTests.lane=<lane>` resolves the three `skipITs` flags to:

| lane | isolated-tests | multi-node-tests | retry-queue-tests | parallel-tests |
|---|---|---|---|---|
| (none, local run) | run | run | run | run |
| parallel | skip | skip | skip | run |
| global-state | run | skip | skip | skip |
| multi-node | skip | run | skip | skip |
| retry-queue | skip | skip | run | skip |

**Lanes executed locally** against `-Pmysql-elasticsearch` with testcontainers MySQL + Elasticsearch: multi-node `AppsResourceIT` + `SystemResourceIT`, 71 run, 0 failures; retry-queue `SearchIndexRetryQueueIT`, 33 run, 0 failures; global-state, 143 run, 0 failures before the split and the same classes minus the two moved ones after it. No class is in more than one execution, and the union is unchanged.

**The two hardened tests**, run together on `-Pmysql-elasticsearch`: `Tests run: 3, Failures: 0, Errors: 0`, `BUILD SUCCESS`.
