### PR TITLE
[2.0] Improve Domo and Astra connection configuration

### DIFF
--- a/ingestion/src/metadata/clients/domo_client.py
+++ b/ingestion/src/metadata/clients/domo_client.py
@@ -36,7 +36,7 @@ from metadata.utils.logger import ingestion_logger
 
 logger = ingestion_logger()
 
-HEADERS = {"Content-Type": "application/json"}
+DEFAULT_HEADERS = {"Content-Type": "application/json"}
 WORKFLOW_URL = "dataprocessing/v1/dataflows"
 
 
@@ -101,7 +101,9 @@ class DomoClient:
         config: Union[DomoDashboardConnection, DomoPipelineConnection, DomoDatabaseConnection],  # noqa: UP007
     ):
         self.config = config
-        HEADERS.update({"X-DOMO-Developer-Token": self.config.accessToken})
+        self.headers = DEFAULT_HEADERS.copy()
+        if self.config.accessToken:
+            self.headers["X-DOMO-Developer-Token"] = self.config.accessToken.get_secret_value()
         client_config: ClientConfig = ClientConfig(
             base_url=clean_uri(self.config.instanceDomain),
             api_version="api/",
@@ -119,7 +121,7 @@ class DomoClient:
             f"metadataOverrides,owners,problems,properties,slicers,subscriptions&includeFiltered=true"
         )
         try:
