### PR TITLE
Fixes #31495: key data product ports by entity id, not request index

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataProductResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataProductResourceIT.java
@@ -2064,6 +2064,50 @@ public class DataProductResourceIT extends BaseEntityIT<DataProduct, CreateDataP
   }
 
   @Test
+  void test_getPorts_survivingPortsKeepIdentityWhenOneDeleted(TestNamespace ns) throws Exception {
+    Domain domain = getOrCreateDomain(ns);
+
+    CreateDataProduct create =
+        new CreateDataProduct()
+            .withName(ns.prefix("dp_deleted_port"))
+            .withDescription("Data product for deleted-port attribution test")
+            .withDomains(List.of(domain.getFullyQualifiedName()));
+    DataProduct dataProduct = createEntity(create);
+
+    Table table1 = createTestTable(ns, "del_port_1", domain);
+    Table table2 = createTestTable(ns, "del_port_2", domain);
+    Table table3 = createTestTable(ns, "del_port_3", domain);
+
+    bulkAddInputPorts(
+        dataProduct.getFullyQualifiedName(),
+        new BulkAssets()
+            .withAssets(
+                List.of(
+                    table1.getEntityReference(),
+                    table2.getEntityReference(),
+                    table3.getEntityReference())));
+
+    // Soft-delete a port. getPaginatedPorts fetches ports with NON_DELETED, so this row drops out
+    // of the entity fetch while its relationship record remains — the exact condition under which
+    // index-based mapping misattributed or silently dropped the surviving ports.
+    SdkClients.adminClient().tables().delete(table2.getId().toString());
+
+    ResultList<Map<String, Object>> inputPorts = getInputPorts(dataProduct.getId(), 10, 0);
+
+    List<UUID> returnedIds = new ArrayList<>();
+    for (Map<String, Object> port : inputPorts.getData()) {
+      returnedIds.add(getEntityId(port));
+    }
+
+    // Each surviving port must be present exactly once and carry its own id — never the deleted
+    // port's id and never a neighbour's data.
+    assertEquals(2, returnedIds.size());
+    assertTrue(returnedIds.contains(table1.getId()));
+    assertTrue(returnedIds.contains(table3.getId()));
+    assertFalse(returnedIds.contains(table2.getId()));
+  }
+
+  @Test
   void test_addPort_rejectsNonDataAssetEntity(TestNamespace ns) throws Exception {
     Domain domain = getOrCreateDomain(ns);
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataProductRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataProductRepository.java
@@ -652,7 +652,9 @@ public class DataProductRepository extends EntityRepository<DataProduct> {
       refsByType.computeIfAbsent(record.getType(), k -> new ArrayList<>()).add(ref);
     }
 
-    // Bulk fetch entities by type and collect in order
+    // Bulk fetch entities by type, keyed by each entity's own id. NON_DELETED filtering and the
+    // absence of an ORDER BY mean getEntities may return fewer entities than requested and in a
+    // different order, so keying by request-list index would misattribute or drop rows.
     // Use empty string if fields is null to avoid NPE
     String fieldsToFetch = fields != null ? fields : "";
     Map<UUID, EntityWithType> entitiesById = new HashMap<>();
@@ -660,9 +662,8 @@ public class DataProductRepository extends EntityRepository<DataProduct> {
       String entityType = entry.getKey();
       List<EntityInterface> entitiesOfType =
           Entity.getEntities(entry.getValue(), fieldsToFetch, NON_DELETED);
-      for (int i = 0; i < entitiesOfType.size(); i++) {
-        entitiesById.put(
-            entry.getValue().get(i).getId(), new EntityWithType(entitiesOfType.get(i), entityType));
+      for (EntityInterface entity : entitiesOfType) {
+        entitiesById.put(entity.getId(), new EntityWithType(entity, entityType));
       }
     }
 
@@ -759,8 +760,10 @@ public class DataProductRepository extends EntityRepository<DataProduct> {
       for (Map.Entry<String, List<EntityReference>> entry : assetsByType.entrySet()) {
         List<EntityInterface> entitiesOfType =
             Entity.getEntities(entry.getValue(), "domains,dataProducts", ALL);
-        for (int i = 0; i < entitiesOfType.size(); i++) {
-          assetEntitiesMap.put(entry.getValue().get(i).getId(), entitiesOfType.get(i));
+        // Key by each entity's own id; getEntities may reorder or drop rows relative to the
+        // request list, so request-index zipping would validate the wrong asset.
+        for (EntityInterface entity : entitiesOfType) {
+          assetEntitiesMap.put(entity.getId(), entity);
         }
       }
     }


### PR DESCRIPTION
### Describe your changes:

Fixes #31495

`DataProductRepository.getPaginatedPorts` (and the sibling `bulkAssetsOperation`) correlated the entities fetched by `Entity.getEntities(...)` with the request list **by list index**. That underlying call resolves to `EntityDAO.findByIds`, which runs `WHERE id IN (...)` with **no `ORDER BY`** and applies the `Include` filter (`NON_DELETED` for the ports view). So the returned rows can arrive in a different order than requested and can be fewer than requested. Zipping them back to the request list by position then attributes each port's data to the wrong id and silently drops the trailing entries — surfacing as an Input/Output Ports badge showing a port while the lineage panel renders empty.

The fix keys each fetched entity by **its own id** (`entity.getId()`) instead of the request-list index, so the subsequent order-preserving lookup by relationship id is always correct regardless of how `findByIds` orders or filters its rows. The same index-zipping existed in `bulkAssetsOperation`, where it could feed the wrong asset entity into add-time validation; it is fixed identically.

---

### Type of change:

- [x] Bug fix

---

### High-level design:

N/A — small change.

---

### Tests:

#### Use cases covered

- Data product input/output ports keep their own identity and are never misattributed when a port asset is soft-deleted (the `NON_DELETED` fetch returns fewer rows than the relationship list).

#### Unit / integration tests

- [x] Added `DataProductResourceIT#test_getPorts_survivingPortsKeepIdentityWhenOneDeleted`: creates three input ports, soft-deletes the middle one, and asserts the two surviving ports are returned with their own ids and the deleted port is absent.
- [x] `mvn clean install -pl openmetadata-service,openmetadata-integration-tests -am -DskipTests` → BUILD SUCCESS.

#### UI

- [ ] N/A — backend only.
