### PR TITLE
fix(security): bump fast-uri to 3.1.7 (cherry-pick #32799 to 2.0)

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/package.json
+++ b/openmetadata-ui-core-components/src/main/resources/ui/package.json
@@ -140,7 +140,7 @@
   },
   "resolutions": {
     "brace-expansion": "5.0.9",
-    "fast-uri": "3.1.6",
+    "fast-uri": "3.1.7",
     "lodash": "4.18.1",
     "minimatch": "10.2.3",
     "nanoid": "3.3.17",

--- a/openmetadata-ui-core-components/src/main/resources/ui/yarn.lock
+++ b/openmetadata-ui-core-components/src/main/resources/ui/yarn.lock
@@ -3707,10 +3707,10 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-uri@3.1.6, fast-uri@^3.0.1:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.6.tgz#bfdd308ef763f835fed059f3c6c925f708e33e3a"
-  integrity sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==
+fast-uri@3.1.7, fast-uri@^3.0.1:
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.7.tgz#743157d957f3cbb4c65310e033dc2ad4ad7dc60a"
+  integrity sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==
 
 fdir@^6.5.0:
   version "6.5.0"

--- a/openmetadata-ui/src/main/resources/ui/package.json
+++ b/openmetadata-ui/src/main/resources/ui/package.json
@@ -300,7 +300,7 @@
     "form-data": "4.0.6",
     "tar-fs": "2.1.4",
     "brace-expansion": "1.1.18",
-    "fast-uri": "3.1.6",
+    "fast-uri": "3.1.7",
     "linkify-it": "5.0.2",
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",

--- a/openmetadata-ui/src/main/resources/ui/yarn.lock
+++ b/openmetadata-ui/src/main/resources/ui/yarn.lock
@@ -7063,10 +7063,10 @@ fast-text-encoding@^1.0.6:
   resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz#0aa25f7f638222e3396d72bf936afcf1d42d6867"
   integrity sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==
 
-fast-uri@3.1.6, fast-uri@^3.0.1:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.6.tgz#bfdd308ef763f835fed059f3c6c925f708e33e3a"
-  integrity sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==
+fast-uri@3.1.7, fast-uri@^3.0.1:
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.7.tgz#743157d957f3cbb4c65310e033dc2ad4ad7dc60a"
+  integrity sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==
 
 fastq@^1.6.0:
   version "1.20.1"


### PR DESCRIPTION
Cherry-pick of #32799 to the `2.0` branch.

Snyk SNYK-JS-FASTURI-19502739 / SNYK-JS-FASTURI-19502854 (Improper Encoding/Escaping of Output, Host Confusion, CVSS 8.7 high) flag fast-uri 3.1.6, pinned via resolutions in both UI workspaces. ajv@8.18.0 (the sole consumer, via @rjsf/validator-ajv8) declares fast-uri ^3.0.1, so 3.1.7 is the correct in-range fix.

Conflict resolution: `2.0` lacks the `browserslist` resolution present on `main` (adjacent context line only); resolved by keeping just the `fast-uri` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)