### PR TITLE
Backport 2.0: Fixes #32806 — add Entity Type filter to team assets and fix quick-filter removal (#32807)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Teams.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Teams.spec.ts
@@ -16,6 +16,7 @@ import {
   Page,
   test as base,
 } from '@playwright/test';
+import { Operation } from 'fast-json-patch';
 import {
   EDIT_USER_FOR_TEAM_RULES,
   OWNER_TEAM_RULES,
@@ -27,6 +28,7 @@ import { DataProduct } from '../../support/domain/DataProduct';
 import { Domain } from '../../support/domain/Domain';
 import { EntityTypeEndpoint } from '../../support/entity/Entity.interface';
 import { TableClass } from '../../support/entity/TableClass';
+import { TopicClass } from '../../support/entity/TopicClass';
 import { TeamClass } from '../../support/team/TeamClass';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
@@ -52,6 +54,7 @@ import {
   addTeamOwnerToEntity,
   addUserInTeam,
   addUserTeam,
+  applyEntityTypeFilterValue,
   checkTeamTabCount,
   createTeam,
   executionOnOwnerGroupTeam,
@@ -60,9 +63,11 @@ import {
   hardDeleteTeam,
   openAddTeamModal,
   searchTeam,
+  selectAssetsFilterFromDropdown,
   softDeleteTeam,
   verifyAssetsInTeamsPage,
   verifyTeamListingAssetCount,
+  waitForTeamAssetsSearchResponse,
 } from '../../utils/team';
 
 base.describe.configure({ mode: 'serial' });
@@ -714,6 +719,128 @@ test.describe('Teams Page', () => {
       await team4.delete(apiContext);
       await afterAction();
     }
+  });
+
+  test.describe('Team assets entity type filter', () => {
+    let filterTable: TableClass;
+    let filterTopic: TopicClass;
+    let filterTeam: TeamClass;
+
+    test.beforeAll(async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      try {
+        // Instantiate here so a retry regenerates entity names instead of
+        // re-creating the same ones and hitting 409s
+        filterTable = new TableClass();
+        filterTopic = new TopicClass();
+        filterTeam = new TeamClass();
+
+        await filterTable.create(apiContext);
+        await filterTopic.create(apiContext);
+        await filterTeam.create(apiContext);
+
+        const ownerPatch: Operation[] = [
+          {
+            op: 'add',
+            path: '/owners/-',
+            value: { id: filterTeam.responseData.id, type: 'team' },
+          },
+        ];
+        await filterTable.patch({ apiContext, patchData: ownerPatch });
+        await filterTopic.patch({ apiContext, patchData: ownerPatch });
+      } finally {
+        await afterAction();
+      }
+    });
+
+    test.afterAll(async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      try {
+        await filterTable.delete(apiContext);
+        await filterTopic.delete(apiContext);
+        await filterTeam.delete(apiContext);
+      } finally {
+        await afterAction();
+      }
+    });
+
+    test('should apply, toggle off and clear the entity type filter', async ({
+      page,
+    }) => {
+      const teamId = filterTeam.responseData.id ?? '';
+
+      expect(teamId).not.toBe('');
+
+      const tableCard = page.getByTestId(
+        `table-data-card_${filterTable.entityResponseData?.['fullyQualifiedName']}`
+      );
+      const topicCard = page.getByTestId(
+        `table-data-card_${filterTopic.entityResponseData?.['fullyQualifiedName']}`
+      );
+      const entityTypeFilterChip = page.getByRole('button', {
+        name: 'Entity Type',
+      });
+
+      await test.step('Apply entity type filter', async () => {
+        await filterTeam.visitTeamPage(page);
+
+        const assetsResponse = waitForTeamAssetsSearchResponse(page, teamId);
+        await page.getByTestId('assets').click();
+        const assetsSearchResponse = await assetsResponse;
+
+        expect(assetsSearchResponse.status()).toBe(200);
+        await waitForAllLoadersToDisappear(page);
+
+        await expect(tableCard).toBeVisible();
+        await expect(topicCard).toBeVisible();
+
+        await selectAssetsFilterFromDropdown(page, 'Entity Type');
+
+        await expect(entityTypeFilterChip).toBeVisible();
+
+        await applyEntityTypeFilterValue(page, teamId, 'table-checkbox');
+
+        await expect(tableCard).toBeVisible();
+        await expect(topicCard).not.toBeVisible();
+      });
+
+      await test.step('Toggle the filter off from the dropdown', async () => {
+        const removeFilterResponse = waitForTeamAssetsSearchResponse(
+          page,
+          teamId
+        );
+        await selectAssetsFilterFromDropdown(page, 'Entity Type');
+        const removeSearchResponse = await removeFilterResponse;
+
+        expect(removeSearchResponse.status()).toBe(200);
+
+        await waitForAllLoadersToDisappear(page);
+
+        await expect(tableCard).toBeVisible();
+        await expect(topicCard).toBeVisible();
+        await expect(entityTypeFilterChip).not.toBeVisible();
+      });
+
+      await test.step('Clear removes the selected filter entirely', async () => {
+        await selectAssetsFilterFromDropdown(page, 'Entity Type');
+        await applyEntityTypeFilterValue(page, teamId, 'table-checkbox');
+
+        await expect(tableCard).toBeVisible();
+        await expect(topicCard).not.toBeVisible();
+
+        const clearResponse = waitForTeamAssetsSearchResponse(page, teamId);
+        await page.getByText('Clear').click();
+        const clearSearchResponse = await clearResponse;
+
+        expect(clearSearchResponse.status()).toBe(200);
+
+        await waitForAllLoadersToDisappear(page);
+
+        await expect(tableCard).toBeVisible();
+        await expect(topicCard).toBeVisible();
+        await expect(entityTypeFilterChip).not.toBeVisible();
+      });
+    });
   });
 
   test('Delete a user from the table', async ({ page }) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -404,6 +404,15 @@ export const clickOutside = async (page: Page) => {
   });
 };
 
