### PR TITLE
Backport 2.0: stabilize flaky Knowledge Graph Ontology lens E2E test (#32889)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/KnowledgeGraph.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/KnowledgeGraph.spec.ts
@@ -226,6 +226,7 @@ test.describe('Knowledge Graph', { tag: ['@knowledge-graph'] }, () => {
     browser,
     page,
   }) => {
+    test.slow();
     const { apiContext, afterAction } = await createNewPage(browser);
     const glossary = new Glossary();
     const glossaryTerm = new GlossaryTerm(glossary);
@@ -272,7 +273,7 @@ test.describe('Knowledge Graph', { tag: ['@knowledge-graph'] }, () => {
 
         expect(response.ok()).toBe(true);
         expect(result.boolean).toBe(true);
-      }).toPass({ intervals: [1_000, 2_000, 5_000], timeout: 60_000 });
+      }).toPass({ intervals: [2_000, 5_000], timeout: 120_000 });
 
       const pageErrors = await openKnowledgeGraph(page, ontologyTable);
       await selectDepth(page, 2, ontologyTable);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/KnowledgeGraph.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/KnowledgeGraph.spec.ts
@@ -272,7 +272,7 @@ test.describe('Knowledge Graph', { tag: ['@knowledge-graph'] }, () => {
 
         expect(response.ok()).toBe(true);
         expect(result.boolean).toBe(true);
-      }).toPass({ intervals: [500, 1_000], timeout: 30_000 });
+      }).toPass({ intervals: [1_000, 2_000, 5_000], timeout: 60_000 });
 
       const pageErrors = await openKnowledgeGraph(page, ontologyTable);
       await selectDepth(page, 2, ontologyTable);


### PR DESCRIPTION
Backport of #32889 to `2.0`.

> [!IMPORTANT]
> **#32889 is not merged yet** — it is open and approved at the time of writing. This backport is cherry-picked from its head (`2fa34870ca`), so if the source PR changes before it lands, this one needs re-syncing. Happy to hold it until #32889 merges — say the word and I'll close or refresh it.

## What it changes

The "Verify the relationship lens can be switched to Ontology" test polls a SPARQL endpoint until the ontology triples are queryable, and the existing budget was too tight for a cold ontology store. Two lines:

- `test.slow()` on the test
- `toPass({ intervals: [500, 1_000], timeout: 30_000 })` → `toPass({ intervals: [2_000, 5_000], timeout: 120_000 })` — longer overall budget and less aggressive polling

2.0 carries the same test with the same original values, so the change is relevant here rather than already-fixed or not-applicable.

## Adaptations

**None.** Both commits cherry-picked cleanly, and the net diff is **identical** to `gh pr diff 32889` (3 changed lines, whitespace-normalised comparison). I kept the source PR's two commits rather than squashing, so authorship is preserved.

## Verification

- Playwright `tsc --project playwright/tsconfig.json`: **169 errors before and after** (pre-existing on `2.0`), none in `KnowledgeGraph.spec.ts`.
- Prettier clean.
- The test itself is not run here — it needs the Knowledge Graph / SPARQL stack, so CI is the real check. Note it is tagged `@knowledge-graph`, so it only runs where that tag is selected.
- eslint left to CI — 2.0's `eslint.config.mjs` needs a `jsonc-eslint-parser` the borrowed `node_modules` cannot provide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
