### PR TITLE
Backport #32578 to 2.0: fix Airflow lineage for dynamically mapped tasks

### DIFF
--- a/ingestion/src/metadata/ingestion/source/pipeline/airflow/models.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/airflow/models.py
@@ -16,7 +16,7 @@ Tableau Source Model module
 from datetime import datetime
 from typing import Any, List, Optional  # noqa: UP035
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class AirflowBaseModel(BaseModel):
@@ -47,6 +47,24 @@ class AirflowTask(BaseModel):
 
     # Allow picking up data from key `inlets` and `_inlets`
     model_config = ConfigDict(populate_by_name=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def lift_mapped_xlets(cls, data: Any) -> Any:
+        """
+        A dynamically mapped task (`.partial(...).expand(...)`) serializes its
+        inlets and outlets inside `partial_kwargs` instead of at the top level.
+        """
+        if not isinstance(data, dict):
+            return data
+        partial_kwargs = data.get("partial_kwargs")
+        if not isinstance(partial_kwargs, dict):
+            return data
+        lifted = dict(data)
+        for key in ("inlets", "outlets"):
+            if not lifted.get(key) and not lifted.get(f"_{key}") and partial_kwargs.get(key):
+                lifted[key] = partial_kwargs[key]
+        return lifted
 
 
 class TaskList(BaseModel):

--- a/ingestion/tests/unit/topology/pipeline/test_airflow.py
+++ b/ingestion/tests/unit/topology/pipeline/test_airflow.py
@@ -233,6 +233,42 @@ class TestAirflow(TestCase):
             ],
         )
 
+    def test_parsing_mapped_task_xlets(self):
+        mapped_task = {
+            "task_id": "mapped",
+            "_is_mapped": True,
+            "_task_type": "EmptyOperator",
+            "partial_kwargs": {
+                "inlets": [
+                    {
+                        "__var": {"tables": ["my_service.my_database.my_schema.input_table"]},
+                        "__type": "dict",
+                    }
+                ],
+                "outlets": [
+                    {
+                        "__var": {"tables": ["my_service.my_database.my_schema.output_table"]},
+                        "__type": "dict",
+                    }
+                ],
+            },
+        }
+
+        task = AirflowTask(**mapped_task)
+
+        assert task.inlets == mapped_task["partial_kwargs"]["inlets"]
+        assert task.outlets == mapped_task["partial_kwargs"]["outlets"]
+
+    def test_parsing_top_level_xlets_win_over_partial_kwargs(self):
+        task = AirflowTask(
+            task_id="plain",
+            _outlets=[{"__var": {"tables": ["a.b.c.d"]}, "__type": "dict"}],
+            partial_kwargs={"outlets": [{"__var": {"tables": ["w.x.y.z"]}, "__type": "dict"}]},
+        )
+
+        assert task.outlets == [{"__var": {"tables": ["a.b.c.d"]}, "__type": "dict"}]
+        assert task.inlets is None
+
     def test_get_dag_owners(self):
         """Test DAG owner extraction from tasks"""
         data = SERIALIZED_DAG["dag"]


### PR DESCRIPTION
### Describe your changes:

Backport of #32578 to `2.0`. Relates to #32577; the issue was closed by the main-branch PR.

Airflow serializes `inlets` and `outlets` for dynamically mapped tasks inside `partial_kwargs`. `AirflowTask` only reads top-level keys on this branch, so mapped tasks produce no lineage edges.

This backport lifts the mapped-task values only when top-level `inlets`/`_inlets` or `outlets`/`_outlets` are empty. Explicit top-level values continue to win.

Applied manually because the release branch retains older typing syntax. The behavior and regression coverage match #32578. Validated against the Airflow 3.3.1 serializer and Pydantic 2.12.5 used by this branch.
