### PR TITLE
fix(playwright): stabilise Tag.spec:629 and OntologyStudioIntegration.spec:242

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyStudioIntegration.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyStudioIntegration.spec.ts
@@ -231,13 +231,21 @@ test.describe('Ontology Studio - Data Mode Asset Cards', () => {
       expect(counts[termFqn] ?? 0).toBeGreaterThan(0);
     }).toPass({ timeout: 60000, intervals: [2000] });
 
-    // /assets/counts and /ontology/data are served by two different indexes and
-    // the ontology-data one lags behind on a cold Elasticsearch. Waiting only
-    // on the counts endpoint let the test start with the ontology-data cluster
-    // still empty — the UI rendered the cluster shell but not the asset card,
-    // and the assertion at line 272 (`ontology-data-asset-<id>` visible) blew
-    // 15s waiting for a card the API had not yet returned. Poll the endpoint
-    // the test actually reads so the two are consistent before the UI runs.
+    // /assets/counts and /ontology/data are served by two different indexes
+    // and the ontology-data one lags behind on a cold Elasticsearch. Waiting
+    // only on the counts endpoint let the test start with the ontology-data
+    // cluster still empty — the UI rendered the cluster shell but not the
+    // asset card, and the assertion at line 272
+    // (`ontology-data-asset-<id>` visible) blew 15s waiting for a card the
+    // API had not yet returned. Poll the endpoint the test actually reads,
+    // matching the exact params the UI sends (see
+    // `useOntologyExplorer.ts:getOntologyDataGraph`), so the two are
+    // consistent before the UI runs. Timeout has to exceed the ES catchup
+    // window; observed 60s occasionally not enough — 180s leaves headroom
+    // for a cold shard. beforeAll's own timeout is bumped in step
+    // (default hook timeout is 60s; we need room for both toPass polls
+    // plus API setup).
+    test.setTimeout(300000);
     await expect(async () => {
       const response = await apiContext.get(
         '/api/v1/glossaryTerms/ontology/data',
@@ -247,17 +255,23 @@ test.describe('Ontology Studio - Data Mode Asset Cards', () => {
             limit: '12',
             offset: '0',
             assetPreviewSize: '4',
+            connectedTermLimit: '25',
+            edgeLimit: '50',
+            lineageEdgeLimit: '25',
           },
         }
       );
       const body = (await response.json()) as {
-        data?: { term?: { id?: string }; assets?: { id?: string }[] }[];
+        clusters?: {
+          term?: { id?: string };
+          assets?: { id?: string }[];
+        }[];
       };
-      const cluster = (body.data ?? []).find((c) => c.term?.id === termId);
+      const cluster = (body.clusters ?? []).find((c) => c.term?.id === termId);
       expect(
         (cluster?.assets ?? []).some((asset) => asset.id === tableId)
       ).toBe(true);
-    }).toPass({ timeout: 60000, intervals: [2000] });
+    }).toPass({ timeout: 180000, intervals: [2000, 5000, 10000] });
 
     await disposeApiContext(page, apiContext);
   });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyStudioIntegration.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyStudioIntegration.spec.ts
@@ -220,6 +220,8 @@ test.describe('Ontology Studio - Data Mode Asset Cards', () => {
     });
     const glossaryFqn = spiralGlossary.responseData.fullyQualifiedName;
     const termFqn = spiralTerm.responseData.fullyQualifiedName;
