### PR TITLE
Backport 2.0: hide the Data Product Reviewers field in OSS (#32914)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.component.tsx
@@ -166,6 +166,36 @@ const normalizeExtensionForApi = (
   return normalized;
 };
 
+const applyDataProductFields = (
+  dataProduct: CreateDataProduct,
+  formData: DomainFormValues,
+  parentDomain?: Domain
+): void => {
+  const domainRef = formData.domains?.value as EntityReference | undefined;
+  if (domainRef?.fullyQualifiedName) {
+    dataProduct.domains = [domainRef.fullyQualifiedName];
+  } else if (parentDomain?.fullyQualifiedName) {
+    dataProduct.domains = [parentDomain.fullyQualifiedName];
+  }
+  if (formData.dataProductType?.value) {
+    dataProduct.dataProductType = formData.dataProductType
+      .value as DataProductType;
+  }
+  if (formData.visibility?.value) {
+    dataProduct.visibility = formData.visibility.value as Visibility;
+  }
+  if (formData.portfolioPriority?.value) {
+    dataProduct.portfolioPriority = formData.portfolioPriority
+      .value as PortfolioPriority;
+  }
+  // Collate-only: no field means the property is never sent.
+  if (domainClassBase.getReviewersField()) {
+    dataProduct.reviewers = formData.reviewers.map(
+      (item) => item.value as EntityReference
+    );
+  }
+};
+
 export const transformDomainFormData = (
   formData: DomainFormValues,
   type: DomainFormType,
@@ -176,9 +206,6 @@ export const transformDomainFormData = (
     (item) => item.value as EntityReference
   );
   const ownersList = formData.owners.map(
-    (item) => item.value as EntityReference
-  );
-  const reviewersList = formData.reviewers.map(
     (item) => item.value as EntityReference
   );
 
@@ -222,25 +249,7 @@ export const transformDomainFormData = (
   } as CreateDomain | CreateDataProduct;
 
   if (type === DomainFormType.DATA_PRODUCT) {
-    const dataProduct = data as CreateDataProduct;
-    const domainRef = formData.domains?.value as EntityReference | undefined;
-    if (domainRef?.fullyQualifiedName) {
-      dataProduct.domains = [domainRef.fullyQualifiedName];
-    } else if (parentDomain?.fullyQualifiedName) {
-      dataProduct.domains = [parentDomain.fullyQualifiedName];
-    }
-    if (formData.dataProductType?.value) {
-      dataProduct.dataProductType = formData.dataProductType
-        .value as DataProductType;
-    }
-    if (formData.visibility?.value) {
-      dataProduct.visibility = formData.visibility.value as Visibility;
-    }
-    if (formData.portfolioPriority?.value) {
-      dataProduct.portfolioPriority = formData.portfolioPriority
-        .value as PortfolioPriority;
-    }
-    dataProduct.reviewers = reviewersList;
+    applyDataProductFields(data as CreateDataProduct, formData, parentDomain);
   } else {
     delete (data as CreateDomain & { domains?: unknown }).domains;
   }
@@ -939,23 +948,21 @@ const AddDomainForm = ({
     type: FieldTypes.USER_TEAM_SELECT,
   });
 
-  const reviewersField: FieldProp = applyIntakeFormRequired({
-    id: 'root/reviewers',
-    label: t('label.reviewer-plural'),
-    name: 'reviewers',
-    placeholder: t('label.select-field', {
-      field: t('label.reviewer-plural'),
-    }),
-    props: {
-      filterOption: () => true,
-      multiple: true,
-      onFocus: handleUserTeamFocus,
-      onSearchChange: (searchText: string) =>
-        debouncedUserTeamSearch(searchText),
-      options: userTeamOptions,
-    },
-    type: FieldTypes.USER_TEAM_SELECT_INPUT,
-  });
+  const baseReviewersField = domainClassBase.getReviewersField();
+  const reviewersField: FieldProp | null = baseReviewersField
+    ? applyIntakeFormRequired({
+        ...baseReviewersField,
+        props: {
+          ...baseReviewersField.props,
+          filterOption: () => true,
+          multiple: true,
+          onFocus: handleUserTeamFocus,
+          onSearchChange: (searchText: string) =>
+            debouncedUserTeamSearch(searchText),
+          options: userTeamOptions,
+        },
+      })
+    : null;
 
   const dataProductTypeField: FieldProp = applyIntakeFormRequired({
     id: 'root/dataProductType',
@@ -1121,7 +1128,7 @@ const AddDomainForm = ({
 
       <div>{getField(ownersField)}</div>
       <div>{getField(expertsField)}</div>
-      {isDataProduct && <div>{getField(reviewersField)}</div>}
+      {isDataProduct && reviewersField && <div>{getField(reviewersField)}</div>}
 
       {customPropertiesLoaded && (
         <AddDomainFormExtensionFields

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.test.tsx
@@ -46,6 +46,7 @@ import {
 } from '../../../generated/type/tagLabel';
 import { getIntakeFormByEntityType } from '../../../rest/intakeFormsAPI';
 import { getCustomPropertiesByEntityType } from '../../../rest/metadataTypeAPI';
+import domainClassBase from '../../../utils/Domain/DomainClassBase';
 import { DomainFormType } from '../DomainPage.interface';
 import AddDomainForm, {
   DOMAIN_FORM_DEFAULTS,
@@ -236,6 +237,7 @@ jest.mock('../../../utils/Domain/DomainClassBase', () => ({
   __esModule: true,
   default: {
     getCoverImageField: jest.fn().mockReturnValue(null),
+    getReviewersField: jest.fn().mockReturnValue(null),
   },
 }));
 
@@ -329,6 +331,11 @@ const AddDomainFormHarness = ({
     />
   );
 };
+
+// `clearMocks` clears calls, not return values, so opt-ins would leak.
+beforeEach(() => {
+  (domainClassBase.getReviewersField as jest.Mock).mockReturnValue(null);
+});
 
 describe('AddDomainForm', () => {
   beforeEach(() => {
@@ -450,6 +457,25 @@ describe('AddDomainForm', () => {
     const form = document.querySelector('form');
 
     expect(form).toBeInTheDocument();
+  });
+
+  it('hides the reviewers field when the class base provides none', () => {
+    render(<AddDomainFormHarness type={DomainFormType.DATA_PRODUCT} />);
+
+    expect(screen.queryByTestId('root/reviewers')).not.toBeInTheDocument();
+  });
+
+  it('renders the reviewers field when the class base provides one', () => {
+    (domainClassBase.getReviewersField as jest.Mock).mockReturnValue({
+      id: 'root/reviewers',
+      label: 'Reviewers',
+      name: 'reviewers',
+      type: 'user_team_select_input',
+    });
+
+    render(<AddDomainFormHarness type={DomainFormType.DATA_PRODUCT} />);
+
+    expect(screen.getByTestId('root/reviewers')).toBeInTheDocument();
   });
 
   it('wires the configured entity-reference and hyperlink intake fields', async () => {
@@ -798,6 +824,37 @@ describe('transformDomainFormData', () => {
     );
 
     expect(result).toHaveProperty('domains', ['Finance']);
+  });
+
+  it('omits reviewers from the DATA_PRODUCT payload when the field is hidden', () => {
+    const result = transformDomainFormData(
+      {
+        ...baseForm,
+        reviewers: [buildItem('reviewer-1', expertRef)],
+      },
+      DomainFormType.DATA_PRODUCT
+    );
+
+    expect(result).not.toHaveProperty('reviewers');
+  });
+
+  it('includes reviewers in the DATA_PRODUCT payload when the field is shown', () => {
+    (domainClassBase.getReviewersField as jest.Mock).mockReturnValue({
+      id: 'root/reviewers',
+      label: 'Reviewers',
+      name: 'reviewers',
+      type: 'user_team_select_input',
+    });
+
+    const result = transformDomainFormData(
+      {
+        ...baseForm,
+        reviewers: [buildItem('reviewer-1', expertRef)],
+      },
+      DomainFormType.DATA_PRODUCT
+    );
+
+    expect(result).toHaveProperty('reviewers', [expertRef]);
   });
 
   it('omits domains when DATA_PRODUCT has neither selection nor parent FQN', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Domain/DomainClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Domain/DomainClassBase.test.ts
@@ -145,6 +145,12 @@ describe('DomainClassBase', () => {
     });
   });
 
+  describe('getReviewersField', () => {
+    it('returns null so OSS never renders the Collate-only reviewers field', () => {
+      expect(instance.getReviewersField()).toBeNull();
+    });
+  });
+
   describe('singleton export', () => {
     it('default export is an instance of DomainClassBase', () => {
       expect(domainClassBase).toBeInstanceOf(DomainClassBase);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Domain/DomainClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Domain/DomainClassBase.ts
@@ -270,6 +270,11 @@ class DomainClassBase {
     return null;
   }
 
+  // Reviewers are Collate-only; overridden downstream.
+  public getReviewersField(): FieldProp | null {
+    return null;
+  }
+
   public getWidgetHeight(widgetName: string) {
     switch (widgetName) {
       case DetailPageWidgetKeys.DESCRIPTION:


### PR DESCRIPTION
Backport of #32914 to `2.0`. **Half of a pair** — see Sequencing below.

> [!IMPORTANT]
> **#32914 is not merged yet** — approved but still open. This is cherry-picked from its head (`28298f8536`), so if the source changes before it lands this needs re-syncing.

## What it does

`DomainClassBase.getReviewersField()` returns `null`, and `AddDomainForm` gates both the rendered field and the submitted payload on it. Effect in OSS: the Data Product form shows no Reviewers field and never sends the property. Collate re-enables it by overriding the method downstream.

## Sequencing — merge the Collate half FIRST

| order | result |
|---|---|
| open-metadata/openmetadata-collate#6452 first | **Safe.** That override is inert until this gate exists — nothing calls `getReviewersField()` yet, so behaviour is unchanged on both sides. |
| **this PR first** | **Temporary regression.** This hides the field in OSS **and on Collate 2.0**, until #6452 lands. |

Collate 2.0's `.gitmodules` tracks OSS `2.0` and its CI runs `git submodule update --init --remote`, so this branch's tip reaches Collate 2.0 immediately — there is no submodule pin to hold it back.

I verified both directions by running the Collate override suite against a plain `origin/2.0` OSS tree and against this branch, rather than assuming.

## Adaptation from main

One. `main` extracted the form's conditional sections into a `renderConditionalSections()` helper, so the 3-way merge offered that whole extraction as the incoming side. 2.0 still renders those sections inline in the JSX, so I kept 2.0's structure and applied only the gate:

```diff
-      {isDataProduct && <div>{getField(reviewersField)}</div>}
+      {isDataProduct && reviewersField && <div>{getField(reviewersField)}</div>}
```

Everything else — `applyDataProductFields`, the nullable `reviewersField`, the base method, and both test files — applied cleanly.

## Verification

- **`AddDomainForm.test.tsx` + `DomainClassBase.test.ts`: 43 tests passing** (101 across all three `AddDomainForm` suites), including the new cases the PR adds.
- Prettier clean on all four files.
- eslint left to CI — 2.0's config needs a `jsonc-eslint-parser` the borrowed `node_modules` cannot provide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)