### PR TITLE
fix(ui): use core NoDataPlaceholder for glossary term-not-found state

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryPage/GlossaryPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryPage/GlossaryPage.component.tsx
@@ -24,6 +24,7 @@ import { RefObject, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { DeleteType } from '../../../components/common/DeleteWidget/DeleteWidget.interface';
+import NoDataPlaceholder from '../../../components/common/EmptyPlaceholder/NoDataPlaceholder';
 import ErrorPlaceHolder from '../../../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import Loader from '../../../components/common/Loader/Loader';
 import ResizableLeftPanels from '../../../components/common/ResizablePanels/ResizableLeftPanels';
@@ -69,7 +70,7 @@ import {
   glossaryTermQueryKey,
   GLOSSARY_TERM_DEFAULT_FIELDS,
 } from '../../../rest/queries/glossaryTermQuery';
-import { getEntityMissingError } from '../../../utils/EntityDisplayPureUtils';
+import { getEntityMissingMessage } from '../../../utils/EntityDisplayPureUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import Fqn from '../../../utils/Fqn';
 import { checkPermission } from '../../../utils/PermissionsUtils';
@@ -564,9 +565,14 @@ const GlossaryPage = () => {
     }
     if (isTermNotFound) {
       return (
-        <ErrorPlaceHolder>
-          {getEntityMissingError(t('label.glossary-term'), glossaryFqn)}
-        </ErrorPlaceHolder>
+        <div className="content-height-with-resizable-panel tw:relative">
+          <NoDataPlaceholder
+            description={getEntityMissingMessage(
+              t('label.glossary-term'),
+              glossaryFqn
+            )}
+          />
+        </div>
       );
     }
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityDisplayPureUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityDisplayPureUtils.tsx
@@ -65,14 +65,23 @@ export const requiredField = (label: string, excludeSpace = false) => (
   </>
 );
 
-export const getEntityMissingError = (entityType: string, fqn: string) => {
+/**
+ * Inline "<entity> instance for <fqn> not found" message, without any block
+ * wrapper, so it can be dropped into inline containers such as the
+ * `EmptyPlaceholder` description slot.
+ */
+export const getEntityMissingMessage = (entityType: string, fqn: string) => {
   return (
-    <p className="tw:m-0!">
+    <>
       {capitalize(entityType)} {t('label.instance-lowercase')}{' '}
       {t('label.for-lowercase')} <strong>{fqn}</strong>{' '}
       {t('label.not-found-lowercase')}
-    </p>
+    </>
   );
+};
+
+export const getEntityMissingError = (entityType: string, fqn: string) => {
+  return <p className="tw:m-0!">{getEntityMissingMessage(entityType, fqn)}</p>;
 };
 
 export const getEntityDeleteMessage = (entity: string, dependents: string) => {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #29914 

The glossary term-not-found branch rendered the legacy ErrorPlaceHolder, which pairs the old SVG illustration with a
redundant "No data available." line above the actual message, and was mounted without a positioned host so the absolutely positioned content drifted to the top of the viewport instead of centering.

Swap it for the core NoDataPlaceholder inside a relative, full-height container matching the empty-glossaries state in the same file.

<img width="1512" height="800" alt="Screenshot 2026-09-07 at 5 01 17 PM" src="https://github.com/user-attachments/assets/dda2c506-2f02-481b-ade9-f06cb4175356" />


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
