### PR TITLE
Backport #32449 to 1.13: parse Protobuf schemas with unmatched topic names

### DIFF
--- a/ingestion/src/metadata/parsers/protobuf_parser.py
+++ b/ingestion/src/metadata/parsers/protobuf_parser.py
@@ -13,17 +13,17 @@
 Utils module to parse the protobuf schema
 """
 
-import glob
-import importlib
-import shutil
-import sys
+import tempfile
 import traceback
 from enum import Enum
-from pathlib import Path, PureWindowsPath
-from typing import List, Optional, Type, Union
+from importlib.resources import files
+from pathlib import Path
+from typing import TypeVar
 
 import grpc_tools.protoc
-from pydantic import BaseModel
+from google.protobuf import descriptor_pb2, descriptor_pool
+from google.protobuf.descriptor import Descriptor, FileDescriptor
+from pydantic import BaseModel, Field
 
 from metadata.generated.schema.entity.data.table import Column, DataType
 from metadata.generated.schema.type.schema import DataTypeTopic, FieldModel
@@ -31,6 +31,12 @@ from metadata.utils.helpers import snake_to_camel
 from metadata.utils.logger import ingestion_logger
 
 logger = ingestion_logger()
+
+ProtobufField = TypeVar("ProtobufField", FieldModel, Column)
+
+PROTO_FILE_NAME = "schema.proto"
+DESCRIPTOR_SET_FILE_NAME = "schema.desc"
+GRPC_TOOLS_PROTO_PATH = files("grpc_tools").joinpath("_proto")
 
 
 class ProtobufDataTypes(Enum):
@@ -75,15 +81,12 @@ class ProtobufParserConfig(BaseModel):
     Protobuf Parser Config class
     :param schema_name: Name of protobuf schema
     :param schema_text: Protobuf schema definition in text format
-    :param base_file_path: A temporary directory will be created under this path for
-      generating the files required for protobuf parsing and compiling. By default
-      the directory will be created under "/tmp/protobuf_openmetadata" unless it is
-      specified in the parameter.
+    :param base_file_path: Optional parent directory for temporary parser files.
     """
 
     schema_name: str
     schema_text: str
-    base_file_path: Optional[str] = "/tmp/protobuf_openmetadata"
+    base_file_path: str | None = Field(default=None)
 
 
 class ProtobufParser:
@@ -93,163 +96,160 @@ class ProtobufParser:
 
     config: ProtobufParserConfig
 
-    def __init__(self, config):
+    def __init__(self, config: ProtobufParserConfig):
         self.config = config
-        self.proto_interface_dir = f"{self.config.base_file_path}/interfaces"
-        self.generated_src_dir = f"{self.config.base_file_path}/generated/"
 
-    def load_module(self, module):
-        """
-        Get the python module from path
-        """
-        module_path = module
-        return __import__(module_path, fromlist=[module])
+    def _compile_descriptor_set(
+        self, working_directory: Path
+    ) -> descriptor_pb2.FileDescriptorSet:
+        """Compile the configured schema into a descriptor set."""
+        interface_directory = working_directory / "interfaces"
+        interface_directory.mkdir()
+        proto_file = interface_directory / PROTO_FILE_NAME
+        proto_file.write_text(self.config.schema_text, encoding="UTF-8")
+        descriptor_set_file = working_directory / DESCRIPTOR_SET_FILE_NAME
 
-    def _get_proto_file_path(self) -> Path:
-        """Resolve the schema file path and keep it inside the interface directory."""
-        schema_name = self.config.schema_name
-        windows_schema_path = PureWindowsPath(schema_name)
-        if windows_schema_path.is_absolute() or len(windows_schema_path.parts) != 1:
-            raise ValueError(f"Invalid protobuf schema name: {schema_name}")
+        exit_code = grpc_tools.protoc.main(
+            [
+                "protoc",
+                f"--proto_path={interface_directory}",
+                f"--proto_path={GRPC_TOOLS_PROTO_PATH}",
+                f"--descriptor_set_out={descriptor_set_file}",
+                "--include_imports",
+                str(proto_file),
+            ]
+        )
+        if exit_code:
+            raise RuntimeError(f"protoc exited with code {exit_code}")
 
