### PR TITLE
Add export support for classification and tag level — Backport 2.0 (#31938)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ClassificationResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ClassificationResourceIT.java
@@ -920,4 +920,229 @@ public class ClassificationResourceIT extends BaseEntityIT<Classification, Creat
                       + tagFqns);
             });
   }
+
+  @Test
+  void test_exportClassificationCsv_containsAllTags(TestNamespace ns) throws Exception {
+    Classification classification = createEntity(createMinimalRequest(ns));
+
+    CreateTag firstTagRequest = new CreateTag();
+    firstTagRequest.setName(ns.prefix("exportTagA"));
+    firstTagRequest.setDescription("Exportable tag A");
+    firstTagRequest.setClassification(classification.getFullyQualifiedName());
+    Tag firstTag = SdkClients.adminClient().tags().create(firstTagRequest);
+
+    CreateTag secondTagRequest = new CreateTag();
+    secondTagRequest.setName(ns.prefix("exportTagB"));
+    secondTagRequest.setDescription("Exportable tag B");
+    secondTagRequest.setClassification(classification.getFullyQualifiedName());
+    Tag secondTag = SdkClients.adminClient().tags().create(secondTagRequest);
+
+    String csv =
+        SdkClients.adminClient()
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.GET,
+                "/v1/classifications/name/" + classification.getFullyQualifiedName() + "/export",
+                null);
+
+    assertNotNull(csv);
+    assertTrue(
+        csv.contains("parent") && csv.contains("mutuallyExclusive"),
+        "Exported CSV must contain the header row");
+    assertTrue(csv.contains(firstTag.getName()), "Exported CSV must contain the first tag");
+    assertTrue(csv.contains(secondTag.getName()), "Exported CSV must contain the second tag");
+  }
+
+  @Test
+  void test_importClassificationCsv_createsTags(TestNamespace ns) throws Exception {
+    Classification classification = createEntity(createMinimalRequest(ns));
+
+    String tagName = ns.prefix("importedTag");
+    String csv =
+        "parent,name*,displayName,description,reviewers,owner,tagStatus,color,iconURL,domains,mutuallyExclusive\n"
+            + ",%s,Imported Tag,An imported tag,,,,,,,\n".formatted(tagName);
+
+    String importResult =
+        SdkClients.adminClient()
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.PUT,
+                "/v1/classifications/name/"
+                    + classification.getFullyQualifiedName()
+                    + "/import?dryRun=false",
+                csv);
+
+    assertNotNull(importResult);
+    assertTrue(importResult.contains(tagName), "Import result must reference the imported tag");
+
+    Tag importedTag =
+        SdkClients.adminClient()
+            .tags()
+            .getByName(classification.getFullyQualifiedName() + "." + tagName);
+    assertNotNull(importedTag, "Imported tag must be created");
+    assertEquals("An imported tag", importedTag.getDescription());
+  }
+
+  @Test
+  void test_importClassificationCsv_renamedRowCreatesNewTag(TestNamespace ns) throws Exception {
+    Classification classification = createEntity(createMinimalRequest(ns));
+    String header =
+        "parent,name*,displayName,description,reviewers,owner,tagStatus,color,iconURL,domains,mutuallyExclusive\n";
+    String importPath =
+        "/v1/classifications/name/"
+            + classification.getFullyQualifiedName()
+            + "/import?dryRun=false";
+
+    String originalName = ns.prefix("renameSource");
+    SdkClients.adminClient()
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.PUT,
+            importPath,
+            header + ",%s,Original,First,,,,,,,\n".formatted(originalName));
+
+    // Re-import with a changed name. A different name produces a different FQN,
+    // so the row is created as a NEW tag rather than renaming the original one.
+    String renamedName = ns.prefix("renameTarget");
+    SdkClients.adminClient()
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.PUT,
+            importPath,
+            header + ",%s,Renamed,First,,,,,,,\n".formatted(renamedName));
+
+    Tag originalTag =
+        SdkClients.adminClient()
+            .tags()
+            .getByName(classification.getFullyQualifiedName() + "." + originalName);
+    Tag renamedTag =
+        SdkClients.adminClient()
+            .tags()
+            .getByName(classification.getFullyQualifiedName() + "." + renamedName);
+
+    assertNotNull(originalTag, "Original tag must still exist after the renamed import");
+    assertNotNull(renamedTag, "Renamed row must be created as a new tag");
+    assertNotEquals(originalTag.getId(), renamedTag.getId());
+  }
+
+  @Test
+  void test_importClassificationCsv_emptyMutuallyExclusivePreservesExisting(TestNamespace ns)
+      throws Exception {
+    Classification classification = createEntity(createMinimalRequest(ns));
+    String header =
+        "parent,name*,displayName,description,reviewers,owner,tagStatus,color,iconURL,domains,mutuallyExclusive\n";
+    String importPath =
+        "/v1/classifications/name/"
+            + classification.getFullyQualifiedName()
+            + "/import?dryRun=false";
+    String tagName = ns.prefix("mutexTag");
+
+    // Create the tag as mutuallyExclusive = true.
+    SdkClients.adminClient()
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.PUT, importPath, header + ",%s,Mutex,desc,,,,,,,true\n".formatted(tagName));
+
+    String tagFqn = classification.getFullyQualifiedName() + "." + tagName;
+    Tag created = SdkClients.adminClient().tags().getByName(tagFqn);
+    assertTrue(created.getMutuallyExclusive(), "Tag should be created as mutuallyExclusive");
+
+    // Re-import with an empty mutuallyExclusive cell: the flag must be preserved,
+    // not silently reset to false.
+    SdkClients.adminClient()
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.PUT,
+            importPath,
+            header + ",%s,Mutex,updated desc,,,,,,,\n".formatted(tagName));
+
+    Tag updated = SdkClients.adminClient().tags().getByName(tagFqn);
+    assertTrue(
+        updated.getMutuallyExclusive(),
+        "Empty mutuallyExclusive cell must not flip an existing true value to false");
+    assertEquals("updated desc", updated.getDescription());
+  }
+
+  @Test
+  void test_importClassificationCsv_systemClassificationRejected() {
+    String csv =
+        "parent,name*,displayName,description,reviewers,owner,tagStatus,color,iconURL,domains,mutuallyExclusive\n"
+            + ",SystemImportedTag,System,Should be rejected,,,,,,,\n";
+
+    Exception exception =
+        assertThrows(
+            Exception.class,
+            () ->
+                SdkClients.adminClient()
+                    .getHttpClient()
+                    .executeForString(
+                        HttpMethod.PUT, "/v1/classifications/name/Tier/import?dryRun=true", csv));
+
+    assertTrue(
+        exception.getMessage().contains("can not be modified"),
+        "System classification import must be rejected: " + exception.getMessage());
+  }
+
+  @Test
+  void test_exportClassificationCsv_systemClassificationRejected() {
+    Exception exception =
+        assertThrows(
+            Exception.class,
+            () ->
+                SdkClients.adminClient()
+                    .getHttpClient()
+                    .executeForString(
+                        HttpMethod.GET, "/v1/classifications/name/Tier/export", null));
+
+    assertTrue(
+        exception.getMessage().contains("can not be modified"),
+        "System classification export must be rejected: " + exception.getMessage());
+  }
+
+  @Test
+  void test_importClassificationCsv_preservesNonCsvTagFields(TestNamespace ns) throws Exception {
+    Classification classification = createEntity(createMinimalRequest(ns));
+    String tagName = ns.prefix("autoClassTag");
+    CreateTag tagRequest = new CreateTag();
+    tagRequest.setName(tagName);
+    tagRequest.setDescription("Tag with auto-classification");
+    tagRequest.setClassification(classification.getFullyQualifiedName());
+    tagRequest.setAutoClassificationEnabled(true);
+    tagRequest.setAutoClassificationPriority(7);
+    SdkClients.adminClient().tags().create(tagRequest);
+    String tagFqn = classification.getFullyQualifiedName() + "." + tagName;
+
+    String csv =
+        SdkClients.adminClient()
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.GET,
+                "/v1/classifications/name/" + classification.getFullyQualifiedName() + "/export",
+                null);
+    SdkClients.adminClient()
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.PUT,
+            "/v1/classifications/name/"
+                + classification.getFullyQualifiedName()
+                + "/import?dryRun=false",
+            csv);
+
+    Tag reimported =
+        SdkClients.adminClient()
+            .getHttpClient()
+            .execute(
+                HttpMethod.GET,
+                "/v1/tags/name/" + tagFqn + "?fields=autoClassificationEnabled",
+                null,
+                Tag.class);
+    assertEquals(
+        Boolean.TRUE,
+        reimported.getAutoClassificationEnabled(),
+        "CSV re-import must preserve autoClassificationEnabled (not in CSV columns)");
+    assertEquals(
+        7,
+        reimported.getAutoClassificationPriority(),
+        "CSV re-import must preserve autoClassificationPriority (not in CSV columns)");
+  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ClassificationRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ClassificationRepository.java
@@ -13,15 +13,24 @@
 
 package org.openmetadata.service.jdbi3;
 
