### PR TITLE
Fixes #32806: add Entity Type filter to team assets and fix quick-filter removal

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Teams.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Teams.spec.ts
@@ -718,13 +718,19 @@ test.describe('Teams Page', () => {
   });
 
   test.describe('Team assets entity type filter', () => {
-    const filterTable = new TableClass();
-    const filterTopic = new TopicClass();
-    const filterTeam = new TeamClass();
+    let filterTable: TableClass;
+    let filterTopic: TopicClass;
+    let filterTeam: TeamClass;
 
     test.beforeAll(async ({ browser }) => {
       const { apiContext, afterAction } = await performAdminLogin(browser);
       try {
+        // Instantiate here so a retry regenerates entity names instead of
+        // re-creating the same ones and hitting 409s
+        filterTable = new TableClass();
+        filterTopic = new TopicClass();
+        filterTeam = new TeamClass();
+
         await filterTable.create(apiContext);
         await filterTopic.create(apiContext);
         await filterTeam.create(apiContext);
@@ -757,7 +763,10 @@ test.describe('Teams Page', () => {
     test('should apply, toggle off and clear the entity type filter', async ({
       page,
     }) => {
-      const teamId = filterTeam.responseData.id;
+      const teamId = filterTeam.responseData.id ?? '';
+
+      expect(teamId).not.toBe('');
+
       const tableCard = page.getByTestId(
         `table-data-card_${filterTable.entityResponseData?.['fullyQualifiedName']}`
       );
@@ -773,7 +782,9 @@ test.describe('Teams Page', () => {
 
         const assetsResponse = waitForTeamAssetsSearchResponse(page, teamId);
         await page.getByTestId('assets').click();
-        await assetsResponse;
+        const assetsSearchResponse = await assetsResponse;
+
+        expect(assetsSearchResponse.status()).toBe(200);
         await waitForAllLoadersToDisappear(page);
 
         await expect(tableCard).toBeVisible();
@@ -795,7 +806,10 @@ test.describe('Teams Page', () => {
           teamId
         );
         await selectAssetsFilterFromDropdown(page, 'Entity Type');
-        await removeFilterResponse;
+        const removeSearchResponse = await removeFilterResponse;
+
+        expect(removeSearchResponse.status()).toBe(200);
+
         await waitForAllLoadersToDisappear(page);
 
         await expect(tableCard).toBeVisible();
@@ -812,7 +826,10 @@ test.describe('Teams Page', () => {
 
         const clearResponse = waitForTeamAssetsSearchResponse(page, teamId);
         await page.getByText('Clear').click();
-        await clearResponse;
+        const clearSearchResponse = await clearResponse;
+
+        expect(clearSearchResponse.status()).toBe(200);
+
         await waitForAllLoadersToDisappear(page);
 
         await expect(tableCard).toBeVisible();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Teams.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Teams.spec.ts
@@ -38,7 +38,6 @@ import {
   toastNotification,
   uuid,
   visitOwnProfilePage,
-  waitForAntdPopupToSettle,
 } from '../../utils/common';
 import {
   addMultiOwner,
@@ -51,6 +50,7 @@ import {
   addTeamOwnerToEntity,
   addUserInTeam,
   addUserTeam,
+  applyEntityTypeFilterValue,
   checkTeamTabCount,
   createTeam,
   executionOnOwnerGroupTeam,
@@ -59,9 +59,11 @@ import {
   hardDeleteTeam,
   openAddTeamModal,
   searchTeam,
+  selectAssetsFilterFromDropdown,
   softDeleteTeam,
   verifyAssetsInTeamsPage,
   verifyTeamListingAssetCount,
+  waitForTeamAssetsSearchResponse,
 } from '../../utils/team';
 
 base.describe.configure({ mode: 'serial' });
@@ -715,64 +717,61 @@ test.describe('Teams Page', () => {
     }
   });
 
-  test('Team assets entity type filter should apply, toggle off and clear', async ({
-    page,
-  }) => {
-    test.slow();
-    const { apiContext, afterAction } = await getApiContext(page);
-    const table = new TableClass();
-    const topic = new TopicClass();
-    const filterTeam = new TeamClass({
-      name: `pw-asset-filter-${id}`,
-      displayName: `pw team asset filter ${id}`,
-      description: 'playwright team for asset entity type filter',
-      teamType: 'Group',
+  test.describe('Team assets entity type filter', () => {
+    const filterTable = new TableClass();
+    const filterTopic = new TopicClass();
+    const filterTeam = new TeamClass();
+
+    test.beforeAll(async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      try {
+        await filterTable.create(apiContext);
+        await filterTopic.create(apiContext);
+        await filterTeam.create(apiContext);
+
+        const ownerPatch: Operation[] = [
+          {
+            op: 'add',
+            path: '/owners/-',
+            value: { id: filterTeam.responseData.id, type: 'team' },
+          },
+        ];
+        await filterTable.patch({ apiContext, patchData: ownerPatch });
+        await filterTopic.patch({ apiContext, patchData: ownerPatch });
+      } finally {
+        await afterAction();
+      }
     });
 
-    await table.create(apiContext);
-    await topic.create(apiContext);
-    await filterTeam.create(apiContext);
-
-    const ownerPatch: Operation[] = [
-      {
-        op: 'add',
-        path: '/owners/-',
-        value: { id: filterTeam.responseData.id, type: 'team' },
-      },
-    ];
-    await table.patch({ apiContext, patchData: ownerPatch });
-    await topic.patch({ apiContext, patchData: ownerPatch });
-
-    const tableFqn = table.entityResponseData?.['fullyQualifiedName'];
-    const topicFqn = topic.entityResponseData?.['fullyQualifiedName'];
-    const tableCard = page.getByTestId(`table-data-card_${tableFqn}`);
-    const topicCard = page.getByTestId(`table-data-card_${topicFqn}`);
-    const entityTypeFilterChip = page.getByRole('button', {
-      name: 'Entity Type',
+    test.afterAll(async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      try {
+        await filterTable.delete(apiContext);
+        await filterTopic.delete(apiContext);
+        await filterTeam.delete(apiContext);
+      } finally {
+        await afterAction();
+      }
     });
 
-    const selectEntityTypeFromMenu = async () => {
-      await page.getByTestId('asset-filter-button').click();
-      const menuItem = page.getByRole('menuitem', { name: 'Entity Type' });
-      await expect(menuItem).toBeVisible();
-      await waitForAntdPopupToSettle(page);
-      await menuItem.click();
-    };
+    test('should apply, toggle off and clear the entity type filter', async ({
+      page,
+    }) => {
+      const teamId = filterTeam.responseData.id;
+      const tableCard = page.getByTestId(
+        `table-data-card_${filterTable.entityResponseData?.['fullyQualifiedName']}`
+      );
+      const topicCard = page.getByTestId(
+        `table-data-card_${filterTopic.entityResponseData?.['fullyQualifiedName']}`
+      );
+      const entityTypeFilterChip = page.getByRole('button', {
+        name: 'Entity Type',
+      });
 
-    const applyTableEntityTypeFilter = async () => {
-      await entityTypeFilterChip.click();
-      await page.getByTestId('table-checkbox').check();
-      const filterResponse = page.waitForResponse('/api/v1/search/query?q=*');
-      await page.getByTestId('update-btn').click();
-      await filterResponse;
-      await waitForAllLoadersToDisappear(page);
-    };
-
-    try {
       await test.step('Apply entity type filter', async () => {
         await filterTeam.visitTeamPage(page);
 
-        const assetsResponse = page.waitForResponse('/api/v1/search/query?q=*');
+        const assetsResponse = waitForTeamAssetsSearchResponse(page, teamId);
         await page.getByTestId('assets').click();
         await assetsResponse;
         await waitForAllLoadersToDisappear(page);
@@ -780,50 +779,47 @@ test.describe('Teams Page', () => {
         await expect(tableCard).toBeVisible();
         await expect(topicCard).toBeVisible();
 
-        await selectEntityTypeFromMenu();
+        await selectAssetsFilterFromDropdown(page, 'Entity Type');
 
         await expect(entityTypeFilterChip).toBeVisible();
 
-        await applyTableEntityTypeFilter();
+        await applyEntityTypeFilterValue(page, teamId, 'table-checkbox');
 
         await expect(tableCard).toBeVisible();
         await expect(topicCard).not.toBeVisible();
       });
 
       await test.step('Toggle the filter off from the dropdown', async () => {
-        const removeFilterResponse = page.waitForResponse(
-          '/api/v1/search/query?q=*'
+        const removeFilterResponse = waitForTeamAssetsSearchResponse(
+          page,
+          teamId
         );
-        await selectEntityTypeFromMenu();
+        await selectAssetsFilterFromDropdown(page, 'Entity Type');
         await removeFilterResponse;
         await waitForAllLoadersToDisappear(page);
 
-        await expect(entityTypeFilterChip).not.toBeVisible();
         await expect(tableCard).toBeVisible();
         await expect(topicCard).toBeVisible();
+        await expect(entityTypeFilterChip).not.toBeVisible();
       });
 
       await test.step('Clear removes the selected filter entirely', async () => {
-        await selectEntityTypeFromMenu();
-        await applyTableEntityTypeFilter();
+        await selectAssetsFilterFromDropdown(page, 'Entity Type');
+        await applyEntityTypeFilterValue(page, teamId, 'table-checkbox');
 
+        await expect(tableCard).toBeVisible();
         await expect(topicCard).not.toBeVisible();
 
-        const clearResponse = page.waitForResponse('/api/v1/search/query?q=*');
+        const clearResponse = waitForTeamAssetsSearchResponse(page, teamId);
         await page.getByText('Clear').click();
         await clearResponse;
         await waitForAllLoadersToDisappear(page);
 
-        await expect(entityTypeFilterChip).not.toBeVisible();
         await expect(tableCard).toBeVisible();
         await expect(topicCard).toBeVisible();
+        await expect(entityTypeFilterChip).not.toBeVisible();
       });
-    } finally {
-      await table.delete(apiContext);
-      await topic.delete(apiContext);
-      await filterTeam.delete(apiContext);
-      await afterAction();
-    }
+    });
   });
 
   test('Delete a user from the table', async ({ page }) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Teams.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Teams.spec.ts
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 import { APIRequestContext, Page } from '@playwright/test';
+import { Operation } from 'fast-json-patch';
 import {
   EDIT_USER_FOR_TEAM_RULES,
   OWNER_TEAM_RULES,
@@ -22,6 +23,7 @@ import { DataProduct } from '../../support/domain/DataProduct';
 import { Domain } from '../../support/domain/Domain';
 import { EntityTypeEndpoint } from '../../support/entity/Entity.interface';
 import { TableClass } from '../../support/entity/TableClass';
+import { TopicClass } from '../../support/entity/TopicClass';
 import { expect, test as base } from '../../support/fixtures/base';
 import { TeamClass } from '../../support/team/TeamClass';
 import { UserClass } from '../../support/user/UserClass';
@@ -36,6 +38,7 @@ import {
   toastNotification,
   uuid,
   visitOwnProfilePage,
+  waitForAntdPopupToSettle,
 } from '../../utils/common';
 import {
   addMultiOwner,
@@ -708,6 +711,117 @@ test.describe('Teams Page', () => {
       await team2.delete(apiContext);
       await team3.delete(apiContext);
       await team4.delete(apiContext);
+      await afterAction();
+    }
+  });
+
+  test('Team assets entity type filter should apply, toggle off and clear', async ({
+    page,
+  }) => {
+    test.slow();
+    const { apiContext, afterAction } = await getApiContext(page);
+    const table = new TableClass();
+    const topic = new TopicClass();
+    const filterTeam = new TeamClass({
+      name: `pw-asset-filter-${id}`,
+      displayName: `pw team asset filter ${id}`,
+      description: 'playwright team for asset entity type filter',
+      teamType: 'Group',
+    });
+
+    await table.create(apiContext);
+    await topic.create(apiContext);
+    await filterTeam.create(apiContext);
+
+    const ownerPatch: Operation[] = [
+      {
+        op: 'add',
+        path: '/owners/-',
+        value: { id: filterTeam.responseData.id, type: 'team' },
+      },
+    ];
+    await table.patch({ apiContext, patchData: ownerPatch });
+    await topic.patch({ apiContext, patchData: ownerPatch });
+
+    const tableFqn = table.entityResponseData?.['fullyQualifiedName'];
+    const topicFqn = topic.entityResponseData?.['fullyQualifiedName'];
+    const tableCard = page.getByTestId(`table-data-card_${tableFqn}`);
+    const topicCard = page.getByTestId(`table-data-card_${topicFqn}`);
+    const entityTypeFilterChip = page.getByRole('button', {
+      name: 'Entity Type',
+    });
+
+    const selectEntityTypeFromMenu = async () => {
+      await page.getByTestId('asset-filter-button').click();
+      const menuItem = page.getByRole('menuitem', { name: 'Entity Type' });
+      await expect(menuItem).toBeVisible();
+      await waitForAntdPopupToSettle(page);
+      await menuItem.click();
+    };
+
+    const applyTableEntityTypeFilter = async () => {
+      await entityTypeFilterChip.click();
+      await page.getByTestId('table-checkbox').check();
+      const filterResponse = page.waitForResponse('/api/v1/search/query?q=*');
+      await page.getByTestId('update-btn').click();
+      await filterResponse;
+      await waitForAllLoadersToDisappear(page);
+    };
+
+    try {
+      await test.step('Apply entity type filter', async () => {
+        await filterTeam.visitTeamPage(page);
+
+        const assetsResponse = page.waitForResponse('/api/v1/search/query?q=*');
+        await page.getByTestId('assets').click();
+        await assetsResponse;
+        await waitForAllLoadersToDisappear(page);
+
+        await expect(tableCard).toBeVisible();
+        await expect(topicCard).toBeVisible();
+
+        await selectEntityTypeFromMenu();
+
+        await expect(entityTypeFilterChip).toBeVisible();
+
+        await applyTableEntityTypeFilter();
+
+        await expect(tableCard).toBeVisible();
+        await expect(topicCard).not.toBeVisible();
+      });
+
+      await test.step('Toggle the filter off from the dropdown', async () => {
+        const removeFilterResponse = page.waitForResponse(
+          '/api/v1/search/query?q=*'
+        );
+        await selectEntityTypeFromMenu();
+        await removeFilterResponse;
+        await waitForAllLoadersToDisappear(page);
+
+        await expect(entityTypeFilterChip).not.toBeVisible();
+        await expect(tableCard).toBeVisible();
+        await expect(topicCard).toBeVisible();
+      });
+
+      await test.step('Clear removes the selected filter entirely', async () => {
+        await selectEntityTypeFromMenu();
+        await applyTableEntityTypeFilter();
+
+        await expect(topicCard).not.toBeVisible();
+
+        const clearResponse = page.waitForResponse('/api/v1/search/query?q=*');
+        await page.getByText('Clear').click();
+        await clearResponse;
+        await waitForAllLoadersToDisappear(page);
+
+        await expect(entityTypeFilterChip).not.toBeVisible();
+        await expect(tableCard).toBeVisible();
+        await expect(topicCard).toBeVisible();
+      });
+    } finally {
+      await table.delete(apiContext);
+      await topic.delete(apiContext);
+      await filterTeam.delete(apiContext);
       await afterAction();
     }
   });

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
@@ -822,8 +822,7 @@ export const waitForTeamAssetsSearchResponse = (page: Page, teamId: string) =>
     (response) =>
       response.url().includes('/api/v1/search/query') &&
       response.url().includes('index=all') &&
-      response.url().includes(teamId) &&
-      response.status() === 200
+      response.url().includes(teamId)
   );
 
 export const selectAssetsFilterFromDropdown = async (
@@ -846,6 +845,8 @@ export const applyEntityTypeFilterValue = async (
   await page.getByTestId(entityTypeCheckboxTestId).check();
   const filterResponse = waitForTeamAssetsSearchResponse(page, teamId);
   await page.getByTestId('update-btn').click();
-  await filterResponse;
+  const response = await filterResponse;
+
+  expect(response.status()).toBe(200);
   await waitForAllLoadersToDisappear(page);
 };

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
@@ -23,6 +23,7 @@ import {
   fillDescriptionBox,
   redirectToHomePage,
   uuid,
+  waitForAntdPopupToSettle,
 } from './common';
 import {
   addMultiOwner,
@@ -809,4 +810,42 @@ export const executionOnOwnerGroupTeam = async (
   await addEmailTeam(page, data.email);
 
   await addUserTeam(page, data.user, data.userName);
+};
+
+/**
+ * Wait for the team assets listing search call. The team id appears in the
+ * encoded query_filter (owners.id term), so the match cannot collide with
+ * other search/query requests on the page.
+ */
+export const waitForTeamAssetsSearchResponse = (page: Page, teamId: string) =>
+  page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/v1/search/query') &&
+      response.url().includes('index=all') &&
+      response.url().includes(teamId) &&
+      response.status() === 200
+  );
+
+export const selectAssetsFilterFromDropdown = async (
+  page: Page,
+  filterLabel: string
+) => {
+  await page.getByTestId('asset-filter-button').click();
+  const menuItem = page.getByRole('menuitem', { name: filterLabel });
+  await expect(menuItem).toBeVisible();
+  await waitForAntdPopupToSettle(page);
+  await menuItem.click();
+};
+
+export const applyEntityTypeFilterValue = async (
+  page: Page,
+  teamId: string,
+  entityTypeCheckboxTestId: string
+) => {
+  await page.getByRole('button', { name: 'Entity Type' }).click();
+  await page.getByTestId(entityTypeCheckboxTestId).check();
+  const filterResponse = waitForTeamAssetsSearchResponse(page, teamId);
+  await page.getByTestId('update-btn').click();
+  await filterResponse;
+  await waitForAllLoadersToDisappear(page);
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/AssetsTabs.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/AssetsTabs.component.tsx
@@ -950,10 +950,12 @@ const AssetsTabs = forwardRef(
       return <div data-testid="manage-dropdown-list-container">{menus}</div>;
     }, []);
 
-    const handleQuickFiltersChange = (data: ExploreQuickFilterField[]) => {
-      const quickFilterQuery = getQuickFilterQuery(data);
-      setQuickFilterQuery(quickFilterQuery);
-    };
+    const handleQuickFiltersChange = useCallback(
+      (data: ExploreQuickFilterField[]) => {
+        setQuickFilterQuery(getQuickFilterQuery(data));
+      },
+      []
+    );
 
     const handleQuickFiltersValueSelect = useCallback(
       (field: ExploreQuickFilterField) => {
@@ -971,7 +973,7 @@ const AssetsTabs = forwardRef(
           return data;
         });
       },
-      [setSelectedQuickFilters]
+      [handleQuickFiltersChange]
     );
 
     const assetListing = useMemo(
@@ -1163,7 +1165,12 @@ const AssetsTabs = forwardRef(
           handleQuickFiltersChange(updatedQuickFilters);
         }
       }
-    }, [selectedFilter, selectedQuickFilters, filters]);
+    }, [
+      selectedFilter,
+      selectedQuickFilters,
+      filters,
+      handleQuickFiltersChange,
+    ]);
 
     useImperativeHandle(ref, () => ({
       refreshAssets() {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/AssetsTabs.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/AssetsTabs.component.tsx
@@ -27,7 +27,7 @@ import {
 import { ItemType } from 'antd/lib/menu/hooks/useItems';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
-import { isObject } from 'lodash';
+import { isEmpty, isObject } from 'lodash';
 import { EntityDetailUnion } from 'Models';
 import {
   forwardRef,
@@ -283,6 +283,8 @@ const AssetsFilterBar = ({
         <Dropdown
           menu={{
             items: filterMenu,
+            multiple: true,
+            selectable: true,
             selectedKeys: selectedFilter,
           }}
           trigger={['click']}>
@@ -460,7 +462,11 @@ const AssetsTabs = forwardRef(
     const entityTypeString = getEntityTypeString(type);
 
     const handleMenuClick = ({ key }: { key: string }) => {
-      setSelectedFilter((prevSelected) => [...prevSelected, key]);
+      setSelectedFilter((prevSelected) =>
+        prevSelected.includes(key)
+          ? prevSelected.filter((selectedKey) => selectedKey !== key)
+          : [...prevSelected, key]
+      );
     };
 
     const filterMenu: ItemType[] = useMemo(() => {
@@ -1110,20 +1116,9 @@ const AssetsTabs = forwardRef(
 
     const clearFilters = useCallback(() => {
       setQuickFilterQuery(undefined);
-      setSelectedQuickFilters((pre) => {
-        const data = pre.map((preField) => {
-          return { ...preField, value: [] };
-        });
-
-        handleQuickFiltersChange(data);
-
-        return data;
-      });
-    }, [
-      setQuickFilterQuery,
-      handleQuickFiltersChange,
-      setSelectedQuickFilters,
-    ]);
+      setSelectedFilter([]);
+      setSelectedQuickFilters([]);
+    }, []);
 
     useEffect(() => {
       fetchAssets({
@@ -1144,28 +1139,29 @@ const AssetsTabs = forwardRef(
     }, [type]);
 
     useEffect(() => {
-      const updatedQuickFilters = filters
-        .filter((filter) => selectedFilter.includes(filter.key))
-        .map((selectedFilterItem) => {
-          const originalFilterItem = selectedQuickFilters?.find(
-            (filter) => filter.key === selectedFilterItem.key
-          );
-
-          return originalFilterItem || selectedFilterItem;
-        });
-
-      const newItems = updatedQuickFilters.filter(
-        (item) =>
-          !selectedQuickFilters.some(
-            (existingItem) => item.key === existingItem.key
-          )
+      const retainedFilters = selectedQuickFilters.filter((field) =>
+        selectedFilter.includes(field.key)
+      );
+      const newFilters = filters.filter(
+        (filter) =>
+          selectedFilter.includes(filter.key) &&
+          !retainedFilters.some((field) => field.key === filter.key)
       );
 
-      if (newItems.length > 0) {
-        setSelectedQuickFilters((prevSelected) => [
-          ...prevSelected,
-          ...newItems,
-        ]);
+      if (
+        newFilters.length > 0 ||
+        retainedFilters.length !== selectedQuickFilters.length
+      ) {
+        const updatedQuickFilters = [...retainedFilters, ...newFilters];
+        setSelectedQuickFilters(updatedQuickFilters);
+
+        const removedFilterHadValue = selectedQuickFilters.some(
+          (field) =>
+            !selectedFilter.includes(field.key) && !isEmpty(field.value)
+        );
+        if (removedFilterHadValue) {
+          handleQuickFiltersChange(updatedQuickFilters);
+        }
       }
     }, [selectedFilter, selectedQuickFilters, filters]);
 

--- a/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
@@ -113,6 +113,17 @@ export const COMMON_DROPDOWN_ITEMS = [
   },
 ];
 
+export const TEAM_ASSETS_DROPDOWN_ITEMS = [
+  {
+    label: 'label.entity-type-plural',
+    labelKeyOptions: {
+      entity: 'label.entity',
+    },
+    key: EntityFields.ENTITY_TYPE,
+  },
+  ...COMMON_DROPDOWN_ITEMS,
+];
+
 export const DATA_ASSET_DROPDOWN_ITEMS = [
   {
     label: 'label.data-asset-plural',

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchPureUtils.ts
@@ -23,6 +23,7 @@ import {
   LINEAGE_DROPDOWN_ITEMS,
   QUICK_FILTER_SOURCE_FIELDS,
   TAG_ASSETS_DROPDOWN_ITEMS,
+  TEAM_ASSETS_DROPDOWN_ITEMS,
 } from '../constants/AdvancedSearch.constants';
 import { NOT_INCLUDE_AGGREGATION_QUICK_FILTER } from '../constants/explore.constants';
 import {
@@ -63,6 +64,9 @@ export const getAssetsPageQuickFilters = (
 
     case AssetsOfEntity.LINEAGE:
       return [...LINEAGE_DROPDOWN_ITEMS];
+
+    case AssetsOfEntity.TEAM:
+      return [...TEAM_ASSETS_DROPDOWN_ITEMS];
 
     default:
       return [...COMMON_DROPDOWN_ITEMS];

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.test.tsx
@@ -21,6 +21,7 @@ import {
   GLOSSARY_ASSETS_DROPDOWN_ITEMS,
   LINEAGE_DROPDOWN_ITEMS,
   TAG_ASSETS_DROPDOWN_ITEMS,
+  TEAM_ASSETS_DROPDOWN_ITEMS,
 } from '../constants/AdvancedSearch.constants';
 import {
   EntityFields,
@@ -695,6 +696,20 @@ describe('AdvancedSearchUtils tests', () => {
     it('should return TAG_ASSETS_DROPDOWN_ITEMS for TAG type', () => {
       expect(getAssetsPageQuickFilters(AssetsOfEntity.TAG)).toEqual(
         TAG_ASSETS_DROPDOWN_ITEMS
+      );
+    });
+
+    it('should return TEAM_ASSETS_DROPDOWN_ITEMS for TEAM type', () => {
+      expect(getAssetsPageQuickFilters(AssetsOfEntity.TEAM)).toEqual(
+        TEAM_ASSETS_DROPDOWN_ITEMS
+      );
+    });
+
+    it('should include the entity type filter for TEAM type', () => {
+      expect(getAssetsPageQuickFilters(AssetsOfEntity.TEAM)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ key: EntityFields.ENTITY_TYPE }),
+        ])
       );
     });
 


### PR DESCRIPTION
### Describe your changes:

Fixes #32806

Teams using the Team → Assets tab had no way to filter the asset list by the type of data asset, and once any quick filter was selected it could never be removed again. This PR:

- **Adds an Entity Type quick filter to the Team assets tab.** New `TEAM_ASSETS_DROPDOWN_ITEMS` constant (the same entity-type filter item Domain/Glossary/Tag assets tabs already use, plus the common filters) and an explicit `AssetsOfEntity.TEAM` case in `getAssetsPageQuickFilters`. All the entity-type machinery (query rewrite `entityType` → `entityType.keyword`, value lowercasing, label/icon formatting, aggregation options) already exists, so no other wiring was needed. Scoped to TEAM deliberately — adding it to `COMMON_DROPDOWN_ITEMS` would also inject it into the Explore per-index filter lists via `SearchClassBase`, where an entity-type filter on a single-index tab is noise.
- **Makes the filter dropdown toggle.** `handleMenuClick` in `AssetsTabs` was append-only (clicking the same item twice even added a duplicate key). Clicking an already-selected filter now removes it; the sync effect drops the field from the chip bar and re-fetches when the removed filter had active values. Added `selectable`/`multiple` to the dropdown menu so the selected filters are visibly highlighted.
- **Makes "Clear" remove the selected filters entirely.** Previously it only emptied the filter *values*, leaving an unremovable chip in the bar.

The `AssetsTabs` fixes apply to every consumer of the shared component: Team, Glossary, Domain, Data Product, Tag, and User assets tabs.


https://github.com/user-attachments/assets/5d45b701-52b5-4411-8f3b-8d571b578d3a



#
### Type of change:
- [x] Bug fix
- [x] Improvement

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Team assets tab shows an Entity Type filter in the filter dropdown; applying it with value "Table" narrows the list to tables only
- Clicking the already-selected Entity Type item in the filter dropdown removes the filter chip and restores the unfiltered list
- "Clear" removes the selected filter entirely (chip disappears) and restores the unfiltered list

#### Unit tests
- Updated `src/utils/AdvancedSearchUtils.test.tsx` — `getAssetsPageQuickFilters` returns `TEAM_ASSETS_DROPDOWN_ITEMS` for TEAM and the result includes the entity-type filter key. `AdvancedSearchUtils.test.tsx` (57), `SearchClassBase.test.ts` (9), and `AssetsTabs.test.tsx` (14) all pass.

#### Backend integration tests
- Not applicable (no backend API changes).

#### Ingestion integration tests
- Not applicable (no ingestion changes).

#### Playwright (UI) tests
- Added `Team assets entity type filter should apply, toggle off and clear` to `playwright/e2e/Pages/Teams.spec.ts` — creates a team owning a table and a topic via API, then exercises apply → toggle-off → clear against the live UI. `yarn lint:playwright` passes with zero errors.

#### Manual testing performed
1. Started the local stack, opened a team page → Assets tab
2. Verified Entity Type appears in the filter dropdown, applied it with "Table", confirmed only table assets are listed
3. Verified clicking Entity Type again in the dropdown removes the chip and restores all assets
4. Verified "Clear" removes the applied filter chip entirely and restores all assets

#
### UI screen recording / screenshots:

Screenshots to be attached in a follow-up comment (filter dropdown with Entity Type entry; applied `Entity Type: Table` chip on the Team assets tab).

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
