### PR TITLE
test(1.13): backport two main test hardenings for hash- and order-dependent lane flakes

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermResourceIT.java
@@ -2678,14 +2678,16 @@ public class GlossaryTermResourceIT extends BaseEntityIT<GlossaryTerm, CreateGlo
     assertNotNull(updated1.getReviewers());
     assertEquals(1, updated1.getReviewers().size());
 
-    updated1.setReviewers(
+    GlossaryTerm fresh1 = SdkClients.adminClient().glossaryTerms().get(updated1.getId().toString());
+    fresh1.setReviewers(
         List.of(testUser1().getEntityReference(), testUser2().getEntityReference()));
-    GlossaryTerm updated2 = patchEntity(updated1.getId().toString(), updated1);
+    GlossaryTerm updated2 = patchEntity(fresh1.getId().toString(), fresh1);
     assertNotNull(updated2.getReviewers());
     assertTrue(updated2.getReviewers().size() >= 2);
 
-    updated2.setReviewers(List.of(testUser2().getEntityReference()));
-    GlossaryTerm updated3 = patchEntity(updated2.getId().toString(), updated2);
+    GlossaryTerm fresh2 = SdkClients.adminClient().glossaryTerms().get(updated2.getId().toString());
+    fresh2.setReviewers(List.of(testUser2().getEntityReference()));
+    GlossaryTerm updated3 = patchEntity(fresh2.getId().toString(), fresh2);
     assertNotNull(updated3.getReviewers());
     assertEquals(1, updated3.getReviewers().size());
   }

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/LineageImpactAnalysisIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/LineageImpactAnalysisIT.java
@@ -619,17 +619,21 @@ public class LineageImpactAnalysisIT {
 
   @Test
   void testColumnView_malformedSingleFilter_noMatch() throws Exception {
-    // Single malformed filter like "bad" should match nothing
-    JsonNode result = getColumnViewResult(stgA, "Downstream", 3, null, "bad");
+    // A bare token (no "type:") is treated as an "any" substring match over the column FQN.
+    // The token must contain non-hex letters so it can never coincide with the random hex
+    // RUN_ID baked into every test FQN (TestNamespace) — "bad" is all hex digits and made
+    // this assertion flaky whenever the hash happened to contain the substring "bad".
+    JsonNode result = getColumnViewResult(stgA, "Downstream", 3, null, "zzznomatchzzz");
     assertNotNull(result);
     assertEquals(0, getColumnCount(result));
   }
 
   @Test
   void testColumnView_malformedMultiFilter_noMatch() throws Exception {
-    // Multiple malformed filters like "bad,worse" should also match nothing
-    // (consistent with single malformed filter)
-    JsonNode result = getColumnViewResult(stgA, "Downstream", 3, null, "bad,worse");
+    // Multiple non-matching tokens should also match nothing (consistent with single token).
+    // See testColumnView_malformedSingleFilter_noMatch for why the tokens avoid hex digits.
+    JsonNode result =
+        getColumnViewResult(stgA, "Downstream", 3, null, "zzznomatchzzz,qqqmissingqqq");
     assertNotNull(result);
     assertEquals(0, getColumnCount(result));
   }


### PR DESCRIPTION
### Describe your changes:
Test-only backport of two `main` hardenings that `1.13` never received. Both are hash- or order-dependent flakes in the integration lanes, both were found while validating #32763 (Fixes #32760), and neither touches product code. After this change both methods are byte-identical to `main`'s.

**1. `GlossaryTermResourceIT.test_glossaryTermReviewersMultipleUpdates`** — `Failed to update entity: User 'admin' is not a reviewer` ([failing check run](https://github.com/open-metadata/OpenMetadata/runs/101061593660)). On `1.13` the test patches a stale local copy of the term between two reviewer changes, so the second patch can carry an outdated reviewer list. `main` re-fetches the term before each patch (`fresh1` / `fresh2`).

**2. `LineageImpactAnalysisIT.testColumnView_malformedSingleFilter_noMatch` and `…_malformedMultiFilter_noMatch`** — `expected: <0> but was: <8>` ([failing check run](https://github.com/open-metadata/OpenMetadata/runs/101500596051)). A bare filter token is an "any" substring match over the column FQN, and `1.13` filters on `"bad"`, which is entirely hex digits. Every test FQN carries a random hex run id, so whenever that hash happens to contain `bad` the filter matches 8 columns instead of 0. `main` switched the tokens to `zzznomatchzzz` / `qqqmissingqqq`, which cannot collide.

#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have tested that my changes work locally.

#
### Testing
`mvn -pl openmetadata-integration-tests -am verify -Pmysql-elasticsearch` against testcontainers MySQL + Elasticsearch, running the three affected methods: `Tests run: 3, Failures: 0, Errors: 0`, `BUILD SUCCESS`.
