### PR TITLE
Fixes #29687: glossary term inverse relation types show wrong perspective

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationEdgeIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationEdgeIT.java
@@ -289,6 +289,67 @@ public class GlossaryTermRelationEdgeIT {
     assertEquals(1, edgeBounded.getEdges().size());
   }
 
+  @Test
+  void customInverseRelationTypesPreserveCorrectPerspective() throws Exception {
+    GlossaryTerm termA = createTerm("InvA");
+    GlossaryTerm termB = createTerm("InvB");
+    GlossaryTerm termC = createTerm("InvC");
+
+    postRelation(termA.getId(), termB.getId(), "narrower", RelationProvenance.MANUAL);
+    postRelation(termA.getId(), termC.getId(), "narrower", RelationProvenance.MANUAL);
+
+    GlossaryTerm reloadedA =
+        client.glossaryTerms().getByName(termA.getFullyQualifiedName(), "relatedTerms");
+    TermRelation aToB = firstEdgeTo(reloadedA, termB.getId());
+    TermRelation aToC = firstEdgeTo(reloadedA, termC.getId());
+    assertNotNull(aToB, "A should have relation to B");
+    assertNotNull(aToC, "A should have relation to C");
+    assertEquals("narrower", aToB.getRelationType(), "A should see 'narrower' toward B");
+    assertEquals("narrower", aToC.getRelationType(), "A should see 'narrower' toward C");
+
+    GlossaryTerm reloadedB =
+        client.glossaryTerms().getByName(termB.getFullyQualifiedName(), "relatedTerms");
+    TermRelation bToA = firstEdgeTo(reloadedB, termA.getId());
+    assertNotNull(bToA, "B should have inverse relation to A");
+    assertEquals("broader", bToA.getRelationType(), "B should see inverse 'broader' toward A");
+
+    GlossaryTerm reloadedC =
+        client.glossaryTerms().getByName(termC.getFullyQualifiedName(), "relatedTerms");
+    TermRelation cToA = firstEdgeTo(reloadedC, termA.getId());
+    assertNotNull(cToA, "C should have inverse relation to A");
+    assertEquals("broader", cToA.getRelationType(), "C should see inverse 'broader' toward A");
+  }
+
+  @Test
+  void addTermRelationDetectsDuplicateAcrossInverse() throws Exception {
+    GlossaryTerm termA = createTerm("DupInvA");
+    GlossaryTerm termB = createTerm("DupInvB");
+
+    postRelation(termA.getId(), termB.getId(), "narrower", RelationProvenance.MANUAL);
+
+    GlossaryTerm reloadedB =
+        client.glossaryTerms().getByName(termB.getFullyQualifiedName(), "relatedTerms");
+    TermRelation bToA = firstEdgeTo(reloadedB, termA.getId());
+    assertNotNull(bToA, "B should see A via inverse");
+    assertEquals("broader", bToA.getRelationType());
+
+    HttpResponse<String> duplicateResponse =
+        postRelationResponse(termB.getId(), termA.getId(), "broader", RelationProvenance.MANUAL);
+    assertTrue(
+        duplicateResponse.statusCode() >= 200 && duplicateResponse.statusCode() < 300,
+        "Duplicate-via-inverse POST should not fail: " + duplicateResponse.body());
+
+    GlossaryTerm reReloadedB =
+        client.glossaryTerms().getByName(termB.getFullyQualifiedName(), "relatedTerms");
+    long countBtoA =
+        reReloadedB.getRelatedTerms() == null
+            ? 0
+            : reReloadedB.getRelatedTerms().stream()
+                .filter(r -> r.getTerm() != null && termA.getId().equals(r.getTerm().getId()))
+                .count();
+    assertEquals(1, countBtoA, "B should have exactly one relation to A, not a duplicate");
+  }
+
   private GlossaryTerm createTerm(String prefix) throws Exception {
     String name = prefix + "_" + UUID.randomUUID().toString().substring(0, 8);
     return client

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
@@ -1484,8 +1484,15 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
     if (typeA.equals(typeB)) {
       return true;
     }
-    String inverseOfA = getInverseRelationType(typeA);
-    return typeB.equals(inverseOfA);
+    return typeB.equals(safeInverseName(typeA)) || typeA.equals(safeInverseName(typeB));
+  }
+
+  private String safeInverseName(String relationType) {
+    try {
+      return getInverseRelationType(relationType);
+    } catch (BadRequestException ignored) {
+      return null;
+    }
   }
 
   private String computeCanonicalRelationType(UUID fromId, UUID toId, String relationType) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
