### PR TITLE
fix(pubsub): apply GCP service account impersonation when creating Pub/Sub clients (#32517)

### DIFF
--- a/ingestion/src/metadata/ingestion/source/messaging/pubsub/connection.py
+++ b/ingestion/src/metadata/ingestion/source/messaging/pubsub/connection.py
@@ -16,6 +16,8 @@ import os
 from dataclasses import dataclass
 
 from google.api_core.exceptions import GoogleAPIError
+from google.auth import default as auth_default
+from google.auth import impersonated_credentials
 from google.cloud import pubsub_v1
 from google.pubsub_v1.services.schema_service import SchemaServiceClient
 
@@ -36,7 +38,7 @@ from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import test_connection_steps
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.constants import THREE_MIN
-from metadata.utils.credentials import set_google_credentials
+from metadata.utils.credentials import GOOGLE_CLOUD_SCOPES, set_google_credentials
 from metadata.utils.logger import ingestion_logger
 
 logger = ingestion_logger()
@@ -107,12 +109,29 @@ class PubSubConnection(BaseConnection[PubSubConnectionConfig, PubSubClient]):
                 if PUBSUB_EMULATOR_HOST in os.environ:
                     del os.environ[PUBSUB_EMULATOR_HOST]
 
-            publisher = pubsub_v1.PublisherClient()
-            subscriber = pubsub_v1.SubscriberClient()
+            # Build the credential object; wrap with impersonated credentials when a
+            # target service account is configured so all Pub/Sub API calls run under
+            # the correct identity rather than falling back to ADC.
+            gcp_credentials = None
+            if not connection.useEmulator and connection.gcpConfig:
+                gcp_credentials, _ = auth_default()
+                impersonate = connection.gcpConfig.gcpImpersonateServiceAccount
+                if impersonate and impersonate.impersonateServiceAccount:
+                    target = impersonate.impersonateServiceAccount.strip()
+                    if target:
+                        gcp_credentials = impersonated_credentials.Credentials(
+                            source_credentials=gcp_credentials,
+                            target_principal=target,
+                            target_scopes=GOOGLE_CLOUD_SCOPES,
+                            lifetime=impersonate.lifetime or 3600,
+                        )
+
+            publisher = pubsub_v1.PublisherClient(credentials=gcp_credentials)
+            subscriber = pubsub_v1.SubscriberClient(credentials=gcp_credentials)
 
             schema_client = None
             if connection.schemaRegistryEnabled and not connection.useEmulator:
-                schema_client = SchemaServiceClient()
+                schema_client = SchemaServiceClient(credentials=gcp_credentials)
 
             project_id = _get_project_id(connection)
             if not project_id:

--- a/ingestion/tests/unit/source/messaging/test_pubsub.py
+++ b/ingestion/tests/unit/source/messaging/test_pubsub.py
@@ -126,20 +126,25 @@ class TestPubSubModels:
 class TestPubSubConnection:
     """Test Pub/Sub connection handling"""
 
+    @patch("metadata.ingestion.source.messaging.pubsub.connection.auth_default")
     @patch("metadata.ingestion.source.messaging.pubsub.connection.set_google_credentials")
     @patch("metadata.ingestion.source.messaging.pubsub.connection.pubsub_v1.PublisherClient")
     @patch("metadata.ingestion.source.messaging.pubsub.connection.pubsub_v1.SubscriberClient")
     @patch("metadata.ingestion.source.messaging.pubsub.connection.SchemaServiceClient")
-    def test_get_connection_with_project_id(self, mock_schema_client, mock_subscriber, mock_publisher, mock_set_creds):
+    def test_get_connection_with_project_id(
+        self, mock_schema_client, mock_subscriber, mock_publisher, mock_set_creds, mock_auth_default
+    ):
         """Test get_connection with explicit project ID"""
         from metadata.ingestion.source.messaging.pubsub.connection import (
             PubSubClient,
             PubSubConnection,
         )
 
+        mock_auth_default.return_value = (MagicMock(), None)
         mock_connection = MagicMock()
         mock_connection.projectId = "test-project"
         mock_connection.gcpConfig = MagicMock()
+        mock_connection.gcpConfig.gcpImpersonateServiceAccount = None
         mock_connection.useEmulator = False
         mock_connection.hostPort = None
         mock_connection.schemaRegistryEnabled = True
@@ -153,16 +158,21 @@ class TestPubSubConnection:
         mock_subscriber.assert_called_once()
         mock_schema_client.assert_called_once()
 
+    @patch("metadata.ingestion.source.messaging.pubsub.connection.auth_default")
     @patch("metadata.ingestion.source.messaging.pubsub.connection.set_google_credentials")
     @patch("metadata.ingestion.source.messaging.pubsub.connection.pubsub_v1.PublisherClient")
     @patch("metadata.ingestion.source.messaging.pubsub.connection.pubsub_v1.SubscriberClient")
-    def test_get_connection_without_schema_registry(self, mock_subscriber, mock_publisher, mock_set_creds):
+    def test_get_connection_without_schema_registry(
+        self, mock_subscriber, mock_publisher, mock_set_creds, mock_auth_default
+    ):
         """Test get_connection with schema registry disabled"""
         from metadata.ingestion.source.messaging.pubsub.connection import PubSubConnection
 
+        mock_auth_default.return_value = (MagicMock(), None)
         mock_connection = MagicMock()
         mock_connection.projectId = "test-project"
         mock_connection.gcpConfig = MagicMock()
+        mock_connection.gcpConfig.gcpImpersonateServiceAccount = None
         mock_connection.useEmulator = False
         mock_connection.hostPort = None
         mock_connection.schemaRegistryEnabled = False
@@ -197,23 +207,82 @@ class TestPubSubConnection:
         mock_set_creds.assert_not_called()
         assert PUBSUB_EMULATOR_HOST not in os.environ
 
+    @patch("metadata.ingestion.source.messaging.pubsub.connection.auth_default")
     @patch("metadata.ingestion.source.messaging.pubsub.connection.set_google_credentials")
     @patch("metadata.ingestion.source.messaging.pubsub.connection.pubsub_v1.PublisherClient")
     @patch("metadata.ingestion.source.messaging.pubsub.connection.pubsub_v1.SubscriberClient")
-    def test_get_connection_missing_project_id_raises(self, mock_subscriber, mock_publisher, mock_set_creds):
+    def test_get_connection_missing_project_id_raises(
+        self, mock_subscriber, mock_publisher, mock_set_creds, mock_auth_default
+    ):
         """Test get_connection raises ValueError when project ID is missing"""
         from metadata.ingestion.source.messaging.pubsub.connection import PubSubConnection
 
+        mock_auth_default.return_value = (MagicMock(), None)
         mock_connection = MagicMock()
         mock_connection.projectId = None
         mock_connection.gcpConfig = MagicMock()
         mock_connection.gcpConfig.gcpConfig = None
+        mock_connection.gcpConfig.gcpImpersonateServiceAccount = None
         mock_connection.useEmulator = False
         mock_connection.hostPort = None
         mock_connection.schemaRegistryEnabled = False
 
         with pytest.raises(ValueError, match="Project ID is required"):
             PubSubConnection(mock_connection)._get_client()
+
+    @patch("metadata.ingestion.source.messaging.pubsub.connection.impersonated_credentials")
+    @patch("metadata.ingestion.source.messaging.pubsub.connection.auth_default")
+    @patch("metadata.ingestion.source.messaging.pubsub.connection.set_google_credentials")
+    @patch("metadata.ingestion.source.messaging.pubsub.connection.pubsub_v1.PublisherClient")
+    @patch("metadata.ingestion.source.messaging.pubsub.connection.pubsub_v1.SubscriberClient")
+    @patch("metadata.ingestion.source.messaging.pubsub.connection.SchemaServiceClient")
+    def test_get_connection_with_impersonation(
+        self,
+        mock_schema_client,
+        mock_subscriber,
+        mock_publisher,
+        mock_set_creds,
+        mock_auth_default,
+        mock_impersonated,
+    ):
+        """When gcpImpersonateServiceAccount is configured all Pub/Sub clients receive
+        the impersonated credential so every API call runs under the target identity.
+
+        Without impersonation the connector falls back to ADC (Application Default
+        Credentials), causing 403 IAM_PERMISSION_DENIED errors on GetTopics and
+        GetSubscriptions even when the impersonated SA has Pub/Sub Viewer (closes #32517).
+        """
+        from metadata.ingestion.source.messaging.pubsub.connection import PubSubConnection
+
+        source_creds = MagicMock()
+        mock_auth_default.return_value = (source_creds, None)
+        impersonated_creds = MagicMock()
+        mock_impersonated.Credentials.return_value = impersonated_creds
+
+        mock_connection = MagicMock()
+        mock_connection.projectId = "test-project"
+        mock_connection.useEmulator = False
+        mock_connection.hostPort = None
+        mock_connection.schemaRegistryEnabled = True
+        mock_connection.gcpConfig = MagicMock()
+        mock_connection.gcpConfig.gcpImpersonateServiceAccount = MagicMock()
+        mock_connection.gcpConfig.gcpImpersonateServiceAccount.impersonateServiceAccount = (
+            "robot@my-project.iam.gserviceaccount.com"
+        )
+        mock_connection.gcpConfig.gcpImpersonateServiceAccount.lifetime = 3600
+
+        PubSubConnection(mock_connection)._get_client()
+
+        # Impersonated credentials must have been built from source_creds + target SA.
+        mock_impersonated.Credentials.assert_called_once()
+        call_kwargs = mock_impersonated.Credentials.call_args.kwargs
+        assert call_kwargs["source_credentials"] is source_creds
+        assert call_kwargs["target_principal"] == "robot@my-project.iam.gserviceaccount.com"
+
+        # Every client must receive the impersonated credential — not None or ADC.
+        mock_publisher.assert_called_once_with(credentials=impersonated_creds)
+        mock_subscriber.assert_called_once_with(credentials=impersonated_creds)
+        mock_schema_client.assert_called_once_with(credentials=impersonated_creds)
 
     def test_get_project_id_from_connection(self):
         """Test _get_project_id extracts project ID from connection config"""


### PR DESCRIPTION
## Summary

Fixes #32517

### Root Cause

When `gcpImpersonateServiceAccount` is configured, `_get_client()` called `set_google_credentials()` to set up the base identity and then constructed `PublisherClient()`, `SubscriberClient()`, and `SchemaServiceClient()` **with no credentials argument**. All three clients then fell back to Application Default Credentials (ADC) — the source service account — rather than the configured target SA. Every GCP API call (`GetTopics`, `GetSubscriptions`, schema registry) ran under the wrong identity, causing `403 IAM_PERMISSION_DENIED` even though the target SA had `roles/pubsub.viewer`.

### What Changed

After `set_google_credentials()` configures the base identity, the fix:
1. Calls `google.auth.default()` to materialise the source credentials.
2. Checks `connection.gcpConfig.gcpImpersonateServiceAccount`; if a non-empty target SA is configured, wraps the source credentials in `google.auth.impersonated_credentials.Credentials`.
3. Passes the resulting credential object explicitly to every Pub/Sub client constructor (`PublisherClient`, `SubscriberClient`, `SchemaServiceClient`).

Without impersonation `gcp_credentials` stays as the plain ADC/JSON-key credential, so the emulator and JSON-key paths are unchanged.

The pattern is identical to the existing **BigQuery** and **Google Drive** connectors.

### Test Evidence

- Updated `test_get_connection_with_project_id`, `test_get_connection_without_schema_registry`, and `test_get_connection_missing_project_id_raises` to mock `auth_default` (newly called in the non-emulator path) and set `gcpImpersonateServiceAccount = None` to exercise the non-impersonation path.
- Added `test_get_connection_with_impersonation` asserting that `impersonated_credentials.Credentials` is built with the correct `source_credentials` and `target_principal`, and that every client receives the impersonated credential.
- Isolation logic test (run locally, not requiring generated schemas): all three scenarios (impersonation configured, not configured, blank SA) validated.

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.

<!-- greptile_comment -->

<!-- greptile_summary -->

<details open><summary>Greptile Summary</summary>

The production change correctly centralizes GCP credential creation and passes the selected default or impersonated credential to Publisher, Subscriber, and Schema Service clients.

- Preserves emulator behavior by leaving credentials unset there.
- Uses the shared impersonation helper for configured target service accounts.
- Adds unit coverage for default and impersonated credential routing, although the new impersonation test does not satisfy the repository’s behavioral-testing requirement.
</details>


<details open><summary>Confidence Score: 4/5</summary>

The production fix appears correct, but the repository’s explicit behavioral-testing requirement should be satisfied before merging.

No production failure was found in the credential flow; the remaining concern is that the new impersonation regression test mocks away both credential creation and client behavior.

**Files Needing Attention:** ingestion/tests/unit/source/messaging/test_pubsub.py
</details>


<details open><summary>Important Files Changed</summary>




| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/messaging/pubsub/connection.py | Selects shared default or impersonated GCP credentials and explicitly supplies them to every Pub/Sub client. |
| ingestion/tests/unit/source/messaging/test_pubsub.py | Updates credential-routing assertions and adds impersonation coverage, but the new test verifies mocked internal wiring rather than observable behavior. |

</details>


<details open><summary>Flowchart</summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    C[Pub/Sub connection configuration] --> E{Use emulator?}
    E -- Yes --> N[Create clients with no explicit credential]
    E -- No --> S[Configure source GCP identity]
    S --> I{Nonblank impersonation target?}
    I -- Yes --> T[Build target service-account credential]
    I -- No --> D[Load default credential]
    T --> P[Publisher, Subscriber, and Schema clients]
    D --> P
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(pubsub): delegate GCP credentia..."](https://github.com/open-metadata/openmetadata/commit/95291f65e0f77a730674f49ac0cc6840cc3be8c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61132931)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary>Context used (3)</summary>

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))
- Knowledge Base — [Metadata ingestion](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/metadata-ingestion.md)
- Knowledge Base — [Ingestion connectors](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/ingestion-connectors.md)
</details>


<!-- /greptile_comment -->