+export const waitForAntdPopupToSettle = async (page: Page) => {
+  await expect(
+    page.locator(
+      '.ant-dropdown:not(.ant-dropdown-hidden)[class*="-appear"], ' +
+        '.ant-dropdown:not(.ant-dropdown-hidden)[class*="-enter"]'
+    )
+  ).toHaveCount(0);
+};
+
 export const searchFromSearchInput = async (
   page: Page,
   searchInput: Locator,

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
@@ -22,6 +22,7 @@ import {
   descriptionBox,
   redirectToHomePage,
   uuid,
+  waitForAntdPopupToSettle,
 } from './common';
 import {
   addMultiOwner,
@@ -692,4 +693,43 @@ export const executionOnOwnerGroupTeam = async (
   await addEmailTeam(page, data.email);
 
   await addUserTeam(page, data.user, data.userName);
+};
+
+/**
+ * Wait for the team assets listing search call. The team id appears in the
+ * encoded query_filter (owners.id term), so the match cannot collide with
+ * other search/query requests on the page.
+ */
+export const waitForTeamAssetsSearchResponse = (page: Page, teamId: string) =>
+  page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/v1/search/query') &&
+      response.url().includes('index=all') &&
+      response.url().includes(teamId)
+  );
+
+export const selectAssetsFilterFromDropdown = async (
+  page: Page,
+  filterLabel: string
+) => {
+  await page.getByTestId('asset-filter-button').click();
+  const menuItem = page.getByRole('menuitem', { name: filterLabel });
+  await expect(menuItem).toBeVisible();
+  await waitForAntdPopupToSettle(page);
+  await menuItem.click();
+};
+
+export const applyEntityTypeFilterValue = async (
+  page: Page,
+  teamId: string,
+  entityTypeCheckboxTestId: string
+) => {
+  await page.getByRole('button', { name: 'Entity Type' }).click();
+  await page.getByTestId(entityTypeCheckboxTestId).check();
+  const filterResponse = waitForTeamAssetsSearchResponse(page, teamId);
+  await page.getByTestId('update-btn').click();
+  const response = await filterResponse;
+
+  expect(response.status()).toBe(200);
+  await waitForAllLoadersToDisappear(page);
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/AssetsTabs.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/AssetsTabs.component.tsx
@@ -27,7 +27,7 @@ import {
 import { ItemType } from 'antd/lib/menu/hooks/useItems';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
-import { isObject } from 'lodash';
+import { isEmpty, isObject } from 'lodash';
 import { EntityDetailUnion } from 'Models';
 import {
   forwardRef,
@@ -201,7 +201,11 @@ const AssetsTabs = forwardRef(
     const entityTypeString = getEntityTypeString(type);
 
     const handleMenuClick = ({ key }: { key: string }) => {
-      setSelectedFilter((prevSelected) => [...prevSelected, key]);
+      setSelectedFilter((prevSelected) =>
+        prevSelected.includes(key)
+          ? prevSelected.filter((selectedKey) => selectedKey !== key)
+          : [...prevSelected, key]
+      );
     };
 
     const filterMenu: ItemType[] = useMemo(() => {
@@ -769,10 +773,12 @@ const AssetsTabs = forwardRef(
       return <div data-testid="manage-dropdown-list-container">{menus}</div>;
     }, []);
 
-    const handleQuickFiltersChange = (data: ExploreQuickFilterField[]) => {
-      const quickFilterQuery = getQuickFilterQuery(data);
-      setQuickFilterQuery(quickFilterQuery);
-    };
+    const handleQuickFiltersChange = useCallback(
+      (data: ExploreQuickFilterField[]) => {
+        setQuickFilterQuery(getQuickFilterQuery(data));
+      },
+      []
+    );
 
     const handleQuickFiltersValueSelect = useCallback(
       (field: ExploreQuickFilterField) => {
@@ -790,7 +796,7 @@ const AssetsTabs = forwardRef(
           return data;
         });
       },
-      [setSelectedQuickFilters]
+      [handleQuickFiltersChange]
     );
 
     const assetListing = useMemo(
@@ -935,20 +941,9 @@ const AssetsTabs = forwardRef(
 
     const clearFilters = useCallback(() => {
       setQuickFilterQuery(undefined);
-      setSelectedQuickFilters((pre) => {
-        const data = pre.map((preField) => {
-          return { ...preField, value: [] };
-        });
-
-        handleQuickFiltersChange(data);
-
-        return data;
-      });
-    }, [
-      setQuickFilterQuery,
-      handleQuickFiltersChange,
-      setSelectedQuickFilters,
-    ]);
+      setSelectedFilter([]);
+      setSelectedQuickFilters([]);
+    }, []);
 
     useEffect(() => {
       fetchAssets({
@@ -969,30 +964,36 @@ const AssetsTabs = forwardRef(
     }, [type]);
 
     useEffect(() => {
-      const updatedQuickFilters = filters
-        .filter((filter) => selectedFilter.includes(filter.key))
-        .map((selectedFilterItem) => {
-          const originalFilterItem = selectedQuickFilters?.find(
-            (filter) => filter.key === selectedFilterItem.key
-          );
-
-          return originalFilterItem || selectedFilterItem;
-        });
-
-      const newItems = updatedQuickFilters.filter(
-        (item) =>
-          !selectedQuickFilters.some(
-            (existingItem) => item.key === existingItem.key
-          )
+      const retainedFilters = selectedQuickFilters.filter((field) =>
+        selectedFilter.includes(field.key)
+      );
+      const newFilters = filters.filter(
+        (filter) =>
+          selectedFilter.includes(filter.key) &&
+          !retainedFilters.some((field) => field.key === filter.key)
       );
 
-      if (newItems.length > 0) {
-        setSelectedQuickFilters((prevSelected) => [
-          ...prevSelected,
-          ...newItems,
-        ]);
+      if (
+        newFilters.length > 0 ||
+        retainedFilters.length !== selectedQuickFilters.length
+      ) {
+        const updatedQuickFilters = [...retainedFilters, ...newFilters];
+        setSelectedQuickFilters(updatedQuickFilters);
+
+        const removedFilterHadValue = selectedQuickFilters.some(
+          (field) =>
+            !selectedFilter.includes(field.key) && !isEmpty(field.value)
+        );
+        if (removedFilterHadValue) {
+          handleQuickFiltersChange(updatedQuickFilters);
+        }
       }
-    }, [selectedFilter, selectedQuickFilters, filters]);
+    }, [
+      selectedFilter,
+      selectedQuickFilters,
+      filters,
+      handleQuickFiltersChange,
+    ]);
 
     useImperativeHandle(ref, () => ({
       refreshAssets() {
@@ -1051,6 +1052,8 @@ const AssetsTabs = forwardRef(
                   <Dropdown
                     menu={{
                       items: filterMenu,
+                      multiple: true,
+                      selectable: true,
                       selectedKeys: selectedFilter,
                     }}
                     trigger={['click']}>

--- a/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
@@ -55,6 +55,17 @@ export const COMMON_DROPDOWN_ITEMS = [
   },
 ];
 
+export const TEAM_ASSETS_DROPDOWN_ITEMS = [
+  {
+    label: 'label.entity-type-plural',
+    labelKeyOptions: {
+      entity: 'label.entity',
+    },
+    key: EntityFields.ENTITY_TYPE,
+  },
+  ...COMMON_DROPDOWN_ITEMS,
+];
+
 export const DATA_ASSET_DROPDOWN_ITEMS = [
   {
     label: 'label.data-asset-plural',

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchPureUtils.ts
@@ -22,6 +22,7 @@ import {
   GLOSSARY_ASSETS_DROPDOWN_ITEMS,
   LINEAGE_DROPDOWN_ITEMS,
   TAG_ASSETS_DROPDOWN_ITEMS,
+  TEAM_ASSETS_DROPDOWN_ITEMS,
 } from '../constants/AdvancedSearch.constants';
 import { NOT_INCLUDE_AGGREGATION_QUICK_FILTER } from '../constants/explore.constants';
 import {
@@ -61,6 +62,9 @@ export const getAssetsPageQuickFilters = (
 
     case AssetsOfEntity.LINEAGE:
       return [...LINEAGE_DROPDOWN_ITEMS];
+
+    case AssetsOfEntity.TEAM:
+      return [...TEAM_ASSETS_DROPDOWN_ITEMS];
 
     default:
       return [...COMMON_DROPDOWN_ITEMS];

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.test.tsx
@@ -21,6 +21,7 @@ import {
   GLOSSARY_ASSETS_DROPDOWN_ITEMS,
   LINEAGE_DROPDOWN_ITEMS,
   TAG_ASSETS_DROPDOWN_ITEMS,
+  TEAM_ASSETS_DROPDOWN_ITEMS,
 } from '../constants/AdvancedSearch.constants';
 import {
   EntityFields,
@@ -695,6 +696,20 @@ describe('AdvancedSearchUtils tests', () => {
     it('should return TAG_ASSETS_DROPDOWN_ITEMS for TAG type', () => {
       expect(getAssetsPageQuickFilters(AssetsOfEntity.TAG)).toEqual(
         TAG_ASSETS_DROPDOWN_ITEMS
+      );
+    });
+
+    it('should return TEAM_ASSETS_DROPDOWN_ITEMS for TEAM type', () => {
+      expect(getAssetsPageQuickFilters(AssetsOfEntity.TEAM)).toEqual(
+        TEAM_ASSETS_DROPDOWN_ITEMS
+      );
+    });
+
+    it('should include the entity type filter for TEAM type', () => {
+      expect(getAssetsPageQuickFilters(AssetsOfEntity.TEAM)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ key: EntityFields.ENTITY_TYPE }),
+        ])
       );
     });
 


### PR DESCRIPTION
Backport of #32807 (fixes #32806) to `2.0`.

## What
- Add **Entity Type** quick filter to the Team assets tab (`TEAM_ASSETS_DROPDOWN_ITEMS`, explicit `TEAM` case in `getAssetsPageQuickFilters`), consistent with the Domain/Glossary/Tag assets tabs.
- `AssetsTabs`: the filter dropdown now toggles a selected filter off (was append-only and could add duplicate keys); removing a filter that had active values re-fetches results.
- `AssetsTabs`: **Clear** now removes the selected filters entirely instead of only emptying their values.
- Playwright: cover apply / toggle-off / clear of the Entity Type filter on the Team assets tab.

## Backport notes (conflicts resolved)
- `Teams.spec.ts`: kept 2.0's `@playwright/test` imports (`support/fixtures/base` does not exist on 2.0); added only the new `Operation` and `TopicClass` imports from the original PR.
- `AssetsTabs.component.tsx`: main's version was refactored into extracted sub-components (`AssetsFilterBar`, module-level handlers) that 2.0 doesn't have — applied the PR's logic changes onto 2.0's inline structure (same toggle, `multiple`/`selectable` dropdown props, memoized `handleQuickFiltersChange`, rewritten filter-sync effect, simplified `clearFilters`).
- `utils/common.ts`: backported `waitForAntdPopupToSettle` (used by the new `selectAssetsFilterFromDropdown` helper; not present on 2.0).

`tsc --noEmit` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
