### PR TITLE
Fix six merge-queue ejections caused by races in the tests, not the PRs

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/eslint-suppressions.json
+++ b/openmetadata-ui/src/main/resources/ui/eslint-suppressions.json
@@ -525,7 +525,7 @@
   },
   "playwright/e2e/Features/TestSuitePipelineRedeploy.spec.ts": {
     "om-playwright/no-positional-locator": {
-      "count": 2
+      "count": 1
     }
   },
   "playwright/e2e/Features/Topic.spec.ts": {

--- a/openmetadata-ui/src/main/resources/ui/eslint-suppressions.json
+++ b/openmetadata-ui/src/main/resources/ui/eslint-suppressions.json
@@ -658,7 +658,7 @@
   },
   "playwright/e2e/Pages/DataProductAndSubdomains.spec.ts": {
     "om-playwright/no-positional-locator": {
-      "count": 5
+      "count": 4
     }
   },
   "playwright/e2e/Pages/DataProducts.spec.ts": {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
@@ -1060,11 +1060,23 @@ test.describe(
         expect(response.status()).toBe(202);
         // Verify exactly one export request was fired (no duplicate calls).
         await expect.poll(() => exportRequestCount).toBe(1);
-        await expect(page.locator('.csv-jobs-tray-launcher')).toBeVisible({
+        // A job reaching a terminal state auto-opens the tray, and the launcher
+        // button only renders while the tray is closed -- so a fast export
+        // removes the very element this used to wait for, and the test lost a
+        // race it could not win. Accept either state, and click only if the
+        // tray has not opened itself.
+        const trayLauncher = page.locator('.csv-jobs-tray-launcher');
+        const trayPopover = page.locator('.csv-jobs-tray-popover');
+
+        await expect(trayLauncher.or(trayPopover)).toBeVisible({
           timeout: 30000,
         });
-        await page.locator('.csv-jobs-tray-launcher').click();
-        await expect(page.locator('.csv-jobs-tray-popover')).toBeVisible();
+
+        if (await trayLauncher.isVisible()) {
+          await trayLauncher.click();
+        }
+
+        await expect(trayPopover).toBeVisible();
         // Verify the export job appears in the tray. Each test uses a dedicated
         // user session so only this test's own job is visible — checking the
         // label is sufficient.
@@ -1074,7 +1086,9 @@ test.describe(
             .filter({ hasText: /Exporting Metrics|Exported Metrics/ })
         ).toBeVisible();
       } finally {
-        await page.close();
+        // A failed test tears the context down first, so closing here throws a
+        // protocol error that replaces the real failure in the report.
+        await page.close().catch(() => undefined);
       }
     });
 
@@ -1118,7 +1132,9 @@ test.describe(
 
         await expectImportedMetricComplexFields(importedMetricName);
       } finally {
-        await page.close();
+        // A failed test tears the context down first, so closing here throws a
+        // protocol error that replaces the real failure in the report.
+        await page.close().catch(() => undefined);
       }
     });
 
@@ -1213,7 +1229,9 @@ test.describe(
           [metricCustomPropertyName]: 'updated custom value',
         });
       } finally {
-        await page.close();
+        // A failed test tears the context down first, so closing here throws a
+        // protocol error that replaces the real failure in the report.
+        await page.close().catch(() => undefined);
       }
     });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Table.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Table.spec.ts
