### PR TITLE
Backport 1.13: import UnitOfMeasurement as a value, not a type (#32794)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/MetricVersionPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/MetricVersionPage.spec.ts
@@ -16,7 +16,7 @@ import {
   PLAYWRIGHT_BASIC_TEST_TAG_OBJ,
 } from '../../constant/config';
 import { MetricClass } from '../../support/entity/MetricClass';
-import { performAdminLogin } from '../../utils/admin';
+import { createAdminApiContext } from '../../utils/admin';
 import { redirectToHomePage } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 
@@ -81,8 +81,12 @@ test.describe(
   'Metric version page',
   { tag: [DOMAIN_TAGS.GOVERNANCE, PLAYWRIGHT_BASIC_TEST_TAG_OBJ.tag] },
   () => {
-    test.beforeAll('Setup metric versions', async ({ browser }) => {
-      const { apiContext, afterAction } = await performAdminLogin(browser);
+    // createAdminApiContext, not performAdminLogin: on 1.13 the latter drives a
+    // real browser login (browser.newPage -> admin.login -> getToken), which
+    // does not fit in the 60s hook budget on a loaded shard. main and 2.0 both
+    // default performAdminLogin to an API-only login, which is what this is.
+    test.beforeAll('Setup metric versions', async () => {
+      const { apiContext, afterAction } = await createAdminApiContext();
 
       // Created already carrying the custom unit, so the initial version has no
       // change description and the header falls back to the entity values. That
@@ -111,8 +115,8 @@ test.describe(
       await afterAction();
     });
 
-    test.afterAll('Cleanup metric', async ({ browser }) => {
-      const { apiContext, afterAction } = await performAdminLogin(browser);
+    test.afterAll('Cleanup metric', async () => {
+      const { apiContext, afterAction } = await createAdminApiContext();
 
       await metric.delete(apiContext);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/MetricVersionPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/MetricVersionPage.spec.ts
@@ -1,0 +1,171 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { expect, Page, test } from '@playwright/test';
+import {
+  DOMAIN_TAGS,
+  PLAYWRIGHT_BASIC_TEST_TAG_OBJ,
+} from '../../constant/config';
+import { MetricClass } from '../../support/entity/MetricClass';
+import { performAdminLogin } from '../../utils/admin';
+import { redirectToHomePage } from '../../utils/common';
+import { waitForAllLoadersToDisappear } from '../../utils/entity';
+
+// use the admin user to login
+test.use({ storageState: 'playwright/.auth/admin.json' });
+
+const metric = new MetricClass();
+
+const CUSTOM_UNIT = 'Leads';
+const CHANGED_UNIT = 'DOLLARS';
+
+// The error boundary renders this title when a render throws. Asserting on the
+// text the user actually sees keeps the check off brittle CSS classes.
+const ERROR_BOUNDARY_TITLE = 'Something went wrong';
+
+// Versions are read back from the API rather than hardcoded. The backend
+// consolidates successive PATCHes by the same user inside the 10 minute session
+// window (EntityRepository.consolidateChanges), so a second patch here would
+// fold into the first version instead of creating a new one. The fixture below
+// therefore needs exactly one patch, and still reads the numbers back so a
+// change in version numbering cannot silently break these tests.
+let initialVersion: string;
+let unitChangedVersion: string;
+
+const toVersionLabel = (version: unknown) =>
+  `v${Number.parseFloat(String(version)).toFixed(1)}`;
+
+/**
+ * Opens the version history panel and selects the given version.
+ *
+ * Regression guard for #32564: the metric branch of the version header read
+ * `UnitOfMeasurement` from a type-only import, so the binding was erased at
+ * build time and evaluating `UnitOfMeasurement.Other` threw
+ * `ReferenceError: UnitOfMeasurement is not defined`, collapsing the whole
+ * version page into the error boundary.
+ */
+const openMetricVersion = async (page: Page, versionLabel: string) => {
+  const versionButton = page.getByTestId('version-button');
+
+  await expect(versionButton).toBeVisible();
+  await expect(versionButton).toBeEnabled();
+
+  const versionResponse = page.waitForResponse((response) =>
+    response
+      .url()
+      .includes(`/api/v1/metrics/${metric.entityResponseData.id}/versions`)
+  );
+
+  await versionButton.click();
+
+  expect((await versionResponse).status()).toBe(200);
+
+  const versionSelector = page.getByTestId(`version-selector-${versionLabel}`);
+
+  await expect(versionSelector).toBeVisible();
+  await versionSelector.click();
+
+  await waitForAllLoadersToDisappear(page);
+};
+
+test.describe(
+  'Metric version page',
+  { tag: [DOMAIN_TAGS.GOVERNANCE, PLAYWRIGHT_BASIC_TEST_TAG_OBJ.tag] },
+  () => {
+    test.beforeAll('Setup metric versions', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+
+      // Created already carrying the custom unit, so the initial version has no
+      // change description and the header falls back to the entity values. That
+      // is the version shape from the issue report, and the one where the
+      // customUnitOfMeasurement substitution branch actually evaluates.
+      metric.entity.unitOfMeasurement = 'OTHER';
+      metric.entity.customUnitOfMeasurement = CUSTOM_UNIT;
+
+      await metric.create(apiContext);
+      initialVersion = toVersionLabel(metric.entityResponseData.version);
+
+      // The single patch this fixture can rely on: moves the unit off OTHER so
+      // the next version renders a unitOfMeasurement diff.
+      await metric.patch({
+        apiContext,
+        patchData: [
+          { op: 'replace', path: '/unitOfMeasurement', value: CHANGED_UNIT },
+        ],
+      });
+      unitChangedVersion = toVersionLabel(metric.entityResponseData.version);
+
+      // Fail loudly if consolidation ever folds the patch into the initial
+      // version — otherwise both tests would silently target the same version.
+      expect(unitChangedVersion).not.toBe(initialVersion);
+
+      await afterAction();
+    });
+
+    test.afterAll('Cleanup metric', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+
+      await metric.delete(apiContext);
+
+      await afterAction();
+    });
+
+    test.beforeEach('Visit metric details page', async ({ page }) => {
+      await redirectToHomePage(page);
+      await metric.visitEntityPage(page);
+      await waitForAllLoadersToDisappear(page);
+    });
+
+    test('should show the custom unit on the version that carries it', async ({
+      page,
+    }) => {
+      await test.step('Open the initial version', async () => {
+        await openMetricVersion(page, initialVersion);
+      });
+
+      await test.step('Version header renders instead of the error boundary', async () => {
+        // The bug surfaced as the error boundary replacing the page, so check
+        // this first — it fails with a clearer message than a locator timeout.
+        await expect(page.getByText(ERROR_BOUNDARY_TITLE)).toBeHidden();
+
+        await expect(
+          page.getByTestId('unit-of-measurement-version-info')
+        ).toContainText(CUSTOM_UNIT);
+        await expect(
+          page.getByTestId('metric-type-version-info')
+        ).toContainText(metric.entity.metricType);
+        await expect(
+          page.getByTestId('granularity-version-info')
+        ).toContainText(metric.entity.granularity);
+      });
+    });
+
+    test('should show both sides of the diff on the version that changes the unit', async ({
+      page,
+    }) => {
+      await test.step('Open the version that changed the unit', async () => {
+        await openMetricVersion(page, unitChangedVersion);
+      });
+
+      await test.step('Unit of measurement shows the old and new value', async () => {
+        await expect(page.getByText(ERROR_BOUNDARY_TITLE)).toBeHidden();
+
+        // On the diffing version the header renders the old/new unit markup
+        // rather than the custom unit, so assert on both sides of the diff.
+        const unitInfo = page.getByTestId('unit-of-measurement-version-info');
+
+        await expect(unitInfo).toContainText('OTHER');
+        await expect(unitInfo).toContainText(CHANGED_UNIT);
+      });
+    });
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/MetricClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/MetricClass.ts
@@ -31,6 +31,7 @@ export class MetricClass extends EntityClass {
     metricType: string;
     displayName: string;
     unitOfMeasurement: string;
+    customUnitOfMeasurement?: string;
   };
 
   entityResponseData: ResponseDataType = {} as ResponseDataType;

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsVersionHeaderUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsVersionHeaderUtils.test.tsx
@@ -1,0 +1,58 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { EntityType } from '../enums/entity.enum';
+import {
+  Metric,
+  MetricGranularity,
+  MetricType,
+  UnitOfMeasurement,
+} from '../generated/entity/data/metric';
+import { getDataAssetsVersionHeaderInfo } from './DataAssetsVersionHeaderUtils';
+
+const mockMetric = {
+  id: 'id',
+  name: 'campaign_conversion_rate',
+  metricType: MetricType.Count,
+  unitOfMeasurement: UnitOfMeasurement.Percentage,
+  granularity: MetricGranularity.Day,
+  changeDescription: { fieldsAdded: [], fieldsUpdated: [], fieldsDeleted: [] },
+} as unknown as Metric;
+
+describe('DataAssetsVersionHeaderUtils', () => {
+  it('should render metric version info without throwing', () => {
+    render(
+      <>{getDataAssetsVersionHeaderInfo(EntityType.METRIC, mockMetric)}</>
+    );
+
+    expect(screen.getByText(UnitOfMeasurement.Percentage)).toBeInTheDocument();
+    expect(screen.getByText(MetricType.Count)).toBeInTheDocument();
+    expect(screen.getByText(MetricGranularity.Day)).toBeInTheDocument();
+  });
+
+  it('should prefer customUnitOfMeasurement when unit is Other', () => {
+    render(
+      <>
+        {getDataAssetsVersionHeaderInfo(EntityType.METRIC, {
+          ...mockMetric,
+          unitOfMeasurement: UnitOfMeasurement.Other,
+          customUnitOfMeasurement: 'Leads',
+        } as unknown as Metric)}
+      </>
+    );
+
+    expect(screen.getByText('Leads')).toBeInTheDocument();
+    expect(screen.queryByText(UnitOfMeasurement.Other)).not.toBeInTheDocument();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsVersionHeaderUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsVersionHeaderUtils.tsx
@@ -22,10 +22,8 @@ import { EntityField } from '../constants/Feeds.constants';
 import { EntityType } from '../enums/entity.enum';
 import type { Chart } from '../generated/entity/data/chart';
 import type { Dashboard } from '../generated/entity/data/dashboard';
-import type {
-  Metric,
-  UnitOfMeasurement,
-} from '../generated/entity/data/metric';
+import type { Metric } from '../generated/entity/data/metric';
+import { UnitOfMeasurement } from '../generated/entity/data/metric';
 import type { Pipeline } from '../generated/entity/data/pipeline';
 import type { Topic } from '../generated/entity/data/topic';
 import type { ChangeDescription } from '../generated/entity/type';
@@ -58,13 +56,15 @@ export const VersionExtraInfoLink = ({
 export const VersionExtraInfoLabel = ({
   label,
   value,
+  dataTestId,
 }: {
   label: string;
   value: string;
+  dataTestId?: string;
 }) => (
   <>
     <Divider className="self-center m-x-sm" type="vertical" />
-    <Space align="center">
+    <Space align="center" data-testid={dataTestId}>
       <Typography.Text className="self-center text-xs whitespace-nowrap">
         {!isEmpty(label) && (
           <span className="text-grey-muted">{`${label}: `}</span>
@@ -219,18 +219,21 @@ export const getDataAssetsVersionHeaderInfo = (
         <>
           {!isEmpty(metricType) && (
             <VersionExtraInfoLabel
+              dataTestId="metric-type-version-info"
               label={t('label.metric-type')}
               value={metricType}
             />
           )}
           {!isEmpty(displayUnitOfMeasurement) && (
             <VersionExtraInfoLabel
+              dataTestId="unit-of-measurement-version-info"
               label={t('label.unit-of-measurement')}
               value={displayUnitOfMeasurement}
             />
           )}
           {!isEmpty(granularity) && (
             <VersionExtraInfoLabel
+              dataTestId="granularity-version-info"
               label={t('label.granularity')}
               value={granularity}
             />


### PR DESCRIPTION
Backport of #32794 to `1.13`. Fixes #32564 on that branch.

## The bug

`DataAssetsVersionHeaderUtils.tsx` pulled `UnitOfMeasurement` in through a **type-only** import, so the binding was erased at build time. The metric branch of the version header then evaluated `UnitOfMeasurement.Other` at runtime and threw `ReferenceError: UnitOfMeasurement is not defined`, collapsing the whole metric version page into the error boundary. 1.13 carries the buggy import verbatim:

```ts
import type {
  Metric,
  UnitOfMeasurement,
} from '../generated/entity/data/metric';
```

`UnitOfMeasurement` is a real `export enum` in 1.13's generated `metric.ts`, so importing it as a value is both valid and the fix.

## What is in here

- The import split — `Metric` stays type-only, `UnitOfMeasurement` becomes a value import.
- `dataTestId` passthrough on `VersionExtraInfoLabel`, and the three ids on the metric branch, so the tests can assert on the rendered values rather than CSS.
- A jest test that renders the metric version header (the regression: it throws without the fix).
- A Playwright spec covering both the version that carries a custom unit and the version that diffs the unit.

## Adaptations from main

Every changed line of the fix itself is byte-identical to main — verified by diff-of-diffs on all four files, comparing `git diff -U0` of the merge commit against `git diff -U0 HEAD^ HEAD` here with whitespace normalised. Four things had to be adapted because 1.13 predates refactors main carries:

- **`DataAssetsVersionHeaderUtils.tsx`** — main has the per-entity branches extracted into `getMetricVersionExtraInfo` etc., so git offered the whole extracted block as the incoming side. Taking it would have imported a refactor that is not part of this fix. 1.13 still renders those branches inline in `getDataAssetsVersionHeaderInfo`'s switch, so I kept HEAD and re-applied the three `dataTestId` props to the inline metric JSX.
- **`MetricClass.ts`** — main's fixture already had `dimensions`/`measures`, which 1.13 lacks and which this PR does not touch. Took only the `customUnitOfMeasurement?` line the PR actually adds.
- **`MetricVersionPage.spec.ts`** — `support/fixtures/base` is main's server-load wrapper and does not exist on 1.13; `expect`/`test` come from `@playwright/test`, as in every sibling spec on this branch.
- **`DataAssetsVersionHeaderUtils.test.tsx`** — 1.13's `MetricType` enum has no `Conversion` member. Used `Count`, which stays distinct from the unit (`PERCENTAGE`) and granularity (`DAY`) the same test asserts on, so the `getByText` lookups remain unambiguous.

## Verification

- Playwright `tsc --project playwright/tsconfig.json`: **103 errors before and after**, none in the touched files (the 103 are pre-existing on `1.13`).
- Prettier clean on all four files.
- The **jest suite could not run locally**: 1.13's `setupTests.js` mocks `@mui/material/styles`, and the `node_modules` borrowed from `main` no longer ships MUI. CI runs it. It passes on the 2.0 backport, where the same borrowed tree does work.
- eslint left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
