### PR TITLE
Populate non-Group team Users tab with inherited sub-group users, cover export (#31770, 2.0)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TeamResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TeamResourceIT.java
@@ -448,6 +448,55 @@ public class TeamResourceIT extends BaseEntityIT<Team, CreateTeam> {
   }
 
   @Test
+  void test_descendantTeams_recursiveSubtree(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    UUID orgId = client.teams().getByName("Organization").getId();
+
+    Team bu =
+        createEntity(
+            new CreateTeam()
+                .withName(ns.prefix("dbu"))
+                .withTeamType(TeamType.BUSINESS_UNIT)
+                .withParents(List.of(orgId)));
+    Team div =
+        createEntity(
+            new CreateTeam()
+                .withName(ns.prefix("ddiv"))
+                .withTeamType(TeamType.DIVISION)
+                .withParents(List.of(bu.getId())));
+    Team dept =
+        createEntity(
+            new CreateTeam()
+                .withName(ns.prefix("ddept"))
+                .withTeamType(TeamType.DEPARTMENT)
+                .withParents(List.of(div.getId())));
+    Team group =
+        createEntity(
+            new CreateTeam()
+                .withName(ns.prefix("dgrp"))
+                .withTeamType(TeamType.GROUP)
+                .withParents(List.of(dept.getId())));
+
+    // descendantTeams is the whole subtree below the team (recursive), excluding itself and any
+    // ancestor. For the Division that is the Department plus the nested Group.
+    Team fetchedDiv = client.teams().get(div.getId().toString(), "descendantTeams");
+    assertNotNull(fetchedDiv.getDescendantTeams());
+    List<UUID> descendantIds =
+        fetchedDiv.getDescendantTeams().stream().map(EntityReference::getId).toList();
+    assertTrue(descendantIds.contains(dept.getId()), "descendants should include the Department");
+    assertTrue(descendantIds.contains(group.getId()), "descendants should include the nested Group");
+    assertFalse(descendantIds.contains(div.getId()), "descendants must exclude the team itself");
+    assertFalse(descendantIds.contains(bu.getId()), "descendants must exclude ancestors");
+
+    // A Group (leaf) team has no descendant teams.
+    Team fetchedGroup = client.teams().get(group.getId().toString(), "descendantTeams");
+    assertNotNull(fetchedGroup.getDescendantTeams());
+    assertTrue(
+        fetchedGroup.getDescendantTeams().isEmpty(),
+        "a leaf Group team has no descendant teams");
+  }
+
+  @Test
   void test_invalidHierarchy_groupCannotHaveChildren(TestNamespace ns) {
     OpenMetadataClient client = SdkClients.adminClient();
 

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/UserResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/UserResourceIT.java
@@ -291,6 +291,97 @@ public class UserResourceIT extends BaseEntityIT<User, CreateUser> {
   }
 
   // ===================================================================
+  // NON-GROUP TEAM USER ROLLUP (issue #31770)
+  //
+  // A non-Group team (Department/Division/BusinessUnit) holds no direct members; its Users tab
+  // (GET /users?team=) and export must roll up the users inherited from its sub-group descendants,
+  // matching the userCount rollup. Group/Organization teams keep direct-membership semantics.
+  // ===================================================================
+
+  @Test
+  void test_nonGroupTeam_listsInheritedUsers(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    UUID orgId = client.teams().getByName("Organization").getId();
+
+    Team department =
+        client
+            .teams()
+            .create(
+                new CreateTeam()
+                    .withName(ns.prefix("dept"))
+                    .withTeamType(CreateTeam.TeamType.DEPARTMENT)
+                    .withParents(List.of(orgId)));
+
+    String memberName = ns.prefix("member");
+    User member =
+        createEntity(new CreateUser().withName(memberName).withEmail(toValidEmail(memberName)));
+
+    Team group =
+        client
+            .teams()
+            .create(
+                new CreateTeam()
+                    .withName(ns.prefix("grp"))
+                    .withTeamType(CreateTeam.TeamType.GROUP)
+                    .withParents(List.of(department.getId()))
+                    .withUsers(List.of(member.getId())));
+
+    // Point 2: listed under its own Group (direct) AND under the parent Department (rollup)
+    assertTrue(
+        findUserInPaginatedResults(member.getId(), "team", group.getName()),
+        "member should be listed under its own Group team");
+    assertTrue(
+        findUserInPaginatedResults(member.getId(), "team", department.getName()),
+        "member should roll up to the parent non-Group (Department) team");
+
+    // A user outside this hierarchy must not roll up to the Department
+    String outsiderName = ns.prefix("outsider");
+    User outsider =
+        createEntity(new CreateUser().withName(outsiderName).withEmail(toValidEmail(outsiderName)));
+    assertFalse(
+        findUserInPaginatedResults(outsider.getId(), "team", department.getName()),
+        "unrelated user must not roll up to the Department");
+  }
+
+  @Test
+  void test_nonGroupTeam_exportIncludesInheritedUsers(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    UUID orgId = client.teams().getByName("Organization").getId();
+
+    Team businessUnit =
+        client
+            .teams()
+            .create(
+                new CreateTeam()
+                    .withName(ns.prefix("bu"))
+                    .withTeamType(CreateTeam.TeamType.BUSINESS_UNIT)
+                    .withParents(List.of(orgId)));
+
+    String memberName = ns.prefix("bumember");
+    User member =
+        createEntity(new CreateUser().withName(memberName).withEmail(toValidEmail(memberName)));
+
+    client
+        .teams()
+        .create(
+            new CreateTeam()
+                .withName(ns.prefix("bugrp"))
+                .withTeamType(CreateTeam.TeamType.GROUP)
+                .withParents(List.of(businessUnit.getId()))
+                .withUsers(List.of(member.getId())));
+
+    // Point 3: exporting the non-Group team's users includes the inherited sub-group member
+    String csv =
+        client
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.GET, "/v1/users/export?team=" + businessUnit.getName(), null);
+    assertTrue(
+        csv.contains(member.getName()),
+        "export of a non-Group team must include users inherited from sub-groups");
+  }
+
+  // ===================================================================
   // USER-SPECIFIC TESTS
   // ===================================================================
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -8343,9 +8343,25 @@ public interface CollectionDAO {
       return User.class;
     }
 
+    /**
+     * Optional subtree filter set by {@code UserResource.list}: when the requested team is a
+     * non-Group team, {@code teamHashes} carries the FQN name hashes of its whole subtree so its
+     * Users tab/export roll up the users inherited from sub-group descendants. Bypasses the
+     * single-team {@code te.nameHash = :team} equality. The hashes are server-computed hex, safe to
+     * inline.
+     */
+    private static String teamRollupCondition(String teamHashesCsv) {
+      String inList =
+          Arrays.stream(teamHashesCsv.split(","))
+              .map(hash -> "'" + hash + "'")
+              .collect(Collectors.joining(","));
+      return " AND te.nameHash IN (" + inList + ") ";
+    }
+
     @Override
     default int listCount(ListFilter filter) {
       String team = EntityInterfaceUtil.quoteName(filter.getQueryParam("team"));
+      String teamHashesCsv = filter.getQueryParam("teamHashes");
       String isBotStr = filter.getQueryParam("isBot");
       String isAdminStr = filter.getQueryParam("isAdmin");
       String lastLoginTimeGreaterThan = filter.getQueryParam("lastLoginTimeGreaterThan");
@@ -8406,7 +8422,13 @@ public interface CollectionDAO {
                 "%s AND ((ue.lastActivityTime IS NOT NULL AND ue.lastActivityTime > %s) OR (ue.lastLoginTime IS NOT NULL AND ue.lastLoginTime > %s)) ",
                 postgresCondition, lastActivityTimeGreaterThan, lastActivityTimeGreaterThan);
       }
+      if (teamHashesCsv != null) {
+        String rollup = teamRollupCondition(teamHashesCsv);
+        mySqlCondition = mySqlCondition + rollup;
+        postgresCondition = postgresCondition + rollup;
+      }
       if (team == null
+          && teamHashesCsv == null
           && isAdminStr == null
           && isBotStr == null
           && lastLoginTimeGreaterThan == null
@@ -8414,13 +8436,18 @@ public interface CollectionDAO {
         return EntityDAO.super.listCount(filter);
       }
       return listCount(
-          getTableName(), mySqlCondition, postgresCondition, team, Relationship.HAS.ordinal());
+          getTableName(),
+          mySqlCondition,
+          postgresCondition,
+          teamHashesCsv != null ? null : team,
+          Relationship.HAS.ordinal());
     }
 
     @Override
     default List<String> listBefore(
         ListFilter filter, int limit, String beforeName, String beforeId) {
       String team = EntityInterfaceUtil.quoteName(filter.getQueryParam("team"));
+      String teamHashesCsv = filter.getQueryParam("teamHashes");
       String isBotStr = filter.getQueryParam("isBot");
       String isAdminStr = filter.getQueryParam("isAdmin");
       String lastLoginTimeGreaterThan = filter.getQueryParam("lastLoginTimeGreaterThan");
@@ -8481,7 +8508,13 @@ public interface CollectionDAO {
                 "%s AND ((ue.lastActivityTime IS NOT NULL AND ue.lastActivityTime > %s) OR (ue.lastLoginTime IS NOT NULL AND ue.lastLoginTime > %s)) ",
                 postgresCondition, lastActivityTimeGreaterThan, lastActivityTimeGreaterThan);
       }