-        interface_dir = Path(self.proto_interface_dir).resolve()
-        file_path = (interface_dir / f"{schema_name}.proto").resolve()
-        if file_path.parent != interface_dir:
-            raise ValueError(
-                f"Protobuf schema path escapes the interface directory: {schema_name}"
-            )
-        return file_path
+        descriptor_set = descriptor_pb2.FileDescriptorSet()
+        descriptor_set.ParseFromString(descriptor_set_file.read_bytes())
+        return descriptor_set
 
-    def create_proto_files(self):
-        """
-        Method to generate the protobuf directory and file structure
-        """
-        try:
-            file_path = self._get_proto_file_path()
+    @staticmethod
+    def _get_file_descriptor(
+        descriptor_set: descriptor_pb2.FileDescriptorSet,
+    ) -> FileDescriptor:
+        """Load the compiled schema into an isolated descriptor pool."""
+        descriptor_protos = {
+            descriptor.name: descriptor for descriptor in descriptor_set.file
+        }
+        descriptor_pool_ = descriptor_pool.DescriptorPool()
+        added_descriptors = set()
 
-            # Create a temporary directory for saving all the files if not already present
-            generated_src_dir_path = Path(self.generated_src_dir)
-            generated_src_dir_path.mkdir(parents=True, exist_ok=True)
-            proto_interface_dir_path = Path(self.proto_interface_dir)
-            proto_interface_dir_path.mkdir(parents=True, exist_ok=True)
+        def add_descriptor(descriptor_name: str) -> None:
+            if descriptor_name in added_descriptors:
+                return
+            descriptor = descriptor_protos.get(descriptor_name)
+            if descriptor is None:
+                raise ValueError(f"Missing Protobuf dependency: {descriptor_name}")
+            for dependency_name in descriptor.dependency:
+                add_descriptor(dependency_name)
+            descriptor_pool_.Add(descriptor)
+            added_descriptors.add(descriptor_name)
 
-            # Create a .proto file under the interfaces directory with schema text
-            with file_path.open("w", encoding="UTF-8") as file:
-                file.write(self.config.schema_text)
-            proto_path = "generated=" + self.proto_interface_dir
-            return proto_path, str(file_path)
-        except Exception as exc:  # pylint: disable=broad-except
-            logger.debug(traceback.format_exc())
+        add_descriptor(PROTO_FILE_NAME)
+        return descriptor_pool_.FindFileByName(PROTO_FILE_NAME)
+
+    def _get_message_descriptor(
+        self, file_descriptor: FileDescriptor
+    ) -> Descriptor | None:
+        """Select the root message represented by the topic schema."""
+        message_types = file_descriptor.message_types_by_name
+        message_descriptor = message_types.get(snake_to_camel(self.config.schema_name))
+        if message_descriptor is None and len(message_types) == 1:
+            message_descriptor = next(iter(message_types.values()))
+        if message_descriptor is None:
             logger.warning(
-                f"Unable to create protobuf directory structure for {self.config.schema_name}: {exc}"
+                "Unable to determine the Protobuf message for %s. Available messages: %s",
+                self.config.schema_name,
+                ", ".join(message_types),
             )
-        return None
-
-    def get_protobuf_python_object(self, proto_path: str, file_path: str):
-        """
-        Method to create protobuf python module and get object
-        """
-        try:
-            # compile the .proto file and create python class
-            grpc_tools.protoc.main(
-                [
-                    "protoc",
-                    file_path,
-                    f"--proto_path={proto_path}",
-                    f"--python_out={self.config.base_file_path}",
-                ]
-            )
-
-            # import the python file
-            sys.path.append(self.generated_src_dir)
-            generated_src_dir_path = Path(self.generated_src_dir)
-            py_file = glob.glob(
-                str(
-                    generated_src_dir_path.joinpath(f"{self.config.schema_name}_pb2.py")
-                )
-            )[0]
-            module_name = Path(py_file).stem
-            message = importlib.import_module(module_name)
-
-            # get the class and create a object instance
-            class_ = getattr(message, snake_to_camel(self.config.schema_name))
-            instance = class_()
-            return instance
-        except Exception as exc:  # pylint: disable=broad-except
-            logger.debug(traceback.format_exc())
-            logger.warning(
-                f"Unable to create protobuf python module for {self.config.schema_name}: {exc}"
-            )
-        return None
+        return message_descriptor
 
     def parse_protobuf_schema(
-        self, cls: Type[BaseModel] = FieldModel
-    ) -> Optional[List[Union[FieldModel, Column]]]:
+        self, cls: type[ProtobufField] = FieldModel
+    ) -> list[ProtobufField] | None:
         """
         Method to parse the protobuf schema
         """
 
         try:
