### PR TITLE
fix(security): authorize glossary-term bulk asset add/remove (backport #32539 to 1.13)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermResourceIT.java
@@ -11,6 +11,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -19,6 +22,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.auth.JwtAuthProvider;
 import org.openmetadata.it.factories.DatabaseSchemaTestFactory;
 import org.openmetadata.it.factories.DatabaseServiceTestFactory;
 import org.openmetadata.it.util.SdkClients;
@@ -32,6 +36,9 @@ import org.openmetadata.schema.api.data.MoveGlossaryTermRequest;
 import org.openmetadata.schema.api.data.TermReference;
 import org.openmetadata.schema.api.feed.CreateThread;
 import org.openmetadata.schema.api.feed.ResolveTask;
+import org.openmetadata.schema.api.policies.CreatePolicy;
+import org.openmetadata.schema.api.teams.CreateRole;
+import org.openmetadata.schema.api.teams.CreateTeam;
 import org.openmetadata.schema.api.teams.CreateUser;
 import org.openmetadata.schema.entity.data.Database;
 import org.openmetadata.schema.entity.data.DatabaseSchema;
@@ -39,19 +46,25 @@ import org.openmetadata.schema.entity.data.Glossary;
 import org.openmetadata.schema.entity.data.GlossaryTerm;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.entity.feed.Thread;
+import org.openmetadata.schema.entity.policies.Policy;
+import org.openmetadata.schema.entity.policies.accessControl.Rule;
 import org.openmetadata.schema.entity.services.DatabaseService;
+import org.openmetadata.schema.entity.teams.Role;
+import org.openmetadata.schema.entity.teams.Team;
 import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.ColumnDataType;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.EntityStatus;
+import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.TaskStatus;
 import org.openmetadata.schema.type.TaskType;
 import org.openmetadata.schema.type.TermRelation;
 import org.openmetadata.schema.type.ThreadType;
 import org.openmetadata.schema.type.api.BulkOperationResult;
+import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.exceptions.InvalidRequestException;
@@ -3814,6 +3827,250 @@ public class GlossaryTermResourceIT extends BaseEntityIT<GlossaryTerm, CreateGlo
     Table refreshed = client.tables().get(tableId.toString(), "tags");
     return refreshed.getTags() != null
         && refreshed.getTags().stream().anyMatch(t -> tagFqn.equals(t.getTagFQN()));
+  }
+
+  // ===================================================================
+  // BULK ASSET AUTHORIZATION — broken access control fix
+  //
+  // /assets/add and /assets/remove must authorize EDIT_GLOSSARY_TERMS on
+  // each target asset. Before the fix they called the repository with no
+  // authorizer, so any authenticated caller could apply/strip a glossary
+  // term on arbitrary assets (GHSA-jmw6-578h-gw4r).
+  // ===================================================================
+
+  @Test
+  void test_bulkRemoveGlossaryFromAssets_deniedUser_isForbidden(TestNamespace ns) throws Exception {
+    OpenMetadataClient admin = SdkClients.adminClient();
+    GlossaryTerm term = createGlossaryTermForBulk(ns, "authz_rm_deny");
+    Table table = createTableTaggedWithTerm(ns, term, "authz_rm_deny");
+    String token = deniedGlossaryEditToken(ns, "rm");
+
+    HttpResponse<String> response = putAssets(term.getId(), "remove", assetsBody(table), token);
+
+    assertEquals(
+        403,
+        response.statusCode(),
+        "A user denied EDIT_GLOSSARY_TERMS must not remove the glossary term: " + response.body());
+    assertTrue(
+        tableHasTag(admin, table.getId(), term.getFullyQualifiedName()),
+        "Glossary term must remain on the asset when removal is rejected");
+  }
+
+  @Test
+  void test_bulkAddGlossaryToAssets_deniedUser_isForbidden(TestNamespace ns) throws Exception {
+    OpenMetadataClient admin = SdkClients.adminClient();
+    GlossaryTerm term = createGlossaryTermForBulk(ns, "authz_add_deny");
+    Table table = createBareTable(ns, "authz_add_deny");
+    String token = deniedGlossaryEditToken(ns, "add");
+
+    HttpResponse<String> response = putAssets(term.getId(), "add", assetsBody(table), token);
+
+    assertEquals(
+        403,
+        response.statusCode(),
+        "A user denied EDIT_GLOSSARY_TERMS must not apply the glossary term: " + response.body());
+    assertFalse(
+        tableHasTag(admin, table.getId(), term.getFullyQualifiedName()),
+        "Glossary term must not be applied to the asset when the add is rejected");
+  }
+
+  @Test
+  void test_bulkAddGlossaryToAssets_authorizedUser_succeeds(TestNamespace ns) throws Exception {
+    GlossaryTerm term = createGlossaryTermForBulk(ns, "authz_add_ok");
+    Table table = createBareTable(ns, "authz_add_ok");
+    // A plain user inherits the DataConsumer role (EDIT_GLOSSARY_TERMS on all assets) from the
+    // Organization team, so the fix must not over-block legitimate callers on the add path.
+    String token = dataConsumerToken(ns, "add");
+
+    HttpResponse<String> response = putAssets(term.getId(), "add", assetsBody(table), token);
+
+    assertAuthorizedBulkSuccess(response);
+  }
+
+  @Test
+  void test_bulkRemoveGlossaryFromAssets_authorizedUser_succeeds(TestNamespace ns)
+      throws Exception {
+    GlossaryTerm term = createGlossaryTermForBulk(ns, "authz_rm_ok");
+    Table table = createTableTaggedWithTerm(ns, term, "authz_rm_ok");
+    String token = dataConsumerToken(ns, "rm");
+
+    HttpResponse<String> response = putAssets(term.getId(), "remove", assetsBody(table), token);
+
+    assertAuthorizedBulkSuccess(response);
+  }
+
+  @Test
+  void test_bulkRemoveGlossaryFromAssets_columnAsset_authorizedUser_succeeds(TestNamespace ns)
+      throws Exception {
+    GlossaryTerm term = createGlossaryTermForBulk(ns, "authz_col_ok");
+    Table table = createTableWithColumnTaggedWithTerm(ns, term, "authz_col_ok");
+    // A column is surfaced as a tableColumn asset but is edited through its table, so a user with
+    // EDIT_GLOSSARY_TERMS on the table must be allowed to remove the column's term (not 403 because
+    // the asset type is "tableColumn").
+    String token = dataConsumerToken(ns, "col_ok");
+
+    HttpResponse<String> response =
+        putAssets(term.getId(), "remove", columnAssetBody(table), token);
+
+    assertAuthorizedBulkSuccess(response);
+  }
+
+  @Test
+  void test_bulkRemoveGlossaryFromAssets_columnAsset_deniedUser_isForbidden(TestNamespace ns)
+      throws Exception {
+    OpenMetadataClient admin = SdkClients.adminClient();
+    GlossaryTerm term = createGlossaryTermForBulk(ns, "authz_col_deny");
+    Table table = createTableWithColumnTaggedWithTerm(ns, term, "authz_col_deny");
+    String token = deniedGlossaryEditToken(ns, "col");
+
+    HttpResponse<String> response =
+        putAssets(term.getId(), "remove", columnAssetBody(table), token);
+
+    assertEquals(
+        403,
+        response.statusCode(),
+        "A user denied EDIT_GLOSSARY_TERMS must not remove a column's term: " + response.body());
+    assertTrue(
+        columnHasTag(admin, table.getId(), "id", term.getFullyQualifiedName()),
+        "Glossary term must remain on the column when the caller is denied");
+  }
+
+  private String assetsBody(Table table) {
+    return "{\"assets\":[{\"id\":\"" + table.getId() + "\",\"type\":\"table\"}],\"dryRun\":false}";
+  }
+
+  private String columnAssetBody(Table table) {
+    // Columns are referenced by FQN. @Valid requires a non-null id on each asset, but neither the
+    // authorization (which maps a column to its parent table) nor the repository (which resolves
+    // the
+    // column by FQN) uses the id value — mirroring the tableColumn asset the Assets page sends.
+    String columnFqn = table.getFullyQualifiedName() + ".id";
+    return "{\"assets\":[{\"id\":\""
+        + UUID.randomUUID()
+        + "\",\"type\":\"tableColumn\",\"fullyQualifiedName\":\""
+        + columnFqn
+        + "\"}],\"dryRun\":false}";
+  }
+
+  private Table createTableWithColumnTaggedWithTerm(
+      TestNamespace ns, GlossaryTerm term, String suffix) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Table table = createBareTable(ns, suffix);
+    TagLabel termLabel =
+        new TagLabel()
+            .withTagFQN(term.getFullyQualifiedName())
+            .withSource(TagLabel.TagSource.GLOSSARY)
+            .withLabelType(TagLabel.LabelType.MANUAL)
+            .withState(TagLabel.State.CONFIRMED);
+    Table fetched = client.tables().get(table.getId().toString(), "columns,tags");
+    fetched.getColumns().get(0).setTags(List.of(termLabel));
+    Table tagged = client.tables().update(table.getId().toString(), fetched);
+    assertTrue(
+        columnHasTag(client, table.getId(), "id", term.getFullyQualifiedName()),
+        "Precondition: the column should carry the glossary term before the bulk remove");
+    return tagged;
+  }
+
+  private boolean columnHasTag(
+      OpenMetadataClient client, UUID tableId, String columnName, String tagFqn) {
+    Table refreshed = client.tables().get(tableId.toString(), "columns,tags");
+    return refreshed.getColumns().stream()
+        .filter(column -> columnName.equals(column.getName()))
+        .findFirst()
+        .map(
+            column ->
+                column.getTags() != null
+                    && column.getTags().stream().anyMatch(t -> tagFqn.equals(t.getTagFQN())))
+        .orElse(false);
+  }
+
+  private HttpResponse<String> putAssets(UUID termId, String action, String body, String token)
+      throws Exception {
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(
+                URI.create(
+                    SdkClients.getServerUrl()
+                        + "/v1/glossaryTerms/"
+                        + termId
+                        + "/assets/"
+                        + action))
+            .header("Authorization", "Bearer " + token)
+            .header("Content-Type", "application/json")
+            .PUT(HttpRequest.BodyPublishers.ofString(body))
+            .build();
+    return HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  /**
+   * Asserts a bulk add/remove succeeded for an authorized caller, using only the synchronous
+   * response so there is no read-after-write race: 200 (not 403) and the BulkOperationResult reports
+   * the asset processed with no failures — which the endpoint only returns after applying the change.
+   */
+  private void assertAuthorizedBulkSuccess(HttpResponse<String> response) {
+    assertEquals(
+        200, response.statusCode(), "An authorized caller must not be blocked: " + response.body());
+    BulkOperationResult result = JsonUtils.readValue(response.body(), BulkOperationResult.class);
+    assertEquals(
+        1,
+        result.getNumberOfRowsPassed(),
+        "The asset must be processed successfully for an authorized caller: " + response.body());
+    assertTrue(
+        result.getFailedRequest() == null || result.getFailedRequest().isEmpty(),
+        "No asset must fail for an authorized caller: " + response.body());
+  }
+
+  /**
+   * A token for a user explicitly denied EDIT_GLOSSARY_TERMS. Every user inherits the DataConsumer
+   * role (which allows glossary-term edits on all assets) from the Organization team, so a genuinely
+   * restricted caller needs an explicit DENY rule — deny wins over the inherited allow.
+   */
+  private String deniedGlossaryEditToken(TestNamespace ns, String suffix) {
+    OpenMetadataClient admin = SdkClients.adminClient();
+    String prefix = ns.shortPrefix("gtNoEdit_" + suffix);
+    Rule deny =
+        new Rule()
+            .withName("DenyGlossaryTermEdit")
+            .withResources(List.of("All"))
+            .withOperations(List.of(MetadataOperation.EDIT_GLOSSARY_TERMS))
+            .withEffect(Rule.Effect.DENY);
+    Policy policy =
+        admin
+            .policies()
+            .create(new CreatePolicy().withName(prefix + "_pol").withRules(List.of(deny)));
+    Role role =
+        admin
+            .roles()
+            .create(
+                new CreateRole()
+                    .withName(prefix + "_role")
+                    .withPolicies(List.of(policy.getFullyQualifiedName())));
+    Team team =
+        admin
+            .teams()
+            .create(
+                new CreateTeam()
+                    .withName(prefix + "_team")
+                    .withTeamType(CreateTeam.TeamType.GROUP)
+                    .withDefaultRoles(List.of(role.getId())));
+    String email = prefix + "@test.openmetadata.org";
+    User user =
+        admin
+            .users()
+            .create(
+                new CreateUser()
+                    .withName(prefix)
+                    .withEmail(email)
+                    .withTeams(List.of(team.getId())));
+    return JwtAuthProvider.tokenFor(user.getEmail(), user.getEmail(), new String[] {}, 3600);
+  }
+
+  private String dataConsumerToken(TestNamespace ns, String suffix) {
+    String prefix = ns.shortPrefix("gtConsumer_" + suffix);
+    String email = prefix + "@test.openmetadata.org";
+    User user =
+        SdkClients.adminClient().users().create(new CreateUser().withName(prefix).withEmail(email));
+    return JwtAuthProvider.tokenFor(user.getEmail(), user.getEmail(), new String[] {}, 3600);
   }
 
   // -------------------------------------------------------------------------

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/EntityResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/EntityResource.java
@@ -903,8 +903,15 @@ public abstract class EntityResource<T extends EntityInterface, K extends Entity
     return Response.accepted().entity(response).type(MediaType.APPLICATION_JSON).build();
   }
 