@@ -1308,7 +1308,7 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
                     rel.getTerm() != null
                         && rel.getTerm().getId() != null
                         && rel.getTerm().getId().equals(termRef.getId())
-                        && relationType.equals(relationTypeOrDefault(rel)));
+                        && isEquivalentRelationType(relationType, relationTypeOrDefault(rel)));
     if (!exists) {
       List<TermRelation> updatedRelations =
           new ArrayList<>(listOrEmpty(original.getRelatedTerms()));
@@ -1345,7 +1345,9 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
   private boolean matchesRelation(TermRelation relation, UUID targetTermId, String relationType) {
     boolean hasTarget =
         relation.getTerm() != null && targetTermId.equals(relation.getTerm().getId());
-    boolean hasType = relationType == null || relationType.equals(relationTypeOrDefault(relation));
+    boolean hasType =
+        relationType == null
+            || isEquivalentRelationType(relationType, relationTypeOrDefault(relation));
     return hasTarget && hasType;
   }
 
@@ -1476,6 +1478,14 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
 
   private String getInverseRelationType(String relationType) {
     return relationshipTypeResolver.inverseName(relationType);
+  }
+
+  private boolean isEquivalentRelationType(String typeA, String typeB) {
+    if (typeA.equals(typeB)) {
+      return true;
+    }
+    String inverseOfA = getInverseRelationType(typeA);
+    return typeB.equals(inverseOfA);
   }
 
   private String computeCanonicalRelationType(UUID fromId, UUID toId, String relationType) {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryTermInverseRelation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryTermInverseRelation.spec.ts
@@ -1,0 +1,148 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { expect, test } from '../../../support/fixtures/base';
+import { Glossary } from '../../../support/glossary/Glossary';
+import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
+import { getDefaultAdminAPIContext } from '../../../utils/common';
+import { addTermRelation } from '../../../utils/ontologyStudio';
+
+test.use({ storageState: 'playwright/.auth/admin.json' });
+
+const glossary = new Glossary();
+const termFrom = new GlossaryTerm(glossary);
+const termTo = new GlossaryTerm(glossary);
+const termParent = new GlossaryTerm(glossary);
+const termChild = new GlossaryTerm(glossary);
+
+test.beforeAll(
+  'Seed glossary terms with inverse relations',
+  async ({ browser }) => {
+    const { apiContext, afterAction } = await getDefaultAdminAPIContext(
+      browser
+    );
+
+    await glossary.create(apiContext);
+    await termFrom.create(apiContext);
+    await termTo.create(apiContext);
+    await termParent.create(apiContext);
+    await termChild.create(apiContext);
+
+    await addTermRelation(apiContext, termFrom, termTo, 'narrower');
+    await addTermRelation(apiContext, termParent, termChild, 'hasPart');
+
+    await afterAction();
+  }
+);
+
+test.afterAll('Clean up glossary data', async ({ browser }) => {
+  const { apiContext, afterAction } = await getDefaultAdminAPIContext(browser);
+
+  await termFrom.delete(apiContext);
+  await termTo.delete(apiContext);
+  await termParent.delete(apiContext);
+  await termChild.delete(apiContext);
+  await glossary.delete(apiContext);
+
+  await afterAction();
+});
+
+test.describe('Glossary Term — Inverse Relation Display (#29687)', () => {
+  test('source term shows the authored relation type', async ({ page }) => {
+    await termFrom.visitEntityPage(page);
+
+    const termToName =
+      termTo.responseData?.displayName ?? termTo.data.displayName;
+
+    await expect(page.getByTestId(termToName)).toBeVisible();
+    await expect(
+      page
+        .getByTestId('related-term-container')
+        .getByText('Narrower', { exact: true })
+    ).toBeVisible();
+  });
+
+  test('target term shows the inverse relation type', async ({ page }) => {
+    await termTo.visitEntityPage(page);
+
+    const termFromName =
+      termFrom.responseData?.displayName ?? termFrom.data.displayName;
+
+    await expect(page.getByTestId(termFromName)).toBeVisible();
+    await expect(
+      page
+        .getByTestId('related-term-container')
+        .getByText('Broader', { exact: true })
+    ).toBeVisible();
+  });
+
+  test('inverse relation type persists after page reload', async ({ page }) => {
+    await termTo.visitEntityPage(page);
+
+    const termFromName =
+      termFrom.responseData?.displayName ?? termFrom.data.displayName;
+
+    await expect(
+      page
+        .getByTestId('related-term-container')
+        .getByText('Broader', { exact: true })
+    ).toBeVisible();
+
+    const reloadRes = page.waitForResponse(
+      (res) =>
+        res.url().includes('/api/v1/glossaryTerms/name/') &&
+        res.status() === 200
+    );
+    await page.reload();
+    await reloadRes;
+
+    await expect(page.getByTestId(termFromName)).toBeVisible();
+    await expect(
+      page
+        .getByTestId('related-term-container')
+        .getByText('Broader', { exact: true })
+    ).toBeVisible();
+  });
+
+  test('hasPart and partOf show on opposite sides of the relation', async ({
+    page,
+  }) => {
+    await termParent.visitEntityPage(page);
+
+    const termChildName =
+      termChild.responseData?.displayName ?? termChild.data.displayName;
+
+    await expect(page.getByTestId(termChildName)).toBeVisible();
+    await expect(
+      page
+        .getByTestId('related-term-container')
+        .getByText('Has Part', { exact: true })
+    ).toBeVisible();
+
+    await termChild.visitEntityPage(page);
+
+    const termParentName =
+      termParent.responseData?.displayName ?? termParent.data.displayName;
+
+    await expect(page.getByTestId(termParentName)).toBeVisible();
+    await expect(
+      page
+        .getByTestId('related-term-container')
+        .getByText('Part Of', { exact: true })
+    ).toBeVisible();
+    await expect(
+      page
+        .getByTestId('related-term-container')
+        .getByText('Has Part', { exact: true })
+    ).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #29687 — When custom glossary term relation types with inverses (e.g. “uses”/“usedIn”) are configured, both sides of a relation can show the same type instead of showing inverses. Editing the type reverts on page refresh. Root cause is UUID-ordering-dependent  one pair works, another doesn’t.

**Root cause:** `addTermRelation` and `matchesRelation` compare user-authored relation types against already-inverted display types returned by `getRelatedTerms()`. When a user sends type `"uses"` but the existing relation displays as `"usedIn"` (after inverse resolution), the check incorrectly concludes the relation doesn't exist — potentially creating duplicate relations or failing to find existing ones for removal.

**Fix:** Add `isEquivalentRelationType()` that treats a type and its registered inverse as equivalent, and use it in:
- `addTermRelation` existence check (prevents duplicate relations across inverse types)
- `matchesRelation` (makes removes robust against inverse type mismatches)

The comparison is symmetric (checks inverse in both directions) and safe for unregistered types (catches `BadRequestException` instead of throwing).

## Changes
- **`GlossaryTermRepository.java`** — new `isEquivalentRelationType` + `safeInverseName` helpers; updated `addTermRelation` dedup check and `matchesRelation` to use them
- **`GlossaryTermRelationEdgeIT.java`** — two new integration tests:
  - `customInverseRelationTypesPreserveCorrectPerspective` — verifies both sides of narrower/broader relations show the correct perspective type
  - `addTermRelationDetectsDuplicateAcrossInverse` — verifies the dedup check recognizes inverse types as equivalent

## Test plan
- [x] Existing `GlossaryTermRelationEdgeIT` tests pass (inverse behavior unchanged for correct cases)
- [x] New `customInverseRelationTypesPreserveCorrectPerspective` test passes
- [x] New `addTermRelationDetectsDuplicateAcrossInverse` test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)