### PR TITLE
Fixes #25712: handle OpenAPI Path Item fields in REST ingestion

### DIFF
--- a/ingestion/src/metadata/ingestion/source/api/rest/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/api/rest/metadata.py
@@ -52,6 +52,7 @@ from metadata.utils.logger import ingestion_logger
 logger = ingestion_logger()
 
 DEFAULT_TAG = "default"
+OPENAPI_OPERATION_METHODS = frozenset({"get", "put", "post", "delete", "options", "head", "patch", "trace"})
 
 
 class RestSource(ApiServiceSource):
@@ -108,13 +109,25 @@ class RestSource(ApiServiceSource):
     def _path_collection_names(self, json_response: dict) -> set[str]:
         """Tag names referenced by operations under ``paths``."""
         collections_set: set[str] = set()
-        for methods in (json_response.get("paths") or {}).values():
-            if not isinstance(methods, dict):
-                continue
-            for info in methods.values():
-                if isinstance(info, dict):
-                    collections_set.update(tag for tag in info.get("tags") or [] if isinstance(tag, str))
+        for _, _, info in self._iter_path_operations(json_response):
+            tags = info.get("tags")
+            if isinstance(tags, list):
+                collections_set.update(tag for tag in tags if isinstance(tag, str))
         return collections_set
