### PR TITLE
fix(pii): corroborate spaCy named entities

### DIFF
--- a/ingestion/src/metadata/pii/tag_analyzer.py
+++ b/ingestion/src/metadata/pii/tag_analyzer.py
@@ -76,21 +76,30 @@ def _corroborated_content_results(evidence: Sequence[_RecognitionEvidence]) -> l
     """Drop an isolated, uncontextualized spaCy named-entity guess.
 
     Pattern recognizers, vetted date results and context-enhanced NER results are strong
-    enough to stand on their own. Uncontextualized statistical NER needs one independent
-    corroborating entity so a repeated model mistake does not classify the whole column.
+    enough to stand on their own. Each uncontextualized statistical NER type needs one
+    independent corroborating entity so a repeated model mistake does not classify the
+    whole column.
 
     Distinct matches are a recall-first heuristic, not proof that an entity is PII: two
     different spaCy mistakes can still corroborate each other. spaCy assigns the same
     recognizer score to both real and mistaken entities, so a higher score threshold would
     not distinguish them, while requiring more matches would miss sparse PII again.
     """
-    uncertain_ner_evidence = [item for item in evidence if _is_uncontextualized_spacy_named_entity(item.result)]
-    distinct_matches = {match for item in uncertain_ner_evidence if (match := _normalized_match(item))}
+    distinct_matches_by_entity: dict[str, set[str]] = {}
+    for item in evidence:
+        if _is_uncontextualized_spacy_named_entity(item.result) and (match := _normalized_match(item)):
+            distinct_matches_by_entity.setdefault(item.result.entity_type, set()).add(match)
 
-    if len(distinct_matches) >= _MIN_DISTINCT_UNCONTEXTUALIZED_NER_MATCHES:
-        return [item.result for item in evidence]
-
-    return [item.result for item in evidence if not _is_uncontextualized_spacy_named_entity(item.result)]
+    corroborated_entities = {
+        entity_type
+        for entity_type, matches in distinct_matches_by_entity.items()
+        if len(matches) >= _MIN_DISTINCT_UNCONTEXTUALIZED_NER_MATCHES
+    }
+    return [
+        item.result
+        for item in evidence
+        if not _is_uncontextualized_spacy_named_entity(item.result) or item.result.entity_type in corroborated_entities
+    ]
 
 
 class TagAnalysis(BaseModel):

--- a/ingestion/src/metadata/pii/tag_analyzer.py
+++ b/ingestion/src/metadata/pii/tag_analyzer.py
@@ -78,6 +78,11 @@ def _corroborated_content_results(evidence: Sequence[_RecognitionEvidence]) -> l
     Pattern recognizers, vetted date results and context-enhanced NER results are strong
     enough to stand on their own. Uncontextualized statistical NER needs one independent
     corroborating entity so a repeated model mistake does not classify the whole column.