@@ -600,10 +600,16 @@ test.describe('Tags and glossary terms should be consistent for search ', () => 
       '[data-row-key="sample_data.ecommerce_db.shopify.dim_customer.shop_id"] [data-testid*="classification-tags"]';
 
     const addButton = page.locator(`${rowSelector} [data-testid="add-tag"]`);
+    const editButton = page.locator(
+      `${rowSelector} [data-testid="edit-button"]`
+    );
+
+    await expect(addButton.or(editButton)).toBeVisible({ timeout: 15000 });
+
     if (await addButton.isVisible()) {
       await addButton.click();
     } else {
-      await page.click(`${rowSelector} [data-testid="edit-button"]`);
+      await editButton.click();
     }
 
     await page

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuitePipelineRedeploy.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuitePipelineRedeploy.spec.ts
@@ -62,14 +62,35 @@ test.describe('Bulk Re-Deploy pipelines ', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
 
     await expect(page.getByRole('button', { name: 'Re Deploy' })).toBeEnabled();
 
-    const redeployResponse = page.waitForResponse(
-      (response) =>
-        response.url().includes('/api/v1/services/ingestionPipelines/deploy') &&
+    // The component awaits Promise.all over every selected pipeline, so the
+    // success toast needs all of them to deploy. Waiting on a single 200 only
+    // proves the first did: when a later deploy fails the UI shows the error
+    // toast instead, and the test then waits out its whole budget for a success
+    // toast that can never arrive. Collect every deploy and report the real
+    // status, so a genuine deploy failure fails fast and says why.
+    const deployStatuses: number[] = [];
+    page.on('response', (response) => {
+      if (
         response.request().method() === 'POST' &&
-        response.status() === 200
-    );
+        response.url().includes('/api/v1/services/ingestionPipelines/deploy')
+      ) {
+        deployStatuses.push(response.status());
+      }
+    });
+
     await page.getByRole('button', { name: 'Re Deploy' }).click();
-    await redeployResponse;
+
+    await expect
+      .poll(() => deployStatuses.length, {
+        message: 'Wait for both selected pipelines to report a deploy result',
+        timeout: 30_000,
+      })
+      .toBe(2);
+
+    expect(
+      deployStatuses,
+      'every selected pipeline must deploy for the success toast to appear'
+    ).toEqual([200, 200]);
 
     await toastNotification(page, /Pipelines Re Deploy Successfully/i);
   });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuitePipelineRedeploy.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuitePipelineRedeploy.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import test, { expect } from '@playwright/test';
+import test, { expect, Response } from '@playwright/test';
 import { PLAYWRIGHT_INGESTION_TAG_OBJ } from '../../constant/config';
 import { GlobalSettingOptions } from '../../constant/settings';
 import { TableClass } from '../../support/entity/TableClass';
@@ -57,8 +57,13 @@ test.describe('Bulk Re-Deploy pipelines ', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
     ).not.toBeEnabled();
     await expect(page.locator('.ant-table-container')).toBeVisible();
 
-    await page.locator(`td [type="checkbox"]`).first().click();
-    await page.locator(`td [type="checkbox"]`).nth(1).click();
+    // One source for how many pipelines this selects, so the deploy assertion
+    // below cannot drift from the selection above.
+    const selectedPipelineCount = 2;
+
+    for (let index = 0; index < selectedPipelineCount; index++) {
+      await page.locator(`td [type="checkbox"]`).nth(index).click();
+    }
 
     await expect(page.getByRole('button', { name: 'Re Deploy' })).toBeEnabled();
 
@@ -69,28 +74,36 @@ test.describe('Bulk Re-Deploy pipelines ', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
     // toast that can never arrive. Collect every deploy and report the real
     // status, so a genuine deploy failure fails fast and says why.
     const deployStatuses: number[] = [];
-    page.on('response', (response) => {
+    const collectDeploy = (response: Response) => {
       if (
         response.request().method() === 'POST' &&
         response.url().includes('/api/v1/services/ingestionPipelines/deploy')
       ) {
         deployStatuses.push(response.status());
       }
-    });
+    };
+    page.on('response', collectDeploy);
 
-    await page.getByRole('button', { name: 'Re Deploy' }).click();
+    try {
+      await page.getByRole('button', { name: 'Re Deploy' }).click();
 
-    await expect
-      .poll(() => deployStatuses.length, {
-        message: 'Wait for both selected pipelines to report a deploy result',
-        timeout: 30_000,
-      })
-      .toBe(2);
+      await expect
+        .poll(() => deployStatuses.length, {
+          message: 'Wait for every selected pipeline to report a deploy result',
+          timeout: 30_000,
+        })
+        .toBe(selectedPipelineCount);
 
-    expect(
-      deployStatuses,
-      'every selected pipeline must deploy for the success toast to appear'
-    ).toEqual([200, 200]);
+      expect(
+        deployStatuses,
+        'every selected pipeline must deploy for the success toast to appear'
+      ).toEqual(Array(selectedPipelineCount).fill(200));
+    } finally {
+      // Scope the listener to the action it observes: left attached it would
+      // keep collecting for the page's lifetime, and a second test in this
+      // describe would then assert against another test's deploys too.
+      page.off('response', collectDeploy);
+    }
 
     await toastNotification(page, /Pipelines Re Deploy Successfully/i);
   });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuitePipelineRedeploy.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuitePipelineRedeploy.spec.ts
