### PR TITLE
Fixes #29687: glossary term inverse relation types show wrong perspective

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationEdgeIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationEdgeIT.java
@@ -289,6 +289,67 @@ public class GlossaryTermRelationEdgeIT {
     assertEquals(1, edgeBounded.getEdges().size());
   }
 
+  @Test
+  void customInverseRelationTypesPreserveCorrectPerspective() throws Exception {
+    GlossaryTerm termA = createTerm("InvA");
+    GlossaryTerm termB = createTerm("InvB");
+    GlossaryTerm termC = createTerm("InvC");
+
+    postRelation(termA.getId(), termB.getId(), "narrower", RelationProvenance.MANUAL);
+    postRelation(termA.getId(), termC.getId(), "narrower", RelationProvenance.MANUAL);
+
+    GlossaryTerm reloadedA =
+        client.glossaryTerms().getByName(termA.getFullyQualifiedName(), "relatedTerms");
+    TermRelation aToB = firstEdgeTo(reloadedA, termB.getId());
+    TermRelation aToC = firstEdgeTo(reloadedA, termC.getId());
+    assertNotNull(aToB, "A should have relation to B");
+    assertNotNull(aToC, "A should have relation to C");
+    assertEquals("narrower", aToB.getRelationType(), "A should see 'narrower' toward B");
+    assertEquals("narrower", aToC.getRelationType(), "A should see 'narrower' toward C");
+
+    GlossaryTerm reloadedB =
+        client.glossaryTerms().getByName(termB.getFullyQualifiedName(), "relatedTerms");
+    TermRelation bToA = firstEdgeTo(reloadedB, termA.getId());
+    assertNotNull(bToA, "B should have inverse relation to A");
+    assertEquals("broader", bToA.getRelationType(), "B should see inverse 'broader' toward A");
+
+    GlossaryTerm reloadedC =
+        client.glossaryTerms().getByName(termC.getFullyQualifiedName(), "relatedTerms");
+    TermRelation cToA = firstEdgeTo(reloadedC, termA.getId());
+    assertNotNull(cToA, "C should have inverse relation to A");
+    assertEquals("broader", cToA.getRelationType(), "C should see inverse 'broader' toward A");
+  }
+
+  @Test
+  void addTermRelationDetectsDuplicateAcrossInverse() throws Exception {
+    GlossaryTerm termA = createTerm("DupInvA");
+    GlossaryTerm termB = createTerm("DupInvB");
+
+    postRelation(termA.getId(), termB.getId(), "narrower", RelationProvenance.MANUAL);
+
+    GlossaryTerm reloadedB =
+        client.glossaryTerms().getByName(termB.getFullyQualifiedName(), "relatedTerms");
+    TermRelation bToA = firstEdgeTo(reloadedB, termA.getId());
+    assertNotNull(bToA, "B should see A via inverse");
+    assertEquals("broader", bToA.getRelationType());
+
+    HttpResponse<String> duplicateResponse =
+        postRelationResponse(termB.getId(), termA.getId(), "broader", RelationProvenance.MANUAL);
+    assertTrue(
+        duplicateResponse.statusCode() >= 200 && duplicateResponse.statusCode() < 300,
+        "Duplicate-via-inverse POST should not fail: " + duplicateResponse.body());
+
+    GlossaryTerm reReloadedB =
+        client.glossaryTerms().getByName(termB.getFullyQualifiedName(), "relatedTerms");
+    long countBtoA =
+        reReloadedB.getRelatedTerms() == null
+            ? 0
+            : reReloadedB.getRelatedTerms().stream()
+                .filter(r -> r.getTerm() != null && termA.getId().equals(r.getTerm().getId()))
+                .count();
+    assertEquals(1, countBtoA, "B should have exactly one relation to A, not a duplicate");
+  }
+
   private GlossaryTerm createTerm(String prefix) throws Exception {
     String name = prefix + "_" + UUID.randomUUID().toString().substring(0, 8);
     return client

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
@@ -1484,8 +1484,15 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
     if (typeA.equals(typeB)) {
       return true;
     }
-    String inverseOfA = getInverseRelationType(typeA);
-    return typeB.equals(inverseOfA);
+    return typeB.equals(safeInverseName(typeA)) || typeA.equals(safeInverseName(typeB));
+  }
+
+  private String safeInverseName(String relationType) {
+    try {
+      return getInverseRelationType(relationType);
+    } catch (BadRequestException ignored) {
+      return null;
+    }
   }
 
   private String computeCanonicalRelationType(UUID fromId, UUID toId, String relationType) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
