### PR TITLE
Backport #31632 to 1.13: explicit pathname on Explore navigate() calls

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/ExplorePage/ExplorePageV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ExplorePage/ExplorePageV1.component.tsx
@@ -24,6 +24,7 @@ import {
   UrlParams,
 } from '../../components/Explore/ExplorePage.interface';
 import ExploreV1 from '../../components/ExploreV1/ExploreV1.component';
+import { ROUTES } from '../../constants/constants';
 import { COMMON_FILTERS_FOR_DIFFERENT_TABS } from '../../constants/explore.constants';
 import {
   mockSearchData,
@@ -45,7 +46,7 @@ import {
   parseSearchParams,
 } from '../../utils/ExplorePureUtils';
 import { fetchEntityData, generateTabItems } from '../../utils/ExploreUtils';
-import { getExplorePath } from '../../utils/RouterUtils';
+import { getExplorePath, getExploreTabPath } from '../../utils/RouterUtils';
 import searchClassBase from '../../utils/SearchClassBase';
 import { useRequiredParams } from '../../utils/useRequiredParams';
 import {
@@ -111,6 +112,13 @@ const ExplorePageV1: FC<unknown> = () => {
   const handlePageChange: ExploreProps['onChangePage'] = (page, size) => {
     setPreference({ globalPageSize: size ?? globalPageSize });
     navigate({
+      // When tab is present, build the pathname from the route param rather
+      // than the router's current location: a search-only navigate is *relative*
+      // and can resolve against a stale route-match context if another component
+      // fired a pushState moments earlier.  When tab is absent (bare /explore
+      // route) fall back to the static ROUTES.EXPLORE constant so the pathname
+      // is never derived from any router state.
+      pathname: tab ? getExploreTabPath(tab) : ROUTES.EXPLORE,
       search: Qs.stringify({
         ...parsedSearch,
         page,
@@ -121,6 +129,7 @@ const ExplorePageV1: FC<unknown> = () => {
 
   const handleSortValueChange = (page: number, sortVal: string) => {
     navigate({
+      pathname: tab ? getExploreTabPath(tab) : ROUTES.EXPLORE,
       search: Qs.stringify({
         ...parsedSearch,
         page,
@@ -132,6 +141,7 @@ const ExplorePageV1: FC<unknown> = () => {
 
   const handleSortOrderChange = (page: number, sortOrderVal: string) => {
     navigate({
+      pathname: tab ? getExploreTabPath(tab) : ROUTES.EXPLORE,
       search: Qs.stringify({
         ...parsedSearch,
         page,
@@ -205,6 +215,7 @@ const ExplorePageV1: FC<unknown> = () => {
   const handleQuickFilterChange = useCallback(
     (quickFilter?: QueryFilterInterface) => {
       navigate({
+        pathname: tab ? getExploreTabPath(tab) : ROUTES.EXPLORE,
         search: Qs.stringify({
           ...parsedSearch,
           quickFilter: quickFilter ? JSON.stringify(quickFilter) : undefined,
@@ -212,7 +223,7 @@ const ExplorePageV1: FC<unknown> = () => {
         }),
       });
     },
-    [history, parsedSearch]
+    [parsedSearch, tab]
   );
 
   const handleShowDeletedChange: ExploreProps['onChangeShowDeleted'] = (
@@ -233,6 +244,7 @@ const ExplorePageV1: FC<unknown> = () => {
       : defaultSearchObject;
 
     navigate({
+      pathname: tab ? getExploreTabPath(tab) : ROUTES.EXPLORE,
       search: Qs.stringify(searchObject),
     });
   };
@@ -370,13 +382,15 @@ const ExplorePageV1: FC<unknown> = () => {
     }
   }, [isTourOpen, fetchDependencies]);
 
+  // handleQuickFilterChange already resets page to 1 in the same navigate —
+  // a separate handlePageChange(1) call here would push a second history
+  // entry against the same memoized parsedSearch and clobber the first.
   const handleAdvanceSearchQuickFiltersChange = useCallback(
     (filter?: QueryFilterInterface) => {
-      handlePageChange(1);
       setAdvancedSearchQuickFilters(filter);
       handleQuickFilterChange(filter);
     },
-    [setAdvancedSearchQuickFilters, history, parsedSearch]
+    [setAdvancedSearchQuickFilters, handleQuickFilterChange]
   );
 
   return (

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ExplorePage/ExplorePageV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ExplorePage/ExplorePageV1.component.tsx
@@ -287,11 +287,17 @@ const ExplorePageV1: FC<unknown> = () => {
     searchCriteria,
   ]);
 
+  // Key this URL-normalizing navigate on location.search, NOT on the
+  // parsedSearch memo: parsedSearch also recomputes when the provider's
+  // queryFilter state lands, and react-router applies the submit's own
+  // navigate in a transition *after* that state update — firing here at
+  // that moment re-pushes the stale pre-submit URL over the new filter.
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- see above
   useEffect(() => {
     if (!isEmpty(parsedSearch)) {
       handlePageChange(page, size);
     }
-  }, [page, size, parsedSearch]);
+  }, [page, size, location.search]);
 
   const getAdvancedSearchQuickFilters = useCallback(() => {
     if (!isString(parsedSearch.quickFilter)) {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ExplorePage/ExplorePageV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ExplorePage/ExplorePageV1.component.tsx
@@ -292,7 +292,7 @@ const ExplorePageV1: FC<unknown> = () => {
   // queryFilter state lands, and react-router applies the submit's own
   // navigate in a transition *after* that state update — firing here at
   // that moment re-pushes the stale pre-submit URL over the new filter.
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- see above
+
   useEffect(() => {
     if (!isEmpty(parsedSearch)) {
       handlePageChange(page, size);

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ExplorePage/ExplorePageV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ExplorePage/ExplorePageV1.test.tsx
@@ -10,8 +10,13 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ExploreProps } from '../../components/Explore/ExplorePage.interface';
+import ExploreV1 from '../../components/ExploreV1/ExploreV1.component';
+import useCustomLocation from '../../hooks/useCustomLocation/useCustomLocation';
+import { getExploreTabPath } from '../../utils/RouterUtils';
 import ExplorePageV1 from './ExplorePageV1.component';
 
 jest.mock(
@@ -54,7 +59,7 @@ jest.mock('react-router-dom', () => ({
       tab: 'tables',
     };
   }),
-  useNavigate: jest.fn(),
+  useNavigate: jest.fn().mockImplementation(() => jest.fn()),
 }));
 
 const mockProps = {
@@ -62,9 +67,254 @@ const mockProps = {
 };
 
 describe('ExplorePageV1', () => {
+  beforeEach(() => {
+    (useCustomLocation as jest.Mock).mockImplementation(() => ({
+      pathname: 'pathname',
+      search: '',
+    }));
+    (useNavigate as jest.Mock).mockImplementation(() => jest.fn());
+  });
+
   it('renders without crashing', async () => {
     render(<ExplorePageV1 {...mockProps} />);
 
     expect(await screen.findByText('ExploreV1')).toBeInTheDocument();
+  });
+
+  it('calls navigate exactly once with quickFilter when filter changes', async () => {
+    const mockNavigate = jest.fn();
+    (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
+
+    let capturedCallback:
+      | ((filter?: Record<string, unknown>) => void)
+      | undefined;
+    (ExploreV1 as jest.Mock).mockImplementationOnce(
+      ({
+        onChangeAdvancedSearchQuickFilters,
+      }: {
+        onChangeAdvancedSearchQuickFilters?: (
+          filter?: Record<string, unknown>
+        ) => void;
+      }) => {
+        capturedCallback = onChangeAdvancedSearchQuickFilters;
+
+        return <p>ExploreV1</p>;
+      }
+    );
+
+    render(<ExplorePageV1 {...mockProps} />);
+    await screen.findByText('ExploreV1');
+
+    const testFilter = {
+      query: {
+        bool: {
+          must: [{ bool: { should: [{ term: { entityType: 'table' } }] } }],
+        },
+      },
+    };
+
+    act(() => {
+      capturedCallback!(testFilter);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate.mock.calls[0][0].search).toContain('quickFilter');
+    expect(mockNavigate.mock.calls[0][0].pathname).toEqual(
+      getExploreTabPath('tables')
+    );
+  });
+
+  it('navigates with a pathname built from the route tab, not the current router location, when a quick filter changes', async () => {
+    // Regression guard for the bug this fix addresses: a stale/unrelated
+    // router location must not leak into the pathname a filter-change
+    // navigation targets.
+    const mockNavigate = jest.fn();
+    (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
+    (useCustomLocation as jest.Mock).mockReturnValue({
+      pathname: '/context-center/dashboard',
+      search: '',
+    });
+
+    let capturedCallback:
+      | ((filter?: Record<string, unknown>) => void)
+      | undefined;
+    (ExploreV1 as jest.Mock).mockImplementationOnce(
+      ({
+        onChangeAdvancedSearchQuickFilters,
+      }: {
+        onChangeAdvancedSearchQuickFilters?: (
+          filter?: Record<string, unknown>
+        ) => void;
+      }) => {
+        capturedCallback = onChangeAdvancedSearchQuickFilters;
+
+        return <p>ExploreV1</p>;
+      }
+    );
+
+    render(<ExplorePageV1 {...mockProps} />);
+    await screen.findByText('ExploreV1');
+
+    act(() => {
+      capturedCallback!({ query: { bool: { must: [] } } });
+    });
+
+    expect(mockNavigate.mock.calls[0][0].pathname).toEqual(
+      getExploreTabPath('tables')
+    );
+    expect(mockNavigate.mock.calls[0][0].pathname).not.toEqual(
+      '/context-center/dashboard'
+    );
+  });
+
+  it('preserves size and resets page when quick filter changes', async () => {
+    const mockNavigate = jest.fn();
+    (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
+    (useCustomLocation as jest.Mock).mockReturnValue({
+      pathname: 'pathname',
+      search: '?page=3&size=25&search=orders',
+    });
+
+    let capturedCallback:
+      | ((filter?: Record<string, unknown>) => void)
+      | undefined;
+    (ExploreV1 as jest.Mock).mockImplementationOnce(
+      ({
+        onChangeAdvancedSearchQuickFilters,
+      }: {
+        onChangeAdvancedSearchQuickFilters?: (
+          filter?: Record<string, unknown>
+        ) => void;
+      }) => {
+        capturedCallback = onChangeAdvancedSearchQuickFilters;
+
+        return <p>ExploreV1</p>;
+      }
+    );
+
+    render(<ExplorePageV1 {...mockProps} />);
+    await screen.findByText('ExploreV1');
+
+    act(() => {
+      capturedCallback?.({
+        query: {
+          bool: {
+            must: [{ bool: { should: [{ term: { entityType: 'table' } }] } }],
+          },
+        },
+      });
+    });
+
+    const lastCall = mockNavigate.mock.calls.at(-1)![0];
+    const searchParams = new URLSearchParams(lastCall.search);
+
+    expect(searchParams.get('page')).toBe('1');
+    expect(searchParams.get('size')).toBe('25');
+    expect(lastCall.pathname).toEqual(getExploreTabPath('tables'));
+  });
+
+  it('resets page when show deleted changes', async () => {
+    const mockNavigate = jest.fn();
+    (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
+    (useCustomLocation as jest.Mock).mockReturnValue({
+      pathname: 'pathname',
+      search: '?page=3&size=25',
+    });
+
+    let capturedCallback: ExploreProps['onChangeShowDeleted'] | undefined;
+    (ExploreV1 as jest.Mock).mockImplementationOnce(
+      ({
+        onChangeShowDeleted,
+      }: {
+        onChangeShowDeleted?: ExploreProps['onChangeShowDeleted'];
+      }) => {
+        capturedCallback = onChangeShowDeleted;
+
+        return <p>ExploreV1</p>;
+      }
+    );
+
+    render(<ExplorePageV1 {...mockProps} />);
+    await screen.findByText('ExploreV1');
+
+    act(() => {
+      capturedCallback?.(true);
+    });
+
+    const lastCall = mockNavigate.mock.calls.at(-1)![0];
+    const searchParams = new URLSearchParams(lastCall.search);
+
+    expect(searchParams.get('page')).toBe('1');
+    expect(searchParams.get('size')).toBe('25');
+    expect(searchParams.get('showDeleted')).toBe('true');
+    expect(lastCall.pathname).toEqual(getExploreTabPath('tables'));
+  });
+
+  it('navigates with a pathname built from the route tab when sort value changes', async () => {
+    const mockNavigate = jest.fn();
+    (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
+
+    let capturedCallback: ((sortVal: string) => void) | undefined;
+    (ExploreV1 as jest.Mock).mockImplementationOnce(
+      ({
+        onChangeSortValue,
+      }: {
+        onChangeSortValue?: (sortVal: string) => void;
+      }) => {
+        capturedCallback = onChangeSortValue;
+
+        return <p>ExploreV1</p>;
+      }
+    );
+
+    render(<ExplorePageV1 {...mockProps} />);
+    await screen.findByText('ExploreV1');
+
+    act(() => {
+      capturedCallback?.('name.keyword');
+    });
+
+    const lastCall = mockNavigate.mock.calls.at(-1)![0];
+
+    expect(lastCall.pathname).toEqual(getExploreTabPath('tables'));
+
+    const searchParams = new URLSearchParams(lastCall.search);
+
+    expect(searchParams.get('sort')).toBe('name.keyword');
+    expect(searchParams.get('page')).toBe('1');
+  });
+
+  it('navigates with a pathname built from the route tab when sort order changes', async () => {
+    const mockNavigate = jest.fn();
+    (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
+
+    let capturedCallback: ((sortOrderVal: string) => void) | undefined;
+    (ExploreV1 as jest.Mock).mockImplementationOnce(
+      ({
+        onChangeSortOder,
+      }: {
+        onChangeSortOder?: (sortOrderVal: string) => void;
+      }) => {
+        capturedCallback = onChangeSortOder;
+
+        return <p>ExploreV1</p>;
+      }
+    );
+
+    render(<ExplorePageV1 {...mockProps} />);
+    await screen.findByText('ExploreV1');
+
+    act(() => {
+      capturedCallback?.('asc');
+    });
+
+    const lastCall = mockNavigate.mock.calls.at(-1)![0];
+
+    expect(lastCall.pathname).toEqual(getExploreTabPath('tables'));
+
+    const searchParams = new URLSearchParams(lastCall.search);
+
+    expect(searchParams.get('sortOrder')).toBe('asc');
+    expect(searchParams.get('page')).toBe('1');
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/RouterUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/RouterUtils.test.ts
@@ -17,7 +17,12 @@ import {
   PLACEHOLDER_SETTING_CATEGORY,
   ROUTES,
 } from '../constants/constants';
-import { getSettingPath, getSettingsPathWithFqn } from './RouterUtils';
+import {
+  getExplorePath,
+  getExploreTabPath,
+  getSettingPath,
+  getSettingsPathWithFqn,
+} from './RouterUtils';
 
 describe('Global Setting routes', () => {
   describe('getSettingPath', () => {
@@ -119,5 +124,49 @@ describe('Global Setting routes', () => {
 
       expect(path).toEqual(expectedPath);
     });
+  });
+});
+
+describe('getExploreTabPath', () => {
+  it('should build the Explore path for the given tab', () => {
+    const path = getExploreTabPath('tables');
+
+    expect(path).toEqual(
+      ROUTES.EXPLORE_WITH_TAB.replace(PLACEHOLDER_ROUTE_TAB, 'tables')
+    );
+  });
+
+  it('should fall back to an empty tab segment when tab is undefined', () => {
+    const path = getExploreTabPath();
+
+    expect(path).toEqual(
+      ROUTES.EXPLORE_WITH_TAB.replace(PLACEHOLDER_ROUTE_TAB, '')
+    );
+  });
+
+  it('should not depend on the current window location', () => {
+    // Regression guard: this pathname must be derivable purely from the
+    // `tab` argument, independent of `window.location`, so callers merging
+    // it into a `navigate({ pathname, search })` call can't be affected by
+    // stale router location state. Changing the current URL between the two
+    // calls must not change the result.
+    const before = getExploreTabPath('dashboards');
+
+    const originalPath = window.location.pathname;
+    window.history.pushState({}, '', '/some/unrelated/page');
+
+    const after = getExploreTabPath('dashboards');
+
+    window.history.pushState({}, '', originalPath);
+
+    expect(after).toEqual(before);
+  });
+});
+
+describe('getExplorePath', () => {
+  it('should build the pathname from getExploreTabPath', () => {
+    const path = getExplorePath({ tab: 'topics' });
+
+    expect(path.startsWith(getExploreTabPath('topics'))).toBe(true);
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/RouterUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/RouterUtils.ts
@@ -749,16 +749,19 @@ export const getServiceDetailsPath = (
   return path;
 };
 
+// Built from the ROUTES constant rather than the router's current location —
+// callers merging this into a `search`-only update need a pathname that
+// can't be affected by the router's location-context resolution.
+export const getExploreTabPath = (tab?: string): string =>
+  ROUTES.EXPLORE_WITH_TAB.replace(PLACEHOLDER_ROUTE_TAB, tab ?? '');
+
 export const getExplorePath: (args: {
   tab?: string;
   search?: string;
   extraParameters?: Record<string, unknown>;
   isPersistFilters?: boolean;
 }) => string = ({ tab, search, extraParameters, isPersistFilters = true }) => {
-  const pathname = ROUTES.EXPLORE_WITH_TAB.replace(
-    PLACEHOLDER_ROUTE_TAB,
-    tab ?? ''
-  );
+  const pathname = getExploreTabPath(tab);
   let paramsObject: Record<string, unknown> = QueryString.parse(
     location.search.startsWith('?')
       ? location.search.substring(1)


### PR DESCRIPTION
## Describe your changes

Backport of #31632 to the `1.13` branch.

**Issue:** After upgrading to 1.13.5, the Explore filter pattern (advanced search / quick filters) reverts to its previous configuration on backward navigation. Reported by a customer via support; already fixed in 2.0.

**Root cause:** 1.13.5 is the first 1.13 release containing the react-router v7 backport (#32469). ExplorePageV1 still had five pathname-less `navigate({ search })` calls written for the v5 `history.push` semantics. Under router v7 these are *relative* navigations resolved against the router's route-match context, which can lag a pushState fired moments earlier — stale search params then get pushed over the fresh URL, reverting the filter. On main this was fixed by #31632; the Explore redesign (#29624, not backportable) independently removed one more affected call site.

**Changes (adapted from the main fix, cherry-pick of 5333f258e2):**
- Explicit `pathname: tab ? getExploreTabPath(tab) : ROUTES.EXPLORE` on all six Explore `navigate()` calls — page change, sort value, sort order, quick filter, show-deleted — including `handlePageChange`, which #31632 did not touch on main because the redesign had already removed it there. `getExploreTabPath` is built from static `ROUTES` constants, independent of all router state.
- Removed the double navigate in `handleAdvanceSearchQuickFiltersChange` (`handlePageChange(1)` followed by `handleQuickFilterChange` against the same memoized `parsedSearch` — the second push clobbered the first and polluted the back stack). The quick-filter navigate already resets `page` to 1.
- Dropped the main-only `handleTreeSelect` hunk (browse tree does not exist on 1.13) and adapted the tests from `currentPage`/`pageSize`/`usePaging` to 1.13's `page`/`size` params.



https://github.com/user-attachments/assets/b8eb1ddc-a03e-4aa6-aa57-3ea81f8ec175



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have added tests around the new logic — Jest: `ExplorePageV1.test.tsx` + `RouterUtils.test.ts`, 19/19 passing, including a regression test that sets a stale `/context-center/dashboard` router location and asserts filter navigation still targets Explore.
- [x] Prettier clean, ESLint exit 0; the 3 pre-existing tsc errors in `ExplorePageV1.component.tsx` exist identically on the 1.13 baseline (verified against HEAD~1).

**Note for reviewers:** regression surface is every Explore filter/sort/pagination URL update — please run the Explore Playwright suite on this PR before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)