### PR TITLE
Keep react-aria Select collections stable while a field-focus re-render is in flight

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/TestLibrary/TestDefinitionForm/TestDefinitionFormBody.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TestLibrary/TestDefinitionForm/TestDefinitionFormBody.tsx
@@ -31,6 +31,7 @@ import {
   lazy,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -175,165 +176,177 @@ const TestDefinitionFormBody: FC<TestDefinitionFormBodyProps> = ({
     [handleActiveField]
   );
 
-  const primaryFields: FieldProp[] = [
-    {
-      name: 'name',
-      label: t('label.name'),
-      type: FieldTypes.TEXT,
-      required: true,
-      id: 'root/name',
-      doc: resolveDoc('name'),
-      placeholder: t('label.enter-entity-name', {
-        entity: t('label.test-definition'),
-      }),
-      rules: {
-        required: t('message.field-text-is-required', {
-          fieldText: t('label.name'),
+  // Memoized so a focus-driven re-render (onFocusCapture -> setActiveField in
+  // the parent) does not hand the react-aria Selects a new props object and
+  // rebuild their collection, which detaches an option mid-click.
+  const primaryFields: FieldProp[] = useMemo(
+    () => [
+      {
+        name: 'name',
+        label: t('label.name'),
+        type: FieldTypes.TEXT,
+        required: true,
+        id: 'root/name',
+        doc: resolveDoc('name'),
+        placeholder: t('label.enter-entity-name', {
+          entity: t('label.test-definition'),
         }),
-      },
-      props: {
-        'data-testid': 'test-definition-name',
-        isDisabled: isEditMode || isReadOnlyField,
-      } as FieldProp['props'],
-    },
-    {
-      name: 'displayName',
-      label: t('label.display-name'),
-      type: FieldTypes.TEXT,
-      required: false,
-      id: 'root/displayName',
-      doc: resolveDoc('displayName'),
-      placeholder: t('label.enter-entity-name', {
-        entity: t('label.display-name'),
-      }),
-      props: {
-        'data-testid': 'display-name',
-      } as FieldProp['props'],
-    },
-    {
-      name: 'description',
-      label: t('label.description'),
-      type: FieldTypes.TEXTAREA,
-      required: false,
-      id: 'root/description',
-      doc: resolveDoc('description'),
-      placeholder: t('label.enter-entity-description', {
-        entity: t('label.test-definition'),
-      }),
-      props: {
-        'data-testid': 'description',
-      } as FieldProp['props'],
-    },
-  ];
-
-  const classificationFields: FieldProp[] = [
-    {
-      name: 'entityType',
-      label: t('label.entity-type'),
-      type: FieldTypes.SELECT,
-      required: true,
-      id: 'root/entityType',
-      doc: resolveDoc('entityType'),
-      placeholder: t('label.select-field', { field: t('label.entity-type') }),
-      rules: {
-        required: t('message.field-text-is-required', {
-          fieldText: t('label.entity-type'),
-        }),
-      },
-      props: {
-        'data-testid': 'entity-type',
-        isDisabled: isReadOnlyField,
-        options: ENTITY_TYPE_OPTIONS,
-      } as FieldProp['props'],
-    },
-    {
-      name: 'testPlatforms',
-      label: t('label.test-platform-plural'),
-      type: FieldTypes.MULTI_SELECT,
-      required: true,
-      id: 'root/testPlatforms',
-      doc: resolveDoc('testPlatforms'),
-      placeholder: t('label.select-field', {
-        field: t('label.test-platform-plural'),
-      }),
-      rules: {
-        required: t('message.field-text-is-required', {
-          fieldText: t('label.test-platform-plural'),
-        }),
-      },
-      props: {
-        'data-testid': 'test-platforms',
-        isDisabled: isReadOnlyField,
-        options: TEST_PLATFORM_OPTIONS,
-      } as FieldProp['props'],
-    },
-    {
-      name: 'dataQualityDimension',
-      label: t('label.data-quality-dimension'),
-      type: FieldTypes.SELECT,
-      required: false,
-      id: 'root/dataQualityDimension',
-      doc: resolveDoc('dataQualityDimension'),
-      placeholder: t('label.select-field', {
-        field: t('label.data-quality-dimension'),
-      }),
-      props: {
-        'data-testid': 'data-quality-dimension',
-        options: DATA_QUALITY_DIMENSION_OPTIONS,
-      } as FieldProp['props'],
-    },
-    {
-      name: 'supportedServices',
-      label: t('label.supported-service-plural'),
-      type: FieldTypes.MULTI_SELECT,
-      required: false,
-      id: 'root/supportedServices',
-      doc: resolveDoc('supportedServices'),
-      helperText: t('message.supported-services-help'),
-      helperTextType: HelperTextType.TOOLTIP,
-      placeholder: t('message.empty-means-all-services'),
-      props: {
-        'data-testid': 'supported-services',
-        isDisabled: isReadOnlyField,
-        options: SUPPORTED_SERVICE_OPTIONS,
-      } as FieldProp['props'],
-    },
-    {
-      name: 'supportedDataTypes',
-      label: t('label.supported-data-type-plural'),
-      type: FieldTypes.MULTI_SELECT,
-      required: false,
-      id: 'root/supportedDataTypes',
-      doc: resolveDoc('supportedDataTypes'),
-      placeholder: t('label.select-field', {
-        field: t('label.supported-data-type-plural'),
-      }),
-      rules: {
-        validate: (value?: FormSelectItem[]) => {
-          const platforms = (form.getValues('testPlatforms') ??
-            []) as FormSelectItem[];
-          const hasOpenMetadata = platforms.some(
-            (platform) =>
-              (typeof platform === 'object' ? platform?.id : platform) ===
-              TestPlatform.OpenMetadata
-          );
-          let result: string | boolean = true;
-          if (hasOpenMetadata && (value ?? []).length === 0) {
-            result = t('message.field-text-is-required', {
-              fieldText: t('label.supported-data-type-plural'),
-            });
-          }
-
-          return result;
+        rules: {
+          required: t('message.field-text-is-required', {
+            fieldText: t('label.name'),
+          }),
         },
+        props: {
+          'data-testid': 'test-definition-name',
+          isDisabled: isEditMode || isReadOnlyField,
+        } as FieldProp['props'],
       },
-      props: {
-        'data-testid': 'supported-data-types',
-        isDisabled: isReadOnlyField,
-        options: SUPPORTED_DATA_TYPE_OPTIONS,
-      } as FieldProp['props'],
-    },
-  ];
+      {
+        name: 'displayName',
+        label: t('label.display-name'),
+        type: FieldTypes.TEXT,
+        required: false,
+        id: 'root/displayName',
+        doc: resolveDoc('displayName'),
+        placeholder: t('label.enter-entity-name', {
+          entity: t('label.display-name'),
+        }),
+        props: {
+          'data-testid': 'display-name',
+        } as FieldProp['props'],
+      },
+      {
+        name: 'description',
+        label: t('label.description'),
+        type: FieldTypes.TEXTAREA,
+        required: false,
+        id: 'root/description',
+        doc: resolveDoc('description'),
+        placeholder: t('label.enter-entity-description', {
+          entity: t('label.test-definition'),
+        }),
+        props: {
+          'data-testid': 'description',
+        } as FieldProp['props'],
+      },
+    ],
+    [t, resolveDoc, isReadOnlyField, isEditMode]
+  );
+
+  // Memoized so a focus-driven re-render (onFocusCapture -> setActiveField in
+  // the parent) does not hand the react-aria Selects a new props object and
+  // rebuild their collection, which detaches an option mid-click.
+  const classificationFields: FieldProp[] = useMemo(
+    () => [
+      {
+        name: 'entityType',
+        label: t('label.entity-type'),
+        type: FieldTypes.SELECT,
+        required: true,
+        id: 'root/entityType',
+        doc: resolveDoc('entityType'),
+        placeholder: t('label.select-field', { field: t('label.entity-type') }),
+        rules: {
+          required: t('message.field-text-is-required', {
+            fieldText: t('label.entity-type'),
+          }),
+        },
+        props: {
+          'data-testid': 'entity-type',
+          isDisabled: isReadOnlyField,
+          options: ENTITY_TYPE_OPTIONS,
+        } as FieldProp['props'],
+      },
+      {
+        name: 'testPlatforms',
+        label: t('label.test-platform-plural'),
+        type: FieldTypes.MULTI_SELECT,
+        required: true,
+        id: 'root/testPlatforms',
+        doc: resolveDoc('testPlatforms'),
+        placeholder: t('label.select-field', {
+          field: t('label.test-platform-plural'),
+        }),
+        rules: {
+          required: t('message.field-text-is-required', {
+            fieldText: t('label.test-platform-plural'),
+          }),
+        },
+        props: {
+          'data-testid': 'test-platforms',
+          isDisabled: isReadOnlyField,
+          options: TEST_PLATFORM_OPTIONS,
+        } as FieldProp['props'],
+      },
+      {
+        name: 'dataQualityDimension',
+        label: t('label.data-quality-dimension'),
+        type: FieldTypes.SELECT,
+        required: false,
+        id: 'root/dataQualityDimension',
+        doc: resolveDoc('dataQualityDimension'),
+        placeholder: t('label.select-field', {
+          field: t('label.data-quality-dimension'),
+        }),
+        props: {
+          'data-testid': 'data-quality-dimension',
+          options: DATA_QUALITY_DIMENSION_OPTIONS,
+        } as FieldProp['props'],
+      },
+      {
+        name: 'supportedServices',
+        label: t('label.supported-service-plural'),
+        type: FieldTypes.MULTI_SELECT,
+        required: false,
+        id: 'root/supportedServices',
+        doc: resolveDoc('supportedServices'),
+        helperText: t('message.supported-services-help'),
+        helperTextType: HelperTextType.TOOLTIP,
+        placeholder: t('message.empty-means-all-services'),
+        props: {
+          'data-testid': 'supported-services',
+          isDisabled: isReadOnlyField,
+          options: SUPPORTED_SERVICE_OPTIONS,
+        } as FieldProp['props'],
+      },
+      {
+        name: 'supportedDataTypes',
+        label: t('label.supported-data-type-plural'),
+        type: FieldTypes.MULTI_SELECT,
+        required: false,
+        id: 'root/supportedDataTypes',
+        doc: resolveDoc('supportedDataTypes'),
+        placeholder: t('label.select-field', {
+          field: t('label.supported-data-type-plural'),
+        }),
+        rules: {
+          validate: (value?: FormSelectItem[]) => {
+            const platforms = (form.getValues('testPlatforms') ??
+              []) as FormSelectItem[];
+            const hasOpenMetadata = platforms.some(
+              (platform) =>
+                (typeof platform === 'object' ? platform?.id : platform) ===
+                TestPlatform.OpenMetadata
+            );
+            let result: string | boolean = true;
+            if (hasOpenMetadata && (value ?? []).length === 0) {
+              result = t('message.field-text-is-required', {
+                fieldText: t('label.supported-data-type-plural'),
+              });
+            }
+
+            return result;
+          },
+        },
+        props: {
+          'data-testid': 'supported-data-types',
+          isDisabled: isReadOnlyField,
+          options: SUPPORTED_DATA_TYPE_OPTIONS,
+        } as FieldProp['props'],
+      },
+    ],
+    [t, resolveDoc, isReadOnlyField, form]
+  );
 
   const enabledField: FieldProp = {
     name: 'enabled',


### PR DESCRIPTION
## Problem

`Features/DataQuality/TestLibrary.spec.ts › should create, edit, and delete a test definition` intermittently times out at 60s in the merge queue and full runs, failing on **both** attempts when it goes red ([run 34031893426](https://github.com/open-metadata/OpenMetadata/actions/runs/34031893426), shard chromium-06):

```
waiting for getByRole('option', { name: 'TABLE', exact: true })
  - locator resolved to <div role="option" data-key="TABLE" ...>
  - attempting click action
  - element was detached from the DOM, retrying
```

## Root cause

Focusing any field runs `onFocusCapture` → `handleActiveField` → `onActiveFieldChange`, which is the parent's `setActiveField` (`TestDefinitionForm.component.tsx`). That re-renders `TestDefinitionFormBody`, and `primaryFields` / `classificationFields` were plain `const` arrays of fresh object literals — so every re-render handed the react-aria `Select` a **new `props` object**, rebuilding its collection and detaching the option that was open under the cursor.

It races the click, which is why it is intermittent rather than a hard failure.

#32631 hoisted the enum-derived option arrays (`ENTITY_TYPE_OPTIONS`, …) to module scope. That stabilised the *options* identity but not the *field descriptor* identity, which is what actually feeds the collection — so the detach survived.

## Fix

Memoize both field arrays. This is the case `.claude/rules/frontend-performance.md` calls out directly: inline object/array props defeat memoization, hoist constants and wrap the rest.

## Verification

- The field definitions are **byte-identical** with the `useMemo` wrapper removed (whitespace/comment-normalised comparison) — the diff is the wrapper plus re-indentation, no behaviour change.
- `TestDefinitionFormBody.test.tsx` passes; 55 tests green across the form's suites.
- ESLint 0 errors / 0 warnings (deps are exactly what `react-hooks/exhaustive-deps` requires; `form` comes from `useForm()` and is a stable RHF reference).
- `tsc --noEmit` clean for this file.

Caveat worth stating: the failing test is intermittent, so a single green run does not prove the race is gone — it proves the mechanism that produced the detach no longer exists on any re-render path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)