### PR TITLE
ci(playwright): fill impact-map gaps causing merge-queue ejections

### DIFF
--- a/.github/playwright/impact-map.json
+++ b/.github/playwright/impact-map.json
@@ -139,7 +139,7 @@
         "SearchRBAC"
       ],
       "specs": [
-        "playwright/e2e/Pages/Explore*.spec.ts",
+        "playwright/e2e/**/Explore*.spec.ts",
         "playwright/e2e/Features/*Search*.spec.ts",
         "playwright/e2e/Flow/*Search*.spec.ts",
         "playwright/e2e/Search/**/*.spec.ts",
@@ -333,13 +333,16 @@
     {
       "sources": [
         "openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/DomainsWidget/**",
-        "openmetadata-ui/src/main/resources/ui/src/components/DataAssets/AssetsSelectionModal/useAssetSelectionState.ts",
+        "openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/DataProductsWidget/**",
+        "openmetadata-ui/src/main/resources/ui/src/components/DataAssets/AssetsSelectionModal/**",
         "openmetadata-ui/src/main/resources/ui/src/rest/domainAPI.ts",
-        "openmetadata-ui/src/main/resources/ui/src/rest/queries/domainQuery.ts"
+        "openmetadata-ui/src/main/resources/ui/src/rest/queries/domainQuery.ts",
+        "openmetadata-ui/src/main/resources/ui/src/rest/dataProductAPI.ts"
       ],
       "projects": ["chromium", "Basic"],
       "specs": [
-        "playwright/e2e/Features/LandingPageWidgets/DomainDataProductsWidgets.spec.ts"
+        "playwright/e2e/Features/LandingPageWidgets/DomainDataProductsWidgets.spec.ts",
+        "playwright/e2e/Features/LandingPageWidgets/**/*.spec.ts"
       ]
     },
     {
@@ -632,6 +635,86 @@
         "playwright/e2e/Features/PersonaAIContextRules.spec.ts",
         "playwright/e2e/Features/PersonaAIContext.spec.ts",
         "playwright/e2e/Features/PersonaAIContextRuleCardAndStates.spec.ts"
+      ]
+    },
+    {
+      "_comment": "Metric page, custom-metric page, bulk-edit grid, and the CSV import/export machinery all funnel through this cluster. MetricBulkImportExportEdit + BulkImport + ClassificationImportExport have been ejecting PRs from the merge queue because none of them named these paths — PR CI skipped them entirely and the queue was the first place they ran. The two playwright helpers are included so a wait/selector fix in importUtils.ts also routes back to the specs that consume it.",
+      "sources": [
+        "openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/**",
+        "openmetadata-ui/src/main/resources/ui/src/pages/AddCustomMetricPage/**",
+        "openmetadata-ui/src/main/resources/ui/src/components/Metric/**",
+        "openmetadata-ui/src/main/resources/ui/src/components/BulkEditEntity/**",
+        "openmetadata-ui/src/main/resources/ui/src/rest/metricsAPI.ts",
+        "openmetadata-ui/src/main/resources/ui/src/rest/customMetricAPI.ts",
+        "openmetadata-ui/src/main/resources/ui/src/rest/importExportAPI.ts",
+        "openmetadata-ui/src/main/resources/ui/playwright/constant/bulkImportExport.ts",
+        "openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts"
+      ],
+      "projects": ["chromium", "ImportExport"],
+      "specs": [
+        "playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts",
+        "playwright/e2e/Features/CustomMetric.spec.ts",
+        "playwright/e2e/Features/BulkImport.spec.ts",
+        "playwright/e2e/Features/BulkImportWithDotInName.spec.ts",
+        "playwright/e2e/Features/BulkEditEntity.spec.ts",
+        "playwright/e2e/Features/BulkEditOperationBadges.spec.ts",
+        "playwright/e2e/Features/BulkEditImportPermissions.spec.ts",
+        "playwright/e2e/Features/ClassificationImportExport.spec.ts",
+        "playwright/e2e/Features/CsvJobsTray.spec.ts"
+      ]
+    },
+    {
+      "_comment": "Column bulk operations and column sorting exercise the ColumnBulkOperations page and columnAPI; keeps ColumnBulkOperationsTagsGlossary tied to both this and the Tag mapping above.",
+      "sources": [
+        "openmetadata-ui/src/main/resources/ui/src/pages/ColumnBulkOperations/**",
+        "openmetadata-ui/src/main/resources/ui/src/rest/columnAPI.ts"
+      ],
+      "projects": ["chromium"],
+      "specs": [
+        "playwright/e2e/Features/ColumnBulkOperations.spec.ts",
+        "playwright/e2e/Features/ColumnSorting.spec.ts",
+        "playwright/e2e/Features/ColumnBulkOperationsTagsGlossary.spec.ts"
+      ]
+    },
+    {
+      "_comment": "Customize pages (Details and AppMode sidebar) plus the customizable-widgets component tree feed the CustomizeDetailPage and CustomizeNavigation specs. Data Insight is included because the customize flow ships a data-insight preview.",
+      "sources": [
+        "openmetadata-ui/src/main/resources/ui/src/pages/CustomizeAppModeSidebarPage/**",
+        "openmetadata-ui/src/main/resources/ui/src/pages/CustomizeDetailsPage/**",
+        "openmetadata-ui/src/main/resources/ui/src/components/MyData/CustomizableComponents/**"
+      ],
+      "projects": ["chromium", "Data Insight"],
+      "specs": [
+        "playwright/e2e/Features/CustomizeDetailPage.spec.ts",
+        "playwright/e2e/Features/CustomizeNavigationNewItems.spec.ts"
+      ]
+    },
+    {
+      "_comment": "Container entity page. Container.spec.ts covers the storage-container details view and had no mapping before this entry.",
+      "sources": [
+        "openmetadata-ui/src/main/resources/ui/src/pages/ContainerPage/**",
+        "openmetadata-ui/src/main/resources/ui/src/components/Container/**"
+      ],
+      "projects": ["chromium"],
+      "specs": [
+        "playwright/e2e/Features/Container.spec.ts"
+      ]
+    },
+    {
+      "_comment": "AppMode covers the ai-shell / admin-shell split. Sources are spread across the AppModeSwitcher, the ai-shell platform tree (routing + sidebar), the Settings AppMode pages, and the appModeSession util. The generated appModePreference schema is included because a schema change ripples into every AppMode spec that reads a persisted preference.",
+      "sources": [
+        "openmetadata-ui/src/main/resources/ui/src/components/AppModeSwitcher/**",
+        "openmetadata-ui/src/main/resources/ui/src/components/platform/ai-shell/**",
+        "openmetadata-ui/src/main/resources/ui/src/pages/SettingsAppModePage/**",
+        "openmetadata-ui/src/main/resources/ui/src/pages/Settings/DefaultAppModePage/**",
+        "openmetadata-ui/src/main/resources/ui/src/pages/CustomizeAppModeSidebarPage/**",
+        "openmetadata-ui/src/main/resources/ui/src/utils/appModeSession.ts",
+        "openmetadata-ui/src/main/resources/ui/src/constants/appMode.constants.ts",
+        "openmetadata-ui/src/main/resources/ui/src/generated/api/teams/preferences/appModePreference.ts"
+      ],
+      "projects": ["chromium"],
+      "specs": [
+        "playwright/e2e/Features/AppMode/**/*.spec.ts"
       ]
     }
   ]


