### PR TITLE
fix(ui): Apply consistent tag chip styling across all surfaces — Backport 2.0 (#32346)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgeCard/KnowledgeCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgeCard/KnowledgeCard.test.tsx
@@ -60,12 +60,30 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       <div {...props}>{children}</div>
     )),
   Dot: jest.fn().mockReturnValue(<span data-testid="dot" />),
+  TooltipTrigger: jest
+    .fn()
+    .mockImplementation(({ children }) => <span>{children}</span>),
   Typography: jest
     .fn()
     .mockImplementation(({ children, ...props }) => (
       <span {...props}>{children}</span>
     )),
 }));
+
+jest.mock('../../../utils/ColorUtils', () => ({
+  reduceColorOpacity: jest.fn().mockReturnValue('rgba(0,0,0,0.05)'),
+}));
+
+jest.mock('../../../components/common/atoms/TagChip/TagChip', () =>
+  jest.fn().mockImplementation(({ label, tagColor, icon, ...props }) => (
+    <span
+      data-color={tagColor}
+      data-icon={icon}
+      data-testid={props['data-testid'] ?? 'tag-chip'}>
+      {label}
+    </span>
+  ))
+);
 
 jest.mock('../../../components/common/PopOverCard/UserPopOverCard', () =>
   jest
@@ -233,7 +251,7 @@ describe('Knowledge Card', () => {
     expect(screen.getByTestId('knowledge-footer')).toBeInTheDocument();
   });
 
-  it('should render at most 2 tags and an overflow badge', () => {
+  it('should render at most 2 tags as TagChip and an overflow count', () => {
     render(<KnowledgeCard {...mockProps} />, { wrapper: MemoryRouter });
 
     const visibleTags = KNOWLEDGE_PAGE_TAGS.slice(0, 2);
@@ -244,6 +262,17 @@ describe('Knowledge Card', () => {
     const overflowCount = KNOWLEDGE_PAGE_TAGS.length - 2;
 
     expect(screen.getByText(`+${overflowCount}`)).toBeInTheDocument();
+  });
+
+  it('should pass tag style color to TagChip', () => {
+    render(<KnowledgeCard {...mockProps} />, { wrapper: MemoryRouter });
+
+    const styledTag = KNOWLEDGE_PAGE_TAGS.find((t) => t.style?.color);
+    if (styledTag) {
+      const chip = screen.getByText(styledTag.displayName ?? styledTag.name);
+
+      expect(chip).toHaveAttribute('data-color', styledTag.style?.color);
+    }
   });
 
   it('should render the edit and delete button for quick link', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgeCard/KnowledgeCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgeCard/KnowledgeCard.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 import {
-  Badge,
   Box,
   ButtonUtility,
   Card,
@@ -20,6 +19,7 @@ import {
 } from '@openmetadata/ui-core-components';
 import { AxiosError } from 'axios';
 import { ReactComponent as EditIcon } from '../../../assets/svg/edit-new.svg';
+import TagChip from '../../../components/common/atoms/TagChip/TagChip';
 import DeleteModal from '../../../components/common/DeleteModal/DeleteModal';
 import UserPopOverCard from '../../../components/common/PopOverCard/UserPopOverCard';
 import { OwnerType } from '../../../enums/user.enum';
@@ -320,25 +320,23 @@ const KnowledgeCard: FC<KnowledgeCardProps> = ({
           <span className="tw:flex-1" />
           <Box align="center" className="tw:gap-1.5">
             {(knowledgePage.tags ?? []).slice(0, 2).map((tag) => (
-              <Badge
-                className="tw:max-w-30"
+              <TagChip
+                icon={tag.style?.iconURL}
                 key={String(tag.tagFQN ?? '')}
-                size="md"
-                type="modern">
-                <Typography
-                  ellipsis
-                  className="tw:text-secondary"
-                  size="text-xs">
-                  {getEntityName(tag)}
-                </Typography>
-              </Badge>
+                label={getEntityName(tag)}
+                maxWidth={120}
+                size="small"
+                tagColor={tag.style?.color}
+                variant="blueGray"
+              />
             ))}
             {(knowledgePage.tags ?? []).length > 2 && (
-              <Badge size="md" type="modern">
-                <Typography className="tw:text-secondary" size="text-xs">
-                  +{(knowledgePage.tags ?? []).length - 2}
-                </Typography>
-              </Badge>
+              <Typography
+                className="tw:text-secondary tw:whitespace-nowrap"
+                size="text-xs"
+                weight="medium">
+                +{(knowledgePage.tags ?? []).length - 2}
+              </Typography>
             )}
           </Box>
         </Box>

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/FieldCard/FieldCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/FieldCard/FieldCard.tsx
@@ -10,21 +10,16 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import {
-  BadgeWithIcon,
-  Button,
-  Typography,
-} from '@openmetadata/ui-core-components';
+import { Button, Typography } from '@openmetadata/ui-core-components';
 import classNames from 'classnames';
 import { startCase } from 'lodash';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ReactComponent as ClassificationIcon } from '../../../assets/svg/classification.svg';
-import { ReactComponent as GlossaryIcon } from '../../../assets/svg/glossary.svg';
 import { TagSource } from '../../../generated/tests/testCase';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import { getDataTypeString } from '../../../utils/TablePureUtils';
 import { prepareConstraintIcon } from '../../../utils/TableUtils';
+import TagChip from '../atoms/TagChip/TagChip';
 import RichTextEditorPreviewerV1 from '../RichTextEditor/RichTextEditorPreviewerV1';
 import { FieldCardProps } from './FieldCard.interface';
 
@@ -377,13 +372,13 @@ const FieldCard: React.FC<FieldCardProps> = ({
                       className="tag-item"
                       data-testid={`tag-${tag.tagFQN}`}
                       key={tag.tagFQN}>
-                      <BadgeWithIcon
-                        color="gray"
-                        iconLeading={ClassificationIcon}
-                        size="xs"
-                        type="color">
-                        {getEntityName(tag)}
-                      </BadgeWithIcon>
+                      <TagChip
+                        icon={tag.style?.iconURL}
+                        label={getEntityName(tag)}
+                        size="small"
+                        tagColor={tag.style?.color}
+                        variant="blueGray"
+                      />
                     </span>
                   ))}
                   {visibleTagsCount !== null &&
@@ -432,13 +427,13 @@ const FieldCard: React.FC<FieldCardProps> = ({
                       className="glossary-term-item"
                       data-testid={`term-${glossaryTerm.tagFQN}`}
                       key={glossaryTerm.tagFQN}>
-                      <BadgeWithIcon
-                        color="gray"
-                        iconLeading={GlossaryIcon}
-                        size="xs"
-                        type="color">
-                        {getEntityName(glossaryTerm)}
-                      </BadgeWithIcon>
+                      <TagChip
+                        icon={glossaryTerm.style?.iconURL}
+                        label={getEntityName(glossaryTerm)}
+                        size="small"
+                        tagColor={glossaryTerm.style?.color}
+                        variant="blueGray"
+                      />
                     </span>
                   ))}
                   {visibleTermsCount !== null &&

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TagBadgeList/TagBadgeList.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TagBadgeList/TagBadgeList.component.tsx
@@ -12,17 +12,27 @@
  */
 
 import {
-  BadgeWithIcon,
   Box,
+  Tooltip,
+  TooltipTrigger,
   Typography,
 } from '@openmetadata/ui-core-components';
-import { Tag01 } from '@untitledui/icons';
+import { Link } from 'react-router-dom';
 import { NO_DATA } from '../../../constants/constants';
 import { TagLabel } from '../../../generated/type/tagLabel';
+import { getTagName, getTagRedirectLink } from '../../../utils/TagsPureUtils';
+import { getTagTooltip } from '../../../utils/TagsUtils';
+import TagChip from '../atoms/TagChip/TagChip';
+
 interface TagBadgeListProps {
   tags: TagLabel[];
   size?: 'sm' | 'lg';
 }
+
+const TAG_CHIP_SIZE_MAP = {
+  sm: 'small',
+  lg: 'medium',
+} as const;
 
 const TagBadgeList = ({ tags, size = 'sm' }: TagBadgeListProps) => {
   if (!tags.length) {
@@ -31,12 +41,34 @@ const TagBadgeList = ({ tags, size = 'sm' }: TagBadgeListProps) => {
 
   const firstTag = tags[0];
   const remaining = tags.length - 1;
+  const tagName = getTagName(firstTag, true);
+  const redirectLink = getTagRedirectLink(firstTag);
 
   return (
     <Box align="center" direction="row" gap={1}>
-      <BadgeWithIcon color="gray" iconLeading={Tag01} size={size} type="color">
-        {firstTag.displayName || firstTag.tagFQN}
-      </BadgeWithIcon>
+      <Tooltip
+        arrow
+        delay={500}
+        placement="top"
+        title={getTagTooltip(firstTag.tagFQN, firstTag.description)}>
+        <TooltipTrigger>
+          <Link
+            className="tw:w-max"
+            data-testid="tag-redirect-link"
+            to={redirectLink}
+            onClick={(e) => e.stopPropagation()}>
+            <TagChip
+              data-testid="tags"
+              icon={firstTag.style?.iconURL}
+              label={tagName}
+              labelDataTestId={`tag-${firstTag.tagFQN}`}
+              size={TAG_CHIP_SIZE_MAP[size]}
+              tagColor={firstTag.style?.color}
+              variant="blueGray"
+            />
+          </Link>
+        </TooltipTrigger>
+      </Tooltip>
       {remaining > 0 && (
         <Typography size="text-xs" weight="medium">
           +{remaining}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TagBadgeList/TagBadgeList.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TagBadgeList/TagBadgeList.test.tsx
@@ -1,0 +1,121 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import {
+  LabelType,
+  State,
+  TagLabel,
+  TagSource,
+} from '../../../generated/type/tagLabel';
+import TagBadgeList from './TagBadgeList.component';
+
+jest.mock('../../../utils/ColorUtils', () => ({
+  reduceColorOpacity: jest.fn().mockReturnValue('rgba(0,0,0,0.05)'),
+}));
+
+jest.mock('../../../utils/TagsUtils', () => ({
+  getTagTooltip: jest.fn().mockReturnValue('tooltip content'),
+}));
+
+const baseMockTag: TagLabel = {
+  tagFQN: 'PII.Sensitive',
+  source: TagSource.Classification,
+  labelType: LabelType.Manual,
+  state: State.Confirmed,
+  name: 'Sensitive',
+  displayName: 'Sensitive',
+};
+
+const styledMockTag: TagLabel = {
+  ...baseMockTag,
+  tagFQN: 'Confidential.Restricted',
+  name: 'Restricted',
+  displayName: 'Restricted',
+  style: {
+    color: '#DC2626',
+    iconURL: 'Lock01',
+  },
+};
+
+describe('TagBadgeList', () => {
+  it('should render no data placeholder when tags array is empty', () => {
+    render(
+      <MemoryRouter>
+        <TagBadgeList tags={[]} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('-')).toBeInTheDocument();
+  });
+
+  it('should render a single tag as TagChip', () => {
+    render(
+      <MemoryRouter>
+        <TagBadgeList tags={[baseMockTag]} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('tags')).toBeInTheDocument();
+    expect(screen.getByTestId('tag-PII.Sensitive')).toBeInTheDocument();
+  });
+
+  it('should render tag with redirect link', () => {
+    render(
+      <MemoryRouter>
+        <TagBadgeList tags={[baseMockTag]} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('tag-redirect-link')).toBeInTheDocument();
+  });
+
+  it('should show +N count when multiple tags exist', () => {
+    const tags = [
+      baseMockTag,
+      { ...baseMockTag, tagFQN: 'PII.NonSensitive', name: 'NonSensitive' },
+      { ...baseMockTag, tagFQN: 'PII.Other', name: 'Other' },
+    ];
+
+    render(
+      <MemoryRouter>
+        <TagBadgeList tags={tags} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('+2')).toBeInTheDocument();
+  });
+
+  it('should not show +N count for single tag', () => {
+    render(
+      <MemoryRouter>
+        <TagBadgeList tags={[baseMockTag]} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText(/\+\d/)).not.toBeInTheDocument();
+  });
+
+  it('should pass tag color and icon to TagChip for styled tags', () => {
+    render(
+      <MemoryRouter>
+        <TagBadgeList tags={[styledMockTag]} />
+      </MemoryRouter>
+    );
+
+    const tagChip = screen.getByTestId('tags');
+
+    expect(tagChip).toBeInTheDocument();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TagSuggestion/TagSuggestion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TagSuggestion/TagSuggestion.tsx
@@ -13,8 +13,6 @@
 
 import {
   Autocomplete,
-  BadgeWithButton,
-  Dot,
   type SelectItemType,
 } from '@openmetadata/ui-core-components';
 import { debounce } from 'lodash';
@@ -37,6 +35,7 @@ import { ensureComboboxMenuOpen } from '../../../utils/formPureUtils';
 import tagClassBase from '../../../utils/TagClassBase';
 import { getTagDisplay } from '../../../utils/TagsPureUtils';
 import { fetchGlossaryList } from '../../../utils/TagsUtils';
+import TagChip from '../atoms/TagChip/TagChip';
 
 type TagSelectItem = SelectItemType & { labelColor?: string };
 
@@ -252,23 +251,18 @@ const TagSuggestion: FC<TagSuggestionProps> = ({
           t('label.select-field', { field: t('label.tag-plural') })
         }
         renderTag={(item, onRemove) => {
-          const tagColor = tagDataMap.current.get(String(item.id))?.style
-            ?.color;
+          const tagData = tagDataMap.current.get(String(item.id));
 
           return (
-            <BadgeWithButton
+            <TagChip
+              icon={tagData?.style?.iconURL}
               key={item.id}
-              size="sm"
-              type="color"
-              onButtonClick={onRemove}>
-              {tagColor && (
-                <Dot
-                  size="sm"
-                  style={{ color: tagColor, marginRight: '2px' }}
-                />
-              )}
-              {item.label ?? item.id}
-            </BadgeWithButton>
+              label={String(item.label ?? item.id)}
+              size="small"
+              tagColor={tagData?.style?.color}
+              variant="blueGray"
+              onDelete={onRemove}
+            />
           );
         }}
         selectedItems={selectedItems}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TagsSection/TagsSection.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TagsSection/TagsSection.test.tsx
@@ -440,16 +440,11 @@ describe('TagsSection', () => {
     });
 
     it('should render tag items with correct structure', () => {
-      const { container } = render(<TagsSection {...defaultProps} />);
+      render(<TagsSection {...defaultProps} />);
 
-      const tagItems = container.querySelectorAll('.tag-item');
-
-      expect(tagItems).toHaveLength(3); // maxDisplayCount
-
-      tagItems.forEach((item) => {
-        expect(item.querySelector('.tag-icon')).toBeInTheDocument();
-        expect(item.querySelector('.tag-name')).toBeInTheDocument();
-      });
+      expect(screen.getByTestId('tag-tag1')).toBeInTheDocument();
+      expect(screen.getByTestId('tag-tag2')).toBeInTheDocument();
+      expect(screen.getByTestId('tag-tag3')).toBeInTheDocument();
     });
   });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TagsSection/TagsSection.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TagsSection/TagsSection.tsx
@@ -13,13 +13,13 @@
 import { Typography } from 'antd';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ReactComponent as ClassificationIcon } from '../../../assets/svg/classification.svg';
 import { ReactComponent as EditIcon } from '../../../assets/svg/edit-new.svg';
 import { DE_ACTIVE_COLOR } from '../../../constants/constants';
 import { TagLabel, TagSource } from '../../../generated/type/tagLabel';
 import { useEditableSection } from '../../../hooks/useEditableSection';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import { updateEntityField } from '../../../utils/EntityUpdateUtils';
+import TagChip from '../atoms/TagChip/TagChip';
 import { EditIconButton } from '../IconButtons/EditIconButton';
 import Loader from '../Loader/Loader';
 import { TagSelectableList } from '../TagSelectableList/TagSelectableList.component';
@@ -169,13 +169,15 @@ const TagsSectionV1: React.FC<TagsSectionProps> = ({
           {editingTags.length > 0 ? (
             <div className="selected-tags-list">
               {editingTags.map((tag) => (
-                <div
-                  className="selected-tag-chip"
+                <TagChip
                   data-testid={`tag-${tag.tagFQN}`}
-                  key={tag.tagFQN}>
-                  <ClassificationIcon className="tag-icon" />
-                  <span className="tag-name">{getEntityName(tag)}</span>
-                </div>
+                  icon={tag.style?.iconURL}
+                  key={tag.tagFQN}
+                  label={getEntityName(tag)}
+                  size="small"
+                  tagColor={tag.style?.color}
+                  variant="blueGray"
+                />
               ))}
             </div>
           ) : (
@@ -222,13 +224,15 @@ const TagsSectionV1: React.FC<TagsSectionProps> = ({
             ? nonTierTags
             : nonTierTags.slice(0, maxVisibleTags)
           ).map((tag) => (
-            <div
-              className="tag-item"
+            <TagChip
               data-testid={`tag-${tag.tagFQN}`}
-              key={tag.tagFQN}>
-              <ClassificationIcon className="tag-icon" />
-              <span className="tag-name">{getEntityName(tag)}</span>
-            </div>
+              icon={tag.style?.iconURL}
+              key={tag.tagFQN}
+              label={getEntityName(tag)}
+              size="small"
+              tagColor={tag.style?.color}
+              variant="blueGray"
+            />
           ))}
           {nonTierTags.length > maxVisibleTags && (
             <button

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPage.test.tsx
@@ -119,6 +119,21 @@ jest.mock('@openmetadata/ui-core-components', () => ({
   defaultColors: { gray: { 50: '#fafafa' } },
 }));
 
+jest.mock('../../../utils/ColorUtils', () => ({
+  reduceColorOpacity: jest.fn().mockReturnValue('rgba(0,0,0,0.05)'),
+}));
+
+jest.mock('../../../components/common/atoms/TagChip/TagChip', () =>
+  jest.fn().mockImplementation(({ label, tagColor, icon, ...props }) => (
+    <span
+      data-color={tagColor}
+      data-icon={icon}
+      data-testid={props['data-testid'] ?? 'tag-chip'}>
+      {label}
+    </span>
+  ))
+);
+
 const mockLocationPathname = '/mock-path';
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPage.tsx
@@ -55,6 +55,7 @@ import {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router-dom';
+import TagChip from '../../../components/common/atoms/TagChip/TagChip';
 import DeleteModal from '../../../components/common/DeleteModal/DeleteModal';
 import {
   CSV_JOBS_REFRESH_EVENT,
@@ -459,18 +460,18 @@ const MetricListPage = () => {
       <span className="metric-list-empty-dash">{t('label.empty-dash')}</span>
     );
 
-    const renderTagPills = (tags: TagLabel[], className: string) => (
+    const renderTagPills = (tags: TagLabel[]) => (
       <div className="metric-list-glossary">
         {tags.length
           ? tags.map((tag) => (
-              <Badge
-                className={className}
-                color="blue"
+              <TagChip
+                icon={tag.style?.iconURL}
                 key={tag.tagFQN}
-                size="sm"
-                type="color">
-                {tag.name ?? tag.tagFQN}
-              </Badge>
+                label={tag.name ?? tag.tagFQN}
+                size="small"
+                tagColor={tag.style?.color}
+                variant="blueGray"
+              />
             ))
           : emptyDash}
       </div>
@@ -543,8 +544,7 @@ const MetricListPage = () => {
         dataIndex: 'tags',
         key: 'glossary',
         width: 240,
-        render: (tags: TagLabel[]) =>
-          renderTagPills(glossaryTerms(tags), 'metric-list-glossary-pill'),
+        render: (tags: TagLabel[]) => renderTagPills(glossaryTerms(tags)),
       },
       entityStatus: {
         title: t('label.status'),
@@ -598,8 +598,7 @@ const MetricListPage = () => {
         dataIndex: 'tags',
         key: 'tags',
         width: 220,
-        render: (tags: TagLabel[]) =>
-          renderTagPills(metricTags(tags), 'metric-list-tag-pill'),
+        render: (tags: TagLabel[]) => renderTagPills(metricTags(tags)),
       },
       domains: {
         title: t('label.domain-plural'),

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtilsV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtilsV1.test.tsx
@@ -84,6 +84,21 @@ jest.mock('./ToastUtils', () => ({
   showErrorToast: jest.fn(),
 }));
 
+jest.mock('./ColorUtils', () => ({
+  reduceColorOpacity: jest.fn().mockReturnValue('rgba(0,0,0,0.05)'),
+}));
+
+jest.mock('../components/common/atoms/TagChip/TagChip', () =>
+  jest.fn().mockImplementation(({ label, tagColor, icon, ...props }) => (
+    <span
+      data-color={tagColor}
+      data-icon={icon}
+      data-testid={props['data-testid'] ?? 'tag-chip'}>
+      {label}
+    </span>
+  ))
+);
+
 jest.mock('../components/common/FieldCard', () => ({
   FieldCard: jest.fn(({ fieldName, dataType, description }) => (
     <div data-testid={`field-card-${fieldName}`}>

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtilsV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtilsV1.tsx
@@ -23,6 +23,7 @@ import { AxiosError } from 'axios';
 import { isEmpty, isUndefined } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ReactComponent as NestedIcon } from '../assets/svg/nested.svg';
+import TagChip from '../components/common/atoms/TagChip/TagChip';
 import { FieldCard } from '../components/common/FieldCard';
 import { NestedFieldCardProps } from '../components/common/FieldCard/FieldCard.interface';
 import Loader from '../components/common/Loader/Loader';
@@ -1052,9 +1053,14 @@ const APIEndpointSchemaV1: React.FC<{
       render: (tags: TagLabel[]) => (
         <div className="d-flex flex-wrap gap-2">
           {tags?.map((tag) => (
-            <span className="tag-container" key={tag.tagFQN}>
-              {tag.displayName || tag.name}
-            </span>
+            <TagChip
+              icon={tag.style?.iconURL}
+              key={tag.tagFQN}
+              label={tag.displayName || tag.name || tag.tagFQN}
+              size="small"
+              tagColor={tag.style?.color}
+              variant="blueGray"
+            />
           )) || (
             <span className="text-grey-muted">
               {t('label.no-entity', { entity: t('label.tag-plural') })}


### PR DESCRIPTION
Backport of #32346 to `2.0`.

Same change as the source PR: generic `Badge` / `BadgeWithIcon` / plain-span tag
rendering is replaced with the shared `TagChip` component, so classification tags
with a custom color and icon render identically on every surface — colored left
bar, tinted background, custom icon, colored text.

Fixes #32327 on `2.0`.

## Applied with `git cherry-pick -x`, two files resolved by hand

10 of the 12 files applied cleanly. The remaining two conflicted because **main
carries a component-extraction refactor that `2.0` does not**, and git wanted to
pull that refactor in as part of the backport:

| File | main | 2.0 | Resolution |
|---|---|---|---|
| `KnowledgeCard.tsx` | footer extracted into `KnowledgeCardFooter` | footer rendered inline | dropped the incoming component, applied `Badge` → `TagChip` to 2.0's inline JSX (`knowledgePage.tags` instead of the extracted `tagList`) |
| `FieldCard.tsx` | `FieldDescription` + `FieldMetadataSection` extracted | tag and glossary-term lists rendered inline | dropped both incoming components, swapped the two `BadgeWithIcon` blocks for `TagChip` in place, dropped the now-unused `ClassificationIcon` / `GlossaryIcon` imports |

Taking the incoming side on either file would have imported a refactor that is not
part of #32346 — in `KnowledgeCard.tsx` it would have added a second, dead footer
component referencing an out-of-scope `t`, while leaving 2.0's actual `Badge`
markup untouched.

## Verification

- **Diff-of-diffs:** for the 10 cleanly-applied files, this PR's changed lines are
  **byte-identical to #32346 after whitespace normalisation** (328 changed lines on
  each side).
- **Prerequisites present on 2.0:** `TagChip` (`components/common/atoms/TagChip`)
  accepts every prop used here (`icon`, `label`, `size`, `variant`, `tagColor`,
  `maxWidth`, `labelDataTestId`, `onDelete`, `data-testid`); `getTagName` /
  `getTagRedirectLink` (`TagsPureUtils`), `getTagTooltip` (`TagsUtils`) and
  `reduceColorOpacity` (`ColorUtils`) all exist; `Tooltip` / `TooltipTrigger` are
  exported from `@openmetadata/ui-core-components`.
- **No orphaned imports:** `BadgeWithIcon`, `BadgeWithButton`, `Dot`, `Tag01`,
  `ClassificationIcon`, `GlossaryIcon` are at 0 occurrences in the files that
  dropped them. `MetricListPage.tsx` keeps its `Badge` import — still used by 7
  unrelated call sites.
- **Unit tests, run locally against this branch:** 155 tests pass across
  `KnowledgeCard`, `TagBadgeList` (new suite), `TagsSection`, `MetricListPage`,
  `EntitySummaryPanelUtilsV1`, `FieldCard`, `TagSuggestion` and `TagChip`.
  `ts-jest` type-checks with `tsconfig.json`, so all seven changed source files
  were type-checked in the process.
- **Prettier:** clean on all changed files.

Not verified locally: `eslint` — 2.0's `eslint.config.mjs` needs a
`jsonc-eslint-parser` version that the borrowed `node_modules` doesn't provide.
CI covers it. Visual QA was done on the source PR (screenshots there); the
rendering code is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
