### PR TITLE
Fixes #32457: Skip JavaUIIT reports for fork PRs

### DIFF
--- a/.github/workflows/java-playwright-nightly.yml
+++ b/.github/workflows/java-playwright-nightly.yml
@@ -393,7 +393,7 @@ jobs:
 
       - name: Publish Test Report
         id: report
-        if: ${{ always() }}
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: scacap/action-surefire-report@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -486,7 +486,7 @@ jobs:
           retention-days: 14
 
       - name: Publish Test Report
-        if: ${{ always() }}
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: scacap/action-surefire-report@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Describe your changes:

Fixes #32457

Follow-up to #32919, whose search changes exposed this fork-only workflow failure.

Fork-originated `pull_request` workflows receive a read-only Checks permission even though the workflow requests `checks: write`. The JavaUIIT Maven suites completed successfully, but both optional Surefire publishing steps attempted to create check runs and changed the jobs to failures.

Apply the repository's existing fork guard to both JavaUIIT report publishers. Fork PRs continue to run and gate on the Maven test steps while skipping the unauthorized API write. Same-repository PRs, merge groups, and manually dispatched runs continue publishing detailed reports.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A — small workflow fix using the same condition as `openmetadata-service-unit-tests.yml`.

#
### Tests:

#### Use cases covered

- Fork PRs skip only the optional Checks API report publisher.
- Trusted workflow contexts continue publishing Surefire reports.
- Maven test failures remain authoritative for the required `java-ui-it` gate.

#### Unit tests

Not applicable — workflow-only change.

#### Backend integration tests

- [x] Not applicable (no backend API changes).

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Not applicable (no UI changes).

#### Manual testing performed

1. `actionlint -ignore 'SC2086' .github/workflows/java-playwright-nightly.yml`
2. `git diff --check`
3. `make harness-check` (completed with the existing repository warnings)

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`.
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code where the behavior is non-obvious.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.
- [x] I have run the applicable workflow validation checks and listed them above.