### PR DESCRIPTION
## Describe your changes

Hygiene pass on `.github/playwright/impact-map.json` to close the largest coverage gaps that keep causing merge-queue ejections. This is the follow-up to #32809 (which shipped the "unmapped code → full" safety net). Together, the safety net catches truly novel edits and this PR removes the specific cases where the safety net has to catch *known* specs.

### Coverage change

- Before: 252 / 362 specs mapped (71%, 111 uncovered)
- After: **280 / 362** specs mapped (77%, 83 uncovered)

The remaining 83 uncovered specs are the natural queue for either follow-up hygiene passes or the auto-generated map in the eventual Option B PR.

### Individual changes

**1. Metric / bulk-edit / CSV cluster — the biggest known miss.** New mapping from `pages/MetricsPage/**`, `pages/AddCustomMetricPage/**`, `components/Metric/**`, `components/BulkEditEntity/**`, `rest/metricsAPI.ts`, `rest/customMetricAPI.ts`, `rest/importExportAPI.ts`, plus the two playwright helpers (`constant/bulkImportExport.ts`, `utils/importUtils.ts`) → routes to 9 specs the merge queue has been discovering for us:

- MetricBulkImportExportEdit
- CustomMetric
- BulkImport / BulkImportWithDotInName
- BulkEditEntity / BulkEditOperationBadges / BulkEditImportPermissions
- ClassificationImportExport
- CsvJobsTray

