### PR TITLE
fix(tests): wait for CockroachDB initialization before schema setup

### DIFF
--- a/ingestion/tests/integration/cockroach/test_partition_schema_scope.py
+++ b/ingestion/tests/integration/cockroach/test_partition_schema_scope.py
@@ -5,6 +5,7 @@ import pytest
 from sqlalchemy import create_engine, text
 from sqlalchemy.exc import OperationalError
 from testcontainers.cockroachdb import CockroachDBContainer
+from testcontainers.core.waiting_utils import wait_for_logs
 
 from metadata.generated.schema.entity.data.table import Table, TableType
 from metadata.workflow.metadata import MetadataWorkflow
@@ -23,6 +24,8 @@ def cockroach_container():
     container = CockroachDBContainer(image=PARTITION_TEST_IMAGE)
     container.start()
     try:
+        # Testcontainers returns after user creation, before database privileges are granted.
+        wait_for_logs(container, "end running init files from /docker-entrypoint-initdb.d")
         yield container
     finally:
         container.stop()


### PR DESCRIPTION
### Describe your changes

The CockroachDB partition-schema integration fixture can execute `CREATE SCHEMA` before the container finishes granting database privileges, causing intermittent `InsufficientPrivilege` setup errors across all three parametrized cases.

Wait for the image's initialization-complete log marker before yielding the container. The wait uses Testcontainers' default timeout of 120 seconds and remains inside the existing cleanup block.

Follow-up to #32755. Observed in https://github.com/open-metadata/OpenMetadata/actions/runs/34143215419/job/101810394646.

### Type of change

- [x] Bug fix

Ruff lint, formatting, Python syntax compilation, and `git diff --check` passed. Full integration tests were not run locally.
