### PR TITLE
[1.13] Backport Airflow API error sanitization

### DIFF
--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/error_handlers.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/error_handlers.py
@@ -23,13 +23,13 @@ logger = api_logger()
 
 @blueprint.app_errorhandler(Exception)
 def handle_any_error(exc):
-    logger.exception("Wild exception: {exc}")
+    logger.exception("Unhandled API exception")
     if isinstance(exc, HTTPException):
-        return ApiResponse.error(exc.code, repr(exc))
-    return ApiResponse.server_error(repr(exc))
+        return ApiResponse.error(exc.code, exc.name)
+    return ApiResponse.server_error()
 
 
 @blueprint.app_errorhandler(MissingArgException)
 def handle_missing_arg(exc):
-    logger.exception(f"Missing Argument Exception: {exc}")
-    return ApiResponse.bad_request(repr(exc))
+    logger.exception("Missing API argument")
+    return ApiResponse.bad_request("Missing required request argument")

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/response.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/response.py
@@ -29,6 +29,7 @@ class ApiResponse:
     STATUS_UNAUTHORIZED = 401
     STATUS_NOT_FOUND = 404
     STATUS_SERVER_ERROR = 500
+    UNEXPECTED_ERROR = "An unexpected problem occurred"
 
     @staticmethod
     def standard_response(status, response_obj) -> Response:
@@ -44,6 +45,10 @@ class ApiResponse:
 
     @staticmethod
     def error(status, error):
+        if not isinstance(status, int):
+            status = ApiResponse.STATUS_SERVER_ERROR
+        if status >= ApiResponse.STATUS_SERVER_ERROR:
+            error = ApiResponse.UNEXPECTED_ERROR
         return ApiResponse.standard_response(status, {"error": error})
 
     @staticmethod
@@ -59,8 +64,10 @@ class ApiResponse:
         return ApiResponse.error(ApiResponse.STATUS_UNAUTHORIZED, error)
 
     @staticmethod
-    def server_error(error="An unexpected problem occurred"):
-        return ApiResponse.error(ApiResponse.STATUS_SERVER_ERROR, error)
+    def server_error():
+        return ApiResponse.error(
+            ApiResponse.STATUS_SERVER_ERROR, ApiResponse.UNEXPECTED_ERROR
+        )
 
 
 class ResponseFormat:

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/deploy.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/deploy.py
@@ -19,6 +19,7 @@ from flask import Blueprint, Response, jsonify, make_response, request
 from openmetadata_managed_apis.api.response import ApiResponse
 from openmetadata_managed_apis.operations.deploy import DagDeployer
 from openmetadata_managed_apis.utils.logger import routes_logger
+from openmetadata_managed_apis.utils.parser import parse_validation_err
 from pydantic import ValidationError
 
 from metadata.ingestion.api.parser import parse_ingestion_pipeline_config_gracefully
@@ -84,7 +85,7 @@ def get_fn(blueprint: Blueprint) -> Callable:
             )
             return ApiResponse.error(
                 status=ApiResponse.STATUS_BAD_REQUEST,
-                error=f"Request Validation Error parsing payload. IngestionPipeline expected: {err}",
+                error=parse_validation_err(err),
             )
 
         except Exception as exc:

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/run_automation.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/run_automation.py
@@ -19,6 +19,7 @@ from flask import Blueprint, Response, request
 from markupsafe import escape
 from openmetadata_managed_apis.api.response import ApiResponse
 from openmetadata_managed_apis.utils.logger import routes_logger
+from openmetadata_managed_apis.utils.parser import parse_validation_err
 from pydantic import ValidationError
 
 from metadata.automations.execute_runner import execute
@@ -88,7 +89,7 @@ def get_fn(blueprint: Blueprint) -> Callable:
             logger.error(msg)
             return ApiResponse.error(
                 status=ApiResponse.STATUS_BAD_REQUEST,
-                error=msg,
+                error=parse_validation_err(err),
             )
 
         except Exception as exc:

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/operations/delete.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/operations/delete.py
@@ -22,6 +22,9 @@ from openmetadata_managed_apis.api.config import (
     DAG_GENERATED_CONFIGS,
 )
 from openmetadata_managed_apis.api.response import ApiResponse
+from openmetadata_managed_apis.utils.logger import operations_logger
+
+logger = operations_logger()
 
 
 def delete_dag_id(dag_id: str) -> Response:
@@ -58,8 +61,11 @@ def delete_dag_id(dag_id: str) -> Response:
     if deleted_dags > 0 and deleted_file and deleted_config:
         return ApiResponse.success({"message": f"DAG [{dag_id}] has been deleted"})
 