@@ -1308,7 +1308,7 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
                     rel.getTerm() != null
                         && rel.getTerm().getId() != null
                         && rel.getTerm().getId().equals(termRef.getId())
-                        && relationType.equals(relationTypeOrDefault(rel)));
+                        && isEquivalentRelationType(relationType, relationTypeOrDefault(rel)));
     if (!exists) {
       List<TermRelation> updatedRelations =
           new ArrayList<>(listOrEmpty(original.getRelatedTerms()));
@@ -1345,7 +1345,9 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
   private boolean matchesRelation(TermRelation relation, UUID targetTermId, String relationType) {
     boolean hasTarget =
         relation.getTerm() != null && targetTermId.equals(relation.getTerm().getId());
-    boolean hasType = relationType == null || relationType.equals(relationTypeOrDefault(relation));
+    boolean hasType =
+        relationType == null
+            || isEquivalentRelationType(relationType, relationTypeOrDefault(relation));
     return hasTarget && hasType;
   }
 
@@ -1476,6 +1478,14 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
 
   private String getInverseRelationType(String relationType) {
     return relationshipTypeResolver.inverseName(relationType);
+  }
+
+  private boolean isEquivalentRelationType(String typeA, String typeB) {
+    if (typeA.equals(typeB)) {
+      return true;
+    }
+    String inverseOfA = getInverseRelationType(typeA);
+    return typeB.equals(inverseOfA);
   }
 
   private String computeCanonicalRelationType(UUID fromId, UUID toId, String relationType) {


### PR DESCRIPTION
## Summary

Fixes #29687 — when custom glossary term relation types with inverses (e.g., "uses"/"usedIn") are used, the inverse relation display is inconsistent depending on UUID ordering of the terms. Both sides of a relation can incorrectly show the same type instead of showing inverses, and editing the type reverts on refresh.

**Root cause:** `addTermRelation` and `matchesRelation` compare user-authored relation types against already-inverted display types returned by `getRelatedTerms()`. When a user sends type `"uses"` but the existing relation displays as `"usedIn"` (after inverse resolution), the check incorrectly concludes the relation doesn't exist — potentially creating duplicate relations or failing to find existing ones for removal.

**Fix:** Add `isEquivalentRelationType()` that treats a type and its registered inverse as equivalent, and use it in:
- `addTermRelation` existence check (prevents duplicate relations across inverse types)
- `matchesRelation` (makes removes robust against inverse type mismatches)

## Changes
- **`GlossaryTermRepository.java`** — new `isEquivalentRelationType` helper; updated `addTermRelation` dedup check and `matchesRelation` to use it
- **`GlossaryTermRelationEdgeIT.java`** — two new integration tests:
  - `customInverseRelationTypesPreserveCorrectPerspective` — verifies both sides of narrower/broader relations show the correct perspective type
  - `addTermRelationDetectsDuplicateAcrossInverse` — verifies the dedup check recognizes inverse types as equivalent

## Test plan
- [ ] Existing `GlossaryTermRelationEdgeIT` tests pass (inverse behavior unchanged for correct cases)
- [ ] New `customInverseRelationTypesPreserveCorrectPerspective` test passes
- [ ] New `addTermRelationDetectsDuplicateAcrossInverse` test passes
- [ ] Manual: create custom "uses"/"usedIn" inverse pair, assign relations, verify both sides show correct perspective

🤖 Generated with [Claude Code](https://claude.com/claude-code)