### PR TITLE
Backport #32794 to 2.0: import UnitOfMeasurement as a value, not a type

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/MetricVersionPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/MetricVersionPage.spec.ts
@@ -1,0 +1,161 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { expect, Page, test } from '@playwright/test';
+import {
+  DOMAIN_TAGS,
+  PLAYWRIGHT_BASIC_TEST_TAG_OBJ,
+} from '../../constant/config';
+import { MetricClass } from '../../support/entity/MetricClass';
+import { performAdminLogin } from '../../utils/admin';
+import { redirectToHomePage } from '../../utils/common';
+import { waitForAllLoadersToDisappear } from '../../utils/entity';
+
+test.use({ storageState: 'playwright/.auth/admin.json' });
+
+const metric = new MetricClass();
+
+const CUSTOM_UNIT = 'Leads';
+
+const ERROR_BOUNDARY_TITLE = 'Something went wrong';
+
+const openMetricVersion = async (page: Page, version: string) => {
+  const versionButton = page.getByTestId('version-button');
+
+  await expect(versionButton).toBeVisible();
+  await expect(versionButton).toBeEnabled();
+
+  const versionResponse = page.waitForResponse((response) =>
+    response
+      .url()
+      .includes(`/api/v1/metrics/${metric.entityResponseData.id}/versions`)
+  );
+
+  await versionButton.click();
+
+  expect((await versionResponse).status()).toBe(200);
+
+  const versionSelector = page.getByTestId(`version-selector-v${version}`);
+
+  await expect(versionSelector).toBeVisible();
+  await versionSelector.click();
+
+  await waitForAllLoadersToDisappear(page);
+};
+
+test.describe(
+  'Metric version page',
+  { tag: [DOMAIN_TAGS.GOVERNANCE, PLAYWRIGHT_BASIC_TEST_TAG_OBJ.tag] },
+  () => {
+    test.beforeAll('Setup metric versions', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+
+      await metric.create(apiContext);
+
+      await metric.patch({
+        apiContext,
+        patchData: [
+          { op: 'replace', path: '/unitOfMeasurement', value: 'OTHER' },
+          { op: 'add', path: '/customUnitOfMeasurement', value: CUSTOM_UNIT },
+        ],
+      });
+
+      await metric.patch({
+        apiContext,
+        patchData: [
+          {
+            op: 'replace',
+            path: '/description',
+            value: 'Updated description for the metric version page test',
+          },
+        ],
+      });
+
+      await afterAction();
+    });
+
+    test.afterAll('Cleanup metric', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+
+      await metric.delete(apiContext);
+
+      await afterAction();
+    });
+
+    test.beforeEach('Visit metric details page', async ({ page }) => {
+      await redirectToHomePage(page);
+      await metric.visitEntityPage(page);
+      await waitForAllLoadersToDisappear(page);
+    });
+
+    test('should show the custom unit on a version that carries it over', async ({
+      page,
+    }) => {
+      test.slow();
+
+      await test.step('Open version 0.3', async () => {
+        await openMetricVersion(page, '0.3');
+      });
+
+      await test.step('Version header renders instead of the error boundary', async () => {
+        await expect(page.getByText(ERROR_BOUNDARY_TITLE)).toBeHidden();
+
+        await expect(
+          page.getByTestId('unit-of-measurement-version-info')
+        ).toContainText(CUSTOM_UNIT);
+        await expect(
+          page.getByTestId('metric-type-version-info')
+        ).toContainText(metric.entity.metricType);
+        await expect(
+          page.getByTestId('granularity-version-info')
+        ).toContainText(metric.entity.granularity);
+      });
+    });
+
+    test('should show both sides of the diff on the version that changes the unit', async ({
+      page,
+    }) => {
+      test.slow();
+
+      await test.step('Open version 0.2', async () => {
+        await openMetricVersion(page, '0.2');
+      });
+
+      await test.step('Unit of measurement shows the old and new value', async () => {
+        await expect(page.getByText(ERROR_BOUNDARY_TITLE)).toBeHidden();
+
+        const unitInfo = page.getByTestId('unit-of-measurement-version-info');
+
+        await expect(unitInfo).toContainText(metric.entity.unitOfMeasurement);
+        await expect(unitInfo).toContainText('OTHER');
+      });
+    });
+
+    test('should show the standard unit on the initial version', async ({
+      page,
+    }) => {
+      test.slow();
+
+      await test.step('Open version 0.1', async () => {
+        await openMetricVersion(page, '0.1');
+      });
+
+      await test.step('Unit of measurement falls back to the entity value', async () => {
+        await expect(page.getByText(ERROR_BOUNDARY_TITLE)).toBeHidden();
+
+        await expect(
+          page.getByTestId('unit-of-measurement-version-info')
+        ).toContainText(metric.entity.unitOfMeasurement);
+      });
+    });
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsVersionHeaderUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsVersionHeaderUtils.test.tsx
@@ -1,0 +1,58 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { EntityType } from '../enums/entity.enum';
+import {
+  Metric,
+  MetricGranularity,
+  MetricType,
+  UnitOfMeasurement,
+} from '../generated/entity/data/metric';
+import { getDataAssetsVersionHeaderInfo } from './DataAssetsVersionHeaderUtils';
+
+const mockMetric = {
+  id: 'id',
+  name: 'campaign_conversion_rate',
+  metricType: MetricType.Conversion,
+  unitOfMeasurement: UnitOfMeasurement.Percentage,
+  granularity: MetricGranularity.Day,
+  changeDescription: { fieldsAdded: [], fieldsUpdated: [], fieldsDeleted: [] },
+} as unknown as Metric;
+
+describe('DataAssetsVersionHeaderUtils', () => {
+  it('should render metric version info without throwing', () => {
+    render(
+      <>{getDataAssetsVersionHeaderInfo(EntityType.METRIC, mockMetric)}</>
+    );
+
+    expect(screen.getByText(UnitOfMeasurement.Percentage)).toBeInTheDocument();
+    expect(screen.getByText(MetricType.Conversion)).toBeInTheDocument();
+    expect(screen.getByText(MetricGranularity.Day)).toBeInTheDocument();
+  });
+
+  it('should prefer customUnitOfMeasurement when unit is Other', () => {
+    render(
+      <>
+        {getDataAssetsVersionHeaderInfo(EntityType.METRIC, {
+          ...mockMetric,
+          unitOfMeasurement: UnitOfMeasurement.Other,
+          customUnitOfMeasurement: 'Leads',
+        } as unknown as Metric)}
+      </>
+    );
+
+    expect(screen.getByText('Leads')).toBeInTheDocument();
+    expect(screen.queryByText(UnitOfMeasurement.Other)).not.toBeInTheDocument();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsVersionHeaderUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsVersionHeaderUtils.tsx
@@ -22,10 +22,8 @@ import { EntityField } from '../constants/Feeds.constants';
 import { EntityType } from '../enums/entity.enum';
 import type { Chart } from '../generated/entity/data/chart';
 import type { Dashboard } from '../generated/entity/data/dashboard';
-import type {
-  Metric,
-  UnitOfMeasurement,
-} from '../generated/entity/data/metric';
+import type { Metric } from '../generated/entity/data/metric';
+import { UnitOfMeasurement } from '../generated/entity/data/metric';
 import type { Pipeline } from '../generated/entity/data/pipeline';
 import type { Topic } from '../generated/entity/data/topic';
 import type { ChangeDescription } from '../generated/entity/type';
@@ -58,13 +56,15 @@ export const VersionExtraInfoLink = ({
 export const VersionExtraInfoLabel = ({
   label,
   value,
+  dataTestId,
 }: {
   label: string;
   value: string;
+  dataTestId?: string;
 }) => (
   <>
     <Divider className="self-center m-x-sm" type="vertical" />
-    <Space align="center">
+    <Space align="center" data-testid={dataTestId}>
       <Typography.Text className="self-center text-xs whitespace-nowrap">
         {!isEmpty(label) && (
           <span className="text-grey-muted">{`${label}: `}</span>
@@ -219,18 +219,21 @@ export const getDataAssetsVersionHeaderInfo = (
         <>
           {!isEmpty(metricType) && (
             <VersionExtraInfoLabel
+              dataTestId="metric-type-version-info"
               label={t('label.metric-type')}
               value={metricType}
             />
           )}
           {!isEmpty(displayUnitOfMeasurement) && (
             <VersionExtraInfoLabel
+              dataTestId="unit-of-measurement-version-info"
               label={t('label.unit-of-measurement')}
               value={displayUnitOfMeasurement}
             />
           )}
           {!isEmpty(granularity) && (
             <VersionExtraInfoLabel
+              dataTestId="granularity-version-info"
               label={t('label.granularity')}
               value={granularity}
             />


### PR DESCRIPTION
### Describe your changes:

Backport of #32794 to `2.0`. Relates to #32564 — the `Fixes` keyword is
deliberately omitted so the issue is closed by #32794 on `main`, not by this
backport.

`UnitOfMeasurement` is an enum, but `DataAssetsVersionHeaderUtils` imported it
inside an `import type { ... }` block. Type-only imports are erased at compile
time, so `UnitOfMeasurement.Other` in `getMetricVersionExtraInfo` reads a
property off `undefined` at runtime and the metric version page throws instead
of rendering. Splitting it into a value import fixes the crash; `Metric` stays
type-only.

Also threads an optional `dataTestId` through `VersionExtraInfoLabel` onto its
`Space` so the three metric rows can be targeted, plus the unit test and
Playwright spec covering the regression.

> [!NOTE]
> #32794 is still open. If it changes before merging, this backport needs the
> same update — it was cut from `5fb9404`.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

Applied by hand rather than by `git cherry-pick`. This file has diverged from
`main` (244 lines on `2.0` vs 257 on `main`) and the third hunk sits at 10-space
indentation on the release branches against 8 on `main`, so its context lines
differ by leading whitespace — the same mismatch that silently relocated a hunk
during the #32515 backport.

Verified before cutting the branch:

- The bug is genuinely present on `2.0` — `UnitOfMeasurement.Other` is used as a
  value while imported as a type.
- The pre-images of all three hunks are byte-identical between `1.13` and `2.0`,
  so both branches carry the same patch.
- Every symbol the two new test files import exists on `2.0`: `DOMAIN_TAGS`,
  `PLAYWRIGHT_BASIC_TEST_TAG_OBJ`, `MetricClass`, `performAdminLogin`,
  `redirectToHomePage`, `waitForAllLoadersToDisappear`, the `MetricType` /
  `MetricGranularity` / `UnitOfMeasurement` enums, `EntityType.METRIC`, and
  `getDataAssetsVersionHeaderInfo` with the same two-argument signature.
- The resulting diff is +161/-0, +58/-0, +8/-5 across the same three paths as
  #32794.

#
### Tests:

The two test files are the regression cover and come across unchanged. The
second unit-test case (`should prefer customUnitOfMeasurement when unit is
Other`) is the one that exercises the bug directly: before the fix it hits
`UnitOfMeasurement.Other` on an erased import and throws.

#
### UI screen recording / screenshots:

N/A — restores rendering that currently throws; no intended visual change.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: N/A.
- [x] I have added tests (unit / Playwright) and listed them above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- metadata-recheck -->
> Linked-issue check is bypassed via `skip-pr-checks`: this backport intentionally
> carries no `Fixes` keyword so #32794 remains the PR that closes #32564.
