### PR TITLE
Fixes #26824: filter column bulk operations metadata status on the aggregate row

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ColumnGridResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ColumnGridResourceIT.java
@@ -13,7 +13,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
@@ -53,17 +52,10 @@ import org.openmetadata.sdk.fluent.Domains;
 import org.openmetadata.sdk.fluent.Tables;
 import org.openmetadata.sdk.network.HttpMethod;
 
-// TEMPORARILY DISABLED — the metadataStatus aggregation on this endpoint reproducibly fails
-// with [search_phase_execution_exception] all shards failed on both postgres+ES+redis (single
-// failure on test_getColumnGrid_withMetadataStatusIncomplete) AND postgres+OpenSearch (the same
-// query crashes the OS container, then 15 follow-up tests in the class fail with Connection
-// refused). Same behavior on PR #28100 with and without the cache changes, so it is a
-// pre-existing aggregator bug, not a cache regression. The ES Java client swallows the
-// underlying `caused_by`, so root-causing the actual ES-side error requires response-body
-// logging that is not wired up yet. Re-enable once the underlying aggregator/index-mapping
-// issue is fixed in a follow-up. See PR #28100 history and CI run 25940411417 for context.
-@Disabled(
-    "ColumnGrid metadataStatus aggregation crashes ES/OS — pre-existing flake, follow-up needed")
+// Re-enabled with #26824: the metadataStatus crash came from the per-document filter query
+// (wildcard/exists on flat-object columns.description/columns.tags), which ES 7.17 and OpenSearch
+// rejected with `search_phase_execution_exception ... all shards failed`. That push-down is gone —
+// status is now filtered on the aggregate grouped item — so the crashing query no longer runs.
 @Execution(ExecutionMode.CONCURRENT)
 @ExtendWith(TestNamespaceExtension.class)
 public class ColumnGridResourceIT {
@@ -314,6 +306,11 @@ public class ColumnGridResourceIT {
 
     assertNotNull(response);
     assertNotNull(response.getColumns());
+    assertAllRowsHaveStatus(response, MetadataStatus.MISSING);
+    assertEquals(
+        response.getColumns().size(),
+        response.getTotalUniqueColumns(),
+        "totalUniqueColumns must reflect the filtered set, not the unfiltered total");
   }
 
   @Test
@@ -328,6 +325,9 @@ public class ColumnGridResourceIT {
 
     assertNotNull(response);
     assertNotNull(response.getColumns());
+    assertFalse(response.getColumns().isEmpty(), "the COMPLETE column should be returned");
+    // The reported bug (#26824): COMPLETE must not surface MISSING/INCOMPLETE/INCONSISTENT rows.
+    assertAllRowsHaveStatus(response, MetadataStatus.COMPLETE);
   }
 
   @Test
@@ -342,6 +342,8 @@ public class ColumnGridResourceIT {
 
     assertNotNull(response);
     assertNotNull(response.getColumns());
+    assertFalse(response.getColumns().isEmpty(), "the INCOMPLETE column should be returned");
+    assertAllRowsHaveStatus(response, MetadataStatus.INCOMPLETE);
   }
 
   @Test
@@ -422,6 +424,80 @@ public class ColumnGridResourceIT {
 
     assertNotNull(response);
     assertNotNull(response.getColumns());
+    assertFalse(response.getColumns().isEmpty(), "the INCONSISTENT column should be returned");
+    assertAllRowsHaveStatus(response, MetadataStatus.INCONSISTENT);
+    assertTrue(
+        response.getColumns().stream().allMatch(ColumnGridItem::getHasVariations),
+        "INCONSISTENT rows have metadata variations across occurrences");
+  }
+
+  @Test
+  void test_getColumnGrid_metadataStatusPaginationCountsAreConsistent(TestNamespace ns)
+      throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+    DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
+
+    // Three COMPLETE columns and one MISSING column in the same service.
+    for (int i = 0; i < 3; i++) {
+      Column complete =
+          Columns.build(ns.prefix("paged_complete_" + i))
+              .withType(ColumnDataType.BIGINT)
+              .withDescription("has description")
+              .withTags(List.of(new TagLabel().withTagFQN("PII.Sensitive")))
+              .create();
+      Tables.create()
+          .name(ns.prefix("paged_table_" + i))
+          .inSchema(schema.getFullyQualifiedName())
+          .withColumns(List.of(complete))
+          .execute();
+    }
+    Column missing =
+        Columns.build(ns.prefix("paged_missing")).withType(ColumnDataType.BIGINT).create();
+    Tables.create()
+        .name(ns.prefix("paged_table_missing"))
+        .inSchema(schema.getFullyQualifiedName())
+        .withColumns(List.of(missing))
+        .execute();
+
+    waitForSearchIndexRefresh(ns);
+
+    ColumnGridResponse page1 =
+        getColumnGrid(
+            client,
+            "size=2&entityTypes=table&metadataStatus=COMPLETE&serviceName=" + service.getName());
+
+    // totalUniqueColumns must count only the 3 COMPLETE columns (not 4), and the page must respect
+    // the requested size — the pagination half of #26824.
+    assertEquals(3, page1.getTotalUniqueColumns());
+    assertEquals(2, page1.getColumns().size());
+    assertAllRowsHaveStatus(page1, MetadataStatus.COMPLETE);
+    assertNotNull(page1.getCursor(), "a second page of COMPLETE columns remains");
+
+    ColumnGridResponse page2 =
+        getColumnGrid(
+            client,
+            "size=2&entityTypes=table&metadataStatus=COMPLETE&serviceName="
+                + service.getName()
+                + "&cursor="
+                + URLEncoder.encode(page1.getCursor(), StandardCharsets.UTF_8));
+
+    assertEquals(3, page2.getTotalUniqueColumns());
+    assertEquals(1, page2.getColumns().size(), "the last page holds the remaining COMPLETE column");
+    assertAllRowsHaveStatus(page2, MetadataStatus.COMPLETE);
+  }
+
+  /**
+   * Every returned row must carry the requested aggregate status — the core guarantee of #26824
+   * (before the fix a COMPLETE/INCOMPLETE filter leaked rows of other statuses).
+   */
+  private void assertAllRowsHaveStatus(ColumnGridResponse response, MetadataStatus expected) {
+    for (ColumnGridItem item : response.getColumns()) {
+      assertEquals(
+          expected,
+          item.getMetadataStatus(),
+          "column '" + item.getColumnName() + "' should have status " + expected);
+    }
   }
 
   @Test
