### PR TITLE
Fixes #32868: keep the merge-queue dequeue report alive on non-Actions check runs

### DIFF
--- a/.github/workflows/merge-queue-dequeue-report.yml
+++ b/.github/workflows/merge-queue-dequeue-report.yml
@@ -127,16 +127,29 @@ jobs:
 
             : > runs.md
             : > runs.slack
-            cut -f1 failures.tsv | sed 's#/job/.*##' | sort -u | while read -r run; do
+            # A check run published through the Checks API rather than by a job
+            # (e.g. "Test Report") has no /job/ segment, so its trailing id is a
+            # check-run id and not a workflow-run id — looking that up under
+            # /actions/runs 404s, and under set -e it fails the whole report.
+            grep -E '/actions/runs/[0-9]+/job/' failures.tsv > actions.tsv || true
+            grep -vE '/actions/runs/[0-9]+/job/' failures.tsv > other.tsv || true
+
+            cut -f1 actions.tsv | sed 's#/job/.*##' | sort -u | while read -r run; do
               run_name=$(gh api "repos/$GH_REPO/actions/runs/${run##*/}" --jq '.name')
               # Matrix jobs carry every parameter; the first one is the shard id.
-              jobs=$(grep -F "$run/job/" failures.tsv | cut -f2 \
+              jobs=$(grep -F "$run/job/" actions.tsv | cut -f2 \
                      | sed 's/ (\([^,)]*\)[^)]*)/ (\1)/' \
                      | awk '{ out = out (out ? ", " : "") $0 } END { print out }')
               echo "- [$run_name]($run) — $jobs" >> runs.md
               # Slack mrkdwn has no []() links; it uses <url|text>.
               echo "• <$run|$run_name> — $jobs" >> runs.slack
             done
+
+            # Nothing to group these under, so each is listed on its own.
+            while IFS=$'\t' read -r url name; do
+              echo "- [$name]($url)" >> runs.md
+              echo "• <$url|$name>" >> runs.slack
+            done < other.tsv
 
             if [ -s runs.md ]; then
               if [ -n "$blocked" ]; then


### PR DESCRIPTION
### Describe your changes:

Fixes #32868

`Merge Queue Dequeue Report` died with `gh: Not Found (HTTP 404)` whenever a dequeued PR had a failing check run published through the **Checks API** rather than by a workflow job. Because `Ping #ci-cleanup` is `if:`-gated on that step's output, the Slack alert was skipped too — so dequeues were silently going unreported.

The step grouped failing checks by workflow run by slicing the check run's `html_url`, assuming every one is an Actions *job* URL:

```bash
cut -f1 failures.tsv | sed 's#/job/.*##' | sort -u | while read -r run; do
  run_name=$(gh api "repos/$GH_REPO/actions/runs/${run##*/}" --jq '.name')
```

The `Test Report` check (JUnit reporter) has no `/job/` segment — `https://github.com/open-metadata/OpenMetadata/runs/101708106672` — so `sed` left it untouched and `${run##*/}` handed a **check-run** id to `/actions/runs/`, which 404s. Under `set -euo pipefail` that killed the step.

This PR partitions `failures.tsv` on the Actions job URL shape: entries that match are grouped by workflow run as before, and the rest are listed on their own instead of having a run name resolved for them. `blocked` still reads the full `failures.tsv`, so required-check detection is unchanged.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- A PR dequeued with a failing `Test Report` (non-Actions) check run still gets its dequeue comment, and `#ci-cleanup` still gets the Slack alert
- Failing Actions jobs are still grouped under their workflow run with matrix shard ids collapsed
- The required check that blocked the queue is still identified

#### Unit tests
N/A — no application code; this is a workflow shell step. Verified by replaying the step against the real failing data (below).

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed

Extracted the step body from the YAML before and after the change and ran both against the real merge-queue commit of PR #32458 (`732e405`, `reason=failed_checks`) with `DRY_RUN=true`:

**Before** — reproduces the CI failure exactly:
```
gh: Not Found (HTTP 404)
=== PRE-PATCH EXIT: 1 ===
```

**After** — exit 0, with the non-Actions check retained:
```
=== EXIT: 0 ===

actions.tsv
  .../actions/runs/34109976452/job/101718523397   playwright-summary
  .../actions/runs/34109976452/job/101711935898   playwright / playwright-ci (chromium-03, ...)
  .../actions/runs/34109976237/job/101708117385   openmetadata-service-unit-tests-status
  .../actions/runs/34109976237/job/101704186814   openmetadata-service-unit-tests
other.tsv
  .../runs/101708106672                           Test Report
```

Rendered report:
> ### 🚦 Removed from the merge queue — `failed_checks` (2026-09-07T11:06:12Z)
>
> Blocked the queue: `playwright-summary`
>
> - [OpenMetadata Service Unit Tests](https://github.com/open-metadata/OpenMetadata/actions/runs/34109976237) — openmetadata-service-unit-tests-status, openmetadata-service-unit-tests
> - [Postgresql PR Playwright E2E Tests](https://github.com/open-metadata/OpenMetadata/actions/runs/34109976452) — playwright-summary, playwright / playwright-ci (chromium-03)
> - [Test Report](https://github.com/open-metadata/OpenMetadata/runs/101708106672)

Also ran `actionlint` (exit 0) and `shellcheck -s bash` on the extracted step (clean).

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. (N/A)
- [x] For UI changes: I attached a screen recording and/or screenshots above. (N/A)
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above. (N/A — workflow shell step, verified by replay above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