+
+    @staticmethod
+    def _iter_path_operations(json_response: dict) -> Iterable[tuple[str, str, dict]]:
+        """Yield only OpenAPI Operation Objects from the document's Path Items."""
+        paths = json_response.get("paths")
+        if not isinstance(paths, dict):
+            return
+
+        for path, path_item in paths.items():
+            if not isinstance(path, str) or not isinstance(path_item, dict):
+                continue
+            for method_type, info in path_item.items():
+                if method_type in OPENAPI_OPERATION_METHODS and isinstance(info, dict):
+                    yield path, method_type, info
 
     def _derive_collections(self) -> list[RESTCollection]:
         """Derive every collection the document describes.
@@ -246,19 +259,17 @@ class RestSource(ApiServiceSource):
 
     def _filter_collection_endpoints(self, collection: RESTCollection) -> dict | None:
         """filter endpoints related to specific collection"""
-        try:
-            filtered_paths = {}
-            for path, methods in self.json_response.get("paths", {}).items():
-                for method_type, info in methods.items():  # noqa: B007, PERF102
-                    if (
-                        collection.name.root == DEFAULT_TAG and not info.get("tags")
-                    ) or collection.name.root in info.get("tags", []):
-                        filtered_paths.update({path: methods})
-                    break
-            return filtered_paths  # noqa: TRY300
-        except Exception as err:  # noqa: F841
+        if not isinstance(self.json_response, dict) or not isinstance(self.json_response.get("paths"), dict):
             logger.warning(f"Error while filtering endpoints for collection {collection.name.root}")
             return None
+
+        filtered_paths = {}
+        for path, method_type, info in self._iter_path_operations(self.json_response):
+            tags = info.get("tags")
+            operation_tags = {tag for tag in tags if isinstance(tag, str)} if isinstance(tags, list) else set()
+            if (collection.name.root == DEFAULT_TAG and not operation_tags) or collection.name.root in operation_tags:
+                filtered_paths.setdefault(path, {})[method_type] = info
+        return filtered_paths
 
     def _prepare_endpoint_data(self, path, method_type, info, collection) -> RESTEndpoint | None:
         try:

--- a/ingestion/tests/unit/topology/api/test_rest.py
+++ b/ingestion/tests/unit/topology/api/test_rest.py
@@ -29,6 +29,7 @@ from metadata.generated.schema.api.data.createAPICollection import (
 from metadata.generated.schema.api.data.createAPIEndpoint import (
     CreateAPIEndpointRequest,
 )
+from metadata.generated.schema.entity.data.apiEndpoint import ApiRequestMethod
 from metadata.generated.schema.entity.services.apiService import (
     ApiConnection,
     ApiService,
@@ -553,6 +554,80 @@ class TestRest:
             "known",
             "default",
             "new",
+        }
+
+    def test_path_parameters_are_not_ingested_as_operations(self):
+        self.rest_source.json_response = {
+            "tags": [{"name": "products"}],
+            "paths": {
+                "/parameters-first": {
+                    "parameters": [{"in": "query", "name": "page"}],
+                    "get": {
+                        "tags": ["products"],
+                        "operationId": "getParametersFirst",
+                    },
+                },
+                "/parameters-last": {
+                    "post": {
+                        "tags": ["products"],
+                        "operationId": "createParametersLast",
+                    },
+                    "parameters": [{"in": "query", "name": "page"}],
+                },
+            },
+        }
+
+        collections = list(self.rest_source.get_api_collections())
+        records = [record for collection in collections for record in self.rest_source.yield_api_endpoint(collection)]
+        endpoints = [record.right for record in records if record.right]
+
+        assert {collection.name.root for collection in collections} == {
+            "products",
+            "default",
+        }
+        assert all(record.left is None for record in records)
+        assert {
+            (endpoint.name.root, endpoint.requestMethod, endpoint.apiCollection.root) for endpoint in endpoints
+        } == {
+            (
+                "/parameters-first/get",
+                ApiRequestMethod.GET,
+                "openapi_rest.products",
+            ),
+            (
+                "/parameters-last/post",
+                ApiRequestMethod.POST,
+                "openapi_rest.products",
+            ),
+        }
+
+    def test_operations_on_one_path_use_their_own_collections(self):
+        self.rest_source.json_response = {
+            "tags": [{"name": "read"}, {"name": "write"}],
+            "paths": {
+                "/items": {
+                    "get": {"tags": ["read"], "operationId": "getItems"},
+                    "post": {"tags": ["write"], "operationId": "createItem"},
+                    "delete": {"operationId": "deleteItem"},
+                    "parameters": [{"in": "path", "name": "itemId"}],
+                }
+            },
+        }
+
+        collections = list(self.rest_source.get_api_collections())
+        records = [record for collection in collections for record in self.rest_source.yield_api_endpoint(collection)]
+        endpoints = [record.right for record in records if record.right]
+
+        assert all(record.left is None for record in records)
+        assert {(endpoint.requestMethod, endpoint.apiCollection.root) for endpoint in endpoints} == {
+            (ApiRequestMethod.GET, "openapi_rest.read"),
+            (ApiRequestMethod.POST, "openapi_rest.write"),
+            (ApiRequestMethod.DELETE, "openapi_rest.default"),
+        }
+        assert {endpoint.name.root for endpoint in endpoints} == {
+            "/items/get",
+            "/items/post",
+            "/items/delete",
         }
 
     def test_get_api_collections_on_unparseable_schema(self):


### PR DESCRIPTION
### Describe your changes:

Fixes #25712

Valid OpenAPI Path Item objects can contain metadata fields such as path-level `parameters`. The REST source was iterating every Path Item field as though it were an HTTP operation, so a `parameters` array could trigger a list/`.get` failure and discard every endpoint collected for that collection. Endpoint filtering also stopped after the first field and retained the entire Path Item, which assigned different operations on the same path to the wrong collection.

This change adds a shared iterator for the OpenAPI HTTP operation keys (`get`, `put`, `post`, `delete`, `options`, `head`, `patch`, and `trace`) and uses it for both collection discovery and endpoint filtering. Path Item metadata is ignored, each operation is filtered by its own tags, and untagged operations continue to use the existing `default` collection.

The behavior was reproduced against the [pinned Open Food Facts OpenAPI document](https://raw.githubusercontent.com/openfoodfacts/openfoodfacts-server/1677e6e831872253fd6f3f6e5dc43e89b92d361e/docs/api/ref/api.yaml). Path-level `parameters` is valid according to the [OpenAPI 3.1.1 Path Item Object specification](https://spec.openapis.org/oas/v3.1.1.html#path-item-object).

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A — small, two-file bug fix with no public API, schema, generated model, database, UI, or documentation changes.

#
### Tests:

#### Use cases covered

- A path-level `parameters` array before an operation does not abort endpoint ingestion.
- A path-level `parameters` array after an operation is not emitted as an endpoint.
- GET and POST operations on one path are assigned independently to their own tagged collections.
- An untagged operation on the same path is assigned only to the existing `default` collection.
- Missing or malformed `paths` continue to be handled without raising.

#### Unit tests

- [x] I added unit tests for the new/changed logic.
- File updated: `ingestion/tests/unit/topology/api/test_rest.py`
- Coverage: **95%** for `metadata.ingestion.source.api.rest.metadata` (375 statements, 12 missed; branch coverage enabled by repository configuration).
- Verification:
  - `python -m pytest tests/unit/topology/api/test_rest.py::TestRest::test_path_parameters_are_not_ingested_as_operations tests/unit/topology/api/test_rest.py::TestRest::test_operations_on_one_path_use_their_own_collections -v` — 2 passed.
  - `python -m pytest tests/unit/topology/api/test_rest.py -v` — 98 passed.
  - `python -m pytest tests/unit/topology/api/ -v` — 120 passed.
  - `python -m pytest tests/unit/topology/api/test_rest.py --cov=metadata.ingestion.source.api.rest.metadata --cov-report=term-missing` — 98 passed, 95% module coverage.
  - `make unit_ingestion_dev_env` — 9,552 passed, 12 skipped, 1 expected xfail.
  - `make py_format`, `make py_format_check`, and `make static-checks` — passed (0 type-check errors; 9 existing warnings outside the changed files).
  - `git diff --check` — passed.

#### Backend integration tests

- [x] Not applicable — no backend API changes.

#### Ingestion integration tests

- [x] Not applicable — this is local OpenAPI document traversal logic with no external service, credential, or network-client behavior change; source behavior is covered by unit tests and the pinned-document replay below.

#### Playwright (UI) tests

- [x] Not applicable — no UI changes.

#### Manual testing performed

1. Downloaded and parsed the pinned Open Food Facts OpenAPI 3.1.0 document through the REST source parser.
2. Replayed the parsed document through `RestSource` collection and endpoint producers.
3. Verified **9 collections** and **13 endpoints** were emitted.
4. Verified both Path Items containing path-level `parameters` were accepted, no `parameters` endpoint was emitted, and the source recorded zero endpoint errors and zero source failures.

#
### UI screen recording / screenshots:

Not applicable — no UI changes.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`.
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] Not applicable for JSON Schema changes — this PR does not change a JSON Schema.
- [x] Not applicable for UI changes — this PR does not change the UI.
- [x] I have added tests and listed them above.
- [x] I have added tests that cover the exact bug-fix scenarios.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