@@ -57,12 +57,25 @@ test.describe('Bulk Re-Deploy pipelines ', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
     ).not.toBeEnabled();
     await expect(page.locator('.ant-table-container')).toBeVisible();
 
-    // One source for how many pipelines this selects, so the deploy assertion
-    // below cannot drift from the selection above.
+    // beforeAll creates one test-suite pipeline per table, and there are two
+    // tables -- so this is the fixture's count, not an arbitrary number. One
+    // source for it, so the deploy assertion below cannot drift from the
+    // selection here.
     const selectedPipelineCount = 2;
+    const rowCheckboxes = page.locator(`td [type="checkbox"]`);
+
+    // The listing is global and can lag behind the pipelines this spec just
+    // created. Wait for enough rows first: nth() on a shorter list auto-waits
+    // and would spend the whole budget instead of saying what was missing.
+    await expect
+      .poll(() => rowCheckboxes.count(), {
+        message: `Wait for at least ${selectedPipelineCount} test-suite pipelines to be listed`,
+        timeout: 30_000,
+      })
+      .toBeGreaterThanOrEqual(selectedPipelineCount);
 
     for (let index = 0; index < selectedPipelineCount; index++) {
-      await page.locator(`td [type="checkbox"]`).nth(index).click();
+      await rowCheckboxes.nth(index).click();
     }
 
     await expect(page.getByRole('button', { name: 'Re Deploy' })).toBeEnabled();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataProductAndSubdomains.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataProductAndSubdomains.spec.ts
@@ -389,30 +389,27 @@ test.describe('Data Product Comprehensive Tests', () => {
         timeout: 10000,
       });
 
-      // Search for table
-      const searchRes = page.waitForResponse('/api/v1/search/query*');
-      await page
-        .getByTestId('asset-selection-modal')
-        .getByTestId('searchbar')
-        .fill(table.entityResponseData.name);
-      await searchRes;
-
-      // Select the table by clicking the checkbox in the card
-      const tableCheckbox = page
-        .getByTestId('asset-selection-modal')
-        .locator(`[data-testid*="${table.entityResponseData.name}"]`)
+      const assetModal = page.getByTestId('asset-selection-modal');
+      const assetName = table.entityResponseData.name;
+      // The card exposes the name either through a data-testid or as plain
+      // text, so match both rather than probing one and falling back.
+      const assetCard = assetModal
+        .locator(`[data-testid*="${assetName}"]`)
+        .or(assetModal.getByText(assetName))
         .first();
 
-      if (await tableCheckbox.isVisible()) {
-        await tableCheckbox.click();
-      } else {
-        // Try clicking the text directly
-        await page
-          .getByTestId('asset-selection-modal')
-          .getByText(table.entityResponseData.name)
-          .first()
-          .click();
-      }
+      // The modal re-queries only when the search text changes, and a table
+      // created moments ago may not be in the search index yet -- so a single
+      // fill can settle on an empty result set that never refreshes. Re-type
+      // to re-issue the query until the asset actually shows up.
+      await expect(async () => {
+        await assetModal.getByTestId('searchbar').fill('');
+        await assetModal.getByTestId('searchbar').fill(assetName);
+
+        await expect(assetCard).toBeVisible({ timeout: 5_000 });
+      }).toPass({ timeout: 60_000 });
+
+      await assetCard.click();
 
       // Save
       const addRes = page.waitForResponse('/api/v1/dataProducts/*/assets/add');

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/ServiceEntityVersionPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/ServiceEntityVersionPage.spec.ts
@@ -61,6 +61,9 @@ const applyServicePatch = async (
   await legacy.patch(apiContext, patchData);
 };
 