+    const termId = spiralTerm.responseData.id;
+    const tableId = spiralTable.entityResponseData.id;
     await expect(async () => {
       const response = await apiContext.get(
         '/api/v1/glossaryTerms/assets/counts',
@@ -227,6 +229,34 @@ test.describe('Ontology Studio - Data Mode Asset Cards', () => {
       );
       const counts = (await response.json()) as Record<string, number>;
       expect(counts[termFqn] ?? 0).toBeGreaterThan(0);
+    }).toPass({ timeout: 60000, intervals: [2000] });
+
+    // /assets/counts and /ontology/data are served by two different indexes and
+    // the ontology-data one lags behind on a cold Elasticsearch. Waiting only
+    // on the counts endpoint let the test start with the ontology-data cluster
+    // still empty — the UI rendered the cluster shell but not the asset card,
+    // and the assertion at line 272 (`ontology-data-asset-<id>` visible) blew
+    // 15s waiting for a card the API had not yet returned. Poll the endpoint
+    // the test actually reads so the two are consistent before the UI runs.
+    await expect(async () => {
+      const response = await apiContext.get(
+        '/api/v1/glossaryTerms/ontology/data',
+        {
+          params: {
+            parent: glossaryFqn,
+            limit: '12',
+            offset: '0',
+            assetPreviewSize: '4',
+          },
+        }
+      );
+      const body = (await response.json()) as {
+        data?: { term?: { id?: string }; assets?: { id?: string }[] }[];
+      };
+      const cluster = (body.data ?? []).find((c) => c.term?.id === termId);
+      expect(
+        (cluster?.assets ?? []).some((asset) => asset.id === tableId)
+      ).toBe(true);
     }).toPass({ timeout: 60000, intervals: [2000] });
 
     await disposeApiContext(page, apiContext);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Tag.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Tag.spec.ts
@@ -630,6 +630,14 @@ test.describe('Tag Page with Limited EditTag Permission', () => {
     adminPage,
     limitedAccessPage,
   }) => {
+    // Two authenticated contexts (admin + limitedAccess) plus asset setup,
+    // add and remove flows on a separate user, and two full tag.visitPage
+    // navigations. Empirically ~90 s on a fresh CI runner — the default 60 s
+    // budget makes the second visitPage race with test teardown, leaving
+    // removeAssetsFromTag's response wait dangling with a closed context on
+    // retry. test.slow() extends the budget to what the flow actually needs.
+    test.slow();
+
     const { afterAction } = await getApiContext(adminPage);
     const { assets, otherAsset, assetCleanup } = await setupAssetsForTag(
       adminPage

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/tag.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/tag.ts
@@ -173,7 +173,19 @@ export const removeAssetsFromTag = async (
   assets: EntityClass[],
   tag: TagClass
 ) => {
-  const res = page.waitForResponse(`/api/v1/tags/name/*`);
+  // `/api/v1/tags/name/*` also fires for the classification-page sidebar that
+  // `tag.visitPage()` navigates through first, and even for other tag lookups
+  // that the layout may issue. The bare glob consumed the wait on those
+  // upstream calls, leaving the tag detail page's own fetch unwaited-for and
+  // the test blocked further down when the loader was still detached. Match
+  // the tag under test specifically so the wait cannot resolve early.
+  const tagFqn = tag.responseData.fullyQualifiedName;
+  const res = page.waitForResponse(
+    (response) =>
+      response.request().method() === 'GET' &&
+      response.url().includes('/api/v1/tags/name/') &&
+      decodeURIComponent(response.url()).includes(tagFqn ?? '')
+  );
   await tag.visitPage(page);
   await res;
 


### PR DESCRIPTION
## Describe your changes

Fixes the two chronic Playwright flakes that have been ejecting PRs from the merge queue — both were unrelated to the PR under test each time, both had the same shape (spec-side race that PR CI never runs often enough to catch), and neither had an open PR or issue targeting them.

### 1. `Pages/Tag.spec.ts:629` — *"Add and Remove Assets and Check Restricted Entity"*

Failing signature seen twice in the last 24 h ([latest — PR #32809 tentative merge](https://github.com/open-metadata/OpenMetadata/actions/runs/34136757304)):

```
Test timeout of 60000ms exceeded.
Error: page.waitForResponse: Target page, context or browser has been closed
waiting for response "/api/v1/tags/name/*"  at ../utils/tag.ts:176
```

The shared `removeAssetsFromTag` helper armed `page.waitForResponse('/api/v1/tags/name/*')`, then called `tag.visitPage(page)`. That helper first navigates through the classification-page sidebar, which itself fires `/api/v1/tags/name/*` on other tags for sidebar state. The bare glob consumed the wait on that upstream call, so the tag detail page's own fetch went un-waited-for — the subsequent loader wait then rescheduled against a half-loaded page, and by retry-time the context was already torn down.

**Fix**: narrow the wait to a URL predicate that matches only the tag being visited:

```ts
const tagFqn = tag.responseData.fullyQualifiedName;
const res = page.waitForResponse(
  (response) =>
    response.request().method() === 'GET' &&
    response.url().includes('/api/v1/tags/name/') &&
    decodeURIComponent(response.url()).includes(tagFqn ?? '')
);
```

Same wait, same shape, but resolves on the response the helper actually depends on.

**Also**: `test.slow()` on the failing test. It runs two authenticated contexts (admin + limitedAccess) plus asset setup + add + remove flows and two full `tag.visitPage` navigations — empirically ~90 s on a fresh CI runner. The default 60 s budget was running out mid-flow, which is why the retry saw a closed context.

### 2. `Features/OntologyStudioIntegration.spec.ts:242` — *"data mode renders tagged assets from the ontology data response"*

Failing signature (seen multiple times, most recently the same PR #32809 run):

```
expect(getByTestId('ontology-data-cluster-<uuid>').getByTestId('ontology-data-asset-<uuid>'))
Expected: visible
Timeout: 15000ms
Error: element(s) not found
```

`beforeAll` polled `/api/v1/glossaryTerms/assets/counts` — served by one index — to confirm the term saw the asset before starting the test. The test then reads `/api/v1/glossaryTerms/ontology/data`, served by a **different** and slower-to-catch-up index. When the two disagreed on a cold Elasticsearch, the UI rendered the cluster shell but not the asset card, and the 15 s wait at `ontology-data-asset-<id> toBeVisible()` timed out against data the API had not yet published.

**Fix**: extend the beforeAll poll to hit the ontology-data endpoint too and verify the cluster's `assets[]` includes the specific table ID the test asserts on. Once both indexes agree, the UI is guaranteed to render the card the test looks for.

## Type of change

- [x] Bug fix — Playwright stability
- No product code touched, no schema change, no CI/workflow change

## Test plan

- `yarn lint:playwright` — 0 errors on touched files (4 pre-existing warnings on untouched lines)
- `yarn tsc:playwright` — 0 new errors on touched files (5 pre-existing errors in `utils/tag.ts:120-163` are untouched and unrelated)
- `yarn pretty:base --check` — clean

**Cannot run the specs locally** without spinning up the full OpenMetadata stack + Elasticsearch (each has an API-driven fixture that needs a live backend). Verification will come from PR CI running these specs directly (both are on the `directChangedSpecs` list for this PR since they're both edited here) plus the follow-on merge-queue full run.

## Follow-up

Neither fix addresses the underlying "two indexes disagree" pattern in the OntologyStudio case — that's a product-side concern for another PR. The test-side fix here just guarantees consistency at test-start time so the test doesn't race the index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)