-    return ApiResponse.error(
-        status=ApiResponse.STATUS_SERVER_ERROR,
-        error=f"Could not find and delete {dag_id}. Deleted dags: {deleted_dags}; "
-        + f"deleted {dag_py_file}: {deleted_file}",
+    logger.error(
+        "Could not fully delete DAG %s. Deleted database records: %s; DAG file: %s; config file: %s",
+        dag_id,
+        deleted_dags,
+        deleted_file,
+        deleted_config,
     )
+    return ApiResponse.server_error()

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/operations/deploy.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/operations/deploy.py
@@ -174,7 +174,7 @@ class DagDeployer:
                 msg = f"Workflow [{self.dag_id}] failed to refresh due to [{exc}]"
                 logger.debug(traceback.format_exc())
                 logger.error(msg)
-                return ApiResponse.server_error({f"message": msg})
+                return ApiResponse.server_error()
 
         scan_dags_job_background()
 

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/operations/health.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/operations/health.py
@@ -36,5 +36,5 @@ def health_response():
         logger.error(msg)
         return ApiResponse.error(
             status=ApiResponse.STATUS_BAD_REQUEST,
-            error=msg,
+            error="Unable to determine the Airflow REST API status.",
         )

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/operations/last_dag_logs.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/operations/last_dag_logs.py
@@ -153,7 +153,8 @@ def last_dag_logs(dag_id: str, task_id: str, after: Optional[int] = None) -> Res
 
     task_log_reader = TaskLogReader()
     if not task_log_reader.supports_read:
-        return ApiResponse.server_error("Task Log Reader does not support read logs.")
+        logger.error("Task log reader does not support reading logs")
+        return ApiResponse.server_error()
 
     # Try to use file streaming for better performance
     try:

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/utils/parser.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/utils/parser.py
@@ -28,34 +28,42 @@ logger = utils_logger()
 
 
 def parse_validation_err(validation_error: ValidationError) -> str:
-    """
-    Convert the validation error into a message to log
-    """
-    missing_fields = [
-        f"Extra parameter '{err.get('loc')[0]}'"
-        if len(err.get("loc")) == 1
-        else f"Extra parameter in {err.get('loc')}"
-        for err in validation_error.errors()
-        if err.get("type") == "value_error.extra"
-    ]
+    """Render validation field locations without input values."""
+    error_details = validation_error.errors()
+    extra_error_types = {"extra_forbidden", "value_error.extra"}
+    missing_error_types = {"missing", "value_error.missing"}
 
     extra_fields = [
-        f"Missing parameter '{err.get('loc')[0]}'"
-        if len(err.get("loc")) == 1
-        else f"Missing parameter in {err.get('loc')}"
-        for err in validation_error.errors()
-        if err.get("type") == "value_error.missing"
+        (
+            f"Extra parameter '{err.get('loc')[0]}'"
+            if len(err.get("loc")) == 1
+            else f"Extra parameter in {err.get('loc')}"
+        )
+        for err in error_details
+        if err.get("type") in extra_error_types
+    ]
+
+    missing_fields = [
+        (
+            f"Missing parameter '{err.get('loc')[0]}'"
+            if len(err.get("loc")) == 1
+            else f"Missing parameter in {err.get('loc')}"
+        )
+        for err in error_details
+        if err.get("type") in missing_error_types
     ]
 
     invalid_fields = [
-        f"Invalid parameter value for  '{err.get('loc')[0]}'"
-        if len(err.get("loc")) == 1
-        else f"Missing parameter in {err.get('loc')}"
-        for err in validation_error.errors()
-        if err.get("type") not in ("value_error.missing", "value_error.extra")
+        (
+            f"Invalid parameter value for '{err.get('loc')[0]}'"
+            if len(err.get("loc")) == 1
+            else f"Invalid parameter value for {err.get('loc')}"
+        )
+        for err in error_details
+        if err.get("type") not in extra_error_types | missing_error_types
     ]
 
-    return "\n".join(missing_fields + extra_fields + invalid_fields)
+    return "\n".join(extra_fields + missing_fields + invalid_fields)
 
 
 def _parse_inner_connection(connection_dict: dict, source_type: str) -> None:

--- a/openmetadata-airflow-apis/tests/unit/test_operation_diagnostics.py
+++ b/openmetadata-airflow-apis/tests/unit/test_operation_diagnostics.py
@@ -1,0 +1,85 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+from types import SimpleNamespace
+
+from flask import Flask
+from openmetadata_managed_apis.operations import delete, last_dag_logs
+
+
+class FakeDagModel:
+    @staticmethod
+    def get_last_dagrun(include_externally_triggered):
+        return SimpleNamespace(
+            get_task_instances=lambda: [SimpleNamespace(task_id="task", try_number=1)]
+        )
+
+
+class FakeQuery:
+    def filter(self, *_args):
+        return self
+
+    def delete(self):
+        return 0
+
+
+class FakeSession:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def query(self, *_args):
+        return FakeQuery()
+
+    def commit(self):
+        return None
+
+
+def test_unsupported_task_log_reader_is_logged(monkeypatch, caplog):
+    monkeypatch.setattr(
+        last_dag_logs.DagModel,
+        "get_dagmodel",
+        lambda **_kwargs: FakeDagModel(),
+    )
+    monkeypatch.setattr(
+        last_dag_logs,
+        "TaskLogReader",
+        lambda: SimpleNamespace(supports_read=False),
+    )
+
+    with (
+        Flask(__name__).app_context(),
+        caplog.at_level(logging.ERROR, logger="AirflowOperations"),
+    ):
+        response = last_dag_logs.last_dag_logs("my_dag", "task")
+
+    assert response.status_code == 500
+    assert "Task log reader does not support reading logs" in caplog.text
+
+
+def test_partial_dag_deletion_is_logged(monkeypatch, tmp_path, caplog):
+    monkeypatch.setattr(delete, "AIRFLOW_DAGS_FOLDER", str(tmp_path / "dags"))
+    monkeypatch.setattr(delete, "DAG_GENERATED_CONFIGS", str(tmp_path / "configs"))
+    monkeypatch.setattr(delete.settings, "Session", FakeSession)
+
+    with (
+        Flask(__name__).app_context(),
+        caplog.at_level(logging.ERROR, logger="AirflowOperations"),
+    ):
+        response = delete.delete_dag_id("my_dag")
+
+    assert response.status_code == 500
+    assert response.get_json() == {"error": "An unexpected problem occurred"}
+    assert "Could not fully delete DAG my_dag" in caplog.text
+    assert "database records: 0; DAG file: False; config file: False" in caplog.text

--- a/openmetadata-airflow-apis/tests/unit/test_parser.py
+++ b/openmetadata-airflow-apis/tests/unit/test_parser.py
@@ -1,0 +1,43 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+from openmetadata_managed_apis.utils.parser import parse_validation_err
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+
+class ValidationConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    required: str
+    port: int
+
+
+def test_parse_validation_err_reports_fields_without_values():
+    with pytest.raises(ValidationError) as exc_info:
+        ValidationConfig.model_validate(
+            {
+                "port": "not-an-integer",
+                "unexpected": "do-not-return",
+            }
+        )
+
+    message = parse_validation_err(exc_info.value)
+
+    assert message == "\n".join(
+        (
+            "Extra parameter 'unexpected'",
+            "Missing parameter 'required'",
+            "Invalid parameter value for 'port'",
+        )
+    )
+    assert "not-an-integer" not in message
+    assert "do-not-return" not in message

--- a/openmetadata-airflow-apis/tests/unit/test_response.py
+++ b/openmetadata-airflow-apis/tests/unit/test_response.py
@@ -1,0 +1,66 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from http import HTTPStatus
+
+import pytest
+from flask import Flask
+from openmetadata_managed_apis.api.response import ApiResponse
+
+
+def test_server_error_does_not_expose_internal_details():
+    internal_detail = "Traceback: password=do-not-return"
+
+    with Flask(__name__).app_context():
+        responses = (
+            ApiResponse.error(ApiResponse.STATUS_SERVER_ERROR, internal_detail),
+            ApiResponse.server_error(),
+        )
+        for response in responses:
+            assert response.status_code == ApiResponse.STATUS_SERVER_ERROR
+            assert response.get_json() == {"error": "An unexpected problem occurred"}
+            assert internal_detail.encode() not in response.data
+
+
+def test_client_error_keeps_safe_actionable_message():
+    message = "Did not receive any JSON request to deploy"
+
+    with Flask(__name__).app_context():
+        response = ApiResponse.bad_request(message)
+        assert response.status_code == ApiResponse.STATUS_BAD_REQUEST
+        assert response.get_json() == {"error": message}
+
+
+@pytest.mark.parametrize(
+    "status,error,expected_status,expected_error",
+    [
+        (
+            None,
+            "Internal detail",
+            ApiResponse.STATUS_SERVER_ERROR,
+            ApiResponse.UNEXPECTED_ERROR,
+        ),
+        (
+            HTTPStatus.BAD_REQUEST,
+            "Invalid request",
+            ApiResponse.STATUS_BAD_REQUEST,
+            "Invalid request",
+        ),
+        (499, "Client closed request", 499, "Client closed request"),
+    ],
+)
+def test_error_handles_missing_enum_and_nonstandard_statuses(
+    status, error, expected_status, expected_error
+):
+    with Flask(__name__).app_context():
+        response = ApiResponse.error(status, error)
+        assert response.status_code == expected_status
+        assert response.get_json() == {"error": expected_error}


### PR DESCRIPTION
Backports the Airflow API response sanitization from #32474 to 1.13. Internal diagnostics remain available in logs while server responses stay generic.