### PR TITLE
test: restore source config in data contract pipeline fixture

### DIFF
--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/DataContractPipelineTokenRefreshTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/DataContractPipelineTokenRefreshTest.java
@@ -41,6 +41,8 @@ import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineServic
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineType;
 import org.openmetadata.schema.entity.teams.AuthenticationMechanism;
 import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.metadataIngestion.SourceConfig;
+import org.openmetadata.schema.metadataIngestion.TestSuitePipeline;
 import org.openmetadata.schema.security.secrets.SecretsManagerClientLoader;
 import org.openmetadata.schema.security.secrets.SecretsManagerProvider;
 import org.openmetadata.schema.security.ssl.VerifySSL;
@@ -304,6 +306,7 @@ class DataContractPipelineTokenRefreshTest {
         .withName("dq-pipeline")
         .withFullyQualifiedName("dq-pipeline")
         .withPipelineType(PipelineType.TEST_SUITE)
+        .withSourceConfig(new SourceConfig().withConfig(new TestSuitePipeline()))
         .withDeployed(deployed);
   }
 


### PR DESCRIPTION
### Describe your changes:

Repair the shared `DataContractPipelineTokenRefreshTest` fixture after #29566 introduced deployment-time source configuration validation. The fixture omitted `sourceConfig`, causing `BadRequestException` before the mocked pipeline client could receive the deployment. This produced three failing tests and also let two fallback tests pass through the wrong exception path.

Populate the fixture with `new SourceConfig().withConfig(new TestSuitePipeline())`, matching real Data Contract DQ pipeline creation and its generated `TestSuite` type default. The existing token-rotation, first-deployment, and runner-failure assertions remain intact.

Follow-up to #29566; covers the interaction with the tests added in #31848. Historical failure: [merge-group service job](https://github.com/open-metadata/OpenMetadata/actions/runs/34088922858/job/101638346862).

### Type of change:

- [x] Bug fix

### Tests:

- Reproduced the baseline on `5e14ff42fe694deb816b316b5c5226134c24c9af`: six token-refresh tests, three failures with the reported empty deployment-token list and exception mismatches.
- After the fixture repair: all six token-refresh tests and all 42 `IngestionPipelineRepositoryTest` cases pass; 48 tests total, zero skipped.
- `mvn -B -pl openmetadata-service spotless:apply spotless:check` passed.
- Full service build passed: 8,751 tests, zero failures/errors, one existing skipped test in `DefaultContextEntityPromptLoaderTest`. Docker-backed Redis, LocalStack, Elasticsearch, and OpenSearch tests executed.
- Backend API, ingestion, and UI integration tests: not applicable to this test-fixture-only change. Production code and schemas are unchanged.

Full service command:

```bash
mvn -B clean package -pl openmetadata-service -am \
  -Pstatic-code-analysis -DfailIfNoTests=false -Dsonar.skip=true
```

### UI screen recording / screenshots:

Not applicable.

### Checklist:

- [x] Existing regression tests fail before the fixture repair and pass afterward.
- [x] Changes are limited to one shared test fixture and its imports.
- [ ] Link the tracking issue and required Shipping project metadata before marking ready for review.

Requiring the existing `openmetadata-service-unit-tests-status` check is a separate maintainer configuration follow-up; this draft does not change branch rules or workflows.