@@ -1424,6 +1500,7 @@ public class ColumnGridResourceIT {
         Columns.build("full_metadata_id")
             .withType(ColumnDataType.BIGINT)
             .withDescription("Primary key with description")
+            .withTags(List.of(new TagLabel().withTagFQN("PII.Sensitive")))
             .create();
 
     Tables.create()

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ColumnGridResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ColumnGridResourceIT.java
@@ -487,6 +487,51 @@ public class ColumnGridResourceIT {
     assertAllRowsHaveStatus(page2, MetadataStatus.COMPLETE);
   }
 
+  @Test
+  void test_getColumnGrid_metadataStatusWithColumnNamePattern(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+    DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
+
+    // Two COMPLETE columns; only one name contains "alpha".
+    String matchName = ns.prefix("alpha_amount");
+    String otherName = ns.prefix("zzz_other");
+    for (String colName : List.of(matchName, otherName)) {
+      Column col =
+          Columns.build(colName)
+              .withType(ColumnDataType.BIGINT)
+              .withDescription("has description")
+              .withTags(List.of(new TagLabel().withTagFQN("PII.Sensitive")))
+              .create();
+      Tables.create()
+          .name(ns.prefix("pat_" + colName))
+          .inSchema(schema.getFullyQualifiedName())
+          .withColumns(List.of(col))
+          .execute();
+    }
+    waitForSearchIndexRefresh(ns);
+
+    ColumnGridResponse response =
+        getColumnGrid(
+            client,
+            "entityTypes=table&metadataStatus=COMPLETE&columnNamePattern=alpha&serviceName="
+                + service.getName());
+
+    // Combining columnNamePattern with a status filter must honor the pattern per column:
+    // the non-matching "zzz_other" column must not leak in (regression for the _source-scan path).
+    assertNotNull(response);
+    assertFalse(response.getColumns().isEmpty(), "the matching COMPLETE column should be returned");
+    assertAllRowsHaveStatus(response, MetadataStatus.COMPLETE);
+    assertTrue(
+        response.getColumns().stream()
+            .allMatch(c -> c.getColumnName().toLowerCase().contains("alpha")),
+        "only columns whose name matches the pattern should be returned");
+    assertEquals(
+        response.getColumns().size(),
+        response.getTotalUniqueColumns(),
+        "totalUniqueColumns must not include pattern-mismatched columns");
+  }
+
   /**
    * Every returned row must carry the requested aggregate status — the core guarantee of #26824
    * (before the fix a COMPLETE/INCOMPLETE filter leaked rows of other statuses).

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ColumnRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ColumnRepository.java
@@ -40,7 +40,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.api.data.BulkColumnUpdatePreview;
 import org.openmetadata.schema.api.data.BulkColumnUpdateRequest;
-import org.openmetadata.schema.api.data.ColumnGridItem;
 import org.openmetadata.schema.api.data.ColumnGridResponse;
 import org.openmetadata.schema.api.data.ColumnMetadata;
 import org.openmetadata.schema.api.data.ColumnOccurrence;
@@ -97,39 +96,10 @@ public class ColumnRepository {
   public ColumnGridResponse getColumnGridPaginated(
       SecurityContext securityContext, ColumnAggregator.ColumnAggregationRequest request)
       throws IOException {
-    ColumnGridResponse response = columnAggregator.aggregateColumns(request);
-
-    if (Boolean.TRUE.equals(request.getHasConflicts())) {
-      response.setColumns(
-          response.getColumns().stream()
-              .filter(ColumnGridItem::getHasVariations)
-              .collect(Collectors.toList()));
-    }
-
-    if (Boolean.TRUE.equals(request.getHasMissingMetadata())) {
-      response.setColumns(
-          response.getColumns().stream()
-              .filter(this::hasMissingMetadata)
-              .collect(Collectors.toList()));
-    }
-
-    // Filter by INCONSISTENT status (requires post-aggregation filtering)
-    if ("INCONSISTENT".equalsIgnoreCase(request.getMetadataStatus())) {
-      response.setColumns(
-          response.getColumns().stream()
-              .filter(ColumnGridItem::getHasVariations)
-              .collect(Collectors.toList()));
-    }
-
-    return response;
-  }
-
-  private boolean hasMissingMetadata(ColumnGridItem item) {
-    return item.getGroups().stream()
-        .anyMatch(
-            group ->
-                (group.getDescription() == null || group.getDescription().isEmpty())
-                    || (group.getTags() == null || group.getTags().isEmpty()));
+    // Row-level filters (metadataStatus / hasConflicts / hasMissingMetadata) are applied inside the
+    // aggregator over the fully-grouped columns, before pagination, so page counts and per-page
+    // size stay correct (#26824). Nothing to post-process here.
+    return columnAggregator.aggregateColumns(request);
   }
 
   public Column getColumnByFQN(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/columns/ColumnResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/columns/ColumnResource.java
@@ -319,13 +319,15 @@ public class ColumnResource {
           boolean hasMissingMetadata,
       @Parameter(
               description =
-                  "Filter by metadata status: MISSING (no description AND no tags), "
+                  "Filter by aggregate metadata status of a column across all its occurrences: "
+                      + "MISSING (no description AND no tags), "
                       + "INCOMPLETE (has description OR tags, but not both), "
-                      + "COMPLETE (has both description AND tags)",
+                      + "COMPLETE (has both description AND tags), "
+                      + "INCONSISTENT (occurrences disagree on description/tags)",
               schema =
                   @Schema(
                       type = "string",
-                      allowableValues = {"MISSING", "INCOMPLETE", "COMPLETE"}))
+                      allowableValues = {"MISSING", "INCOMPLETE", "COMPLETE", "INCONSISTENT"}))
           @QueryParam("metadataStatus")
           String metadataStatus,
       @Parameter(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/ColumnAggregator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/ColumnAggregator.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import org.openmetadata.schema.api.data.ColumnGridItem;
 import org.openmetadata.schema.api.data.ColumnGridResponse;
@@ -145,6 +146,21 @@ public interface ColumnAggregator {
       return status.trim().equalsIgnoreCase(itemStatus);
     }
     return true;
+  }
+
+  /**
+   * Drop columns whose name doesn't contain the request's {@code columnNamePattern}
+   * (case-insensitive). The name wildcard in the search query only scopes which entities are
+   * scanned; flat-object mapping can't isolate the matching column, so the pattern is enforced per
+   * column here. Shared by the ES and OS row-filter scans so their pattern semantics can't drift.
+   */
+  static void applyColumnNamePattern(
+      Map<String, ?> columnsByName, ColumnAggregationRequest request) {
+    if (nullOrEmptyStr(request.getColumnNamePattern())) {
+      return;
+    }
+    String pattern = request.getColumnNamePattern().toLowerCase(Locale.ROOT);
+    columnsByName.keySet().removeIf(name -> !name.toLowerCase(Locale.ROOT).contains(pattern));
   }
 
   /** A column has missing metadata if any of its groups lacks a description or tags. */

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/ColumnAggregator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/ColumnAggregator.java
@@ -34,15 +34,6 @@ public interface ColumnAggregator {
   /** Max column names to retrieve in the names-only query during pattern search. */
   int MAX_PATTERN_SEARCH_NAMES = 10000;
 
-  /** Terms include array matching every column name (row-level-filter path has no name pattern). */
-  String MATCH_ALL_NAMES_REGEX = ".*";
-
-  /**
-   * Batch size for fetching occurrence data by column name in the row-level-filter path. Bounds the
-   * terms-include array and top_hits fan-out per query when many names must be materialized.
-   */
-  int ROW_FILTER_DATA_BATCH = 1000;
-
   /**
    * Number of sample docs pulled per column-name bucket to populate occurrences. Caps
    * {@code ColumnGridItem.totalOccurrences}; columns appearing in more entities than this

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/ColumnAggregator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/ColumnAggregator.java
@@ -16,9 +16,12 @@ package org.openmetadata.service.search;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import org.openmetadata.schema.api.data.ColumnGridItem;
 import org.openmetadata.schema.api.data.ColumnGridResponse;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.slf4j.Logger;
@@ -30,6 +33,15 @@ public interface ColumnAggregator {
 
   /** Max column names to retrieve in the names-only query during pattern search. */
   int MAX_PATTERN_SEARCH_NAMES = 10000;
+
+  /** Terms include array matching every column name (row-level-filter path has no name pattern). */
+  String MATCH_ALL_NAMES_REGEX = ".*";
+
+  /**
+   * Batch size for fetching occurrence data by column name in the row-level-filter path. Bounds the
+   * terms-include array and top_hits fan-out per query when many names must be materialized.
+   */
+  int ROW_FILTER_DATA_BATCH = 1000;
 
   /**
    * Number of sample docs pulled per column-name bucket to populate occurrences. Caps
@@ -113,6 +125,92 @@ public interface ColumnAggregator {
       return 0;
     }
     return (int) value;
+  }
+
+  /**
+   * True if a request carries a row-level filter — one that acts on the aggregate status of a
+   * grouped column (metadataStatus, hasConflicts, hasMissingMetadata) rather than on individual
+   * documents. These cannot be pushed into the search query (the aggregate status is only known
+   * after grouping occurrences), so they are applied via {@link #paginateFilteredItems}.
+   */
+  static boolean hasRowLevelFilter(ColumnAggregationRequest request) {
+    return !nullOrEmptyStr(request.getMetadataStatus())
+        || Boolean.TRUE.equals(request.getHasConflicts())
+        || Boolean.TRUE.equals(request.getHasMissingMetadata());
+  }
+
+  /** True if the grouped column satisfies every active row-level filter on the request. */
+  static boolean matchesRowFilters(ColumnGridItem item, ColumnAggregationRequest request) {
+    if (Boolean.TRUE.equals(request.getHasConflicts())
+        && !Boolean.TRUE.equals(item.getHasVariations())) {
+      return false;
+    }
+    if (Boolean.TRUE.equals(request.getHasMissingMetadata()) && !itemHasMissingMetadata(item)) {
+      return false;
+    }
+    String status = request.getMetadataStatus();
+    if (!nullOrEmptyStr(status)) {
+      String itemStatus = item.getMetadataStatus() != null ? item.getMetadataStatus().value() : "";
+      return status.trim().equalsIgnoreCase(itemStatus);
+    }
+    return true;
+  }
+
+  /** A column has missing metadata if any of its groups lacks a description or tags. */
+  static boolean itemHasMissingMetadata(ColumnGridItem item) {
+    if (item.getGroups() == null) {
+      return true;
+    }
+    return item.getGroups().stream()
+        .anyMatch(
+            group ->
+                (group.getDescription() == null || group.getDescription().isEmpty())
+                    || (group.getTags() == null || group.getTags().isEmpty()));
+  }
+
+  /**
+   * Apply row-level filters to the fully-grouped column list and paginate the result in memory.
+   * Filtering the aggregate items (not documents) is what makes a "Complete"/"Incomplete"/… filter
+   * return only rows whose displayed status matches, and computing totals from the filtered set is
+   * what keeps the page count and per-page size correct (issue #26824). Ordering is by column name
+   * (case-insensitive) so the offset cursor is stable across pages.
+   */
+  static ColumnGridResponse paginateFilteredItems(
+      List<ColumnGridItem> allItems, ColumnAggregationRequest request) {
+    List<ColumnGridItem> filtered =
+        allItems.stream()
+            .filter(item -> matchesRowFilters(item, request))
+            .sorted(
+                Comparator.comparing(
+                    ColumnGridItem::getColumnName,
+                    Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)))
+            .toList();
+
+    int totalUniqueColumns = filtered.size();
+    int totalOccurrences =
+        filtered.stream()
+            .mapToInt(item -> item.getTotalOccurrences() != null ? item.getTotalOccurrences() : 0)
+            .sum();
+
+    int offset = decodeSearchOffset(request.getCursor());
+    int pageSize = request.getSize();
+    int fromIndex = Math.min(offset, totalUniqueColumns);
+    int toIndex = Math.min(offset + pageSize, totalUniqueColumns);
+
+    List<ColumnGridItem> page = new ArrayList<>(filtered.subList(fromIndex, toIndex));
+    boolean hasMore = toIndex < totalUniqueColumns;
+    String cursor = hasMore ? encodeSearchOffset(toIndex) : null;
+
+    ColumnGridResponse response = new ColumnGridResponse();
+    response.setColumns(page);
+    response.setTotalUniqueColumns(totalUniqueColumns);
+    response.setTotalOccurrences(totalOccurrences);
+    response.setCursor(cursor);
+    return response;
+  }
+
+  private static boolean nullOrEmptyStr(String s) {
+    return s == null || s.isBlank();
   }
 
   /** Phase 1 result: matching column names and the total doc_count summed across buckets. */

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchColumnAggregator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchColumnAggregator.java
@@ -115,7 +115,20 @@ public class ElasticSearchColumnAggregator implements ColumnAggregator {
             .removeIf(e -> !e.getKey().toLowerCase(Locale.ROOT).contains(pattern));
       }
 
+      // Row-level filter (metadataStatus / hasConflicts / hasMissingMetadata) acts on the
+      // aggregate status, so group everything then filter + paginate the items.
+      if (ColumnAggregator.hasRowLevelFilter(request)) {
+        List<ColumnGridItem> gridItems = ColumnMetadataGrouper.groupColumns(taggedColumns);
+        return ColumnAggregator.paginateFilteredItems(gridItems, request);
+      }
+
       return aggregateColumnsWithKnownNames(request, taggedColumns);
+    }
+
+    // Row-level filter (no tag filter): materialize all candidate columns, then filter the
+    // aggregate items and paginate in memory so counts and per-page size stay correct (#26824).
+    if (ColumnAggregator.hasRowLevelFilter(request)) {
+      return aggregateColumnsWithRowFilters(request, entityTypes);
     }
 
     // Pattern-only path (no tag filter): use terms agg with include regex
