### PR TITLE
Fixes #32957: stop the ingestion bot blanking a user-curated displayName [1.13]

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BaseEntityIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BaseEntityIT.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.openmetadata.it.auth.JwtAuthProvider;
 import org.openmetadata.it.bootstrap.SharedEntities;
 import org.openmetadata.it.util.EntityValidation;
 import org.openmetadata.it.util.SdkClients;
@@ -33,10 +34,21 @@ import org.openmetadata.it.util.TestNamespaceExtension;
 import org.openmetadata.it.util.UpdateType;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.api.domains.CreateDataProduct;
+import org.openmetadata.schema.api.policies.CreatePolicy;
+import org.openmetadata.schema.api.teams.CreateRole;
+import org.openmetadata.schema.api.teams.CreateUser;
+import org.openmetadata.schema.auth.JWTAuthMechanism;
+import org.openmetadata.schema.auth.JWTTokenExpiry;
 import org.openmetadata.schema.entity.domains.DataProduct;
+import org.openmetadata.schema.entity.policies.Policy;
+import org.openmetadata.schema.entity.policies.accessControl.Rule;
+import org.openmetadata.schema.entity.teams.AuthenticationMechanism;
+import org.openmetadata.schema.entity.teams.Role;
+import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.type.ApiStatus;
 import org.openmetadata.schema.type.ChangeDescription;
 import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.api.BulkOperationResult;
 import org.openmetadata.schema.type.api.BulkResponse;
@@ -46,6 +58,9 @@ import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.exceptions.InvalidRequestException;
 import org.openmetadata.sdk.fluent.Users;
 import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.sdk.services.policies.PolicyService;
+import org.openmetadata.sdk.services.teams.RoleService;
+import org.openmetadata.sdk.services.teams.UserService;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.EntityRepository;
 import org.openmetadata.service.util.TestUtils;
@@ -4751,6 +4766,205 @@ public abstract class BaseEntityIT<T extends EntityInterface, K> {
       requests.add(createRequest(ns.prefix(prefix + i), ns));
     }
     return requests;