+import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+import static org.openmetadata.csv.CsvUtil.addDomains;
+import static org.openmetadata.csv.CsvUtil.addEntityReference;
+import static org.openmetadata.csv.CsvUtil.addField;
+import static org.openmetadata.csv.CsvUtil.addOwners;
+import static org.openmetadata.csv.CsvUtil.addReviewers;
 import static org.openmetadata.service.Entity.CLASSIFICATION;
 import static org.openmetadata.service.Entity.TAG;
 import static org.openmetadata.service.search.SearchClient.GLOBAL_SEARCH_ALIAS;
 import static org.openmetadata.service.search.SearchClient.TAG_SEARCH_INDEX;
 import static org.openmetadata.service.search.SearchConstants.TAGS_FQN;
 
+import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,25 +38,40 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
+import org.openmetadata.csv.CsvExportProgressCallback;
+import org.openmetadata.csv.CsvImportProgressCallback;
+import org.openmetadata.csv.EntityCsv;
+import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.entity.classification.Classification;
 import org.openmetadata.schema.entity.classification.Tag;
+import org.openmetadata.schema.entity.type.Style;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.EntityStatus;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.ProviderType;
 import org.openmetadata.schema.type.Relationship;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.TagLabel.TagSource;
 import org.openmetadata.schema.type.change.ChangeSource;
+import org.openmetadata.schema.type.csv.CsvDocumentation;
+import org.openmetadata.schema.type.csv.CsvFile;
+import org.openmetadata.schema.type.csv.CsvHeader;
+import org.openmetadata.schema.type.csv.CsvImportResult;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.CatalogExceptionMessage;
+import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.jdbi3.CollectionDAO.EntityRelationshipRecord;
 import org.openmetadata.service.resources.feeds.MessageParser;
 import org.openmetadata.service.resources.tags.ClassificationResource;
 import org.openmetadata.service.security.policyevaluator.PolicyConditionUpdater;