@@ -264,6 +277,54 @@ public class ElasticSearchColumnAggregator implements ColumnAggregator {
     String cursor = hasMore ? ColumnAggregator.encodeSearchOffset(toIndex) : null;
 
     return buildResponse(gridItems, cursor, hasMore, totalUniqueColumns, totalOccurrences);
+  }
+
+  /**
+   * Row-level-filter path (metadataStatus / hasConflicts / hasMissingMetadata, no tag filter). The
+   * filter acts on the aggregate status of a grouped column, which is only known after grouping all
+   * of its occurrences — so we enumerate every candidate name (respecting any column-name pattern
+   * and scope filters), fetch their occurrences, group them, then filter + paginate the items in
+   * memory. This keeps the page count and per-page size consistent with the filtered result set.
+   */
+  private ColumnGridResponse aggregateColumnsWithRowFilters(
+      ColumnAggregationRequest request, List<String> entityTypes) throws IOException {
+
+    Map<String, List<String>> fieldPathToEntityTypes = groupByFieldPath(entityTypes);
+    String regex =
+        !nullOrEmpty(request.getColumnNamePattern())
+            ? ColumnAggregator.toCaseInsensitiveRegex(request.getColumnNamePattern())
+            : MATCH_ALL_NAMES_REGEX;
+
+    Map<String, List<ColumnWithContext>> allColumnsByName = new HashMap<>();
+
+    for (Map.Entry<String, List<String>> entry : fieldPathToEntityTypes.entrySet()) {
+      String columnNameKeyword = entry.getKey();
+      List<String> indexes = resolveIndexNames(entry.getValue());
+      String columnFieldPath = INDEX_CONFIGS.get(entry.getValue().getFirst()).columnFieldPath();
+      Query query = buildFilters(request, columnNameKeyword, null);
+
+      try {
+        List<String> names = executeNamesQuery(query, indexes, columnNameKeyword, regex).names();
+        for (int i = 0; i < names.size(); i += ROW_FILTER_DATA_BATCH) {
+          List<String> batch = names.subList(i, Math.min(i + ROW_FILTER_DATA_BATCH, names.size()));
+          Map<String, List<ColumnWithContext>> columnsByName =
+              executePageDataQuery(query, indexes, columnNameKeyword, columnFieldPath, batch);
+          for (Map.Entry<String, List<ColumnWithContext>> colEntry : columnsByName.entrySet()) {
+            allColumnsByName
+                .computeIfAbsent(colEntry.getKey(), k -> new ArrayList<>())
+                .addAll(colEntry.getValue());
+          }
+        }
+      } catch (ElasticsearchException e) {
+        if (!isIndexNotFoundException(e)) {
+          logShardFailureDetails(e, indexes, query);
+          throw e;
+        }
+      }
+    }
+
+    List<ColumnGridItem> gridItems = ColumnMetadataGrouper.groupColumns(allColumnsByName);
+    return ColumnAggregator.paginateFilteredItems(gridItems, request);
   }
 
   /**
@@ -461,7 +522,6 @@ public class ElasticSearchColumnAggregator implements ColumnAggregator {
     addSchemaFilter(boolBuilder, request);
     addDomainFilter(boolBuilder, request);
     addColumnNamePatternFilter(boolBuilder, request, columnNameKeyword);
-    addMetadataStatusFilter(boolBuilder, request, columnFieldPath);
 
     String tagFQNField = columnNameKeyword.replace(".name.keyword", ".tags.tagFQN");
     List<String> allTags = new ArrayList<>();
@@ -562,7 +622,6 @@ public class ElasticSearchColumnAggregator implements ColumnAggregator {
     addDomainFilter(boolBuilder, request);
     addColumnNamePatternFilter(boolBuilder, request, columnNameKeyword);
     addTagFilters(boolBuilder, request, columnNameKeyword, columnNamesFromTagFilter);
-    addMetadataStatusFilter(boolBuilder, request, columnFieldPath);
 
     return Query.of(q -> q.bool(boolBuilder.build()));
   }
@@ -678,62 +737,6 @@ public class ElasticSearchColumnAggregator implements ColumnAggregator {
       boolBuilder.filter(
           Query.of(q -> q.terms(t -> t.field(tagFQNField).terms(tv -> tv.value(values)))));
     }
-  }
-
-  private void addMetadataStatusFilter(
-      BoolQuery.Builder boolBuilder, ColumnAggregationRequest request, String columnFieldPath) {
-    if (!nullOrEmpty(request.getMetadataStatus())) {
-      Query metadataStatusQuery =
-          buildMetadataStatusFilter(request.getMetadataStatus(), columnFieldPath);
-      if (metadataStatusQuery != null) {
-        boolBuilder.filter(metadataStatusQuery);
-      }
-    }
-  }
-
-  private Query buildMetadataStatusFilter(String status, String columnFieldPath) {
-    String descField = columnFieldPath + ".description";
-    String tagsField = columnFieldPath + ".tags";
-
-    Query hasDesc = hasNonEmptyField(descField);
-    Query hasTags = existsQuery(tagsField);
-    Query noDesc = hasEmptyOrMissingField(descField);
-    Query noTags = notExistsQuery(tagsField);
-
-    return switch (status.toUpperCase()) {
-      case "MISSING" -> Query.of(q -> q.bool(b -> b.must(noDesc).must(noTags)));
-      case "INCOMPLETE" -> Query.of(
-          q ->
-              q.bool(
-                  b ->
-                      b.should(Query.of(qs -> qs.bool(bs -> bs.must(hasDesc).must(noTags))))
-                          .should(Query.of(qs -> qs.bool(bs -> bs.must(noDesc).must(hasTags))))
-                          .minimumShouldMatch("1")));
-      case "COMPLETE" -> Query.of(q -> q.bool(b -> b.must(hasDesc).must(hasTags)));
-      default -> null;
-    };
-  }
-
-  private Query existsQuery(String field) {
-    return Query.of(q -> q.exists(e -> e.field(field)));
-  }
-
-  private Query notExistsQuery(String field) {
-    return Query.of(q -> q.bool(b -> b.mustNot(existsQuery(field))));
-  }
-
-  // `wildcard(field, "?*")` matches any doc whose indexed terms include at least one token of
-  // at least one character — the analyzer-friendly equivalent of "field has non-empty value".
-  // We can't use `term(field, "")` against analyzed text fields like `columns.description`: the
-  // field's analyzer produces no tokens for the empty string and ES 7.17 rejects the term query
-  // with `search_phase_execution_exception ... all shards failed`. Caught by
-  // ColumnGridResourceIT#test_getColumnGrid_withMetadataStatusIncomplete.
-  private Query hasNonEmptyField(String field) {
-    return Query.of(q -> q.wildcard(w -> w.field(field).value("?*")));
-  }
-
-  private Query hasEmptyOrMissingField(String field) {
-    return Query.of(q -> q.bool(b -> b.mustNot(hasNonEmptyField(field))));
   }
 
   /** Phase 1: Get all matching column names using terms agg with include regex (no top_hits). */

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchColumnAggregator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchColumnAggregator.java
@@ -285,8 +285,8 @@ public class ElasticSearchColumnAggregator implements ColumnAggregator {
    * of a column's occurrences. We read {@code _source} for the scoped entities in one scan per
    * field-path group (the same mechanism the tag path uses), restricting {@code _source} to the
    * column and identity fields, then group every column and filter + paginate the items in memory.
-   * This keeps the page count and per-page size consistent with the filtered result set, reads all
-   * occurrences (no top_hits sampling gap), and avoids one query per name.
+   * This keeps the page count and per-page size consistent with the filtered result set and reads
+   * every occurrence of each scanned entity, up to the {@code size(10000)}-entity scan cap.
    */
   private ColumnGridResponse aggregateColumnsWithRowFilters(
       ColumnAggregationRequest request, List<String> entityTypes) throws IOException {
@@ -309,6 +309,14 @@ public class ElasticSearchColumnAggregator implements ColumnAggregator {
           throw e;
         }
       }
+    }
+
+    // The name-pattern wildcard in buildFilters only decides which entities are scanned;
+    // flat-object
+    // mapping can't isolate the matching column. Drop columns whose name doesn't match, per column.
+    if (!nullOrEmpty(request.getColumnNamePattern())) {
+      String pattern = request.getColumnNamePattern().toLowerCase(Locale.ROOT);
+      allColumnsByName.keySet().removeIf(name -> !name.toLowerCase(Locale.ROOT).contains(pattern));
     }
 
     List<ColumnGridItem> gridItems = ColumnMetadataGrouper.groupColumns(allColumnsByName);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchColumnAggregator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchColumnAggregator.java