An edit to `pages/MetricsPage/MetricsPage.tsx` now selects the 8 relevant specs (verified live), instead of falling through to canary + none of these.

**2. Column bulk operations.** `pages/ColumnBulkOperations/**` + `rest/columnAPI.ts` → ColumnBulkOperations, ColumnBulkOperationsTagsGlossary, ColumnSorting.

**3. Customize pages.** `pages/CustomizeAppModeSidebarPage/**`, `pages/CustomizeDetailsPage/**`, `components/MyData/CustomizableComponents/**` → CustomizeDetailPage + CustomizeNavigationNewItems.

**4. Container.** `pages/ContainerPage/**`, `components/Container/**` → Container.spec.ts.

**5. AppMode (whole AI-shell surface).** AppModeSwitcher, platform/ai-shell (routing + sidebar), SettingsAppModePage, DefaultAppModePage, CustomizeAppModeSidebarPage, appModeSession util, appMode constants, and the generated appModePreference schema → Features/AppMode/**/*.spec.ts (8 specs).

**6. Broaden Explore glob** from `Pages/Explore*.spec.ts` to `**/Explore*.spec.ts`. Adds the 5 Features/Explore* specs (Composition, QueryBar, QuickFilters, SortOrder, UrlState) and 2 Flow/Explore* specs that were previously skipped for any `components/Explore/**` change.

**7. Broaden DomainDataProductsWidgets mapping.** Adds `Widgets/DataProductsWidget/**`, the whole `DataAssets/AssetsSelectionModal/**` folder (was one file), and `rest/dataProductAPI.ts`. Spec pattern expanded from a single file to the whole `LandingPageWidgets/` folder.

## Type of change

- [x] CI change (no product code touched)

## Tests

- All 94 planner unit tests still pass — none needed a change because the additions are pure JSON.
- Live simulations against the new map:

  ```
  # MetricsPage edit → 15 targeted specs including all 8 Metric/Bulk/Classification ones
  $ echo "openmetadata-ui/…/pages/MetricsPage/MetricsPage.tsx" > /tmp/changed
  $ python3 .github/scripts/select_playwright_tests.py --event-name pull_request …
  { "mode": "targeted", "unmappedChange": false, "selected_count": 15, "metric_specs_selected": [
      "BulkEditEntity", "BulkEditImportPermissions", "BulkEditOperationBadges",
      "BulkImport", "BulkImportWithDotInName", "ClassificationImportExport",
      "CustomMetric", "MetricBulkImportExportEdit"
  ] }

  # dataProductAPI.ts edit → all 4 LandingPage widget specs picked up
  # Explore.tsx edit → 13 Explore specs across Pages/, Features/, Flow/
  ```

## Not addressed here

- 83 specs are still uncovered. The heavy hitters remaining are Announcements, BlockEditor, ChangeSummaryBadge, DescriptionSuggestion, EntityRename*, ExpandableCard, and a long tail of Feature-flag-adjacent specs. Adding source→spec entries by hand is O(hours) per batch and lossy; the durable fix is Option B (auto-generate the map from the TS import graph) which I'll open next.
- I intentionally did **not** promote `generated/**` or `components/common/**` into `sharedInfrastructure`. That would trigger the canary slice for every schema/common-component change on top of the specific mapping — worth doing but a policy call to make separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)