### PR TITLE
Fixes #30679: detach conflicting data products on data product domain change

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataProductResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataProductResourceIT.java
@@ -652,6 +652,111 @@ public class DataProductResourceIT extends BaseEntityIT<DataProduct, CreateDataP
   }
 
   @Test
+  void test_domainChangeDetachesConflictingDataProducts(TestNamespace ns) throws Exception {
+    Domain finance = createTestDomain(ns, "finance");
+    Domain hr = createTestDomain(ns, "hr");
+
+    DataProduct movingProduct =
+        createEntity(
+            new CreateDataProduct()
+                .withName(ns.prefix("dp_moving"))
+                .withDescription("Data product whose domain will move")
+                .withDomains(List.of(finance.getFullyQualifiedName())));
+    DataProduct stayingProduct =
+        createEntity(
+            new CreateDataProduct()
+                .withName(ns.prefix("dp_staying"))
+                .withDescription("Data product that stays in finance")
+                .withDomains(List.of(finance.getFullyQualifiedName())));
+
+    var schema = createSchemaWithDomain(ns, "schema_conflict", finance);
+    EntityReference schemaRef = schema.getEntityReference();
+    bulkAddAssets(
+        movingProduct.getFullyQualifiedName(), new BulkAssets().withAssets(List.of(schemaRef)));
+    bulkAddAssets(
+        stayingProduct.getFullyQualifiedName(), new BulkAssets().withAssets(List.of(schemaRef)));
+
+    moveDataProductDomain(movingProduct, hr);
+
+    List<EntityReference> schemaDataProducts =
+        SdkClients.adminClient()
+            .databaseSchemas()
+            .get(schema.getId().toString(), "dataProducts")
+            .getDataProducts();
+    assertTrue(
+        hasDataProduct(schemaDataProducts, movingProduct.getId()),
+        "The moved data product now shares the schema's new domain and must be kept");
+    assertFalse(
+        hasDataProduct(schemaDataProducts, stayingProduct.getId()),
+        "The data product left behind in finance must be detached from the moved schema");
+
+    // The schema must stay writable — before the fix this edit failed domain validation with 400.
+    var editableSchema =
+        SdkClients.adminClient().databaseSchemas().get(schema.getId().toString(), "dataProducts");
+    editableSchema.setDescription("edited after data product domain move");
+    SdkClients.adminClient()
+        .databaseSchemas()
+        .update(editableSchema.getId().toString(), editableSchema);
+  }
+
+  @Test
+  void test_domainChangeDetachesConflictingDataProductsOnInheritedDescendants(TestNamespace ns)
+      throws Exception {
+    Domain finance = createTestDomain(ns, "finance_desc");
+    Domain hr = createTestDomain(ns, "hr_desc");
+
+    DataProduct movingProduct =
+        createEntity(
+            new CreateDataProduct()
+                .withName(ns.prefix("dp_moving_desc"))
+                .withDescription("Data product on the parent schema")
+                .withDomains(List.of(finance.getFullyQualifiedName())));
+    DataProduct childProduct =
+        createEntity(
+            new CreateDataProduct()
+                .withName(ns.prefix("dp_child"))
+                .withDescription("Data product on the inheriting child table")
+                .withDomains(List.of(finance.getFullyQualifiedName())));
+
+    var schema = createSchemaWithDomain(ns, "schema_parent", finance);
+    Table childTable = createChildTable(ns, "inheriting_child", schema, null);
+    bulkAddAssets(
+        movingProduct.getFullyQualifiedName(),
+        new BulkAssets().withAssets(List.of(schema.getEntityReference())));
+    bulkAddAssets(
+        childProduct.getFullyQualifiedName(),
+        new BulkAssets().withAssets(List.of(childTable.getEntityReference())));
+
+    moveDataProductDomain(movingProduct, hr);
+
+    List<EntityReference> childDataProducts =
+        SdkClients.adminClient()
+            .tables()
+            .get(childTable.getId().toString(), "dataProducts")
+            .getDataProducts();
+    assertFalse(
+        hasDataProduct(childDataProducts, childProduct.getId()),
+        "A data product on an inherited-domain descendant must be detached when its ancestor moves");
+
+    var editableChild =
+        SdkClients.adminClient().tables().get(childTable.getId().toString(), "dataProducts");
+    editableChild.setDescription("edited after ancestor domain move");
+    SdkClients.adminClient().tables().update(editableChild.getId().toString(), editableChild);
+  }
+
+  private void moveDataProductDomain(DataProduct dataProduct, Domain targetDomain) {
+    DataProduct current =
+        SdkClients.adminClient().dataProducts().get(dataProduct.getId().toString(), "domains");
+    current.setDomains(List.of(targetDomain.getEntityReference()));
+    SdkClients.adminClient().dataProducts().update(current.getId().toString(), current);
+  }
+
+  private boolean hasDataProduct(List<EntityReference> dataProducts, UUID dataProductId) {
+    return dataProducts != null
+        && dataProducts.stream().anyMatch(dp -> dp.getId().equals(dataProductId));
+  }
+
+  @Test
   void test_entityStatusUpdateAndPatch(TestNamespace ns) throws Exception {
     Domain domain = getOrCreateDomain(ns);
     CreateDataProduct createDataProduct =

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataProductRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataProductRepository.java
@@ -29,6 +29,7 @@ import static org.openmetadata.service.exception.CatalogExceptionMessage.notRevi
 import static org.openmetadata.service.util.EntityUtil.fieldDeleted;
 import static org.openmetadata.service.util.EntityUtil.mergedInheritedEntityRefs;
 import static org.openmetadata.service.util.LineageUtil.addDomainLineage;
+import static org.openmetadata.service.util.LineageUtil.removeDataProductsLineage;
 import static org.openmetadata.service.util.LineageUtil.removeDomainLineage;
 
 import java.util.ArrayList;
@@ -47,9 +48,11 @@ import org.jdbi.v3.sqlobject.transaction.Transaction;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.api.domains.DataProductPortsView;
 import org.openmetadata.schema.api.domains.PaginatedEntities;
+import org.openmetadata.schema.configuration.EntityRulesSettings;
 import org.openmetadata.schema.entity.domains.DataProduct;
 import org.openmetadata.schema.entity.domains.Domain;
 import org.openmetadata.schema.entity.teams.Team;
+import org.openmetadata.schema.settings.SettingsType;
 import org.openmetadata.schema.type.ApiStatus;
 import org.openmetadata.schema.type.ChangeDescription;
 import org.openmetadata.schema.type.ChangeEvent;
@@ -67,6 +70,7 @@ import org.openmetadata.service.Entity;
 import org.openmetadata.service.events.lifecycle.EntityLifecycleEventDispatcher;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.resources.domains.DataProductResource;
+import org.openmetadata.service.resources.settings.SettingsCache;
 import org.openmetadata.service.rules.RuleEngine;
 import org.openmetadata.service.rules.RuleValidationException;
 import org.openmetadata.service.search.DefaultInheritedFieldEntitySearch;
@@ -90,6 +94,9 @@ import org.openmetadata.service.util.LineageUtil;
 public class DataProductRepository extends EntityRepository<DataProduct> {
   private static final String UPDATE_FIELDS =
       "experts,domains"; // Domain can now be updated with asset migration
+
+  private static final String DATA_PRODUCT_DOMAIN_VALIDATION_RULE =
+      "Data Product Domain Validation";
 
   private InheritedFieldEntitySearch inheritedFieldEntitySearch;
 
@@ -1053,6 +1060,15 @@ public class DataProductRepository extends EntityRepository<DataProduct> {
           searchRepository.propagateInheritedDomainsToChildren(assetRefs, updatedDomains);
         }
       }
+
+      // Moving the data product's domain re-homes its assets, which can strand any OTHER data
+      // product still assigned to those assets (or to descendants that inherit their domain) whose
+      // domain no longer matches — leaving the asset permanently failing "Data Product Domain
+      // Validation" on every later edit. Detach those, mirroring the Domain page cleanup. Only when
+      // the rule is enabled; with it off the mismatch is a legal configuration and is left as-is.
+      if (!assetRecords.isEmpty() && isDataProductDomainValidationRuleEnabled()) {
+        detachConflictingDataProductsAfterDomainChange(assetRecords, updatedDomains);
+      }
     }
 
     private void updateDataProductDomainContainment(
@@ -1182,6 +1198,107 @@ public class DataProductRepository extends EntityRepository<DataProduct> {
       Entity.getConversationRepository()
           .updateEntityReference(updated.getEntityReference(), oldFqn);
     }
+  }
+
+  private boolean isDataProductDomainValidationRuleEnabled() {
+    try {
+      EntityRulesSettings settings =
+          SettingsCache.getSetting(SettingsType.ENTITY_RULES_SETTINGS, EntityRulesSettings.class);
+      if (settings == null || nullOrEmpty(settings.getEntitySemantics())) {
+        return false;
+      }
+      return settings.getEntitySemantics().stream()
+          .anyMatch(
+              rule ->
+                  DATA_PRODUCT_DOMAIN_VALIDATION_RULE.equals(rule.getName())
+                      && Boolean.TRUE.equals(rule.getEnabled()));
+    } catch (EntityNotFoundException e) {
+      LOG.debug(
+          "Entity rules settings unavailable, skipping data product detach: {}", e.getMessage());
+      return false;
+    }
+  }
+
+  private void detachConflictingDataProductsAfterDomainChange(
+      List<CollectionDAO.EntityRelationshipRecord> assetRecords, List<EntityReference> newDomains) {
+    Set<UUID> newDomainIds =
+        newDomains.stream().map(EntityReference::getId).collect(Collectors.toSet());
+    for (CollectionDAO.EntityRelationshipRecord record : assetRecords) {
+      EntityReference asset =
+          Entity.getEntityReferenceById(record.getType(), record.getId(), NON_DELETED);
+      detachConflictingDataProducts(asset, ownDomainIds(asset));
+      detachConflictingDataProductsFromDescendants(asset, newDomainIds);
+    }
+  }
+
+  /**
+   * Descendants with no domain of their own inherit this asset's new domains, so their assigned data
+   * products face the same conflict. A descendant that carries its own domain is unaffected and its
+   * subtree keeps inheriting from it, so the walk stops there.
+   */
+  private void detachConflictingDataProductsFromDescendants(
+      EntityReference asset, Set<UUID> inheritedDomainIds) {
+    for (EntityReference child : getContainedChildren(asset)) {
+      if (!ownDomainIds(child).isEmpty()) {
+        continue;
+      }
+      detachConflictingDataProducts(child, inheritedDomainIds);
+      detachConflictingDataProductsFromDescendants(child, inheritedDomainIds);
+    }
+  }
+
+  private void detachConflictingDataProducts(EntityReference asset, Set<UUID> effectiveDomainIds) {
+    List<EntityReference> conflicting =
+        getDataProducts(asset.getId(), asset.getType()).stream()
+            .filter(dataProduct -> conflictsWithDomains(dataProduct, effectiveDomainIds))
+            .toList();
+    if (conflicting.isEmpty()) {
+      return;
+    }
+    removeDataProductAssignments(asset, conflicting);
+  }
+
+  private boolean conflictsWithDomains(EntityReference dataProduct, Set<UUID> effectiveDomainIds) {
+    Set<UUID> dataProductDomainIds =
+        findFrom(dataProduct.getId(), DATA_PRODUCT, Relationship.CONTAINS, DOMAIN, NON_DELETED)
+            .stream()
+            .map(EntityReference::getId)
+            .collect(Collectors.toSet());
+    return !dataProductDomainIds.isEmpty()
+        && Collections.disjoint(dataProductDomainIds, effectiveDomainIds);
+  }
+
+  private void removeDataProductAssignments(
+      EntityReference asset, List<EntityReference> dataProducts) {
+    daoCollection
+        .relationshipDAO()
+        .bulkRemoveFromRelationship(
+            dataProducts.stream().map(EntityReference::getId).toList(),
+            asset.getId(),
+            DATA_PRODUCT,
+            asset.getType(),
+            Relationship.HAS.ordinal());
+    removeDataProductsLineage(asset.getId(), asset.getType(), dataProducts);
+    EntityRepository.invalidateCacheForEntity(
+        asset.getType(), asset.getId(), asset.getFullyQualifiedName());
+    if (searchRepository != null) {
+      searchRepository.updateEntity(asset);
+    }
+  }
+
+  private Set<UUID> ownDomainIds(EntityReference asset) {
+    return findFrom(asset.getId(), asset.getType(), Relationship.HAS, DOMAIN, NON_DELETED).stream()
+        .map(EntityReference::getId)
+        .collect(Collectors.toSet());
+  }
+
+  private List<EntityReference> getContainedChildren(EntityReference parent) {
+    return daoCollection
+        .relationshipDAO()
+        .findTo(parent.getId(), parent.getType(), Relationship.CONTAINS.ordinal())
+        .stream()
+        .map(record -> Entity.getEntityReferenceById(record.getType(), record.getId(), NON_DELETED))
+        .toList();
   }
 
   private Map<UUID, List<EntityReference>> batchFetchExperts(List<DataProduct> dataProducts) {


### PR DESCRIPTION
Closes #30679

## Describe your changes

Changing a Data Product's domain re-homes its assets to the new domain, but left behind any *other* data product still assigned to those assets whose domain no longer matched. The affected assets then failed the default **Data Product Domain Validation** rule on every subsequent edit (`400 RULE_VIOLATION`), and a reindex could not recover the state because the mismatch is persisted, not an indexing artifact. The Data Product domain change was the only route that let this through — the Domain page move, changing an asset's own domain, and cross-domain assignment are all already handled or rejected.

After the existing asset-domain migration in `DataProductRepository.updateDataProductDomains`, this detaches the now-conflicting data-product assignments, mirroring the Domain page `cleanupDataProducts` behaviour:

- **Direct assets** — for each migrated asset, any assigned data product whose domains no longer intersect the asset's new domains is detached (relationship + lineage removed, caches invalidated, asset reindexed).
- **Inherited-domain descendants** — the check walks the containment subtree of each migrated asset. A descendant that inherits its domain (no explicit domain of its own) is reconciled against the new inherited domain; the walk stops at any node that carries its own domain, since it and its subtree are unaffected. This covers the reported case where a child table assigned to a data product that stayed behind broke identically, even though only its parent was the moved product's asset.

The detach reuses the validation rule's exact **disjoint-domain** semantics, so matching assignments — including the moved data product itself — are preserved and nothing is over-detached. A data product with no domains never conflicts.

The whole step is gated on the **Data Product Domain Validation** rule being enabled. When the rule is disabled the mismatch is a legal configuration and assignments are left untouched, matching pre-existing behaviour.

---

Deferred to a fast-follow (kept out to keep this diff focused): enriching the rule-violation message to name the offending data product and domain. That requires threading specifics out of the boolean JsonLogic operation in the shared rule engine — a different, cross-cutting concern. With this fix these domain-change flows no longer trigger the violation in the first place.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

Added two integration tests in `DataProductResourceIT`, both verified RED without the fix and GREEN with it (full class green, no regressions):

- `test_domainChangeDetachesConflictingDataProducts` — a schema in `Finance` assigned to two data products (both in `Finance`); moving one to `HR` detaches the one left behind, keeps the moved one, and the schema stays editable.
- `test_domainChangeDetachesConflictingDataProductsOnInheritedDescendants` — a child table inheriting its schema's domain and assigned to a data product that stays in `Finance`; moving the schema's data product to `HR` detaches the child's conflicting assignment and the child stays editable.

The rule-disabled branch is not covered by an integration test because the IT harness cannot toggle the global rule at runtime (see the pre-existing `@Disabled` tests noting `EntityRulesUtil.toggleRule not working via API`); the gate is exercised via the enabled default path.















<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61530660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the previously reported correctness issues are fixed and no new actionable failures remain.

<details open><summary>Summary</summary>

The PR reconciles data-product assignments after a data product’s domains change, removing assignments that conflict with migrated or inherited asset domains.
- Traverses inheriting descendants in bounded hydration chunks and prunes explicitly domained subtrees.
- Removes conflicting relationships and lineage, invalidates caches, and defers batched reindexing until commit.
- Adds integration coverage for direct assets, inherited descendants, soft-deleted assets, and domain removal.
- Exposes rule-enabled lookup so cleanup runs only when domain validation is active.
</details>

<details open><summary>Diagram</summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Data product domains change] --> B[Migrate direct asset domains]
  B --> C{Domain validation rule enabled?}
  C -- No --> Z[Leave assignments unchanged]
  C -- Yes --> D[Reconcile direct assets]
  D --> E[Walk containment levels]
  E --> F{Child has explicit domain?}
  F -- Yes --> G[Prune child subtree]
  F -- No --> H[Use inherited parent domains]
  H --> I{Assignment conflicts?}
  I -- No --> E
  I -- Yes --> J[Remove relationship and lineage]
  J --> K[Invalidate asset cache]
  K --> L[Queue asset for reindex]
  L --> E
  E --> M[Defer batched reindex until commit]
```
</details>

<sub>Reviews (8) · Last reviewed commit: ["perf: bound descendant reconciliation me..."](https://github.com/open-metadata/openmetadata/commit/25c7fc075336beee486827b017b67c134fec990d)</sub>

<!-- /greptile_comment -->