### PR TITLE
Fixes 32935: Add PageHeader density options

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/page-header/page-header.stories.test.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/page-header/page-header.stories.test.tsx
@@ -1,0 +1,40 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { CompactDensity } from '../../../stories/PageHeader.stories';
+
+describe('PageHeader.stories', () => {
+  it('updates the explanatory copy when the density control changes', () => {
+    const story = CompactDensity;
+    const { rerender } = render(
+      story.render({ ...story.args, density: 'compact' })
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Compact density — 12px' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Reduced vertical padding for denser application shells')
+    ).toBeInTheDocument();
+
+    rerender(story.render({ ...story.args, density: 'comfortable' }));
+
+    expect(
+      screen.getByRole('heading', { name: 'Comfortable density — 16px' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Default vertical padding for standard page layouts')
+    ).toBeInTheDocument();
+  });
+});

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/page-header/page-header.test.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/page-header/page-header.test.tsx
@@ -55,6 +55,42 @@ describe('PageHeader', () => {
     expect(screen.getByText('A subtitle')).toBeInTheDocument();
   });
 
+  it.each([
+    ['comfortable', 'tw:py-4'],
+    ['compact', 'tw:py-3'],
+  ] as const)('applies %s vertical padding', (density, expectedClass) => {
+    render(<PageHeader density={density} title="Titled" />);
+
+    expect(screen.getByTestId('page-header')).toHaveClass(expectedClass);
+  });
+
+  it('uses comfortable density by default', () => {
+    render(<PageHeader title="Titled" />);
+
+    expect(screen.getByTestId('page-header')).toHaveClass('tw:py-4');
+  });
+
+  it.each([
+    ['comfortable', 'tw:pt-4'],
+    ['compact', 'tw:pt-3'],
+  ] as const)(
+    'removes bottom padding from the %s density when a footer is present',
+    (density, expectedClass) => {
+      render(
+        <PageHeader
+          density={density}
+          footer={<div data-testid="footer" />}
+          title="Titled"
+        />
+      );
+
+      expect(screen.getByTestId('page-header')).toHaveClass(
+        expectedClass,
+        'tw:pb-0'
+      );
+    }
+  );
+
   it('renders a default FeaturedIcon tile when icon is a component', () => {
     const Icon = ({ className }: { className?: string }) => (
       <svg className={className} data-testid="header-icon" />

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/page-header/page-header.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/page-header/page-header.tsx
@@ -21,13 +21,26 @@ import { Typography } from '../../foundations/typography';
 import { Breadcrumbs } from '../breadcrumbs/breadcrumbs';
 import type { BreadcrumbItemType } from '../breadcrumbs/breadcrumbs';
 import { Tabs } from '../tabs/tabs';
-import type { PageHeaderProps, PageHeaderTab } from './page-header.types';
+import type {
+  PageHeaderDensity,
+  PageHeaderProps,
+  PageHeaderTab,
+} from './page-header.types';
 
 export type {
+  PageHeaderDensity,
   PageHeaderProps,
   PageHeaderTab,
   PageHeaderVariant,
 } from './page-header.types';
+
+const PADDING_BY_DENSITY: Record<
+  PageHeaderDensity,
+  { default: string; withFooter: string }
+> = {
+  compact: { default: 'tw:py-3', withFooter: 'tw:pt-3 tw:pb-0' },
+  comfortable: { default: 'tw:py-4', withFooter: 'tw:pt-4 tw:pb-0' },
+};
 
 // Distinguishes a breadcrumb items array from a ReactNode (which can itself be
 // an array of elements) by shape — items are plain objects carrying `id`+`label`.
@@ -122,6 +135,7 @@ export const PageHeader = ({
   search,
   actions,
   footer,
+  density = 'comfortable',
   variant = 'flat',
   className,
   'data-testid': dataTestId = 'page-header',
@@ -129,7 +143,9 @@ export const PageHeader = ({
 }: PageHeaderProps) => {
   // When the header renders a footer (the tab strip), the tabs sit flush at the
   // bottom edge of the card — drop the card's bottom padding but keep the top.
-  const paddingClass = footer ? 'tw:pt-4 tw:pb-0' : 'tw:py-4';
+  const paddingClass = footer
+    ? PADDING_BY_DENSITY[density].withFooter
+    : PADDING_BY_DENSITY[density].default;
 
   const leadingNode =
     typeof icon === 'function' ? (

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/page-header/page-header.types.ts
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/page-header/page-header.types.ts
@@ -14,6 +14,7 @@ import type { ComponentProps, FC, HTMLAttributes, ReactNode } from 'react';
 import type { Input } from '../../base/input/input';
 import type { BreadcrumbItemType } from '../breadcrumbs/breadcrumbs';
 
+export type PageHeaderDensity = 'compact' | 'comfortable';
 export type PageHeaderVariant = 'flat' | 'gradient';
 
 export interface PageHeaderTab {
@@ -65,6 +66,8 @@ export interface PageHeaderProps
    * optional per-tab `count` badge), or a custom node for full control.
    */
   footer?: ReactNode | PageHeaderTab[];
+  /** Vertical spacing. Defaults to 'comfortable'. */
+  density?: PageHeaderDensity;
   /** Visual treatment. 'gradient' applies the brand-tinted card per Figma. */
   variant?: PageHeaderVariant;
   'data-testid'?: string;

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/stories/PageHeader.stories.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/stories/PageHeader.stories.tsx
@@ -69,8 +69,8 @@ export const Basic: Story = {
 export const CompactDensity: Story = {
   args: {
     density: 'compact',
-    subtitle: '12px vertical padding for denser application shells',
-    title: 'Compact page header',
+    subtitle: 'Reduced vertical padding for denser application shells',
+    title: 'Compact density — 12px',
   },
   render: (args) => (
     <Frame>
@@ -82,8 +82,8 @@ export const CompactDensity: Story = {
 export const ComfortableDensity: Story = {
   args: {
     density: 'comfortable',
-    subtitle: '16px vertical padding for the default page rhythm',
-    title: 'Comfortable page header',
+    subtitle: 'Default vertical padding for standard page layouts',
+    title: 'Comfortable density — 16px',
   },
   render: (args) => (
     <Frame>

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/stories/PageHeader.stories.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/stories/PageHeader.stories.tsx
@@ -54,6 +54,35 @@ const Frame = ({ children }: { children: React.ReactNode }) => (
   <div className="tw:bg-secondary tw:p-4">{children}</div>
 );
 
+const DENSITY_COPY = {
+  compact: {
+    subtitle: 'Reduced vertical padding for denser application shells',
+    title: 'Compact density — 12px',
+  },
+  comfortable: {
+    subtitle: 'Default vertical padding for standard page layouts',
+    title: 'Comfortable density — 16px',
+  },
+} as const;
+
+const renderDensityStory = (args: React.ComponentProps<typeof PageHeader>) => {
+  const density = args.density ?? 'comfortable';
+  const copy = DENSITY_COPY[density];
+
+  // Keep the explanatory copy synchronized when the Storybook density control
+  // overrides the preset selected from the sidebar.
+  return (
+    <Frame>
+      <PageHeader
+        {...args}
+        density={density}
+        subtitle={copy.subtitle}
+        title={copy.title}
+      />
+    </Frame>
+  );
+};
+
 export const Basic: Story = {
   args: {
     title: 'Snowflake',
@@ -69,27 +98,17 @@ export const Basic: Story = {
 export const CompactDensity: Story = {
   args: {
     density: 'compact',
-    subtitle: 'Reduced vertical padding for denser application shells',
-    title: 'Compact density — 12px',
+    ...DENSITY_COPY.compact,
   },
-  render: (args) => (
-    <Frame>
-      <PageHeader {...args} />
-    </Frame>
-  ),
+  render: renderDensityStory,
 };
 
 export const ComfortableDensity: Story = {
   args: {
     density: 'comfortable',
-    subtitle: 'Default vertical padding for standard page layouts',
-    title: 'Comfortable density — 16px',
+    ...DENSITY_COPY.comfortable,
   },
-  render: (args) => (
-    <Frame>
-      <PageHeader {...args} />
-    </Frame>
-  ),
+  render: renderDensityStory,
 };
 
 // Variation 1 — the standard header assembled from convenience props: an `icon`

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/stories/PageHeader.stories.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/stories/PageHeader.stories.tsx
@@ -28,6 +28,10 @@ const meta = {
   },
   tags: ['autodocs'],
   argTypes: {
+    density: {
+      control: 'inline-radio',
+      options: ['compact', 'comfortable'],
+    },
     variant: {
       control: 'inline-radio',
       options: ['flat', 'gradient'],
@@ -54,6 +58,32 @@ export const Basic: Story = {
   args: {
     title: 'Snowflake',
     subtitle: 'Production data warehouse service',
+  },
+  render: (args) => (
+    <Frame>
+      <PageHeader {...args} />
+    </Frame>
+  ),
+};
+
+export const CompactDensity: Story = {
+  args: {
+    density: 'compact',
+    subtitle: '12px vertical padding for denser application shells',
+    title: 'Compact page header',
+  },
+  render: (args) => (
+    <Frame>
+      <PageHeader {...args} />
+    </Frame>
+  ),
+};
+
+export const ComfortableDensity: Story = {
+  args: {
+    density: 'comfortable',
+    subtitle: '16px vertical padding for the default page rhythm',
+    title: 'Comfortable page header',
   },
   render: (args) => (
     <Frame>


### PR DESCRIPTION
### Describe your changes:

Part of #32935

This adds the core-component prerequisite for migrating application headers:

- Adds a semantic `density` option to `PageHeader`: `compact` uses 12px vertical padding and `comfortable` uses the existing 16px default.
- Preserves zero bottom padding whenever a footer is present, keeping footer tabs flush with the card edge.
- Exports the density type and documents both modes through Storybook controls and examples.
- Leaves the public `PageLayout` API unchanged and does not add an `actionsClassName` escape hatch.

#
### Type of change:

- [x] Improvement

#
### High-level design:

N/A — this is a small, backward-compatible addition to an existing core component. An exhaustive density-to-padding map keeps the two semantic modes aligned with the design-system spacing scale while preserving the existing footer branch.

#
### Tests:

#### Use cases covered

- Comfortable density remains the default and applies 16px vertical padding.
- Compact density applies 12px vertical padding.
- Both densities remove bottom padding when a footer is present.
- Storybook exposes both density examples, and changing the density control updates the explanatory title and subtitle.

#### Unit tests

- [x] I added unit tests for the new/changed logic.
- Files updated:
  - `src/components/application/page-header/page-header.test.tsx`
  - `src/components/application/page-header/page-header.stories.test.tsx`
- Result: 28 focused PageHeader and Storybook behavior tests passed.
- Coverage: Not collected because the core-components package does not configure a coverage provider.

#### Backend integration tests

- [x] Not applicable (no backend API changes).

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Not applicable — this is an additive presentational component API covered by unit tests and Storybook; no application route changed.

#### Manual testing performed

1. Built the core-components package and verified generated declarations export `PageHeaderDensity`.
2. Built the static Storybook and verified the compact and comfortable PageHeader entries were generated.
3. Ran TypeScript type-checking and the changed-file UI checkstyle workflow.

A full core-components test run also reproduced one existing failure in the unchanged table selection test (`can omit the selection cell for a full-width synthetic row`); the table source and test match `origin/main`.

#
### UI screen recording / screenshots:

TODO: Attach compact and comfortable Storybook screenshots before marking this PR ready for review.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`.
- [x] My PR is linked to a GitHub issue above.
- [x] I have commented on my code where the behavior is non-obvious.
- [x] Not applicable for JSON Schema changes; this PR does not modify schemas.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests and listed them above.

#### Improvement

- [x] I have added tests around the new logic.
- [x] Not applicable for connector or ingestion documentation.

