### PR TITLE
fix: index file columns for search (#32800)

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/FileIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/FileIndex.java
@@ -1,18 +1,17 @@
 package org.openmetadata.service.search.indexes;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openmetadata.schema.entity.data.File;
+import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.service.Entity;
+import org.openmetadata.service.search.models.FlattenColumn;
 
-public class FileIndex implements DataAssetIndex {
+public record FileIndex(File file) implements ColumnIndex, DataAssetIndex {
   final Set<String> excludeFileFields = Set.of("changeDescription", "incrementalChangeDescription");
-  final File file;
-
-  public FileIndex(File file) {
-    this.file = file;
-  }
 
   @Override
   public Object getEntity() {
@@ -45,6 +44,22 @@ public class FileIndex implements DataAssetIndex {
   }
 
   public Map<String, Object> buildSearchIndexDocInternal(Map<String, Object> doc) {
+    if (file.getColumns() != null) {
+      List<FlattenColumn> cols = new ArrayList<>();
+      parseColumns(file.getColumns(), cols, null);
+
+      List<String> columnsWithChildrenName = new ArrayList<>();
+      Set<List<TagLabel>> childTags = new HashSet<>();
+      for (FlattenColumn col : cols) {
+        columnsWithChildrenName.add(col.getName());
+        if (col.getTags() != null) {
+          childTags.add(col.getTags());
+        }
+      }
+      doc.put("columnNames", columnsWithChildrenName);
+      doc.put("columnNamesFuzzy", String.join(" ", columnsWithChildrenName));
+      mergeChildTags(doc, childTags);
+    }
     doc.put("directory", getEntityWithDisplayName(file.getDirectory()));
     doc.put("fileType", file.getFileType());
     doc.put("mimeType", file.getMimeType());
@@ -66,6 +81,10 @@ public class FileIndex implements DataAssetIndex {
     fields.put("fileType", 3.0f);
     fields.put("mimeType", 2.0f);
     fields.put("fileExtension", 3.0f);
+    fields.put("columns.name", 5.0f);
+    fields.put("columns.displayName", 5.0f);
+    fields.put("columns.description", 2.0f);
+    fields.put("columnNamesFuzzy", 3.0f);
     return fields;
   }
 }

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/file_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/file_index_mapping.json
@@ -831,6 +831,45 @@
           }
         }
       },
+      "columns": {
+        "properties": {
+          "name": {
+            "type": "text",
+            "analyzer": "om_analyzer",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer"
+              },
+              "ngram": {
+                "type": "text",
+                "analyzer": "om_ngram"
+              }
+            }
+          },
+          "displayName": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "fullyQualifiedName": {
+            "type": "keyword",
+            "normalizer": "lowercase_normalizer"
+          },
+          "dataType": {
+            "type": "text"
+          },
+          "description": {
+            "type": "text",
+            "analyzer": "om_analyzer",
+            "similarity": "boolean",
+            "term_vector": "with_positions_offsets"
+          },
+          "children": {
+            "type": "object",
+            "enabled": false
+          }
+        }
+      },
       "fingerprint": {
         "type": "keyword"
       },
@@ -860,6 +899,13 @@
       "lineageSqlQueries": {
         "type": "object",
         "enabled": false
+      },
+      "columnNames": {
+        "type": "keyword"
+      },
+      "columnNamesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
       }
     }
   }

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/file_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/file_index_mapping.json
@@ -778,6 +778,45 @@
           }
         }
       },
+      "columns": {
+        "properties": {
+          "name": {
+            "type": "text",
+            "analyzer": "om_analyzer",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer"
+              },
+              "ngram": {
+                "type": "text",
+                "analyzer": "om_ngram"
+              }
+            }
+          },
+          "displayName": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "fullyQualifiedName": {
+            "type": "keyword",
+            "normalizer": "lowercase_normalizer"
+          },
+          "dataType": {
+            "type": "text"
+          },
+          "description": {
+            "type": "text",
+            "analyzer": "om_analyzer",
+            "similarity": "boolean",
+            "term_vector": "with_positions_offsets"
+          },
+          "children": {
+            "type": "object",
+            "enabled": false
+          }
+        }
+      },
       "fingerprint": {
         "type": "keyword"
       },
@@ -807,6 +846,13 @@
       "lineageSqlQueries": {
         "type": "object",
         "enabled": false
+      },
+      "columnNames": {
+        "type": "keyword"
+      },
+      "columnNamesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
       }
     }
   }

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/file_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/file_index_mapping.json
@@ -722,6 +722,45 @@
           }
         }
       },
