### PR TITLE
[2.0] Backport #31392: refresh Athena assume-role credentials

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/athena/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/athena/connection.py
@@ -49,6 +49,7 @@ from metadata.ingestion.connections.builders import (
     get_connection_args_common,
 )
 from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.connections.strategies import ClientStrategy
 from metadata.utils.filters import filter_by_schema
 
 if TYPE_CHECKING:
@@ -56,6 +57,7 @@ if TYPE_CHECKING:
     from metadata.core.connections.test_connection import ChecksProvider
     from metadata.core.connections.test_connection.classifier import Matcher
     from metadata.generated.schema.type.filterPattern import FilterPattern
+    from metadata.ingestion.models.custom_pydantic import CustomSecretStr
 
 # Cap how many schemas the test connection probes so a catalog with many
 # databases cannot exhaust the test-connection timeout.
@@ -232,47 +234,93 @@ class AthenaChecks:
         )
 
 
-class AthenaConnection(BaseConnection[AthenaConnectionConfig, Engine]):
-    @staticmethod
-    def get_connection_url(connection: AthenaConnectionConfig) -> str:
-        """
-        Method to get connection url
-        """
-        aws_access_key_id = connection.awsConfig.awsAccessKeyId
-        aws_secret_access_key = connection.awsConfig.awsSecretAccessKey
-        aws_session_token = connection.awsConfig.awsSessionToken
-        if connection.awsConfig.assumeRoleArn:
-            assume_configs = AWSClient.get_assume_role_config(connection.awsConfig)
-            if assume_configs:
-                aws_access_key_id = assume_configs.accessKeyId
-                aws_secret_access_key = assume_configs.secretAccessKey
-                aws_session_token = assume_configs.sessionToken
+def _get_connection_url(
+    connection: AthenaConnectionConfig,
+    aws_access_key_id: str | None = None,
+    aws_secret_access_key: CustomSecretStr | None = None,
+    aws_session_token: str | None = None,
+) -> str:
+    url = f"{connection.scheme.value}://"  # pyright: ignore[reportOptionalMemberAccess]
+    if aws_access_key_id:
+        url += aws_access_key_id
+        if aws_secret_access_key:
+            url += f":{aws_secret_access_key.get_secret_value()}"
+    else:
+        url += ":"
+    url += f"@athena.{connection.awsConfig.awsRegion}.amazonaws.com:443"
 
-        url = f"{connection.scheme.value}://"  # pyright: ignore[reportOptionalMemberAccess]
-        if aws_access_key_id:
-            url += aws_access_key_id
-            if aws_secret_access_key:
-                url += f":{aws_secret_access_key.get_secret_value()}"
-        else:
-            url += ":"
-        url += f"@athena.{connection.awsConfig.awsRegion}.amazonaws.com:443"
+    url += f"?s3_staging_dir={quote_plus(str(connection.s3StagingDir))}"
+    if connection.workgroup:
+        url += f"&work_group={connection.workgroup}"
+    if aws_session_token:
+        url += f"&aws_session_token={quote_plus(aws_session_token)}"
+    if connection.catalogId:
+        url += f"&catalog_name={quote_plus(connection.catalogId)}"
 
-        url += f"?s3_staging_dir={quote_plus(str(connection.s3StagingDir))}"
-        if connection.workgroup:
-            url += f"&work_group={connection.workgroup}"
-        if aws_session_token:
-            url += f"&aws_session_token={quote_plus(aws_session_token)}"
-        if connection.catalogId:
-            url += f"&catalog_name={quote_plus(connection.catalogId)}"
+    return url
 
-        return url
 
