### PR TITLE
fix(ci): skip missing dirs in type-generation git-add for 2.0 compat

### DIFF
--- a/.github/workflows/typescript-type-generation.yml
+++ b/.github/workflows/typescript-type-generation.yml
@@ -167,9 +167,11 @@ jobs:
         id: git-check
         continue-on-error: true
         run: |
-          git add openmetadata-ui/src/main/resources/ui/src/generated/ \
-                  openmetadata-ui/src/main/resources/ui/src/jsons/ \
-                  openmetadata-ui/src/main/resources/ui/public/jsons/
+          for dir in openmetadata-ui/src/main/resources/ui/src/generated/ \
+                     openmetadata-ui/src/main/resources/ui/src/jsons/ \
+                     openmetadata-ui/src/main/resources/ui/public/jsons/; do
+            [ -d "$dir" ] && git add "$dir"
+          done
           git diff --cached --quiet
 
       - name: Configure Git


### PR DESCRIPTION
## Summary

- **Root cause**: `pull_request_target` runs the workflow YAML from the default branch (`main`), not the PR's target branch. The `main` workflow's "Check for changes" step does `git add` on `public/jsons/`, which doesn't exist on the `2.0` release branch. `git add` fails (exit 128), `continue-on-error: true` sets `outcome` to `failure`, and downstream steps attempt a commit on an empty staging area → CI failure.
- **Fix**: Loop over directories and only `git add` those that exist, so the workflow works correctly for PRs targeting both `main` and `2.0`.

Fixes the CI failure on PR #32834 and any other PR targeting the `2.0` branch that touches JSON schemas.

## Test plan

- [ ] Re-run the `generate-types` job on PR #32834 — it should pass (or skip the commit step cleanly if types are already up to date)
- [ ] Verify `main`-targeted PRs with schema changes still auto-commit generated types correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)