### PR TITLE
Backport #32484 to 1.13: scope BigQuery multi-project ADC connections

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/bigquery/helper.py
+++ b/ingestion/src/metadata/ingestion/source/database/bigquery/helper.py
@@ -24,6 +24,10 @@ from sqlalchemy import inspect, text
 from metadata.generated.schema.entity.services.connections.database.bigQueryConnection import (
     BigQueryConnection,
 )
+from metadata.generated.schema.security.credentials.gcpCredentials import (
+    GcpADC,
+    GcpCredentialsPath,
+)
 from metadata.generated.schema.security.credentials.gcpValues import (
     GcpCredentialsValues,
     SingleProjectId,
@@ -119,7 +123,10 @@ def get_inspector_details(
     if new_service_connection.usageLocation:
         kwargs["location"] = new_service_connection.usageLocation
 
-    if isinstance(new_service_connection.credentials.gcpConfig, GcpCredentialsValues):
+    if isinstance(
+        new_service_connection.credentials.gcpConfig,
+        (GcpCredentialsValues, GcpADC, GcpCredentialsPath),
+    ):
         new_service_connection.credentials.gcpConfig.projectId = SingleProjectId(
             database_name
         )

--- a/ingestion/tests/unit/topology/database/test_bigquery.py
+++ b/ingestion/tests/unit/topology/database/test_bigquery.py
@@ -35,6 +35,9 @@ from metadata.generated.schema.entity.data.table import (
     TableConstraint,
     TableType,
 )
+from metadata.generated.schema.entity.services.connections.database.bigQueryConnection import (
+    BigQueryConnection,
+)
 from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
     OpenMetadataConnection,
 )
@@ -694,9 +697,6 @@ class BigqueryUnitTest(TestCase):
         """
         from google.auth.credentials import Credentials
 
-        from metadata.generated.schema.entity.services.connections.database.bigQueryConnection import (
-            BigQueryConnection,
-        )
         from metadata.ingestion.source.database.bigquery.helper import (
             get_inspector_details,
         )
@@ -731,6 +731,36 @@ class BigqueryUnitTest(TestCase):
         )
         assert "location=eu" not in str(result_null.engine.url)
         assert result_null.client._location is None
+
+    @patch("metadata.utils.credentials.auth.default")
+    def test_inspector_scopes_adc_and_path_credentials(self, mock_auth_default):
+        from google.auth.credentials import Credentials
+
+        from metadata.ingestion.source.database.bigquery.helper import (
+            get_inspector_details,
+        )
+
+        mock_auth_default.return_value = (Mock(spec=Credentials), "project-one")
+
+        for gcp_config in (
+            {"type": "gcp_adc", "projectId": ["project-one", "project-two"]},
+            {
+                "type": "gcp_credential_path",
+                "path": "credentials.json",
+                "projectId": ["project-one", "project-two"],
+            },
+        ):
+            config = deepcopy(mock_bq_config["source"]["serviceConnection"]["config"])
+            config["credentials"]["gcpConfig"] = gcp_config
+            service_connection = BigQueryConnection.model_validate(config)
+
+            result = get_inspector_details("project-two", service_connection)
+
+            assert str(result.engine.url).startswith("bigquery://project-two")
+            assert service_connection.credentials.gcpConfig.projectId.root == [
+                "project-one",
+                "project-two",
+            ]
 
 
 class BigqueryLineageSourceTest(TestCase):


### PR DESCRIPTION
### Describe your changes:

Backport of #32484 to `1.13`.

Scopes BigQuery multi-project connections to the current project when using Application Default Credentials or a credential-file path. Without this override, each database iteration connects to the first configured project.

The project-scoping logic is inline in `get_inspector_details` on this branch, so the fix is adapted there. The regression test verifies the resulting engine URL uses the requested project.

Fixes #32485 on the `1.13` line.

#
### Type of change:

- [x] Bug fix

#
### Checklist:

- [x] I have read the [CONTRIBUTING](https://docs.open-metadata.org/developers/contribute) document.
- [x] For JSON Schema changes: not applicable.
- [x] I have added a regression test for the affected credential types.