+import org.openmetadata.service.util.EntityFieldUtils;
 import org.openmetadata.service.util.EntityUtil.Fields;
 import org.openmetadata.service.util.EntityUtil.RelationIncludes;
 import org.openmetadata.service.util.FullyQualifiedName;
@@ -243,6 +267,193 @@ public class ClassificationRepository extends EntityRepository<Classification> {
     return daoCollection
         .tagUsageDAO()
         .getTagCount(TagSource.CLASSIFICATION.ordinal(), classification.getFullyQualifiedName());
+  }
+
+  /** Export a classification with all its tags as CSV */
+  @Override
+  public String exportToCsv(String name, String user, boolean recursive) throws IOException {
+    return exportToCsv(name, user, recursive, null);
+  }
+
+  @Override
+  public String exportToCsv(
+      String name, String user, boolean recursive, CsvExportProgressCallback callback)
+      throws IOException {
+    Classification classification = getByName(null, name, Fields.EMPTY_FIELDS);
+    validateNotSystemClassification(classification);
+    return new ClassificationCsv(classification, user)
+        .exportCsv(listTagsForCsv(classification), callback);
+  }
+
+  /** Import tags into a classification from CSV */
+  @Override
+  public CsvImportResult importFromCsv(
+      String name,
+      String csv,
+      boolean dryRun,
+      String user,
+      boolean recursive,
+      CsvImportProgressCallback callback)
+      throws IOException {
+    Classification classification = getByName(null, name, Fields.EMPTY_FIELDS);
+    validateNotSystemClassification(classification);
+    return new ClassificationCsv(classification, user).importCsv(csv, dryRun, callback);
+  }
+
+  /**
+   * System-generated classifications (e.g. Tier, Certification) are managed by the platform, so
+   * their tags cannot be bulk imported or exported - matching how the UI hides these actions.
+   */
+  private void validateNotSystemClassification(Classification classification) {
+    if (ProviderType.SYSTEM.equals(classification.getProvider())) {
+      throw new IllegalArgumentException(
+          CatalogExceptionMessage.systemEntityModifyNotAllowed(
+              classification.getName(), CLASSIFICATION));
+    }
+  }
+
+  private List<Tag> listTagsForCsv(Classification classification) {
+    TagRepository repository = (TagRepository) Entity.getEntityRepository(TAG);
+    List<Tag> tags =
+        repository.listAllForCSV(
+            repository.getFields("owners,reviewers,parent,domains"),
+            classification.getFullyQualifiedName());
+    tags.sort(Comparator.comparing(EntityInterface::getFullyQualifiedName));
+    return tags;
+  }
+
+  public static class ClassificationCsv extends EntityCsv<Tag> {
+    public static final CsvDocumentation DOCUMENTATION =
+        getCsvDocumentation(Entity.CLASSIFICATION, false);
+    public static final List<CsvHeader> HEADERS = DOCUMENTATION.getHeaders();
+    private final Classification classification;
+
+    ClassificationCsv(Classification classification, String user) {
+      super(TAG, HEADERS, user);
+      this.classification = classification;
+    }
+
+    @Override
+    protected void createEntity(CSVPrinter printer, List<CSVRecord> csvRecords) throws IOException {
+      CSVRecord csvRecord = getNextRecord(printer, csvRecords);
+      if (csvRecord == null) {
+        return;
+      }
+      String parentFqn = csvRecord.get(0);
+      String tagFqn =
+          nullOrEmpty(parentFqn)
+              ? FullyQualifiedName.build(classification.getFullyQualifiedName(), csvRecord.get(1))
+              : FullyQualifiedName.add(parentFqn, csvRecord.get(1));
+      Tag existingTag =
+          ((TagRepository) Entity.getEntityRepository(TAG)).findByNameOrNull(tagFqn, Include.ALL);
+      // On update, start from the stored tag so fields the CSV does not carry (recognizers,
+      // auto-classification, deprecated, ...) are retained instead of reset to their defaults.
+      // Any field added to the tag schema later is preserved automatically - no per-field handling.
+      Tag tag = existingTag != null ? existingTag : new Tag();
+      tag.withClassification(classification.getEntityReference())
+          .withParent(getParentReference(printer, csvRecord, parentFqn))
+          .withName(csvRecord.get(1))
+          .withFullyQualifiedName(tagFqn)
+          .withDisplayName(csvRecord.get(2))
+          .withDescription(csvRecord.get(3))
+          .withReviewers(getReviewers(printer, csvRecord, 4))
+          .withOwners(getOwners(printer, csvRecord, 5))
+          .withEntityStatus(getTagStatus(printer, csvRecord))
+          .withStyle(getStyle(csvRecord))
+          .withDomains(getDomains(printer, csvRecord, 9))
+          .withMutuallyExclusive(getMutuallyExclusive(csvRecord, existingTag));
+
+      if (processRecord) {
+        createEntity(printer, csvRecord, tag, TAG);
+      }
+    }
+
+    private EntityReference getParentReference(
+        CSVPrinter printer, CSVRecord csvRecord, String parentFqn) throws IOException {
+      EntityReference parentRef = null;
+      if (!nullOrEmpty(parentFqn)) {
+        try {
+          Tag parentTag =
+              getEntityWithDependencyResolution(TAG, parentFqn, "*", Include.NON_DELETED);
+          parentRef = parentTag.getEntityReference();
+        } catch (EntityNotFoundException ex) {
+          parentRef = getEntityReference(printer, csvRecord, 0, TAG);
+        }
+      }
+      return parentRef;
+    }
+
+    private EntityStatus getTagStatus(CSVPrinter printer, CSVRecord csvRecord) throws IOException {
+      EntityStatus status = null;
+      if (processRecord) {
+        String tagStatus = csvRecord.get(6);
+        try {
+          status =
+              nullOrEmpty(tagStatus)
+                  ? EntityStatus.DRAFT
+                  : EntityFieldUtils.parseEntityStatus(tagStatus);
+        } catch (IllegalArgumentException ex) {
+          importFailure(
+              printer,
+              invalidField(6, String.format("Tag status %s is invalid", tagStatus)),
+              csvRecord);
+          processRecord = false;
+        }
+      }
+      return status;
+    }
+
+    private Style getStyle(CSVRecord csvRecord) {
+      Style style = null;
+      if (processRecord) {
+        String color = csvRecord.get(7);
+        String iconURL = csvRecord.get(8);
+        if (!nullOrEmpty(color) || !nullOrEmpty(iconURL)) {
+          style = new Style();
+          if (!nullOrEmpty(color)) {
+            style.setColor(color);
+          }
+          if (!nullOrEmpty(iconURL)) {
+            style.setIconURL(iconURL);
+          }
+        }
+      }
+      return style;
+    }
+
+    private Boolean getMutuallyExclusive(CSVRecord csvRecord, Tag existingTag) {
+      String value = csvRecord.get(10);
+      if (nullOrEmpty(value)) {
+        // An empty cell must not silently flip the flag: keep the existing value
+        // when updating a tag, and only default to false when creating a new one.
+        return existingTag != null ? existingTag.getMutuallyExclusive() : Boolean.FALSE;
+      }
+      return Boolean.parseBoolean(value);
+    }
+
+    @Override
+    protected void addRecord(CsvFile csvFile, Tag entity) {
+      List<String> recordList = new ArrayList<>();
+      addEntityReference(recordList, entity.getParent());
+      addField(recordList, entity.getName());
+      addField(recordList, entity.getDisplayName());
+      addField(recordList, entity.getDescription());
+      addReviewers(recordList, entity.getReviewers());
+      addOwners(recordList, entity.getOwners());
+      addField(
+          recordList, entity.getEntityStatus() != null ? entity.getEntityStatus().value() : null);
+      addField(recordList, entity.getStyle() != null ? entity.getStyle().getColor() : null);
+      addField(recordList, entity.getStyle() != null ? entity.getStyle().getIconURL() : null);
+      addDomains(recordList, getDirectDomains(entity.getDomains()));
+      addField(recordList, entity.getMutuallyExclusive());
+      addRecord(csvFile, recordList);
+    }
+
+    private static List<EntityReference> getDirectDomains(List<EntityReference> domains) {
+      return listOrEmpty(domains).stream()
+          .filter(domain -> !Boolean.TRUE.equals(domain.getInherited()))
+          .toList();
+    }
   }
 
   public static class TagLabelMapper implements RowMapper<TagLabel> {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/tags/ClassificationResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/tags/ClassificationResource.java
@@ -42,6 +42,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import jakarta.ws.rs.core.UriInfo;
+import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
@@ -51,6 +52,7 @@ import org.openmetadata.schema.entity.classification.Classification;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
+import org.openmetadata.schema.type.csv.CsvImportResult;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.ClassificationRepository;
@@ -59,6 +61,7 @@ import org.openmetadata.service.limits.Limits;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.resources.EntityResource;
 import org.openmetadata.service.security.Authorizer;
+import org.openmetadata.service.util.CSVExportResponse;
 
 @Slf4j
 @Path("/v1/classifications")
@@ -482,5 +485,119 @@ public class ClassificationResource
       @Context SecurityContext securityContext,
       @Valid RestoreEntity restore) {
     return restoreEntity(uriInfo, securityContext, restore.getId());
+  }
+
+  @GET
+  @Path("/name/{name}/exportAsync")
+  @Produces(MediaType.APPLICATION_JSON)
+  @Valid
+  @Operation(
+      operationId = "exportClassification",
+      summary = "Export classification in CSV format",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Exported csv with tags of the classification",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = CSVExportResponse.class)))
+      })
+  public Response exportCsvAsync(
+      @Context SecurityContext securityContext,
+      @Parameter(description = "Name of the classification", schema = @Schema(type = "string"))
+          @PathParam("name")
+          String name) {
+    return exportCsvInternalAsync(securityContext, name, false);
+  }
+
+  @GET
+  @Path("/name/{name}/export")
+  @Produces(MediaType.TEXT_PLAIN)
+  @Valid
+  @Operation(
+      operationId = "exportClassification",
+      summary = "Export classification in CSV format",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Exported csv with tags of the classification",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = String.class)))
+      })
+  public String exportCsv(
+      @Context SecurityContext securityContext,
+      @Parameter(description = "Name of the classification", schema = @Schema(type = "string"))
+          @PathParam("name")
+          String name)
+      throws IOException {
+    return exportCsvInternal(securityContext, name, false);
+  }
+
+  @PUT
+  @Path("/name/{name}/import")
+  @Consumes(MediaType.TEXT_PLAIN)
+  @Valid
+  @Operation(
+      operationId = "importClassification",
+      summary = "Import tags from CSV to create, and update tags of a classification",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Import result",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = CsvImportResult.class)))
+      })
+  public CsvImportResult importCsv(
+      @Context UriInfo uriInfo,
+      @Context SecurityContext securityContext,
+      @Parameter(description = "Name of the classification", schema = @Schema(type = "string"))
+          @PathParam("name")
+          String name,
+      @Parameter(
+              description =
+                  "Dry-run when true is used for validating the CSV without really importing it. (default=true)",
+              schema = @Schema(type = "boolean"))
+          @DefaultValue("true")
+          @QueryParam("dryRun")
+          boolean dryRun,
+      String csv)
+      throws IOException {
+    return importCsvInternal(uriInfo, securityContext, name, csv, dryRun, false);
+  }
+
+  @PUT
+  @Path("/name/{name}/importAsync")
+  @Consumes(MediaType.TEXT_PLAIN)
+  @Produces(MediaType.APPLICATION_JSON)
+  @Valid
+  @Operation(
+      operationId = "importClassificationAsync",
+      summary = "Import tags of a classification in CSV format asynchronously",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Import initiated successfully",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = CsvImportResult.class)))
+      })
+  public Response importCsvAsync(
+      @Context UriInfo uriInfo,
+      @Context SecurityContext securityContext,
+      @Parameter(description = "Name of the classification", schema = @Schema(type = "string"))
+          @PathParam("name")
+          String name,
+      @RequestBody(description = "CSV data to import", required = true) String csv,
+      @Parameter(description = "Dry run the import", schema = @Schema(type = "boolean"))
+          @QueryParam("dryRun")
+          @DefaultValue("true")
+          boolean dryRun) {
+    return importCsvInternalAsync(uriInfo, securityContext, name, csv, dryRun, false);
   }
 }

