### PR TITLE
Backport #32367 to 1.13: Looker — flush sink buffer before resolving data models

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
@@ -29,6 +29,7 @@ from typing import (
     Dict,
     Iterable,
     List,
+    NamedTuple,
     Optional,
     Sequence,
     Set,
@@ -106,6 +107,7 @@ from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.lineage.models import ConnectionTypeDialectMapper, Dialect
 from metadata.ingestion.lineage.parser import LineageParser
 from metadata.ingestion.lineage.sql_lineage import get_column_fqn
+from metadata.ingestion.models.barrier import Barrier
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.dashboard.dashboard_service import (
@@ -158,6 +160,47 @@ TEMP_FOLDER_DIRECTORY = os.path.join(os.getcwd(), "tmp")
 REPO_TMP_LOCAL_PATH = f"{TEMP_FOLDER_DIRECTORY}/lookml_repos"
 
 LOOKER_TAG_CATEGORY = "LookerTags"
+
+
+class _EndOfExplores:
+    """Producer-side end-of-stream marker for the bulk data-model stage.
+
+    A stage processor is called once per produced entity and gets no "end of stream" hook,
+    but the buffer must be flushed exactly once, after the last explore. `list_datamodels`
+    appends this so `yield_bulk_datamodel` can recognise that point.
+
+    It cannot be a `Barrier`: producer yields are the stage processor's *input* and never
+    reach the sink, so a Barrier here would be handed to `yield_bulk_datamodel` as `model`
+    and flush nothing. The real Barrier is yielded from `_yield_bulk_datamodel_lineage`, on
+    the `Either(right=...)` output channel the sink actually reads.
+
+    It replaces a `processed_count >= total_explores` counter: the total was taken from every
+    explore in every model, while the producer skips models that fail the filter and explores
+    whose fetch raises, so one filtered explore left the count permanently short and
+    standalone views were never processed at all.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "<end of explores>"
+
+
+DATAMODEL_LINEAGE_SENTINEL = _EndOfExplores()
+
+
+class ExploreRef(NamedTuple):
+    """The only two fields view lineage needs off a `LookmlModelExplore`.
+
+    Deferred lineage keeps one entry per (view, explore) pair until the flush. Holding the
+    SDK object there would pin its whole fieldset — measured at ~250 KB per explore — for
+    the length of the bulk stage, so a large instance would carry hundreds of MB it never
+    reads. Two strings cost ~200 B.
+    """
+
+    # Optional to match the SDK, where both fields are `str | None`.
+    model_name: str | None
+    name: str | None
 
 
 def clean_dashboard_name(name: str) -> str:
@@ -215,6 +258,14 @@ class LookerSource(DashboardServiceSource):
         self._parsed_views: Optional[Dict[str, str]] = {}
         self._unparsed_views: Optional[Dict[str, str]] = {}
         self._derived_dependencies = nx.DiGraph()
+
+        # Data models yielded by the bulk stage but not yet written by the sink. They are
+        # resolved in `_yield_bulk_datamodel_lineage`, after the Barrier has flushed them.
+        self._pending_explores: list[str] = []
+        self._pending_views: list[tuple[str, str]] = []
+        self._processed_view_names: set[str] = set()
+        self._pending_view_lineage: list[tuple[LookMlView, ExploreRef, str]] = []
+        self._pending_standalone_lineage: list[tuple[LookMlView, str, str, str]] = []
 
         self._added_lineage: Optional[Dict] = {}
 
@@ -435,9 +486,12 @@ class LookerSource(DashboardServiceSource):
 
         return self._repo_credentials
 
-    def list_datamodels(self) -> Iterable[LookmlModelExplore]:
+    def list_datamodels(self) -> Iterable:
         """
-        Fetch explores with the SDK
+        Fetch explores with the SDK.
+
+        Yields `LookmlModelExplore`s followed by `DATAMODEL_LINEAGE_SENTINEL`, hence the
+        untyped `Iterable`.
         """
         if self.source_config.includeDataModels:
             # First, pick up all the LookML Models
@@ -458,6 +512,10 @@ class LookerSource(DashboardServiceSource):
             except Exception as err:
                 logger.debug(traceback.format_exc())
                 logger.error(f"Unexpected error fetching LookML models - {err}")
+
+            # Always close the stream, even when the explore fetch blew up: standalone
+            # views and the lineage of whatever was yielded still need to be drawn.
+            yield DATAMODEL_LINEAGE_SENTINEL
 
     def fetch_lookml_explores(
         self, all_lookml_models: Sequence[LookmlModel]
@@ -517,10 +575,11 @@ class LookerSource(DashboardServiceSource):
         if not first_project:
             return
 
-        # Get the first model name for naming purposes
+        # Get the first model name for naming purposes. An unnamed model would otherwise
+        # build data models called "None_<view>_view".
         first_model_name = (
-            self._all_lookml_models[0].name if self._all_lookml_models else "default"
-        )
+            self._all_lookml_models[0].name if self._all_lookml_models else None
+        ) or "default"
 
         project_parser = self._project_parsers.get(first_project)
         if not project_parser:
@@ -528,8 +587,9 @@ class LookerSource(DashboardServiceSource):
 
         # Iterate through all cached views
         for view_name, view in project_parser._views_cache.items():
-            # Skip if view was already processed
-            if view_name in self._views_cache:
+            # Skip if view was already processed. `_views_cache` is only filled after the
+            # Barrier flush, so the explore pass records its views here as it goes.
+            if view_name in self._processed_view_names:
                 logger.debug(f"View [{view_name}] already processed, skipping")
                 continue
 
@@ -576,13 +636,12 @@ class LookerSource(DashboardServiceSource):
                 yield Either(right=data_model_request)
                 self.register_record_datamodel(datamodel_request=data_model_request)
 
-                # Build and cache the view model
-                view_data_model = self._build_data_model(datamodel_view_name)
-                self._views_cache[view.name] = view_data_model
-
-                # Add lineage for standalone views
-                yield from self._add_standalone_view_lineage(
-                    view, first_project, first_model_name
+                # Resolution and lineage are deferred to `_yield_bulk_datamodel_lineage`,
+                # once the Barrier has committed this request.
+                self._pending_views.append((view.name, datamodel_view_name))
+                self._processed_view_names.add(view.name)
+                self._pending_standalone_lineage.append(
+                    (view, first_project, first_model_name, datamodel_view_name)
                 )
 
             except ValidationError as err:
@@ -636,15 +695,15 @@ class LookerSource(DashboardServiceSource):
         self, model: LookmlModelExplore
     ) -> Iterable[Either[CreateDashboardDataModelRequest]]:
         """
-        Get the Explore and View information and prepare
-        the model creation request.
+        Get the Explore and View information and prepare the model creation request.
 
-        After processing all explores, this method also processes standalone views
-        from the repository that aren't associated with any explore.
+        This stage only *writes*: the created data models are still buffered in the sink,
+        so nothing here may read them back. Resolution and lineage happen once the
+        producer's sentinel arrives, in `_yield_bulk_datamodel_lineage`.
         """
-        # Initialize the flag to track if we've started processing standalone views
-        if not hasattr(self, "_standalone_views_processed"):
-            self._standalone_views_processed = False
+        if model is DATAMODEL_LINEAGE_SENTINEL:
+            yield from self._yield_bulk_datamodel_lineage()
+            return
 
         try:
             datamodel_name = build_datamodel_name(model.model_name, model.name)
@@ -681,15 +740,8 @@ class LookerSource(DashboardServiceSource):
                 yield Either(right=explore_datamodel)
                 self.register_record_datamodel(datamodel_request=explore_datamodel)
 
-                # build datamodel by our hand since ack_sink=False
-                self.context.get().dataModel = self._build_data_model(datamodel_name)
-                self._view_data_model = copy.deepcopy(self.context.get().dataModel)
-
-                # Maybe use the project_name as key too?
-                # Save the explores for when we create the lineage with the dashboards and views
-                self._explores_cache[
-                    explore_datamodel.name.root
-                ] = self.context.get().dataModel  # This is the newly created explore
+                # Resolved after the Barrier flush; see `_resolve_pending_datamodels`.
+                self._pending_explores.append(explore_datamodel.name.root)
 
                 # We can get VIEWs from the JOINs to know the dependencies
                 # We will only try and fetch if we have the credentials
@@ -737,30 +789,73 @@ class LookerSource(DashboardServiceSource):
                     stackTrace=traceback.format_exc(),
                 )
             )
-        finally:
-            # After processing the last explore, process standalone views
-            # This is a sentinel pattern - we check if this is the last model
-            if not self._standalone_views_processed and hasattr(
-                self, "_all_lookml_models"
-            ):
-                # Count how many explores we've processed
-                if not hasattr(self, "_explores_processed_count"):
-                    self._explores_processed_count = 0
-                self._explores_processed_count += 1
 
-                # Calculate total explores
-                total_explores = sum(
-                    len(m.explores) if m.explores else 0
-                    for m in self._all_lookml_models
-                )
+    def _yield_bulk_datamodel_lineage(self) -> Iterable[Either]:
+        """Close the bulk data-model stage: write what is left, then draw lineage.
 
-                # If this is the last explore, process standalone views
-                if self._explores_processed_count >= total_explores:
-                    self._standalone_views_processed = True
-                    logger.info(
-                        "All explores processed, now processing standalone views"
+        Standalone views are yielded here too, so a single Barrier covers every data
+        model of the stage. Resolving them all up front also means view-to-view
+        `extends` lineage can find its parents in `_views_cache`.
+        """
+        yield from self.yield_standalone_datamodels()
+
+        # The data models above are still in the sink's bulk buffer. Commit them before
+        # anything looks them up by name, or every lookup below comes back empty.
+        yield Either(
+            right=Barrier(
+                reason="looker_datamodel_lineage_flush"
+            )  # pyright: ignore[reportCallIssue]
+        )
+
+        resolved = self._resolve_pending_datamodels()
+
+        for view, explore, datamodel_view_name in self._pending_view_lineage:
+            self._view_data_model = resolved.get(datamodel_view_name)
+            yield from self.add_view_lineage(view, explore)
+        self._pending_view_lineage = []
+
+        for (
+            view,
+            project_name,
+            model_name,
+            datamodel_view_name,
+        ) in self._pending_standalone_lineage:
+            self._view_data_model = resolved.get(datamodel_view_name)
+            yield from self._add_standalone_view_lineage(view, project_name, model_name)
+        self._pending_standalone_lineage = []
+
+    def _resolve_pending_datamodels(self) -> dict[str, DashboardDataModel | None]:
+        """Fetch the data models written by this stage, keyed by their data model name.
+
+        A view joined from several explores is yielded once per explore, so the same
+        name is fetched only once and the caches keep the last-writer-wins semantics
+        the interleaved implementation had.
+        """
+        resolved: dict[str, DashboardDataModel | None] = {}
+
+        def resolve(data_model_name: str) -> DashboardDataModel | None:
+            if data_model_name not in resolved:
+                try:
+                    resolved[data_model_name] = self._build_data_model(data_model_name)
+                except Exception as err:
+                    # One flaky lookup must not cost every other view its lineage; the
+                    # None lands in the caches and the lineage builders skip that view.
+                    logger.warning(
+                        "Error fetching data model [%s]: %s", data_model_name, err
                     )
-                    yield from self.yield_standalone_datamodels()
+                    logger.debug(traceback.format_exc())
+                    resolved[data_model_name] = None
+            return resolved[data_model_name]
+
+        for datamodel_name in self._pending_explores:
+            self._explores_cache[datamodel_name] = resolve(datamodel_name)
+        self._pending_explores = []
+
+        for view_name, datamodel_view_name in self._pending_views:
+            self._views_cache[view_name] = resolve(datamodel_view_name)
+        self._pending_views = []
+
+        return resolved
 
     def _get_explore_sql(self, explore: LookmlModelExplore) -> Optional[str]:
         """
@@ -833,10 +928,19 @@ class LookerSource(DashboardServiceSource):
                     else None,
                 )
                 yield Either(right=data_model_request)
-                self._view_data_model = self._build_data_model(datamodel_view_name)
-                self._views_cache[view.name] = self._view_data_model
                 self.register_record_datamodel(datamodel_request=data_model_request)
-                yield from self.add_view_lineage(view, explore)
+
+                # Resolution and lineage are deferred to `_yield_bulk_datamodel_lineage`,
+                # once the Barrier has committed this request.
+                self._pending_views.append((view.name, datamodel_view_name))
+                self._processed_view_names.add(view.name)
+                self._pending_view_lineage.append(
+                    (
+                        view,
+                        ExploreRef(explore.model_name, explore.name),
+                        datamodel_view_name,
+                    )
+                )
             else:
                 logger.warning(
                     f"Cannot find the view [{view_name}] in the configured repositories. "
@@ -1021,9 +1125,17 @@ class LookerSource(DashboardServiceSource):
         This handles view-to-table lineage and view-to-view lineage via extends.
         """
         try:
-            # Set the current view data model for lineage processing
-            datamodel_view_name = f"{model_name}_{view.name}_view"
-            self._view_data_model = self._build_data_model(datamodel_view_name)
+            # `_yield_bulk_datamodel_lineage` resolves and sets `_view_data_model` after
+            # the Barrier flush; a miss means the data model never made it to the server.
+            if not self._view_data_model:
+                logger.warning(
+                    "Skipping lineage for standalone view [%s]: its data model [%s_%s_view] "
+                    "was not found in OpenMetadata.",
+                    view.name,
+                    model_name,
+                    view.name,
+                )
+                return
 
             # Handle view-to-view lineage via extends
             if view.extends__all:
@@ -1118,12 +1230,24 @@ class LookerSource(DashboardServiceSource):
             )
 
     def add_view_lineage(
-        self, view: LookMlView, explore: LookmlModelExplore
+        self,
+        view: LookMlView,
+        explore: Union[LookmlModelExplore, ExploreRef],
     ) -> Iterable[Either[AddLineageRequest]]:
         """
         Add the lineage source -> view -> explore
         """
         try:
+            # `_yield_bulk_datamodel_lineage` resolves and sets `_view_data_model` after
+            # the Barrier flush; a miss means the data model never made it to the server.
+            if not self._view_data_model:
+                logger.warning(
+                    "Skipping lineage for view [%s] of explore [%s]: its data model was not found in OpenMetadata.",
+                    view.name,
+                    explore.name,
+                )
+                return
+
             # This is the name we store in the cache
             explore_name = build_datamodel_name(explore.model_name, explore.name)
             explore_model = self._explores_cache.get(explore_name)

--- a/ingestion/src/metadata/utils/logger.py
+++ b/ingestion/src/metadata/utils/logger.py
@@ -32,6 +32,7 @@ from metadata.generated.schema.entity.datacontract.dataContractResult import (
 from metadata.generated.schema.type.queryParserData import QueryParserData
 from metadata.generated.schema.type.tableQuery import TableQueries
 from metadata.ingestion.api.models import Entity
+from metadata.ingestion.models.barrier import Barrier
 from metadata.ingestion.models.delete_entity import DeleteEntity
 from metadata.ingestion.models.life_cycle import OMetaLifeCycleData
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
@@ -264,6 +265,16 @@ def _(record: AddLineageRequest) -> str:
     )
 
     return f"{type_} [{name_str}id: {id_}]"
+
+
+@get_log_name.register
+def _(record: Barrier) -> None:
+    """A Barrier is a control record, not an ingested asset.
+
+    Returning None keeps it out of Status.scanned, which would otherwise report the
+    flush as a scanned record and inflate the connector's record count.
+    """
+    return
 
 
 @get_log_name.register

--- a/ingestion/tests/unit/topology/dashboard/test_looker_lineage_barrier.py
+++ b/ingestion/tests/unit/topology/dashboard/test_looker_lineage_barrier.py
@@ -1,0 +1,444 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Looker must not read back a data model it has only just yielded.
+
+``CreateDashboardDataModelRequest`` records sit in ``MetadataRestSink``'s bulk buffer
+until it reaches ``bulk_sink_batch_size``, so a ``get_by_name`` issued straight after
+the yield returns ``None``. The source has to emit a ``Barrier`` first and resolve the
+data models afterwards.
+
+The fixtures below model that sink semantics directly: ``_build_data_model`` returns
+``None`` until a ``Barrier`` has travelled down the stream.
+"""
+
+import sys
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from looker_sdk.sdk.api40.models import (
+    LookmlModelExplore,
+    LookmlModelExploreFieldset,
+    LookmlModelExploreJoins,
+)
+
+from metadata.generated.schema.api.data.createDashboardDataModel import (
+    CreateDashboardDataModelRequest,
+)
+from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
+from metadata.generated.schema.entity.data.dashboardDataModel import (
+    DashboardDataModel,
+    DataModelType,
+)
+from metadata.generated.schema.metadataIngestion.workflow import (
+    OpenMetadataWorkflowConfig,
+)
+from metadata.generated.schema.type.entityReference import EntityReference
+from metadata.ingestion.api.status import Status
+from metadata.ingestion.models.barrier import Barrier
+from metadata.ingestion.source.dashboard.looker.metadata import (
+    DATAMODEL_LINEAGE_SENTINEL,
+    ExploreRef,
+    LookerSource,
+)
+from metadata.ingestion.source.dashboard.looker.models import LookMlView
+
+MOCK_LOOKER_CONFIG = {
+    "source": {
+        "type": "looker",
+        "serviceName": "test_looker",
+        "serviceConnection": {
+            "config": {
+                "type": "Looker",
+                "clientId": "test",
+                "clientSecret": "test",
+                "hostPort": "https://my-looker.com",
+            }
+        },
+        "sourceConfig": {"config": {"type": "DashboardMetadata"}},
+    },
+    "sink": {"type": "metadata-rest", "config": {}},
+    "workflowConfig": {
+        "openMetadataServerConfig": {
+            "hostPort": "http://localhost:8585/api",
+            "authProvider": "openmetadata",
+            "securityConfig": {"jwtToken": "token"},
+        }
+    },
+}
+
+EXPECTED_DATA_MODELS = [
+    "my_model_joined_view_view",
+    "my_model_my_explore",
+    "my_model_my_view_view",
+    "my_model_orphan_view_view",
+]
+
+
+def _data_model(name: str) -> DashboardDataModel:
+    return DashboardDataModel(
+        id=uuid.uuid4(),
+        name=name,
+        displayName=name,
+        service=EntityReference(id=uuid.uuid4(), type="dashboardService"),
+        dataModelType=DataModelType.LookMlView,
+        columns=[],
+    )
+
+
+def _rights(records, of_type):
+    return [
+        either.right
+        for either in records
+        if either.right is not None and isinstance(either.right, of_type)
+    ]
+
+
+def _first_index(records, of_type) -> int:
+    for index, either in enumerate(records):
+        if either.right is not None and isinstance(either.right, of_type):
+            return index
+    return -1
+
+
+@pytest.fixture
+def looker():
+    with patch(
+        "metadata.ingestion.source.dashboard.dashboard_service.DashboardServiceSource.test_connection",
+        return_value=False,
+    ):
+        config = OpenMetadataWorkflowConfig.model_validate(MOCK_LOOKER_CONFIG)
+        source = LookerSource.create(
+            MOCK_LOOKER_CONFIG["source"],
+            config.workflowConfig.openMetadataServerConfig,
+        )
+    source.context.get().__dict__["dashboard_service"] = "test_looker"
+    return source
+
+
+@pytest.fixture
+def explore():
+    return LookmlModelExplore(
+        name="my_explore",
+        model_name="my_model",
+        project_name="my_project",
+        view_name="my_view",
+        joins=[LookmlModelExploreJoins(name="joined_view")],
+        fields=LookmlModelExploreFieldset(dimensions=[], measures=[]),
+    )
+
+
+@pytest.fixture
+def bulk_stage(looker, explore):
+    """Run the bulk data-model stage the way the workflow does.
+
+    Returns a callable giving back the emitted records in order plus, for every
+    ``_build_data_model`` call, the stream index at which it happened.
+    """
+    views = {
+        "my_view": LookMlView(name="my_view", sql_table_name="db.schema.my_table"),
+        "joined_view": LookMlView(
+            name="joined_view", sql_table_name="db.schema.joined_table"
+        ),
+        # Referenced by no explore, so it goes down the standalone path. `extends` gives it
+        # an edge that needs no dbServicePrefixes, and its parent is a view resolved by the
+        # same flush — which only works because the barrier precedes resolution.
+        "orphan_view": LookMlView(name="orphan_view", extends__all=[["my_view"]]),
+    }
+
+    def find_view(view_name):
+        """`_process_view` calls this by keyword, so `views.get` cannot stand in."""
+        return views.get(view_name)
+
+    parser = MagicMock()
+    parser._views_cache = views
+    parser.parsed_files = {}
+    parser.find_view.side_effect = find_view
+
+    looker._repo_credentials = True
+    looker._project_parsers = {"my_project": parser}
+    looker._all_lookml_models = [
+        SimpleNamespace(name="my_model", explores=[SimpleNamespace(name="my_explore")])
+    ]
+
+    def run():
+        records = []
+        lookups = []
+        flushed = False
+
+        def build_data_model(data_model_name):
+            lookups.append((len(records), data_model_name))
+            return _data_model(data_model_name) if flushed else None
+
+        with (
+            patch.object(LookerSource, "register_record_datamodel", return_value=None),
+            patch.object(LookerSource, "_get_explore_sql", return_value=None),
+            patch.object(
+                LookerSource, "_build_data_model", side_effect=build_data_model
+            ),
+            patch.object(LookerSource, "get_db_service_prefixes", return_value=[]),
+        ):
+            for node_entity in (explore, DATAMODEL_LINEAGE_SENTINEL):
+                for either in looker.yield_bulk_datamodel(node_entity):
+                    records.append(either)
+                    # The sink commits the buffer synchronously on a Barrier.
+                    if either.right is not None and isinstance(either.right, Barrier):
+                        flushed = True
+
+        return records, lookups
+
+    return run
+
+
+class TestLookerLineageBarrier:
+    """Ordering contract between the data-model writes and the lineage reads."""
+
+    def test_no_data_model_lookup_before_the_barrier(self, bulk_stage):
+        """Every read-back must happen after the buffer has been flushed."""
+        records, lookups = bulk_stage()
+
+        barrier_index = _first_index(records, Barrier)
+        assert barrier_index != -1, "The bulk stage must emit a Barrier"
+        assert lookups, "The stage should still resolve its data models"
+
+        early = [name for index, name in lookups if index < barrier_index]
+        assert early == [], f"Data models resolved before the Barrier: {early}"
+
+    def test_barrier_precedes_every_lineage_record(self, bulk_stage):
+        records, _ = bulk_stage()
+
+        lineage_index = _first_index(records, AddLineageRequest)
+        assert lineage_index != -1, "The stage should emit lineage"
+        assert _first_index(records, Barrier) < lineage_index
+
+    def test_data_models_are_created_before_the_barrier(self, bulk_stage):
+        """The whole point of the barrier is that the creates precede it."""
+        records, _ = bulk_stage()
+
+        barrier_index = _first_index(records, Barrier)
+        creates = [
+            index
+            for index, either in enumerate(records)
+            if either.right is not None
+            and isinstance(either.right, CreateDashboardDataModelRequest)
+        ]
+
+        assert creates
+        assert all(index < barrier_index for index in creates)
+
+    def test_view_lineage_is_emitted_and_not_reported_as_failure(self, bulk_stage):
+        """The regression: 306 'NoneType has no attribute name' errors."""
+        records, _ = bulk_stage()
+
+        failures = [either.left.error for either in records if either.left is not None]
+        assert failures == [], f"Bulk stage reported failures: {failures}"
+        assert _rights(
+            records, AddLineageRequest
+        ), "View -> explore lineage should be produced"
+
+    def test_only_one_barrier_per_bulk_stage(self, bulk_stage):
+        records, _ = bulk_stage()
+
+        assert (
+            len(_rights(records, Barrier)) == 1
+        ), "One flush is enough for the whole stage"
+
+    def test_explore_views_are_not_re_emitted_as_standalone_views(self, bulk_stage):
+        """`_views_cache` now fills after the flush, so the dedup can't rely on it."""
+        records, _ = bulk_stage()
+
+        created = [
+            request.name.root
+            for request in _rights(records, CreateDashboardDataModelRequest)
+        ]
+
+        assert sorted(created) == sorted(
+            set(created)
+        ), f"Duplicate data models: {created}"
+        assert sorted(created) == EXPECTED_DATA_MODELS
+
+    def test_a_failed_lookup_does_not_sink_the_whole_lineage_phase(self, looker):
+        """One flaky GET must cost only its own view's lineage."""
+
+        def flaky(data_model_name):
+            if data_model_name == "my_model_my_view_view":
+                raise RuntimeError("boom")
+            return _data_model(data_model_name)
+
+        looker._pending_views = [
+            ("my_view", "my_model_my_view_view"),
+            ("other_view", "my_model_other_view_view"),
+        ]
+
+        with patch.object(LookerSource, "_build_data_model", side_effect=flaky):
+            resolved = looker._resolve_pending_datamodels()
+
+        assert resolved["my_model_my_view_view"] is None
+        assert resolved["my_model_other_view_view"] is not None
+        assert looker._views_cache["other_view"] is not None
+
+    def test_standalone_view_lineage_also_runs_after_the_barrier(
+        self, bulk_stage, looker
+    ):
+        """The standalone path is the other half of the bug (109 of the 306 failures)."""
+        records, _ = bulk_stage()
+
+        assert (
+            looker._views_cache["orphan_view"] is not None
+        ), "standalone view must resolve"
+
+        # orphan_view extends my_view, so the edge is my_view -> orphan_view.
+        parent = looker._views_cache["my_view"]
+        child = looker._views_cache["orphan_view"]
+        extends_edges = [
+            r
+            for r in _rights(records, AddLineageRequest)
+            if r.edge.fromEntity.id.root == parent.id.root
+            and r.edge.toEntity.id.root == child.id.root
+        ]
+        assert (
+            extends_edges
+        ), "standalone view -> extends parent lineage should be produced"
+
+    def test_deferred_lineage_does_not_pin_the_explore_sdk_object(
+        self, looker, bulk_stage
+    ):
+        """Deferring lineage must not retain LookmlModelExplore for the whole stage.
+
+        The SDK object carries the full fieldset — measured at ~250 KB per explore, so a
+        1,000-explore instance would hold ~250 MB it never reads. Only model_name and name
+        are used, so the pending entry keeps an ExploreRef instead.
+        """
+        # The lineage loop clears the list, so snapshot it at the flush while it is populated.
+        captured = []
+        original = LookerSource._resolve_pending_datamodels
+
+        def snapshot(self):
+            captured.extend(self._pending_view_lineage)
+            return original(self)
+
+        with patch.object(
+            LookerSource,
+            "_resolve_pending_datamodels",
+            autospec=True,
+            side_effect=snapshot,
+        ):
+            bulk_stage()
+
+        assert captured, "the stage should defer at least one view -> explore lineage"
+        for _, held, _ in captured:
+            assert not isinstance(
+                held, LookmlModelExplore
+            ), f"pending lineage pins the SDK explore ({sys.getsizeof(held)} B shallow); use ExploreRef"
+            assert isinstance(held, ExploreRef)
+            assert (held.model_name, held.name) == ("my_model", "my_explore")
+
+    def test_barrier_is_not_counted_as_a_scanned_record(self):
+        """A flush is a control record, not an ingested asset."""
+        status = Status()
+        status.scanned(Barrier(reason="looker_datamodel_lineage_flush"))
+
+        assert status.records == []
+
+
+class TestProducerClosesTheStream:
+    """`list_datamodels` must always close with the sentinel.
+
+    Without it `_yield_bulk_datamodel_lineage` never runs and the whole lineage phase
+    vanishes silently — no error, no edges. Nothing else in the suite covers this, so
+    dropping the yield used to be an undetectable regression.
+    """
+
+    def _models(self, looker, explore_side_effect=None):
+        looker.client.all_lookml_models = MagicMock(
+            return_value=[
+                SimpleNamespace(
+                    name="m1", project_name="p", explores=[SimpleNamespace(name="e1")]
+                )
+            ]
+        )
+        looker.client.lookml_model_explore = MagicMock(
+            side_effect=explore_side_effect
+            or (lambda **_: SimpleNamespace(name="e1", model_name="m1"))
+        )
+
+    def test_sentinel_is_yielded_last(self, looker):
+        self._models(looker)
+
+        produced = list(looker.list_datamodels())
+
+        assert produced[-1] is DATAMODEL_LINEAGE_SENTINEL
+        assert sum(1 for p in produced if p is DATAMODEL_LINEAGE_SENTINEL) == 1
+
+    def test_sentinel_is_yielded_when_a_single_explore_fetch_fails(self, looker):
+        """`fetch_lookml_explores` swallows this one, so the stream just ends early."""
+        self._models(looker, explore_side_effect=Exception("explore 500"))
+
+        produced = list(looker.list_datamodels())
+
+        assert produced == [DATAMODEL_LINEAGE_SENTINEL]
+
+    def test_sentinel_is_yielded_when_the_model_listing_itself_blows_up(self, looker):
+        """The outer handler must not swallow the sentinel with the error.
+
+        Standalone views and the lineage of whatever was already yielded still need
+        drawing, so the sentinel lives after the `except`, not inside the `try`.
+        """
+        looker.client.all_lookml_models = MagicMock(
+            side_effect=Exception("looker api down")
+        )
+
+        produced = list(looker.list_datamodels())
+
+        assert produced == [DATAMODEL_LINEAGE_SENTINEL]
+
+    def test_no_sentinel_when_data_models_are_disabled(self, looker):
+        """Nothing was written, so there is nothing to flush or resolve."""
+        looker.source_config.includeDataModels = False
+
+        assert list(looker.list_datamodels()) == []
+
+    def test_the_sentinel_is_not_a_barrier(self, looker):
+        """Producer yields are the stage's input and never reach the sink.
+
+        A Barrier here would be handed to `yield_bulk_datamodel` as `model` and flush
+        nothing; the real Barrier goes out on the Either channel instead.
+        """
+        assert not isinstance(DATAMODEL_LINEAGE_SENTINEL, Barrier)
+        assert repr(DATAMODEL_LINEAGE_SENTINEL) == "<end of explores>"
+
+
+class TestLookerMissingDataModel:
+    """A data model that genuinely fails to create must not crash the stage."""
+
+    def test_add_view_lineage_skips_when_data_model_is_missing(self, looker, explore):
+        looker._view_data_model = None
+        looker._explores_cache["my_model_my_explore"] = _data_model(
+            "my_model_my_explore"
+        )
+
+        results = list(looker.add_view_lineage(LookMlView(name="my_view"), explore))
+
+        assert results == [], "A missing data model is a skip, not a stack trace"
+
+    def test_standalone_view_lineage_skips_when_data_model_is_missing(self, looker):
+        looker._view_data_model = None
+
+        results = list(
+            looker._add_standalone_view_lineage(
+                LookMlView(name="my_view", sql_table_name="db.schema.my_table"),
+                "my_project",
+                "my_model",
+            )
+        )
+
+        assert results == [], "A missing data model is a skip, not a stack trace"


### PR DESCRIPTION
### Describe your changes:

Backport of #32367 to **1.13**. Original fix: Fixes #32338

`yield_bulk_datamodel` yielded a `CreateDashboardDataModelRequest` and then immediately read it back with `get_by_name`. Since #24393 that record sits in `MetadataRestSink`'s bulk buffer until it reaches `bulk_sink_batch_size` (default 100), so the lookup returned `None` and `add_view_lineage` died on `self._view_data_model.name`. The bulk data-model stage is split into write → `Barrier` → resolve → lineage, reusing the sentinel/`Barrier` pattern PowerBI already uses on this branch, so every data model is committed before anything looks it up.

#
### Type of change:
- [x] Bug fix

#
### Backport notes

`git cherry-pick -x 9c63cf6e2048abd89e26951170f62595a7145b95` — conflicts in `looker/metadata.py` only, all from 1.13 pre-dating main's formatting/typing modernisation and the progress-tracking work. Resolved as follows; **no behavioural deviation from #32367**:

- kept 1.13's `typing` imports (`Dict`/`List`/`Optional`/…) and added `NamedTuple`; `add_view_lineage` takes `Union[LookmlModelExplore, ExploreRef]` instead of the `|` form
- dropped main-only code that landed in the conflict windows (`_reconcilable_explore_total`, `progress_tracking.manual.track`) — not present on 1.13
- kept `add_view_lineage` without `# noqa: C901` (a ruff rule; 1.13 lints with pylint)
- reformatted with the branch-pinned toolchain (`black==22.3.0`, isort, pycln) rather than main's ruff-format, so the diff carries no formatting churn

#
### Tests:

- `ingestion/tests/unit/topology/dashboard/test_looker_lineage_barrier.py` — **17 passed**
- `ingestion/tests/unit/topology/dashboard/` + `tests/unit/test_logger.py` — **511 passed, 1 skipped** (`test_ssrs.py` excluded: pre-existing `ModuleNotFoundError: requests_ntlm`, missing optional extra locally, unrelated to this change)
- `black --check` / `isort --check-only` / `pycln --diff` with the versions pinned in `ingestion/setup.py`: clean
- `basedpyright 1.39.3 -p ingestion/pyproject.toml --baselinemode=discard`: no new diagnostics (the `Either(right=Barrier(...))` `reportCallIssue` suppression was verified to actually suppress in its reflowed position — removing it reproduces the error)
- `pylint~=3.2.0`: no new message classes; file score 9.49 → 9.56

Verified the `Barrier` plumbing this fix depends on is fully present on 1.13 (`ingestion/models/barrier.py`, `sink/metadata_rest.py`, `api/topology_runner.py`).

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR is linked to a GitHub issue via `Fixes #32338` in #32367.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable, no schema changes.
- [x] I have added a test that covers the exact scenario we are fixing (carried over from #32367).

> `skip-pr-checks` is set because GitHub only populates `closingIssuesReferences` for PRs targeting the default branch, so **PR Metadata Validation** can never resolve `Fixes #32338` on a release-branch backport. Same handling as #32568, #32590, #32763.
