### PR TITLE
fix(ui): hide the Data Product Reviewers field in OSS

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.component.tsx
@@ -166,6 +166,37 @@ const normalizeExtensionForApi = (
   return normalized;
 };
 
+const applyDataProductFields = (
+  dataProduct: CreateDataProduct,
+  formData: DomainFormValues,
+  parentDomain?: Domain
+): void => {
+  const domainRef = formData.domains?.value as EntityReference | undefined;
+  if (domainRef?.fullyQualifiedName) {
+    dataProduct.domains = [domainRef.fullyQualifiedName];
+  } else if (parentDomain?.fullyQualifiedName) {
+    dataProduct.domains = [parentDomain.fullyQualifiedName];
+  }
+  if (formData.dataProductType?.value) {
+    dataProduct.dataProductType = formData.dataProductType
+      .value as DataProductType;
+  }
+  if (formData.visibility?.value) {
+    dataProduct.visibility = formData.visibility.value as Visibility;
+  }
+  if (formData.portfolioPriority?.value) {
+    dataProduct.portfolioPriority = formData.portfolioPriority
+      .value as PortfolioPriority;
+  }
+  // Reviewers are a Collate-only capability: the base class returns no field in
+  // OSS, so the property is never sent on the create payload there.
+  if (domainClassBase.getReviewersField()) {
+    dataProduct.reviewers = formData.reviewers.map(
+      (item) => item.value as EntityReference
+    );
+  }
+};
+
 export const transformDomainFormData = (
   formData: DomainFormValues,
   type: DomainFormType,
@@ -176,9 +207,6 @@ export const transformDomainFormData = (
     (item) => item.value as EntityReference
   );
   const ownersList = formData.owners.map(
-    (item) => item.value as EntityReference
-  );
-  const reviewersList = formData.reviewers.map(
     (item) => item.value as EntityReference
   );
 
@@ -222,25 +250,7 @@ export const transformDomainFormData = (
   } as CreateDomain | CreateDataProduct;
 
   if (type === DomainFormType.DATA_PRODUCT) {
-    const dataProduct = data as CreateDataProduct;
-    const domainRef = formData.domains?.value as EntityReference | undefined;
-    if (domainRef?.fullyQualifiedName) {
-      dataProduct.domains = [domainRef.fullyQualifiedName];
-    } else if (parentDomain?.fullyQualifiedName) {
-      dataProduct.domains = [parentDomain.fullyQualifiedName];
-    }
-    if (formData.dataProductType?.value) {
-      dataProduct.dataProductType = formData.dataProductType
-        .value as DataProductType;
-    }
-    if (formData.visibility?.value) {
-      dataProduct.visibility = formData.visibility.value as Visibility;
-    }
-    if (formData.portfolioPriority?.value) {
-      dataProduct.portfolioPriority = formData.portfolioPriority
-        .value as PortfolioPriority;
-    }
-    dataProduct.reviewers = reviewersList;
+    applyDataProductFields(data as CreateDataProduct, formData, parentDomain);
   } else {
     delete (data as CreateDomain & { domains?: unknown }).domains;
   }
@@ -947,23 +957,21 @@ const AddDomainForm = ({
     type: FieldTypes.USER_TEAM_SELECT,
   });
 
-  const reviewersField: FieldProp = applyIntakeFormRequired({
-    id: 'root/reviewers',
-    label: t('label.reviewer-plural'),
-    name: 'reviewers',
-    placeholder: t('label.select-field', {
-      field: t('label.reviewer-plural'),
-    }),
-    props: {
-      filterOption: () => true,
-      multiple: true,
-      onFocus: handleUserTeamFocus,
-      onSearchChange: (searchText: string) =>
-        debouncedUserTeamSearch(searchText),
-      options: userTeamOptions,
-    },
-    type: FieldTypes.USER_TEAM_SELECT_INPUT,
-  });
+  const baseReviewersField = domainClassBase.getReviewersField();
+  const reviewersField: FieldProp | null = baseReviewersField
+    ? applyIntakeFormRequired({
+        ...baseReviewersField,
+        props: {
+          ...baseReviewersField.props,
+          filterOption: () => true,
+          multiple: true,
+          onFocus: handleUserTeamFocus,
+          onSearchChange: (searchText: string) =>
+            debouncedUserTeamSearch(searchText),
+          options: userTeamOptions,
+        },
+      })
+    : null;
 
   const dataProductTypeField: FieldProp = applyIntakeFormRequired({
     id: 'root/dataProductType',
@@ -1065,7 +1073,9 @@ const AddDomainForm = ({
 
       <div>{getField(ownersField)}</div>
       <div>{getField(expertsField)}</div>
-      {isDataProduct && <div>{getField(reviewersField)}</div>}
+      {isDataProduct && reviewersField && (
+        <div>{getField(reviewersField)}</div>
+      )}
 
       {customPropertiesLoaded && (
         <AddDomainFormExtensionFields

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.component.tsx
@@ -1073,9 +1073,7 @@ const AddDomainForm = ({
 
       <div>{getField(ownersField)}</div>
       <div>{getField(expertsField)}</div>
-      {isDataProduct && reviewersField && (
-        <div>{getField(reviewersField)}</div>
-      )}
+      {isDataProduct && reviewersField && <div>{getField(reviewersField)}</div>}
 
       {customPropertiesLoaded && (
         <AddDomainFormExtensionFields

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.component.tsx
@@ -188,8 +188,7 @@ const applyDataProductFields = (
     dataProduct.portfolioPriority = formData.portfolioPriority
       .value as PortfolioPriority;
   }
-  // Reviewers are a Collate-only capability: the base class returns no field in
-  // OSS, so the property is never sent on the create payload there.
+  // Collate-only: no field means the property is never sent.
   if (domainClassBase.getReviewersField()) {
     dataProduct.reviewers = formData.reviewers.map(
       (item) => item.value as EntityReference

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.test.tsx
@@ -46,6 +46,7 @@ import {
 } from '../../../generated/type/tagLabel';
 import { getIntakeFormByEntityType } from '../../../rest/intakeFormsAPI';
 import { getCustomPropertiesByEntityType } from '../../../rest/metadataTypeAPI';
+import domainClassBase from '../../../utils/Domain/DomainClassBase';
 import { DomainFormType } from '../DomainPage.interface';
 import AddDomainForm, {
   DOMAIN_FORM_DEFAULTS,
@@ -236,6 +237,7 @@ jest.mock('../../../utils/Domain/DomainClassBase', () => ({
   __esModule: true,
   default: {
     getCoverImageField: jest.fn().mockReturnValue(null),
+    getReviewersField: jest.fn().mockReturnValue(null),
   },
 }));
 
@@ -329,6 +331,12 @@ const AddDomainFormHarness = ({
     />
   );
 };
+
+// jest's `clearMocks` only clears calls, not return values, so tests that opt
+// the Collate-only reviewers field in must not leak it into the next test.
+beforeEach(() => {
+  (domainClassBase.getReviewersField as jest.Mock).mockReturnValue(null);
+});
 
 describe('AddDomainForm', () => {
   beforeEach(() => {
@@ -450,6 +458,25 @@ describe('AddDomainForm', () => {
     const form = document.querySelector('form');
 
     expect(form).toBeInTheDocument();
+  });
+
+  it('hides the reviewers field when the class base provides none', () => {
+    render(<AddDomainFormHarness type={DomainFormType.DATA_PRODUCT} />);
+
+    expect(screen.queryByTestId('root/reviewers')).not.toBeInTheDocument();
+  });
+
+  it('renders the reviewers field when the class base provides one', () => {
+    (domainClassBase.getReviewersField as jest.Mock).mockReturnValue({
+      id: 'root/reviewers',
+      label: 'Reviewers',
+      name: 'reviewers',
+      type: 'user_team_select_input',
+    });
+
+    render(<AddDomainFormHarness type={DomainFormType.DATA_PRODUCT} />);
+
+    expect(screen.getByTestId('root/reviewers')).toBeInTheDocument();
   });
 
   it('wires the configured entity-reference and hyperlink intake fields', async () => {
@@ -799,6 +826,37 @@ describe('transformDomainFormData', () => {
     );
 
     expect(result).toHaveProperty('domains', ['Finance']);
+  });
+
+  it('omits reviewers from the DATA_PRODUCT payload when the field is hidden', () => {
+    const result = transformDomainFormData(
+      {
+        ...baseForm,
+        reviewers: [buildItem('reviewer-1', expertRef)],
+      },
+      DomainFormType.DATA_PRODUCT
+    );
+
+    expect(result).not.toHaveProperty('reviewers');
+  });
+
+  it('includes reviewers in the DATA_PRODUCT payload when the field is shown', () => {
+    (domainClassBase.getReviewersField as jest.Mock).mockReturnValue({
+      id: 'root/reviewers',
+      label: 'Reviewers',
+      name: 'reviewers',
+      type: 'user_team_select_input',
+    });
+
+    const result = transformDomainFormData(
+      {
+        ...baseForm,
+        reviewers: [buildItem('reviewer-1', expertRef)],
+      },
+      DomainFormType.DATA_PRODUCT
+    );
+
+    expect(result).toHaveProperty('reviewers', [expertRef]);
   });
 
   it('omits domains when DATA_PRODUCT has neither selection nor parent FQN', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.test.tsx
@@ -332,8 +332,7 @@ const AddDomainFormHarness = ({
   );
 };
 
-// jest's `clearMocks` only clears calls, not return values, so tests that opt
-// the Collate-only reviewers field in must not leak it into the next test.
+// `clearMocks` clears calls, not return values, so opt-ins would leak.
 beforeEach(() => {
   (domainClassBase.getReviewersField as jest.Mock).mockReturnValue(null);
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Domain/DomainClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Domain/DomainClassBase.test.ts
@@ -146,9 +146,6 @@ describe('DomainClassBase', () => {
   });
 
   describe('getReviewersField', () => {
-    // Guards the OSS default itself: AddDomainForm's own tests mock this class,
-    // so only an assertion on the real one keeps the Collate-only Reviewers
-    // field from reappearing on the Data Product creation form.
     it('returns null so OSS never renders the Collate-only reviewers field', () => {
       expect(instance.getReviewersField()).toBeNull();
     });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Domain/DomainClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Domain/DomainClassBase.test.ts
@@ -145,6 +145,15 @@ describe('DomainClassBase', () => {
     });
   });
 
+  describe('getReviewersField', () => {
+    // Guards the OSS default itself: AddDomainForm's own tests mock this class,
+    // so only an assertion on the real one keeps the Collate-only Reviewers
+    // field from reappearing on the Data Product creation form.
+    it('returns null so OSS never renders the Collate-only reviewers field', () => {
+      expect(instance.getReviewersField()).toBeNull();
+    });
+  });
+
   describe('singleton export', () => {
     it('default export is an instance of DomainClassBase', () => {
       expect(domainClassBase).toBeInstanceOf(DomainClassBase);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Domain/DomainClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Domain/DomainClassBase.ts
@@ -270,10 +270,7 @@ class DomainClassBase {
     return null;
   }
 
-  /**
-   * Reviewers are a Collate-only capability on Data Products. The base class
-   * returns null so the field is never rendered — and never submitted — in OSS.
-   */
+  // Reviewers are Collate-only; overridden downstream.
   public getReviewersField(): FieldProp | null {
     return null;
   }

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Domain/DomainClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Domain/DomainClassBase.ts
@@ -270,6 +270,14 @@ class DomainClassBase {
     return null;
   }
 
+  /**
+   * Reviewers are a Collate-only capability on Data Products. The base class
+   * returns null so the field is never rendered — and never submitted — in OSS.
+   */
+  public getReviewersField(): FieldProp | null {
+    return null;
+  }
+
   public getWidgetHeight(widgetName: string) {
     switch (widgetName) {
       case DetailPageWidgetKeys.DESCRIPTION:


### PR DESCRIPTION
## Problem

Reviewers are a Collate-only capability on Data Products. The details page already reflected that — `DomainClassBase`'s default layout omits the `REVIEWER` widget — but the shared `AddDomainForm` rendered the reviewers input for every Data Product, gated only on `isDataProduct`.

The result: OSS users saw and filled in a **Reviewers** field during Data Product creation, and it silently disappeared once the entity was created.

## Fix

Gate the field behind a new `DomainClassBase.getReviewersField()`, which returns `null` in OSS and is overridden downstream to supply the real field. This mirrors the `getCoverImageField()` pattern directly above it.

- `AddDomainForm` derives the field from the class base and merges in the runtime props (user/team options, focus and search handlers).
- The render site skips it when there is no field.
- `transformDomainFormData` no longer sets `reviewers` on the create payload when the field is hidden, so OSS never sends the property at all.

One incidental refactor: adding the payload guard pushed `transformDomainFormData` to cyclomatic complexity 11, failing `sonarjs/cyclomatic-complexity`. The `DATA_PRODUCT` branch is now extracted into `applyDataProductFields` — same behaviour, both functions comfortably under the limit.

## Tests

- Reviewers field is not rendered for `DATA_PRODUCT` when the class base supplies none, and is rendered when it does.
- `transformDomainFormData` omits `reviewers` when the field is hidden and includes it when shown.

`AddDomainForm` suite: 90 passed. Note that `clearMocks` only clears calls, not return values, so a file-level `beforeEach` resets the class-base mock — otherwise the opt-in tests leak into later ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)