### PR TITLE
Fixes #26451: reject an OpenMetadata URL without an http(s) scheme (#32542)

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
@@ -124,6 +124,7 @@ import org.openmetadata.service.security.auth.validator.SamlValidator;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.GlossaryTermRelationSettingsUtil;
 import org.openmetadata.service.util.LdapUtil;
+import org.openmetadata.service.util.OpenMetadataBaseUrlValidator;
 import org.openmetadata.service.util.OpenMetadataConnectionBuilder;
 import org.openmetadata.service.util.RestUtil;
 import org.openmetadata.service.util.ValidationErrorBuilder;
@@ -309,6 +310,7 @@ public class SystemRepository {
 
   @Transaction
   public Response createOrUpdate(Settings setting) {
+    OpenMetadataBaseUrlValidator.validate(setting);
     Settings oldValue = dao.getConfigWithKey(setting.getConfigType().toString());
     preserveEmailSettings(setting, oldValue);
 
@@ -366,6 +368,7 @@ public class SystemRepository {
     Object updatedConfigValue = JsonUtils.readValue(jsonString, Object.class);
     original.setConfigValue(updatedConfigValue);
     preserveEmailSettings(original, stored);
+    OpenMetadataBaseUrlValidator.validate(original);
     updateSettingIfCurrent(original, expectedJson);
     prepareFetchedSettings(original);
     return (new RestUtil.PutResponse<>(Response.Status.OK, original, ENTITY_UPDATED)).toResponse();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataBaseUrlValidator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataBaseUrlValidator.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.util;
+
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+
+import okhttp3.HttpUrl;
+import org.openmetadata.schema.api.configuration.OpenMetadataBaseUrlConfiguration;
+import org.openmetadata.schema.settings.Settings;
+import org.openmetadata.schema.settings.SettingsType;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.exception.SystemSettingsException;
+
+/**
+ * The OpenMetadata base URL prefixes every entity {@code href} the API hands out, and those hrefs
+ * are parsed as absolute URLs by the ingestion framework. A scheme-less value such as {@code
+ * example.org} yields {@code example.org/api/v1/...}, which only fails much later during ingestion
+ * or a test connection (issue #26451). Reject it at the boundary.
+ *
+ * <p>Parsing goes through okhttp's {@link HttpUrl} — the same type {@code
+ * DefaultOperationalConfigProvider} uses to build the default value. It accepts only absolute
+ * http/https URLs, and unlike {@link java.net.URI} it follows WHATWG host rules, so an internal
+ * hostname containing an underscore stays valid. That is also the standard the browser's {@code new
+ * URL()} implements, so the UI form and this check agree on what is valid.
+ *
+ * <p>This deliberately does not delegate to {@link URLValidator}: that guards <em>outbound</em>
+ * fetches against SSRF and so rejects loopback and private-range hosts, which are valid
+ * OpenMetadata base URLs (the shipped default is {@code http://localhost:8585}, and Kubernetes
+ * deployments commonly use a cluster IP).
+ */
+public final class OpenMetadataBaseUrlValidator {
+  private static final String INVALID_URL_MESSAGE =
+      "OpenMetadata URL '%s' must be an absolute http or https URL including the host, for example https://example.org";
+
+  private OpenMetadataBaseUrlValidator() {}
+
+  /** No-op for every setting other than the OpenMetadata base URL configuration. */
+  public static void validate(Settings setting) {
+    boolean isBaseUrlSetting =
+        setting != null
+            && setting.getConfigType() == SettingsType.OPEN_METADATA_BASE_URL_CONFIGURATION;
+    if (isBaseUrlSetting) {
+      validateUrl(
+          JsonUtils.convertValue(setting.getConfigValue(), OpenMetadataBaseUrlConfiguration.class)
+              .getOpenMetadataUrl());
+    }
+  }
+
+  public static void validateUrl(String openMetadataUrl) {
+    if (nullOrEmpty(openMetadataUrl)) {
+      throw new SystemSettingsException("OpenMetadata URL must not be empty");
+    }
+
+    if (HttpUrl.parse(openMetadataUrl) == null) {
+      throw new SystemSettingsException(String.format(INVALID_URL_MESSAGE, openMetadataUrl));
+    }
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataBaseUrlValidator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataBaseUrlValidator.java
@@ -51,9 +51,9 @@ public final class OpenMetadataBaseUrlValidator {
         setting != null
             && setting.getConfigType() == SettingsType.OPEN_METADATA_BASE_URL_CONFIGURATION;
     if (isBaseUrlSetting) {
-      validateUrl(
-          JsonUtils.convertValue(setting.getConfigValue(), OpenMetadataBaseUrlConfiguration.class)
-              .getOpenMetadataUrl());
+      OpenMetadataBaseUrlConfiguration config =
+          JsonUtils.convertValue(setting.getConfigValue(), OpenMetadataBaseUrlConfiguration.class);
+      validateUrl(config == null ? null : config.getOpenMetadataUrl());
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
@@ -481,6 +481,7 @@ public class OpenMetadataOperations implements Callable<Integer> {
               required = true)
           String openMetadataUrl) {
     try {
+      OpenMetadataBaseUrlValidator.validateUrl(openMetadataUrl);
       URI uri = URI.create(openMetadataUrl);
       parseConfig();
       Settings updatedSettings =

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/OpenMetadataBaseUrlValidatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/OpenMetadataBaseUrlValidatorTest.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.util;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openmetadata.schema.api.configuration.LoginConfiguration;
+import org.openmetadata.schema.api.configuration.OpenMetadataBaseUrlConfiguration;
+import org.openmetadata.schema.settings.Settings;
+import org.openmetadata.schema.settings.SettingsType;
+import org.openmetadata.service.exception.SystemSettingsException;
+
+class OpenMetadataBaseUrlValidatorTest {
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "http://localhost:8585",
+        "https://example.org",
+        "https://example.org/openmetadata",
+        "HTTPS://example.org",
+        "http://my_host:8585"
+      })
+  void acceptsAbsoluteHttpUrl(String url) {
+    assertDoesNotThrow(() -> OpenMetadataBaseUrlValidator.validateUrl(url));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {"example.org", "localhost:8585", "/api/v1", "ftp://example.org", "http://"})
+  void rejectsUrlWithoutHttpSchemeAndHost(String url) {
+    SystemSettingsException ex =
+        assertThrows(
+            SystemSettingsException.class, () -> OpenMetadataBaseUrlValidator.validateUrl(url));
+    assertTrue(ex.getMessage().contains(url));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void rejectsMissingUrl(String url) {
+    assertThrows(
+        SystemSettingsException.class, () -> OpenMetadataBaseUrlValidator.validateUrl(url));
+  }
+
+  @Test
+  void rejectsBaseUrlSettingWithoutScheme() {
+    Settings setting =
+        new Settings()
+            .withConfigType(SettingsType.OPEN_METADATA_BASE_URL_CONFIGURATION)
+            .withConfigValue(
+                new OpenMetadataBaseUrlConfiguration().withOpenMetadataUrl("example.org"));
+
+    assertThrows(
+        SystemSettingsException.class, () -> OpenMetadataBaseUrlValidator.validate(setting));
+  }
+
+  @Test
+  void acceptsBaseUrlSettingWithScheme() {
+    Settings setting =
+        new Settings()
+            .withConfigType(SettingsType.OPEN_METADATA_BASE_URL_CONFIGURATION)
+            .withConfigValue(
+                new OpenMetadataBaseUrlConfiguration().withOpenMetadataUrl("https://example.org"));
+
+    assertDoesNotThrow(() -> OpenMetadataBaseUrlValidator.validate(setting));
+  }
+
+  @Test
+  void ignoresOtherSettingTypes() {
+    Settings setting =
+        new Settings()
+            .withConfigType(SettingsType.LOGIN_CONFIGURATION)
+            .withConfigValue(new LoginConfiguration().withMaxLoginFailAttempts(3));
+
+    assertDoesNotThrow(() -> OpenMetadataBaseUrlValidator.validate(setting));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/OpenMetadataBaseUrlValidatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/OpenMetadataBaseUrlValidatorTest.java
@@ -83,6 +83,15 @@ class OpenMetadataBaseUrlValidatorTest {
   }
 
   @Test
+  void rejectsBaseUrlSettingWithoutConfigValue() {
+    Settings setting =
+        new Settings().withConfigType(SettingsType.OPEN_METADATA_BASE_URL_CONFIGURATION);
+
+    assertThrows(
+        SystemSettingsException.class, () -> OpenMetadataBaseUrlValidator.validate(setting));
+  }
+
+  @Test
   void ignoresOtherSettingTypes() {
     Settings setting =
         new Settings()

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/OmdURLConfiguration.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/OmdURLConfiguration.spec.ts
@@ -47,4 +47,22 @@ test.describe('OM URL configuration', () => {
       'http://localhost:8080'
     );
   });
+
+  test('url without a scheme is rejected before saving', async ({ page }) => {
+    await page.click('[data-testid="edit-button"]');
+
+    let settingsUpdated = false;
+    page.on('request', (request) => {
+      settingsUpdated =
+        settingsUpdated ||
+        (request.method() === 'PUT' &&
+          request.url().includes('/api/v1/system/settings'));
+    });
+
+    await page.fill('[data-testid="open-metadata-url-input"]', 'example.org');
+    await page.click('[data-testid="save-button"]');
+
+    await expect(page.getByText('Invalid URL format')).toBeVisible();
+    expect(settingsUpdated).toBe(false);
+  });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/pages/Configuration/EditUrlConfiguration/EditUrlConfigurationPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/Configuration/EditUrlConfiguration/EditUrlConfigurationPage.tsx
@@ -36,6 +36,7 @@ import {
   getSettingsConfigFromConfigType,
   updateSettingsConfig,
 } from '../../../rest/settingConfigAPI';
+import { getHyperlinkUrlValidationErrorKey } from '../../../utils/CustomProperty.utils';
 import { getSettingPath } from '../../../utils/RouterUtils';
 import { showErrorToast, showSuccessToast } from '../../../utils/ToastUtils';
 
@@ -140,7 +141,20 @@ const EditUrlConfigurationPage = () => {
         <Item
           label={t('label.brand-name-url')}
           name="openMetadataUrl"
-          rules={[{ required: true }]}>
+          rules={[
+            { required: true },
+            {
+              validator: (_, value) => {
+                const errorKey = getHyperlinkUrlValidationErrorKey(
+                  typeof value === 'string' ? value : undefined
+                );
+
+                return errorKey
+                  ? Promise.reject(new Error(t(errorKey)))
+                  : Promise.resolve();
+              },
+            },
+          ]}>
           <Input
             data-testid="open-metadata-url-input"
             id="root/openMetadataUrl-input"


### PR DESCRIPTION
fixes #26451

Backport of #32542 to `2.0`. Cherry-picked from `7dbe317` with no conflicts — identical diff (6 files, +200/−1).

A scheme-less OpenMetadata URL (e.g. `example.org`) was accepted, so entity `href` values were built as `example.org/api/v1/...` and only failed much later as a pydantic `url_parsing` error during ingestion or a test connection. Now rejected at the boundary: `OpenMetadataBaseUrlValidator` (400) on `SystemRepository.createOrUpdate`/`patchSetting` and the `setOpenMetadataUrl` CLI, plus inline validation on the UI form.

Verified on this branch: builds clean, `spotless:check` passes, `OpenMetadataBaseUrlValidatorTest` + `URLValidatorTest` 24/24.