### PR TITLE
fix(grafana): backport collapsed-row panel ingestion to 1.13

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/grafana/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/grafana/metadata.py
@@ -11,8 +11,10 @@
 """
 Grafana source module
 """
+
 import traceback
-from typing import Dict, Iterable, List, Optional, Set
+from collections.abc import Iterable
+from typing import cast
 
 from metadata.generated.schema.api.data.createChart import CreateChartRequest
 from metadata.generated.schema.api.data.createDashboard import CreateDashboardRequest
@@ -45,7 +47,9 @@ from metadata.ingestion.lineage.models import ConnectionTypeDialectMapper, Diale
 from metadata.ingestion.lineage.parser import LineageParser
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.dashboard.dashboard_service import DashboardServiceSource
-from metadata.ingestion.source.dashboard.grafana.client import GrafanaApiClient
+from metadata.ingestion.source.dashboard.grafana.client import (  # noqa: TC001
+    GrafanaApiClient,
+)
 from metadata.ingestion.source.dashboard.grafana.models import (
     GrafanaDashboardResponse,
     GrafanaDatasource,
@@ -77,18 +81,18 @@ class GrafanaSource(DashboardServiceSource):
         metadata: OpenMetadata,
     ):
         super().__init__(config, metadata)
-        self.client: GrafanaApiClient = self.connection_obj
-        self.folders: List[GrafanaFolder] = []
-        self.datasources: Dict[str, GrafanaDatasource] = {}
-        self.dashboards: List[GrafanaSearchResult] = []
-        self.tags: Set[str] = set()
+        self.client: GrafanaApiClient = cast("GrafanaApiClient", self.client)
+        self.folders: list[GrafanaFolder] = []
+        self.datasources: dict[str, GrafanaDatasource] = {}
+        self.dashboards: list[GrafanaSearchResult] = []
+        self.tags: set[str] = set()
 
     @classmethod
     def create(
         cls,
         config_dict: dict,
         metadata: OpenMetadata,
-        pipeline_name: Optional[str] = None,
+        pipeline_name: str | None = None,
     ):
         config: WorkflowSource = WorkflowSource.model_validate(config_dict)
         connection: GrafanaConnection = config.serviceConnection.root.config
@@ -107,32 +111,30 @@ class GrafanaSource(DashboardServiceSource):
         for ds in datasources:
             self.datasources[ds.uid] = ds
             self.datasources[ds.name] = ds
-        logger.info(f"Found {len(datasources)} datasources")
+        logger.info("Found %s datasources", len(datasources))
 
-    def get_dashboards_list(self) -> Optional[List[dict]]:
+    def get_dashboards_list(self) -> list[dict] | None:
         """Get list of dashboards"""
         dashboards_list = self.client.search_dashboards()
-        return dashboards_list
+        return dashboards_list  # noqa: RET504
 
     def get_dashboard_name(self, dashboard: dict) -> str:
         """Get dashboard name"""
         return dashboard.uid
 
-    def get_dashboard_details(
-        self, dashboard: dict
-    ) -> Optional[GrafanaDashboardResponse]:
+    def get_dashboard_details(self, dashboard: dict) -> GrafanaDashboardResponse | None:
         """Get detailed dashboard information"""
         try:
             return self.client.get_dashboard(dashboard.uid)
         except Exception as exc:
             logger.warning(
-                f"Failed to get dashboard details for {dashboard['uid']}: {exc}"
+                "Failed to get dashboard details for %s: %s", dashboard["uid"], exc
             )
             return None
 
     def get_owner_ref(
         self, dashboard_details: GrafanaDashboardResponse
-    ) -> Optional[EntityReferenceList]:
+    ) -> EntityReferenceList | None:
         """Get owner reference from dashboard metadata"""
         try:
             if dashboard_details.meta.createdBy:
@@ -141,7 +143,7 @@ class GrafanaSource(DashboardServiceSource):
                     dashboard_details.meta.createdBy
                 )
         except Exception as err:
-            logger.debug(f"Could not fetch owner data: {err}")
+            logger.debug("Could not fetch owner data: %s", err)
         return None
 
     def yield_dashboard(
@@ -196,6 +198,25 @@ class GrafanaSource(DashboardServiceSource):
                 )
             )
 
+    @staticmethod
+    def _flatten_panels(
+        panels: list[GrafanaPanel],
+    ) -> list[GrafanaPanel]:
+        """Flatten top-level panels, recursing into collapsed row panels.
+
+        When a Grafana row is collapsed the API moves child panels from the
+        top-level ``dashboard.panels`` list into the row panel's own ``panels``
+        field.  Expanded rows keep their children at the top level, so in that
+        case the row's ``panels`` list is empty and nothing extra is yielded.
+        """
+        result: list[GrafanaPanel] = []
+        for panel in panels or []:
+            if panel.type == "row" and panel.collapsed and panel.panels:
+                result.extend(panel.panels)
+            else:
+                result.append(panel)
+        return result
+
     def yield_dashboard_chart(
         self, dashboard_details: GrafanaDashboardResponse
     ) -> Iterable[Either[CreateChartRequest]]:
@@ -203,7 +224,7 @@ class GrafanaSource(DashboardServiceSource):
         if not dashboard_details.dashboard.panels:
             return
 
-        for panel in dashboard_details.dashboard.panels:
+        for panel in self._flatten_panels(dashboard_details.dashboard.panels):
             try:
                 # Skip row panels and panels without visualizations
                 if panel.type in ["row", "text"]:
