### PR TITLE
fix(ui): show custom property display name in intake form extension fields

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainFormExtensionFields.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainFormExtensionFields.test.tsx
@@ -366,6 +366,18 @@ describe('AddDomainFormExtensionFields', () => {
     );
   });
 
+  it('labels the field with the custom property display name when set', () => {
+    const definition: CustomProperty = {
+      ...buildDefinition('string'),
+      displayName: 'Owner Team',
+    };
+
+    render(<ExtensionFieldsHarness definition={definition} />);
+
+    expect(screen.getByText('Owner Team')).toBeInTheDocument();
+    expect(screen.queryByText(definition.name)).not.toBeInTheDocument();
+  });
+
   it.each([
     ['entityReference', { config: ['glossaryTerm'] }, 'ENTITYREFERENCE'],
     ['hyperlink-cp', undefined, 'HYPERLINK'],

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainFormExtensionFields.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainFormExtensionFields.tsx
@@ -1054,11 +1054,14 @@ const ExtensionField = ({
     propertyName
   )}` as const;
   const dataTestId = `extension-${propertyName}`;
-  const label = formField.fieldLabel;
+  // Prefer the custom property's current displayName so the field shows the
+  // human-friendly name (e.g. "Owner Team") rather than the raw property name
+  // captured in fieldLabel at design time; fall back to fieldLabel when the
+  // definition is missing or has no displayName.
+  const label = definition?.displayName || formField.fieldLabel;
   const isRequired = Boolean(formField.required);
   const requiredMessage =
-    formField.errorMessage ||
-    t('label.field-required', { field: formField.fieldLabel });
+    formField.errorMessage || t('label.field-required', { field: label });
   // Without the definition we cannot pick the right widget or serialize the
   // value, so a text input here would submit an untyped string and the backend
   // would reject it. Surface the failure instead of collecting a bad value.


### PR DESCRIPTION
## Describe your changes

The **Data Product intake form** (`AddDomainForm` with `type=DATA_PRODUCT`, also used for Domains and Glossary intake) rendered custom-property "extension" fields using the label snapshotted into `IntakeFormField.fieldLabel` at design time — typically the raw property `name`. When a custom property was named like a native field (e.g. `owners`), its field label collided with the native **"Owners"** picker, so users could not tell the entity owner apart from the custom-property owner.

This change makes the extension field prefer the custom property's current `displayName`:

- `AddDomainFormExtensionFields.tsx` → `label = definition?.displayName || formField.fieldLabel` (falls back to the snapshot label when the definition is missing or has no displayName). The required-validation message uses the same resolved label.

All other custom-property value editors (`PropertyValue`, `EditTableTypePropertyModal`, the entity Custom Properties tab) already derive their labels via `getEntityName()` (= `displayName || name`), so no other forms needed changing. The Glossary intake form reuses `AddDomainFormExtensionFields` and inherits the fix.

Fixes open-metadata/openmetadata-collate#4725

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

- `AddDomainFormExtensionFields.test.tsx` — added a case asserting the field label uses the custom property `displayName` when set (falls back to name otherwise). Full suite: 59 passed.
- `yarn lint` (eslint) — 0 errors; `prettier --check` — clean.

## Screenshots / recording

Before: native "Owners" field and a custom property named "owners" both showed similar labels, indistinguishable.
After: the custom-property field shows its `displayName`, distinct from the native "Owners" field.