### PR TITLE
fix(ui): close DOMPurify math-equation bypass and mention-dropdown XSS (backport #32875 to 2.0)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedEditor/FeedEditor.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedEditor/FeedEditor.test.tsx
@@ -27,6 +27,7 @@ interface MentionModule {
     item: Record<string, unknown>,
     insertItem: (item: unknown) => void
   ) => void;
+  renderItem: (item: Record<string, unknown>) => HTMLElement;
 }
 
 interface CapturedQuillProps {
@@ -213,5 +214,23 @@ describe('Test FeedEditor Component', () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+
+  it('escapes HTML in entity names rendered in the mention suggestion list', async () => {
+    const { container } = render(<FeedEditor {...mockFeedEditorProp} />, {
+      wrapper: MemoryRouter,
+    });
+    await findByTestId(container, 'react-quill');
+
+    const payload = '<img src=x onerror=alert(1)>';
+    const wrapper = mentionModule().renderItem({
+      type: 'table',
+      name: payload,
+      breadcrumbs: [{ name: payload }],
+    });
+
+    // The payload must appear as literal text, never as parsed markup.
+    expect(wrapper.querySelector('img')).toBeNull();
+    expect(wrapper.textContent).toContain(payload);
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedEditor/FeedEditor.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedEditor/FeedEditor.tsx
@@ -14,7 +14,7 @@
 
 import { TextAreaEmoji } from '@windmillcode/quill-emoji';
 import classNames from 'classnames';
-import { debounce, isNil } from 'lodash';
+import { debounce, escape, isNil } from 'lodash';
 import { Parchment } from 'quill';
 import 'quill-mention/autoregister';
 import QuillMarkdown from 'quilljs-markdown';
@@ -164,8 +164,12 @@ export const FeedEditor = forwardRef<EditorContentRef, FeedEditorProp>(
           return item.avatarEle;
         }
 
+        // Escape all search-index-sourced values (names are user-editable)
+        // before interpolating into the innerHTML template below
         const breadcrumbsData = item.breadcrumbs
-          ? item.breadcrumbs.map((obj: { name: string }) => obj.name).join('/')
+          ? item.breadcrumbs
+              .map((obj: { name: string }) => escape(obj.name))
+              .join('/')
           : '';
 
         const breadcrumbEle = breadcrumbsData
@@ -182,7 +186,7 @@ export const FeedEditor = forwardRef<EditorContentRef, FeedEditorProp>(
         );
 
         const typeSpan = !breadcrumbEle
-          ? `<span class="text-grey-muted text-xs">${item.type}</span>`
+          ? `<span class="text-grey-muted text-xs">${escape(item.type)}</span>`
           : '';
 
         const result = `<div class="d-flex items-center gap-2">
@@ -191,7 +195,9 @@ export const FeedEditor = forwardRef<EditorContentRef, FeedEditorProp>(
             ${breadcrumbEle}
             <div class="d-flex flex-col">
               ${typeSpan}
-              <span class="font-medium truncate w-56">${item.name}</span>
+              <span class="font-medium truncate w-56">${escape(
+                item.name
+              )}</span>
             </div>
           </div>
         </div>`;

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkPopup/LinkPopup.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkPopup/LinkPopup.test.tsx
@@ -42,6 +42,7 @@ describe('LinkPopup', () => {
 
     expect(open).toHaveAttribute('href', 'https://example.com');
     expect(open).toHaveAttribute('target', '_blank');
+    expect(open).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
   it('should call handleLinkToggle when edit is clicked', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkPopup/LinkPopup.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkPopup/LinkPopup.tsx
@@ -44,6 +44,7 @@ const LinkPopup: FC<LinkPopupProps> = ({
         data-testid="link-popup-open"
         href={href}
         icon={<ExternalLinkIcon width={iconSize + 2} />}
+        rel="noopener noreferrer"
         target="_blank"
         type="link"
       />

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/OverviewSection/CommonEntitySummaryInfoV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/OverviewSection/CommonEntitySummaryInfoV1.test.tsx
@@ -156,6 +156,7 @@ describe('CommonEntitySummaryInfoV1', () => {
 
     expect(anchor).toBeInTheDocument();
     expect(anchor).toHaveAttribute('href', 'https://open-metadata.org');
+    expect(anchor).toHaveAttribute('rel', 'noopener noreferrer');
     expect(screen.getByTestId('external-link-icon')).toBeInTheDocument();
   });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/OverviewSection/CommonEntitySummaryInfoV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/OverviewSection/CommonEntitySummaryInfoV1.tsx
@@ -63,7 +63,11 @@ const CommonEntitySummaryInfoV1: React.FC<CommonEntitySummaryInfoV1Props> = ({
 
     if (info.isExternal && info.value !== '-') {
       return (
-        <a className="summary-item-link" href={info.url} target="_blank">
+        <a
+          className="summary-item-link"
+          href={info.url}
+          rel="noopener noreferrer"
+          target="_blank">
           {info.value}
           <Icon
             className="m-l-xs"

--- a/openmetadata-ui/src/main/resources/ui/src/utils/sanitize.utils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/sanitize.utils.test.ts
@@ -107,6 +107,24 @@ describe('getSanitizeContent', () => {
       expect(result).toContain('<p>Formula</p>');
     });
 
+    it('should sanitize payloads nested inside a block-math-equation tag', () => {
+      const input =
+        '<block-math-equation math_equation="x^2"><img src="x" onerror="alert(1)"></block-math-equation>';
+      const result = getSanitizeContent(input);
+
+      expect(result).not.toContain('onerror');
+      expect(result).toContain('math_equation="x^2"');
+    });
+
+    it('should sanitize event-handler attributes on the block-math-equation tag itself', () => {
+      const input =
+        '<block-math-equation math_equation="x^2" onclick="alert(1)"></block-math-equation>';
+      const result = getSanitizeContent(input);
+
+      expect(result).not.toContain('onclick');
+      expect(result).toContain('math_equation="x^2"');
+    });
+
     it('should preserve math equations alongside entity links', () => {
       const input =
         '<block-math-equation math_equation="y=mx+b"></block-math-equation><#E::team::Accounting|@Accounting>';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/sanitize.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/sanitize.utils.ts
@@ -17,30 +17,25 @@ export const getSanitizeContent = (html: string): string => {
   // user's text itself contains a placeholder-shaped string.
   const nonce = Math.random().toString(36).slice(2, 10);
 
-  // Protect math equations from DOMPurify's unknown-tag stripping
-  const mathEquationRegex =
-    /<block-math-equation[^>]*>[\s\S]*?<\/block-math-equation>/g;
-  const mathEquations: string[] = [];
-  let mathEquationIndex = 0;
-
-  const mathProtected = html.replaceAll(mathEquationRegex, (match) => {
-    mathEquations.push(match);
-
-    return `__OM_MATH_EQ_${nonce}_${mathEquationIndex++}__`;
-  });
-
   // Protect entity links from DOMPurify encoding
   const entityLinkRegex = /<#E::[^>]+>/g;
   const entityLinks: string[] = [];
   let entityLinkIndex = 0;
 
-  const protectedHtml = mathProtected.replaceAll(entityLinkRegex, (match) => {
+  const protectedHtml = html.replaceAll(entityLinkRegex, (match) => {
     entityLinks.push(match);
 
     return `__OM_ENTITY_LINK_${nonce}_${entityLinkIndex++}__`;
   });
 
-  const sanitizedContent = DOMPurify.sanitize(protectedHtml);
+  // Allowlist the math-equation custom tag and its attributes instead of
+  // exempting the whole match from sanitization — a raw-substring exemption
+  // would let attacker-controlled attributes/children (e.g. <img onerror>)
+  // nested inside the tag bypass DOMPurify entirely.
+  const sanitizedContent = DOMPurify.sanitize(protectedHtml, {
+    ADD_TAGS: ['block-math-equation'],
+    ADD_ATTR: ['math_equation', 'isediting'],
+  });
 
   // Restore entity links — use replacer fn so '$' in values is inserted verbatim
   let restoredContent = sanitizedContent;
@@ -48,13 +43,6 @@ export const getSanitizeContent = (html: string): string => {
     restoredContent = restoredContent.replace(
       `__OM_ENTITY_LINK_${nonce}_${index}__`,
       () => link
-    );
-  });
-
-  mathEquations.forEach((eq, index) => {
-    restoredContent = restoredContent.replace(
-      `__OM_MATH_EQ_${nonce}_${index}__`,
-      () => eq
     );
   });
 


### PR DESCRIPTION
## Describe your changes

Backport of #32875 to the `2.0` branch. Clean cherry-pick, no conflicts.

- **High — DOMPurify bypass via `<block-math-equation>` (stored XSS)**: `getSanitizeContent()` exempted the entire matched substring (attributes + nested children) from sanitization and restored it verbatim; a nested `<img onerror>` survived intact. Replaced the exemption with `ADD_TAGS: ['block-math-equation']` + `ADD_ATTR: ['math_equation', 'isediting']` so DOMPurify sanitizes nested content and event handlers while preserving legitimate equations.
- **High — mention-dropdown innerHTML XSS (stored XSS)**: `FeedEditor.renderItems()` interpolated user-editable entity `displayName`/`name`/breadcrumb values unescaped into an `innerHTML` template; now escaped with lodash `escape`.
- **Medium — reverse tabnabbing**: `rel="noopener noreferrer"` added to `target=_blank` links in `CommonEntitySummaryInfoV1` and `LinkPopup`.

Includes the same test additions as the original PR (sanitize nested-payload/event-handler tests, mention-escape test, `rel` assertions).

## Type of change

- [x] Bug fix (security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)