-            response = self.client.get(path=url, headers=HEADERS)
+            response = self.client.get(path=url, headers=self.headers)
 
             if isinstance(response, list) and len(response) > 0:
                 return DomoChartDetails(
@@ -137,7 +139,7 @@ class DomoClient:
 
     def get_pipelines(self):
         try:
-            response = self.client.get(path=WORKFLOW_URL, headers=HEADERS)
+            response = self.client.get(path=WORKFLOW_URL, headers=self.headers)
             return response  # noqa: RET504, TRY300
         except Exception as exc:
             logger.error(f"Error while getting pipelines - {exc}")
@@ -147,7 +149,7 @@ class DomoClient:
     def get_runs(self, workflow_id):
         try:
             url = f"dataprocessing/v1/dataflows/{workflow_id}/executions?limit=100&offset=0"
-            response = self.client.get(path=url, headers=HEADERS)
+            response = self.client.get(path=url, headers=self.headers)
             return response  # noqa: RET504, TRY300
         except Exception as exc:
             logger.warning(f"Error while getting runs for pipeline {workflow_id} - {exc}")
@@ -161,7 +163,7 @@ class DomoClient:
         This helps us validate that the provided Access Token is correct for Domo Dashboard.
         """
         try:
-            self.client.get(path="content/v1/cards", headers=HEADERS)
+            self.client.get(path="content/v1/cards", headers=self.headers)
         except Exception as exc:
             logger.debug(traceback.format_exc())
             logger.error(f"Error listing cards due to [{exc}]")

--- a/ingestion/src/metadata/ingestion/source/database/cassandra/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/cassandra/connection.py
@@ -55,13 +55,17 @@ class CassandraConnection(BaseConnection[CassandraConnectionConfig, CassandraSes
         cluster_config = {}
         if hasattr(connection.authType, "cloudConfig"):
             cloud_config = connection.authType.cloudConfig  # pyright: ignore[reportOptionalMemberAccess, reportAttributeAccessIssue]
+            token = cloud_config.token  # pyright: ignore[reportOptionalMemberAccess]
             cluster_cloud_config = {
                 "connect_timeout": cloud_config.connectTimeout,  # pyright: ignore[reportOptionalMemberAccess]
                 "use_default_tempdir": True,
                 "secure_connect_bundle": cloud_config.secureConnectBundle,  # pyright: ignore[reportOptionalMemberAccess]
             }
             profile = ExecutionProfile(request_timeout=cloud_config.requestTimeout)  # pyright: ignore[reportOptionalMemberAccess, reportArgumentType]
-            auth_provider = PlainTextAuthProvider("token", cloud_config.token)  # pyright: ignore[reportOptionalMemberAccess]
+            auth_provider = PlainTextAuthProvider(
+                "token",
+                token.get_secret_value() if token else None,
+            )
             cluster_config.update(
                 {
                     "cloud": cluster_cloud_config,

--- a/ingestion/tests/unit/source/dashboard/domodashboard/test_connection.py
+++ b/ingestion/tests/unit/source/dashboard/domodashboard/test_connection.py
@@ -12,16 +12,66 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from metadata.clients.domo_client import DomoClient
+from metadata.generated.schema.entity.services.connections.dashboard.domoDashboardConnection import (
+    DomoDashboardConnection as DomoDashboardConnectionConfig,
+)
 from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.source.dashboard.domodashboard.connection import (
     DomoDashboardConnection,
 )
 
 CONNECTION_MODULE = "metadata.ingestion.source.dashboard.domodashboard.connection"
+DEVELOPER_TOKEN = "domo-developer-token"
 
 
 def test_domodashboard_connection_is_base_connection():
     assert issubclass(DomoDashboardConnection, BaseConnection)
+
+
+def test_domo_client_sends_unwrapped_developer_token():
+    config = DomoDashboardConnectionConfig(
+        clientId="client-id",
+        secretToken="client-secret",
+        accessToken=DEVELOPER_TOKEN,
+        instanceDomain="https://example.domo.com",
+    )
+    client = DomoClient(config)
+    client.client = MagicMock()
+
+    client.test_list_cards()
+
+    headers = client.client.get.call_args.kwargs["headers"]
+    assert headers["X-DOMO-Developer-Token"] == DEVELOPER_TOKEN
+
+
+@pytest.mark.parametrize("second_token", ["other-developer-token", None])
+def test_domo_clients_keep_developer_tokens_isolated(second_token):
+    first_client = DomoClient(
+        DomoDashboardConnectionConfig(
+            clientId="first-client-id",
+            secretToken="first-client-secret",
+            accessToken=DEVELOPER_TOKEN,
+            instanceDomain="https://first.example.domo.com",
+        )
+    )
+    first_client.client = MagicMock()
+
+    DomoClient(
+        DomoDashboardConnectionConfig(
+            clientId="second-client-id",
+            secretToken="second-client-secret",
+            accessToken=second_token,
+            instanceDomain="https://second.example.domo.com",
+        )
+    )
+
+    first_client.test_list_cards()
+
+    headers = first_client.client.get.call_args.kwargs["headers"]
+    assert headers["X-DOMO-Developer-Token"] == DEVELOPER_TOKEN
 
 
 def test_get_client_builds_the_ompydomo_client():

--- a/ingestion/tests/unit/source/database/cassandra/test_connection.py
+++ b/ingestion/tests/unit/source/database/cassandra/test_connection.py
@@ -12,6 +12,10 @@
 
 from unittest.mock import patch
 
+from metadata.generated.schema.entity.services.connections.database.cassandra.cloudConfig import (
+    CloudConfig,
+    CloudConfig1,
+)
 from metadata.generated.schema.entity.services.connections.database.cassandraConnection import (
     CassandraConnection as CassandraConnectionConfig,
 )
@@ -25,6 +29,17 @@ def _config() -> CassandraConnectionConfig:
     return CassandraConnectionConfig(hostPort="localhost:9042")
 
 
+def _cloud_config(token: str | None = "astra-token") -> CassandraConnectionConfig:
+    return CassandraConnectionConfig(
+        authType=CloudConfig(
+            cloudConfig=CloudConfig1(
+                token=token,
+                secureConnectBundle="/tmp/secure-connect-bundle.zip",
+            )
+        )
+    )
+
+
 def test_cassandra_connection_is_base_connection():
     assert issubclass(CassandraConnection, BaseConnection)
 
@@ -35,6 +50,22 @@ def test_get_client_connects_a_cluster_session():
     mock_cluster.assert_called_once()
     mock_cluster.return_value.connect.assert_called_once_with()
     assert session is mock_cluster.return_value.connect.return_value
+
+
+def test_get_client_unwraps_astra_token():
+    with patch(f"{CONNECTION_MODULE}.Cluster") as mock_cluster:
+        _ = CassandraConnection(_cloud_config()).client
+
+    auth_provider = mock_cluster.call_args.kwargs["auth_provider"]
+    assert auth_provider.password == "astra-token"
+
+
+def test_get_client_allows_missing_astra_token():
+    with patch(f"{CONNECTION_MODULE}.Cluster") as mock_cluster:
+        _ = CassandraConnection(_cloud_config(token=None)).client
+
+    auth_provider = mock_cluster.call_args.kwargs["auth_provider"]
+    assert auth_provider.password is None
 
 
 def test_close_shuts_down_the_cluster():

--- a/openmetadata-service/src/test/java/org/openmetadata/service/secrets/masker/PasswordEntityMaskerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/secrets/masker/PasswordEntityMaskerTest.java
@@ -6,10 +6,16 @@ import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.entity.services.ServiceType;
+import org.openmetadata.schema.services.connections.dashboard.DomoDashboardConnection;
+import org.openmetadata.schema.services.connections.database.CassandraConnection;
 import org.openmetadata.schema.services.connections.database.MysqlConnection;
+import org.openmetadata.schema.services.connections.database.cassandra.CloudConfig;
+import org.openmetadata.schema.services.connections.database.cassandra.CloudConfig__1;
 import org.openmetadata.service.exception.EntityMaskException;
 
 public class PasswordEntityMaskerTest extends TestEntityMasker {
+  private static final String TOKEN = "openmetadata-token";
+
   public PasswordEntityMaskerTest() {
     CONFIG.setMaskPasswordsAPI(true);
   }
@@ -17,6 +23,47 @@ public class PasswordEntityMaskerTest extends TestEntityMasker {
   @Override
   protected String getMaskedPassword() {
     return PasswordEntityMasker.PASSWORD_MASK;
+  }
+
+  @Test
+  void testDomoDeveloperTokenIsMaskedAndRestored() {
+    DomoDashboardConnection original = new DomoDashboardConnection().withAccessToken(TOKEN);
+
+    DomoDashboardConnection masked =
+        (DomoDashboardConnection)
+            EntityMaskerFactory.createEntityMasker()
+                .maskServiceConnectionConfig(original, "DomoDashboard", ServiceType.DASHBOARD);
+    assertEquals(getMaskedPassword(), masked.getAccessToken());
+
+    DomoDashboardConnection restored =
+        (DomoDashboardConnection)
+            EntityMaskerFactory.createEntityMasker()
+                .unmaskServiceConnectionConfig(
+                    masked, original, "DomoDashboard", ServiceType.DASHBOARD);
+    assertEquals(TOKEN, restored.getAccessToken());
+  }
+
+  @Test
+  void testAstraTokenIsMaskedAndRestored() {
+    CloudConfig cloudConfig =
+        new CloudConfig().withCloudConfig(new CloudConfig__1().withToken(TOKEN));
+    CassandraConnection original = new CassandraConnection().withAuthType(cloudConfig);
+
+    CassandraConnection masked =
+        (CassandraConnection)
+            EntityMaskerFactory.createEntityMasker()
+                .maskServiceConnectionConfig(original, "Cassandra", ServiceType.DATABASE);
+    assertEquals(getMaskedPassword(), astraToken(masked));
+
+    CassandraConnection restored =
+        (CassandraConnection)
+            EntityMaskerFactory.createEntityMasker()
+                .unmaskServiceConnectionConfig(masked, original, "Cassandra", ServiceType.DATABASE);
+    assertEquals(TOKEN, astraToken(restored));
+  }
+
+  private String astraToken(CassandraConnection connection) {
+    return ((CloudConfig) connection.getAuthType()).getCloudConfig().getToken();
   }
 
   @Test

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/dashboard/domoDashboardConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/dashboard/domoDashboardConnection.json
@@ -34,7 +34,8 @@
       "accessToken": {
         "title": "Access Token",
         "description": "Access token to connect to DOMO",
-        "type": "string"
+        "type": "string",
+        "format": "password"
       },
       "apiHost": {
         "expose": true,
@@ -78,4 +79,3 @@
     "additionalProperties": false,
     "required": ["clientId", "secretToken", "instanceDomain"]
   }
-  

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/cassandra/cloudConfig.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/cassandra/cloudConfig.json
@@ -24,7 +24,8 @@
                 "token": {
                     "title": "Token",
                     "description": "The Astra DB application token used for authentication.",
-                    "type": "string"
+                    "type": "string",
+                    "format": "password"
                 },
                 "secureConnectBundle": {
                     "title": "Secure Connect Bundle",

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/domoDatabaseConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/domoDatabaseConnection.json
@@ -34,7 +34,8 @@
       "accessToken": {
         "title": "Access Token",
         "description": "Access token to connect to DOMO",
-        "type": "string"
+        "type": "string",
+        "format": "password"
       },
       "apiHost": {
         "expose": true,
@@ -78,4 +79,3 @@
     "additionalProperties": false,
     "required": ["clientId", "secretToken", "instanceDomain"]
   }
-  

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/pipeline/domoPipelineConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/pipeline/domoPipelineConnection.json
@@ -34,7 +34,8 @@
       "accessToken": {
         "title": "Access Token",
         "description": "Access token to connect to DOMO",
-        "type": "string"
+        "type": "string",
+        "format": "password"
       },
       "apiHost": {
         "expose": true,
@@ -63,4 +64,3 @@
     "additionalProperties": false,
     "required": ["clientId","secretToken","instanceDomain"]
   }
-  


### PR DESCRIPTION
Backports #32545.

- align Domo and Astra connection fields with existing password-field conventions
- pass resolved connection values to the Domo and Cassandra clients
- keep Domo request headers isolated per client instance
- retain regression coverage for connection masking and client construction