### PR TITLE
Backport #32484 to 2.0: scope BigQuery multi-project ADC connections

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/bigquery/helper.py
+++ b/ingestion/src/metadata/ingestion/source/database/bigquery/helper.py
@@ -25,6 +25,10 @@ from sqlalchemy import inspect, text
 from metadata.generated.schema.entity.services.connections.database.bigQueryConnection import (
     BigQueryConnection,
 )
+from metadata.generated.schema.security.credentials.gcpCredentials import (
+    GcpADC,
+    GcpCredentialsPath,
+)
 from metadata.generated.schema.security.credentials.gcpValues import (
     GcpCredentialsValues,
     SingleProjectId,
@@ -68,7 +72,10 @@ def clone_connection_for_project(database_name: str, service_connection: BigQuer
     project in a multi-project connection can be inspected/tested independently.
     """
     new_service_connection = deepcopy(service_connection)
-    if isinstance(new_service_connection.credentials.gcpConfig, GcpCredentialsValues):
+    if isinstance(
+        new_service_connection.credentials.gcpConfig,
+        (GcpCredentialsValues, GcpADC, GcpCredentialsPath),
+    ):
         new_service_connection.credentials.gcpConfig.projectId = SingleProjectId(database_name)
     return new_service_connection
 

--- a/ingestion/tests/unit/topology/database/test_bigquery.py
+++ b/ingestion/tests/unit/topology/database/test_bigquery.py
@@ -35,6 +35,9 @@ from metadata.generated.schema.entity.data.table import (
     TableConstraint,
     TableType,
 )
+from metadata.generated.schema.entity.services.connections.database.bigQueryConnection import (
+    BigQueryConnection,
+)
 from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
     OpenMetadataConnection,
 )
@@ -678,9 +681,6 @@ class BigqueryUnitTest(TestCase):
         """
         from google.auth.credentials import Credentials
 
-        from metadata.generated.schema.entity.services.connections.database.bigQueryConnection import (
-            BigQueryConnection,
-        )
         from metadata.ingestion.source.database.bigquery.helper import (
             get_inspector_details,
         )
@@ -705,6 +705,31 @@ class BigqueryUnitTest(TestCase):
         result_null = get_inspector_details(database_name="test-project", service_connection=service_connection_null)
         assert "location=eu" not in str(result_null.engine.url)
         assert result_null.client._location is None
+
+    def test_clone_connection_for_project_scopes_adc_and_path_credentials(self):
+        from metadata.ingestion.source.database.bigquery.helper import (
+            clone_connection_for_project,
+        )
+
+        for gcp_config in (
+            {"type": "gcp_adc", "projectId": ["project-one", "project-two"]},
+            {
+                "type": "gcp_credential_path",
+                "path": "credentials.json",
+                "projectId": ["project-one", "project-two"],
+            },
+        ):
+            config = deepcopy(mock_bq_config["source"]["serviceConnection"]["config"])
+            config["credentials"]["gcpConfig"] = gcp_config
+            service_connection = BigQueryConnection.model_validate(config)
+
+            scoped = clone_connection_for_project("project-two", service_connection)
+
+            assert scoped.credentials.gcpConfig.projectId.root == "project-two"
+            assert service_connection.credentials.gcpConfig.projectId.root == [
+                "project-one",
+                "project-two",
+            ]
 
 
 class BigqueryLineageSourceTest(TestCase):


### PR DESCRIPTION
### Describe your changes:

Backport of #32484 to `2.0`.

Scopes BigQuery multi-project connections to the current project when using Application Default Credentials or a credential-file path. Without this override, each database iteration connects to the first configured project.

Fixes #32485 on the `2.0` line.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A — small backport.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:

- [x] I have read the [CONTRIBUTING](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR is linked to a GitHub issue.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.
- [x] I have added a regression test for the affected credential types.