-  public Response bulkAddToAssetsAsync(
-      SecurityContext securityContext, UUID entityId, BulkAssetsRequestInterface request) {
+  /**
+   * Authorizes a bulk asset tag/glossary operation: the caller must hold {@code operation} on every
+   * target asset's entity type, otherwise the whole request is rejected. Admins and bots are
+   * exempt. This is the shared permission gate for the bulk asset endpoints (classification tags on
+   * {@link org.openmetadata.service.resources.tags.TagResource}, glossary terms on
+   * GlossaryTermResource); it only validates permissions and performs no business logic.
+   */
+  protected void authorizeBulkAssetsPermission(
+      SecurityContext securityContext, List<EntityReference> assets, MetadataOperation operation) {
     SubjectContext subjectContext = getSubjectContext(securityContext);
     String user = subjectContext.user().getName();
 
@@ -915,14 +922,14 @@ public abstract class EntityResource<T extends EntityInterface, K extends Entity
                     permission.getPermissions().stream()
                         .anyMatch(
                             perm ->
-                                MetadataOperation.EDIT_TAGS.equals(perm.getOperation())
+                                operation.equals(perm.getOperation())
                                     && Permission.Access.ALLOW.equals(perm.getAccess())))
             .map(ResourcePermission::getResource)
             .collect(Collectors.toSet());
 
     // Validate if all entity types in the request are in the permissible resources
     List<String> unauthorizedEntityTypes =
-        request.getAssets().stream()
+        assets.stream()
             .map(EntityReference::getType)
             .filter(entityType -> !editPermissibleResources.contains(entityType))
             .distinct()
@@ -933,8 +940,14 @@ public abstract class EntityResource<T extends EntityInterface, K extends Entity
         && !subjectContext.isBot()) {
       throw new AuthorizationException(
           CatalogExceptionMessage.resourcePermissionNotAllowed(
-              user, List.of(MetadataOperation.EDIT_TAGS), unauthorizedEntityTypes));
+              user, List.of(operation), unauthorizedEntityTypes));
     }