@@ -253,7 +274,7 @@ class GrafanaSource(DashboardServiceSource):
     def yield_dashboard_lineage_details(
         self,
         dashboard_details: GrafanaDashboardResponse,
-        db_service_prefix: Optional[str] = None,
+        db_service_prefix: str | None = None,
     ) -> Iterable[Either[AddLineageRequest]]:
         """
         Get lineage between dashboard and data sources
@@ -276,8 +297,8 @@ class GrafanaSource(DashboardServiceSource):
             if not to_entity:
                 return
 
-            # Extract lineage from panels
-            for panel in dashboard_details.dashboard.panels:
+            # Extract lineage from panels (including those inside collapsed rows)
+            for panel in self._flatten_panels(dashboard_details.dashboard.panels):
                 if not panel.targets:
                     continue
 
@@ -303,7 +324,7 @@ class GrafanaSource(DashboardServiceSource):
         target: GrafanaTarget,
         panel: GrafanaPanel,
         to_entity: LineageDashboard,
-        db_service_prefix: Optional[str] = None,
+        db_service_prefix: str | None = None,
     ) -> Iterable[Either[AddLineageRequest]]:
         """Process lineage for a single panel target"""
         try:
@@ -406,36 +427,36 @@ class GrafanaSource(DashboardServiceSource):
 
         except Exception as exc:
             hash_prefix = f"[{query_hash}] " if "query_hash" in locals() else ""
-            logger.debug(f"{hash_prefix}Error processing panel lineage: {exc}")
+            logger.debug("%sError processing panel lineage: %s", hash_prefix, exc)
             logger.error(traceback.format_exc())
 
     def _extract_datasource_name(
         self, target: GrafanaTarget, panel: GrafanaPanel
-    ) -> Optional[str]:
+    ) -> str | None:
         """Extract datasource name from target or panel"""
         try:
             # Try target datasource first
             if target.datasource:
                 if isinstance(target.datasource, str):
                     return target.datasource
-                elif isinstance(target.datasource, dict):
+                elif isinstance(target.datasource, dict):  # noqa: RET505
                     return target.datasource.get("uid") or target.datasource.get("type")
 
             # Fall back to panel datasource
             if panel.datasource:
                 if isinstance(panel.datasource, str):
                     return panel.datasource
-                elif isinstance(panel.datasource, dict):
+                elif isinstance(panel.datasource, dict):  # noqa: RET505
                     return panel.datasource.get("uid") or panel.datasource.get("type")
 
-            return None
+            return None  # noqa: TRY300
         except Exception as exc:
-            logger.debug(f"Error extracting datasource name: {exc}")
+            logger.debug("Error extracting datasource name: %s", exc)
             return None
 
     def _extract_sql_query(
         self, target: GrafanaTarget, datasource: GrafanaDatasource
-    ) -> Optional[str]:
+    ) -> str | None:
         """Extract SQL query from target based on datasource type"""
         try:
             # Handle different datasource types
@@ -446,14 +467,14 @@ class GrafanaSource(DashboardServiceSource):
                 "clickhouse",
             ]:
                 return target.rawSql or target.query
-            elif datasource.type in ["prometheus", "elasticsearch"]:
+            elif datasource.type in ["prometheus", "elasticsearch"]:  # noqa: RET505
                 # Prometheus and Elasticsearch queries aren't SQL
                 return None
             else:
                 # Try generic query field
                 return target.query
         except Exception as exc:
-            logger.debug(f"Error extracting SQL query: {exc}")
+            logger.debug("Error extracting SQL query: %s", exc)
             return None
 
     def _map_panel_type_to_chart_type(self, panel_type: str) -> str:

--- a/ingestion/src/metadata/ingestion/source/dashboard/grafana/models.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/grafana/models.py
@@ -11,8 +11,9 @@
 """
 Grafana API response models
 """
+
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -21,9 +22,9 @@ class GrafanaUser(BaseModel):
     """Grafana user model"""
 
     id: int
-    email: Optional[str] = None
-    name: Optional[str] = None
-    login: Optional[str] = None
+    email: str | None = None
+    name: str | None = None
+    login: str | None = None
 
 
 class GrafanaFolder(BaseModel):
@@ -32,39 +33,39 @@ class GrafanaFolder(BaseModel):
     id: int
     uid: str
     title: str
-    url: Optional[str] = None
-    type: Optional[str] = None
-    tags: Optional[List[str]] = None
-    created: Optional[datetime] = None
-    updated: Optional[datetime] = None
-    createdBy: Optional[str] = None
-    updatedBy: Optional[str] = None
-    version: Optional[int] = None
+    url: str | None = None
+    type: str | None = None
+    tags: list[str] | None = None
+    created: datetime | None = None
+    updated: datetime | None = None
+    createdBy: str | None = None  # noqa: N815
+    updatedBy: str | None = None  # noqa: N815
+    version: int | None = None
 
 
 class GrafanaDatasource(BaseModel):
     """Grafana datasource model"""
 
-    id: Optional[int] = None
-    uid: Optional[str] = None
+    id: int | None = None
+    uid: str | None = None
     name: str
     type: str
-    url: Optional[str] = None
-    database: Optional[str] = None
-    isDefault: Optional[bool] = None
-    jsonData: Optional[Dict[str, Any]] = None
+    url: str | None = None
+    database: str | None = None
+    isDefault: bool | None = None  # noqa: N815
+    jsonData: dict[str, Any] | None = None  # noqa: N815
 
 
 class GrafanaTarget(BaseModel):
     """Grafana panel target/query model"""
 
-    refId: Optional[str] = None
-    datasource: Optional[Union[str, Dict[str, Any]]] = None
-    rawSql: Optional[str] = None
-    query: Optional[str] = None
-    expr: Optional[str] = None  # For Prometheus queries
-    format: Optional[Any] = None
-    hide: Optional[bool] = False
+    refId: str | None = None  # noqa: N815
+    datasource: str | dict[str, Any] | None = None
+    rawSql: str | None = None  # noqa: N815
+    query: str | None = None
+    expr: str | None = None  # For Prometheus queries
+    format: Any | None = None
+    hide: bool | None = False
 
 
 class GrafanaPanel(BaseModel):
@@ -72,66 +73,71 @@ class GrafanaPanel(BaseModel):
 
     id: int
     type: str
-    title: Optional[str] = None
-    description: Optional[str] = None
-    datasource: Optional[Union[str, Dict[str, Any]]] = None
-    targets: Optional[List[GrafanaTarget]] = Field(default_factory=list)
-    gridPos: Optional[Dict[str, int]] = None
-    options: Optional[Dict[str, Any]] = None
-    fieldConfig: Optional[Dict[str, Any]] = None
-    transparent: Optional[bool] = None
-    pluginVersion: Optional[str] = None
+    title: str | None = None
+    description: str | None = None
+    datasource: str | dict[str, Any] | None = None
+    targets: list[GrafanaTarget] | None = Field(default_factory=list)
+    gridPos: dict[str, int] | None = None  # noqa: N815
+    options: dict[str, Any] | None = None
+    fieldConfig: dict[str, Any] | None = None  # noqa: N815
+    transparent: bool | None = None
+    pluginVersion: str | None = None  # noqa: N815
+    collapsed: bool | None = None
+    panels: list["GrafanaPanel"] | None = Field(default_factory=list)
+
+
+GrafanaPanel.model_rebuild()
 
 
 class GrafanaDashboard(BaseModel):
     """Grafana dashboard model"""
 
-    id: Optional[int] = None
+    id: int | None = None
     uid: str
     title: str
-    tags: Optional[List[str]] = Field(default_factory=list)
-    style: Optional[str] = None
-    timezone: Optional[str] = None
-    panels: Optional[List[GrafanaPanel]] = Field(default_factory=list)
-    editable: Optional[bool] = None
-    time: Optional[Dict[str, Any]] = None
-    timepicker: Optional[Dict[str, Any]] = None
-    templating: Optional[Dict[str, Any]] = None
-    annotations: Optional[Dict[str, Any]] = None
-    refresh: Optional[Union[str, bool]] = None
-    schemaVersion: Optional[int] = None
-    version: Optional[int] = None
-    description: Optional[str] = None
-    gnetId: Optional[Any] = None
-    links: Optional[List[Dict[str, Any]]] = None
+    tags: list[str] | None = Field(default_factory=list)
+    style: str | None = None
+    timezone: str | None = None
+    panels: list[GrafanaPanel] | None = Field(default_factory=list)
+    editable: bool | None = None
+    time: dict[str, Any] | None = None
+    timepicker: dict[str, Any] | None = None
+    templating: dict[str, Any] | None = None
+    annotations: dict[str, Any] | None = None
+    refresh: str | bool | None = None
+    schemaVersion: int | None = None  # noqa: N815
+    version: int | None = None
+    description: str | None = None
+    gnetId: Any | None = None  # noqa: N815
+    links: list[dict[str, Any]] | None = None
 
 
 class GrafanaDashboardMeta(BaseModel):
     """Grafana dashboard metadata model"""
 
     type: str
-    canSave: bool
-    canEdit: bool
-    canAdmin: bool
-    canStar: bool
-    canDelete: bool
+    canSave: bool  # noqa: N815
+    canEdit: bool  # noqa: N815
+    canAdmin: bool  # noqa: N815
+    canStar: bool  # noqa: N815
+    canDelete: bool  # noqa: N815
     slug: str
     url: str
-    expires: Optional[datetime] = None
-    created: Optional[datetime] = None
-    updated: Optional[datetime] = None
-    updatedBy: Optional[str] = None
-    createdBy: Optional[str] = None
-    version: Optional[int] = None
-    hasAcl: Optional[bool] = None
-    isFolder: Optional[bool] = None
-    folderId: Optional[int] = None
-    folderUid: Optional[str] = None
-    folderTitle: Optional[str] = None
-    folderUrl: Optional[str] = None
-    provisioned: Optional[bool] = None
-    provisionedExternalId: Optional[str] = None
-    annotationsPermissions: Optional[Dict[str, Any]] = None
+    expires: datetime | None = None
+    created: datetime | None = None
+    updated: datetime | None = None
+    updatedBy: str | None = None  # noqa: N815
+    createdBy: str | None = None  # noqa: N815
+    version: int | None = None
+    hasAcl: bool | None = None  # noqa: N815
+    isFolder: bool | None = None  # noqa: N815
+    folderId: int | None = None  # noqa: N815
+    folderUid: str | None = None  # noqa: N815
+    folderTitle: str | None = None  # noqa: N815
+    folderUrl: str | None = None  # noqa: N815
+    provisioned: bool | None = None
+    provisionedExternalId: str | None = None  # noqa: N815
+    annotationsPermissions: dict[str, Any] | None = None  # noqa: N815
 
 
 class GrafanaDashboardResponse(BaseModel):
@@ -151,9 +157,9 @@ class GrafanaSearchResult(BaseModel):
     url: str
     slug: str
     type: str  # "dash-db" for dashboards, "dash-folder" for folders
-    tags: Optional[List[str]] = Field(default_factory=list)
-    isStarred: bool
-    folderId: Optional[int] = None
-    folderUid: Optional[str] = None
-    folderTitle: Optional[str] = None
-    folderUrl: Optional[str] = None
+    tags: list[str] | None = Field(default_factory=list)
+    isStarred: bool  # noqa: N815
+    folderId: int | None = None  # noqa: N815
+    folderUid: str | None = None  # noqa: N815
+    folderTitle: str | None = None  # noqa: N815
+    folderUrl: str | None = None  # noqa: N815

--- a/ingestion/tests/unit/topology/dashboard/test_grafana.py
+++ b/ingestion/tests/unit/topology/dashboard/test_grafana.py
@@ -14,7 +14,6 @@ Test Grafana Dashboard using the topology
 """
 
 import uuid