+      "columns": {
+        "properties": {
+          "name": {
+            "type": "text",
+            "analyzer": "om_analyzer",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer"
+              },
+              "ngram": {
+                "type": "text",
+                "analyzer": "om_ngram"
+              }
+            }
+          },
+          "displayName": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "fullyQualifiedName": {
+            "type": "keyword",
+            "normalizer": "lowercase_normalizer"
+          },
+          "dataType": {
+            "type": "text"
+          },
+          "description": {
+            "type": "text",
+            "analyzer": "om_analyzer",
+            "similarity": "boolean",
+            "term_vector": "with_positions_offsets"
+          },
+          "children": {
+            "type": "object",
+            "enabled": false
+          }
+        }
+      },
       "fingerprint": {
         "type": "keyword"
       },
@@ -751,6 +790,13 @@
       "lineageSqlQueries": {
         "type": "object",
         "enabled": false
+      },
+      "columnNames": {
+        "type": "keyword"
+      },
+      "columnNamesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
       }
     }
   }

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/file_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/file_index_mapping.json
@@ -751,6 +751,45 @@
           }
         }
       },
+      "columns": {
+        "properties": {
+          "name": {
+            "type": "text",
+            "analyzer": "om_analyzer",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer"
+              },
+              "ngram": {
+                "type": "text",
+                "analyzer": "om_ngram"
+              }
+            }
+          },
+          "displayName": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "fullyQualifiedName": {
+            "type": "keyword",
+            "normalizer": "lowercase_normalizer"
+          },
+          "dataType": {
+            "type": "text"
+          },
+          "description": {
+            "type": "text",
+            "analyzer": "om_analyzer",
+            "similarity": "boolean",
+            "term_vector": "with_positions_offsets"
+          },
+          "children": {
+            "type": "object",
+            "enabled": false
+          }
+        }
+      },
       "fingerprint": {
         "type": "keyword"
       },
@@ -780,6 +819,13 @@
       "lineageSqlQueries": {
         "type": "object",
         "enabled": false
+      },
+      "columnNames": {
+        "type": "keyword"
+      },
+      "columnNamesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
       }
     }
   }


### PR DESCRIPTION
Fixes #32800.

File entities carry columns (schema file.json defines getColumns()) and getRequiredReindexFields already lists "columns", but the index mapping and FileIndex never ingested them, so File assets never match column queries in Explore. This adds the columns/columnNamesFuzzy mapping (4 locales) and ColumnIndex support.

Please add the safe-to-test label.

<!-- greptile_comment -->

<!-- greptile_summary -->

<details open><summary>Greptile Summary</summary>

This PR adds File column metadata to search indexing so File assets can participate in column-based Explore queries.
- Makes `FileIndex` a `ColumnIndex` and derives column names, fuzzy text, and child tags.
- Adds weighted column fields to File search configuration.
- Adds column mappings for all four supported search locales.
- The Japanese and Chinese column text mappings need their locale-specific analyzers before the fix works consistently across supported locales.
</details>


<details open><summary>Confidence Score: 4/5</summary>

The PR should not merge until the Japanese and Chinese File column mappings use their locale-specific analyzers, otherwise the search fix remains incomplete for those supported locales.

The Java indexing flow and English/Russian mappings follow established implementations, but Japanese and Chinese column text is indexed without the tokenizers used by equivalent localized column mappings, causing realistic missed matches.

**Files Needing Attention:** openmetadata-spec/src/main/resources/elasticsearch/jp/file_index_mapping.json, openmetadata-spec/src/main/resources/elasticsearch/zh/file_index_mapping.json
</details>


<details open><summary>Important Files Changed</summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/FileIndex.java | Implements the established ColumnIndex pattern to flatten File columns, merge child tags, and expose weighted column search fields. |
| openmetadata-spec/src/main/resources/elasticsearch/en/file_index_mapping.json | Adds File column mappings using the appropriate English analyzer. |
| openmetadata-spec/src/main/resources/elasticsearch/jp/file_index_mapping.json | Adds the required fields but uses the generic analyzer for Japanese column text rather than the established Japanese analyzer. |
| openmetadata-spec/src/main/resources/elasticsearch/ru/file_index_mapping.json | Adds File column mappings using the locale's Russian-aware `om_analyzer`. |
| openmetadata-spec/src/main/resources/elasticsearch/zh/file_index_mapping.json | Adds the required fields but bypasses the established IK analyzers for Chinese column text. |

</details>


<details open><summary>Flowchart</summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[File entity columns] --> B[SearchIndex serializes entity]
  B --> C[FileIndex flattens columns]
  C --> D[columnNames and columnNamesFuzzy]
  B --> E[columns text fields]
  D --> F[Explore column query]
  E --> F
  F --> G[Matching File assets]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["\[FIX\] make excludeFileFields static in F..."](https://github.com/open-metadata/openmetadata/commit/ea23117a40ddaba721a256806afe19cc557c2a18) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61481355)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->