### PR TITLE
test: retry cockroach fixture DDL past the testcontainers GRANT race

### DIFF
--- a/ingestion/tests/integration/cockroach/conftest.py
+++ b/ingestion/tests/integration/cockroach/conftest.py
@@ -1,9 +1,11 @@
 import os
 import textwrap
+import time
 import uuid
 
 import pytest
 from sqlalchemy import create_engine, text
+from sqlalchemy.exc import DBAPIError
 
 from _openmetadata_testutils.helpers.docker import try_bind
 from metadata.generated.schema.api.services.createDatabaseService import (
@@ -16,6 +18,41 @@ from metadata.generated.schema.entity.services.databaseService import (
     DatabaseConnection,
     DatabaseServiceType,
 )
+
+# CockroachDB rejects a statement for two reasons that are pure startup/lease noise
+# and say nothing about the statement itself:
+#
+# * 42501 insufficient_privilege — the container entrypoint logs
+#   `finished creating default user`, which is the readiness predicate testcontainers
+#   waits on, *before* it runs `GRANT ALL ON DATABASE <db> TO <user>`. The first
+#   statements therefore race the GRANT and can fail with
+#   "user cockroach does not have CREATE privilege on database roach".
+# * 40001 serialization_failure — a schema change cannot publish a new descriptor
+#   version while an older version is still leased ("restart transaction").
+TRANSIENT_PGCODES = frozenset({"42501", "40001"})
+
+GRANT_WAIT_TIMEOUT_SECONDS = 60
+
+
+def execute_ddl(conn, statements, timeout: float = GRANT_WAIT_TIMEOUT_SECONDS) -> None:
+    """Run each statement in its own transaction, retrying transient failures.
+
+    Committing per statement means a retry replays only the statement that failed
+    instead of the whole batch.
+    """
+    for stmt in statements:
+        deadline = time.monotonic() + timeout
+        while True:
+            try:
+                conn.execute(text(textwrap.dedent(stmt)))
+                conn.commit()
+                break
+            except DBAPIError as exc:
+                conn.rollback()
+                pgcode = getattr(exc.orig, "pgcode", None)
+                if pgcode not in TRANSIENT_PGCODES or time.monotonic() >= deadline:
+                    raise
+                time.sleep(0.5)
 
 
 @pytest.fixture(scope="module")
@@ -35,10 +72,10 @@ def cockroach_container():
         testcontainers_config.max_tries = old_max_tries
         engine = create_engine(container.get_connection_url())
         with engine.connect() as conn:
-            conn.execute(
-                text(
-                    textwrap.dedent(
-                        """
+            execute_ddl(
+                conn,
+                [
+                    """
                     CREATE TABLE user_profiles (
                         user_id UUID PRIMARY KEY,
                         first_name TEXT,
@@ -48,10 +85,8 @@ def cockroach_container():
                         is_active BOOLEAN
                     );
                     """
-                    )
-                )
+                ],
             )
-            conn.commit()
 
         yield container
 
@@ -142,8 +177,6 @@ def create_test_data(cockroach_container):
     ]
 
     with engine.connect() as conn:
-        for stmt in setup_statements:
-            conn.execute(text(textwrap.dedent(stmt)))
-        conn.commit()
+        execute_ddl(conn, setup_statements)
 
     yield

--- a/ingestion/tests/integration/cockroach/test_partition_schema_scope.py
+++ b/ingestion/tests/integration/cockroach/test_partition_schema_scope.py
@@ -1,13 +1,11 @@
-import textwrap
-import time
-
 import pytest
-from sqlalchemy import create_engine, text
-from sqlalchemy.exc import OperationalError
+from sqlalchemy import create_engine
 from testcontainers.cockroachdb import CockroachDBContainer
 
 from metadata.generated.schema.entity.data.table import Table, TableType
 from metadata.workflow.metadata import MetadataWorkflow
+
+from .conftest import execute_ddl  # noqa: TID252
 
 # Partitioning requires an enterprise-enabled cluster. The shared conftest
 # fixture uses `cockroachdb/cockroach:v23.1.0`, where `PARTITION BY` needs a
@@ -20,8 +18,17 @@ PARTITION_TEST_IMAGE = "cockroachdb/cockroach:v24.3.0"
 def cockroach_container():
     """Override the shared conftest fixture with a v24.3 image that supports
     partitioning on a license-free single-node dev cluster."""
+    from testcontainers.core.config import testcontainers_config
+
+    old_max_tries = testcontainers_config.max_tries
+    testcontainers_config.max_tries = 240
+
     container = CockroachDBContainer(image=PARTITION_TEST_IMAGE)
-    container.start()
+    try:
+        container.start()
+    finally:
+        testcontainers_config.max_tries = old_max_tries
+
     try:
         yield container
     finally:
@@ -79,22 +86,7 @@ def prepare_partitioned_schemas(cockroach_container):
         """,
     ]
     with engine.connect() as conn:
-        for stmt in sql:
-            # CockroachDB schema changes can transiently fail with a
-            # SerializationFailure ("cannot publish new versions for
-            # descriptors ... old versions still in use") when descriptors are
-            # leased. Commit each DDL in its own transaction and retry.
-            for attempt in range(5):
-                try:
-                    conn.execute(text(textwrap.dedent(stmt)))
-                    conn.commit()
-                    break
-                except OperationalError as exc:
-                    conn.rollback()
-                    if "restart transaction" in str(exc).lower() and attempt < 4:
-                        time.sleep(1)
-                        continue
-                    raise
+        execute_ddl(conn, sql)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Describe your changes:

Not applicable — CI test-infra flake, no user-facing issue filed.

I fixed the intermittent `python / Integration Tests` failure that has been dequeuing PRs from the merge queue, because it fails on shared shards and looks like the queued PR's fault:

```
psycopg2.errors.InsufficientPrivilege: user cockroach does not have CREATE privilege on database roach
[SQL: CREATE SCHEMA IF NOT EXISTS analytics;]
```

`CockroachDBContainer._connect` waits for the log line `finished creating default user*`, but cockroach's `build/deploy/cockroach.sh` `setup_db()` emits that line inside `create_default_user` and only *afterwards* runs `GRANT ALL ON DATABASE roach TO cockroach` + `GRANT admin TO cockroach`. The container is therefore declared ready with zero grants applied, and the first fixture statement races the GRANT. Real container log, in order:

```
finished creating default user "cockroach"   <- testcontainers stops waiting HERE
GRANT                                        <- GRANT ALL ON DATABASE roach TO cockroach
GRANT                                        <- GRANT admin TO cockroach
```

The entrypoint logic is byte-identical in v23.1.0 and v24.3.0, so every cockroach fixture was exposed — the v24.3 partition test just happened to lose the race first.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change (2 test files).

Approach: a shared `execute_ddl(conn, statements, timeout=60)` helper in `ingestion/tests/integration/cockroach/conftest.py` that commits each statement in its own transaction and retries on `exc.orig.pgcode` in `{42501, 40001}` until a deadline.

- `42501` insufficient_privilege — the GRANT race described above.
- `40001` serialization_failure — the pre-existing "restart transaction" descriptor-lease noise on schema changes.

Matching on pgcode rather than on message substrings is deliberate: the previous bespoke loop in `test_partition_schema_scope.py` did `if "restart transaction" in str(exc).lower()`, which is brittle across CockroachDB versions and could not have caught the privilege error at all. The helper replaces that loop and now also guards the two shared conftest fixtures (`cockroach_container`, `create_test_data`), which had the same race.

Rejected alternative: subclassing `CockroachDBContainer` to add a grants-visible readiness probe. It fixes the wait rather than the symptom, but it needs a privileged `SHOW GRANTS` connection during startup and would have to be kept in sync with upstream testcontainers' `_connect`; retrying the statements we already issue is smaller and version-agnostic.

Also restores `testcontainers_config.max_tries = 240` in the partition test's container override (the shared fixture already sets it) so slow CI runners do not time out during container startup, and wraps the restore in `try`/`finally` so a failed `start()` cannot leak the raised value into other modules.

#
### Tests:

#### Use cases covered
- A cockroach integration-test fixture that issues DDL immediately after container startup succeeds even when it wins the race against the entrypoint's `GRANT` statements.
- The pre-existing serialization-failure retry behaviour for partitioned-table DDL is preserved.

#### Unit tests
Not applicable — this PR only changes integration-test fixtures; there is no production code and no new logic to unit test.

#### Backend integration tests
Not applicable — no backend API changes.

#### Ingestion integration tests
Files updated:
- `ingestion/tests/integration/cockroach/conftest.py` — added `execute_ddl`, applied to `cockroach_container` and `create_test_data`
- `ingestion/tests/integration/cockroach/test_partition_schema_scope.py` — uses `execute_ddl`, drops the bespoke substring-matching retry loop, restores `max_tries`

No coverage number: these are the tests, not code under test.

#### Playwright (UI) tests
Not applicable — no UI changes.

#### Manual testing performed

The flake is a sub-second timing race, so I measured it against real containers rather than asserting it away.

1. Confirmed the failure is not the queued PR's fault: merge_group run [34149179346](https://github.com/open-metadata/OpenMetadata/actions/runs/34149179346) (pr-32607) failed `Integration Tests (shard-3, 3.10)`, while sibling run [34149180171](https://github.com/open-metadata/OpenMetadata/actions/runs/34149180171) — same commit set, same shard, same test — passed. Run [34149183313](https://github.com/open-metadata/OpenMetadata/actions/runs/34149183313) (pr-32524) failed identically.
2. Confirmed the ordering in the entrypoint by diffing `build/deploy/cockroach.sh` at tags `v23.1.0` and `v24.3.0` (identical `setup_db` logic) and by reading `docker logs` from a live `cockroachdb/cockroach:v24.3.0` container — see the log excerpt above.
3. Instrumented a fresh container to poll `docker logs` for `finished creating default user` and immediately attempt `CREATE SCHEMA`: **0 GRANT statements had been emitted** at the moment the readiness predicate was satisfied, and 2 of 3 containers returned the exact CI error on the first attempt. Race window ~0.3–0.5s.
4. Ran the **unguarded** fixture DDL (current `main` code path) against 6 fresh v24.3.0 containers: **5 pass / 1 fail**, with the exact CI error.
5. Ran the **guarded** path (`execute_ddl`) against 12 fresh v24.3.0 containers: **12 pass / 0 fail**, with 5 retries fired — i.e. the race was hit 5 times and absorbed.
6. Ran the v23.1.0 conftest path (`CREATE TABLE user_profiles` + `create_test_data` statements) through `execute_ddl` against 4 fresh containers: **4 pass / 0 fail, 0 retries** — no regression on the image the other cockroach tests use.
7. `ruff check --fix` and `ruff format` (v0.15.12, `--config ingestion/pyproject.toml`) on both files: clean, `2 files left unchanged`. `basedpyright` has `include = ["src"]`, so tests are out of scope.

Not run: `pytest` itself. This Claude Code worktree has no `env/` venv, so I exercised the fixture logic standalone against real CockroachDB containers (steps 3–6) instead of through the pytest harness. The CI run on this PR is the end-to-end check.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` — no issue filed; this is CI test-infra only.
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above — see above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing. The fixed test *is* the scenario: `test_partition_schema_scope.py` is the test that was failing, and the fix is verified by the 6-run / 12-run container comparison in "Manual testing performed" above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