+  }
+
+  public Response bulkAddToAssetsAsync(
+      SecurityContext securityContext, UUID entityId, BulkAssetsRequestInterface request) {
+    authorizeBulkAssetsPermission(
+        securityContext, request.getAssets(), MetadataOperation.EDIT_TAGS);
 
     String jobId = UUID.randomUUID().toString();
     ExecutorService executorService = AsyncService.getInstance().getExecutorService();
@@ -959,34 +972,8 @@ public abstract class EntityResource<T extends EntityInterface, K extends Entity
 
   public Response bulkRemoveFromAssetsAsync(
       SecurityContext securityContext, UUID entityId, BulkAssetsRequestInterface request) {
-    SubjectContext subjectContext = getSubjectContext(securityContext);
-    String user = subjectContext.user().getName();
-    Set<String> editPermissibleResources =
-        authorizer.listPermissions(securityContext, user).stream()
-            .filter(
-                permission ->
-                    permission.getPermissions().stream()
-                        .anyMatch(
-                            perm ->
-                                MetadataOperation.EDIT_TAGS.equals(perm.getOperation())
-                                    && Permission.Access.ALLOW.equals(perm.getAccess())))
-            .map(ResourcePermission::getResource)
-            .collect(Collectors.toSet());
-
-    List<String> unauthorizedEntityTypes =
-        request.getAssets().stream()
-            .map(EntityReference::getType)
-            .filter(entityType -> !editPermissibleResources.contains(entityType))
-            .distinct()
-            .toList();
-
-    if (!unauthorizedEntityTypes.isEmpty()
-        && !subjectContext.isAdmin()
-        && !subjectContext.isBot()) {
-      throw new AuthorizationException(
-          CatalogExceptionMessage.resourcePermissionNotAllowed(
-              user, List.of(MetadataOperation.EDIT_TAGS), unauthorizedEntityTypes));
-    }
+    authorizeBulkAssetsPermission(
+        securityContext, request.getAssets(), MetadataOperation.EDIT_TAGS);
     String jobId = UUID.randomUUID().toString();
     ExecutorService executorService = AsyncService.getInstance().getExecutorService();
     executorService.submit(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/glossary/GlossaryTermResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/glossary/GlossaryTermResource.java
@@ -13,6 +13,7 @@
 
 package org.openmetadata.service.resources.glossary;
 
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.service.Entity.ADMIN_USER_NAME;
 import static org.openmetadata.service.Entity.GLOSSARY;
 import static org.openmetadata.service.Entity.GLOSSARY_TERM;
@@ -891,6 +892,10 @@ public class GlossaryTermResource extends EntityResource<GlossaryTerm, GlossaryT
       @Parameter(description = "Id of the Entity", schema = @Schema(type = "UUID")) @PathParam("id")
           UUID id,
       @Valid AddGlossaryToAssetsRequest request) {
+    authorizeBulkAssetsPermission(
+        securityContext,
+        permissionAssets(request.getAssets()),
+        MetadataOperation.EDIT_GLOSSARY_TERMS);
     return Response.ok().entity(repository.bulkAddAndValidateGlossaryToAssets(id, request)).build();
   }
 
@@ -941,7 +946,33 @@ public class GlossaryTermResource extends EntityResource<GlossaryTerm, GlossaryT
       @Parameter(description = "Id of the Entity", schema = @Schema(type = "UUID")) @PathParam("id")
           UUID id,
       @Valid AddGlossaryToAssetsRequest request) {
+    authorizeBulkAssetsPermission(
+        securityContext,
+        permissionAssets(request.getAssets()),
+        MetadataOperation.EDIT_GLOSSARY_TERMS);
     return Response.ok().entity(repository.bulkRemoveGlossaryToAssets(id, request)).build();
+  }
+
+  /**
+   * Table columns are surfaced as {@code tableColumn} assets (e.g. on a glossary term's Assets page)
+   * but are edited through their parent table — they are not a resource with their own permissions.
+   * Present them as tables for the type-level permission check so a caller who may edit the table's
+   * glossary terms may edit its columns' too. The original references reach the repository unchanged,
+   * so the tag is still applied to / removed from the column itself.
+   */
+  private List<EntityReference> permissionAssets(List<EntityReference> assets) {
+    if (nullOrEmpty(assets)) {
+      return assets;
+    }
+    return assets.stream()
+        .map(
+            asset ->
+                Entity.TABLE_COLUMN.equals(asset.getType())
+                    ? new EntityReference()
+                        .withType(Entity.TABLE)
+                        .withFullyQualifiedName(asset.getFullyQualifiedName())
+                    : asset)
+        .toList();
   }
 
   @GET


### PR DESCRIPTION
### Describe your changes:

Backport of #32539 to `1.13`.

Security advisory: https://github.com/open-metadata/OpenMetadata/security/advisories/GHSA-jmw6-578h-gw4r

**Broken access control on the glossary-term bulk asset endpoints.**

`PUT /v1/glossaryTerms/{id}/assets/add` and `/assets/remove` invoked the repository without consulting the authorizer, so any authenticated caller could apply or strip a glossary term on arbitrary assets regardless of their permissions.

Both endpoints now authorize `EDIT_GLOSSARY_TERMS` on each target asset via the shared `EntityResource.authorizeBulkAssetsPermission` helper (the classification-tag bulk endpoints keep `EDIT_TAGS`). Column (`tableColumn`) assets — which appear on a term's Assets page — are authorized through their parent table.

This is a clean port of the net change from #32539 on main.

---

### Type of change:

- [x] Bug fix

---

### Tests:

Added to `GlossaryTermResourceIT`: a caller denied `EDIT_GLOSSARY_TERMS` gets `403` on both add and remove (asset unchanged), an authorized data consumer succeeds (`200`, asserted on the synchronous `BulkOperationResult`), and a column asset is authorized via its parent table. Compiles on `1.13`; behavior verified on main (identical code).
