### PR TITLE
Backport #31710 to 2.0: forward the sample-data validation timeout across docker exec

### DIFF
--- a/.github/workflows/mysql-nightly-e2e.yml
+++ b/.github/workflows/mysql-nightly-e2e.yml
@@ -75,8 +75,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
+      # Without STRICT, a sample-data DAG that outruns the validation window only
+      # logs a warning: startup continues, the reindex rebuilds the search indexes
+      # from a database still being written, and the shard fails ~40 minutes later
+      # as a bogus SearchRelevance regression. Fail at setup instead.
       - name: Setup Openmetadata Test Environment
         uses: ./.github/actions/setup-openmetadata-test-environment
+        env:
+          STRICT_DAG_VALIDATION: "true"
+          VALIDATION_TIMEOUT_SECONDS: "600"
         with:
           python-version: "3.10"
           args: "-d mysql"

--- a/docker/run_local_docker_common.sh
+++ b/docker/run_local_docker_common.sh
@@ -43,6 +43,36 @@ run_with_timeout() {
   fi
 }
 
+prepare_sample_data_validation_env() {
+  local trigger_succeeded=$1
+  local validation_timeout=$2
+  local retry_interval=$3
+  local logical_date=$4
+  local dag_run_id=$5
+  local max_retries=$6
+
+  validate_compose_env=(
+    -e "VALIDATE_COMPOSE_TIMEOUT_SECONDS=${validation_timeout}"
+    -e "VALIDATE_COMPOSE_RETRY_INTERVAL_SECONDS=${retry_interval}"
+  )
+
+  # The logical date only identifies a run when the POST creating that run
+  # succeeded. Falling back to a scheduled/latest run could accept stale data.
+  if [ "$trigger_succeeded" != "true" ]; then
+    return 1
+  fi
+
+  validate_compose_env+=(-e "VALIDATE_COMPOSE_LOGICAL_DATE=${logical_date}")
+  if [ -n "$dag_run_id" ]; then
+    validate_compose_env+=(-e "VALIDATE_COMPOSE_DAG_RUN_ID=${dag_run_id}")
+  fi
+  if [ -n "$max_retries" ]; then
+    validate_compose_env+=(-e "VALIDATE_COMPOSE_MAX_RETRIES=${max_retries}")
+  fi
+
+  return 0
+}
+
 parse_app_run_status_line() {
   local payload=$1
   local payload_shape=$2
@@ -560,37 +590,79 @@ run_local_docker_main() {
       --data-raw "{\"logical_date\": \"$LOGICAL_DATE\"}")
 
     http_code=$(echo "$response" | tail -n1)
-    if [ "$http_code" = "200" ] || [ "$http_code" = "201" ]; then
+    trigger_response_body=$(echo "$response" | sed '$d')
+    triggered_dag_run_id=""
+    trigger_succeeded=false
+    if [[ "$http_code" =~ ^2[0-9][0-9]$ ]]; then
+      trigger_succeeded=true
+      triggered_dag_run_id=$(printf '%s' "$trigger_response_body" | python3 -c "import json, sys; response = json.load(sys.stdin); print(response.get('dag_run_id', '') if isinstance(response, dict) else '')" 2>/dev/null || echo "")
       echo "✓ Successfully triggered sample_data DAG"
+      if [ -z "$triggered_dag_run_id" ]; then
+        echo "⚠ Trigger response did not include a DAG run id; validating only the trigger logical date."
+      fi
     else
       echo "⚠ Could not trigger sample_data DAG (HTTP ${http_code})"
-      echo "  Response: $(echo "$response" | sed '$d')"
-      echo "  Note: DAG may run automatically on schedule"
+      echo "  Response: ${trigger_response_body}"
+      echo "  Scheduled runs cannot be validated as belonging to this startup."
     fi
 
-    echo 'Validate sample data DAG...'
-    sleep 5
-
-    echo "Running DAG validation (this may take a few minutes)..."
     sample_data_validation_failed=false
     validation_timeout_seconds="${VALIDATION_TIMEOUT_SECONDS:-300}"
+    validate_compose_margin=60
 
-    docker exec -i openmetadata_ingestion \
-      timeout --kill-after=10s "$validation_timeout_seconds" python - < docker/validate_compose.py || {
-      local exit_code=$?
+    if ! [[ "$validation_timeout_seconds" =~ ^[1-9][0-9]*$ ]] || [ "$validation_timeout_seconds" -le "$validate_compose_margin" ]; then
+      echo "✗ VALIDATION_TIMEOUT_SECONDS must be an integer greater than ${validate_compose_margin} seconds to preserve timeout diagnostics."
+      exit 1
+    fi
+
+    # docker exec starts a process in the container's own environment — the
+    # VALIDATE_COMPOSE_* exports above (and in run_local_docker_rdf.sh) do NOT
+    # cross the boundary unless forwarded explicitly. Without this the validator
+    # silently fell back to its module defaults, capping the wait at 150s while
+    # the RDF lane believed it had granted 600s.
+    validate_compose_retry_interval="${VALIDATE_COMPOSE_RETRY_INTERVAL_SECONDS:-10}"
+    # Leave the inner deadline below the outer `timeout` so we exit with the
+    # validator's own diagnostics instead of being SIGTERMed mid-report. The margin
+    # has to cover the validator's whole post-deadline diagnostic pass
+    # (DIAGNOSTIC_BUDGET_SECONDS plus one in-flight poll), so every accepted
+    # validation window reserves the same 60-second margin.
+    validate_compose_timeout=$(( validation_timeout_seconds - validate_compose_margin ))
+
+    if ! prepare_sample_data_validation_env \
+      "$trigger_succeeded" \
+      "$validate_compose_timeout" \
+      "$validate_compose_retry_interval" \
+      "$LOGICAL_DATE" \
+      "$triggered_dag_run_id" \
+      "${VALIDATE_COMPOSE_MAX_RETRIES:-}"; then
       sample_data_validation_failed=true
-      if [ $exit_code -eq 124 ]; then
-        echo "⚠ Warning: DAG validation timed out after ${validation_timeout_seconds} seconds"
-        echo "  The DAG may still be running. Check Airflow UI at http://localhost:8080"
-      else
-        echo "⚠ Warning: DAG validation failed with exit code $exit_code"
-      fi
-      echo "  Continuing with remaining setup..."
-    }
+      echo "⚠ Skipping sample_data DAG validation because its trigger did not succeed."
+    else
+      echo 'Validate sample data DAG...'
+      sleep 5
+
+      echo "Running DAG validation (this may take a few minutes)..."
+      docker exec -i \
+        "${validate_compose_env[@]}" \
+        openmetadata_ingestion \
+        timeout --kill-after=10s "$validation_timeout_seconds" python -u - < docker/validate_compose.py || {
+        local exit_code=$?
+        sample_data_validation_failed=true
+        if [ $exit_code -eq 124 ]; then
+          echo "⚠ Warning: DAG validation timed out after ${validation_timeout_seconds} seconds"
+          echo "  The DAG may still be running. Check Airflow UI at http://localhost:8080"
+        else
+          echo "⚠ Warning: DAG validation failed with exit code $exit_code"
+        fi
+      }
+    fi
 
     if [[ "${STRICT_DAG_VALIDATION:-false}" == "true" && "$sample_data_validation_failed" == "true" ]]; then
       echo "✗ Startup requires sample data ingestion to complete before continuing."
       exit 1
+    fi
+    if [[ "$sample_data_validation_failed" == "true" ]]; then
+      echo "⚠ Continuing with remaining setup despite sample-data validation failure."
     fi
 
     sleep 5

--- a/docker/run_local_docker_rdf.sh
+++ b/docker/run_local_docker_rdf.sh
@@ -55,11 +55,11 @@ if [[ $startFuseki == "true" ]]; then
   export RDF_BASE_URI="${RDF_BASE_URI:-https://open-metadata.org/}"
   export RDF_DATASET="${RDF_DATASET:-openmetadata}"
   # RDF listeners slow down sample-data ingestion enough that the default 5-minute
-  # validation window is too aggressive for CI.
-  export VALIDATE_COMPOSE_MAX_RETRIES="${VALIDATE_COMPOSE_MAX_RETRIES:-60}"
-  export VALIDATE_COMPOSE_DAG_RUN_RETRIES="${VALIDATE_COMPOSE_DAG_RUN_RETRIES:-120}"
+  # validation window is too aggressive for CI. VALIDATION_TIMEOUT_SECONDS is the only
+  # knob: it sets the outer `timeout` and the validator's deadline is derived from it.
+  # Do not reintroduce VALIDATE_COMPOSE_MAX_RETRIES here — it overrides that deadline,
+  # so raising VALIDATION_TIMEOUT_SECONDS would silently have no effect.
   export VALIDATE_COMPOSE_RETRY_INTERVAL_SECONDS="${VALIDATE_COMPOSE_RETRY_INTERVAL_SECONDS:-10}"
-  export VALIDATE_COMPOSE_DAG_RUN_POLL_SECONDS="${VALIDATE_COMPOSE_DAG_RUN_POLL_SECONDS:-5}"
   export VALIDATION_TIMEOUT_SECONDS="${VALIDATION_TIMEOUT_SECONDS:-900}"
   export APP_RUN_WAIT_TIMEOUT_SECONDS="${APP_RUN_WAIT_TIMEOUT_SECONDS:-900}"
   export STRICT_DAG_VALIDATION=true
@@ -75,9 +75,7 @@ else
   unset RDF_BASE_URI
   unset RDF_DATASET
   unset VALIDATE_COMPOSE_MAX_RETRIES
-  unset VALIDATE_COMPOSE_DAG_RUN_RETRIES
   unset VALIDATE_COMPOSE_RETRY_INTERVAL_SECONDS
-  unset VALIDATE_COMPOSE_DAG_RUN_POLL_SECONDS
   export VALIDATION_TIMEOUT_SECONDS="${VALIDATION_TIMEOUT_SECONDS:-300}"
   export APP_RUN_WAIT_TIMEOUT_SECONDS="${APP_RUN_WAIT_TIMEOUT_SECONDS:-300}"
   unset STRICT_DAG_VALIDATION

--- a/docker/validate_compose.py
+++ b/docker/validate_compose.py
@@ -1,20 +1,85 @@
+"""Wait for the sample_data DAG triggered by run_local_docker_common.sh to finish.
+
+This runs inside the openmetadata_ingestion container via `docker exec`, which does
+NOT inherit the host shell's exports. Every knob therefore has to be handed over as
+an explicit `-e` flag by the caller; see the `docker exec` invocation in
+run_local_docker_common.sh.
+
+Output uses plain `print(flush=True)` rather than metadata.utils.logger: that module's
+`basicConfig` never sets a level, so the root logger stays at WARNING and every INFO
+progress line is silently dropped — the reason CI failures here used to arrive with no
+diagnostics at all.
+
+Every HTTP call is bounded by the time actually left, and the post-deadline diagnostic
+pass gets its own small budget. A flat per-request timeout larger than the caller's
+margin would let one stalled Airflow call carry the process past the outer `timeout`,
+which killed the very diagnostics this script exists to print.
+
+The wait is governed by VALIDATION_TIMEOUT_SECONDS on the host, forwarded here as
+VALIDATE_COMPOSE_TIMEOUT_SECONDS. VALIDATE_COMPOSE_MAX_RETRIES may shorten that
+deadline, but it cannot extend past the outer timeout's diagnostic margin.
+"""
+
 import os
+import sys
 import time
-from pprint import pprint
-from typing import Optional, Tuple
+from urllib.parse import quote, urlencode
 
 import requests
-from metadata.utils.logger import log_ansi_encoded_string
 
-
-HEADER_JSON = {"Content-Type": "application/json"}
-REQUESTS_TIMEOUT = 60 * 5
 AIRFLOW_URL = "http://localhost:8080"
 USERNAME = "admin"
 PASSWORD = "admin"
 
-_access_token: Optional[str] = None
-_last_dag_logs_supported: Optional[bool] = None
+DAG_ID = "sample_data"
+TASK_ID = "ingest_using_recipe"
+
+# Upper bound for a single poll request. Well under any caller margin, so a stalled
+# Airflow cannot outlive the deadline.
+POLL_REQUEST_TIMEOUT = 30
+# Floor, so a request issued moments before the deadline still gets a fair chance
+# rather than failing on a sub-second timeout.
+MIN_REQUEST_TIMEOUT = 5
+# The diagnostic pass runs *after* the deadline, inside the caller's margin, so it is
+# capped hard: total wall clock and per request.
+DIAGNOSTIC_BUDGET_SECONDS = 20
+DIAGNOSTIC_REQUEST_TIMEOUT = 8
+TASK_INSTANCE_PAGE_SIZE = 100
+
+_access_token: str | None = None
+_http_session: requests.Session | None = None
+_last_dag_logs_supported: bool | None = None
+_deadline: float | None = None
+
+
+def log(message: str) -> None:
+    print(message, flush=True)
+
+
+def get_http_session() -> requests.Session:
+    """Return the HTTP session shared by this validator invocation."""
+    global _http_session
+
+    if _http_session is None:
+        _http_session = requests.Session()
+    return _http_session
+
+
+def get_json_object(
+    response: requests.Response, response_name: str
+) -> dict[str, object] | None:
+    """Parse an Airflow JSON object without turning a proxy error into a validator crash."""
+    try:
+        payload = response.json()
+    except ValueError:
+        log(f"Airflow returned invalid JSON for {response_name}.")
+        return None
+
+    if not isinstance(payload, dict):
+        log(f"Airflow returned an invalid {response_name} response.")
+        return None
+
+    return payload
 
 
 def get_env_int(name: str, default: int) -> int:
@@ -25,164 +90,408 @@ def get_env_int(name: str, default: int) -> int:
     try:
         return int(value)
     except ValueError:
-        log_ansi_encoded_string(
-            message=f"Invalid integer for {name}: {value}. Falling back to {default}."
-        )
+        log(f"Invalid integer for {name}: {value}. Falling back to {default}.")
         return default
 
 
-def get_access_token() -> str:
-    """Get OAuth access token for Airflow 3.x API."""
+def resolve_timeout_seconds(poll_interval_seconds: int) -> int:
+    """
+    Wall-clock budget for the whole wait.
+
+    An explicit retry count can shorten the wait, but cannot let it outlive the
+    forwarded deadline. The host reserves the remaining outer-timeout budget for
+    diagnostics, so extending this deadline would let `timeout` kill their output.
+    """
+    timeout_seconds = get_env_int("VALIDATE_COMPOSE_TIMEOUT_SECONDS", 600)
+    if os.getenv("VALIDATE_COMPOSE_MAX_RETRIES") is not None:
+        retry_timeout_seconds = get_env_int("VALIDATE_COMPOSE_MAX_RETRIES", 60) * poll_interval_seconds
+        return min(timeout_seconds, retry_timeout_seconds)
+
+    return timeout_seconds
+
+
+def remaining_seconds() -> float:
+    """Time left before the wait deadline; infinite until main() sets one."""
+    if _deadline is None:
+        return float("inf")
+
+    return _deadline - time.monotonic()
+
+
+def poll_request_timeout() -> float:
+    """Bound a poll request by whatever budget is actually left."""
+    return max(MIN_REQUEST_TIMEOUT, min(POLL_REQUEST_TIMEOUT, remaining_seconds()))
+
+
+def get_access_token(timeout: float) -> str | None:
+    """Get OAuth access token for the Airflow 3.x API."""
     global _access_token
 
     if _access_token:
         return _access_token
 
-    response = requests.post(
-        f"{AIRFLOW_URL}/auth/token",
-        headers={"Content-Type": "application/json"},
-        json={"username": USERNAME, "password": PASSWORD},
-        timeout=10
-    )
+    try:
+        response = get_http_session().post(
+            f"{AIRFLOW_URL}/auth/token",
+            headers={"Content-Type": "application/json"},
+            json={"username": USERNAME, "password": PASSWORD},
+            timeout=timeout,
+        )
+    except requests.exceptions.RequestException as exc:
+        log(f"Could not reach the Airflow token endpoint: {exc}")
+        return None
 
-    if response.status_code == 201:
-        data = response.json()
-        _access_token = data.get("access_token")
-        return _access_token
-    else:
-        raise Exception(f"Failed to get access token: {response.status_code} - {response.text}")
+    if response.status_code != 201:
+        log(f"Failed to get access token: {response.status_code} - {response.text}")
+        return None
+
+    payload = get_json_object(response, "access-token")
+    if payload is None:
+        return None
+
+    access_token = payload.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        log("Airflow access-token response did not contain an access token.")
+        return None
+
+    _access_token = access_token
+    return _access_token
 
 
-def get_auth_headers() -> dict:
-    """Get authorization headers with Bearer token."""
-    token = get_access_token()
-    return {
-        "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json"
-    }
-
-
-def get_last_run_info() -> Tuple[str, str]:
+def airflow_get(path: str, timeout: float) -> requests.Response | None:
     """
-    Make sure we can pick up the latest run info
-    """
-    max_retries = get_env_int("VALIDATE_COMPOSE_DAG_RUN_RETRIES", 30)
-    poll_interval_seconds = get_env_int("VALIDATE_COMPOSE_DAG_RUN_POLL_SECONDS", 5)
-    retries = 0
+    GET an Airflow API path, refreshing the cached token on 401.
 
-    while retries < max_retries:
+    Returns None on any transport/auth problem so callers can keep polling: the
+    Airflow API is routinely unreachable for the first ~40s after the container
+    starts, and a blip mid-poll must not abort the wait.
+    """
+    global _access_token
+
+    # Authentication shares this endpoint's budget; otherwise a token refresh can
+    # double the duration of a poll issued close to the validation deadline.
+    request_deadline = time.monotonic() + timeout
+    for request_attempt in range(2):
+        remaining = request_deadline - time.monotonic()
+        if remaining <= 0:
+            log(f"No time left to call {path} after authentication.")
+            return None
+
+        token = get_access_token(remaining)
+        if not token:
+            return None
+
+        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+        remaining = request_deadline - time.monotonic()
+        if remaining <= 0:
+            log(f"No time left to call {path} after authentication.")
+            return None
+
         try:
-            res = requests.get(
-                f"{AIRFLOW_URL}/api/v2/dags/sample_data/dagRuns",
-                headers=get_auth_headers(),
-                timeout=REQUESTS_TIMEOUT
+            response = get_http_session().get(
+                f"{AIRFLOW_URL}{path}", headers=headers, timeout=remaining
             )
-            res.raise_for_status()
-            runs = res.json()
-            dag_runs = runs.get("dag_runs", [])
+        except requests.exceptions.RequestException as exc:
+            log(f"Error calling {path}: {exc}")
+            return None
 
-            if dag_runs and len(dag_runs) > 0:
-                # Sort by logical_date descending to get the latest run
-                dag_runs_sorted = sorted(
-                    dag_runs,
-                    key=lambda x: x.get("logical_date", ""),
-                    reverse=True
-                )
-                dag_run = dag_runs_sorted[0]
-                dag_run_id = dag_run.get("dag_run_id")
-                state = dag_run.get("state", "").lower()
+        if response.status_code != 401:
+            return response
 
-                if dag_run_id:
-                    log_ansi_encoded_string(
-                        message=f"Found DAG run: {dag_run_id} with state: {state}"
-                    )
-                    return dag_run_id, state
-            else:
-                log_ansi_encoded_string(message="No DAG runs found yet, waiting...")
+        _access_token = None
+        if request_attempt == 0:
+            log(f"Airflow token rejected on {path}; refreshing it once.")
+        else:
+            log(f"Airflow token rejected after refresh on {path}.")
 
-        except requests.exceptions.HTTPError as e:
-            if e.response.status_code == 401:
-                global _access_token
-                _access_token = None
-            log_ansi_encoded_string(message=f"Error getting DAG runs: {e}")
-
-        time.sleep(poll_interval_seconds)
-        retries += 1
-
-    return None, None
+    return None
 
 
-def print_last_run_logs() -> None:
+def get_last_run_info(
+    target_dag_run_id: str | None,
+    target_logical_date: str | None,
+    timeout: float,
+) -> tuple[str | None, str | None, bool]:
     """
-    Show the logs
+    Targeted sample_data DAG run id and state.
+
+    The third element reports whether the poll itself succeeded, so the caller can
+    tell "Airflow has no run yet" apart from "we could not reach Airflow" — during the
+    ~40s startup window those are very different things.
     """
+    if target_dag_run_id:
+        path = f"/api/v2/dags/{DAG_ID}/dagRuns/{quote(target_dag_run_id, safe='')}"
+    else:
+        query_params: dict[str, str | int] = {"limit": 1, "order_by": "-logical_date"}
+        if target_logical_date:
+            query_params["logical_date_gte"] = target_logical_date
+            query_params["logical_date_lte"] = target_logical_date
+        path = f"/api/v2/dags/{DAG_ID}/dagRuns?{urlencode(query_params)}"
+
+    response = airflow_get(path, timeout)
+    if response is None:
+        return None, None, False
+
+    if response.status_code != 200:
+        log(f"Error getting DAG runs: {response.status_code} - {response.text}")
+        return None, None, False
+
+    payload = get_json_object(response, "DAG-run" if target_dag_run_id else "DAG-runs")
+    if payload is None:
+        return None, None, False
+
+    if target_dag_run_id:
+        dag_run_id = payload.get("dag_run_id")
+        if not isinstance(dag_run_id, str) or not dag_run_id:
+            log("Airflow DAG-run response did not contain a dag_run_id.")
+            return None, None, False
+
+        state = payload.get("state")
+        return dag_run_id, state.lower() if isinstance(state, str) else "", True
+
+    dag_runs = payload.get("dag_runs")
+    if not isinstance(dag_runs, list):
+        log("Airflow DAG-runs response did not contain a list of dag_runs.")
+        return None, None, False
+    if not dag_runs:
+        return None, None, True
+
+    if not all(isinstance(run, dict) for run in dag_runs):
+        log("Airflow DAG-runs response contained an invalid DAG run.")
+        return None, None, False
+
+    dag_run = max(
+        dag_runs,
+        key=lambda run: run.get("logical_date")
+        if isinstance(run.get("logical_date"), str)
+        else "",
+    )
+    dag_run_id = dag_run.get("dag_run_id")
+    if not isinstance(dag_run_id, str) or not dag_run_id:
+        log("Airflow DAG-runs response did not contain a dag_run_id.")
+        return None, None, False
+
+    state = dag_run.get("state")
+    return dag_run_id, state.lower() if isinstance(state, str) else "", True
+
+
+def print_last_run_logs(timeout: float) -> None:
+    """Show the task logs, when the OpenMetadata Airflow plugin route is available."""
     global _last_dag_logs_supported
 
-    try:
-        response = requests.get(
-            f"{AIRFLOW_URL}/api/v2/openmetadata/last_dag_logs?dag_id=sample_data&task_id=ingest_using_recipe",
-            headers=get_auth_headers(),
-            timeout=REQUESTS_TIMEOUT
-        )
+    if _last_dag_logs_supported is False:
+        return
 
-        if response.status_code == 404:
-            if _last_dag_logs_supported is not False:
-                log_ansi_encoded_string(
-                    message="Airflow last_dag_logs route is unavailable. Skipping task log fetch."
-                )
-                _last_dag_logs_supported = False
+    response = airflow_get(f"/api/v2/openmetadata/last_dag_logs?dag_id={DAG_ID}&task_id={TASK_ID}", timeout)
+    if response is None:
+        return
+
+    if response.status_code == 404:
+        log("Airflow last_dag_logs route is unavailable. Skipping task log fetch.")
+        _last_dag_logs_supported = False
+        return
+
+    if response.status_code != 200:
+        log(f"Could not fetch logs: {response.status_code} - {response.text}")
+        return
+
+    _last_dag_logs_supported = True
+    log(response.text)
+
+
+def print_task_instance_states(dag_run_id: str, timeout: float) -> None:
+    """
+    Report per-task state for the run.
+
+    This is what tells "the DAG needed a few more seconds" apart from "a task is
+    stuck or dead" when the deadline is hit — without it the failure is
+    indistinguishable from a hang.
+    """
+    request_deadline = time.monotonic() + timeout
+    offset = 0
+    task_instances_path = (
+        f"/api/v2/dags/{DAG_ID}/dagRuns/{quote(dag_run_id, safe='')}/taskInstances"
+    )
+
+    while True:
+        remaining = request_deadline - time.monotonic()
+        if remaining <= 0:
+            log("Diagnostic request budget exhausted while fetching task-instance states.")
             return
 
-        response.raise_for_status()
-        _last_dag_logs_supported = True
-        pprint(response.text)
-    except Exception as e:
-        log_ansi_encoded_string(message=f"Could not fetch logs: {e}")
+        query_params = {"limit": TASK_INSTANCE_PAGE_SIZE, "offset": offset}
+        path = f"{task_instances_path}?{urlencode(query_params)}"
+        response = airflow_get(path, remaining)
+        if response is None:
+            return
+        if response.status_code != 200:
+            log(f"Could not fetch task instances: {response.status_code} - {response.text}")
+            return
 
+        payload = get_json_object(response, "task-instances")
+        if payload is None:
+            return
 
-def main():
-    max_retries = get_env_int("VALIDATE_COMPOSE_MAX_RETRIES", 15)
-    retry_interval_seconds = get_env_int("VALIDATE_COMPOSE_RETRY_INTERVAL_SECONDS", 10)
-    retries = 0
+        task_instances = payload.get("task_instances")
+        if not isinstance(task_instances, list):
+            log("Airflow task-instances response did not contain a list of task_instances.")
+            return
 
-    while retries < max_retries:
-        dag_run_id, state = get_last_run_info()
-
-        if not dag_run_id:
-            log_ansi_encoded_string(
-                message="Waiting for DAG run to start...",
+        if offset == 0:
+            log(f"Task instances for {dag_run_id}:")
+        for task in task_instances:
+            if not isinstance(task, dict):
+                log("Airflow task-instances response contained an invalid task instance.")
+                continue
+            log(
+                f"  - {task.get('task_id')}: state={task.get('state')} "
+                f"try={task.get('try_number')} start={task.get('start_date')} "
+                f"end={task.get('end_date')} duration={task.get('duration')}"
             )
-            time.sleep(retry_interval_seconds)
-            retries += 1
-            continue
 
-        if state == "success":
-            log_ansi_encoded_string(message=f"DAG run: [{dag_run_id}, {state}]")
-            print_last_run_logs()
-            log_ansi_encoded_string(message="Sample data ingestion completed successfully!")
-            break
-        elif state in ["running", "queued"]:
-            log_ansi_encoded_string(
-                message=f"DAG run [{dag_run_id}] is {state}. Waiting for completion...",
-            )
-            print_last_run_logs()
-            time.sleep(retry_interval_seconds)
-            retries += 1
-        elif state == "failed":
-            log_ansi_encoded_string(message=f"DAG run [{dag_run_id}] FAILED!")
-            print_last_run_logs()
-            raise Exception(f"Sample data ingestion failed. DAG run state: {state}")
+        offset += len(task_instances)
+        total_entries = payload.get("total_entries")
+        if total_entries is not None:
+            if type(total_entries) is not int:
+                log("Airflow task-instances response contained an invalid total_entries value.")
+                return
+            if offset >= total_entries:
+                return
+            if not task_instances:
+                log("Airflow task-instances response ended before total_entries.")
+                return
+        elif len(task_instances) < TASK_INSTANCE_PAGE_SIZE:
+            return
+
+
+def dump_diagnostics(
+    dag_run_id: str | None,
+    dag_run_state: str | None,
+) -> tuple[str | None, str | None]:
+    """
+    Best-effort failure detail, on a hard budget.
+
+    Runs after the deadline has already passed, so it lives entirely inside the
+    caller's margin below the outer `timeout`. Each step is skipped rather than
+    allowed to overrun — partial diagnostics beat being SIGTERMed with none.
+    """
+    budget_end = time.monotonic() + DIAGNOSTIC_BUDGET_SECONDS
+
+    def step_timeout() -> float | None:
+        left = budget_end - time.monotonic()
+        if left <= 1:
+            return None
+        return min(DIAGNOSTIC_REQUEST_TIMEOUT, left)
+
+    diagnostic_dag_run_id = dag_run_id
+    diagnostic_dag_run_state = dag_run_state
+
+    if dag_run_id:
+        timeout = step_timeout()
+        if timeout is None:
+            log("Diagnostic budget exhausted; skipping DAG-run state.")
         else:
-            log_ansi_encoded_string(
-                message=f"Waiting for sample data ingestion. Current state: {state}",
+            observed_dag_run_id, observed_state, _ = get_last_run_info(
+                dag_run_id,
+                None,
+                timeout,
             )
-            print_last_run_logs()
-            time.sleep(retry_interval_seconds)
-            retries += 1
+            if observed_dag_run_id:
+                diagnostic_dag_run_id = observed_dag_run_id
+                diagnostic_dag_run_state = observed_state
+                log(
+                    f"Diagnostic DAG run [{observed_dag_run_id}] is "
+                    f"{observed_state or 'unknown'}."
+                )
 
-    if retries == max_retries:
-        raise Exception("Max retries exceeded. Sample data ingestion was not successful.")
+        timeout = step_timeout()
+        if timeout is None:
+            log("Diagnostic budget exhausted; skipping task-instance states.")
+        else:
+            print_task_instance_states(dag_run_id, timeout)
+
+    timeout = step_timeout()
+    if timeout is None:
+        log("Diagnostic budget exhausted; skipping task log fetch.")
+    else:
+        print_last_run_logs(timeout)
+
+    return diagnostic_dag_run_id, diagnostic_dag_run_state
+
+
+def main() -> None:
+    global _deadline
+
+    poll_interval_seconds = get_env_int("VALIDATE_COMPOSE_RETRY_INTERVAL_SECONDS", 10)
+    timeout_seconds = resolve_timeout_seconds(poll_interval_seconds)
+    _deadline = time.monotonic() + timeout_seconds
+    target_dag_run_id = os.getenv("VALIDATE_COMPOSE_DAG_RUN_ID") or None
+    target_logical_date = os.getenv("VALIDATE_COMPOSE_LOGICAL_DATE") or None
+
+    if target_dag_run_id:
+        target_description = f"DAG run {target_dag_run_id}"
+    elif target_logical_date:
+        target_description = f"DAG run at logical date {target_logical_date}"
+    else:
+        target_description = f"latest {DAG_ID} DAG run"
+    log(f"Waiting up to {timeout_seconds}s for {target_description} (polling every {poll_interval_seconds}s).")
+
+    last_observed_dag_run_id: str | None = None
+    last_observed_state: str | None = None
+
+    while True:
+        dag_run_id, state, polled = get_last_run_info(
+            target_dag_run_id,
+            target_logical_date,
+            poll_request_timeout(),
+        )
+        if dag_run_id:
+            last_observed_dag_run_id = dag_run_id
+            last_observed_state = state
+
+        if dag_run_id and state == "success":
+            log(f"DAG run: [{dag_run_id}, {state}]")
+            print_last_run_logs(poll_request_timeout())
+            log("Sample data ingestion completed successfully!")
+            return
+
+        if dag_run_id and state == "failed":
+            log(f"DAG run [{dag_run_id}] FAILED!")
+            dump_diagnostics(dag_run_id, state)
+            raise SystemExit(f"Sample data ingestion failed. DAG run state: {state}")
+
+        if dag_run_id:
+            log(f"DAG run [{dag_run_id}] is {state}. Waiting for completion...")
+        elif polled:
+            log("Airflow has no DAG run yet. Waiting for it to start...")
+        else:
+            log("Could not reach the Airflow API. Retrying...")
+
+        remaining = remaining_seconds()
+        if remaining <= 0:
+            break
+
+        time.sleep(min(poll_interval_seconds, remaining))
+
+    log(f"Timed out after {timeout_seconds}s waiting for the {DAG_ID} DAG.")
+    diagnostic_dag_run_id, diagnostic_dag_run_state = dump_diagnostics(
+        last_observed_dag_run_id or target_dag_run_id,
+        last_observed_state,
+    )
+    if diagnostic_dag_run_id:
+        last_observed_dag_run_id = diagnostic_dag_run_id
+        last_observed_state = diagnostic_dag_run_state
+    raise SystemExit(
+        f"Sample data ingestion did not finish within {timeout_seconds}s "
+        f"(last observed run={last_observed_dag_run_id}, state={last_observed_state}). Raise "
+        "VALIDATION_TIMEOUT_SECONDS if the run above was still making progress."
+    )
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except SystemExit as exc:
+        if exc.code:
+            log(f"ERROR: {exc.code}")
+        sys.exit(1 if exc.code else 0)

--- a/ingestion/tests/unit/test_validate_compose.py
+++ b/ingestion/tests/unit/test_validate_compose.py
@@ -1,0 +1,512 @@
+#  Copyright 2026 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Regression coverage for sample-data DAG validation."""
+
+import importlib.util
+import subprocess
+from pathlib import Path
+from types import ModuleType
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+import requests
+
+VALIDATE_COMPOSE_PATH = Path(__file__).resolve().parents[3] / "docker" / "validate_compose.py"
+RUN_LOCAL_DOCKER_COMMON_PATH = Path(__file__).resolve().parents[3] / "docker" / "run_local_docker_common.sh"
+
+
+class FakeClock:
+    """Deterministic clock for a validator polling cycle."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class FakeAirflowResponse:
+    """Minimal response returned by the Airflow HTTP boundary."""
+
+    def __init__(
+        self,
+        payload: object,
+        text: str = "",
+        status_code: int = 200,
+        json_error: ValueError | None = None,
+    ) -> None:
+        self.payload = payload
+        self.text = text
+        self.status_code = status_code
+        self.json_error = json_error
+
+    def json(self) -> object:
+        if self.json_error:
+            raise self.json_error
+        return self.payload
+
+
+class FakeTokenResponse:
+    """Minimal token response returned by the Airflow authentication boundary."""
+
+    status_code = 201
+
+    def json(self) -> dict[str, str]:
+        return {"access_token": "token"}
+
+
+class FakeHttpSession:
+    """Scriptable HTTP boundary for the container-side Airflow client."""
+
+    def __init__(
+        self,
+        post_responses: list[FakeAirflowResponse | FakeTokenResponse],
+        get_responses: list[FakeAirflowResponse | requests.exceptions.RequestException],
+    ) -> None:
+        self.post_responses = post_responses
+        self.get_responses = get_responses
+        self.post_calls: list[dict[str, object]] = []
+        self.get_calls: list[dict[str, object]] = []
+
+    def post(self, url: str, **kwargs: object) -> FakeAirflowResponse | FakeTokenResponse:
+        self.post_calls.append({"url": url, **kwargs})
+        return self.post_responses.pop(0)
+
+    def get(self, url: str, **kwargs: object) -> FakeAirflowResponse:
+        self.get_calls.append({"url": url, **kwargs})
+        response = self.get_responses.pop(0)
+        if isinstance(response, requests.exceptions.RequestException):
+            raise response
+        return response
+
+
+def load_validate_compose() -> ModuleType:
+    """Load the Docker-executed validator without running its CLI entry point."""
+    spec = importlib.util.spec_from_file_location("validate_compose_test_module", VALIDATE_COMPOSE_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def prepare_sample_data_validation_env(
+    trigger_succeeded: str,
+    logical_date: str,
+    dag_run_id: str,
+    max_retries: str,
+) -> tuple[int, list[str]]:
+    """Run the shell's validation environment builder and return its outcome."""
+    command = """
+source "$1"
+prepare_sample_data_validation_env "$2" "$3" "$4" "$5" "$6" "$7"
+status=$?
+printf '%s\\n' "${validate_compose_env[@]}"
+exit "$status"
+"""
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            command,
+            "bash",
+            str(RUN_LOCAL_DOCKER_COMMON_PATH),
+            trigger_succeeded,
+            "240",
+            "10",
+            logical_date,
+            dag_run_id,
+            max_retries,
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    return result.returncode, result.stdout.splitlines()
+
+
+def test_failed_trigger_does_not_prepare_a_validation_target() -> None:
+    """A failed POST cannot safely be validated as an unrelated scheduled DAG run."""
+    exit_code, environment = prepare_sample_data_validation_env(
+        "false",
+        "2026-08-24T00:00:00Z",
+        "",
+        "",
+    )
+
+    assert exit_code == 1
+    assert environment == [
+        "-e",
+        "VALIDATE_COMPOSE_TIMEOUT_SECONDS=240",
+        "-e",
+        "VALIDATE_COMPOSE_RETRY_INTERVAL_SECONDS=10",
+    ]
+
+
+def test_successful_trigger_preserves_its_validation_target() -> None:
+    """A successful trigger keeps both its logical date and explicit run identity."""
+    exit_code, environment = prepare_sample_data_validation_env(
+        "true",
+        "2026-08-24T00:00:00Z",
+        "manual__target",
+        "7",
+    )
+
+    assert exit_code == 0
+    assert environment == [
+        "-e",
+        "VALIDATE_COMPOSE_TIMEOUT_SECONDS=240",
+        "-e",
+        "VALIDATE_COMPOSE_RETRY_INTERVAL_SECONDS=10",
+        "-e",
+        "VALIDATE_COMPOSE_LOGICAL_DATE=2026-08-24T00:00:00Z",
+        "-e",
+        "VALIDATE_COMPOSE_DAG_RUN_ID=manual__target",
+        "-e",
+        "VALIDATE_COMPOSE_MAX_RETRIES=7",
+    ]
+
+
+def test_successful_trigger_without_run_id_targets_its_logical_date() -> None:
+    """A successful POST can safely use its submitted logical date as a fallback target."""
+    exit_code, environment = prepare_sample_data_validation_env(
+        "true",
+        "2026-08-24T00:00:00Z",
+        "",
+        "",
+    )
+
+    assert exit_code == 0
+    assert environment == [
+        "-e",
+        "VALIDATE_COMPOSE_TIMEOUT_SECONDS=240",
+        "-e",
+        "VALIDATE_COMPOSE_RETRY_INTERVAL_SECONDS=10",
+        "-e",
+        "VALIDATE_COMPOSE_LOGICAL_DATE=2026-08-24T00:00:00Z",
+    ]
+
+
+def test_main_does_not_accept_historical_success_for_triggered_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The validator follows the specific run created by the startup script."""
+    validator = load_validate_compose()
+    requested_paths: list[str] = []
+
+    def airflow_get(path: str, _timeout: float) -> FakeAirflowResponse:
+        requested_paths.append(path)
+        if path.endswith("manual__target"):
+            return FakeAirflowResponse({"dag_run_id": "manual__target", "state": "failed"})
+        if path.endswith("/dagRuns"):
+            return FakeAirflowResponse(
+                {
+                    "dag_runs": [
+                        {
+                            "dag_run_id": "historical-success",
+                            "logical_date": "2026-08-23T00:00:00Z",
+                            "state": "success",
+                        }
+                    ]
+                }
+            )
+        if path.endswith("taskInstances"):
+            return FakeAirflowResponse({"task_instances": []})
+        return FakeAirflowResponse({}, text="last task log")
+
+    monkeypatch.setattr(validator, "airflow_get", airflow_get)
+    monkeypatch.setenv("VALIDATE_COMPOSE_DAG_RUN_ID", "manual__target")
+    monkeypatch.setenv("VALIDATE_COMPOSE_TIMEOUT_SECONDS", "240")
+
+    with pytest.raises(SystemExit, match="DAG run state: failed"):
+        validator.main()
+
+    assert requested_paths[0] == "/api/v2/dags/sample_data/dagRuns/manual__target"
+    assert "/api/v2/dags/sample_data/dagRuns" not in requested_paths
+
+
+def test_get_last_run_info_filters_by_trigger_logical_date(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A malformed trigger response cannot fall back to unrelated historical runs."""
+    validator = load_validate_compose()
+    requested_paths: list[str] = []
+
+    def airflow_get(path: str, _timeout: float) -> FakeAirflowResponse:
+        requested_paths.append(path)
+        return FakeAirflowResponse(
+            {
+                "dag_runs": [
+                    {
+                        "dag_run_id": "manual__target",
+                        "logical_date": "2026-08-24T00:00:00Z",
+                        "state": "queued",
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setattr(validator, "airflow_get", airflow_get)
+
+    assert validator.get_last_run_info(None, "2026-08-24T00:00:00Z", 1) == (
+        "manual__target",
+        "queued",
+        True,
+    )
+    query = parse_qs(urlparse(requested_paths[0]).query)
+    assert query == {
+        "limit": ["1"],
+        "order_by": ["-logical_date"],
+        "logical_date_gte": ["2026-08-24T00:00:00Z"],
+        "logical_date_lte": ["2026-08-24T00:00:00Z"],
+    }
+
+
+def test_retry_count_cannot_extend_the_forwarded_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The shell's reserved diagnostic margin remains enforceable."""
+    validator = load_validate_compose()
+
+    monkeypatch.setenv("VALIDATE_COMPOSE_TIMEOUT_SECONDS", "240")
+    monkeypatch.setenv("VALIDATE_COMPOSE_MAX_RETRIES", "60")
+
+    assert validator.resolve_timeout_seconds(10) == 240
+
+
+def test_timeout_keeps_last_observed_run_after_transient_poll_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Timeout diagnostics retain and report the last run after a transient poll failure."""
+    validator = load_validate_compose()
+    clock = FakeClock()
+    airflow_responses = iter(
+        [
+            FakeAirflowResponse(
+                {
+                    "dag_runs": [
+                        {
+                            "dag_run_id": "run-1",
+                            "logical_date": "2026-08-24T00:00:00Z",
+                            "state": "running",
+                        }
+                    ]
+                }
+            ),
+            None,
+            FakeAirflowResponse({"dag_run_id": "run-1", "state": "running"}),
+            FakeAirflowResponse(
+                {
+                    "task_instances": [
+                        {
+                            "task_id": "ingest_using_recipe",
+                            "state": "running",
+                            "try_number": 1,
+                            "start_date": "2026-08-24T00:00:00Z",
+                            "end_date": None,
+                            "duration": 1,
+                        }
+                    ]
+                }
+            ),
+            FakeAirflowResponse({}, text="last task log"),
+        ]
+    )
+
+    monkeypatch.setattr(validator, "time", clock)
+    monkeypatch.setattr(validator, "airflow_get", lambda _path, _timeout: next(airflow_responses))
+    monkeypatch.setenv("VALIDATE_COMPOSE_RETRY_INTERVAL_SECONDS", "1")
+    monkeypatch.setenv("VALIDATE_COMPOSE_TIMEOUT_SECONDS", "1")
+    monkeypatch.delenv("VALIDATE_COMPOSE_MAX_RETRIES", raising=False)
+
+    with pytest.raises(SystemExit) as exit_info:
+        validator.main()
+
+    output = capsys.readouterr().out
+    assert "Task instances for run-1:" in output
+    assert "ingest_using_recipe: state=running" in output
+    assert "last observed run=run-1, state=running" in str(exit_info.value)
+
+
+def test_timeout_diagnoses_known_triggered_run_after_poll_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A known target still gets run and task diagnostics after transient poll failures."""
+    validator = load_validate_compose()
+    clock = FakeClock()
+    session = FakeHttpSession(
+        post_responses=[FakeTokenResponse()],
+        get_responses=[
+            requests.exceptions.ConnectionError("first poll failed"),
+            requests.exceptions.ConnectionError("second poll failed"),
+            FakeAirflowResponse({"dag_run_id": "manual__target", "state": "running"}),
+            FakeAirflowResponse(
+                {
+                    "task_instances": [
+                        {
+                            "task_id": "ingest_using_recipe",
+                            "state": "running",
+                            "try_number": 1,
+                            "start_date": "2026-08-24T00:00:00Z",
+                            "end_date": None,
+                            "duration": 1,
+                        }
+                    ]
+                }
+            ),
+            FakeAirflowResponse({}, text="last task log"),
+        ],
+    )
+
+    monkeypatch.setattr(validator, "time", clock)
+    monkeypatch.setattr(validator, "get_http_session", lambda: session)
+    monkeypatch.setenv("VALIDATE_COMPOSE_DAG_RUN_ID", "manual__target")
+    monkeypatch.setenv("VALIDATE_COMPOSE_RETRY_INTERVAL_SECONDS", "1")
+    monkeypatch.setenv("VALIDATE_COMPOSE_TIMEOUT_SECONDS", "1")
+    monkeypatch.delenv("VALIDATE_COMPOSE_MAX_RETRIES", raising=False)
+
+    with pytest.raises(SystemExit) as exit_info:
+        validator.main()
+
+    output = capsys.readouterr().out
+    assert "Diagnostic DAG run [manual__target] is running." in output
+    assert "Task instances for manual__target:" in output
+    assert "last observed run=manual__target, state=running" in str(exit_info.value)
+
+
+def test_airflow_get_reauthenticates_once_within_the_caller_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rejected cached token is refreshed before diagnostic requests give up."""
+    validator = load_validate_compose()
+    session = FakeHttpSession(
+        post_responses=[FakeTokenResponse()],
+        get_responses=[
+            FakeAirflowResponse({}, status_code=401),
+            FakeAirflowResponse({"dag_run_id": "manual__target", "state": "running"}),
+        ],
+    )
+    validator._access_token = "stale-token"
+
+    monkeypatch.setattr(validator, "get_http_session", lambda: session)
+
+    response = validator.airflow_get("/api/v2/dags/sample_data/dagRuns/manual__target", 10)
+
+    assert response is not None
+    assert response.status_code == 200
+    assert [call["headers"]["Authorization"] for call in session.get_calls] == [
+        "Bearer stale-token",
+        "Bearer token",
+    ]
+    assert len(session.post_calls) == 1
+    assert session.post_calls[0]["timeout"] <= 10
+
+
+def test_get_last_run_info_treats_malformed_airflow_responses_as_transient(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Bad JSON and malformed DAG-run lists keep validation alive for diagnostics."""
+    validator = load_validate_compose()
+    session = FakeHttpSession(
+        post_responses=[FakeTokenResponse()],
+        get_responses=[
+            FakeAirflowResponse(None, json_error=ValueError("invalid JSON")),
+            FakeAirflowResponse({"dag_runs": {"not": "a list"}}),
+        ],
+    )
+
+    monkeypatch.setattr(validator, "get_http_session", lambda: session)
+
+    assert validator.get_last_run_info("manual__target", None, 10) == (None, None, False)
+    assert validator.get_last_run_info(None, "2026-08-24T00:00:00Z", 10) == (
+        None,
+        None,
+        False,
+    )
+    output = capsys.readouterr().out
+    assert "Airflow returned invalid JSON for DAG-run." in output
+    assert "Airflow DAG-runs response did not contain a list of dag_runs." in output
+
+
+def test_task_diagnostics_encode_run_ids_and_paginate(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Timeout diagnostics report every task from the correctly encoded target route."""
+    validator = load_validate_compose()
+    session = FakeHttpSession(
+        post_responses=[FakeTokenResponse()],
+        get_responses=[
+            FakeAirflowResponse(
+                {
+                    "task_instances": [{"task_id": "first-task", "state": "running"}],
+                    "total_entries": 2,
+                }
+            ),
+            FakeAirflowResponse(
+                {
+                    "task_instances": [{"task_id": "second-task", "state": "queued"}],
+                    "total_entries": 2,
+                }
+            ),
+        ],
+    )
+
+    monkeypatch.setattr(validator, "get_http_session", lambda: session)
+
+    validator.print_task_instance_states("manual/a?b", 8)
+
+    output = capsys.readouterr().out
+    assert "Task instances for manual/a?b:" in output
+    assert "first-task: state=running" in output
+    assert "second-task: state=queued" in output
+    assert [urlparse(call["url"]).path for call in session.get_calls] == [
+        "/api/v2/dags/sample_data/dagRuns/manual%2Fa%3Fb/taskInstances",
+        "/api/v2/dags/sample_data/dagRuns/manual%2Fa%3Fb/taskInstances",
+    ]
+    assert [parse_qs(urlparse(call["url"]).query) for call in session.get_calls] == [
+        {"limit": ["100"], "offset": ["0"]},
+        {"limit": ["100"], "offset": ["1"]},
+    ]
+
+
+def test_airflow_get_uses_remaining_timeout_after_authentication(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Authentication and the protected request share one caller-provided budget."""
+    validator = load_validate_compose()
+    clock = FakeClock()
+    post_timeouts: list[float] = []
+    get_timeouts: list[float] = []
+
+    def post(*_args, **kwargs) -> FakeTokenResponse:
+        post_timeouts.append(kwargs["timeout"])
+        clock.now += 7
+        return FakeTokenResponse()
+
+    def get(*_args, **kwargs) -> FakeAirflowResponse:
+        get_timeouts.append(kwargs["timeout"])
+        return FakeAirflowResponse({})
+
+    session = FakeHttpSession([], [])
+    monkeypatch.setattr(validator, "time", clock)
+    monkeypatch.setattr(session, "post", post)
+    monkeypatch.setattr(session, "get", get)
+    monkeypatch.setattr(validator, "get_http_session", lambda: session)
+
+    response = validator.airflow_get("/api/v2/dags/sample_data/dagRuns", timeout=10)
+
+    assert response is not None
+    assert post_timeouts == [10]
+    assert get_timeouts == [3]


### PR DESCRIPTION
Backport of #31710 (fixes #31708) to `2.0`, plus one branch-specific follow-up.

## Why

The 2026-09-07 nightly failed 7 `SearchRelevance.spec.ts` assertions on MySQL ([run 34070858017](https://github.com/open-metadata/OpenMetadata/actions/runs/34070858017), shard 2/7) while Postgres passed. It was triaged as a search-recall / ranking / MySQL-specific bug. It is none of those:

- The **same OM SHA** (`1631a8118`) passed the night before (run 34002114930) and 09-08 passed on `2fed88229`. Same code, different outcome.
- The failing job's setup shows sample-data ingestion never finished:

  ```
  01:17:15  Triggering sample_data DAG...  ✓ Successfully triggered
  01:17:20  Running DAG validation (this may take a few minutes)...
  01:19:56  Exception: Max retries exceeded. Sample data ingestion was not successful.
            ⚠ Warning: DAG validation failed with exit code 1
              Continuing with remaining setup...
  01:20:10  ✔running reindexing
  01:22:56  ✓ SearchIndexingApplication completed successfully
  ```

  The reindex rebuilt the search indexes from a database the DAG was still writing to.
- It gave up after 150s, not the configured 300s, for exactly the reason #31708 describes: `run_local_docker_common.sh` invoked the validator through a bare `docker exec`, so no `VALIDATE_COMPOSE_*` value crossed the container boundary and `validate_compose.py` fell back to `15 × 10s`. The outer `timeout` is dead code — the step exited 1, not 124. And every progress line was swallowed by `metadata/utils/logger.py` leaving the root logger at WARNING, so the failure arrived with zero diagnostics.

The `2.0` symptom is worse than the RDF lane's in #31708. There, `STRICT_DAG_VALIDATION=true` makes startup fail immediately with a clear message. Here it is unset, so the run continues silently and surfaces ~40 minutes later as a fake search regression.

The missing entities confirm the mechanism: `provider_address`, `provider_address_texas` and `provider_directory` were absent from the index, while `service_job_registry`, `work`, `customer`, `customers` and `customer_profile(s)` were present — all added by the same commit (#29853), the present ones sitting *later* in the same `tables.json`. That rules out stale sample data (it was current) and truncated ingestion (that drops the tail, not the middle).

## Contents

1. `471bd6a` — clean `git cherry-pick -x` of 3ce479810e (#31710). No conflicts. Forwards the knobs with explicit `-e` flags, derives the inner deadline from `VALIDATION_TIMEOUT_SECONDS`, bounds each Airflow request by the remaining budget, and makes the validator print its own diagnostics.
2. `3df33c2` — sets `STRICT_DAG_VALIDATION: "true"` and `VALIDATION_TIMEOUT_SECONDS: "600"` on `mysql-nightly-e2e.yml`, matching what the fixture lane already does on `main`. Without this, commit 1 only widens the window (150s → 240s) and the silent-continue remains. Drop this commit if you would rather keep the backport pure — the lane stays flaky but at least becomes diagnosable.

`nick-fields/retry` (`max_attempts: 2`) already wraps startup in the setup action, so a single slow DAG still gets a second chance before the job fails.

## Verification

- `ingestion/tests/unit/test_validate_compose.py` — 12/12 pass against the backported files (the suite asserts on `run_local_docker_common.sh` as well as the validator).
- `bash -n` clean on `run_local_docker_common.sh` and `run_local_docker_rdf.sh`.
- 2.0-only `unpause_dag "index_metadata"` preserved through the pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)