### PR TITLE
fix(service): carry column tags forward when a column dataType changes

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DashboardDataModelResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DashboardDataModelResourceIT.java
@@ -924,4 +924,85 @@ public class DashboardDataModelResourceIT
       }
     }
   }
+
+  /**
+   * Issue #30639: a column whose dataType changes is recorded as deleted + re-added rather than
+   * updated, because EntityUtil.columnMatch compares dataType. updateColumns then removes the
+   * deleted column's tag_usage rows, so the carry-forward must move user-applied tags onto the
+   * re-added column, which occupies the same FQN. The Tableau connector hits this when it promotes
+   * a physical column's type onto the field it mirrors (RECORD -> STRING).
+   */
+  @Test
+  void test_columnTagsSurviveDataTypeChange(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    String shortId = ns.shortPrefix();
+
+    Classification classification =
+        client
+            .classifications()
+            .create(
+                new CreateClassification()
+                    .withName("cls_" + shortId)
+                    .withDescription("Test classification"));
+    Tag columnTag =
+        client
+            .tags()
+            .create(
+                new CreateTag()
+                    .withName("ct_" + shortId)
+                    .withClassification(classification.getName())
+                    .withDescription("Column level tag"));
+    TagLabel columnTagLabel =
+        new TagLabel()
+            .withTagFQN(columnTag.getFullyQualifiedName())
+            .withSource(TagLabel.TagSource.CLASSIFICATION);
+
+    DashboardService service = DashboardServiceTestFactory.createLooker(ns);
+    String name = ns.prefix("dm_coltype");
+
+    DashboardDataModel created =
+        createEntity(
+            new CreateDashboardDataModel()
+                .withName(name)
+                .withService(service.getFullyQualifiedName())
+                .withDataModelType(DataModelType.LookMlView)
+                .withColumns(
+                    List.of(
+                        new Column()
+                            .withName("customer_name")
+                            .withDataType(ColumnDataType.RECORD)
+                            .withTags(List.of(columnTagLabel)))));
+
+    String entityId = created.getId().toString();
+    DashboardDataModel tagged = getEntityWithFields(entityId, "columns,tags");
+    assertEquals(
+        1,
+        tagged.getColumns().get(0).getTags().size(),
+        "Column tag should be present after create");
+
+    // Re-ingest the same column with the physical type promoted onto it and no tags in the
+    // payload, which is what a connector sends.
+    BulkOperationResult result =
+        executeBulkAsBot(
+            List.of(
+                new CreateDashboardDataModel()
+                    .withName(name)
+                    .withService(service.getFullyQualifiedName())
+                    .withDataModelType(DataModelType.LookMlView)
+                    .withColumns(
+                        List.of(
+                            new Column()
+                                .withName("customer_name")
+                                .withDataType(ColumnDataType.STRING)))),
+            false);
+    assertNotNull(result);
+
+    DashboardDataModel afterTypeChange = getEntityWithFields(entityId, "columns,tags");
+    Column column = afterTypeChange.getColumns().get(0);
+    assertEquals(ColumnDataType.STRING, column.getDataType(), "dataType should have changed");
+    assertNotNull(column.getTags(), "Column tags must survive a dataType change");
+    assertEquals(
+        1, column.getTags().size(), "User-applied column tag must survive a dataType change");
+    assertEquals(columnTag.getFullyQualifiedName(), column.getTags().get(0).getTagFQN());
+  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -10850,7 +10850,11 @@ public abstract class EntityRepository<T extends EntityInterface> {
           if (nullOrEmpty(addedColumn.getDescription())) {
             addedColumn.setDescription(deleted.getDescription());
           }
-          if (nullOrEmpty(addedColumn.getTags()) && nullOrEmpty(deleted.getTags())) {
+          // Carry the tags forward only when the re-added column has none of its own and the
+          // deleted one actually had some. A column is re-added rather than updated whenever its
+          // dataType changes (see EntityUtil.columnMatch), and the deleteTagsByTarget below would
+          // otherwise drop user-applied tags from a column that still exists under the same FQN.
+          if (nullOrEmpty(addedColumn.getTags()) && !nullOrEmpty(deleted.getTags())) {
             addedColumn.setTags(deleted.getTags());
           }
         }


### PR DESCRIPTION
# Carry column tags forward when a column's dataType changes

Fixes #32832

## Describe your changes

`EntityUtil.columnMatch` compares **name + dataType + arrayDataType**. A column whose dataType
changes therefore does not "match" its stored counterpart: `recordListChange` records it as
**deleted + re-added** rather than updated. `EntityRepository.updateColumns` then calls
`deleteTagsByTarget(deleted.getFullyQualifiedName())` — and because the column keeps its name, the
re-added column occupies that exact same FQN, so the delete removes the tag rows of a column that
still exists.

`updateColumns` already has a carry-forward for this case, but its tags guard was inverted:

```java
if (nullOrEmpty(addedColumn.getDescription())) {          // 1 condition — correct
  addedColumn.setDescription(deleted.getDescription());
}
if (nullOrEmpty(addedColumn.getTags()) && nullOrEmpty(deleted.getTags())) {   // 2 conditions
  addedColumn.setTags(deleted.getTags());
}
```

The extra `nullOrEmpty(deleted.getTags())` restricts the branch to the case where the deleted column
had **no** tags — so it can only ever assign an empty list onto an already-empty list. Enumerated:

| `deleted.tags` | `added.tags` | fires? | effect |
|---|---|---|---|
| has tags | empty | **no** | **tags silently lost** |
| empty | empty | yes | copies empty onto empty — no-op |
| has tags | has tags | no | keeps incoming (correct) |
| empty | has tags | no | keeps incoming (correct) |

The branch is a provable no-op for every possible input: `setTags` could never transfer a tag. The
one row it exists to handle is precisely the row it excludes.

This PR removes the extra condition (as an explicit `!nullOrEmpty(deleted.getTags())`, mirroring the
description branch) so user-applied tags move onto the re-added column, which is then re-persisted by
the existing `applyTagsAddInFlushAndDeferRdf` call a few lines below.

**Not a behaviour change in intent.** The comment directly above the block already states
`carry forward tags and description if deletedColumns matches added column`, and both branches were
authored in the same hunk of the same commit (`d84a2b3ed7c`, #10548) — they were meant to be
symmetric. Descriptions have worked correctly since; tags never have.

## Why it matters

- **Not connector-specific.** Any entity going through `updateColumns` is affected whenever a column
  keeps its name but changes type — e.g. a source column altered `INT` → `BIGINT` or
  `VARCHAR` → `TEXT` drops every tag on it at the next ingestion. Tables included, since 2023.
- **Higher impact than the description case.** Column tags drive policy: PII classification, masking,
  access rules. Silently de-classifying a column tagged `PersonalData.Personal` is a governance
  failure, not a cosmetic one.
- It is currently reachable via the Tableau connector fix in #30928 / the follow-up, which promotes a
  physical column's type onto the field that mirrors it (`RECORD` → `STRING`).

## Ordering (why the one-line change is sufficient)

Within `updateColumns` the sequence is:

1. carry-forward — mutates `addedColumn`
2. `deleteTagsByTarget(deleted FQN)` — an immediate DAO call, clears the old rows
3. `applyTagsAddInFlushAndDeferRdf(added.getTags(), added FQN)` — queued to the flush, re-inserts

Delete precedes the insert, so tags set in step 1 survive step 2 and land in step 3. No reordering is
required.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How was this tested

**Integration test** — `DashboardDataModelResourceIT#test_columnTagsSurviveDataTypeChange`:
creates a data model column as `RECORD` with a classification tag, then re-ingests it via
`executeBulkAsBot` as `STRING` with **no** `tags` field in the payload (what a connector actually
sends), and asserts the tag is still there.

The test deliberately uses the bulk path rather than `patchEntity`: a PATCH emits an explicit
`remove /columns/0/tags` op and would pass without the fix, testing nothing.

**Verified against a live instance** (local Docker stack, Tableau connector, dashboard data model
column `Order Date`). Server-recorded change for the run:

```
FIELDSDELETED:  2473e105  Order Date  dataType=RECORD  tags=['KnowledgeCenter.HowToGuide']
FIELDSADDED:    2473e105  Order Date  dataType=DATE    tags=[]
```

The stored column had the tag, the incoming column had none — exactly the row the old condition
excluded. After the fix the tag is present in the resulting entity, with its label intact:

```json
{ "tagFQN": "KnowledgeCenter.HowToGuide", "source": "Classification",
  "labelType": "Manual", "state": "Confirmed", "appliedBy": "admin" }
```

`labelType` and `state` are preserved; only `appliedAt` is refreshed, since the row is deleted and
re-inserted. The identical run against the pre-fix build dropped the tag.

## Known limitation (not addressed here)

Tags and descriptions on **child** columns of a re-added column are still lost, and their
`tag_usage` rows are left orphaned:

- `updateColumns` hits `continue` for a re-added column before reaching the child recursion, so
  children are never carried forward.
- `deleteTagsByTarget` is `DELETE ... WHERE targetFQNHash = :targetFQNHash` — an exact match, with no
  prefix cascade — so a child's rows are never cleaned up either.

Observable effect: the tag keeps a non-zero `usageCount` while pointing at a column that no longer
resolves, and if a child column later reappears under the same FQN the tag resurrects. This is
pre-existing behaviour for any tagged nested column and is out of scope for this fix; it likely wants
its own issue.