-from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -34,9 +33,6 @@ from metadata.generated.schema.entity.services.databaseService import (
     DatabaseConnection,
     DatabaseService,
     DatabaseServiceType,
-)
-from metadata.generated.schema.metadataIngestion.workflow import (
-    OpenMetadataWorkflowConfig,
 )
 from metadata.generated.schema.type.basic import (
     EntityName,
@@ -220,7 +216,7 @@ MOCK_PANELS = [
     ),
     GrafanaPanel(
         id=4,
-        type="row",  # Should be skipped
+        type="row",  # expanded row — no nested panels, skipped by consumer
         title="Row Panel",
     ),
 ]
@@ -285,8 +281,8 @@ EXPECTED_DASHBOARD = CreateDashboardRequest(
     ),
     charts=[],
     service=FullyQualifiedEntityName("mock_grafana"),
-    tags=[],  # Tags would be added if tag creation was mocked
-    owners=None,  # Would be set if owner lookup was mocked
+    tags=[],
+    owners=None,
 )
 
 EXPECTED_CHARTS = [
@@ -322,100 +318,157 @@ EXPECTED_CHARTS = [
     ),
 ]
 
-
-class GrafanaUnitTest(TestCase):
-    """
-    Implements the necessary unit tests for the Grafana Dashboard connector
-    """
-
-    @patch(
-        "metadata.ingestion.source.dashboard.dashboard_service.DashboardServiceSource.test_connection"
-    )
-    @patch("metadata.ingestion.source.dashboard.grafana.connection.get_connection")
-    def __init__(self, methodName, get_connection, test_connection) -> None:
-        super().__init__(methodName)
-        # Mock the connection to return a mock client
-        mock_client = MagicMock()
-        mock_client.get_folders.return_value = MOCK_FOLDERS
-        mock_client.search_dashboards.return_value = MOCK_SEARCH_RESULTS
-        mock_client.get_dashboard.return_value = MOCK_DASHBOARD_RESPONSE
-        mock_client.get_datasources.return_value = MOCK_DATASOURCES
-        get_connection.return_value = mock_client
-        test_connection.return_value = False
-
-        self.config = OpenMetadataWorkflowConfig.model_validate(mock_config)
-        # Mock OpenMetadata client to avoid connection attempts
-        with patch("metadata.ingestion.ometa.ometa_api.OpenMetadata") as mock_om:
-            mock_metadata = MagicMock()
-            mock_metadata.get_by_name.return_value = None
-            mock_metadata.get_reference_by_email.return_value = None
-            mock_om.return_value = mock_metadata
-
-            self.grafana: GrafanaSource = GrafanaSource.create(
-                mock_config["source"],
-                mock_metadata,
+# ---------------------------------------------------------------------------
+# Collapsed-row fixtures
+# Two charts nested inside a collapsed row panel (id=20).
+# ---------------------------------------------------------------------------
+MOCK_COLLAPSED_PANELS = [
+    GrafanaPanel(
+        id=21,
+        type="graph",
+        title="Nested Chart A",
+        datasource={"uid": "postgres-uid", "type": "postgres"},
+        targets=[
+            GrafanaTarget(
+                refId="A",
+                datasource={"uid": "postgres-uid", "type": "postgres"},
+                rawSql="SELECT date_trunc('day', ts) AS day, SUM(amount) FROM orders GROUP BY 1",
             )
+        ],
+    ),
+    GrafanaPanel(
+        id=22,
+        type="table",
+        title="Nested Chart B",
+        datasource={"uid": "postgres-uid", "type": "postgres"},
+        targets=[
+            GrafanaTarget(
+                refId="A",
+                datasource={"uid": "postgres-uid", "type": "postgres"},
+                rawSql="SELECT product_id, SUM(qty) FROM order_items GROUP BY 1",
+            )
+        ],
+    ),
+]
 
-        # Mock the client
-        self.grafana.client = MagicMock()
-        self.grafana.client.get_folders.return_value = MOCK_FOLDERS
-        self.grafana.client.search_dashboards.return_value = MOCK_SEARCH_RESULTS
-        self.grafana.client.get_dashboard.return_value = MOCK_DASHBOARD_RESPONSE
-        self.grafana.client.get_datasources.return_value = MOCK_DATASOURCES
+MOCK_COLLAPSED_ROW = GrafanaPanel(
+    id=20,
+    type="row",
+    title="Hidden Metrics",
+    collapsed=True,
+    panels=MOCK_COLLAPSED_PANELS,
+)
 
-        # Set up context
-        self.grafana.context.get().__dict__[
-            "dashboard_service"
-        ] = MOCK_DASHBOARD_SERVICE.fullyQualifiedName.root
-        self.grafana.context.get().__dict__["charts"] = []
+# Dashboard whose top-level panels include an expanded row (id=4, no children)
+# and a collapsed row (id=20) that wraps two charts.
+MOCK_DASHBOARD_WITH_COLLAPSED_ROW = GrafanaDashboardResponse(
+    dashboard=GrafanaDashboard(
+        id=2,
+        uid="test-dashboard-uid",
+        title="Test Dashboard",
+        tags=["production"],
+        panels=[
+            MOCK_PANELS[0],  # graph  (id=1)
+            MOCK_PANELS[1],  # table  (id=2)
+            MOCK_PANELS[3],  # expanded row (id=4) — kept as-is, skipped by consumer
+            MOCK_COLLAPSED_ROW,  # collapsed row (id=20) → exposes charts 21 and 22
+        ],
+        description="Test with collapsed rows",
+        version=6,
+    ),
+    meta=MOCK_DASHBOARD_RESPONSE.meta,
+)
+
+
+class TestGrafana:
+    """Unit tests for the Grafana dashboard connector."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        with (
+            patch(
+                "metadata.ingestion.source.dashboard.dashboard_service.DashboardServiceSource.test_connection"
+            ),
+            patch(
+                "metadata.ingestion.source.dashboard.grafana.connection.get_connection"
+            ) as get_connection,
+        ):
+            mock_client = MagicMock()
+            mock_client.get_folders.return_value = MOCK_FOLDERS
+            mock_client.search_dashboards.return_value = MOCK_SEARCH_RESULTS
+            mock_client.get_dashboard.return_value = MOCK_DASHBOARD_RESPONSE
+            mock_client.get_datasources.return_value = MOCK_DATASOURCES
+            get_connection.return_value = mock_client
+
+            with patch("metadata.ingestion.ometa.ometa_api.OpenMetadata") as mock_om:
+                mock_metadata = MagicMock()
+                mock_metadata.get_by_name.return_value = None
+                mock_metadata.get_reference_by_email.return_value = None
+                mock_om.return_value = mock_metadata
+
+                self.grafana: GrafanaSource = GrafanaSource.create(
+                    mock_config["source"],
+                    mock_metadata,
+                )
+
+            self.grafana.client = MagicMock()
+            self.grafana.client.get_folders.return_value = MOCK_FOLDERS
+            self.grafana.client.search_dashboards.return_value = MOCK_SEARCH_RESULTS
+            self.grafana.client.get_dashboard.return_value = MOCK_DASHBOARD_RESPONSE
+            self.grafana.client.get_datasources.return_value = MOCK_DATASOURCES
+
+            self.grafana.context.get().__dict__[
+                "dashboard_service"
+            ] = MOCK_DASHBOARD_SERVICE.fullyQualifiedName.root
+            self.grafana.context.get().__dict__["charts"] = []
+
+            yield
+
+    # -----------------------------------------------------------------------
+    # Core connector tests
+    # -----------------------------------------------------------------------
 
     def test_prepare(self):
-        """Test prepare method fetches folders, dashboards, and datasources"""
+        """Test prepare method fetches folders, dashboards, and datasources."""
         self.grafana.prepare()
 
-        # Check that data was fetched
-        # prepare only loads datasources at the moment
-        self.assertEqual(len(self.grafana.folders), 0)
-        self.assertEqual(len(self.grafana.dashboards), 0)
+        assert len(self.grafana.folders) == 0
+        assert len(self.grafana.dashboards) == 0
         # We store datasources by both UID and name, so 2 datasources = 4 entries
-        self.assertEqual(len(self.grafana.datasources), 4)
-        self.assertIn("PostgreSQL", self.grafana.datasources)
-        # Tags aggregation currently not performed in prepare
-        self.assertEqual(len(getattr(self.grafana, "tags", set())), 0)
+        assert len(self.grafana.datasources) == 4
+        assert "PostgreSQL" in self.grafana.datasources
+        assert len(getattr(self.grafana, "tags", set())) == 0
 
     def test_get_dashboard_name(self):
-        """Test dashboard name extraction"""
-        # Pass an object with attribute uid as expected by source
+        """Test dashboard name extraction."""
         dashboard = MagicMock()
         dashboard.uid = "test-uid"
-        self.assertEqual(self.grafana.get_dashboard_name(dashboard), "test-uid")
+        assert self.grafana.get_dashboard_name(dashboard) == "test-uid"
 
     def test_get_dashboard_details(self):
-        """Test fetching dashboard details"""
-        # Pass an object with attribute uid as expected by source
+        """Test fetching dashboard details."""
         dashboard = MagicMock()
         dashboard.uid = "test-dashboard-uid"
         details = self.grafana.get_dashboard_details(dashboard)
-        self.assertIsNotNone(details)
-        self.assertEqual(details.dashboard.uid, "test-dashboard-uid")
+        assert details is not None
+        assert details.dashboard.uid == "test-dashboard-uid"
 
     def test_yield_dashboard(self):
-        """Test dashboard creation"""
+        """Test dashboard creation."""
         results = list(self.grafana.yield_dashboard(MOCK_DASHBOARD_RESPONSE))
 
-        self.assertEqual(len(results), 1)
-        self.assertIsInstance(results[0], Either)
+        assert len(results) == 1
+        assert isinstance(results[0], Either)
 
         dashboard = results[0].right
-        self.assertEqual(dashboard.name, EntityName("test-dashboard-uid"))
-        # Current implementation does not prefix folder title in display name
-        self.assertEqual(dashboard.displayName, "Test Dashboard")
-        self.assertEqual(dashboard.description, Markdown("Test dashboard description"))
-        self.assertIn("/d/test-dashboard-uid/test-dashboard", dashboard.sourceUrl.root)
-        self.assertEqual(dashboard.service, FullyQualifiedEntityName("mock_grafana"))
+        assert dashboard.name == EntityName("test-dashboard-uid")
+        assert dashboard.displayName == "Test Dashboard"
+        assert dashboard.description == Markdown("Test dashboard description")
+        assert "/d/test-dashboard-uid/test-dashboard" in dashboard.sourceUrl.root
+        assert dashboard.service == FullyQualifiedEntityName("mock_grafana")
 
     def test_yield_dashboard_without_folder(self):
-        """Test dashboard creation without folder"""
+        """Test dashboard creation without folder."""
         dashboard_response = GrafanaDashboardResponse(
             dashboard=MOCK_DASHBOARD_RESPONSE.dashboard,
             meta=GrafanaDashboardMeta(
@@ -425,29 +478,108 @@ class GrafanaUnitTest(TestCase):
 
         results = list(self.grafana.yield_dashboard(dashboard_response))
         dashboard = results[0].right
-        self.assertEqual(dashboard.displayName, "Test Dashboard")  # No folder prefix
+        assert dashboard.displayName == "Test Dashboard"
+
+    # -----------------------------------------------------------------------
+    # Chart ingestion — expanded-row regression + collapsed-row behaviour
+    # -----------------------------------------------------------------------
 
     def test_yield_dashboard_chart(self):
-        """Test chart extraction from panels"""
-        chart_list = []
-        results = self.grafana.yield_dashboard_chart(MOCK_DASHBOARD_RESPONSE)
+        """Flat panels are yielded; expanded row panels (type='row') are skipped."""
+        charts = [
+            r.right
+            for r in self.grafana.yield_dashboard_chart(MOCK_DASHBOARD_RESPONSE)
+            if r.right
+        ]
 
-        for result in results:
-            if isinstance(result, Either) and result.right:
-                chart_list.append(result.right)
+        # Panels 1, 2, 3 → charts; panel 4 (expanded row) → skipped
+        assert len(charts) == 3
 
-        # Should have 3 charts (row panel is skipped)
-        self.assertEqual(len(chart_list), 3)
+        for expected, actual in zip(EXPECTED_CHARTS, charts, strict=False):
+            assert expected.name == actual.name
+            assert expected.displayName == actual.displayName
+            assert expected.chartType == actual.chartType
+            assert expected.service == actual.service
 
-        # Verify chart details
-        for expected, actual in zip(EXPECTED_CHARTS, chart_list):
-            self.assertEqual(expected.name, actual.name)
-            self.assertEqual(expected.displayName, actual.displayName)
-            self.assertEqual(expected.chartType, actual.chartType)
-            self.assertEqual(expected.service, actual.service)
+    def test_yield_dashboard_chart_expanded_row_is_not_yielded(self):
+        """Regression: expanded row panels are never surfaced as charts."""
+        charts = [
+            r.right
+            for r in self.grafana.yield_dashboard_chart(MOCK_DASHBOARD_RESPONSE)
+            if r.right
+        ]
+        names = {c.name.root for c in charts}
+        assert "test-dashboard-uid_4" not in names
+
+    def test_yield_dashboard_chart_collapsed_row_panels_are_yielded(self):
+        """Charts nested inside a collapsed row are yielded; the row wrapper is not."""
+        charts = [
+            r.right
+            for r in self.grafana.yield_dashboard_chart(
+                MOCK_DASHBOARD_WITH_COLLAPSED_ROW
+            )
+            if r.right
+        ]
+        names = {c.name.root for c in charts}
+
+        # Nested panels from the collapsed row must appear.
+        assert (
+            "test-dashboard-uid_21" in names
+        ), "Panel 21 nested in collapsed row must be yielded"
+        assert (
+            "test-dashboard-uid_22" in names
+        ), "Panel 22 nested in collapsed row must be yielded"
+
+        # Neither the collapsed-row wrapper nor the expanded row must appear as a chart.
+        assert (
+            "test-dashboard-uid_20" not in names
+        ), "Collapsed row wrapper must not appear as a chart"
+        assert (
+            "test-dashboard-uid_4" not in names
+        ), "Expanded row must not appear as a chart"
+
+        # Total: panels 1 and 2 from MOCK_PANELS plus panels 21 and 22 from collapsed row = 4
+        assert len(charts) == 4
+
+    # -----------------------------------------------------------------------
+    # Lineage — collapsed-row behaviour
+    # -----------------------------------------------------------------------
+
+    def test_yield_dashboard_lineage_collapsed_row_panels_contribute(self):
+        """Panels nested inside a collapsed row are processed for lineage; the row wrapper is not."""
+        self.grafana.metadata.get_by_name = MagicMock(return_value=EXAMPLE_DASHBOARD)
+
+        with patch.object(
+            GrafanaSource,
+            "_process_panel_lineage",
+            side_effect=lambda *args, **kwargs: iter([]),
+        ) as mock_process:
+            list(
+                self.grafana.yield_dashboard_lineage_details(
+                    MOCK_DASHBOARD_WITH_COLLAPSED_ROW, "mock_postgres"
+                )
+            )
+
+        processed_panel_ids = {
+            call.kwargs["panel"].id for call in mock_process.call_args_list
+        }
+        assert (
+            21 in processed_panel_ids
+        ), "Panel 21 (nested in collapsed row) must be processed for lineage"
+        assert (
+            22 in processed_panel_ids
+        ), "Panel 22 (nested in collapsed row) must be processed for lineage"
+        # The row wrapper must never reach the lineage processor.
+        assert (
+            20 not in processed_panel_ids
+        ), "Collapsed row wrapper (id=20) must not be passed to lineage"
+
+    # -----------------------------------------------------------------------
+    # Helpers and mapping
+    # -----------------------------------------------------------------------
 
     def test_panel_type_mapping(self):
-        """Test Grafana panel type to OpenMetadata chart type mapping"""
+        """Test Grafana panel type to OpenMetadata chart type mapping."""
         test_cases = {
             "graph": "Line",
             "timeseries": "Line",
@@ -466,102 +598,69 @@ class GrafanaUnitTest(TestCase):
 
         for panel_type, expected_chart_type in test_cases.items():
             result = self.grafana._map_panel_type_to_chart_type(panel_type)
-            self.assertEqual(result.value, expected_chart_type)
-
-    @pytest.mark.skip(reason="Lineage test requires complex mocking - to be fixed")
-    @patch("metadata.ingestion.lineage.sql_lineage.search_table_entities")
-    def test_yield_dashboard_lineage_details(self, mock_search_table):
-        """Test lineage extraction from SQL queries"""
-        # Mock table search to return our example table
-        mock_search_table.return_value = EXAMPLE_TABLE
-
-        # Mock metadata.get_by_name to return the dashboard
-        self.grafana.metadata.get_by_name = MagicMock(return_value=EXAMPLE_DASHBOARD)
-
-        # Get lineage
-        lineage_results = list(
-            self.grafana.yield_dashboard_lineage_details(
-                MOCK_DASHBOARD_RESPONSE, "mock_postgres"
-            )
-        )
-
-        # Should have lineage for panels with SQL queries (panels 1 and 2)
-        # Panel 3 has Prometheus query which doesn't generate lineage
-        # Panel 4 is a row type which is skipped
-        self.assertEqual(len(lineage_results), 2)
-
-        # Verify search_table_entities was called with correct SQL
-        self.assertEqual(mock_search_table.call_count, 2)
-
-        # Check first call (panel 1)
-        first_call = mock_search_table.call_args_list[0]
-        self.assertIn("SELECT date_trunc", first_call.kwargs["query"])
-
-        # Check second call (panel 2)
-        second_call = mock_search_table.call_args_list[1]
-        self.assertIn("SELECT name, email", second_call.kwargs["query"])
+            assert result.value == expected_chart_type
 
     def test_extract_datasource_name(self):
-        """Test datasource name extraction from different formats"""
-        # Test with string datasource
-        target = GrafanaTarget(datasource="postgres-uid")
+        """Test datasource name extraction from different formats."""
         panel = GrafanaPanel(id=1, type="graph", title="Test")
-        result = self.grafana._extract_datasource_name(target, panel)
-        self.assertEqual(result, "postgres-uid")
 
-        # Test with dict datasource
+        target = GrafanaTarget(datasource="postgres-uid")
+        assert self.grafana._extract_datasource_name(target, panel) == "postgres-uid"
+
         target = GrafanaTarget(datasource={"uid": "postgres-uid", "type": "postgres"})
-        result = self.grafana._extract_datasource_name(target, panel)
-        self.assertEqual(result, "postgres-uid")
+        assert self.grafana._extract_datasource_name(target, panel) == "postgres-uid"
 
-        # Test fallback to panel datasource
         target = GrafanaTarget()
-        panel = GrafanaPanel(
+        panel_with_ds = GrafanaPanel(
             id=1, type="graph", title="Test", datasource="panel-datasource"
         )
-        result = self.grafana._extract_datasource_name(target, panel)
-        self.assertEqual(result, "panel-datasource")
+        assert (
+            self.grafana._extract_datasource_name(target, panel_with_ds)
+            == "panel-datasource"
+        )
 
     def test_extract_sql_query(self):
-        """Test SQL query extraction based on datasource type"""
-        postgres_ds = MOCK_DATASOURCES[0]
-        # Align datasource type with supported SQL types in current implementation
-        postgres_ds.type = "grafana-postgresql-datasource"
+        """Test SQL query extraction based on datasource type."""
+        postgres_ds = GrafanaDatasource(
+            id=1,
+            uid="postgres-uid",
+            name="PostgreSQL",
+            type="grafana-postgresql-datasource",
+            url="postgres:5432",
+            database="production",
+            isDefault=True,
+        )
         prometheus_ds = MOCK_DATASOURCES[1]
 
-        # Test SQL datasource
         target = GrafanaTarget(rawSql="SELECT * FROM customers")
-        result = self.grafana._extract_sql_query(target, postgres_ds)
-        self.assertEqual(result, "SELECT * FROM customers")
+        assert (
+            self.grafana._extract_sql_query(target, postgres_ds)
+            == "SELECT * FROM customers"
+        )
 
-        # Test non-SQL datasource (Prometheus)
         target = GrafanaTarget(expr="up{job='prometheus'}")
-        result = self.grafana._extract_sql_query(target, prometheus_ds)
-        self.assertIsNone(result)
+        assert self.grafana._extract_sql_query(target, prometheus_ds) is None
 
     def test_get_owner_ref(self):
-        """Test owner reference extraction"""
-        # Mock the metadata API to return a user reference
+        """Test owner reference extraction."""
         mock_owner = EntityReference(id=str(uuid.uuid4()), type="user")
         self.grafana.metadata.get_reference_by_email = MagicMock(
             return_value=mock_owner
         )
 
         owner_ref = self.grafana.get_owner_ref(MOCK_DASHBOARD_RESPONSE)
-        self.assertIsNotNone(owner_ref)
+        assert owner_ref is not None
 
-        # Test with no createdBy
         dashboard_response = GrafanaDashboardResponse(
             dashboard=MOCK_DASHBOARD_RESPONSE.dashboard,
             meta=GrafanaDashboardMeta(
                 **{**MOCK_DASHBOARD_RESPONSE.meta.model_dump(), "createdBy": None}
             ),
         )
-        owner_ref = self.grafana.get_owner_ref(dashboard_response)
-        self.assertIsNone(owner_ref)
+        assert self.grafana.get_owner_ref(dashboard_response) is None
 
     def test_complete_json_parsing(self):
-        """Test complete JSON parsing from raw dict through all nested levels"""
+        """Test complete JSON parsing from raw dict through all nested levels."""
         complete_json = {
             "dashboard": {
                 "id": 123,
@@ -635,75 +734,49 @@ class GrafanaUnitTest(TestCase):
             },
         }
 
-        expected_output = GrafanaDashboardResponse(
-            dashboard=GrafanaDashboard(
-                id=123,
-                uid="complete-test-uid",
-                title="Complete Test Dashboard",
-                tags=["test", "integration"],
-                description="Full integration test dashboard",
-                version=10,
-                panels=[
-                    GrafanaPanel(
-                        id=1,
-                        type="graph",
-                        title="SQL Query Panel",
-                        description="Panel with SQL query",
-                        datasource={"uid": "postgres-ds", "type": "postgres"},
-                        targets=[
-                            GrafanaTarget(
-                                refId="A",
-                                datasource={"uid": "postgres-ds", "type": "postgres"},
-                                rawSql="SELECT * FROM users WHERE created_at > now() - interval '1 day'",
-                                format="time_series",
-                            ),
-                            GrafanaTarget(
-                                refId="B",
-                                datasource={"uid": "postgres-ds", "type": "postgres"},
-                                rawSql="SELECT COUNT(*) FROM orders",
-                                format=0,
-                            ),
-                        ],
-                    ),
-                    GrafanaPanel(
-                        id=2,
-                        type="stat",
-                        title="Prometheus Panel",
-                        datasource="prometheus-ds",
-                        targets=[
-                            GrafanaTarget(
-                                refId="A",
-                                datasource="prometheus-ds",
-                                expr="rate(http_requests_total[5m])",
-                                format=None,
-                            )
-                        ],
-                    ),
-                ],
-            ),
-            meta=GrafanaDashboardMeta(
-                type="db",
-                canSave=True,
-                canEdit=True,
-                canAdmin=False,
-                canStar=True,
-                canDelete=False,
-                slug="complete-test-dashboard",
-                url="/d/complete-test-uid/complete-test-dashboard",
-                created="2024-01-01T00:00:00Z",
-                updated="2024-02-01T12:30:00Z",
-                updatedBy="user@example.com",
-                createdBy="admin@example.com",
-                version=10,
-                folderId=5,
-                folderUid="test-folder",
-                folderTitle="Test Folder",
-                folderUrl="/dashboards/f/test-folder/test-folder",
-            ),
-        )
-
         parsed_response = GrafanaDashboardResponse(**complete_json)
-        self.assertEqual(parsed_response, expected_output)
+
+        dashboard = parsed_response.dashboard
+        assert dashboard.uid == "complete-test-uid"
+        assert dashboard.title == "Complete Test Dashboard"
+        assert dashboard.tags == ["test", "integration"]
+        assert dashboard.version == 10
+        assert len(dashboard.panels) == 2
+
+        # Panel 0: SQL panel with a dict datasource and two nested targets.
+        sql_panel = dashboard.panels[0]
+        assert sql_panel.type == "graph"
+        assert sql_panel.datasource == {"uid": "postgres-ds", "type": "postgres"}
+        assert len(sql_panel.targets) == 2
+        assert sql_panel.targets[0].rawSql.startswith("SELECT * FROM users")
+        assert sql_panel.targets[0].format == "time_series"
+        assert sql_panel.targets[0].datasource == {
+            "uid": "postgres-ds",
+            "type": "postgres",
+        }
+        assert sql_panel.targets[1].rawSql == "SELECT COUNT(*) FROM orders"
+        # format=0 is a valid, falsy value and must survive as 0, not coerced to None.
+        assert sql_panel.targets[1].format == 0
+        assert sql_panel.targets[1].format is not None
+
+        # Panel 1: Prometheus panel with a string datasource and an expr target.
+        prom_panel = dashboard.panels[1]
+        assert prom_panel.datasource == "prometheus-ds"
+        assert prom_panel.targets[0].expr == "rate(http_requests_total[5m])"
+        assert prom_panel.targets[0].rawSql is None
+        assert prom_panel.targets[0].format is None
+        assert prom_panel.targets[0].datasource == "prometheus-ds"
+
+        # Meta fields carried through deserialization.
+        meta = parsed_response.meta
+        assert meta.canAdmin is False
+        assert meta.canDelete is False
+        assert meta.createdBy == "admin@example.com"
+        assert meta.updatedBy == "user@example.com"
+        assert meta.folderId == 5
+        assert meta.folderUid == "test-folder"
+        assert meta.folderTitle == "Test Folder"
+        assert meta.url == "/d/complete-test-uid/complete-test-dashboard"
 
     def test_chart_source_state_populated(self):
         """Verify register_record_chart populates chart_source_state after yield_dashboard_chart."""

--- a/ingestion/tests/unit/topology/dashboard/test_grafana_simple.py
+++ b/ingestion/tests/unit/topology/dashboard/test_grafana_simple.py
@@ -13,15 +13,17 @@
 Simple unit tests for Grafana connector components
 """
 
-from unittest import TestCase
 from unittest.mock import MagicMock
 
 from metadata.ingestion.source.dashboard.grafana.client import GrafanaApiClient
 from metadata.ingestion.source.dashboard.grafana.metadata import GrafanaSource
-from metadata.ingestion.source.dashboard.grafana.models import GrafanaDashboardResponse
+from metadata.ingestion.source.dashboard.grafana.models import (
+    GrafanaDashboardResponse,
+    GrafanaPanel,
+)
 
 
-class TestGrafanaComponents(TestCase):
+class TestGrafanaComponents:
     """Test individual Grafana components"""
 
     def test_panel_type_mapping(self):
@@ -53,7 +55,7 @@ class TestGrafanaComponents(TestCase):
         for panel_type, expected_chart_type in test_cases.items():
             result = source._map_panel_type_to_chart_type(panel_type)
             # The method returns an enum value, compare its value
-            self.assertEqual(result.value, expected_chart_type)
+            assert result.value == expected_chart_type
 
     def test_extract_datasource_name(self):
         """Test datasource name extraction"""
@@ -68,19 +70,16 @@ class TestGrafanaComponents(TestCase):
         panel = MagicMock()
         panel.datasource = None
 
-        result = source._extract_datasource_name(target, panel)
-        self.assertEqual(result, "postgres-uid")
+        assert source._extract_datasource_name(target, panel) == "postgres-uid"
 
         # Test with dict datasource in target
         target.datasource = {"uid": "postgres-uid", "type": "postgres"}
-        result = source._extract_datasource_name(target, panel)
-        self.assertEqual(result, "postgres-uid")
+        assert source._extract_datasource_name(target, panel) == "postgres-uid"
 
         # Test fallback to panel datasource
         target.datasource = None
         panel.datasource = "panel-datasource"
-        result = source._extract_datasource_name(target, panel)
-        self.assertEqual(result, "panel-datasource")
+        assert source._extract_datasource_name(target, panel) == "panel-datasource"
 
     def test_dashboard_response_parsing(self):
         """Test parsing of dashboard response"""
@@ -110,10 +109,57 @@ class TestGrafanaComponents(TestCase):
         }
 
         response = GrafanaDashboardResponse(**dashboard_data)