+  }
+
+  /**
+   * Test: A bot whose policy DENIES {@code EditDisplayName} (the ingestion bot, via
+   * {@code IngestionBotPolicy}/{@code DefaultBotPolicy}) must NOT overwrite a user-curated
+   * {@code displayName} through a single-entity PUT.
+   *
+   * <p>A per-entity PUT authorizes with the coarse {@code EDIT_ALL} operation, which does not
+   * intersect the field-level {@code EditDisplayName} deny - so the bot reaches the repository,
+   * where {@code EntityRepository#updateDisplayName} re-applies that field-level deny and preserves
+   * the user value. This is the regression guard for tag ingestion blanking a curated displayName:
+   * the connector PUTs a CreateTag whose displayName is null.
+   */
+  @Test
+  void test_singleEntityPut_ingestionBot_preservesUserDisplayName(TestNamespace ns) {
+    if (!supportsBulkAPI) return;
+
+    K request = createRequest(ns.prefix("put_denydn_"), ns);
+    if (!hasSetter(request, "setDisplayName", String.class)) return;
+    T created = createEntity(request);
+    String fqn = created.getFullyQualifiedName();
+
+    String userDisplayName = "User Curated Display Name";
+    T entity = getEntityByName(fqn);
+    entity.setDisplayName(userDisplayName);
+    patchEntity(entity.getId().toString(), entity);
+
+    setFieldViaReflection(request, "setDisplayName", String.class, null);
+    HttpResponse<String> response = putAs(request, getBotToken());
+    assertTrue(
+        response.statusCode() == 200 || response.statusCode() == 201,
+        "Bot single-entity PUT should be authorized via EDIT_ALL: "
+            + response.statusCode()
+            + " "
+            + response.body());
+
+    T result = getEntityByName(fqn);
+    assertEquals(
+        userDisplayName,
+        result.getDisplayName(),
+        "Ingestion bot (EditDisplayName denied) must NOT blank a user displayName via PUT: " + fqn);
+  }
+
+  /**
+   * Test: A bot whose policy does NOT deny {@code EditDisplayName} (modeling the SCIM bot, whose
+   * {@code ScimBotPolicy} carries no {@code DisplayName-Deny}) CAN still update {@code displayName}
+   * through a single-entity PUT.
+   *
+   * <p>Contrast with {@link #test_singleEntityPut_ingestionBot_preservesUserDisplayName}: the
+   * difference is purely the bot's policy, which is exactly what the in-code guard keys on. Without
+   * this, the guard would re-break SCIM displayName sync (#21879).
+   */
+  @Test
+  void test_singleEntityPut_displayNameAllowedBot_updatesDisplayName(TestNamespace ns) {
+    if (!supportsBulkAPI) return;
+
+    K request = createRequest(ns.prefix("put_allowdn_"), ns);
+    if (!hasSetter(request, "setDisplayName", String.class)) return;
+    T created = createEntity(request);
+    String fqn = created.getFullyQualifiedName();
+
+    String userDisplayName = "User Curated Display Name";
+    T entity = getEntityByName(fqn);
+    entity.setDisplayName(userDisplayName);
+    patchEntity(entity.getId().toString(), entity);
+
+    String botDisplayName = "SCIM-like Bot Display Name";
+    setFieldViaReflection(request, "setDisplayName", String.class, botDisplayName);
+    HttpResponse<String> response = putAs(request, displayNameAllowedBotToken());
+    assertTrue(
+        response.statusCode() == 200 || response.statusCode() == 201,
+        "Allowed-bot single-entity PUT should succeed: "
+            + response.statusCode()
+            + " "
+            + response.body());
+
+    T result = getEntityByName(fqn);
+    assertEquals(
+        botDisplayName,
+        result.getDisplayName(),
+        "Bot allowed EditDisplayName (SCIM-like) must update displayName via PUT: " + fqn);
+  }
+
+  /** Whether this entity's create request exposes {@code setterName}, so the test can skip. */
+  private boolean hasSetter(K createRequest, String setterName, Class<?> paramType) {
+    try {
+      createRequest.getClass().getMethod(setterName, paramType);
+      return true;
+    } catch (NoSuchMethodException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Single-entity createOrUpdate (PUT) over raw HTTP using the given bearer token. The SDK fluent
+   * clients always authenticate as admin, so the raw call is how a test drives a per-entity PUT as
+   * a specific bot identity.
+   */
+  protected HttpResponse<String> putAs(K request, String token) {
+    try {
+      String url = SdkClients.getServerUrl() + getResourcePath();
+      if (url.endsWith("/")) {
+        url = url.substring(0, url.length() - 1);
+      }
+      java.net.http.HttpRequest httpRequest =
+          java.net.http.HttpRequest.newBuilder()
+              .uri(java.net.URI.create(url))
+              .header("Authorization", "Bearer " + token)
+              .header("Content-Type", "application/json")
+              .PUT(java.net.http.HttpRequest.BodyPublishers.ofString(JsonUtils.pojoToJson(request)))
+              .build();
+      return java.net.http.HttpClient.newHttpClient()
+          .send(httpRequest, HttpResponse.BodyHandlers.ofString());
+    } catch (Exception e) {
+      throw new RuntimeException("Single-entity PUT failed: " + e.getMessage(), e);
+    }
+  }
+
+  // Lazily provisioned (once per session) bot whose policy allows EditAll and does NOT deny
+  // EditDisplayName, modeling the SCIM bot. API-created bots are force-assigned DefaultBotRole
+  // (which denies EditDisplayName), so that role is stripped via a raw JSON-Patch after creation.
+  private static volatile String displayNameAllowedBotToken;
+
+  protected static synchronized String displayNameAllowedBotToken() {
+    if (displayNameAllowedBotToken == null) {
+      displayNameAllowedBotToken = provisionDisplayNameAllowedBot();
+    }
+    return displayNameAllowedBotToken;
+  }
+
+  private static String provisionDisplayNameAllowedBot() {
+    try {
+      OpenMetadataClient admin = SdkClients.adminClient();
+      String suffix = UUID.randomUUID().toString().substring(0, 8);
+      Policy policy =
+          new PolicyService(admin.getHttpClient())
+              .create(
+                  new CreatePolicy()
+                      .withName("displayNameAllowedBotPolicy_" + suffix)
+                      .withRules(
+                          List.of(
+                              new Rule()
+                                  .withName("AllowEditAll")
+                                  .withResources(List.of("All"))
+                                  .withOperations(
+                                      List.of(
+                                          MetadataOperation.EDIT_ALL,
+                                          MetadataOperation.VIEW_ALL,
+                                          MetadataOperation.CREATE))
+                                  .withEffect(Rule.Effect.ALLOW))));
+      Role role =
+          new RoleService(admin.getHttpClient())
+              .create(
+                  new CreateRole()
+                      .withName("displayNameAllowedBotRole_" + suffix)
+                      .withPolicies(List.of(policy.getName())));
+      String email = "displayname-allowed-bot-" + suffix + "@open-metadata.org";
+      User bot =
+          new UserService(admin.getHttpClient())
+              .create(
+                  new CreateUser()
+                      .withName("displayname-allowed-bot-" + suffix)
+                      .withEmail(email)
+                      .withIsBot(true)
+                      .withAuthenticationMechanism(
+                          new AuthenticationMechanism()
+                              .withAuthType(AuthenticationMechanism.AuthType.JWT)
+                              .withConfig(
+                                  new JWTAuthMechanism()
+                                      .withJWTTokenExpiry(JWTTokenExpiry.Unlimited)))
+                      .withRoles(List.of(role.getId())));
+      stripDefaultBotRole(bot.getId().toString(), role.getId().toString());
+      return JwtAuthProvider.tokenFor(email, email, new String[] {role.getName()}, 86400);
+    } catch (Exception e) {
+      throw new RuntimeException(
+          "Failed to provision displayName-allowed bot: " + e.getMessage(), e);
+    }
+  }
+
+  // Replace the bot's roles (auto-assigned DefaultBotRole + the custom role) with ONLY the custom
+  // role via a raw JSON-Patch, so its effective policy no longer denies EditDisplayName.
+  private static void stripDefaultBotRole(String botId, String roleId) throws Exception {
+    String patch =
+        "[{\"op\":\"replace\",\"path\":\"/roles\",\"value\":[{\"id\":\""
+            + roleId
+            + "\",\"type\":\"role\"}]}]";
+    java.net.http.HttpRequest req =
+        java.net.http.HttpRequest.newBuilder()
+            .uri(java.net.URI.create(SdkClients.getServerUrl() + "/v1/users/" + botId))
+            .header("Authorization", "Bearer " + SdkClients.getAdminToken())
+            .header("Content-Type", "application/json-patch+json")
+            .method("PATCH", java.net.http.HttpRequest.BodyPublishers.ofString(patch))
+            .build();
+    HttpResponse<String> resp =
+        java.net.http.HttpClient.newHttpClient().send(req, HttpResponse.BodyHandlers.ofString());
+    if (resp.statusCode() != 200) {
+      throw new IllegalStateException(
+          "Failed to strip DefaultBotRole: " + resp.statusCode() + " " + resp.body());
+    }
   }
 
   private String getBotToken() {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -201,8 +201,11 @@ import org.openmetadata.schema.type.EventType;
 import org.openmetadata.schema.type.FieldChange;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.LifeCycle;
+import org.openmetadata.schema.type.MetadataOperation;
+import org.openmetadata.schema.type.Permission;
 import org.openmetadata.schema.type.ProviderType;
 import org.openmetadata.schema.type.Relationship;
+import org.openmetadata.schema.type.ResourcePermission;
 import org.openmetadata.schema.type.SuggestionType;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.TagLabelMetadata;
@@ -257,6 +260,7 @@ import org.openmetadata.service.search.SearchRepository;
 import org.openmetadata.service.search.SearchResultListMapper;
 import org.openmetadata.service.search.SearchSortFilter;
 import org.openmetadata.service.security.AuthorizationException;
+import org.openmetadata.service.security.policyevaluator.PolicyEvaluator;
 import org.openmetadata.service.security.policyevaluator.SubjectContext;
 import org.openmetadata.service.util.EntityETag;
 import org.openmetadata.service.util.EntityFieldUtils;
@@ -8579,7 +8583,23 @@ public abstract class EntityRepository<T extends EntityInterface> {
     }
 
     private void updateDisplayName() {
-      recordChange(FIELD_DISPLAY_NAME, original.getDisplayName(), updated.getDisplayName());
+      // A bot whose policy denies EditDisplayName (e.g. the ingestion bot via DefaultBotPolicy /
+      // IngestionBotPolicy) must not clobber a user-curated displayName. A PUT authorizes with the
+      // coarse EDIT_ALL operation, which does not intersect that field-level deny, so re-apply it
+      // here. Bots the policy allows - for example the SCIM bot syncing identity attributes through
+      // the repository - fall through and update it. PATCH is left to the policy layer, so a
+      // deliberate force-sync (the ingestion override_metadata PATCH) still gets through.
+      boolean preserveUserDisplayName =
+          operation.isPut()
+              && updatedByBot()
+              && !nullOrEmpty(original.getDisplayName())
+              && !Objects.equals(original.getDisplayName(), updated.getDisplayName())
+              && updatingBotDeniedOperation(MetadataOperation.EDIT_DISPLAY_NAME);
+      if (preserveUserDisplayName) {
+        updated.setDisplayName(original.getDisplayName());
+      } else {
+        recordChange(FIELD_DISPLAY_NAME, original.getDisplayName(), updated.getDisplayName());
+      }
     }
 
     private void updateEntityStatus(boolean consolidatingChanges) {
@@ -9782,6 +9802,27 @@ public abstract class EntityRepository<T extends EntityInterface> {
 
     public final boolean updatedByBot() {
       return Boolean.TRUE.equals(updatingUser.getIsBot());
+    }
+
+    /**
+     * Whether the bot performing this update is denied {@code operation} by policy. A PUT
+     * authorizes with the coarse EDIT_ALL operation, which does not intersect a field-level deny
+     * (e.g. DisplayName-Deny on the ingestion bot), so callers re-apply the field-level check here.
+     * Returns false for users the policy does not explicitly deny (including the SCIM bot).
+     */
+    private boolean updatingBotDeniedOperation(MetadataOperation operation) {
+      boolean denied = false;
+      if (updatingUser != null) {
+        SubjectContext subjectContext = SubjectContext.getSubjectContext(updatingUser.getName());
+        ResourcePermission permission = PolicyEvaluator.getPermission(subjectContext, entityType);
+        denied =
+            permission.getPermissions().stream()
+                .anyMatch(
+                    p ->
+                        operation.equals(p.getOperation())
+                            && Permission.Access.DENY.equals(p.getAccess()));
+      }
+      return denied;
     }
 
     @VisibleForTesting

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -9805,12 +9805,15 @@ public abstract class EntityRepository<T extends EntityInterface> {
     }
 
     /**
-     * Whether the bot performing this update is denied {@code operation} by policy. A PUT
+     * Whether the bot performing this update is denied {@code metadataOperation} by policy. A PUT
      * authorizes with the coarse EDIT_ALL operation, which does not intersect a field-level deny
      * (e.g. DisplayName-Deny on the ingestion bot), so callers re-apply the field-level check here.
      * Returns false for users the policy does not explicitly deny (including the SCIM bot).
+     *
+     * <p>The parameter is deliberately not named {@code operation}: that would shadow this
+     * updater's own {@code operation} field, which holds the PUT/PATCH {@link Operation}.
      */
-    private boolean updatingBotDeniedOperation(MetadataOperation operation) {
+    private boolean updatingBotDeniedOperation(MetadataOperation metadataOperation) {
       boolean denied = false;
       if (updatingUser != null) {
         SubjectContext subjectContext = SubjectContext.getSubjectContext(updatingUser.getName());
@@ -9819,7 +9822,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
             permission.getPermissions().stream()
                 .anyMatch(
                     p ->
-                        operation.equals(p.getOperation())
+                        metadataOperation.equals(p.getOperation())
                             && Permission.Access.DENY.equals(p.getAccess()));
       }
       return denied;


### PR DESCRIPTION
### Describe your changes:

Fixes #32957

**1.13 only.** `main` and `2.0` are already correct.

#### What's broken

On 1.13, `EntityRepository.EntityUpdater.updateDisplayName()` is a bare `recordChange()`:

```java
private void updateDisplayName() {
  recordChange(FIELD_DISPLAY_NAME, original.getDisplayName(), updated.getDisplayName());
}
```

`IngestionBotPolicy`'s `DisplayName-Deny` rule exists on 1.13 and is byte-identical to main's, but it never fires — a PUT authorizes with the coarse `EDIT_ALL` operation, which does not intersect a field-level deny. So an ingestion-bot PUT carrying `displayName=null` silently clears a displayName a user curated in the UI.

Most visible with **Snowflake tag ingestion**: the sink writes tags through a plain per-entity PUT (`write_classification_and_tag` → `metadata.create_or_update`) and the `CreateTag` payload has no displayName. Curate "OSS Email Tag" on `General.Email` in the UI, re-run metadata ingestion, and it comes back blank.

The pipeline's `overrideMetadata` flag is **not** involved — reproduced with it both `true` and `false`. That name collides with the *server-side* `EntityUpdater.overrideMetadata`, which is a different mechanism and does not exist anywhere in 1.13's Java.

#### Why main/2.0 are fine

Two commits, neither on 1.13:

| Commit | PR | Role |
|---|---|---|
| `f49e46438d1` | #28155 | Introduced the guard **and** the server-side `overrideMetadata` field |
| `eac204ed830` | #28676 | Made it policy-aware so the SCIM bot isn't blocked |

Neither cherry-picks: both reference `overrideMetadata`, so they don't compile on 1.13. This ports the policy-aware guard by hand.

#### What this changes

`updateDisplayName()` now preserves a user-curated displayName only when the updating bot is actually **DENIED** `EditDisplayName` by policy. Bots the policy allows — notably SCIM, whose `ScimBotPolicy` has no `DisplayName-Deny` — still update it.

**One deliberate divergence from main: the condition keeps `operation.isPut()`.** main can drop it because bulk `overrideMetadata=true` is its force-sync escape hatch; 1.13 has no such path. Its only escape hatch is the ingestion-side `override_metadata` PATCH built in `topology_runner.create_patch_request`, which puts `displayName` back into the payload via `RESTRICT_UPDATE_LIST`. Dropping `isPut()` here would make the server silently revert those PATCHes.

This is the detail most worth a reviewer's eye.

#### Scope

Affects **every entity** on 1.13, not just tags. Connectors that genuinely source a displayName (Tableau, Looker, PowerBI) stop propagating renames via PUT and fall back to the `override_metadata` PATCH. That is exactly main's behavior today, so this converges 1.13 rather than diverging it — but it is broader than the tag bug alone, and worth a maintainer's call.

The guard is bot-scoped by design (same as main): a CLI run with a *personal* JWT in the workflow YAML still overwrites displayName, on 1.13 and main alike.

#### How I tested

- Reproduced on a 1.13 instance: service created and metadata ingestion run entirely from the UI, so the pipeline authenticates as `ingestion-bot` (`OpenMetadataConnectionBuilder.getBotFromPipeline()` maps `METADATA, DBT -> INGESTION_BOT_NAME`); ingested entities show `updatedBy=ingestion-bot`. Curated displayName cleared on re-run, with `overrideMetadata` both `true` and `false`.
- Verified the deny actually reaches tags: `DisplayName-Deny` is `resources: ["All"]`, and `CompiledRule.matchResource` expands `"All"` to every resource except `scim`.
- `openmetadata-service` and `openmetadata-integration-tests` compile clean; `spotless:check` passes on both.

**Not yet run: a live RED/GREEN of the new ITs against a 1.13 server** — I don't have one built. Would appreciate CI or a reviewer confirming.

#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. — no schema changes
- [x] I have added a test that covers the exact scenario we are fixing.

`BaseEntityIT`, adapted from #28676 (its originals lean on `putAs` / `hasField` / `invoke` helpers that don't exist on 1.13, so those are added):

- `test_singleEntityPut_ingestionBot_preservesUserDisplayName` — PUTs `displayName=null` as the ingestion bot, matching the tag-ingestion shape exactly
- `test_singleEntityPut_displayNameAllowedBot_updatesDisplayName` — provisions a bot with no `DisplayName-Deny` and asserts it can still update, guarding against re-breaking SCIM sync (#21879)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
