### PR TITLE
fix(1.13): stabilize security configuration manager test

### DIFF
--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/auth/SecurityConfigurationManagerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/auth/SecurityConfigurationManagerTest.java
@@ -153,18 +153,14 @@ public class SecurityConfigurationManagerTest {
 
   @Test
   void testConfigGettersReturnNullWhenNotInitialized() {
-    AuthenticationConfiguration auth = SecurityConfigurationManager.getCurrentAuthConfig();
-    AuthorizerConfiguration authz = SecurityConfigurationManager.getCurrentAuthzConfig();
-    MCPConfiguration mcp = SecurityConfigurationManager.getCurrentMcpConfig();
+    SecurityConfigurationManager manager = SecurityConfigurationManager.getInstance();
+    manager.setCurrentAuthConfig(null);
+    manager.setCurrentAuthzConfig(null);
+    manager.setCurrentMcpConfig(null);
 
-    if (auth == null && authz == null && mcp == null) {
-      assertNull(auth);
-      assertNull(authz);
-      assertNull(mcp);
-    } else {
-      assertNotNull(auth);
-      assertNotNull(authz);
-    }
+    assertNull(SecurityConfigurationManager.getCurrentAuthConfig());
+    assertNull(SecurityConfigurationManager.getCurrentAuthzConfig());
+    assertNull(SecurityConfigurationManager.getCurrentMcpConfig());
   }
 
   @Test


### PR DESCRIPTION
### Describe your changes:

This fixes a branch-level flaky service unit test exposed by #32373 and independently by #32590.

`SamlAuthServletHandlerTest` mutates the `SecurityConfigurationManager` singleton and can leave the authorizer configuration populated while the authentication configuration is null. `testConfigGettersReturnNullWhenNotInitialized` depended on ambient singleton state and assumed only two possible states: all configuration is null, or authentication and authorization are both populated. Surefire filesystem ordering can therefore make the test fail even though the PR under test did not touch this code.

The test now establishes its own uninitialized precondition by clearing authentication, authorization, and MCP configuration before asserting all three getters return null. There are no production-code changes.

### Type of change:

- [x] Bug fix

### Verification:

- Reproduced on unmodified `origin/1.13` with `SamlAuthServletHandlerTest,SecurityConfigurationManagerTest`: 31 tests, 1 failure.
- Ran the same ordered test selection after the fix: 31 tests, 0 failures.
- Ran `mvn -pl openmetadata-service spotless:apply`.
- Ran `mvn -pl openmetadata-service spotless:check`.

### Checklist:

- [x] I have read the [CONTRIBUTING](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have added a test fix that covers the exact scenario.
- [x] No schema or migration changes are required.