+/** Setup failures, keyed by test name, so one service cannot fail the rest. */
+const setupErrors = new Map<string, unknown>();
+
 const entities = {
   'Api Service': new ApiServiceClass(),
   'Api Collection': new ApiCollectionClass(),
@@ -95,49 +98,58 @@ test.describe('Service Version pages', () => {
     await adminUser.create(apiContext);
     await adminUser.setAdminRole(apiContext);
 
-    for (const entity of Object.values(entities)) {
-      await entity.create(apiContext);
-      const domain = EntityDataClass.domain1.responseData;
-      const patchData: Operation[] = [
-        {
-          op: 'add',
-          path: '/tags/0',
-          value: {
-            labelType: 'Manual',
-            state: 'Confirmed',
-            source: 'Classification',
-            tagFQN: 'PersonalData.SpecialCategory',
-          },
-        },
-        {
-          op: 'add',
-          path: '/tags/1',
-          value: {
-            labelType: 'Manual',
-            state: 'Confirmed',
-            source: 'Classification',
-            tagFQN: 'PII.Sensitive',
-          },
-        },
-        {
-          op: 'add',
-          path: '/description',
-          value: 'Description for newly added service',
-        },
-        {
-          op: 'add',
-          path: '/domains',
-          value: [
-            {
-              id: domain.id,
-              type: 'domain',
-              name: domain.name,
-              description: domain.description,
+    for (const [key, entity] of Object.entries(entities)) {
+      try {
+        await entity.create(apiContext);
+        const domain = EntityDataClass.domain1.responseData;
+        const patchData: Operation[] = [
+          {
+            op: 'add',
+            path: '/tags/0',
+            value: {
+              labelType: 'Manual',
+              state: 'Confirmed',
+              source: 'Classification',
+              tagFQN: 'PersonalData.SpecialCategory',
             },
-          ],
-        },
-      ];
-      await applyServicePatch(entity, apiContext, patchData);
+          },
+          {
+            op: 'add',
+            path: '/tags/1',
+            value: {
+              labelType: 'Manual',
+              state: 'Confirmed',
+              source: 'Classification',
+              tagFQN: 'PII.Sensitive',
+            },
+          },
+          {
+            op: 'add',
+            path: '/description',
+            value: 'Description for newly added service',
+          },
+          {
+            op: 'add',
+            path: '/domains',
+            value: [
+              {
+                id: domain.id,
+                type: 'domain',
+                name: domain.name,
+                description: domain.description,
+              },
+            ],
+          },
+        ];
+        await applyServicePatch(entity, apiContext, patchData);
+      } catch (error) {
+        // Setup for all eleven services shares this hook, so an API hiccup on
+        // one of them used to fail the other ten tests and get attributed to
+        // whichever test ran first -- a 404 patching the api service is why
+        // "Storage Service" has been the top flake. Record it against its own
+        // key instead and let only that test report it.
+        setupErrors.set(key, error);
+      }
     }
 
     await afterAction();
@@ -168,6 +180,12 @@ test.describe('Service Version pages', () => {
      * in the UI to highlight what changed between versions
      */
     test(key, async ({ page }) => {
+      const setupError = setupErrors.get(key);
+
+      if (setupError) {
+        throw setupError;
+      }
+
       await entity.visitEntityPage(page);
       const versionDetailResponse = page.waitForResponse(`**/versions/0.2`);
       await page.locator('[data-testid="version-button"]').click();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/ServiceEntityVersionPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/ServiceEntityVersionPage.spec.ts
@@ -105,7 +105,7 @@ test.describe('Service Version pages', () => {
         const patchData: Operation[] = [
           {
             op: 'add',
-            path: '/tags/0',
+            path: '/tags/-',
             value: {
               labelType: 'Manual',
               state: 'Confirmed',
@@ -115,7 +115,7 @@ test.describe('Service Version pages', () => {
           },
           {
             op: 'add',
-            path: '/tags/1',
+            path: '/tags/-',
             value: {
               labelType: 'Manual',
               state: 'Confirmed',

--- a/openmetadata-ui/src/main/resources/ui/playwright/eslint-rules/tests/corpus.test.mjs
+++ b/openmetadata-ui/src/main/resources/ui/playwright/eslint-rules/tests/corpus.test.mjs
@@ -41,7 +41,7 @@ test('the suppressions baseline matches its recorded state exactly', () => {
   // of the same rule in the same file stays invisible here.
   const EXPECTED = {
     'om-playwright/justified-rule-disable': 12,
-    'om-playwright/no-positional-locator': 1310,
+    'om-playwright/no-positional-locator': 1308,
     'om-playwright/require-assertion-per-test': 1,
     'playwright/no-skipped-test': 4,
     'playwright/no-wait-for-selector': 35,

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/apiResponse.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/apiResponse.ts
@@ -188,10 +188,25 @@ export const createOrFetch = async <T = ResponseBody>(
       `${lookupPath}/${encodeURIComponent(entityFqn)}?${params.join('&')}`
     );
 
-    return await okJson<T>(
+    const existing = await okJson<T>(
       getResponse,
       `${label}: fetch existing "${entityFqn}"`
     );
+
+    // A soft-deleted entity keeps its name, so it is a legitimate source of the
+    // 409 -- but handing it back gives the caller an id that 404s on the very
+    // next write, which is how a stale fixture surfaces as "instance not found"
+    // several calls later, far from the cause. Restoring is not right either:
+    // restore is async and returns the entity mid-history, while callers expect
+    // a fresh one. Fail here, where the situation is still legible.
+    if ((existing as { deleted?: boolean })?.deleted) {
+      throw new Error(
+        `${label}: "${entityFqn}" already exists but is soft-deleted, so it cannot be ` +
+          `used or written to. Hard-delete the leftover, or give this fixture a unique name.`
+      );
+    }
+
+    return existing;
   }
 
   return await okJson<T>(createResponse, label);

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/apiResponse.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/apiResponse.ts
@@ -193,16 +193,19 @@ export const createOrFetch = async <T = ResponseBody>(
       `${label}: fetch existing "${entityFqn}"`
     );
 
-    // A soft-deleted entity keeps its name, so it is a legitimate source of the
-    // 409 -- but handing it back gives the caller an id that 404s on the very
-    // next write, which is how a stale fixture surfaces as "instance not found"
-    // several calls later, far from the cause. Restoring is not right either:
-    // restore is async and returns the entity mid-history, while callers expect
-    // a fresh one. Fail here, where the situation is still legible.
+    // `include=all` above will happily return a soft-deleted entity, and handing
+    // one back gives the caller an id that 404s on its next write -- surfacing
+    // as "instance not found" several calls later, far from the cause.
+    //
+    // No caller is known to reach this: fixture names carry a uuid, and the
+    // shared fixtures are hard-deleted in teardown, so a soft-deleted name
+    // collision should not be constructible. It is kept because the cost is one
+    // comparison and the alternative failure is very hard to read -- not because
+    // it was observed. Delete it rather than build on it if it stays unreached.
     if ((existing as { deleted?: boolean })?.deleted) {
       throw new Error(
-        `${label}: "${entityFqn}" already exists but is soft-deleted, so it cannot be ` +
-          `used or written to. Hard-delete the leftover, or give this fixture a unique name.`
+        `${label}: "${entityFqn}" exists but is soft-deleted, so it cannot be written ` +
+          `to. Something is reusing a name across a delete -- do not silently adopt it.`
       );
     }
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
@@ -527,16 +527,48 @@ export const selectDataProduct = async (
   await waitForAllLoadersToDisappear(page);
   await searchBox.waitFor({ state: 'visible' });
 
-  await Promise.all([
-    page.waitForResponse('/api/v1/search/query?q=*&index=dataProduct*'),
-    searchBox.fill(dataProduct.name),
-  ]);
+  const dataProductRow = page.getByTestId(dataProduct.name);
 
-  await waitForSearchDebounce(page);
+  // Same eventual consistency as the domain listing above: a data product
+  // created moments ago can be missing from the first query, and the listing
+  // re-queries only when the search text changes. Retry the search, reloading
+  // between attempts, so the row is clicked only once it is really there.
+  //
+  // The response wait deliberately lives outside this callback -- waits here
+  // are test-bound, so a `waitForResponse` that never matches would hang the
+  // callback and the poll could never retry it.
+  let hasSearched = false;
+  await expect
+    .poll(
+      async () => {
+        if (hasSearched) {
+          await page.reload();
+          await waitForAllLoadersToDisappear(page);
+          await searchBox.waitFor({ state: 'visible' });
+        }
+        hasSearched = true;
+
+        await searchBox.fill('');
+        await searchBox.fill(dataProduct.name);
+
+        await waitForSearchDebounce(page);
+
+        return dataProductRow.isVisible();
+      },
+      {
+        message: `Wait for data product "${dataProduct.name}" to appear in the data product listing`,
+        // Deliberately well under the default 60s test budget: most callers of
+        // this helper do not set test.slow(), and a poll sized to the whole
+        // budget would starve the rest of the test instead of failing it.
+        timeout: 30_000,
+        intervals: [1_000, 2_000, 3_000, 5_000],
+      }
+    )
+    .toBe(true);
 
   await Promise.all([
     page.waitForResponse('/api/v1/dataProducts/name/*'),
-    page.getByTestId(dataProduct.name).click(),
+    dataProductRow.click(),
   ]);
 
   await waitForAllLoadersToDisappear(page);

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
@@ -722,14 +722,23 @@ export const updateDescription = async (
   validationContainerTestId = 'asset-description-container',
   endpoint?: EntityTypeEndpoint
 ) => {
+  // The description widget is lazy-loaded behind a Suspense skeleton that is
+  // not a [data-testid="loader"], so the generic loader wait does not cover it
+  // -- on Metric in particular the edit affordance was looked for before the
+  // widget had mounted.
+  await waitForWidgetsToRender(page);
+
   const editDescriptionButton = page.getByTestId('edit-description');
   const editButton = page.getByTestId('edit-button');
 
-  try {
-    await expect(editDescriptionButton).toBeVisible();
+  // Entities expose one affordance or the other. Gate on whichever renders:
+  // the previous try/catch spent a full expect timeout failing the first
+  // before it even looked for the second.
+  await expect(editDescriptionButton.or(editButton)).toBeVisible();
+
+  if (await editDescriptionButton.isVisible()) {
     await editDescriptionButton.click();
-  } catch {
-    await expect(editButton).toBeVisible();
+  } else {
     await editButton.click();
   }
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
@@ -731,14 +731,15 @@ export const updateDescription = async (
   const editDescriptionButton = page.getByTestId('edit-description');
   const editButton = page.getByTestId('edit-button');
 
-  // Entities expose one affordance or the other. Gate on whichever renders:
-  // the previous try/catch spent a full expect timeout failing the first
-  // before it even looked for the second.
-  await expect(editDescriptionButton.or(editButton)).toBeVisible();
-
-  if (await editDescriptionButton.isVisible()) {
+  // Prefer the dedicated affordance and fall back to the generic one. These
+  // must NOT be combined with .or(): a page carries one `edit-description` but
+  // several `edit-button`s, so the union is ambiguous under strict mode where
+  // each locator alone is not.
+  try {
+    await expect(editDescriptionButton).toBeVisible();
     await editDescriptionButton.click();
-  } else {
+  } catch {
+    await expect(editButton).toBeVisible();
     await editButton.click();
   }
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts
@@ -261,13 +261,20 @@ export const navigateToEntityPanelTab = async (page: Page, tabName: string) => {
 
 export const editTags = async (page: Page, tagName: string) => {
   const editIcon = page.locator('[data-testid="edit-icon-tags"]');
+  // Fallback for ML Model, which uses an 'Add' chip instead of the edit icon.
+  const addTagChip = page.locator(
+    '[data-testid="entity-tags"] [data-testid="add-tag"]'
+  );
+
+  // isVisible() resolves immediately, so gate on whichever affordance renders
+  // before discriminating -- otherwise a slow render picks the wrong branch
+  // and the click waits out the test.
+  await expect(editIcon.or(addTagChip)).toBeVisible({ timeout: 15000 });
+
   if (await editIcon.isVisible()) {
     await editIcon.click();
   } else {
-    // Fallback for ML Model which uses an 'Add' chip
-    await page
-      .locator('[data-testid="entity-tags"] [data-testid="add-tag"]')
-      .click();
+    await addTagChip.click();
   }
 
   await page
@@ -319,13 +326,17 @@ export const editGlossaryTerms = async (page: Page, termName?: string) => {
     });
 
   const editIcon = page.locator('[data-testid="edit-glossary-terms"]');
+  // Fallback for ML Model, which uses an 'Add' chip instead of the edit icon.
+  const addTermChip = page.locator(
+    '[data-testid="glossary-container"] [data-testid="add-tag"]'
+  );
+
+  await expect(editIcon.or(addTermChip)).toBeVisible({ timeout: 15000 });
+
   if (await editIcon.isVisible()) {
     await editIcon.click();
   } else {
-    // Fallback for ML Model which uses an 'Add' chip
-    await page
-      .locator('[data-testid="glossary-container"] [data-testid="add-tag"]')
-      .click();
+    await addTermChip.click();
   }
 
   await page
@@ -542,20 +553,17 @@ export const removeOwnerFromPanel = async (
         ? 'owner-select-users-search-bar'
         : 'owner-select-teams-search-bar';
     const searchBar = page.getByTestId(searchBarDataTestId);
+    // The search bar is absent for some owner widgets; filling it is the only
+    // part that differs, so keep one selection path for both shapes.
     if (await searchBar.isVisible()) {
       await searchBar.fill(ownerName);
-      const ownerItem = page
-        .locator('.ant-list-item')
-        .filter({ hasText: ownerName });
-      await ownerItem.waitFor({ state: 'visible' });
-      await ownerItem.click();
-    } else {
-      const ownerItem = page
-        .locator('.ant-list-item')
-        .filter({ hasText: ownerName });
-      await ownerItem.waitFor({ state: 'visible' });
-      await ownerItem.click();
     }
+
+    const ownerItem = page
+      .locator('.ant-list-item')
+      .filter({ hasText: ownerName });
+    await ownerItem.waitFor({ state: 'visible' });
+    await ownerItem.click();
   }
 
   const updateButton = page.getByTestId('selectable-list-update-btn');

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts
@@ -269,7 +269,13 @@ export const editTags = async (page: Page, tagName: string) => {
   // isVisible() resolves immediately, so gate on whichever affordance renders
   // before discriminating -- otherwise a slow render picks the wrong branch
   // and the click waits out the test.
-  await expect(editIcon.or(addTagChip)).toBeVisible({ timeout: 15000 });
+  // Counted, not unioned: a combined locator would be ambiguous under strict
+  // mode on any page carrying more than one of either affordance.
+  await expect
+    .poll(async () => (await editIcon.count()) + (await addTagChip.count()), {
+      timeout: 15000,
+    })
+    .toBeGreaterThan(0);
 
   if (await editIcon.isVisible()) {
     await editIcon.click();
@@ -331,7 +337,13 @@ export const editGlossaryTerms = async (page: Page, termName?: string) => {
     '[data-testid="glossary-container"] [data-testid="add-tag"]'
   );
 
-  await expect(editIcon.or(addTermChip)).toBeVisible({ timeout: 15000 });
+  // Counted, not unioned: a combined locator would be ambiguous under strict
+  // mode on any page carrying more than one of either affordance.
+  await expect
+    .poll(async () => (await editIcon.count()) + (await addTermChip.count()), {
+      timeout: 15000,
+    })
+    .toBeGreaterThan(0);
 
   if (await editIcon.isVisible()) {
     await editIcon.click();


### PR DESCRIPTION
### Describe your changes:

Six PRs were ejected from the merge queue in the last three days for failures their diffs could not have caused. This fixes the races behind them.

The pattern in every case: the test synchronises on an **HTTP response** when what it needs is **content**, then reads it **once**. A 200 proves a request finished; it does not prove Elasticsearch has indexed the row or that React has mounted the widget. When the race is lost there is no retry, so the test waits out its full budget — which is why these fail on *both* attempts and eject the PR rather than passing on retry.

| Ejected PR | Failing test | Cause |
|---|---|---|
| [#32713](https://github.com/open-metadata/OpenMetadata/pull/32713) | `DataProductAndSubdomains` › Add assets to data product | awaited the modal's own initial unfiltered search, then clicked a locator that never resolves |
| [#32713](https://github.com/open-metadata/OpenMetadata/pull/32713) | `selectDataProduct` (retry path) | one-shot search; the unhardened twin of `selectDomain` |
| [#32865](https://github.com/open-metadata/OpenMetadata/pull/32865) | `TestSuitePipelineRedeploy` › Re-deploy all | selected two pipelines, verified one |
| [#32301](https://github.com/open-metadata/OpenMetadata/pull/32301) | `MetricBulkImportExportEdit` › async export job | a fast export auto-opens the tray, removing the launcher the test waited on |
| — | `ServiceEntityVersionPage` › Storage Service | one shared `beforeAll` set up all eleven services; any hiccup failed all eleven |
| — | `EntityDataConsumer` › Update description | the description widget is lazy behind a Suspense skeleton the loader wait never covered |

`#32865` and `#32301` are the two Chirag asked me to pick up in `#ci-cleanup`.

Two of these were misattributed in a way worth calling out: `#32301`'s entire diff is two Python files (`tableau/metadata.py` and its unit test), and `#32865`'s is a glossary `NoDataPlaceholder` change. Neither can reach the UI code that failed.

### Type of change:

- [x] Bug fix

### High-level design:

Three recurring shapes, fixed the same way each time:

**Wait for content, retry the trigger.** Re-issue the search until the asset actually appears, instead of asserting once against a result set that never refreshes.

**Gate before discriminating.** `isVisible()` resolves immediately with no retry, so using it to choose between two affordances lets one slow render commit to a branch whose click then blocks. Gate on `a.or(b)` first — the idiom already used in `odcsImportExport.ts` and `bot.ts`.

**Contain blast radius and keep failures legible.** A shared hook now records per-entity failures instead of aborting; `createOrFetch` refuses to return a soft-deleted entity rather than handing back an id that 404s several calls later; `page.close()` in `finally` no longer throws a protocol error over the real failure.

Sizing was deliberate: `selectDataProduct`'s poll is 30s, not the 60s its twin uses, because most of its 13 calling specs have no `test.slow()` and a poll sized to the whole test budget starves the test instead of failing it. The response wait also stays *outside* the poll callback — waits here are test-bound, so one that never matches would hang the callback and defeat the retry.

### Tests:

#### Use cases covered
Playwright-only change; no product code is touched. Each fix targets a specific ejection traced from its run artifacts.

#### Unit tests
- [x] Not applicable — test-infrastructure change.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] This PR *is* the Playwright change.

Verified locally: `yarn lint:playwright` 0 errors at the 214 baseline, `yarn tsc:playwright` at the 165 baseline, and the exact CI checkstyle sequence (organize-imports → `lint:base --fix` → `pretty:base --write`) leaves a clean tree. `eslint-suppressions.json` **shrinks** by one — pruned with `yarn lint:playwright:suppressions`.

#### Manual test steps
Not reproducible on demand: these races only lose under merge-queue load. A green run shows the happy path is intact; it does **not** exercise the retry paths, since on healthy CI the first attempt succeeds and the loops never run. That confidence comes from the fixes matching patterns already in production use here — `selectDomain`'s retry, and IncidentManager's re-trigger.

### UI screen recording / screenshots:

Not applicable — no UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
### Note for reviewers: `.or()` is only safe for mutually exclusive locators

The first full run on this branch failed 9 tests across 5 specs because I wrote
`expect(a.or(b)).toBeVisible()` in `updateDescription`. That assertion is strict,
and a DataContracts page carries one `edit-description` but seven `edit-button`s,
so the union resolved to 8 elements and threw. The original try/catch worked
precisely because it only ever evaluated `edit-description`, which alone is
unambiguous.

The gate is right where at most one of the two can ever match — `odcsImportExport`
(addButton XOR manageButton), the tray launcher/popover, two locators scoped to a
single table row. It is wrong wherever both exist or either can repeat. The three
`.or()` uses left in this PR were each checked against that rule.

Local validation against a live server (this now works, and is ~50s per spec vs
~25min for CI):

```
[chromium] › EntityDataSteward.spec.ts:130 › Pipeline › Update description
  4 passed (48.9s)
```
