### PR TITLE
chore(ui): sanitize stringToHTML output via DOMPurify (2.0 backport)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.test.ts
@@ -41,6 +41,7 @@ import {
   removeAttachmentsWithoutUrl,
   replaceCallback,
   slugify,
+  stringToHTML,
   stripMarkdown,
 } from './StringUtils';
 
@@ -450,6 +451,91 @@ describe('StringUtils', () => {
       const result = getTrimmedContent(content, 1000);
 
       expect(result).not.toContain('line-four');
+    });
+  });
+
+  describe('stringToHTML sanitization', () => {
+    // Helper: stringify the parse() output to a comparable HTML string.
+    const toHtml = (result: string | JSX.Element | JSX.Element[]): string => {
+      if (typeof result === 'string') {
+        return result;
+      }
+      const nodes = Array.isArray(result) ? result : [result];
+
+      return nodes
+        .map((node) => {
+          if (typeof node === 'string') {
+            return node;
+          }
+          const { type, props } = node;
+          const tag =
+            typeof type === 'string' ? type : (type as { name?: string }).name;
+          const attrs = Object.entries(props ?? {})
+            .filter(([k]) => k !== 'children')
+            .map(([k, v]) => `${k}="${String(v)}"`)
+            .join(' ');
+          const children = (props as { children?: unknown })?.children ?? '';
+
+          return `<${tag}${attrs ? ' ' + attrs : ''}>${
+            typeof children === 'string' ? children : ''
+          }</${tag}>`;
+        })
+        .join('');
+    };
+
+    it('returns falsy input untouched', () => {
+      expect(stringToHTML('')).toBe('');
+    });
+
+    it('strips <iframe>', () => {
+      const payload =
+        '<iframe src="javascript:alert(document.domain)"></iframe>';
+      const html = toHtml(stringToHTML(payload));
+
+      expect(html).not.toContain('<iframe');
+      expect(html).not.toContain('javascript:');
+    });
+
+    it('strips <script> tags', () => {
+      const payload = '<script>alert(1)</script>hello';
+      const html = toHtml(stringToHTML(payload));
+
+      expect(html).not.toContain('<script');
+      expect(html).toContain('hello');
+    });
+
+    it('strips inline event-handler attributes (onerror, onclick)', () => {
+      const payload = '<img src=x onerror="alert(1)">';
+      const html = toHtml(stringToHTML(payload));
+
+      expect(html).not.toMatch(/onerror=/i);
+    });
+
+    it('strips <form><button formaction=javascript:...>', () => {
+      const payload =
+        '<form><button formaction="javascript:alert(document.cookie)">team_test</button></form>';
+      const html = toHtml(stringToHTML(payload));
+
+      expect(html).not.toMatch(/formaction=["']?javascript:/i);
+    });
+
+    it('preserves the highlightSearchText <span> wrapper', () => {
+      const highlighted =
+        '<span data-highlight="true" class="text-highlighter">foo</span>';
+      const html = toHtml(stringToHTML(highlighted));
+
+      expect(html).toContain('foo');
+      expect(html).toContain('text-highlighter');
+    });
+
+    it('preserves benign diff/highlight tags (<mark>, <ins>, <del>, <em>)', () => {
+      const payload = '<mark>m</mark><ins>i</ins><del>d</del><em>e</em>';
+      const html = toHtml(stringToHTML(payload));
+
+      expect(html).toContain('m');
+      expect(html).toContain('i');
+      expect(html).toContain('d');
+      expect(html).toContain('e');
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.ts
@@ -12,6 +12,7 @@
  */
 
 import { AxiosError } from 'axios';
+import DOMPurify from 'dompurify';
 import parse from 'html-react-parser';
 import { get, isString } from 'lodash';
 import removeMarkdown from 'remove-markdown';
@@ -91,15 +92,19 @@ export const getQueryWithSlash = (query: string): string =>
   query.replaceAll(/["']/g, String.raw`\$&`);
 
 /**
- * Convert a template string into HTML DOM nodes
- * Same as React.createElement(type, options, children)
- * @param  {String} str The template string
- * @return {Node}       The template HTML
+ * Convert a template string into HTML DOM nodes.
+ * Input is sanitized with DOMPurify before being parsed so any HTML string
+ * flowing through this helper — search-hit highlights, entity
+ * name/displayName in headers and summary panels, version diff snippets —
+ * is scrubbed before being turned into React nodes. DOMPurify's default
+ * profile preserves the benign markup callers rely on
+ * (<span class>, <mark>, <em>, <ins>, <del>) while stripping <iframe>,
+ * <script>, event handler attributes, and javascript:/data: URLs.
  */
 export const stringToHTML = function (
   strHTML: string
 ): string | JSX.Element | JSX.Element[] {
-  return strHTML ? parse(strHTML) : strHTML;
+  return strHTML ? parse(DOMPurify.sanitize(strHTML)) : strHTML;
 };
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/utils/mocks/EntitySummaryPanelUtils.mock.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/mocks/EntitySummaryPanelUtils.mock.tsx
@@ -93,11 +93,13 @@ export const mockTagsSortAndHighlightResponse = [
 
 export const mockTagFQNsForHighlight = ['PersonalData.SpecialCategory'];
 
+// Mirrors what highlightSearchText() actually emits (`class=`, not the JSX
+// `className=`) so the string is valid HTML that DOMPurify won't strip.
 export const mockListItemNameHighlight =
-  '<span className="text-highlighter">title2</span>';
+  '<span class="text-highlighter">title2</span>';
 
 const mockListItemDescriptionHighlight =
-  'some description of <span className="text-highlighter">title2</span>';
+  'some description of <span class="text-highlighter">title2</span>';
 
 export const mockHighlights = {
   'columns.name': [mockListItemNameHighlight],


### PR DESCRIPTION
Backport to 2.0 of the same change proposed against `main` in #32949.

## Summary

`stringToHTML` in `openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.ts` is a thin wrapper around `html-react-parser`'s `parse()`, used across the UI to render stored user content — entity `name` / `displayName` in headers, search-hit highlights, version-diff snippets, service/table/team lists, ingestion pipeline names, etc.

Today `parse()` receives the raw string as-is. This change routes it through `DOMPurify.sanitize()` first so the helper produces a safe DOM tree regardless of what stored content flows in.

DOMPurify's default profile keeps the benign markup callers actually rely on:

- the `<span data-highlight class="text-highlighter">` wrapper emitted by `highlightSearchText`
- `<mark>`, `<em>`, `<ins>`, `<del>` used by search-hit rendering and version diffs

and strips things that have no legitimate reason to appear inside a helper called `stringToHTML`:

- disallowed elements (`<iframe>`, `<script>`, `<form>`, `<object>`, `<embed>`)
- inline event-handler attributes (`onerror`, `onclick`, `formaction`, …)
- `javascript:` / `data:` URL schemes

Mirrors the existing `getSanitizeContent()` helper used by `SanitizedInput`.

## Changes

- `openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.ts` — wrap `parse()` input in `DOMPurify.sanitize()` inside `stringToHTML`; expanded JSDoc.
- `openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.test.ts` — added `stringToHTML sanitization` describe covering `<iframe>`, `<script>`, `<img onerror>`, `<form><button formaction=javascript:>` (all stripped) and the benign `<span class>`, `<mark>`, `<em>`, `<ins>`, `<del>` tags (all preserved).

## Test plan

- [x] Same change validated on the `main` branch: `yarn jest src/utils/StringUtils.test.ts` — 92/92 pass; `EntityHeaderTitle` tests pass.
- [ ] CI on this backport branch to re-run the same suites against the 2.0 tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)