### PR TITLE
fix(security): bump Jackson to clear CVE-2026-83557 and CVE-2026-19032

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,8 @@
     <mockito.version>5.14.2</mockito.version>
     <!-- Upgrading slf4j causes dropwizard issues -->
     <slf4j.version>2.0.4</slf4j.version>
-    <jackson.version>2.18.9</jackson.version>
+    <!-- 2.18.10 clears CVE-2026-83557 and CVE-2026-19032 (patch over 2.18.9). -->
+    <jackson.version>2.18.10</jackson.version>
     <!-- Single source for the AWS SDK v2 BOM version, consumed by the root BOM
          import below and by openmetadata-service's BOM import. -->
     <awssdk.version>2.41.30</awssdk.version>
@@ -888,12 +889,13 @@
         <version>1.85</version>
       </dependency>
       <!-- Force patched tools.jackson 3.x (jsonschema2pojo-core pulls 3.0.2 transitively).
-           3.1.5 adds CVE-2026-59889. jsonschema2pojo-core is scope=provided so none of this
-           reaches the runtime classpath, but Snyk's Maven scanner walks the provided tree. -->
+           3.1.6 clears CVE-2026-83557 and CVE-2026-19032.
+           jsonschema2pojo-core is scope=provided so none of this reaches the runtime
+           classpath, but Snyk's Maven scanner walks the provided tree. -->
       <dependency>
         <groupId>tools.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## What

Bumps the two Jackson pins in the root `pom.xml` to their same-line patch releases:

| Artifact | Before | After | Fix line |
|---|---|---|---|
| `com.fasterxml.jackson` (`jackson.version`) | 2.18.9 | **2.18.10** | 2.18.x → 2.18.10 |
| `tools.jackson` jackson-bom (3.x) | 3.1.5 | **3.1.6** | 3.1.x → 3.1.6 |

## Why

Both **CVE-2026-83557** and **CVE-2026-19032** are flagged against the currently pinned Jackson versions:
- `jackson-databind` on the 2.18.x line is only fixed in **2.18.10** (2.18.9 is still vulnerable).
- The `tools.jackson` 3.x tree (pulled transitively via `jsonschema2pojo-core`, scope=provided) is fixed in **3.1.6**.

Both are patch releases within the same minor line — binary-compatible, no API changes.

## Testing

`mvn clean install -pl openmetadata-service -am -DskipTests` → **BUILD SUCCESS** (openmetadata-spec + openmetadata-service compile against the bumped Jackson).