### PR TITLE
Backport #32549 to 2.0: Support BigQuery STRUCT profiling

### DIFF
--- a/ingestion/src/metadata/profiler/interface/sqlalchemy/bigquery/profiler_interface.py
+++ b/ingestion/src/metadata/profiler/interface/sqlalchemy/bigquery/profiler_interface.py
@@ -14,10 +14,12 @@ Interfaces with database for all database engine
 supporting sqlalchemy abstraction layer
 """
 
+from collections.abc import Iterable
 from copy import deepcopy
-from typing import List, Type, cast  # noqa: UP035
+from typing import Any, List, Type, cast  # noqa: UP035
 
 from sqlalchemy import Column, inspect
+from sqlalchemy.sql.type_api import TypeEngine
 
 from metadata.generated.schema.entity.data.table import SystemProfile
 from metadata.generated.schema.security.credentials.gcpValues import SingleProjectId
@@ -63,7 +65,11 @@ class BigQueryProfilerInterface(SQAProfilerInterface):
         )
         return instance.get_system_metrics()
 
-    def _get_struct_columns(self, columns: dict, parent: str):
+    def _get_struct_columns(
+        self,
+        columns: Iterable[tuple[str, TypeEngine[Any]]],
+        parent: str,
+    ):
         """"""
         # pylint: disable=import-outside-toplevel
         from sqlalchemy_bigquery import STRUCT  # noqa: PLC0415
@@ -73,7 +79,11 @@ class BigQueryProfilerInterface(SQAProfilerInterface):
             if not isinstance(value, STRUCT):
                 col = Column(f"{parent}.{key}", value)
                 # pylint: disable=protected-access
-                col._set_parent(self.table.__table__)
+                col._set_parent(
+                    self.table.__table__,
+                    all_names={c.name: c for c in self.table.__table__.columns},
+                    allow_replacements=True,
+                )
                 # pylint: enable=protected-access
                 columns_list.append(col)
             else:

--- a/ingestion/tests/unit/observability/profiler/sqlalchemy/bigquery/test_bigquery_profiler_sql.py
+++ b/ingestion/tests/unit/observability/profiler/sqlalchemy/bigquery/test_bigquery_profiler_sql.py
@@ -19,8 +19,12 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.sqltypes import NullType
+from sqlalchemy_bigquery import STRUCT
 from sqlalchemy_bigquery.base import BigQueryDialect
 
+from metadata.profiler.interface.sqlalchemy.bigquery.profiler_interface import (
+    BigQueryProfilerInterface,
+)
 from metadata.profiler.interface.sqlalchemy.profiler_interface import (
     SQAProfilerInterface,
 )
@@ -98,6 +102,18 @@ def _grouped_output_label(sql, source):
     match = re.search(r"AS `([^`]+)` FROM `" + re.escape(source) + "`", sql)
     assert match, f"No grouped output alias found in:\n{sql}"
     return match.group(1)
+
+
+def test_struct_columns_are_attached_to_the_profiled_table():
+    struct = STRUCT(email=sa.String)
+    table = sa.Table(TABLE_NAME, sa.MetaData(), sa.Column("customer", struct))
+    profiler = object.__new__(BigQueryProfilerInterface)
+    profiler._table = SimpleNamespace(__table__=table)
+
+    columns = profiler._get_struct_columns(struct._STRUCT_fields, "customer")
+
+    assert [column.name for column in columns] == [NESTED_COLUMN]
+    assert columns[0].table is table
 
 
 def test_nested_struct_countif_references_the_grouped_subquery_alias():


### PR DESCRIPTION
### Describe your changes:

Backport of #32549 to `2.0`. Original commit: `6b0d26b831df8564a4978399768e8f5dff8f61b9`.

Fixes #32548 on the `2.0` line.

BigQuery STRUCT-column expansion called SQLAlchemy 1.x's `Column._set_parent(parent)`. Under SQLAlchemy 2 that signature requires the keyword-only `all_names` and `allow_replacements` arguments, so profiling **any** table containing a STRUCT raised:

```
TypeError: Column._set_parent() missing 2 required keyword-only arguments: 'all_names' and 'allow_replacements'
```

`_get_struct_columns` now passes the required parent-registration context, and the type hint moves from `dict` to `Iterable[tuple[str, TypeEngine[Any]]]` (the actual shape of `STRUCT._STRUCT_fields`).

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — cherry-pick of a small change.

#
### Cherry-pick notes:

One conflict, in the `typing` import line only — `2.0` carries `from typing import List, Type, cast  # noqa: UP035` where `main` has `from typing import cast`. Resolved by adding `Any` to the `2.0` form:

```python
from typing import Any, List, Type, cast  # noqa: UP035
```

The functional hunks (`Iterable`/`TypeEngine` imports, the `_set_parent` call, the test) applied cleanly. The resulting diff is otherwise identical to #32549.

#
### Tests:

#### Unit tests
- [x] Cherry-picked the regression test from #32549.
- File: `ingestion/tests/unit/observability/profiler/sqlalchemy/bigquery/test_bigquery_profiler_sql.py`
- `test_struct_columns_are_attached_to_the_profiled_table` — asserts the flattened STRUCT leaf is attached to the profiled table. Verified RED before the fix (the exact `TypeError` above) and GREEN after.
- Full BigQuery profiler suite on this branch: **7 passed**.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable — live BigQuery profiling was already validated on #32549 against `main` (92/92 STRUCT tables profiled, 184 profiler records, zero errors). The code here is byte-identical apart from the import line.

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
- `ruff check` + `ruff format --check` on both changed files — clean.
- `basedpyright` on the changed source file — `0 errors, 0 warnings, 0 notes`.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing.
