### PR TITLE
Backport 2.0: use core NoDataPlaceholder for glossary term-not-found state (#32865)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryPage/GlossaryPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryPage/GlossaryPage.component.tsx
@@ -24,6 +24,7 @@ import { RefObject, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { DeleteType } from '../../../components/common/DeleteWidget/DeleteWidget.interface';
+import NoDataPlaceholder from '../../../components/common/EmptyPlaceholder/NoDataPlaceholder';
 import ErrorPlaceHolder from '../../../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import Loader from '../../../components/common/Loader/Loader';
 import ResizableLeftPanels from '../../../components/common/ResizablePanels/ResizableLeftPanels';
@@ -69,7 +70,7 @@ import {
   glossaryTermQueryKey,
   GLOSSARY_TERM_DEFAULT_FIELDS,
 } from '../../../rest/queries/glossaryTermQuery';
-import { getEntityMissingError } from '../../../utils/EntityDisplayPureUtils';
+import { getEntityMissingMessage } from '../../../utils/EntityDisplayPureUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import Fqn from '../../../utils/Fqn';
 import { checkPermission } from '../../../utils/PermissionsUtils';
@@ -557,9 +558,14 @@ const GlossaryPage = () => {
     glossaryElement = <Loader />;
   } else if (isTermNotFound) {
     glossaryElement = (
-      <ErrorPlaceHolder>
-        {getEntityMissingError(t('label.glossary-term'), glossaryFqn)}
-      </ErrorPlaceHolder>
+      <div className="content-height-with-resizable-panel tw:relative">
+        <NoDataPlaceholder
+          description={getEntityMissingMessage(
+            t('label.glossary-term'),
+            glossaryFqn
+          )}
+        />
+      </div>
     );
   } else {
     glossaryElement = (

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityDisplayPureUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityDisplayPureUtils.tsx
@@ -68,14 +68,23 @@ export const requiredField = (label: string, excludeSpace = false) => (
   </>
 );
 
-export const getEntityMissingError = (entityType: string, fqn: string) => {
+/**
+ * Inline "<entity> instance for <fqn> not found" message, without any block
+ * wrapper, so it can be dropped into inline containers such as the
+ * `EmptyPlaceholder` description slot.
+ */
+export const getEntityMissingMessage = (entityType: string, fqn: string) => {
   return (
-    <p>
+    <>
       {capitalize(entityType)} {t('label.instance-lowercase')}{' '}
       {t('label.for-lowercase')} <strong>{fqn}</strong>{' '}
       {t('label.not-found-lowercase')}
-    </p>
+    </>
   );
+};
+
+export const getEntityMissingError = (entityType: string, fqn: string) => {
+  return <p>{getEntityMissingMessage(entityType, fqn)}</p>;
 };
 
 export const getEntityDeleteMessage = (entity: string, dependents: string) => {


### PR DESCRIPTION
Backport of #32865 to `2.0`.

## What it changes

When a glossary term FQN does not resolve, the page rendered a bare `ErrorPlaceHolder` wrapping a `<p>`. It now renders the core `NoDataPlaceholder` inside a `content-height-with-resizable-panel` container, so the empty state matches every other one in the product.

To make that possible, `getEntityMissingError` is split:

- `getEntityMissingMessage` — the inline message with **no** block wrapper, so it can go into `EmptyPlaceholder`'s `description` slot.
- `getEntityMissingError` — unchanged behaviour for its existing callers, now implemented in terms of the message.

## Adaptations from main

Two, both because 2.0's baseline differs from main.

**`GlossaryPage.component.tsx`** — main has this branch inside a `renderGlossaryElement()` helper with early returns, so git offered that whole extraction as the incoming side. 2.0 still builds a `let glossaryElement` through `if / else if / else` and renders it twice further down (once as `ResizableLeftPanels`' `secondPanel.children`, once bare), so taking the incoming side would not even compile. I kept HEAD's structure and applied only the placeholder swap.

Worth noting: the resulting **changed lines are identical to main's** — verified by diff-of-diffs (`git diff -U0` of the merge commit vs `git diff -U0 HEAD^ HEAD` here, whitespace-normalised, 14 changed lines, line-for-line equal). The structural difference is context, not delta.

**`EntityDisplayPureUtils.tsx`** — the reinstated `getEntityMissingError` wrapper keeps 2.0's plain `<p>` rather than main's `<p className="tw:m-0!">`.

That class is **pre-existing on main** — the PR's diff shows it on the removed line too, so it is not part of this change. Meanwhile ~40 files render their not-found state through this helper. Pulling `tw:m-0!` back would silently change the margin on all of them, which is a visual change well outside the scope of this fix. So the only intended difference from main's diff is:

```diff
-  return <p className="tw:m-0!">{getEntityMissingMessage(entityType, fqn)}</p>;
+  return <p>{getEntityMissingMessage(entityType, fqn)}</p>;
```

## Verification

- **Every jest suite that touches `getEntityMissingError` passes — 15 suites, 295 tests**, including `GlossaryPage.test.tsx` (10/10). `ts-jest` runs with `tsconfig.json` and no `isolatedModules`, so each suite type-checks the sources it imports.
- Prettier clean on both files.
- eslint left to CI — 2.0's `eslint.config.mjs` needs a `jsonc-eslint-parser` that the borrowed `node_modules` cannot provide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
