### PR TITLE
Backport 2.0: move glossary term icon/color onto the shared pickers (#32856)

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/index.ts
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/index.ts
@@ -89,6 +89,7 @@ export * from './base/video-player/play-button-icon';
 // Application components
 export * from './application/form-field/form-field.types';
 export * from './application/form-field/form-item-label';
+export * from './application/form-field/fields/color-picker-field';
 export * from './application/form-field/fields/icon-picker-field';
 export * from './application/form-field/field-doc-panel';
 export * from './application/form-field/field-doc-popover';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryAdvancedOperations.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryAdvancedOperations.spec.ts
@@ -31,9 +31,12 @@ import {
 } from '../../../utils/entity';
 import {
   addMultiOwnerInDialog,
+  fillStyleIconUrl,
   openAddGlossaryTermModal,
   selectActiveGlossary,
   selectActiveGlossaryTerm,
+  selectStyleColor,
+  selectStyleIcon,
 } from '../../../utils/glossary';
 import { sidebarClick } from '../../../utils/sidebar';
 
@@ -388,9 +391,9 @@ test.describe('Glossary Advanced Operations', () => {
       await page.fill('[data-testid="name"]', termName);
       await page.locator(descriptionBox).fill('Term with custom color');
 
-      // Set custom color
-      const customColor = '#FF5733';
-      await page.getByTestId('color-color-input').fill(customColor);
+      // Set custom color (must be one of the palette swatches)
+      const customColor = '#F14C75';
+      await selectStyleColor(page, customColor);
 
       const createResponse = page.waitForResponse('/api/v1/glossaryTerms');
       await page.click('[data-testid="save-glossary-term"]');
@@ -425,9 +428,9 @@ test.describe('Glossary Advanced Operations', () => {
       await page.fill('[data-testid="name"]', termName);
       await page.locator(descriptionBox).fill('Term with custom icon');
 
-      // Set custom icon URL
+      // Set custom icon URL through the picker's URL tab
       const iconUrl = 'https://example.com/icon.png';
-      await page.getByTestId('icon-url').fill(iconUrl);
+      await fillStyleIconUrl(page, iconUrl);
 
       const createResponse = page.waitForResponse('/api/v1/glossaryTerms');
       await page.click('[data-testid="save-glossary-term"]');
@@ -438,6 +441,44 @@ test.describe('Glossary Advanced Operations', () => {
       expect(responseData.style?.iconURL).toBe(iconUrl);
 
       // Verify term is created
+      await expect(page.getByTestId(termName)).toBeVisible();
+    } finally {
+      await glossary.delete(apiContext);
+      await afterAction();
+    }
+  });
+
+  // T-C16b: Create term with a built-in icon picked from the grid
+  test('should create term with an icon picked from the picker grid', async ({
+    page,
+  }) => {
+    const { apiContext, afterAction } = await getApiContext(page);
+    const glossary = new Glossary();
+
+    try {
+      await glossary.create(apiContext);
+      await redirectToHomePage(page);
+      await sidebarClick(page, SidebarItem.GLOSSARY);
+      await selectActiveGlossary(page, glossary.data.displayName);
+
+      await openAddGlossaryTermModal(page);
+
+      const termName = `GridIconTerm${Date.now()}`;
+      await page.fill('[data-testid="name"]', termName);
+      await page.locator(descriptionBox).fill('Term with a built-in icon');
+
+      // The grid stores the icon's name, not a URL — the UI resolves it back
+      // to the component when rendering.
+      const iconName = 'Folder';
+      await selectStyleIcon(page, iconName);
+
+      const createResponse = page.waitForResponse('/api/v1/glossaryTerms');
+      await page.click('[data-testid="save-glossary-term"]');
+      const response = await createResponse;
+      const responseData = await response.json();
+
+      expect(responseData.style?.iconURL).toBe(iconName);
+
       await expect(page.getByTestId(termName)).toBeVisible();
     } finally {
       await glossary.delete(apiContext);
@@ -467,10 +508,9 @@ test.describe('Glossary Advanced Operations', () => {
 
       await page.locator('[role="dialog"].edit-glossary-modal').waitFor();
 
-      // Set custom color
-      const customColor = '#28A745';
-      await page.getByTestId('color-color-input').clear();
-      await page.getByTestId('color-color-input').fill(customColor);
+      // Set custom color (must be one of the palette swatches)
+      const customColor = '#05A580';
+      await selectStyleColor(page, customColor);
 
       const updateResponse = page.waitForResponse('/api/v1/glossaryTerms/*');
       await page.click('[data-testid="save-glossary-term"]');
@@ -508,10 +548,9 @@ test.describe('Glossary Advanced Operations', () => {
 
       await page.locator('[role="dialog"].edit-glossary-modal').waitFor();
 
-      // Set custom icon URL
+      // Set custom icon URL through the picker's URL tab
       const iconUrl = 'https://example.com/new-icon.png';
-      await page.getByTestId('icon-url').clear();
-      await page.getByTestId('icon-url').fill(iconUrl);
+      await fillStyleIconUrl(page, iconUrl);
 
       const updateResponse = page.waitForResponse('/api/v1/glossaryTerms/*');
       await page.click('[data-testid="save-glossary-term"]');

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryTermDetails.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryTermDetails.spec.ts
@@ -24,6 +24,7 @@ import {
   addRelatedTerms,
   addRelatedTermsByRelationType,
   addSynonyms,
+  fillStyleIconUrl,
   openAddGlossaryTermModal,
   selectActiveGlossary,
   selectActiveGlossaryTerm,
@@ -445,9 +446,9 @@ test.describe('Glossary Term Details Operations', () => {
       await page.locator('#name-0').fill('Documentation');
       await page.locator('#url-0').fill('https://docs.example.com');
 
-      // Add icon URL (custom style)
+      // Add icon URL (custom style) through the picker's URL tab
       const iconUrl = 'https://example.com/icon.png';
-      await page.getByTestId('icon-url').fill(iconUrl);
+      await fillStyleIconUrl(page, iconUrl);
 
       // Submit the term
       const createResponse = page.waitForResponse('/api/v1/glossaryTerms');

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
@@ -606,11 +606,11 @@ export const fillGlossaryTermDetails = async (
   await page.locator('#url-0').fill('https://test.com');
 
   if (term.icon) {
-    await page.locator('[data-testid="icon-url"]').fill(term.icon);
+    await fillStyleIconUrl(page, term.icon);
   }
 
   if (term.color) {
-    await page.locator('[data-testid="color-color-input"]').fill(term.color);
+    await selectStyleColor(page, term.color);
   }
 
   if (!isUndefined(term.owners)) {
@@ -624,6 +624,35 @@ export const fillGlossaryTermDetails = async (
       type: 'Users',
     });
   }
+};
+
+/**
+ * The icon field is a picker, not a text input: the trigger opens a popover
+ * with an icon grid and a URL tab. Re-clicking the trigger closes the popover
+ * so it cannot cover the form's Save button.
+ */
+export const selectStyleIcon = async (page: Page, iconName: string) => {
+  await page.getByTestId('icon-picker-btn').click();
+  await page.getByRole('button', { name: iconName, exact: true }).click();
+};
+
+export const fillStyleIconUrl = async (page: Page, iconUrl: string) => {
+  await page.getByTestId('icon-picker-btn').click();
+  await page.getByRole('tab', { name: 'URL' }).click();
+
+  const urlInput = page.getByRole('textbox', { name: 'Icon URL' });
+  await urlInput.fill(iconUrl);
+
+  await page.getByTestId('icon-picker-btn').click();
+  await expect(urlInput).not.toBeVisible();
+};
+
+/**
+ * `color` must be one of ENTITY_PALETTE_HEX (uppercase) — the colour field is a
+ * fixed palette of swatches, so an arbitrary hex cannot be picked.
+ */
+export const selectStyleColor = async (page: Page, color: string) => {
+  await page.getByRole('button', { name: `Select color ${color}` }).click();
 };
 
 export const verifyTaskCreated = async (

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/AddGlossaryTermForm/AddGlossaryTermForm.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/AddGlossaryTermForm/AddGlossaryTermForm.component.tsx
@@ -11,6 +11,11 @@
  *  limitations under the License.
  */
 import { PlusOutlined } from '@ant-design/icons';
+import {
+  ColorPickerField,
+  FormSelectItem,
+  IconPickerField,
+} from '@openmetadata/ui-core-components';
 import { Button, Col, Form, FormProps, Input, Row, Space } from 'antd';
 import { DefaultOptionType } from 'antd/lib/select';
 import { AxiosError } from 'axios';
@@ -19,7 +24,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as DeleteIcon } from '../../../assets/svg/ic-delete.svg';
 import { NAME_FIELD_RULES } from '../../../constants/Form.constants';
-import { HEX_COLOR_CODE_REGEX } from '../../../constants/regex.constants';
 import { EntityType } from '../../../enums/entity.enum';
 import {
   CustomProperty,
@@ -46,6 +50,10 @@ import { referenceURLValidator } from '../../../utils/GlossaryPureUtils';
 import { getIntakeFormFields } from '../../../utils/IntakeFormUtils';
 import { fetchGlossaryList } from '../../../utils/TagsUtils';
 import { showErrorToast } from '../../../utils/ToastUtils';
+import {
+  AVAILABLE_ICONS,
+  DEFAULT_GLOSSARY_TERM_ICON,
+} from '../../common/IconPicker/IconPicker.constants';
 import { OwnerLabel } from '../../common/OwnerLabel/OwnerLabel.component';
 import { AddGlossaryTermFormProps } from './AddGlossaryTermForm.interface';
 import GlossaryTermIntakeFields, {
@@ -201,6 +209,23 @@ const AddGlossaryTermForm = ({
     ? reviewersData
     : [reviewersData];
 
+  const selectedColor = Form.useWatch<string | undefined>('color', form);
+
+  const iconOptions = useMemo<FormSelectItem[]>(
+    () =>
+      [
+        DEFAULT_GLOSSARY_TERM_ICON,
+        ...AVAILABLE_ICONS.filter(
+          (icon) => icon.name !== DEFAULT_GLOSSARY_TERM_ICON.name
+        ),
+      ].map((icon) => ({
+        icon: icon.component,
+        id: icon.name,
+        label: icon.name,
+      })),
+    []
+  );
+
   const isMutuallyExclusive = Form.useWatch<boolean | undefined>(
     'mutuallyExclusive',
     form
@@ -315,11 +340,13 @@ const AddGlossaryTermForm = ({
       if (reviewers) {
         form.setFieldValue('reviewers', reviewers);
       }
+      // The fields are flat (`color`, `iconURL`); writing the nested
+      // `style.*` paths here meant an existing style never reached the form.
       if (style?.color) {
-        form.setFieldValue('style.color', style.color);
+        form.setFieldValue('color', style.color);
       }
       if (style?.iconURL) {
-        form.setFieldValue('style.iconURL', style.iconURL);
+        form.setFieldValue('iconURL', style.iconURL);
       }
 
       if (owners) {
@@ -426,17 +453,43 @@ const AddGlossaryTermForm = ({
         filterOptions: [glossaryTerm?.fullyQualifiedName ?? ''],
       },
     },
+    // antd's Form.Item feeds the real `value`/`onChange` into these controlled
+    // pickers, so the `value` below only satisfies their prop types.
     {
       name: 'iconURL',
       id: 'root/iconURL',
-      label: t('label.icon-url'),
+      label: t('label.icon'),
       required: false,
-      placeholder: t('label.icon-url'),
-      type: FieldTypes.TEXT,
-      helperText: t('message.govern-url-size-message'),
+      type: FieldTypes.COMPONENT,
+      helperText: t('message.icon-aspect-ratio'),
+      helperTextType: HelperTextType.Tooltip,
+      formItemProps: {
+        getValueProps: (value) => ({ value: (value as string) ?? '' }),
+      },
       props: {
-        'data-testid': 'icon-url',
-        tooltipPlacement: 'right',
+        children: (
+          <IconPickerField
+            allowUrl
+            backgroundColor={selectedColor}
+            data-testid="icon-picker-btn"
+            defaultIcon={DEFAULT_GLOSSARY_TERM_ICON}
+            items={iconOptions}
+            labels={{
+              customIconUrl: t('label.icon-url'),
+              emptyState: t('label.no-entity-available', {
+                entity: t('label.icon-plural'),
+              }),
+              enterIconUrl: t('label.enter-entity', {
+                entity: t('label.icon-url'),
+              }),
+              iconsTab: t('label.icon-plural'),
+              urlTab: t('label.url'),
+            }}
+            name="iconURL"
+            placeholder={t('label.icon-url')}
+            value=""
+          />
+        ),
       },
     },
     {
@@ -444,13 +497,13 @@ const AddGlossaryTermForm = ({
       id: 'root/color',
       label: t('label.color'),
       required: false,
-      type: FieldTypes.COLOR_PICKER,
-      rules: [
-        {
-          pattern: HEX_COLOR_CODE_REGEX,
-          message: t('message.hex-color-validation'),
-        },
-      ],
+      type: FieldTypes.COMPONENT,
+      formItemProps: {
+        getValueProps: (value) => ({ value: (value as string) ?? '' }),
+      },
+      props: {
+        children: <ColorPickerField data-testid="color-picker" value="" />,
+      },
     },
     {
       name: 'mutuallyExclusive',

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/AddGlossaryTermForm/AddGlossaryTermForm.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/AddGlossaryTermForm/AddGlossaryTermForm.test.tsx
@@ -19,6 +19,7 @@ import {
   waitFor,
 } from '@testing-library/react';
 import { CreateGlossaryTerm } from '../../../generated/api/data/createGlossaryTerm';
+import { GlossaryTerm } from '../../../generated/entity/data/glossaryTerm';
 import { Config, CustomProperty } from '../../../generated/entity/type';
 import {
   FieldKind,
@@ -224,12 +225,14 @@ const createIntakeFormWithFields = (
 interface FormHarnessProps {
   editMode?: boolean;
   formValues?: Partial<CreateGlossaryTerm>;
+  glossaryTerm?: GlossaryTerm;
   onSave: (value: GlossaryTermForm) => void | Promise<void>;
 }
 
 const FormHarness = ({
   editMode = false,
   formValues,
+  glossaryTerm,
   onSave,
 }: FormHarnessProps) => {
   const [form] = Form.useForm<CreateGlossaryTerm>();
@@ -239,6 +242,7 @@ const FormHarness = ({
       <AddGlossaryTermForm
         editMode={editMode}
         formRef={form}
+        glossaryTerm={glossaryTerm}
         onCancel={jest.fn()}
         onSave={onSave}
       />
@@ -505,4 +509,63 @@ describe('AddGlossaryTermForm intake fields', () => {
       expect(await screen.findByText(errorMessage)).toBeInTheDocument();
     }
   );
+});
+
+describe('AddGlossaryTermForm style fields', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getIntakeFormByEntityType as jest.Mock).mockResolvedValue(undefined);
+    (getCustomPropertiesByEntityType as jest.Mock).mockResolvedValue([]);
+  });
+
+  it('prefills the icon and colour of the term being edited', async () => {
+    render(
+      <FormHarness
+        editMode
+        glossaryTerm={
+          {
+            name: 'term',
+            style: { color: '#FF0000', iconURL: 'File01' },
+          } as GlossaryTerm
+        }
+        onSave={jest.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('root/iconURL')).toHaveValue('File01');
+    });
+
+    expect(screen.getByTestId('root/color')).toHaveValue('#FF0000');
+  });
+
+  it('carries the picked icon and colour into the save payload as style', async () => {
+    const onSave = jest.fn();
+
+    render(
+      <FormHarness
+        formValues={
+          {
+            name: 'term',
+            description: 'a term',
+            color: '#0000FF',
+            iconURL: 'Folder',
+          } as Partial<CreateGlossaryTerm>
+        }
+        onSave={onSave}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('submit-values'));
+    });
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          style: { color: '#0000FF', iconURL: 'Folder' },
+        })
+      );
+    });
+  });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.component.tsx
@@ -31,6 +31,7 @@ import { ReactComponent as VersionIcon } from '../../../assets/svg/ic-version.sv
 import { ReactComponent as IconDropdown } from '../../../assets/svg/menu.svg';
 import { ReactComponent as StyleIcon } from '../../../assets/svg/style.svg';
 import DeleteModal from '../../../components/common/DeleteModal/DeleteModal';
+import { Icon as EntityStyleIcon } from '../../../components/common/Icon/Icon';
 import { ManageButtonItemLabel } from '../../../components/common/ManageButtonContentItem/ManageButtonContentItem.component';
 import { useEntityExportModalProvider } from '../../../components/Entity/EntityExportModalProvider/EntityExportModalProvider.component';
 import { EntityHeader } from '../../../components/Entity/EntityHeader/EntityHeader.component';
@@ -67,13 +68,14 @@ import {
 } from '../../../utils/RouterUtils';
 import { showErrorToast } from '../../../utils/ToastUtils';
 import { useRequiredParams } from '../../../utils/useRequiredParams';
+import { DEFAULT_GLOSSARY_TERM_ICON } from '../../common/IconPicker/IconPicker.constants';
 import { TitleBreadcrumbProps } from '../../common/TitleBreadcrumb/TitleBreadcrumb.interface';
 import { useGenericContext } from '../../Customization/GenericProvider/GenericContext';
 import { EntityStatusBadge } from '../../Entity/EntityStatusBadge/EntityStatusBadge.component';
 import Voting from '../../Entity/Voting/Voting.component';
 import { LearningIcon } from '../../Learning/LearningIcon/LearningIcon.component';
 import ChangeParentHierarchy from '../../Modals/ChangeParentHierarchy/ChangeParentHierarchy.component';
-import StyleModal from '../../Modals/StyleModal/StyleModal.component';
+import IconColorModal from '../../Modals/IconColorModal/IconColorModal';
 import ImportOntologyModal from '../ImportOntologyModal/ImportOntologyModal.component';
 import { useGlossaryStore } from '../useGlossary.store';
 import { GlossaryHeaderProps } from './GlossaryHeader.interface';
@@ -189,25 +191,21 @@ const GlossaryHeader = ({
       );
     }
 
-    if (selectedData.style?.iconURL) {
-      return (
-        <img
-          className="align-middle object-contain"
-          data-testid="icon"
-          height={36}
-          src={selectedData.style?.iconURL}
-          width={32}
-        />
-      );
-    }
-
     return (
-      <IconTerm
+      <EntityStyleIcon
         className="align-middle"
-        color={DE_ACTIVE_COLOR}
-        height={36}
-        name="doc"
-        width={32}
+        fallback={
+          <IconTerm
+            className="align-middle"
+            color={DE_ACTIVE_COLOR}
+            height={36}
+            name="doc"
+            width={32}
+          />
+        }
+        iconValue={selectedData.style?.iconURL}
+        imageClassName="align-middle object-contain"
+        size={36}
       />
     );
   }, [selectedData, isGlossary]);
@@ -673,7 +671,8 @@ const GlossaryHeader = ({
         onSave={onNameSave}
       />
 
-      <StyleModal
+      <IconColorModal
+        defaultIcon={DEFAULT_GLOSSARY_TERM_ICON}
         open={isStyleEditing}
         style={selectedData.style}
         onCancel={() => setIsStyleEditing(false)}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.test.tsx
@@ -110,8 +110,8 @@ jest.mock(
   }
 );
 
-jest.mock('../../Modals/StyleModal/StyleModal.component', () => {
-  return jest.fn().mockImplementation(() => <p>StyleModal</p>);
+jest.mock('../../Modals/IconColorModal/IconColorModal', () => {
+  return jest.fn().mockImplementation(() => <p>IconColorModal</p>);
 });
 
 jest.mock('../../Entity/Voting/Voting.component', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
@@ -53,6 +53,7 @@ import { ReactComponent as DownUpArrowIcon } from '../../../assets/svg/ic-down-u
 import { ReactComponent as UpDownArrowIcon } from '../../../assets/svg/ic-up-down-arrow.svg';
 import { ReactComponent as PlusOutlinedIcon } from '../../../assets/svg/plus-outlined.svg';
 import ErrorPlaceHolder from '../../../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
+import { Icon as EntityStyleIcon } from '../../../components/common/Icon/Icon';
 import { OwnerLabel } from '../../../components/common/OwnerLabel/OwnerLabel.component';
 import StatusBadge from '../../../components/common/StatusBadge/StatusBadge.component';
 import {
@@ -765,15 +766,13 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
 
           return (
             <div className="tw:flex tw:min-w-0 tw:items-center">
-              {record.style?.iconURL && (
-                <img
-                  alt={record.name}
-                  className="m-r-xss"
-                  data-testid="tag-icon"
-                  height={12}
-                  src={record.style.iconURL}
-                />
-              )}
+              <EntityStyleIcon
+                alt={record.name}
+                className="m-r-xs tw:shrink-0"
+                iconValue={record.style?.iconURL}
+                imageClassName="tw:block"
+                size={18}
+              />
               <Link
                 className="cursor-pointer tw:inline-block tw:max-w-50 tw:truncate"
                 data-testid={name}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.test.tsx
@@ -1037,9 +1037,10 @@ describe('Test GlossaryTermTab component', () => {
       });
 
       await waitFor(() => {
-        const tagIcon = screen.getByTestId('tag-icon');
-
-        expect(tagIcon).toBeInTheDocument();
+        expect(screen.getByTestId('icon-image')).toHaveAttribute(
+          'src',
+          'https://example.com/icon.png'
+        );
       });
     });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/IconColorModal/IconColorModal.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/IconColorModal/IconColorModal.interface.ts
@@ -10,11 +10,13 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Style } from '../../../generated/type/schema';
+import { IconDefinition } from '../../common/IconPicker/IconPicker.interface';
+import { StyleModalProps } from '../StyleModal/StyleModal.interface';
 
-export interface IconColorModalProps {
-  open: boolean;
-  style?: Style;
-  onSubmit: (value: Style) => Promise<void>;
-  onCancel: () => void;
+export interface IconColorModalProps extends StyleModalProps {
+  /**
+   * Shown in the picker trigger while nothing is selected, and listed first in
+   * the icon grid. Defaults to the tag icon.
+   */
+  defaultIcon?: IconDefinition;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/IconColorModal/IconColorModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/IconColorModal/IconColorModal.tsx
@@ -22,27 +22,22 @@ import {
   Modal,
   ModalOverlay,
 } from '@openmetadata/ui-core-components';
-import { FC, useEffect, useState } from 'react';
+import { FC, useEffect, useMemo, useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Style } from '../../../generated/type/schema';
-import { AVAILABLE_ICONS, DEFAULT_TAG_ICON } from '../../common/IconPicker';
-import { StyleModalProps } from '../StyleModal/StyleModal.interface';
-
-const ICON_OPTIONS = [
+import {
+  AVAILABLE_ICONS,
   DEFAULT_TAG_ICON,
-  ...AVAILABLE_ICONS.filter((icon) => icon.name !== DEFAULT_TAG_ICON.name),
-].map((icon) => ({
-  icon: icon.component,
-  id: icon.name,
-  label: icon.name,
-}));
+} from '../../common/IconPicker/IconPicker.constants';
+import { IconColorModalProps } from './IconColorModal.interface';
 
-const IconColorModal: FC<StyleModalProps> = ({
+const IconColorModal: FC<IconColorModalProps> = ({
   open,
   onCancel,
   onSubmit,
   style,
+  defaultIcon = DEFAULT_TAG_ICON,
 }) => {
   const { t } = useTranslation();
   const form = useForm<Style>({
@@ -65,6 +60,19 @@ const IconColorModal: FC<StyleModalProps> = ({
 
   const selectedColor = useWatch({ control: form.control, name: 'color' });
 
+  const iconOptions = useMemo(
+    () =>
+      [
+        defaultIcon,
+        ...AVAILABLE_ICONS.filter((icon) => icon.name !== defaultIcon.name),
+      ].map((icon) => ({
+        icon: icon.component,
+        id: icon.name,
+        label: icon.name,
+      })),
+    [defaultIcon]
+  );
+
   const handleSubmit = async (values: Style) => {
     try {
       setIsSaving(true);
@@ -85,8 +93,8 @@ const IconColorModal: FC<StyleModalProps> = ({
       allowUrl: true,
       backgroundColor: selectedColor,
       'data-testid': 'icon-picker-btn',
-      defaultIcon: DEFAULT_TAG_ICON,
-      options: ICON_OPTIONS,
+      defaultIcon,
+      options: iconOptions,
     },
     type: FieldTypes.ICON_PICKER,
   };

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/IconPicker/IconPicker.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/IconPicker/IconPicker.constants.ts
@@ -68,6 +68,11 @@ export const DEFAULT_DATA_PRODUCT_ICON: IconDefinition = {
   component: Cube01,
   category: 'default',
 };
+export const DEFAULT_GLOSSARY_TERM_ICON: IconDefinition = {
+  name: 'File01',
+  component: File01,
+  category: 'default',
+};
 export const DEFAULT_TAG_ICON: IconDefinition = {
   name: 'LayersThree01',
   component: LayersThree01,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/IconUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/IconUtils.tsx
@@ -80,7 +80,7 @@ export const getTagImageSrc = (iconURL: string): string => {
     return iconURL;
   }
 
-  return `${window.location.origin}/${iconURL}`;
+  return `${window.location.origin}/${iconURL.replace(/^\/+/, '')}`;
 };
 
 // Map of icon names to their components


### PR DESCRIPTION
Backport of #32856 to `2.0`.

## What it does

Glossary term icon/colour move onto the shared pickers: `StyleModal` → `IconColorModal` (with `DEFAULT_GLOSSARY_TERM_ICON`), and the hand-rolled `style?.iconURL ? <img> : <IconTerm>` branches in the header and the term tab collapse into the shared `Icon` component with a `fallback`.

12 of the 14 files applied cleanly. Three adaptations, all forced by 2.0's baseline.

## Adaptations

**`GlossaryHeader.component.tsx` and `GlossaryTermTab.component.tsx`** — these have diverged sharply from main: **750 and 999** changed lines against main's pre-PR state, versus PR deltas of only **40 and 19**. Git's 3-way merge was worse than useless there, offering whole extracted components as the incoming side (main has `GlossaryHeaderModals` and `GlossaryTermNameCell` extracted; 2.0 has both inline).

So I discarded the merge for those two, restored 2.0's files, and applied the two real deltas by hand. Diff-of-diffs against main then matches **line for line, order-independent**, with a single expected exception:

```
< - alt=""
```

main's `<img>` carried `alt=""` and 2.0's never did, so main's diff removes a line that does not exist here. (The `StyleModal → IconColorModal` hunk also lands at a different offset, because main keeps that modal in the extracted `GlossaryHeaderModals` while 2.0 has it inline — same lines, different position.)

**`GlossaryAdvancedOperations.spec.ts`** — the new test called `fillDescriptionBox`, which only exists in main's `playwright/utils/common.ts`. Switched to 2.0's idiom, `page.locator(descriptionBox).fill(...)`, matching the other five call sites in that same file. `tsc` caught this one; it would otherwise have been a broken spec.

## Verification

- **Jest: 102/102** across the five affected suites — `AddGlossaryTermForm`, `GlossaryHeader`, `GlossaryTermTab`, `IconColorModal`, `IconUtils`.
- Playwright `tsc --project playwright/tsconfig.json`: back to **2.0's exact baseline — 169 errors total, 2 of them in `glossary.ts`**, both pre-existing (they merely shift line numbers as the file grows). Before the `fillDescriptionBox` fix this read 170/3, which is how the regression surfaced.
- Prettier clean on all touched files.
- eslint left to CI — 2.0's config needs a `jsonc-eslint-parser` the borrowed `node_modules` cannot provide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