+      if (teamHashesCsv != null) {
+        String rollup = teamRollupCondition(teamHashesCsv);
+        mySqlCondition = mySqlCondition + rollup;
+        postgresCondition = postgresCondition + rollup;
+      }
       if (team == null
+          && teamHashesCsv == null
           && isAdminStr == null
           && isBotStr == null
           && lastLoginTimeGreaterThan == null
@@ -8492,7 +8525,7 @@ public interface CollectionDAO {
           getTableName(),
           mySqlCondition,
           postgresCondition,
-          team,
+          teamHashesCsv != null ? null : team,
           limit,
           beforeName,
           beforeId,
@@ -8502,6 +8535,7 @@ public interface CollectionDAO {
     @Override
     default List<String> listAfter(ListFilter filter, int limit, String afterName, String afterId) {
       String team = EntityInterfaceUtil.quoteName(filter.getQueryParam("team"));
+      String teamHashesCsv = filter.getQueryParam("teamHashes");
       String isBotStr = filter.getQueryParam("isBot");
       String isAdminStr = filter.getQueryParam("isAdmin");
       String lastLoginTimeGreaterThan = filter.getQueryParam("lastLoginTimeGreaterThan");
@@ -8562,7 +8596,13 @@ public interface CollectionDAO {
                 "%s AND ((ue.lastActivityTime IS NOT NULL AND ue.lastActivityTime > %s) OR (ue.lastLoginTime IS NOT NULL AND ue.lastLoginTime > %s)) ",
                 postgresCondition, lastActivityTimeGreaterThan, lastActivityTimeGreaterThan);
       }
+      if (teamHashesCsv != null) {
+        String rollup = teamRollupCondition(teamHashesCsv);
+        mySqlCondition = mySqlCondition + rollup;
+        postgresCondition = postgresCondition + rollup;
+      }
       if (team == null
+          && teamHashesCsv == null
           && isAdminStr == null
           && isBotStr == null
           && lastLoginTimeGreaterThan == null
@@ -8573,7 +8613,7 @@ public interface CollectionDAO {
           getTableName(),
           mySqlCondition,
           postgresCondition,
-          team,
+          teamHashesCsv != null ? null : team,
           limit,
           afterName,
           afterId,

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TeamRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TeamRepository.java
@@ -48,6 +48,7 @@ import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
@@ -89,6 +90,7 @@ import org.openmetadata.schema.type.csv.CsvErrorType;
 import org.openmetadata.schema.type.csv.CsvFile;
 import org.openmetadata.schema.type.csv.CsvHeader;
 import org.openmetadata.schema.type.csv.CsvImportResult;
+import org.openmetadata.schema.utils.EntityInterfaceUtil;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.CatalogExceptionMessage;
@@ -106,6 +108,7 @@ import org.openmetadata.service.security.policyevaluator.PolicyConditionUpdater;
 import org.openmetadata.service.security.policyevaluator.SubjectCache;
 import org.openmetadata.service.security.policyevaluator.SubjectContext;
 import org.openmetadata.service.util.EntityUtil;
+import org.openmetadata.service.util.FullyQualifiedName;
 import org.openmetadata.service.util.RestUtil;
 
 @Slf4j
@@ -793,6 +796,37 @@ public class TeamRepository extends EntityRepository<Team> {
   private Integer getUserCount(UUID teamId) {
     List<EntityRelationshipRecord> records = getUsersRelationshipRecords(teamId);
     return countDistinct(records, resolveActiveUserIds(records));
+  }
+
+  /**
+   * Name hashes to match when listing/exporting the users under {@code teamName}'s umbrella. Group
+   * and Organization teams keep direct membership (empty result &rarr; callers fall back to the
+   * plain {@code team} filter). Department/Division/BusinessUnit teams expand to the whole subtree
+   * (self + all descendants) so their Users tab and export show the rollup of users inherited from
+   * sub-groups, matching what {@link #getUserCount} already counts.
+   */
+  public List<String> getUserRollupTeamHashes(String teamName) {
+    Team team;
+    try {
+      team = getByName(null, teamName, Fields.EMPTY_FIELDS);
+    } catch (EntityNotFoundException e) {
+      // Unknown team name: leave the plain team filter to return an empty page (existing behavior).
+      return Collections.emptyList();
+    }
+    TeamType teamType = team.getTeamType();
+    if (teamType != DEPARTMENT && teamType != DIVISION && teamType != BUSINESS_UNIT) {
+      return Collections.emptyList();
+    }
+    List<String> hashes = new ArrayList<>();
+    collectSubtreeTeamHashes(team.getId(), team.getName(), hashes);
+    return hashes;
+  }
+
+  private void collectSubtreeTeamHashes(UUID teamId, String teamName, List<String> hashes) {
+    hashes.add(FullyQualifiedName.buildHash(EntityInterfaceUtil.quoteName(teamName)));
+    for (EntityReference child : getChildren(teamId)) {
+      collectSubtreeTeamHashes(child.getId(), child.getName(), hashes);
+    }
   }
 
   /**

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TeamRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TeamRepository.java
@@ -166,6 +166,8 @@ public class TeamRepository extends EntityRepository<Team> {
         fields.contains("childrenCount") ? getChildrenCount(team) : team.getChildrenCount());
     team.setUserCount(
         fields.contains("userCount") ? getUserCount(team.getId()) : team.getUserCount());
+    team.setDescendantTeams(
+        fields.contains("descendantTeams") ? getDescendantTeams(team) : team.getDescendantTeams());
     team.setDomains(fields.contains(FIELD_DOMAINS) ? getDomains(team.getId()) : team.getDomains());
   }
 
@@ -185,6 +187,7 @@ public class TeamRepository extends EntityRepository<Team> {
     if (!fields.contains("userCount")) {
       team.setUserCount(0);
     }
+    team.setDescendantTeams(fields.contains("descendantTeams") ? team.getDescendantTeams() : null);
   }
 
   private void fetchAndSetUsers(List<Team> teams, Fields fields) {
@@ -826,6 +829,25 @@ public class TeamRepository extends EntityRepository<Team> {
     hashes.add(FullyQualifiedName.buildHash(EntityInterfaceUtil.quoteName(teamName)));
     for (EntityReference child : getChildren(teamId)) {
       collectSubtreeTeamHashes(child.getId(), child.getName(), hashes);
+    }
+  }
+
+  /**
+   * All teams nested under {@code team}, resolved recursively (the subtree, excluding the team
+   * itself). Computed on read like {@code childrenCount}/{@code userCount} — nothing is stored, so it
+   * stays correct across reparents/renames with no reindex. Backs the {@code descendantTeams} field
+   * the Users tab uses to scope its member search to a non-Group team's sub-groups.
+   */
+  private List<EntityReference> getDescendantTeams(Team team) {
+    List<EntityReference> descendants = new ArrayList<>();
+    collectDescendantTeams(team.getId(), descendants);
+    return descendants;
+  }
+
+  private void collectDescendantTeams(UUID teamId, List<EntityReference> descendants) {
+    for (EntityReference child : getChildren(teamId)) {
+      descendants.add(child);
+      collectDescendantTeams(child.getId(), descendants);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/TeamResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/TeamResource.java
@@ -91,7 +91,7 @@ public class TeamResource extends EntityResource<Team, TeamRepository> {
   public static final String COLLECTION_PATH = "/v1/teams/";
   private final TeamMapper mapper = new TeamMapper();
   static final String FIELDS =
-      "owners,profile,users,owns,defaultRoles,defaultPersona,parents,children,policies,userCount,childrenCount,domains";
+      "owners,profile,users,owns,defaultRoles,defaultPersona,parents,children,descendantTeams,policies,userCount,childrenCount,domains";
 
   @Override
   public Team addHref(UriInfo uriInfo, Team team) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
@@ -137,6 +137,7 @@ import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.RoleRepository;
+import org.openmetadata.service.jdbi3.TeamRepository;
 import org.openmetadata.service.jdbi3.TokenRepository;
 import org.openmetadata.service.jdbi3.UserPreferencesRepository;
 import org.openmetadata.service.jdbi3.UserRepository;
@@ -321,6 +322,15 @@ public class UserResource extends EntityResource<User, UserRepository> {
           @DefaultValue("non-deleted")
           Include include) {
     ListFilter filter = new ListFilter(include).addQueryParam("team", teamParam);
+    if (teamParam != null) {
+      // Non-Group teams (Department/Division/BusinessUnit) hold no direct members; list the rollup
+      // of users inherited from their sub-group descendants (empty for Group/Organization teams).
+      TeamRepository teamRepository = (TeamRepository) Entity.getEntityRepository(Entity.TEAM);
+      List<String> rollupTeamHashes = teamRepository.getUserRollupTeamHashes(teamParam);
+      if (!rollupTeamHashes.isEmpty()) {
+        filter.addQueryParam("teamHashes", String.join(",", rollupTeamHashes));
+      }
+    }
     if (isAdmin != null) {
       filter.addQueryParam("isAdmin", String.valueOf(isAdmin));
     }

--- a/openmetadata-spec/src/main/resources/json/schema/entity/teams/team.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/teams/team.json
@@ -84,6 +84,10 @@
       "description" : "Children teams. An `Organization` can have `BusinessUnit`, `Division` or `Department` as children. A `BusinessUnit` can have `BusinessUnit`, `Division`, or `Department` as children. A `Division` can have `Division` or `Department` as children. A `Department` can have `Department` as children.",
       "$ref" : "../../type/entityReferenceList.json"
     },
+    "descendantTeams" : {
+      "description" : "All teams nested under this team, resolved recursively (the full subtree, excluding this team itself). Computed on read; not stored.",
+      "$ref" : "../../type/entityReferenceList.json"
+    },
     "users": {
       "description": "Users that are part of the team.",
       "$ref": "../../type/entityReferenceList.json",

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/TeamDetailsV1.utils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/TeamDetailsV1.utils.tsx
@@ -32,7 +32,9 @@ export const getTabs = (
     },
     users: {
       name: i18n.t('label.user-plural'),
-      count: currentTeam.users?.length ?? 0,
+      // userCount is the rollup (includes sub-group members for non-Group teams); fall back to the
+      // direct users array so Group teams and partial fetches still render a count.
+      count: currentTeam.userCount ?? currentTeam.users?.length ?? 0,
       key: TeamsPageTab.USERS,
     },
     assets: {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/UserTab/UserTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/UserTab/UserTab.component.tsx
@@ -138,7 +138,20 @@ export const UserTab = ({
       query: text,
       pageNumber: currentPage,
       pageSize,
-      queryFilter: getTermQuery({ 'teams.id': currentTeam?.id }),
+      // Scope the search to this team's whole subtree: the team itself plus every descendant team
+      // (descendantTeams is computed on the team, empty for a Group team). Matching each user's
+      // direct teams.id against that set finds members inherited from sub-groups, mirroring the
+      // Users tab list. minimum_should_match=1 makes it an OR (IN) over the team ids.
+      queryFilter: getTermQuery(
+        {
+          'teams.id': [
+            currentTeam.id,
+            ...(currentTeam.descendantTeams?.map((team) => team.id) ?? []),
+          ],
+        },
+        'should',
+        1
+      ),
       searchIndex: SearchIndex.USER,
     })
       .then((res) => {
@@ -284,7 +297,9 @@ export const UserTab = ({
         key: 'export-button',
       },
     ];
-    if (permission.EditAll) {
+    // Import adds users to the team, which is only allowed for Group teams. Export is offered for
+    // all team types so a non-Group team can export the users rolled up from its sub-groups.
+    if (isGroupType && permission.EditAll) {
       option.push({
         label: (
           <ManageButtonItemLabel
@@ -302,7 +317,7 @@ export const UserTab = ({
     }
 
     return option;
-  }, [handleUserExportClick, handleImportClick, permission, t]);
+  }, [handleUserExportClick, handleImportClick, permission, t, isGroupType]);
 
   const handleRemoveUser = () => {
     if (deletingUser?.id) {
@@ -391,11 +406,10 @@ export const UserTab = ({
         }}
         dataSource={sortedUser}
         extraTableFilters={
-          !currentTeam.deleted &&
-          isGroupType && (
+          !currentTeam.deleted && (
             <Col>
               <Space>
-                {users.length > 0 && editUserPermission && (
+                {isGroupType && users.length > 0 && editUserPermission && (
                   <UserSelectableList
                     hasPermission
                     includeBot

--- a/openmetadata-ui/src/main/resources/ui/src/enums/entity.enum.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/enums/entity.enum.ts
@@ -118,6 +118,7 @@ export enum TabSpecificField {
   CHARTS = 'charts',
   CHILDREN = 'children',
   CHILDREN_COUNT = 'childrenCount',
+  DESCENDANT_TEAMS = 'descendantTeams',
   COLUMNS = 'columns',
   CUSTOM_METRICS = 'customMetrics',
   CUSTOM_PROPERTIES = 'customProperties',

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/teams/team.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/teams/team.ts
@@ -45,6 +45,11 @@ export interface Team {
      */
     deleted?: boolean;
     /**
+     * All teams nested under this team, resolved recursively (the full subtree, excluding this
+     * team itself). Computed on read; not stored.
+     */
+    descendantTeams?: EntityReference[];
+    /**
      * Description of the team.
      */
     description?: string;

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TeamsPage/TeamsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TeamsPage/TeamsPage.tsx
@@ -274,6 +274,7 @@ const TeamsPage = () => {
             TabSpecificField.DEFAULT_PERSONA,
             TabSpecificField.POLICIES,
             TabSpecificField.CHILDREN_COUNT,
+            TabSpecificField.DESCENDANT_TEAMS,
             TabSpecificField.DOMAINS,
           ],
           include: Include.All,


### PR DESCRIPTION
Part of #31770.

This PR does two things: it **populates the Users tab for non-Group teams** with the users inherited from their sub-groups, and it **adds a regression test** for the user export of a non-Group team.

It does **not** cover the rest of #31770 — the "Add User" UI gating, removing a stuck user from a non-Group team, or the API-side block on adding users directly to non-Group teams — so it is intentionally scoped and does not close the issue.

---

## Problem

On a non-Group team (`Department` / `Division` / `BusinessUnit`) the **Users tab comes back empty** even when its sub-group descendants have members, and users inherited from those sub-groups are **not surfaced for export**. Meanwhile the team's `userCount` already reflects the whole subtree, so the count and the list disagree.

The asymmetry is in the backend:

- The Users tab is driven by `GET /v1/users?team=<team>`, whose `UserDAO` query matches `te.nameHash = :team` — **direct membership only**. A non-Group team has no direct `HAS user` rows, so it returns nothing.
- `Team.userCount` (`getUsersRelationshipRecords`) already **recurses the subtree**, which is why the count is non-zero while the tab is empty.

(Point 1 of the ticket — blocking direct user-add to non-Group teams via the PATCH API — is tracked separately and is not part of this PR.)

---

## Change

Make user listing under a non-Group team return the **rollup of users inherited from its sub-group descendants**, matching what `userCount` already counts. Group and Organization teams are unchanged and keep direct-membership semantics.

- `TeamRepository.getUserRollupTeamHashes(teamName)` — for `Department` / `Division` / `BusinessUnit` returns the FQN name hashes of the team plus all descendants; returns empty for Group / Organization (and for unknown names, preserving the current empty-page behavior).
- `UserResource.list` — when `?team=` names a non-Group team, adds those hashes as a `teamHashes` filter param.
- `CollectionDAO.UserDAO` (`listCount` / `listBefore` / `listAfter`) — when `teamHashes` is present, injects `AND te.nameHash IN (...)` through the existing condition mechanism and bypasses the single-team equality. No SQL-string rewrites; pagination is preserved. The hashes are server-computed hex, safe to inline.

The CSV export (`GET /v1/users/export?team=` → `UserCsv.listUsers`) **already recurses the team hierarchy**, so point 3 was already functionally correct on `2.0`; this PR adds a regression test that locks it in and keeps it consistent with the fixed tab.

Deliberately **not** touched: `TeamRepository.getUsers()` / `fetchAndSetUsers()` (the entity `users` field) stay direct-members-only, because PATCH/diff on team membership depends on that.

---

## Tests

Two integration tests added to `UserResourceIT` (embedded server + Testcontainers), both green:

- `test_nonGroupTeam_listsInheritedUsers` — a member of a sub-group is listed under both its own Group and the parent Department (rollup); an unrelated user is **not** rolled up (negative case).
- `test_nonGroupTeam_exportIncludesInheritedUsers` — exporting a `BusinessUnit` includes the member inherited from its sub-group.

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
```

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) documentation.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] New and existing integration tests pass locally with my changes.