--- a/openmetadata-service/src/main/resources/json/data/classification/classificationCsvDocumentation.json
+++ b/openmetadata-service/src/main/resources/json/data/classification/classificationCsvDocumentation.json
@@ -1,0 +1,105 @@
+{
+  "summary": "Classification CSV file is used for importing and exporting tags of an **existing** classification.",
+  "headers": [
+    {
+      "name": "parent",
+      "required": false,
+      "description": "Fully qualified name of the parent tag. If the tag being created is at the root of the classification without any parent tag, leave this as empty.",
+      "examples": [
+        "`\"\"` or empty, if the tag is at the root of the classification.",
+        "`PII.Sensitive` as parent to create a tag `SSN` under it."
+      ]
+    },
+    {
+      "name": "name",
+      "required": true,
+      "description": "The name of the tag being created.",
+      "examples": [
+        "`Sensitive`, `NonSensitive`"
+      ]
+    },
+    {
+      "name": "displayName",
+      "required": false,
+      "description": "Display name for the tag.",
+      "examples": [
+        "`Sensitive Data`, `Non Sensitive`"
+      ]
+    },
+    {
+      "name": "description",
+      "required": false,
+      "description": "Description for the tag in Markdown format.",
+      "examples": [
+        "`Personally identifiable information` as defined by the **Legal Team**."
+      ]
+    },
+    {
+      "name": "reviewers",
+      "required": false,
+      "description": "Reviewers as 'user:name' pairs, separated by ';'.",
+      "examples": [
+        "`user:john`",
+        "`user:john;user:adam`"
+      ]
+    },
+    {
+      "name": "owner",
+      "required": false,
+      "description": "Owners as 'type:name' pairs, separated by ';'. Use the prefix 'team' for a team owner and 'user' for a user owner.",
+      "examples": [
+        "`team:marketing`",
+        "`user:john`",
+        "`team:marketing;user:john`"
+      ]
+    },
+    {
+      "name": "tagStatus",
+      "required": false,
+      "description": "Status of the tag. Allowed values `Draft`, `In Review`, `Approved`, `Deprecated`, or `Rejected`.",
+      "examples": [
+        "`Draft`",
+        "`Approved`",
+        "`Deprecated`"
+      ]
+    },
+    {
+      "name": "color",
+      "required": false,
+      "description": "Hex color code to customize the appearance of the tag in UI.",
+      "examples": [
+        "`#FF5733` - Red color",
+        "`#00FF00` - Green color",
+        "`#0000FF` - Blue color",
+        "`#123456` - Custom color"
+      ]
+    },
+    {
+      "name": "iconURL",
+      "required": false,
+      "description": "URL to an icon image to display with the tag.",
+      "examples": [
+        "`https://example.com/icon.png`",
+        "`https://example.com/icons/tag-icon.svg`",
+        "`https://cdn.example.com/classification/icon.jpg`"
+      ]
+    },
+    {
+      "name": "domains",
+      "required": false,
+      "description": "Fully qualified names of the domains the tag belongs to, separated by ';'.",
+      "examples": [
+        "Marketing", "Sales;Operations"
+      ]
+    },
+    {
+      "name": "mutuallyExclusive",
+      "required": false,
+      "description": "Set to `true` when the children tags under this tag are mutually exclusive, so an entity can be labelled with only one of them. Defaults to `false`.",
+      "examples": [
+        "`true`",
+        "`false`"
+      ]
+    }
+  ]
+}

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ClassificationImportExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ClassificationImportExport.spec.ts
@@ -1,0 +1,116 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { expect, test } from '@playwright/test';
+import { ClassificationClass } from '../../support/tag/ClassificationClass';
+import { TagClass } from '../../support/tag/TagClass';
+import { UserClass } from '../../support/user/UserClass';
+import { createNewPage, redirectToHomePage } from '../../utils/common';
+import { suppressCsvJobsTray } from '../../utils/importUtils';
+import { performUserLogin } from '../../utils/user';
+
+test.use({ storageState: 'playwright/.auth/admin.json' });
+
+const userClassification = new ClassificationClass();
+const systemClassification = new ClassificationClass({ provider: 'system' });
+const userTag = new TagClass({ classification: userClassification.data.name });
+const exportUser = new UserClass(undefined, true);
+
+test.describe('Classification Import Export', { tag: '@import-export' }, () => {
+  test.beforeAll('Setup classifications and a tag', async ({ browser }) => {
+    const { apiContext, afterAction } = await createNewPage(browser);
+    await userClassification.create(apiContext);
+    await systemClassification.create(apiContext);
+    await userTag.create(apiContext);
+    await exportUser.create(apiContext);
+    await afterAction();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await redirectToHomePage(page);
+  });
+
+  test('user classification manage button offers import and export', async ({
+    page,
+  }) => {
+    await userClassification.visitPage(page);
+
+    await page.getByTestId('manage-button').click();
+
+    await expect(page.getByTestId('import-button')).toBeVisible();
+    await expect(page.getByTestId('export-button')).toBeVisible();
+  });
+
+  test('system classification hides import and export', async ({ page }) => {
+    await systemClassification.visitPage(page);
+
+    await page.getByTestId('manage-button').click();
+
+    await expect(page.getByTestId('edit-classification')).toBeVisible();
+
+    await expect(page.getByTestId('import-button')).toHaveCount(0);
+    await expect(page.getByTestId('export-button')).toHaveCount(0);
+  });
+
+  test('export starts a CSV export job for the classification', async ({
+    browser,
+  }) => {
+    test.slow();
+
+    const { page, afterAction } = await performUserLogin(browser, exportUser);
+
+    try {
+      await suppressCsvJobsTray(page);
+      await redirectToHomePage(page);
+      await userClassification.visitPage(page);
+
+      await page.getByTestId('manage-button').click();
+
+      const exportButton = page.getByTestId('export-button');
+      await expect(exportButton).toBeVisible();
+
+      const exportResponse = page.waitForResponse(
+        (response) =>
+          response.url().includes('/api/v1/classifications/name/') &&
+          response.url().includes('/exportAsync') &&
+          response.request().method() === 'GET'
+      );
+
+      await exportButton.click();
+
+      const response = await exportResponse;
+      expect(response.ok()).toBeTruthy();
+    } finally {
+      await afterAction();
+    }
+  });
+
+  test('import navigates to the classification bulk import page', async ({
+    page,
+  }) => {
+    test.slow();
+
+    await userClassification.visitPage(page);
+
+    await page.getByTestId('manage-button').click();
+
+    const importButton = page.getByTestId('import-button');
+    await expect(importButton).toBeVisible();
+    await importButton.click();
+
+    await page.waitForURL('**/bulk/import/classification/**');
+
+    await expect(
+      page.getByText('Drag & Drop or Browse CSV file here')
+    ).toBeVisible();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/Classifications/ClassificationDetails/ClassificationDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Classifications/ClassificationDetails/ClassificationDetails.test.tsx
@@ -424,6 +424,43 @@ describe('ClassificationDetails', () => {
     expect(screen.getByTestId('disable-button')).toBeInTheDocument();
   });
 
+  it('should hide import and export options for system classifications but show them for user classifications', async () => {
+    const systemClassification = {
+      ...mockClassification,
+      provider: ProviderType.System,
+    };
+
+    const { unmount } = render(
+      <MemoryRouter>
+        <ClassificationDetails
+          {...defaultProps}
+          currentClassification={systemClassification}
+        />
+      </MemoryRouter>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('system-badge')).toBeInTheDocument()
+    );
+
+    expect(screen.queryByTestId('export-button')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('import-button')).not.toBeInTheDocument();
+
+    unmount();
+
+    render(
+      <MemoryRouter>
+        <ClassificationDetails {...defaultProps} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('export-button')).toBeInTheDocument()
+    );
+
+    expect(screen.getByTestId('import-button')).toBeInTheDocument();
+  });
+
   it('should toggle classification enabled state when disable button is clicked', async () => {
     const systemClassification = {
       ...mockClassification,
@@ -489,6 +526,7 @@ describe('ClassificationDetails', () => {
       EditAll: false,
       Delete: false,
       EditDisplayName: false,
+      ViewAll: false,
     };
 
     render(

--- a/openmetadata-ui/src/main/resources/ui/src/components/Classifications/ClassificationDetails/ClassificationDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Classifications/ClassificationDetails/ClassificationDetails.tsx
@@ -31,9 +31,12 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { ReactComponent as IconTag } from '../../../assets/svg/classification.svg';
 import { ReactComponent as LockIcon } from '../../../assets/svg/closed-lock.svg';
+import { ReactComponent as ExportIcon } from '../../../assets/svg/ic-export.svg';
+import { ReactComponent as ImportIcon } from '../../../assets/svg/ic-import.svg';
 import { ReactComponent as VersionIcon } from '../../../assets/svg/ic-version.svg';
 import { DE_ACTIVE_COLOR } from '../../../constants/constants';
 import { CustomizeEntityType } from '../../../constants/Customize.constants';
+import { ExportTypes } from '../../../constants/Export.constants';
 import { usePermissionProvider } from '../../../context/PermissionProvider/PermissionProvider';
 import { ResourceEntity } from '../../../context/PermissionProvider/PermissionProvider.interface';
 import { EntityType, TabSpecificField } from '../../../enums/entity.enum';
@@ -44,13 +47,14 @@ import { Paging } from '../../../generated/type/paging';
 import { usePaging } from '../../../hooks/paging/usePaging';
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
 import { useFqn } from '../../../hooks/useFqn';
-import { getTags } from '../../../rest/tagAPI';
+import { exportClassificationInCSVFormat, getTags } from '../../../rest/tagAPI';
 import { getClassificationInfo } from '../../../utils/ClassificationPureUtils';
 import {
   getClassificationExtraDropdownContent,
   getTagsTableColumn,
 } from '../../../utils/ClassificationUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
+import { getEntityImportPath } from '../../../utils/EntityPureUtils';
 import { checkPermission } from '../../../utils/PermissionsUtils';
 import {
   getClassificationDetailsPath,
@@ -63,11 +67,13 @@ import AppBadge from '../../common/Badge/Badge.component';
 import Description from '../../common/EntityDescription/Description';
 import ManageButton from '../../common/EntityPageInfos/ManageButton/ManageButton';
 import Loader from '../../common/Loader/Loader';
+import { ManageButtonItemLabel } from '../../common/ManageButtonContentItem/ManageButtonContentItem.component';
 import { NextPreviousProps } from '../../common/NextPrevious/NextPrevious.interface';
 import Table from '../../common/Table/Table';
 import { GenericProvider } from '../../Customization/GenericProvider/GenericProvider';
 import { DomainLabelV2 } from '../../DataAssets/DomainLabelV2/DomainLabelV2';
 import { OwnerLabelV2 } from '../../DataAssets/OwnerLabelV2/OwnerLabelV2';
+import { useEntityExportModalProvider } from '../../Entity/EntityExportModalProvider/EntityExportModalProvider.component';
 import EntityHeaderTitle from '../../Entity/EntityHeaderTitle/EntityHeaderTitle.component';
 import './classification-details.less';
 import { ClassificationDetailsProps } from './ClassificationDetails.interface';
@@ -109,6 +115,7 @@ const ClassificationDetails = forwardRef(
   ) => {
     const { theme } = useApplicationStore();
     const { permissions } = usePermissionProvider();
+    const { showModal } = useEntityExportModalProvider();
     const { t } = useTranslation();
     const { fqn: tagCategoryName } = useFqn();
     const navigate = useNavigate();
@@ -267,12 +274,71 @@ const ClassificationDetails = forwardRef(
       [isVersionView, isClassificationDisabled, editClassificationPermission]
     );
 
+    // Import/export are not offered for system-generated classifications
+    // (e.g. Tier, Certification), whose tags are managed by the platform.
+    const showExportOption = useMemo(
+      () =>
+        !isVersionView &&
+        !isSystemClassification &&
+        classificationPermissions.ViewAll,
+      [isVersionView, isSystemClassification, classificationPermissions]
+    );
+
+    // Import creates/updates tags, so it needs full EditAll access and is not
+    // available in version view, on a disabled classification, or on a
+    // system-generated classification.
+    const showImportOption = useMemo(
+      () =>
+        !isVersionView &&
+        !isClassificationDisabled &&
+        !isSystemClassification &&
+        classificationPermissions.EditAll,
+      [
+        isVersionView,
+        isClassificationDisabled,
+        isSystemClassification,
+        classificationPermissions,
+      ]
+    );
+
     const showManageButton = useMemo(
       () =>
         !isVersionView &&
-        (showEditOption || deletePermission || showDisableOption),
-      [showEditOption, deletePermission, showDisableOption, isVersionView]
+        (showEditOption ||
+          deletePermission ||
+          showDisableOption ||
+          showExportOption ||
+          showImportOption),
+      [
+        showEditOption,
+        deletePermission,
+        showDisableOption,
+        showExportOption,
+        showImportOption,
+        isVersionView,
+      ]
     );
+
+    const handleClassificationExportClick = useCallback(() => {
+      if (currentClassification?.fullyQualifiedName) {
+        showModal({
+          name: currentClassification.fullyQualifiedName,
+          onExport: exportClassificationInCSVFormat,
+          exportTypes: [ExportTypes.CSV],
+        });
+      }
+    }, [currentClassification, showModal]);
+
+    const handleClassificationImportClick = useCallback(() => {
+      if (currentClassification?.fullyQualifiedName) {
+        navigate(
+          getEntityImportPath(
+            EntityType.CLASSIFICATION,
+            currentClassification.fullyQualifiedName
+          )
+        );
+      }
+    }, [currentClassification, navigate]);
 
     const handleUpdateDescription = async (updatedHTML: string) => {
       if (!isUndefined(currentClassification)) {
@@ -332,20 +398,61 @@ const ClassificationDetails = forwardRef(
     );
 
     const extraDropdownContent = useMemo(
-      () =>
-        getClassificationExtraDropdownContent(
+      () => [
+        ...getClassificationExtraDropdownContent(
           showDisableOption,
           isClassificationDisabled,
           handleEnableDisableClassificationClick,
           showEditOption,
           handleEditClassificationClick
         ),
+        ...(showImportOption
+          ? [
+              {
+                label: (
+                  <ManageButtonItemLabel
+                    description={t('message.import-entity-help', {
+                      entity: t('label.tag-lowercase-plural'),
+                    })}
+                    icon={ImportIcon}
+                    id="import-button"
+                    name={t('label.import')}
+                  />
+                ),
+                key: 'import-button',
+                onClick: handleClassificationImportClick,
+              },
+            ]
+          : []),
+        ...(showExportOption
+          ? [
+              {
+                label: (
+                  <ManageButtonItemLabel
+                    description={t('message.export-entity-help', {
+                      entity: t('label.tag-lowercase-plural'),
+                    })}
+                    icon={ExportIcon}
+                    id="export-button"
+                    name={t('label.export')}
+                  />
+                ),
+                key: 'export-button',
+                onClick: handleClassificationExportClick,
+              },
+            ]
+          : []),
+      ],
       [
         isClassificationDisabled,
         showDisableOption,
         handleEnableDisableClassificationClick,
         showEditOption,
         handleEditClassificationClick,
+        showImportOption,
+        handleClassificationImportClick,
+        showExportOption,
+        handleClassificationExportClick,
       ]
     );
 

--- a/openmetadata-ui/src/main/resources/ui/src/constants/BulkImport.constant.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/BulkImport.constant.ts
@@ -22,6 +22,7 @@ export const SUPPORTED_BULK_IMPORT_EDIT_ENTITY = [
   ResourceEntity.GLOSSARY,
   ResourceEntity.METRIC,
   ResourceEntity.TEST_CASE,
+  ResourceEntity.CLASSIFICATION,
 ];
 
 export enum VALIDATION_STEP {

--- a/openmetadata-ui/src/main/resources/ui/src/rest/tagAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/tagAPI.ts
@@ -195,3 +195,13 @@ export const getClassificationVersionData = async (
 
   return response.data;
 };
+
+export const exportClassificationInCSVFormat = async (
+  classificationName: string
+) => {
+  const response = await APIClient.get<CSVExportResponse>(
+    `${BASE_URL}/name/${getEncodedFqn(classificationName)}/exportAsync`
+  );
+
+  return response.data;
+};


### PR DESCRIPTION
Backport of #31938 to `2.0`.

Fixes - #23053 

Original PR: https://github.com/open-metadata/OpenMetadata/pull/31938 (fixes #23053)
Merge commit cherry-picked: `3419b64c92e1b299fb55eb848e471fd853e70240`

### Describe your changes:

Adds CSV import/export support at the classification and tag level:

- `ClassificationRepository` — classification-scoped CSV import and export, including tag field parsing, serialization, and preservation of tag fields that have no CSV column.
- `ClassificationResource` — synchronous and asynchronous CSV import/export REST endpoints.
- `classificationCsvDocumentation.json` — documents the supported classification tag CSV columns and the owner/reviewer separators.
- `ClassificationDetails.tsx` — permission-aware Import and Export actions, hidden for system classifications.
- Backend integration tests, a frontend unit test, and a Playwright spec.

### Type of change:

- [x] Improvement

### High-level design:

Straight backport — no design changes from the original PR.

### Tests:

#### Backend integration tests

`ClassificationResourceIT` (backported unchanged) covers export contents, tag creation and updates, rejection of system classifications, and preservation of fields absent from the CSV.

#### Unit tests

`ClassificationDetails.test.tsx` — **18 passed, 0 failed** locally against this branch.

#### Playwright (UI) tests

`ClassificationImportExport.spec.ts` (backported unchanged).

#### Backport verification performed

- Cherry-pick applied **cleanly** — no conflicts in any of the 9 files.
- **Diff-of-diffs check:** for every changed path, the whitespace-normalized `git diff -U0` of the original merge commit on `main` is **identical line-for-line** to the diff of this commit on `2.0`. No hunk was misplaced and no out-of-scope refactor was pulled in.
- **Symbol availability on `2.0` confirmed** for every dependency the change introduces: `CsvExportProgressCallback`, `CsvImportProgressCallback`, `EntityFieldUtils.parseEntityStatus`, `EntityStatus`, `CsvUtil.addDomains`/`addOwners`/`addReviewers`/`addField`/`addEntityReference`, `EntityRepository.listAllForCSV`, `CSVExportResponse`, and the `exportCsvInternal`/`exportCsvInternalAsync`/`importCsvInternal`/`importCsvInternalAsync` base helpers on `EntityResource` — the latter have the same declarations at the same line numbers as on `main`. UI side: `ic-export.svg`, `ic-import.svg`, `ExportTypes`, `getEntityImportPath`, `ManageButtonItemLabel`, `useEntityExportModalProvider`, and the `message.import-entity-help` locale key all exist on `2.0`.
- `prettier --check` clean on all changed UI files.
- Java compilation and eslint were **not** run locally (local lombok/JDK 21 toolchain fails in the unrelated `common` module; `2.0`'s eslint config needs a parser export the available `node_modules` doesn't provide). Both are left to CI.

### UI screen recording / screenshots:

See the recording on the original PR #31938 — the UI is unchanged from it.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
