### PR TITLE
ci(visual-regression): make required-check status appear on every PR

### DIFF
--- a/.github/workflows/playwright-visual.yml
+++ b/.github/workflows/playwright-visual.yml
@@ -27,9 +27,15 @@
 name: playwright-visual-regression
 
 on:
+  merge_group:
+  # Paths filter deliberately removed from the trigger — the workflow always
+  # fires so its required-check status posts on every PR. Path filtering moved
+  # into the `check-changes` job below (dorny/paths-filter), matching the
+  # pattern `ui-checkstyle.yml` uses: PRs without UI-relevant changes skip
+  # the expensive build/test job (green skipped status) while the required
+  # check still reports. Without this, backend-only PRs never see the check
+  # appear and stay stuck at "waiting for required status" forever.
   pull_request:
-    paths:
-      - "openmetadata-ui/**"
   workflow_dispatch:
 
 concurrency:
@@ -37,10 +43,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      ui-changed: ${{ steps.filter.outputs.ui }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        if: ${{ github.event_name == 'merge_group' }}
+        with:
+          fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || '' }}
+          filters: |
+            ui:
+              - 'openmetadata-ui/**'
+              - '.github/workflows/playwright-visual.yml'
+
   playwright-visual-regression:
     name: playwright-visual-regression
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.ui-changed == 'true' && !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft }}
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary

Match the `ui-checkstyle.yml` pattern for `playwright-visual-regression`: keep the workflow trigger unconditional and move path filtering into an in-job `dorny/paths-filter` step. Without this, backend-only PRs never trigger `playwright-visual-regression`, its required-check status never posts, and the PR stalls at "waiting for required status" indefinitely.

## Changes

- Drop the top-level `paths: openmetadata-ui/**` filter on the `pull_request` trigger so every PR (including backend-only) sees the workflow start.
- Add a `check-changes` job that runs `dorny/paths-filter@v4` and publishes a `ui-changed` output. Filter watches `openmetadata-ui/**` plus this workflow's own file so a workflow edit self-tests.
- Gate `playwright-visual-regression` on `needs.check-changes.outputs.ui-changed == 'true'`. When the flag is false the job skips (green status), which required-check gating treats as a pass.
- Add `merge_group:` so the merge queue sees the same status.

Same shape `ui-checkstyle.yml` already uses — this workflow just hadn't been aligned yet.

## Test plan

- [ ] Backend-only PR (touching only `ingestion/**` or `openmetadata-service/**`) sees `playwright-visual-regression` post a green "skipped" status.
- [ ] UI-touching PR still runs the full visual-regression suite.
- [ ] `merge_group` invocation reports the same status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)