-            proto_path, file_path = self.create_proto_files()
-            instance = self.get_protobuf_python_object(
-                proto_path=proto_path, file_path=file_path
+            base_file_path = self.config.base_file_path
+            temporary_parent = (
+                Path(base_file_path).expanduser()
+                if base_file_path and base_file_path.strip()
+                else None
             )
+            if temporary_parent:
+                temporary_parent.mkdir(parents=True, exist_ok=True)
 
-            field_models = [
-                cls(
-                    name=instance.DESCRIPTOR.name,
-                    dataType="RECORD",
-                    children=self.get_protobuf_fields(
-                        instance.DESCRIPTOR.fields, cls=cls
-                    ),
-                )
-            ]
+            with tempfile.TemporaryDirectory(
+                prefix="protobuf_om_", dir=temporary_parent
+            ) as temporary_directory:
+                descriptor_set = self._compile_descriptor_set(Path(temporary_directory))
+                file_descriptor = self._get_file_descriptor(descriptor_set)
+                message_descriptor = self._get_message_descriptor(file_descriptor)
+                if message_descriptor is None:
+                    return None
 
-            # Clean up the tmp folder
-            if Path(self.config.base_file_path).exists():
-                shutil.rmtree(self.config.base_file_path)
-
-            return field_models
+                return [
+                    cls.model_validate(
+                        {
+                            "name": message_descriptor.name,
+                            "dataType": "RECORD",
+                            "children": self.get_protobuf_fields(
+                                message_descriptor.fields, cls=cls
+                            ),
+                        }
+                    )
+                ]
         except Exception as exc:  # pylint: disable=broad-except
             logger.debug(traceback.format_exc())
             logger.warning(
-                f"Unable to parse protobuf schema for {self.config.schema_name}: {exc}"
+                "Unable to parse protobuf schema for %s: %s",
+                self.config.schema_name,
+                exc,
             )
         return None
 
-    def _get_field_type(self, type_: int, cls: Type[BaseModel] = FieldModel) -> str:
+    def _get_field_type(self, type_: int, cls: type[ProtobufField] = FieldModel) -> str:
         if type_ > 18:
             return DataType.UNKNOWN.value
         data_type = ProtobufDataTypes(type_).name
-        if cls == Column and data_type == DataTypeTopic.FIXED.value:
+        if cls is Column and data_type == DataTypeTopic.FIXED.value:
             return DataType.INT.value
         return data_type
 
     def get_protobuf_fields(
-        self, fields, cls: Type[BaseModel] = FieldModel
-    ) -> Optional[List[Union[FieldModel, Column]]]:
+        self,
+        fields,
+        cls: type[ProtobufField] = FieldModel,
+    ) -> list[ProtobufField]:
         """
         Recursively convert the parsed schema into required models
         """