-        self.assertEqual(response.dashboard.uid, "test-uid")
-        self.assertEqual(response.dashboard.title, "Test Dashboard")
-        self.assertEqual(len(response.dashboard.panels), 1)
-        self.assertEqual(response.meta.slug, "test-dashboard")
+        assert response.dashboard.uid == "test-uid"
+        assert response.dashboard.title == "Test Dashboard"
+        assert len(response.dashboard.panels) == 1
+        assert response.meta.slug == "test-dashboard"
+
+    def test_flatten_panels_collapsed_row(self):
+        """Panels nested inside a collapsed row must be surfaced at the top level."""
+        panels = [
+            GrafanaPanel(id=1, type="graph", title="Top Level"),
+            GrafanaPanel(
+                id=2,
+                type="row",
+                title="Collapsed",
+                collapsed=True,
+                panels=[
+                    GrafanaPanel(id=3, type="stat", title="Nested A"),
+                    GrafanaPanel(id=4, type="table", title="Nested B"),
+                ],
+            ),
+            GrafanaPanel(
+                id=5, type="row", title="Expanded", collapsed=False, panels=[]
+            ),
+            GrafanaPanel(id=6, type="bargauge", title="After Expanded Row"),
+        ]
+        flat = GrafanaSource._flatten_panels(panels)
+
+        panel_ids = [p.id for p in flat]
+        # Collapsed row (id=2) is replaced by its children 3 & 4; the expanded
+        # row (id=5) stays as-is and its child (id=6) is already top-level.
+        assert 1 in panel_ids, "Top-level panel must survive"
+        assert 3 in panel_ids, "First panel inside collapsed row must be surfaced"
+        assert 4 in panel_ids, "Second panel inside collapsed row must be surfaced"
+        assert 2 not in panel_ids, "Collapsed row sentinel must not appear in output"
+        assert 5 in panel_ids, "Expanded row sentinel stays (for type filtering)"
+        assert 6 in panel_ids, "Child of expanded row at top level must survive"
+        assert len(flat) == 5
+
+    def test_flatten_panels_expanded_row_unchanged(self):
+        """An expanded row (collapsed=False, empty panels) must not lose panels."""
+        panels = [
+            GrafanaPanel(id=1, type="graph", title="Normal"),
+            GrafanaPanel(id=2, type="row", title="Row", collapsed=False, panels=[]),
+            GrafanaPanel(id=3, type="stat", title="After Row"),
+        ]
+        flat = GrafanaSource._flatten_panels(panels)
+        assert [p.id for p in flat] == [1, 2, 3]
+
+    def test_flatten_panels_no_panels(self):
+        """Empty or None input must not raise."""
+        assert GrafanaSource._flatten_panels([]) == []
+        assert GrafanaSource._flatten_panels(None) == []
 
     def test_api_client_initialization(self):
         """Test API client initialization"""
@@ -124,11 +170,11 @@ class TestGrafanaComponents(TestCase):
             page_size=50,
         )
 
-        self.assertEqual(client.host_port, "https://grafana.example.com")
-        self.assertEqual(client.page_size, 50)
-        self.assertTrue(client.verify_ssl)
+        assert client.host_port == "https://grafana.example.com"
+        assert client.page_size == 50
+        assert client.verify_ssl
 
         # Test session headers
         session = client.session
-        self.assertEqual(session.headers["Authorization"], "Bearer test_key")
-        self.assertEqual(session.headers["Accept"], "application/json")
+        assert session.headers["Authorization"] == "Bearer test_key"
+        assert session.headers["Accept"] == "application/json"


### PR DESCRIPTION
Backports #31611 to the 1.13 release branch. Grafana panels nested inside collapsed rows are flattened before chart and lineage ingestion, with behavioral coverage for both consumers. The touched connector files use the same modern Python typing style as main.