+
+    Distinct matches are a recall-first heuristic, not proof that an entity is PII: two
+    different spaCy mistakes can still corroborate each other. spaCy assigns the same
+    recognizer score to both real and mistaken entities, so a higher score threshold would
+    not distinguish them, while requiring more matches would miss sparse PII again.
     """
     uncertain_ner_evidence = [item for item in evidence if _is_uncontextualized_spacy_named_entity(item.result)]
     distinct_matches = {match for item in uncertain_ner_evidence if (match := _normalized_match(item))}

--- a/ingestion/src/metadata/pii/tag_analyzer.py
+++ b/ingestion/src/metadata/pii/tag_analyzer.py
@@ -1,5 +1,6 @@
 import copy
 from collections.abc import Sequence
+from dataclasses import dataclass
 from itertools import groupby
 from typing import final
 
@@ -18,7 +19,9 @@ from metadata.generated.schema.type import recognizer, tagLabelRecognizerMetadat
 from metadata.generated.schema.type.classificationLanguages import (
     ClassificationLanguage,
 )
+from metadata.generated.schema.type.predefinedRecognizer import Name
 from metadata.generated.schema.type.recognizer import RecognizerException
+from metadata.pii.algorithms import presidio_constants
 from metadata.pii.algorithms.feature_extraction import split_column_name
 from metadata.pii.algorithms.presidio_patches import (
     PresidioRecognizerResultPatcher,
@@ -42,6 +45,47 @@ TARGET_MAP = {
     recognizer.Target.content: tagLabelRecognizerMetadata.Target.content,
     recognizer.Target.column_name: tagLabelRecognizerMetadata.Target.column_name,
 }
+
+_NAMED_ENTITY_TYPES = frozenset({"PERSON", "LOCATION", "NRP"})
+_MIN_DISTINCT_UNCONTEXTUALIZED_NER_MATCHES = 2
+
+
+@dataclass(frozen=True)
+class _RecognitionEvidence:
+    value: str
+    result: RecognizerResult
+
+
+def _is_uncontextualized_spacy_named_entity(result: RecognizerResult) -> bool:
+    metadata = result.recognition_metadata or {}
+    return (
+        result.entity_type in _NAMED_ENTITY_TYPES
+        and metadata.get(presidio_constants.RECOGNIZER_METADATA_NAME) == Name.SpacyRecognizer.value
+        and not metadata.get(RecognizerResult.IS_SCORE_ENHANCED_BY_CONTEXT_KEY)
+    )
+
+
+def _normalized_match(evidence: _RecognitionEvidence) -> str:
+    result = evidence.result
+    if not 0 <= result.start < result.end <= len(evidence.value):
+        return ""
+    return " ".join(evidence.value[result.start : result.end].casefold().split())
+
+
+def _corroborated_content_results(evidence: Sequence[_RecognitionEvidence]) -> list[RecognizerResult]:
+    """Drop an isolated, uncontextualized spaCy named-entity guess.
+
+    Pattern recognizers, vetted date results and context-enhanced NER results are strong
+    enough to stand on their own. Uncontextualized statistical NER needs one independent
+    corroborating entity so a repeated model mistake does not classify the whole column.
+    """
+    uncertain_ner_evidence = [item for item in evidence if _is_uncontextualized_spacy_named_entity(item.result)]
+    distinct_matches = {match for item in uncertain_ner_evidence if (match := _normalized_match(item))}
+
+    if len(distinct_matches) >= _MIN_DISTINCT_UNCONTEXTUALIZED_NER_MATCHES:
+        return [item.result for item in evidence]
+
+    return [item.result for item in evidence if not _is_uncontextualized_spacy_named_entity(item.result)]
 
 
 class TagAnalysis(BaseModel):
@@ -169,9 +213,9 @@ class TagAnalyzer:
         recognizers: list[EntityRecognizer],
         context: list[str] | None = None,
         result_patcher: PresidioRecognizerResultPatcher | None = None,
-    ) -> list[RecognizerResult]:
+    ) -> list[_RecognitionEvidence]:
         values = [text_or_values] if isinstance(text_or_values, str) else list(text_or_values)
-        results: list[RecognizerResult] = []
+        evidence: list[_RecognitionEvidence] = []
 
         if self._language is not ClassificationLanguage.any:
             analyzer = self.build_analyzer_with(recognizers)
@@ -182,8 +226,9 @@ class TagAnalyzer:
                     context=context,
                     return_decision_process=True,
                 )
-                results.extend(result_patcher(value_results, value) if result_patcher else value_results)
-            return results
+                patched_results = result_patcher(value_results, value) if result_patcher else value_results
+                evidence.extend(_RecognitionEvidence(value=value, result=result) for result in patched_results)
+            return evidence
 
         sorted_recs = sorted(recognizers, key=lambda r: r.supported_language)
         for lang, group in groupby(sorted_recs, key=lambda r: r.supported_language):
@@ -207,8 +252,9 @@ class TagAnalyzer:
                     context=context,
                     return_decision_process=True,
                 )
-                results.extend(result_patcher(value_results, value) if result_patcher else value_results)
-        return results
+                patched_results = result_patcher(value_results, value) if result_patcher else value_results
+                evidence.extend(_RecognitionEvidence(value=value, result=result) for result in patched_results)
+        return evidence
 
     def analyze(
         self,
@@ -221,21 +267,20 @@ class TagAnalyzer:
             content_recognizers = self.content_recognizers
             if content_recognizers:
                 context = split_column_name(self._column_name)
-                content_results = self._analyze_with(
+                content_evidence = self._analyze_with(
                     str_values,
                     content_recognizers,
                     context=context,
-                    # Scoring on the strongest single match means every stray NER hit counts,
-                    # where the old average buried them; the patchers are what keeps identifier
-                    # columns from turning into PII.
                     result_patcher=combine_patchers(date_time_patcher, named_entity_patcher),
                 )
+                content_results = _corroborated_content_results(content_evidence)
                 # Use the maximum individual recogniser score rather than the average over all
                 # sampled values.  Averaging dilutes genuine PII hits: a single social-insurance
                 # number among 50 sampled rows would score 0.85 / 50 = 0.017 — far below any
                 # reasonable minimumConfidence.  For a security control, sensitivity is
                 # contaminating, not statistical: one confirmed hit is enough to classify the
-                # column as PII.  (Fixes #32070)
+                # column as PII. Statistical named-entity guesses are corroborated above before
+                # they are eligible for this maximum. (Fixes #32070)
                 content_score = max((r.score for r in content_results), default=0.0)
 
         column_results: list[RecognizerResult] = []
@@ -243,7 +288,9 @@ class TagAnalyzer:
         if run_column_analysis:
             column_recognizers = self.column_recognizers
             if column_recognizers:
-                column_results = self._analyze_with(self._column_name, column_recognizers)
+                column_results = [
+                    evidence.result for evidence in self._analyze_with(self._column_name, column_recognizers)
+                ]
                 column_score = min(sum(r.score for r in column_results), 1.0)
 
         column_wins = column_score >= content_score and bool(column_results)

--- a/ingestion/tests/unit/metadata/pii/test_tag_scoring.py
+++ b/ingestion/tests/unit/metadata/pii/test_tag_scoring.py
@@ -458,6 +458,32 @@ class TestTagAnalyzer:
 
         assert analysis.score == 1.0
 
+    def test_analyze_content_corroborates_each_spacy_entity_type_independently(self, column: Column):
+        spacy_recognizer = RecognizerFactory.create(
+            name="SpacyRecognizer",
+            recognizerConfig=PredefinedRecognizerFactory.create(
+                name=Name.SpacyRecognizer,
+                supportedEntities=[PIIEntity.PERSON, PIIEntity.LOCATION],
+            ),
+            target=Target.content,
+        )
+        named_entity_tag = TagFactory.create(
+            tag_name="NamedEntity",
+            autoClassificationEnabled=True,
+            recognizers=[spacy_recognizer],
+            description="Named entity",
+        )
+        analyzer = TagAnalyzer(
+            tag=named_entity_tag,
+            column=column,
+            nlp_engine=load_nlp_engine(),
+        )
+
+        analysis = analyzer.analyze(str_values=["François", "Paris"])
+
+        assert analysis.score == 0.0
+        assert analysis.recognizer_results == []
+
     def test_analyze_content_with_emails(self, tag_analyzer, email_tag: Tag):
         """Test content analysis with email data"""
         values = ["john@example.com", "jane@test.org", "bob@company.co.uk"]

--- a/ingestion/tests/unit/metadata/pii/test_tag_scoring.py
+++ b/ingestion/tests/unit/metadata/pii/test_tag_scoring.py
@@ -344,6 +344,32 @@ class TestTagAnalyzer:
             nlp_engine=load_nlp_engine(),
         )
 
+    @pytest.fixture
+    def person_tag(self) -> Tag:
+        spacy_recognizer = RecognizerFactory.create(
+            name="SpacyRecognizer",
+            recognizerConfig=PredefinedRecognizerFactory.create(
+                name=Name.SpacyRecognizer,
+                supportedEntities=[PIIEntity.PERSON],
+                context=["name"],
+            ),
+            target=Target.content,
+        )
+        return TagFactory.create(
+            tag_name="Person",
+            autoClassificationEnabled=True,
+            recognizers=[spacy_recognizer],
+            description="Person name",
+        )
+
+    @pytest.fixture
+    def person_tag_analyzer(self, person_tag: Tag, column: Column) -> TagAnalyzer:
+        return TagAnalyzer(
+            tag=person_tag,
+            column=column,
+            nlp_engine=load_nlp_engine(),
+        )
+
     def test_analyze_content_rejects_epoch_timestamp_as_date(self, date_tag_analyzer: TagAnalyzer):
         analysis = date_tag_analyzer.analyze(str_values=["1760000000123"])
 
@@ -355,6 +381,82 @@ class TestTagAnalyzer:
 
         assert analysis.score > 0.0
         assert [result.entity_type for result in analysis.recognizer_results] == [PIIEntity.DATE_TIME.value]
+
+    @pytest.mark.parametrize(
+        "values",
+        [
+            pytest.param(
+                [
+                    "Safari",
+                    "Edge",
+                    "Safari",
+                    "Chrome",
+                    "Chrome",
+                    "Firefox",
+                    "Firefox",
+                    "Google Search App",
+                    "Chrome",
+                    "Edge",
+                ],
+                id="browser",
+            ),
+            pytest.param(
+                [
+                    "flickr",
+                    "google_search",
+                    "flickr",
+                    "flickr",
+                    "flickr",
+                    "flickr",
+                    "google_search",
+                    "commons.m.wikimedia.org",
+                    "google_search",
+                    "google_search",
+                ],
+                id="channel-subtype",
+            ),
+        ],
+    )
+    def test_analyze_content_rejects_repeated_spacy_named_entity_guess(
+        self,
+        person_tag_analyzer: TagAnalyzer,
+        values: list[str],
+    ):
+        analysis = person_tag_analyzer.analyze(str_values=values)
+
+        assert analysis.score == 0.0
+        assert analysis.recognizer_results == []
+
+    def test_analyze_content_preserves_distinct_minority_names(self, person_tag_analyzer: TagAnalyzer):
+        names = [
+            "Geneviève",
+            "François",
+            "Mathieu",
+            "Sylvie",
+            "Nathalie",
+            "Isabelle",
+            "Céline",
+            "Jean-Marc",
+        ]
+        analysis = person_tag_analyzer.analyze(str_values=names + [str(value) for value in range(42)])
+
+        assert analysis.score >= 0.8
+
+    def test_analyze_content_preserves_single_contextual_name(self, person_tag: Tag):
+        name_column = Column(
+            name=ColumnName(root="employee_name"),
+            dataType=DataType.STRING,
+            fullyQualifiedName="test.table.employee_name",
+        )
+        analyzer = TagAnalyzer(
+            tag=person_tag,
+            column=name_column,
+            nlp_engine=load_nlp_engine(),
+        )
+
+        analysis = analyzer.analyze(str_values=["François"])
+
+        assert analysis.score == 1.0
 
     def test_analyze_content_with_emails(self, tag_analyzer, email_tag: Tag):
         """Test content analysis with email data"""


### PR DESCRIPTION
## Summary

Keep #32153 strongest-match scoring for deterministic, validated-date, and context-enhanced results, while requiring two distinct matches of the same entity type to corroborate uncontextualized spaCy `PERSON`, `LOCATION`, or `NRP` predictions.
This prevents repeated categorical model mistakes (`Safari` and `commons.m.wikimedia.org`) from tagging browser/channel columns without reintroducing sample-size dilution for real names or deterministic PII.
Two different NER mistakes of the same type can still corroborate each other; that deliberate recall/precision boundary keeps the sparse real-name case from #32070 detectable without pretending spaCy probabilities are calibrated.
Adds regression coverage for the Collate fixtures, sparse names, single contextual names, and independent corroboration by entity type.

Closes #32877

## Testing

- `pytest ingestion/tests/unit/metadata/pii ingestion/tests/unit/pii` — 295 passed
- Focused real-tag scoring: address retains Location/Sensitive; browser and channel-subtype return no tags
- `ruff check` and `ruff format --check` on changed files