-    def _get_client(self) -> Engine:
-        engine = create_generic_db_connection(
-            connection=self.service_connection,
-            get_connection_url_fn=self.get_connection_url,
+def get_connection_url(connection: AthenaConnectionConfig) -> str:
+    """Build the existing Athena URL with static AWS credentials."""
+    aws_access_key_id = connection.awsConfig.awsAccessKeyId
+    aws_secret_access_key = connection.awsConfig.awsSecretAccessKey
+    aws_session_token = connection.awsConfig.awsSessionToken
+    if connection.awsConfig.assumeRoleArn:
+        assume_configs = AWSClient.get_assume_role_config(connection.awsConfig)
+        if assume_configs:
+            aws_access_key_id = assume_configs.accessKeyId
+            aws_secret_access_key = assume_configs.secretAccessKey
+            aws_session_token = assume_configs.sessionToken
+    return _get_connection_url(
+        connection,
+        aws_access_key_id,
+        aws_secret_access_key,
+        aws_session_token,
+    )
+
+
+def get_connection_url_without_credentials(connection: AthenaConnectionConfig) -> str:
+    """Build an Athena URL that delegates authentication to a Boto3 session."""
+    return _get_connection_url(connection)
+
+
+class AthenaStandardStrategy(ClientStrategy[AthenaConnectionConfig, Engine]):
+    """Build the standard Athena engine without altering its connection path."""
+
+    def build(self) -> Engine:
+        return create_generic_db_connection(
+            connection=self._connection,
+            get_connection_url_fn=get_connection_url,
             get_connection_args_fn=get_connection_args_common,
         )
+
+
+class AthenaAssumeRoleStrategy(ClientStrategy[AthenaConnectionConfig, Engine]):
+    """Build an Athena engine that refreshes assumed-role credentials."""
+
+    def build(self) -> Engine:
+        connection_args = get_connection_args_common(self._connection)
+        if "session" in connection_args:
+            raise ValueError("Athena connectionArguments must not define 'session' when assumeRoleArn is configured.")
+        session = AWSClient(self._connection.awsConfig).create_session()
+        return create_generic_db_connection(
+            connection=self._connection,
+            get_connection_url_fn=get_connection_url_without_credentials,
+            get_connection_args_fn=lambda _: {**connection_args, "session": session},
+        )
+
+
+class AthenaConnection(BaseConnection[AthenaConnectionConfig, Engine]):
+    get_connection_url = staticmethod(get_connection_url)
+    get_connection_url_without_credentials = staticmethod(get_connection_url_without_credentials)
+
+    def _get_client(self) -> Engine:
+        if self.service_connection.awsConfig.assumeRoleArn:
+            strategy: ClientStrategy[AthenaConnectionConfig, Engine] = AthenaAssumeRoleStrategy(self.service_connection)
+        else:
+            strategy = AthenaStandardStrategy(self.service_connection)
+
+        engine = strategy.build()
         self._on_close(engine.dispose)
         return engine
 

--- a/ingestion/tests/unit/source/database/athena/test_connection.py
+++ b/ingestion/tests/unit/source/database/athena/test_connection.py
@@ -17,6 +17,7 @@ import pytest
 from botocore.exceptions import ClientError, EndpointConnectionError
 from sqlalchemy import create_engine
 
+from metadata.clients.aws_client import AWSClient
 from metadata.core.connections.lifetime import Borrowed
 from metadata.core.connections.test_connection.check import collect_checks
 from metadata.core.connections.test_connection.checks.database import DatabaseStep
@@ -34,8 +35,10 @@ from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.source.database.athena import connection as athena_connection
 from metadata.ingestion.source.database.athena.connection import (
     ATHENA_ERRORS,
+    AthenaAssumeRoleStrategy,
     AthenaChecks,
     AthenaConnection,
+    AthenaStandardStrategy,
 )
 
 CONNECTION_MODULE = "metadata.ingestion.source.database.athena.connection"
@@ -73,10 +76,75 @@ def test_athena_connection_is_base_connection():
     assert issubclass(AthenaConnection, BaseConnection)
 
 
-def test_get_client_uses_the_class_url_builder():
-    with patch(f"{CONNECTION_MODULE}.create_generic_db_connection") as mock_connection:
+def test_standard_strategy_does_not_resolve_connection_arguments_before_the_builder():
+    with (
+        patch(f"{CONNECTION_MODULE}.create_generic_db_connection") as mock_connection,
+        patch(f"{CONNECTION_MODULE}.get_connection_args_common") as mock_connection_args,
+    ):
         _ = AthenaConnection(_config()).client
+    assert mock_connection_args.call_count == 0
     assert mock_connection.call_args.kwargs["get_connection_url_fn"].__name__ == "get_connection_url"
+    assert mock_connection.call_args.kwargs["get_connection_args_fn"] is mock_connection_args
+
+
+def test_get_client_selects_the_standard_strategy_without_an_assume_role():
+    with patch.object(AthenaStandardStrategy, "build", return_value=MagicMock()) as mock_build:
+        _ = AthenaConnection(_config()).client
+
+    mock_build.assert_called_once_with()
+
+
+def test_get_client_selects_the_assume_role_strategy_with_an_assume_role():
+    config = _config(
+        awsConfig=AWSCredentials(
+            awsRegion="us-east-2",
+            assumeRoleArn="arn:aws:iam::123456789012:role/metadata-reader",
+        )
+    )
+
+    with patch.object(AthenaAssumeRoleStrategy, "build", return_value=MagicMock()) as mock_build:
+        _ = AthenaConnection(config).client
+
+    mock_build.assert_called_once_with()
+
+
+def test_assume_role_uses_refreshable_session_without_url_credentials():
+    refreshable_session = MagicMock()
+    config = _config(
+        awsConfig=AWSCredentials(
+            awsRegion="us-east-2",
+            assumeRoleArn="arn:aws:iam::123456789012:role/metadata-reader",
+        ),
+        catalogId="my_catalog",
+    )
+
+    with (
+        patch.object(AWSClient, "create_session", return_value=refreshable_session),
+        patch(f"{CONNECTION_MODULE}.create_generic_db_connection") as mock_connection,
+    ):
+        _ = AthenaConnection(config).client
+
+    url_builder = mock_connection.call_args.kwargs["get_connection_url_fn"]
+    args_builder = mock_connection.call_args.kwargs["get_connection_args_fn"]
+    assert url_builder(config) == (
+        "awsathena+rest://:@athena.us-east-2.amazonaws.com:443"
+        "?s3_staging_dir=s3%3A%2F%2Fpostgres%2Finput%2F&work_group=primary"
+        "&catalog_name=my_catalog"
+    )
+    assert args_builder(config) == {"session": refreshable_session}
+
+
+def test_assume_role_rejects_connection_argument_session():
+    config = _config(
+        awsConfig=AWSCredentials(
+            awsRegion="us-east-2",
+            assumeRoleArn="arn:aws:iam::123456789012:role/metadata-reader",
+        ),
+        connectionArguments={"session": "not-a-boto3-session"},
+    )
+
+    with pytest.raises(ValueError, match="must not define 'session'"):
+        _ = AthenaConnection(config).client
 
 
 def test_get_client_registers_engine_disposal():


### PR DESCRIPTION
Backport of #31392 to 2.0.

Athena assume-role connections now pass the refreshable Boto3 session to PyAthena instead of embedding one-time STS credentials in the URL. Conflicting user-provided session arguments are rejected.

The behavior and regression coverage match the original change.