@@ -282,20 +282,18 @@ public class ElasticSearchColumnAggregator implements ColumnAggregator {
   /**
    * Row-level-filter path (metadataStatus / hasConflicts / hasMissingMetadata, no tag filter). The
    * filter acts on the aggregate status of a grouped column, which is only known after grouping all
-   * of its occurrences — so we enumerate every candidate name (respecting any column-name pattern
-   * and scope filters), fetch their occurrences, group them, then filter + paginate the items in
-   * memory. This keeps the page count and per-page size consistent with the filtered result set.
+   * of a column's occurrences. We read {@code _source} for the scoped entities in one scan per
+   * field-path group (the same mechanism the tag path uses), restricting {@code _source} to the
+   * column and identity fields, then group every column and filter + paginate the items in memory.
+   * This keeps the page count and per-page size consistent with the filtered result set, reads all
+   * occurrences (no top_hits sampling gap), and avoids one query per name.
    */
   private ColumnGridResponse aggregateColumnsWithRowFilters(
       ColumnAggregationRequest request, List<String> entityTypes) throws IOException {
 
     Map<String, List<String>> fieldPathToEntityTypes = groupByFieldPath(entityTypes);
-    String regex =
-        !nullOrEmpty(request.getColumnNamePattern())
-            ? ColumnAggregator.toCaseInsensitiveRegex(request.getColumnNamePattern())
-            : MATCH_ALL_NAMES_REGEX;
-
-    Map<String, List<ColumnWithContext>> allColumnsByName = new HashMap<>();
+    Map<String, List<ColumnWithContext>> allColumnsByName =
+        new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
     for (Map.Entry<String, List<String>> entry : fieldPathToEntityTypes.entrySet()) {
       String columnNameKeyword = entry.getKey();
@@ -304,17 +302,7 @@ public class ElasticSearchColumnAggregator implements ColumnAggregator {
       Query query = buildFilters(request, columnNameKeyword, null);
 
       try {
-        List<String> names = executeNamesQuery(query, indexes, columnNameKeyword, regex).names();
-        for (int i = 0; i < names.size(); i += ROW_FILTER_DATA_BATCH) {
-          List<String> batch = names.subList(i, Math.min(i + ROW_FILTER_DATA_BATCH, names.size()));
-          Map<String, List<ColumnWithContext>> columnsByName =
-              executePageDataQuery(query, indexes, columnNameKeyword, columnFieldPath, batch);
-          for (Map.Entry<String, List<ColumnWithContext>> colEntry : columnsByName.entrySet()) {
-            allColumnsByName
-                .computeIfAbsent(colEntry.getKey(), k -> new ArrayList<>())
-                .addAll(colEntry.getValue());
-          }
-        }
+        fetchColumnsFromSource(indexes, query, columnFieldPath, allColumnsByName);
       } catch (ElasticsearchException e) {
         if (!isIndexNotFoundException(e)) {
           logShardFailureDetails(e, indexes, query);
@@ -325,6 +313,46 @@ public class ElasticSearchColumnAggregator implements ColumnAggregator {
 
     List<ColumnGridItem> gridItems = ColumnMetadataGrouper.groupColumns(allColumnsByName);
     return ColumnAggregator.paginateFilteredItems(gridItems, request);
+  }
+
+  /** {@code _source} fields needed to build grid items: entity identity + the whole column tree. */
+  private List<String> statusScanSourceIncludes(String columnFieldPath) {
+    return List.of(
+        "fullyQualifiedName",
+        "entityType",
+        "displayName",
+        "service.name",
+        "database.name",
+        "databaseSchema.name",
+        columnFieldPath);
+  }
+
+  private void fetchColumnsFromSource(
+      List<String> indexes,
+      Query query,
+      String columnFieldPath,
+      Map<String, List<ColumnWithContext>> columnsByName)
+      throws IOException {
+
+    List<String> includes = statusScanSourceIncludes(columnFieldPath);
+    SearchRequest searchRequest =
+        SearchRequest.of(
+            s ->
+                s.index(indexes)
+                    .query(query)
+                    .source(src -> src.filter(f -> f.includes(includes)))
+                    .size(10000));
+
+    SearchResponse<JsonData> response = client.search(searchRequest, JsonData.class);
+    long totalHits = response.hits().total() != null ? response.hits().total().value() : 0;
+    if (totalHits > 10000) {
+      LOG.warn(
+          "Metadata-status source-fetch matched {} entities; only first 10000 scanned.", totalHits);
+    }
+
+    for (Hit<JsonData> hit : response.hits().hits()) {
+      extractMatchingColumnsFromHit(hit, columnFieldPath, Set.of(), true, columnsByName);
+    }
   }
 
   /**
@@ -427,7 +455,7 @@ public class ElasticSearchColumnAggregator implements ColumnAggregator {
     }
 
     for (Hit<JsonData> hit : response.hits().hits()) {
-      extractMatchingColumnsFromHit(hit, columnFieldPath, targetTags, columnsByName);
+      extractMatchingColumnsFromHit(hit, columnFieldPath, targetTags, false, columnsByName);
     }
   }
 
@@ -435,6 +463,7 @@ public class ElasticSearchColumnAggregator implements ColumnAggregator {
       Hit<JsonData> hit,
       String columnFieldPath,
       Set<String> targetTags,
+      boolean includeAllColumns,
       Map<String, List<ColumnWithContext>> columnsByName) {
     if (hit.source() == null) {
       return;
@@ -457,7 +486,8 @@ public class ElasticSearchColumnAggregator implements ColumnAggregator {
       if (columnsData != null && columnsData.isArray()) {
         for (JsonNode columnData : columnsData) {
           String colName = getTextField(columnData, "name");
-          if (colName != null && columnHasTargetTag(columnData, targetTags)) {
+          if (colName != null
+              && (includeAllColumns || columnHasTargetTag(columnData, targetTags))) {
             Column column = parseColumn(columnData, entityFQN);
             columnsByName
                 .computeIfAbsent(colName, k -> new ArrayList<>())

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchColumnAggregator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchColumnAggregator.java
@@ -311,13 +311,7 @@ public class ElasticSearchColumnAggregator implements ColumnAggregator {
       }
     }
 
-    // The name-pattern wildcard in buildFilters only decides which entities are scanned;
-    // flat-object
-    // mapping can't isolate the matching column. Drop columns whose name doesn't match, per column.
-    if (!nullOrEmpty(request.getColumnNamePattern())) {
-      String pattern = request.getColumnNamePattern().toLowerCase(Locale.ROOT);
-      allColumnsByName.keySet().removeIf(name -> !name.toLowerCase(Locale.ROOT).contains(pattern));
-    }
+    ColumnAggregator.applyColumnNamePattern(allColumnsByName, request);
 
     List<ColumnGridItem> gridItems = ColumnMetadataGrouper.groupColumns(allColumnsByName);
     return ColumnAggregator.paginateFilteredItems(gridItems, request);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchColumnAggregator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchColumnAggregator.java
@@ -211,25 +211,11 @@ public class OpenSearchColumnAggregator implements ColumnAggregator {
       throws IOException {
 
     Query query = buildFilters(request, null);
-    String regex =
-        !nullOrEmpty(request.getColumnNamePattern())
-            ? ColumnAggregator.toCaseInsensitiveRegex(request.getColumnNamePattern())
-            : ColumnAggregator.MATCH_ALL_NAMES_REGEX;
+    Map<String, List<ColumnWithContext>> allColumnsByName =
+        new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
     try {
-      List<String> names = executeNamesQuery(query, regex).names();
-      Map<String, List<ColumnWithContext>> allColumnsByName = new HashMap<>();
-      for (int i = 0; i < names.size(); i += ColumnAggregator.ROW_FILTER_DATA_BATCH) {
-        List<String> batch =
-            names.subList(i, Math.min(i + ColumnAggregator.ROW_FILTER_DATA_BATCH, names.size()));
-        Map<String, List<ColumnWithContext>> columnsByName = executePageDataQuery(query, batch);
-        for (Map.Entry<String, List<ColumnWithContext>> colEntry : columnsByName.entrySet()) {
-          allColumnsByName
-              .computeIfAbsent(colEntry.getKey(), k -> new ArrayList<>())
-              .addAll(colEntry.getValue());
-        }
-      }
-
+      fetchColumnsFromSource(query, allColumnsByName);
       List<ColumnGridItem> gridItems = ColumnMetadataGrouper.groupColumns(allColumnsByName);
       return ColumnAggregator.paginateFilteredItems(gridItems, request);
     } catch (OpenSearchException e) {
@@ -238,6 +224,47 @@ public class OpenSearchColumnAggregator implements ColumnAggregator {
         return buildResponse(new ArrayList<>(), null, false, 0, 0);
       }
       throw e;
+    }
+  }
+
+  /**
+   * Read {@code _source} for the scoped entities in one scan, restricted to the column and identity
+   * fields, and extract every column. Backs the row-level-filter path (status / conflicts / missing
+   * metadata), which must group all of a column's occurrences before it can filter on the aggregate
+   * status.
+   */
+  private void fetchColumnsFromSource(
+      Query query, Map<String, List<ColumnWithContext>> columnsByName) throws IOException {
+
+    List<String> resolvedIndexes = resolveIndexNames();
+    List<String> includes =
+        List.of(
+            "fullyQualifiedName",
+            "entityType",
+            "displayName",
+            "service.name",
+            "database.name",
+            "databaseSchema.name",
+            "columns");
+
+    SearchRequest searchRequest =
+        SearchRequest.of(
+            s ->
+                s.index(resolvedIndexes)
+                    .query(query)
+                    .source(src -> src.filter(f -> f.includes(includes)))
+                    .size(10000));
+
+    SearchResponse<JsonData> response = client.search(searchRequest, JsonData.class);
+    long totalHits = response.hits().total() != null ? response.hits().total().value() : 0;
+    if (totalHits > 10000) {
+      LOG.warn(
+          "Metadata-status source-fetch matched {} entities; only first 10000 scanned.", totalHits);
+    }
+
+    for (os.org.opensearch.client.opensearch.core.search.Hit<JsonData> hit :
+        response.hits().hits()) {
+      extractMatchingColumnsFromHit(hit, Set.of(), true, columnsByName);
     }
   }
 
@@ -337,13 +364,14 @@ public class OpenSearchColumnAggregator implements ColumnAggregator {
 
     for (os.org.opensearch.client.opensearch.core.search.Hit<JsonData> hit :
         response.hits().hits()) {
-      extractMatchingColumnsFromHit(hit, targetTags, columnsByName);
+      extractMatchingColumnsFromHit(hit, targetTags, false, columnsByName);
     }
   }
 
   private void extractMatchingColumnsFromHit(
       os.org.opensearch.client.opensearch.core.search.Hit<JsonData> hit,
       Set<String> targetTags,
+      boolean includeAllColumns,
       Map<String, List<ColumnWithContext>> columnsByName) {
     if (hit.source() == null) {
       return;
@@ -366,7 +394,8 @@ public class OpenSearchColumnAggregator implements ColumnAggregator {
       if (columnsData != null && columnsData.isArray()) {
         for (JsonNode columnData : columnsData) {
           String colName = getTextField(columnData, "name");
-          if (colName != null && columnHasTargetTag(columnData, targetTags)) {
+          if (colName != null
+              && (includeAllColumns || columnHasTargetTag(columnData, targetTags))) {
             Column column = parseColumn(columnData, entityFQN);
             columnsByName
                 .computeIfAbsent(colName, k -> new ArrayList<>())

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchColumnAggregator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchColumnAggregator.java
@@ -218,16 +218,7 @@ public class OpenSearchColumnAggregator implements ColumnAggregator {
 
     try {
       fetchColumnsFromSource(query, allColumnsByName);
-
-      // The name-pattern wildcard in buildFilters only decides which entities are scanned;
-      // flat-object mapping can't isolate the matching column. Drop non-matching columns per
-      // column.
-      if (!nullOrEmpty(request.getColumnNamePattern())) {
-        String pattern = request.getColumnNamePattern().toLowerCase(Locale.ROOT);
-        allColumnsByName
-            .keySet()
-            .removeIf(name -> !name.toLowerCase(Locale.ROOT).contains(pattern));
-      }
+      ColumnAggregator.applyColumnNamePattern(allColumnsByName, request);
 
       List<ColumnGridItem> gridItems = ColumnMetadataGrouper.groupColumns(allColumnsByName);
       return ColumnAggregator.paginateFilteredItems(gridItems, request);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchColumnAggregator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchColumnAggregator.java
@@ -98,7 +98,20 @@ public class OpenSearchColumnAggregator implements ColumnAggregator {
             .removeIf(e -> !e.getKey().toLowerCase(Locale.ROOT).contains(pattern));
       }
 
+      // Row-level filter (metadataStatus / hasConflicts / hasMissingMetadata) acts on the
+      // aggregate status, so group everything then filter + paginate the items.
+      if (ColumnAggregator.hasRowLevelFilter(request)) {
+        List<ColumnGridItem> gridItems = ColumnMetadataGrouper.groupColumns(taggedColumns);
+        return ColumnAggregator.paginateFilteredItems(gridItems, request);
+      }
+
       return aggregateColumnsWithKnownNames(request, taggedColumns);
+    }
+
+    // Row-level filter (no tag filter): materialize all candidate columns, then filter the
+    // aggregate items and paginate in memory so counts and per-page size stay correct (#26824).
+    if (ColumnAggregator.hasRowLevelFilter(request)) {
+      return aggregateColumnsWithRowFilters(request);
     }
 
     // Pattern-only path (no tag filter): use terms agg with include regex
@@ -178,6 +191,47 @@ public class OpenSearchColumnAggregator implements ColumnAggregator {
       String cursor = hasMore ? ColumnAggregator.encodeSearchOffset(toIndex) : null;
 
       return buildResponse(gridItems, cursor, hasMore, totalUniqueColumns, totalOccurrences);
+    } catch (OpenSearchException e) {
+      if (isIndexNotFoundException(e)) {
+        LOG.warn("Search index not found, returning empty results");
+        return buildResponse(new ArrayList<>(), null, false, 0, 0);
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Row-level-filter path (metadataStatus / hasConflicts / hasMissingMetadata, no tag filter). The
+   * filter acts on the aggregate status of a grouped column, which is only known after grouping all
+   * of its occurrences — so we enumerate every candidate name (respecting any column-name pattern
+   * and scope filters), fetch their occurrences, group them, then filter + paginate the items in
+   * memory. This keeps the page count and per-page size consistent with the filtered result set.
+   */
+  private ColumnGridResponse aggregateColumnsWithRowFilters(ColumnAggregationRequest request)
+      throws IOException {
+
+    Query query = buildFilters(request, null);
+    String regex =
+        !nullOrEmpty(request.getColumnNamePattern())
+            ? ColumnAggregator.toCaseInsensitiveRegex(request.getColumnNamePattern())
+            : ColumnAggregator.MATCH_ALL_NAMES_REGEX;
+
+    try {
+      List<String> names = executeNamesQuery(query, regex).names();
+      Map<String, List<ColumnWithContext>> allColumnsByName = new HashMap<>();
+      for (int i = 0; i < names.size(); i += ColumnAggregator.ROW_FILTER_DATA_BATCH) {
+        List<String> batch =
+            names.subList(i, Math.min(i + ColumnAggregator.ROW_FILTER_DATA_BATCH, names.size()));
+        Map<String, List<ColumnWithContext>> columnsByName = executePageDataQuery(query, batch);
+        for (Map.Entry<String, List<ColumnWithContext>> colEntry : columnsByName.entrySet()) {
+          allColumnsByName
+              .computeIfAbsent(colEntry.getKey(), k -> new ArrayList<>())
+              .addAll(colEntry.getValue());
+        }
+      }
+
+      List<ColumnGridItem> gridItems = ColumnMetadataGrouper.groupColumns(allColumnsByName);
+      return ColumnAggregator.paginateFilteredItems(gridItems, request);
     } catch (OpenSearchException e) {
       if (isIndexNotFoundException(e)) {
         LOG.warn("Search index not found, returning empty results");
@@ -376,7 +430,6 @@ public class OpenSearchColumnAggregator implements ColumnAggregator {
     addSchemaFilter(boolBuilder, request);
     addDomainFilter(boolBuilder, request);
     addColumnNamePatternFilter(boolBuilder, request);
-    addMetadataStatusFilter(boolBuilder, request);
 
     List<String> allTags = new ArrayList<>();
     if (!nullOrEmpty(request.getTags())) {
@@ -427,7 +480,6 @@ public class OpenSearchColumnAggregator implements ColumnAggregator {
     addDomainFilter(boolBuilder, request);
     addColumnNamePatternFilter(boolBuilder, request);
     addTagFilters(boolBuilder, request, columnNamesFromTagFilter);
-    addMetadataStatusFilter(boolBuilder, request);
 
     return Query.of(q -> q.bool(boolBuilder.build()));
   }
@@ -548,61 +600,6 @@ public class OpenSearchColumnAggregator implements ColumnAggregator {
           Query.of(
               q -> q.terms(t -> t.field("columns.tags.tagFQN").terms(tv -> tv.value(values)))));
     }
-  }
-
-  private void addMetadataStatusFilter(
-      BoolQuery.Builder boolBuilder, ColumnAggregationRequest request) {
-    if (!nullOrEmpty(request.getMetadataStatus())) {
-      Query metadataStatusQuery = buildMetadataStatusFilter(request.getMetadataStatus());
-      if (metadataStatusQuery != null) {
-        boolBuilder.filter(metadataStatusQuery);
-      }
-    }
-  }
-
-  private Query buildMetadataStatusFilter(String status) {
-    String descField = "columns.description";
-    String tagsField = "columns.tags";
-
-    Query hasDesc = hasNonEmptyField(descField);
-    Query hasTags = existsQuery(tagsField);
-    Query noDesc = hasEmptyOrMissingField(descField);
-    Query noTags = notExistsQuery(tagsField);
-
-    return switch (status.toUpperCase()) {
-      case "MISSING" -> Query.of(q -> q.bool(b -> b.must(noDesc).must(noTags)));
-      case "INCOMPLETE" -> Query.of(
-          q ->
-              q.bool(
-                  b ->
-                      b.should(Query.of(qs -> qs.bool(bs -> bs.must(hasDesc).must(noTags))))
-                          .should(Query.of(qs -> qs.bool(bs -> bs.must(noDesc).must(hasTags))))
-                          .minimumShouldMatch("1")));
-      case "COMPLETE" -> Query.of(q -> q.bool(b -> b.must(hasDesc).must(hasTags)));
-      default -> null;
-    };
-  }
-
-  private Query existsQuery(String field) {
-    return Query.of(q -> q.exists(e -> e.field(field)));
-  }
-
-  private Query notExistsQuery(String field) {
-    return Query.of(q -> q.bool(b -> b.mustNot(existsQuery(field))));
-  }
-
-  // `wildcard(field, "?*")` matches any doc whose indexed terms include at least one token of
-  // at least one character — the analyzer-friendly equivalent of "field has non-empty value".
-  // We can't use `term(field, "")` against analyzed text fields like `columns.description`: the
-  // field's analyzer produces no tokens for the empty string and OS rejects the term query with
-  // `search_phase_execution_exception ... all shards failed`. Caught by
-  // ColumnGridResourceIT#test_getColumnGrid_withMetadataStatusIncomplete.
-  private Query hasNonEmptyField(String field) {
-    return Query.of(q -> q.wildcard(w -> w.field(field).value("?*")));
-  }
-
-  private Query hasEmptyOrMissingField(String field) {
-    return Query.of(q -> q.bool(b -> b.mustNot(hasNonEmptyField(field))));
   }
 
   /** Phase 1: Get all matching column names using terms agg with include regex (no top_hits). */

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchColumnAggregator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchColumnAggregator.java
@@ -203,9 +203,11 @@ public class OpenSearchColumnAggregator implements ColumnAggregator {
   /**
    * Row-level-filter path (metadataStatus / hasConflicts / hasMissingMetadata, no tag filter). The
    * filter acts on the aggregate status of a grouped column, which is only known after grouping all
-   * of its occurrences — so we enumerate every candidate name (respecting any column-name pattern
-   * and scope filters), fetch their occurrences, group them, then filter + paginate the items in
-   * memory. This keeps the page count and per-page size consistent with the filtered result set.
+   * of a column's occurrences. We read {@code _source} for the scoped entities in one scan (the same
+   * mechanism the tag path uses), restricting {@code _source} to the column and identity fields,
+   * then group every column and filter + paginate the items in memory. This keeps the page count and
+   * per-page size consistent with the filtered set and reads every occurrence of each scanned
+   * entity, up to the {@code size(10000)}-entity scan cap.
    */
   private ColumnGridResponse aggregateColumnsWithRowFilters(ColumnAggregationRequest request)
       throws IOException {
@@ -216,6 +218,17 @@ public class OpenSearchColumnAggregator implements ColumnAggregator {
 
     try {
       fetchColumnsFromSource(query, allColumnsByName);
+
+      // The name-pattern wildcard in buildFilters only decides which entities are scanned;
+      // flat-object mapping can't isolate the matching column. Drop non-matching columns per
+      // column.
+      if (!nullOrEmpty(request.getColumnNamePattern())) {
+        String pattern = request.getColumnNamePattern().toLowerCase(Locale.ROOT);
+        allColumnsByName
+            .keySet()
+            .removeIf(name -> !name.toLowerCase(Locale.ROOT).contains(pattern));
+      }
+
       List<ColumnGridItem> gridItems = ColumnMetadataGrouper.groupColumns(allColumnsByName);
       return ColumnAggregator.paginateFilteredItems(gridItems, request);
     } catch (OpenSearchException e) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/ColumnAggregatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/ColumnAggregatorTest.java
@@ -15,10 +15,20 @@ package org.openmetadata.service.search;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.api.data.ColumnGridItem;
+import org.openmetadata.schema.api.data.ColumnGridResponse;
+import org.openmetadata.schema.api.data.ColumnMetadataGroup;
+import org.openmetadata.schema.api.data.MetadataStatus;
+import org.openmetadata.schema.type.TagLabel;
+import org.openmetadata.service.search.ColumnAggregator.ColumnAggregationRequest;
 
 class ColumnAggregatorTest {
 
@@ -108,5 +118,129 @@ class ColumnAggregatorTest {
     assertTrue(pattern.matcher("prefix_a+b*c?_suffix").matches());
     // Plus and star should be literal, not regex quantifiers
     assertFalse(pattern.matcher("abbbbc").matches());
+  }
+
+  // ---- Row-level (post-grouping) filter + pagination helpers (issue #26824) ----
+
+  private static ColumnGridItem item(String name, MetadataStatus status, boolean hasVariations) {
+    ColumnGridItem gi = new ColumnGridItem();
+    gi.setColumnName(name);
+    gi.setMetadataStatus(status);
+    gi.setHasVariations(hasVariations);
+    gi.setTotalOccurrences(1);
+    ColumnMetadataGroup group = new ColumnMetadataGroup();
+    if (status == MetadataStatus.COMPLETE || status == MetadataStatus.INCONSISTENT) {
+      group.setDescription("desc");
+      group.setTags(List.of(new TagLabel().withTagFQN("PII.Sensitive")));
+    } else if (status == MetadataStatus.INCOMPLETE) {
+      group.setDescription("desc");
+    }
+    gi.setGroups(new ArrayList<>(List.of(group)));
+    return gi;
+  }
+
+  private static ColumnAggregationRequest request(String metadataStatus) {
+    ColumnAggregationRequest r = new ColumnAggregationRequest();
+    r.setMetadataStatus(metadataStatus);
+    return r;
+  }
+
+  @Test
+  void matchesRowFilters_metadataStatusMatchesAggregateStatus() {
+    ColumnGridItem complete = item("a", MetadataStatus.COMPLETE, false);
+    ColumnGridItem incomplete = item("b", MetadataStatus.INCOMPLETE, false);
+
+    assertTrue(ColumnAggregator.matchesRowFilters(complete, request("COMPLETE")));
+    assertFalse(ColumnAggregator.matchesRowFilters(incomplete, request("COMPLETE")));
+    assertTrue(ColumnAggregator.matchesRowFilters(incomplete, request("INCOMPLETE")));
+    // Case-insensitive
+    assertTrue(ColumnAggregator.matchesRowFilters(complete, request("complete")));
+  }
+
+  @Test
+  void matchesRowFilters_inconsistentIsAFirstClassStatus() {
+    ColumnGridItem inconsistent = item("a", MetadataStatus.INCONSISTENT, true);
+    ColumnGridItem complete = item("b", MetadataStatus.COMPLETE, false);
+
+    // The reported bug: "COMPLETE" must NOT return inconsistent rows.
+    assertFalse(ColumnAggregator.matchesRowFilters(inconsistent, request("COMPLETE")));
+    assertTrue(ColumnAggregator.matchesRowFilters(inconsistent, request("INCONSISTENT")));
+    assertFalse(ColumnAggregator.matchesRowFilters(complete, request("INCONSISTENT")));
+  }
+
+  @Test
+  void matchesRowFilters_nullOrBlankStatusMatchesEverything() {
+    ColumnGridItem complete = item("a", MetadataStatus.COMPLETE, false);
+    assertTrue(ColumnAggregator.matchesRowFilters(complete, request(null)));
+    assertTrue(ColumnAggregator.matchesRowFilters(complete, request("   ")));
+  }
+
+  @Test
+  void matchesRowFilters_hasConflictsRequiresVariations() {
+    ColumnAggregationRequest r = new ColumnAggregationRequest();
+    r.setHasConflicts(true);
+    assertTrue(ColumnAggregator.matchesRowFilters(item("a", MetadataStatus.INCONSISTENT, true), r));
+    assertFalse(ColumnAggregator.matchesRowFilters(item("b", MetadataStatus.COMPLETE, false), r));
+  }
+
+  @Test
+  void paginateFilteredItems_filtersAndComputesTotalsFromFilteredSet() {
+    List<ColumnGridItem> all =
+        new ArrayList<>(
+            List.of(
+                item("complete_1", MetadataStatus.COMPLETE, false),
+                item("inconsistent_1", MetadataStatus.INCONSISTENT, true),
+                item("complete_2", MetadataStatus.COMPLETE, false),
+                item("missing_1", MetadataStatus.MISSING, false)));
+
+    ColumnAggregationRequest r = request("COMPLETE");
+    r.setSize(10);
+
+    ColumnGridResponse resp = ColumnAggregator.paginateFilteredItems(all, r);
+
+    // Only the two COMPLETE rows survive, and totals reflect the FILTERED set (not 4).
+    assertEquals(2, resp.getTotalUniqueColumns());
+    assertEquals(2, resp.getColumns().size());
+    assertTrue(
+        resp.getColumns().stream().allMatch(c -> c.getMetadataStatus() == MetadataStatus.COMPLETE));
+    assertNull(resp.getCursor());
+  }
+
+  @Test
+  void paginateFilteredItems_paginatesConsistentlyAcrossPages() {
+    List<ColumnGridItem> all = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      all.add(item(String.format("col_%02d", i), MetadataStatus.COMPLETE, false));
+    }
+
+    ColumnAggregationRequest page1 = request("COMPLETE");
+    page1.setSize(2);
+    ColumnGridResponse r1 = ColumnAggregator.paginateFilteredItems(all, page1);
+
+    assertEquals(5, r1.getTotalUniqueColumns());
+    assertEquals(2, r1.getColumns().size());
+    assertEquals("col_00", r1.getColumns().get(0).getColumnName());
+    assertEquals("col_01", r1.getColumns().get(1).getColumnName());
+    assertNotNull(r1.getCursor(), "more pages remain, so a cursor is returned");
+
+    ColumnAggregationRequest page2 = request("COMPLETE");
+    page2.setSize(2);
+    page2.setCursor(r1.getCursor());
+    ColumnGridResponse r2 = ColumnAggregator.paginateFilteredItems(all, page2);
+
+    assertEquals(5, r2.getTotalUniqueColumns());
+    assertEquals(2, r2.getColumns().size());
+    assertEquals("col_02", r2.getColumns().get(0).getColumnName());
+    assertEquals("col_03", r2.getColumns().get(1).getColumnName());
+    assertNotNull(r2.getCursor());
+
+    ColumnAggregationRequest page3 = request("COMPLETE");
+    page3.setSize(2);
+    page3.setCursor(r2.getCursor());
+    ColumnGridResponse r3 = ColumnAggregator.paginateFilteredItems(all, page3);
+
+    assertEquals(1, r3.getColumns().size(), "last page has the remaining single item");
+    assertEquals("col_04", r3.getColumns().get(0).getColumnName());
+    assertNull(r3.getCursor(), "cursor is null on the last page");
   }
 }


### PR DESCRIPTION
### Describe your changes:

Fixes #26824

In Column Bulk Operations, the "Has / Missing Metadata" filter (`metadataStatus`) did not actually hide rows of other statuses, and the page counts were wrong. Picking "Complete" or "Incomplete" still showed Missing/Inconsistent rows, and the number of items per page drifted from page to page.

Root cause was that the filter ran in the wrong place. `metadataStatus` (MISSING/INCOMPLETE/COMPLETE) was pushed down as a **per-document** search query, while INCONSISTENT/`hasConflicts`/`hasMissingMetadata` were applied **after** the aggregator had already paginated and computed the totals. But the status shown for a row is an **aggregate** over all of a column's occurrences (INCONSISTENT when they disagree), so a per-document filter re-grouped into rows whose status differed from the request, and the post-pagination filter shrank the page while the total stayed unfiltered.

This moves every status/row-level filter to run on the fully-grouped items, before pagination, and derives the totals from the filtered set — so a status filter returns only rows of that status and the page count and per-page size stay correct.

As a bonus, the removed per-document query is the wildcard/exists query on flat-object `columns.description`/`columns.tags` that crashed ES/OS with `search_phase_execution_exception ... all shards failed` and had `ColumnGridResourceIT` disabled. With it gone, the IT is re-enabled.

---

### Type of change:

- [x] Bug fix

---

### High-level design:

The column-grid aggregator already runs three paths (composite browse, terms-agg name pattern, tag/glossary source read) introduced in #27216, each ending in `ColumnMetadataGrouper.groupColumns`.

A filter that depends on a row's **aggregate** status can't be a per-document push-down or a per-page post-filter — it has to run on the grouped items. So:

- Added shared, pure helpers on the `ColumnAggregator` interface: `hasRowLevelFilter`, `matchesRowFilters`, and `paginateFilteredItems` (filter grouped items by aggregate status / `hasConflicts` / `hasMissingMetadata`, then paginate in memory with totals computed from the filtered set). These are unit-tested with no ES/OS needed.
- When a row-level filter is active, both aggregators read `_source` for the scoped entities in one scan per field-path group — the same mechanism the tag/glossary filter already uses — group every column, then filter + paginate the items. The `_source` is restricted to the column tree and entity-identity fields, so the per-entity payload stays small (it drops the heavy entity-level derived fields like `columnNames`/`columnNamesFuzzy`). When no such filter is active, the existing composite/pattern paths are untouched.
- Removed the per-document `metadataStatus` query and its now-dead helpers from both aggregators, and removed the post-pagination filter block from `ColumnRepository`.
- `ColumnResource` now documents INCONSISTENT as a supported `metadataStatus` value (it is now handled uniformly with the others).

Scale note: the scan is bounded to 10K entities per field-path group (the same bound the tag path uses, logged at WARN when exceeded) and only runs when a status/row-level filter is active. Because it reads every occurrence (not a `top_hits` sample), the aggregate status can't be misclassified by under-sampling.

---

### Tests:

#### Use cases covered

- Selecting `metadataStatus=COMPLETE` returns only rows whose aggregate status is COMPLETE (no Missing/Incomplete/Inconsistent leak) — the reported bug.
- Same for MISSING, INCOMPLETE, and INCONSISTENT.
- With a status filter and `size=2` over 3 matching + 1 non-matching column, `totalUniqueColumns` is 3 (not 4), page 1 has 2 rows with a cursor, page 2 has the remaining 1 — the pagination half of the bug.

#### Unit tests

- [x] Added to `ColumnAggregatorTest`: `matchesRowFilters` (status match, case-insensitivity, INCONSISTENT as first-class, null/blank passes all, `hasConflicts`) and `paginateFilteredItems` (filtered totals; multi-page cursor consistency).

#### Backend integration tests

- [x] Re-enabled `ColumnGridResourceIT` (removed the `@Disabled` that the crashing query forced) and strengthened its status tests to assert every returned row carries the requested status; added `test_getColumnGrid_metadataStatusPaginationCountsAreConsistent`. Fixed `createTableWithFullMetadata` to add a tag so the "Complete" fixture is genuinely COMPLETE (it previously had a description but no tags → INCOMPLETE, which the old assert-not-null test never caught).

#### Playwright (UI) tests

- [ ] Not applicable (no UI changes).

#### Manual testing performed

Backend-only change. Validated the pure filter/pagination logic with the new `ColumnAggregatorTest` unit tests locally; the re-enabled ES/OS `ColumnGridResourceIT` runs against testcontainers in CI.

Additionally ran a full end-to-end filter test on a fresh local stack built from this branch, on **both** search engines (MySQL+Elasticsearch and Postgres+OpenSearch), seeded with ~13k unique columns across tables and dashboard data models (including a 12k-column wide table) with mixed statuses/tags. Every filter and combination (metadataStatus × columnNamePattern × scope, hasConflicts, hasMissingMetadata, entityTypes, pagination) returned correct results with correct totals and no crashes attributable to this change — 80/80 checks on ES, 33/33 on OS. See the test-summary comment on this PR for details.

---

### UI screen recording / screenshots:

Not applicable.

---

### Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not needed (no schema changes).
- [x] For UI changes: not applicable.
- [x] I have added tests (unit + integration) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.
