### PR TITLE
fix(security): bump fast-uri to 3.1.7

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/package.json
+++ b/openmetadata-ui-core-components/src/main/resources/ui/package.json
@@ -172,7 +172,7 @@
   "resolutions": {
     "brace-expansion": "5.0.9",
     "browserslist": "4.28.8",
-    "fast-uri": "3.1.6",
+    "fast-uri": "3.1.7",
     "lodash": "4.18.1",
     "minimatch": "10.2.3",
     "nanoid": "3.3.17",

--- a/openmetadata-ui-core-components/src/main/resources/ui/yarn.lock
+++ b/openmetadata-ui-core-components/src/main/resources/ui/yarn.lock
@@ -4294,10 +4294,10 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-uri@3.1.6, fast-uri@^3.0.1:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.6.tgz#bfdd308ef763f835fed059f3c6c925f708e33e3a"
-  integrity sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==
+fast-uri@3.1.7, fast-uri@^3.0.1:
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.7.tgz#743157d957f3cbb4c65310e033dc2ad4ad7dc60a"
+  integrity sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==
 
 fastq@^1.13.0:
   version "1.20.1"

--- a/openmetadata-ui/src/main/resources/ui/package.json
+++ b/openmetadata-ui/src/main/resources/ui/package.json
@@ -316,7 +316,7 @@
     "tar-fs": "2.1.4",
     "brace-expansion": "1.1.18",
     "browserslist": "4.28.8",
-    "fast-uri": "3.1.6",
+    "fast-uri": "3.1.7",
     "linkify-it": "5.0.2",
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",

--- a/openmetadata-ui/src/main/resources/ui/yarn.lock
+++ b/openmetadata-ui/src/main/resources/ui/yarn.lock
@@ -7290,10 +7290,10 @@ fast-text-encoding@^1.0.6:
   resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz#0aa25f7f638222e3396d72bf936afcf1d42d6867"
   integrity sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==
 
-fast-uri@3.1.6, fast-uri@^3.0.1:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.6.tgz#bfdd308ef763f835fed059f3c6c925f708e33e3a"
-  integrity sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==
+fast-uri@3.1.7, fast-uri@^3.0.1:
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.7.tgz#743157d957f3cbb4c65310e033dc2ad4ad7dc60a"
+  integrity sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==
 
 fastq@^1.6.0:
   version "1.20.1"


### PR DESCRIPTION
## Advisory

- **SNYK-JS-FASTURI-19502739** — Improper Encoding or Escaping of Output, `fast-uri` 3.1.6, CVSS 8.7 (high)
- **SNYK-JS-FASTURI-19502854** — Host Confusion, `fast-uri` 3.1.6, CVSS 8.7 (high)

Both reported by the 2026-09-07 `security-scan` run against `server-dep-scan` and `ui-dep-scan` (same `openmetadata-ui/.../yarn.lock` target, reported twice). Raw finding:

```
packageName: fast-uri, version: 3.1.6
fixedIn: ['2.4.6', '3.1.7', '4.1.4']
isUpgradable: true, isPatchable: false
from: open-metadata@0.1.0 > @rjsf/validator-ajv8@5.24.13 > ajv@8.18.0 > fast-uri@3.1.6
```

## Why 3.1.7 and not 2.4.6 or 4.1.4

`fast-uri` is pulled in transitively by `ajv@8.18.0` (via `@rjsf/validator-ajv8`), which declares `"fast-uri": "^3.0.1"` (`npm view ajv@8.18.0 dependencies`). Only `3.1.7` falls inside that declared range — `2.4.6` is a lower major line (would be a downgrade) and `4.1.4` is outside `^3.0.1`. Forcing either would pin a version the dependent never asked for.

## What was verified

- `npm view fast-uri versions` — `3.1.7` is a real published release (not a fictional/incoherent fix version).
- `npm view ajv@8.18.0 dependencies` — confirms `fast-uri: ^3.0.1`, so `3.1.7` is in-range.
- Both `openmetadata-ui/src/main/resources/ui/package.json` and `openmetadata-ui-core-components/src/main/resources/ui/package.json` pin `fast-uri` in their `resolutions` block at the exact vulnerable version `3.1.6` — updated both to `3.1.7`.
- `grep` across both `src/` trees — no direct import of `fast-uri` anywhere in first-party code; it is purely a transitive dependency of `ajv`. This is a patch-level bump (3.1.6 → 3.1.7) within the same major/minor line, not an API-surface change.
- Regenerated both lockfiles with `yarn install --ignore-scripts` (yarn classic 1.22.19, Node 22.17.0 via `nvm` — the checked-out Node was 23.6.1, which fails on `@windmillcode/quill-emoji`'s `engines.node` gate; that mismatch is pre-existing and unrelated to this change). Lockfile diffs are minimal (8 lines each) and touch only the `fast-uri` entry.

## What was not tested

- No `yarn build`, no test suite, no dev server run against either workspace.
- No manual exercise of any code path that goes through `ajv`/`@rjsf/validator-ajv8` (e.g. JSON-schema-driven forms in the UI).

## Manifests touched

- `openmetadata-ui/src/main/resources/ui/package.json` + `yarn.lock`
- `openmetadata-ui-core-components/src/main/resources/ui/package.json` + `yarn.lock`