### PR TITLE
fix(ui): close DOMPurify math-equation bypass and mention-dropdown XSS

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedEditor/FeedEditor.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedEditor/FeedEditor.test.tsx
@@ -27,6 +27,7 @@ interface MentionModule {
     item: Record<string, unknown>,
     insertItem: (item: unknown) => void
   ) => void;
+  renderItem: (item: Record<string, unknown>) => HTMLElement;
 }
 
 interface CapturedQuillProps {
@@ -217,5 +218,23 @@ describe('Test FeedEditor Component', () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+
+  it('escapes HTML in entity names rendered in the mention suggestion list', async () => {
+    const { container } = render(<FeedEditor {...mockFeedEditorProp} />, {
+      wrapper: MemoryRouter,
+    });
+    await findByTestId(container, 'react-quill');
+
+    const payload = '<img src=x onerror=alert(1)>';
+    const wrapper = mentionModule().renderItem({
+      type: 'table',
+      name: payload,
+      breadcrumbs: [{ name: payload }],
+    });
+
+    // The payload must appear as literal text, never as parsed markup.
+    expect(wrapper.querySelector('img')).toBeNull();
+    expect(wrapper.textContent).toContain(payload);
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedEditor/FeedEditor.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedEditor/FeedEditor.tsx
@@ -14,7 +14,7 @@
 
 import { TextAreaEmoji } from '@windmillcode/quill-emoji';
 import classNames from 'classnames';
-import { debounce, isNil } from 'lodash';
+import { debounce, escape, isNil } from 'lodash';
 import { Parchment } from 'quill';
 import 'quill-mention/autoregister';
 import QuillMarkdown from 'quilljs-markdown';
@@ -164,8 +164,12 @@ export const FeedEditor = forwardRef<EditorContentRef, FeedEditorProp>(
           return item.avatarEle;
         }
 
+        // Escape all search-index-sourced values (names are user-editable)
+        // before interpolating into the innerHTML template below
         const breadcrumbsData = item.breadcrumbs
-          ? item.breadcrumbs.map((obj: { name: string }) => obj.name).join('/')
+          ? item.breadcrumbs
+              .map((obj: { name: string }) => escape(obj.name))
+              .join('/')
           : '';
 
         const breadcrumbEle = breadcrumbsData
@@ -182,7 +186,7 @@ export const FeedEditor = forwardRef<EditorContentRef, FeedEditorProp>(
         );
 
         const typeSpan = !breadcrumbEle
-          ? `<span class="text-grey-muted text-xs">${item.type}</span>`
+          ? `<span class="text-grey-muted text-xs">${escape(item.type)}</span>`
           : '';
 
         const result = `<div class="d-flex items-center gap-2">
@@ -191,7 +195,9 @@ export const FeedEditor = forwardRef<EditorContentRef, FeedEditorProp>(
             ${breadcrumbEle}
             <div class="d-flex flex-col">
               ${typeSpan}
-              <span class="font-medium truncate w-56">${item.name}</span>
+              <span class="font-medium truncate w-56">${escape(
+                item.name
+              )}</span>
             </div>
           </div>
         </div>`;

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkPopup/LinkPopup.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkPopup/LinkPopup.test.tsx
@@ -42,6 +42,7 @@ describe('LinkPopup', () => {
 
     expect(open).toHaveAttribute('href', 'https://example.com');
     expect(open).toHaveAttribute('target', '_blank');
+    expect(open).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
   it('should call handleLinkToggle when edit is clicked', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkPopup/LinkPopup.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkPopup/LinkPopup.tsx
@@ -44,6 +44,7 @@ const LinkPopup: FC<LinkPopupProps> = ({
         data-testid="link-popup-open"
         href={href}
         icon={<ExternalLinkIcon width={iconSize + 2} />}
+        rel="noopener noreferrer"
         target="_blank"
         type="link"
       />

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/OverviewSection/CommonEntitySummaryInfoV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/OverviewSection/CommonEntitySummaryInfoV1.test.tsx
@@ -157,6 +157,7 @@ describe('CommonEntitySummaryInfoV1', () => {
 
     expect(anchor).toBeInTheDocument();
     expect(anchor).toHaveAttribute('href', 'https://open-metadata.org');
+    expect(anchor).toHaveAttribute('rel', 'noopener noreferrer');
     expect(screen.getByTestId('external-link-icon')).toBeInTheDocument();
   });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/OverviewSection/CommonEntitySummaryInfoV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/OverviewSection/CommonEntitySummaryInfoV1.tsx
@@ -63,7 +63,11 @@ const CommonEntitySummaryInfoV1: React.FC<CommonEntitySummaryInfoV1Props> = ({
 
     if (info.isExternal && info.value !== '-') {
       return (
-        <a className="summary-item-link" href={info.url} target="_blank">
+        <a
+          className="summary-item-link"
+          href={info.url}
+          rel="noopener noreferrer"
+          target="_blank">
           {info.value}
           <Icon
             className="m-l-xs"

--- a/openmetadata-ui/src/main/resources/ui/src/utils/sanitize.utils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/sanitize.utils.test.ts
@@ -107,6 +107,24 @@ describe('getSanitizeContent', () => {
       expect(result).toContain('<p>Formula</p>');
     });
 
+    it('should sanitize payloads nested inside a block-math-equation tag', () => {
+      const input =
+        '<block-math-equation math_equation="x^2"><img src="x" onerror="alert(1)"></block-math-equation>';
+      const result = getSanitizeContent(input);
+
+      expect(result).not.toContain('onerror');
+      expect(result).toContain('math_equation="x^2"');
+    });
+
+    it('should sanitize event-handler attributes on the block-math-equation tag itself', () => {
+      const input =
+        '<block-math-equation math_equation="x^2" onclick="alert(1)"></block-math-equation>';
+      const result = getSanitizeContent(input);
+
+      expect(result).not.toContain('onclick');
+      expect(result).toContain('math_equation="x^2"');
+    });
+
     it('should preserve math equations alongside entity links', () => {
       const input =
         '<block-math-equation math_equation="y=mx+b"></block-math-equation><#E::team::Accounting|@Accounting>';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/sanitize.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/sanitize.utils.ts
@@ -17,30 +17,25 @@ export const getSanitizeContent = (html: string): string => {
   // user's text itself contains a placeholder-shaped string.
   const nonce = Math.random().toString(36).slice(2, 10);
 
-  // Protect math equations from DOMPurify's unknown-tag stripping
-  const mathEquationRegex =
-    /<block-math-equation[^>]*>[\s\S]*?<\/block-math-equation>/g;
-  const mathEquations: string[] = [];
-  let mathEquationIndex = 0;
-
-  const mathProtected = html.replaceAll(mathEquationRegex, (match) => {
-    mathEquations.push(match);
-
-    return `__OM_MATH_EQ_${nonce}_${mathEquationIndex++}__`;
-  });
-
   // Protect entity links from DOMPurify encoding
   const entityLinkRegex = /<#E::[^>]+>/g;
   const entityLinks: string[] = [];
   let entityLinkIndex = 0;
 
-  const protectedHtml = mathProtected.replaceAll(entityLinkRegex, (match) => {
+  const protectedHtml = html.replaceAll(entityLinkRegex, (match) => {
     entityLinks.push(match);
 
     return `__OM_ENTITY_LINK_${nonce}_${entityLinkIndex++}__`;
   });
 
-  const sanitizedContent = DOMPurify.sanitize(protectedHtml);
+  // Allowlist the math-equation custom tag and its attributes instead of
+  // exempting the whole match from sanitization — a raw-substring exemption
+  // would let attacker-controlled attributes/children (e.g. <img onerror>)
+  // nested inside the tag bypass DOMPurify entirely.
+  const sanitizedContent = DOMPurify.sanitize(protectedHtml, {
+    ADD_TAGS: ['block-math-equation'],
+    ADD_ATTR: ['math_equation', 'isediting'],
+  });
 
   // Restore entity links — use replacer fn so '$' in values is inserted verbatim
   let restoredContent = sanitizedContent;
@@ -48,13 +43,6 @@ export const getSanitizeContent = (html: string): string => {
     restoredContent = restoredContent.replace(
       `__OM_ENTITY_LINK_${nonce}_${index}__`,
       () => link
-    );
-  });
-
-  mathEquations.forEach((eq, index) => {
-    restoredContent = restoredContent.replace(
-      `__OM_MATH_EQ_${nonce}_${index}__`,
-      () => eq
     );
   });
 


### PR DESCRIPTION
## Describe your changes

Fixes three UI security findings from a nightly security sweep:

- **High — DOMPurify bypass via `<block-math-equation>` (stored XSS)**: `getSanitizeContent()` regex-extracted the *entire* matched `<block-math-equation>...</block-math-equation>` substring — opening-tag attributes and nested children included — into a placeholder before `DOMPurify.sanitize()`, then restored the raw original verbatim. A payload like `<block-math-equation><img src=x onerror=...></block-math-equation>` in any description/comment survived sanitization intact and fired at the pre-processing `innerHTML` step (`transformImgTagsToFileAttachment`) before the editor schema could strip it. Fixed by dropping the exemption and allowlisting the tag properly via `ADD_TAGS: ['block-math-equation']` + `ADD_ATTR: ['math_equation', 'isediting']`, so DOMPurify sanitizes nested content and event-handler attributes normally while preserving legitimate equations.
- **High — mention-dropdown innerHTML XSS (stored XSS)**: `FeedEditor.renderItems()` interpolated `item.name`, `item.type`, and breadcrumb names (search-index data sourced from user-editable `displayName`/`name` fields) unescaped into an HTML template assigned via `innerHTML`. A poisoned displayName executed when any user typed `@`/`#` in the feed editor. Fixed by escaping all interpolated values with lodash `escape`.
- **Medium — reverse tabnabbing**: added `rel="noopener noreferrer"` to the `target=_blank` external-source link in `CommonEntitySummaryInfoV1` and the open-link Button in `LinkPopup` (antd `Button`, unlike `Typography.Link`, injects no default rel).

<img width="1512" height="908" alt="Screenshot 2026-09-07 at 9 27 04 PM" src="https://github.com/user-attachments/assets/f3a39d6b-7599-4a96-8f4c-eb1e4f8dd15d" />

<img width="1512" height="908" alt="Screenshot 2026-09-07 at 9 27 24 PM" src="https://github.com/user-attachments/assets/d78b3f3c-1089-4d52-ad66-efcf1aea329d" />

<img width="1512" height="908" alt="Screenshot 2026-09-07 at 9 29 02 PM" src="https://github.com/user-attachments/assets/95877c21-953f-4d88-9133-6e4eb3e99355" />


## Tests

- `sanitize.utils.test.ts`: 2 new tests — nested payload inside `block-math-equation` is stripped; event-handler attributes on the tag itself are stripped. All existing math-equation/entity-link preservation tests pass unchanged.
- `FeedEditor.test.tsx`: new test driving the real `renderItem` handler with a hostile entity name — asserts it renders as literal text, never parsed markup.
- `LinkPopup.test.tsx` / `CommonEntitySummaryInfoV1.test.tsx`: assert `rel="noopener noreferrer"` on the external links.

`yarn jest` on the 4 touched suites: 44 passed. `yarn eslint` on changed files: 0 errors, no new warnings.

## Type of change

- [x] Bug fix (security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)