### PR TITLE
Fixes 32936: Preserve JSON types in Elasticsearch and OpenSearch scripted upserts

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchEntityManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchEntityManager.java
@@ -428,7 +428,8 @@ public class ElasticSearchEntityManager implements EntityManagementClient {
                           .refresh(Refresh.True)
                           .retryOnConflict(3)
                           .scriptedUpsert(true)
-                          .upsert(params)
+                          // Nested JsonData wrappers serialize as {} in a generic upsert document.
+                          .upsert(JsonUtils.getMap(doc))
                           .script(
                               s ->
                                   s.source(ss -> ss.scriptString(scriptTxt))

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchEntityManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchEntityManager.java
@@ -461,7 +461,8 @@ public class OpenSearchEntityManager implements EntityManagementClient {
                           .refresh(Refresh.True)
                           .retryOnConflict(3)
                           .scriptedUpsert(true)
-                          .upsert(params)
+                          // Nested JsonData wrappers serialize as {} in a generic upsert document.
+                          .upsert(JsonUtils.getMap(doc))
                           .script(
                               s ->
                                   s.inline(

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/ElasticSearchEntityManagerUpsertTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/ElasticSearchEntityManagerUpsertTest.java
@@ -1,0 +1,112 @@
+package org.openmetadata.service.search.elasticsearch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import es.co.elastic.clients.elasticsearch.ElasticsearchClient;
+import es.co.elastic.clients.elasticsearch.core.UpdateRequest;
+import es.co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import es.co.elastic.clients.transport.ElasticsearchTransport;
+import es.co.elastic.clients.util.ObjectBuilder;
+import jakarta.json.stream.JsonGenerator;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openmetadata.service.search.SearchClient;
+
+class ElasticSearchEntityManagerUpsertTest {
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void updatePreservesJsonTypesInUpsertAndScriptParameters(boolean emptySuites) throws Exception {
+    final List<Map<String, Object>> suites =
+        emptySuites ? List.of() : List.of(Map.of("id", "suite-id", "name", "suite", "basic", true));
+    final Map<String, Object> document =
+        Map.of(
+            "name",
+            "data_exists",
+            "testSuites",
+            suites,
+            "testSuitesRevision",
+            2L,
+            "testCaseResult",
+            Map.of("testCaseStatus", "Success", "timestamp", 123L));
+    final JsonNode payload = captureUpdate(document);
+    final JsonNode expected = objectMapper.readTree(objectMapper.writeValueAsString(document));
+
+    // JsonData values work as script parameters but serialize as {} inside a generic Map upsert.
+    assertTrue(payload.path("upsert").path("testSuites").isArray(), payload.toString());
+    assertEquals(expected, payload.path("upsert"));
+    assertEquals(expected, payload.path("script").path("params"));
+    assertTrue(payload.path("scripted_upsert").asBoolean());
+  }
+
+  @Test
+  void updateRetainsNullFieldRemovalParameters() throws Exception {
+    final Map<String, Object> document = new HashMap<>();
+    document.put("name", "data_exists");
+    document.put("tier", null);
+    final JsonNode payload = captureUpdate(document);
+    final JsonNode parameters = payload.path("script").path("params");
+
+    assertEquals("data_exists", payload.path("upsert").path("name").asText());
+    assertEquals("data_exists", parameters.path("name").asText());
+    assertFalse(parameters.has("tier"));
+    assertEquals(objectMapper.readTree("[\"tier\"]"), parameters.path("fieldsToRemove"));
+  }
+
+  @Test
+  void updatePreservesEmptyDocument() throws Exception {
+    final JsonNode payload = captureUpdate(Map.of());
+
+    assertEquals(objectMapper.readTree("{}"), payload.path("upsert"));
+    assertEquals(objectMapper.readTree("{}"), payload.path("script").path("params"));
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private JsonNode captureUpdate(Map<String, Object> document) throws Exception {
+    final ElasticsearchClient client = mock(ElasticsearchClient.class);
+    when(client._transport()).thenReturn(mock(ElasticsearchTransport.class));
+    final AtomicReference<JsonNode> payload = new AtomicReference<>();
+    doAnswer(
+            invocation -> {
+              final Function<
+                      UpdateRequest.Builder<Map, Map>, ObjectBuilder<UpdateRequest<Map, Map>>>
+                  build = invocation.getArgument(0);
+              payload.set(serialize(build.apply(new UpdateRequest.Builder<>()).build()));
+              return null;
+            })
+        .when(client)
+        .update(any(Function.class), eq(Map.class));
+    new ElasticSearchEntityManager(client)
+        .updateEntity(
+            "test_case_search_index", "case-id", document, SearchClient.DEFAULT_UPDATE_SCRIPT);
+    assertNotNull(payload.get(), "The update request must be serializable");
+    return payload.get();
+  }
+
+  private JsonNode serialize(UpdateRequest<?, ?> request) throws Exception {
+    final JacksonJsonpMapper mapper = new JacksonJsonpMapper();
+    final StringWriter writer = new StringWriter();
+    try (JsonGenerator generator = mapper.jsonProvider().createGenerator(writer)) {
+      request.serialize(generator, mapper);
+    }
+    return objectMapper.readTree(writer.toString());
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchEntityManagerUpsertTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchEntityManagerUpsertTest.java
@@ -1,0 +1,112 @@
+package org.openmetadata.service.search.opensearch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.stream.JsonGenerator;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openmetadata.service.search.SearchClient;
+import os.org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import os.org.opensearch.client.opensearch.OpenSearchClient;
+import os.org.opensearch.client.opensearch.core.UpdateRequest;
+import os.org.opensearch.client.transport.OpenSearchTransport;
+import os.org.opensearch.client.util.ObjectBuilder;
+
+class OpenSearchEntityManagerUpsertTest {
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void updatePreservesJsonTypesInUpsertAndScriptParameters(boolean emptySuites) throws Exception {
+    final List<Map<String, Object>> suites =
+        emptySuites ? List.of() : List.of(Map.of("id", "suite-id", "name", "suite", "basic", true));
+    final Map<String, Object> document =
+        Map.of(
+            "name",
+            "data_exists",
+            "testSuites",
+            suites,
+            "testSuitesRevision",
+            2L,
+            "testCaseResult",
+            Map.of("testCaseStatus", "Success", "timestamp", 123L));
+    final JsonNode payload = captureUpdate(document);
+    final JsonNode expected = objectMapper.readTree(objectMapper.writeValueAsString(document));
+
+    // JsonData values work as script parameters but serialize as {} inside a generic Map upsert.
+    assertTrue(payload.path("upsert").path("testSuites").isArray(), payload.toString());
+    assertEquals(expected, payload.path("upsert"));
+    assertEquals(expected, payload.path("script").path("params"));
+    assertTrue(payload.path("scripted_upsert").asBoolean());
+  }
+
+  @Test
+  void updateRetainsNullFieldRemovalParameters() throws Exception {
+    final Map<String, Object> document = new HashMap<>();
+    document.put("name", "data_exists");
+    document.put("tier", null);
+    final JsonNode payload = captureUpdate(document);
+    final JsonNode parameters = payload.path("script").path("params");
+
+    assertEquals("data_exists", payload.path("upsert").path("name").asText());
+    assertEquals("data_exists", parameters.path("name").asText());
+    assertFalse(parameters.has("tier"));
+    assertEquals(objectMapper.readTree("[\"tier\"]"), parameters.path("fieldsToRemove"));
+  }
+
+  @Test
+  void updatePreservesEmptyDocument() throws Exception {
+    final JsonNode payload = captureUpdate(Map.of());
+
+    assertEquals(objectMapper.readTree("{}"), payload.path("upsert"));
+    assertEquals(objectMapper.readTree("{}"), payload.path("script").path("params"));
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private JsonNode captureUpdate(Map<String, Object> document) throws Exception {
+    final OpenSearchClient client = mock(OpenSearchClient.class);
+    when(client._transport()).thenReturn(mock(OpenSearchTransport.class));
+    final AtomicReference<JsonNode> payload = new AtomicReference<>();
+    doAnswer(
+            invocation -> {
+              final Function<
+                      UpdateRequest.Builder<Map, Map>, ObjectBuilder<UpdateRequest<Map, Map>>>
+                  build = invocation.getArgument(0);
+              payload.set(serialize(build.apply(new UpdateRequest.Builder<>()).build()));
+              return null;
+            })
+        .when(client)
+        .update(any(Function.class), eq(Map.class));
+    new OpenSearchEntityManager(client)
+        .updateEntity(
+            "test_case_search_index", "case-id", document, SearchClient.DEFAULT_UPDATE_SCRIPT);
+    assertNotNull(payload.get(), "The update request must be serializable");
+    return payload.get();
+  }
+
+  private JsonNode serialize(UpdateRequest<?, ?> request) throws Exception {
+    final JacksonJsonpMapper mapper = new JacksonJsonpMapper();
+    final StringWriter writer = new StringWriter();
+    try (JsonGenerator generator = mapper.jsonProvider().createGenerator(writer)) {
+      request.serialize(generator, mapper);
+    }
+    return objectMapper.readTree(writer.toString());
+  }
+}


### PR DESCRIPTION
### Describe your changes:

Fixes #32936

Use plain JSON values for the upsert document in the Elasticsearch and OpenSearch entity managers, while retaining `JsonData` wrappers for script parameters.

Previously, the same `Map<String, JsonData>` was used for both. Nested `JsonData` values could serialize as `{}` in the upsert document. When creating a missing search document, this could store `TestCase.testSuites` as an object instead of an array, causing deserialization failures in Data Quality listings.

This change prevents malformed documents from being created through this path. Existing malformed search documents still require reindexing.

### Type of change:

- [x] Bug fix

### High-level design:

Small change affecting four files.

- Build the upsert document using `JsonUtils.getMap(doc)`.
- Keep script parameters and existing relationship-preservation logic unchanged.
- Add regression tests for both search clients using their actual request serializers.

No API or JSON Schema changes.

### Tests:

#### Use cases covered

- Creating a missing search document preserves populated and empty `testSuites` arrays.
- Nested objects and scalar fields retain their JSON types.
- Script parameters retain their expected values.
- Null-field removal parameters remain unchanged.
- Empty documents remain valid.

#### Unit tests

- [x] Added unit tests for the changed logic.

Files added:

- `openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/ElasticSearchEntityManagerUpsertTest.java`
- `openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchEntityManagerUpsertTest.java`

Results:

- Before the fix: 6 of the 8 added tests failed.
- After the fix: all 8 added tests passed.
- Selected entity-manager and search-repository tests: **159 passed, 0 failures, 0 errors, 0 skipped**.

JaCoCo coverage from the selected test suite:

- Changed upsert lines: covered in both implementations.
- `ElasticSearchEntityManager`: 6.57% line coverage.
- `OpenSearchEntityManager`: 6.87% line coverage.

The 90% whole-class coverage target is not met. These tests focus on the affected update path; the full backend test suite was not run.

#### Backend integration tests

- No new or changed API endpoints.
- No integration tests added under `openmetadata-integration-tests/`.
- Local Elasticsearch verification is described below.

#### Ingestion integration tests

Not applicable — no ingestion changes.

#### Playwright (UI) tests

Not applicable — no UI changes.

#### Manual testing performed

1. Invoked the fixed Elasticsearch entity-manager method against local Elasticsearch 9.3.0.
2. Verified that newly created documents preserve populated and empty `testSuites` arrays and deserialize into `TestCase`.
3. Verified that updates preserve existing relationships while updating test results.
4. Verified null-field removal using the default update script.
5. Removed the temporary verification indices.

Additional checks:

- Maven Spotless checks passed.
- Commit hooks passed using Java 21.
- `git diff --check` passed.

OpenSearch was verified through request-serialization tests, not a live OpenSearch instance. Full REST API/UI E2E testing was not performed.

### UI screen recording / screenshots:

Not applicable — no UI changes.

### Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`.
- [x] My PR is linked to a GitHub issue via `Fixes #32936` above.
- [x] I have commented on the non-obvious serialization behavior.
- [x] I have added tests and listed them above.
- [x] I have added regression tests covering the scenario being fixed.

JSON Schema migrations and UI screenshots are not applicable.