-        field_models = []
+        field_models: list[ProtobufField] = []
 
         for field in fields:
             try:
                 field_models.append(
-                    cls(
-                        name=field.name,
-                        dataType=self._get_field_type(field.type, cls=cls),
-                        children=(
-                            self.get_protobuf_fields(field.message_type.fields, cls=cls)
+                    cls.model_validate(
+                        {
+                            "name": field.name,
+                            "dataType": self._get_field_type(field.type, cls=cls),
+                            "children": self.get_protobuf_fields(
+                                field.message_type.fields, cls=cls
+                            )
                             if field.type == 11
-                            else None
-                        ),
+                            else None,
+                        }
                     )
                 )
             except Exception as exc:  # pylint: disable=broad-except
                 logger.debug(traceback.format_exc())
                 logger.warning(
-                    f"Unable to parse the protobuf schema into models: {exc}"
+                    "Unable to parse the protobuf schema into models: %s", exc
                 )
 
         return field_models

--- a/ingestion/src/metadata/utils/messaging_utils.py
+++ b/ingestion/src/metadata/utils/messaging_utils.py
@@ -30,7 +30,11 @@ def merge_and_clean_protobuf_schema(schema_text: Optional[str]) -> Optional[str]
         lines = schema_text.splitlines() if schema_text else []
         new_lines = []
         for i, line in enumerate(lines):
-            if not re.search(r'import ".*";', line) and not re.search(
+            is_import = re.search(r'import ".*";', line)
+            is_well_known_type_import = re.search(
+                r'import "google/protobuf/.*\.proto";', line
+            )
+            if (not is_import or is_well_known_type_import) and not re.search(
                 r"option .*;", line
             ):
                 if re.search(r'\s*syntax\s*=\s*"proto\d+";\s*', line) and i != 0:

--- a/ingestion/tests/integration/kafka/conftest.py
+++ b/ingestion/tests/integration/kafka/conftest.py
@@ -4,6 +4,8 @@ from textwrap import dedent
 
 import pytest
 import testcontainers.core.network
+from confluent_kafka.admin import AdminClient, NewTopic
+from confluent_kafka.schema_registry import Schema, SchemaRegistryClient
 from docker.types import EndpointConfig
 from testcontainers.core.container import DockerContainer
 from testcontainers.kafka import KafkaContainer
@@ -25,6 +27,20 @@ from metadata.generated.schema.entity.services.messagingService import (
 from metadata.generated.schema.metadataIngestion.messagingServiceMetadataPipeline import (
     MessagingMetadataConfigType,
 )
+
+LOANS_TOPIC = "loans"
+LOANS_PROTOBUF_SCHEMA = dedent(
+    """
+    syntax = "proto3";
+    package org.example.loans;
+
+    message MyLoanRecord {
+      int32 my_field1 = 1;
+      double my_field2 = 2;
+      string my_field3 = 3;
+    }
+    """
+).strip()
 
 
 def _connect_to_network(
@@ -99,6 +115,25 @@ def kafka_container(docker_network):
     _connect_to_network(container, docker_network, "kafka")
     with container:
         yield container
+
+
+@pytest.fixture(scope="module")
+def protobuf_topic(kafka_container, schema_registry_container):
+    admin_client = AdminClient(
+        {"bootstrap.servers": kafka_container.get_bootstrap_server()}
+    )
+    admin_client.create_topics(
+        [NewTopic(LOANS_TOPIC, num_partitions=1, replication_factor=1)]
+    )[LOANS_TOPIC].result(timeout=10)
+
+    schema_registry_client = SchemaRegistryClient(
+        {"url": schema_registry_container.get_connection_url()}
+    )
+    schema_registry_client.register_schema(
+        f"{LOANS_TOPIC}-value",
+        Schema(LOANS_PROTOBUF_SCHEMA, "PROTOBUF"),
+    )
+    return LOANS_TOPIC
 
 
 @pytest.fixture(scope="module")

--- a/ingestion/tests/integration/kafka/test_metadata.py
+++ b/ingestion/tests/integration/kafka/test_metadata.py
@@ -11,6 +11,36 @@ def test_ingest_metadata(
     metadata_assertions()
 
 
+def test_ingest_protobuf_schema_when_message_name_differs_from_topic(
+    patch_passwords_for_db_services,
+    run_workflow,
+    ingestion_config,
+    metadata,
+    db_service,
+    protobuf_topic,
+):
+    run_workflow(MetadataWorkflow, ingestion_config)
+
+    topic: Topic = metadata.get_by_name(
+        entity=Topic,
+        fqn=f"{db_service.fullyQualifiedName.root}.{protobuf_topic}",
+        fields=["*"],
+        nullable=False,
+    )
+
+    assert topic.messageSchema is not None
+    assert topic.messageSchema.schemaType.value == "Protobuf"
+    assert len(topic.messageSchema.schemaFields) == 1
+    root = topic.messageSchema.schemaFields[0]
+    assert root.name.root == "MyLoanRecord"
+    assert root.dataType.name == "RECORD"
+    assert [(field.name.root, field.dataType.name) for field in root.children] == [
+        ("my_field1", "INT"),
+        ("my_field2", "DOUBLE"),
+        ("my_field3", "STRING"),
+    ]
+
+
 @pytest.fixture(
     scope="module",
     params=[

--- a/ingestion/tests/unit/test_protobuf_parser.py
+++ b/ingestion/tests/unit/test_protobuf_parser.py
@@ -14,8 +14,10 @@ Protobuf parser tests
 """
 
 import os
-from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
 
+import grpc_tools.protoc
 import pytest
 
 from metadata.generated.schema.entity.data.table import Column
@@ -138,48 +140,273 @@ class ProtobufParserTests:
 
 
 @pytest.mark.parametrize("schema_name", ["../outside", r"..\outside", r"C:\outside"])
-def test_create_proto_files_rejects_traversal_schema_names(tmp_path, schema_name):
+def test_schema_name_does_not_control_temporary_file_paths(tmp_path, schema_name):
     parser = ProtobufParser(
         config=ProtobufParserConfig(
             schema_name=schema_name,
-            schema_text='syntax = "proto3";',
+            schema_text='syntax = "proto3"; message SafeRecord {}',
             base_file_path=str(tmp_path / "protobuf"),
         )
     )
 
-    assert parser.create_proto_files() is None
+    parsed_schema = parser.parse_protobuf_schema()
+
+    assert parsed_schema is not None
+    assert parsed_schema[0].name.root == "SafeRecord"
     assert not (tmp_path / "protobuf" / "outside.proto").exists()
     assert not (tmp_path / "outside.proto").exists()
 
 
-def test_create_proto_files_rejects_absolute_schema_name(tmp_path):
+def test_absolute_schema_name_does_not_control_temporary_file_paths(tmp_path):
     outside_path = tmp_path / "outside"
     parser = ProtobufParser(
         config=ProtobufParserConfig(
             schema_name=str(outside_path),
-            schema_text='syntax = "proto3";',
+            schema_text='syntax = "proto3"; message SafeRecord {}',
             base_file_path=str(tmp_path / "protobuf"),
         )
     )
 
-    assert parser.create_proto_files() is None
+    parsed_schema = parser.parse_protobuf_schema()
+
+    assert parsed_schema is not None
+    assert parsed_schema[0].name.root == "SafeRecord"
     assert not outside_path.with_suffix(".proto").exists()
 
 
-def test_create_proto_files_accepts_simple_schema_name(tmp_path):
+def test_parse_preserves_configured_temporary_parent(tmp_path):
+    base_file_path = tmp_path / "protobuf"
+    base_file_path.mkdir()
+    sentinel = base_file_path / "keep.txt"
+    sentinel.write_text("keep", encoding="UTF-8")
     parser = ProtobufParser(
         config=ProtobufParserConfig(
             schema_name="safe_schema",
-            schema_text='syntax = "proto3";',
+            schema_text='syntax = "proto3"; message SafeSchema {}',
+            base_file_path=str(base_file_path),
+        )
+    )
+
+    parsed_schema = parser.parse_protobuf_schema()
+
+    assert parsed_schema is not None
+    assert parsed_schema[0].name.root == "SafeSchema"
+    assert sentinel.read_text(encoding="UTF-8") == "keep"
+    assert {path.name for path in base_file_path.iterdir()} == {"keep.txt"}
+
+
+def test_parse_uses_only_top_level_message_when_topic_name_does_not_match(tmp_path):
+    parser = ProtobufParser(
+        config=ProtobufParserConfig(
+            schema_name="loans",
+            schema_text="""
+                syntax = "proto3";
+                package org.example.loans;
+
+                message MyLoanRecord {
+                    int32 my_field1 = 1;
+                    double my_field2 = 2;
+                    string my_field3 = 3;
+                }
+            """,
             base_file_path=str(tmp_path / "protobuf"),
         )
     )
 
-    proto_path, file_path = parser.create_proto_files()
+    parsed_schema = parser.parse_protobuf_schema()
 
-    assert proto_path == f"generated={tmp_path / 'protobuf' / 'interfaces'}"
-    assert (
-        Path(file_path).resolve()
-        == (tmp_path / "protobuf" / "interfaces" / "safe_schema.proto").resolve()
+    assert parsed_schema is not None
+    assert parsed_schema[0].name.root == "MyLoanRecord"
+    assert parsed_schema[0].dataType.name == "RECORD"
+    assert [
+        (field.name.root, field.dataType.name) for field in parsed_schema[0].children
+    ] == [
+        ("my_field1", "INT"),
+        ("my_field2", "DOUBLE"),
+        ("my_field3", "STRING"),
+    ]
+
+
+def test_parse_does_not_guess_when_multiple_top_level_messages_do_not_match_topic(
+    tmp_path,
+):
+    base_file_path = tmp_path / "protobuf"
+    base_file_path.mkdir()
+    sentinel = base_file_path / "keep.txt"
+    sentinel.write_text("keep", encoding="UTF-8")
+    parser = ProtobufParser(
+        config=ProtobufParserConfig(
+            schema_name="loan_events",
+            schema_text="""
+                syntax = "proto3";
+
+                message LoanCreated {}
+                message LoanApproved {}
+            """,
+            base_file_path=str(base_file_path),
+        )
     )
-    assert Path(file_path).read_text(encoding="UTF-8") == 'syntax = "proto3";'
+
+    assert parser.parse_protobuf_schema() is None
+    assert sentinel.read_text(encoding="UTF-8") == "keep"
+    assert not (base_file_path / "generated").exists()
+    assert not (base_file_path / "interfaces").exists()
+
+
+def test_reparse_same_schema_name_uses_latest_schema(tmp_path):
+    def parse(schema_text):
+        return ProtobufParser(
+            config=ProtobufParserConfig(
+                schema_name="event",
+                schema_text=schema_text,
+                base_file_path=str(tmp_path),
+            )
+        ).parse_protobuf_schema()
+
+    first_schema = parse(
+        'syntax = "proto3"; package org.example; message Event { string first_field = 1; }'
+    )
+    second_schema = parse(
+        'syntax = "proto3"; package org.example; message Event { int32 second_field = 1; }'
+    )
+
+    assert first_schema is not None
+    assert second_schema is not None
+    assert [
+        (field.name.root, field.dataType.name) for field in first_schema[0].children
+    ] == [("first_field", "STRING")]
+    assert [
+        (field.name.root, field.dataType.name) for field in second_schema[0].children
+    ] == [("second_field", "INT")]
+
+
+def test_parse_accepts_topic_name_that_is_not_a_python_identifier(tmp_path):
+    parser = ProtobufParser(
+        config=ProtobufParserConfig(
+            schema_name="loan.events-v1",
+            schema_text='syntax = "proto3"; message LoanEvent { string event_id = 1; }',
+            base_file_path=str(tmp_path),
+        )
+    )
+
+    parsed_schema = parser.parse_protobuf_schema()
+
+    assert parsed_schema is not None
+    assert parsed_schema[0].name.root == "LoanEvent"
+
+
+def test_none_temporary_parent_does_not_create_relative_none_directory(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    parser = ProtobufParser(
+        config=ProtobufParserConfig(
+            schema_name="event",
+            schema_text='syntax = "proto3"; message Event {}',
+            base_file_path=None,
+        )
+    )
+
+    assert parser.parse_protobuf_schema() is not None
+    assert not (tmp_path / "None").exists()
+
+
+def test_whitespace_temporary_parent_uses_system_temporary_directory(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    parser = ProtobufParser(
+        config=ProtobufParserConfig(
+            schema_name="event",
+            schema_text='syntax = "proto3"; message Event {}',
+            base_file_path="  \t",
+        )
+    )
+
+    assert parser.parse_protobuf_schema() is not None
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_parse_well_known_type_after_reference_preprocessing(tmp_path):
+    schema_text = merge_and_clean_protobuf_schema(
+        'syntax = "proto3";\n'
+        'import "details.proto";\n'
+        'import "google/protobuf/timestamp.proto";\n'
+        "message Details { string source = 1; }\n"
+        "message Event {\n"
+        "  Details details = 1;\n"
+        "  google.protobuf.Timestamp created_at = 2;\n"
+        "}"
+    )
+    parser = ProtobufParser(
+        config=ProtobufParserConfig(
+            schema_name="event",
+            schema_text=schema_text,
+            base_file_path=str(tmp_path),
+        )
+    )
+
+    parsed_schema = parser.parse_protobuf_schema()
+
+    assert parsed_schema is not None
+    assert parsed_schema[0].name.root == "Event"
+    assert [
+        (field.name.root, field.dataType.name) for field in parsed_schema[0].children
+    ] == [
+        ("details", "RECORD"),
+        ("created_at", "RECORD"),
+    ]
+    assert [
+        (field.name.root, field.dataType.name)
+        for field in parsed_schema[0].children[0].children
+    ] == [
+        ("source", "STRING"),
+    ]
+    assert [
+        (field.name.root, field.dataType.name)
+        for field in parsed_schema[0].children[1].children
+    ] == [
+        ("seconds", "INT"),
+        ("nanos", "INT"),
+    ]
+
+
+def test_protoc_failure_reports_exit_code(tmp_path, caplog):
+    parser = ProtobufParser(
+        config=ProtobufParserConfig(
+            schema_name="event",
+            schema_text='syntax = "proto3"; message Event { invalid field = 1; }',
+            base_file_path=str(tmp_path),
+        )
+    )
+
+    assert parser.parse_protobuf_schema() is None
+    assert "protoc exited with code" in caplog.text
+
+
+def test_concurrent_parses_use_isolated_temporary_directories(tmp_path, monkeypatch):
+    parser_count = 4
+    compile_barrier = Barrier(parser_count)
+    protoc_main = grpc_tools.protoc.main
+
+    def synchronized_protoc(args):
+        compile_barrier.wait(timeout=10)
+        return protoc_main(args)
+
+    monkeypatch.setattr(grpc_tools.protoc, "main", synchronized_protoc)
+
+    def parse(index):
+        parsed_schema = ProtobufParser(
+            config=ProtobufParserConfig(
+                schema_name="event",
+                schema_text=f'syntax = "proto3"; message Event {{ string field_{index} = 1; }}',
+                base_file_path=str(tmp_path),
+            )
+        ).parse_protobuf_schema()
+        return parsed_schema[0].children[0].name.root if parsed_schema else None
+
+    with ThreadPoolExecutor(max_workers=parser_count) as executor:
+        parsed_names = list(executor.map(parse, range(parser_count)))
+
+    assert parsed_names == [f"field_{index}" for index in range(parser_count)]
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
### Describe your changes:

Fixes #15274

Backports #32449 to the 1.13 release branch. Protobuf schema parsing now falls back to the sole top-level message when the topic name does not match, while keeping ambiguous schemas unresolved. It also isolates compilation per parse and supports well-known Protobuf imports.

### Type of change:

- [x] Bug fix

### High-level design:

Uses descriptor-set compilation with a private descriptor pool and per-parse temporary directory.

### Tests:

- Parser unit tests: 14 passed
- Changed-file pre-commit formatting checks: passed
- Targeted static typing: passed with 0 errors (one existing untyped-parameter warning)
- The full 1.13 Python formatting target remains red on eight untouched branch files
- Kafka integration setup was attempted for the 2.0 backport, but OpenMetadata on localhost:8585 was unavailable

### UI screen recording / screenshots:

Not applicable.

### Checklist:

- [x] I have read the CONTRIBUTING document.
- [x] My PR is linked to a GitHub issue via Fixes #15274 above.
- [x] I have added tests for the exact regression.
- [x] No JSON Schema or UI changes are included.
