### PR TITLE
fix(doris): use DATETIME instead of TIMESTAMP in profiler partition CAST

### DIFF
--- a/ingestion/src/metadata/profiler/orm/functions/datetime.py
+++ b/ingestion/src/metadata/profiler/orm/functions/datetime.py
@@ -107,8 +107,9 @@ def _(elements, compiler, **kwargs):
 
 
 @compiles(DatetimeAddFn, Dialects.MySQL)
+@compiles(DatetimeAddFn, Dialects.Doris)
 def _(elements, compiler, **kwargs):
-    """MySQL date and datetime function"""
+    """MySQL and Doris date and datetime function"""
     return mysql_function(elements, compiler, **kwargs)
 
 
@@ -186,8 +187,9 @@ def _(elements, compiler, **kwargs):  # pylint: disable=unused-argument
 
 
 @compiles(TimestampAddFn, Dialects.MySQL)
+@compiles(TimestampAddFn, Dialects.Doris)
 def _(elements, compiler, **kwargs):
-    """MySQL timestamp function"""
+    """MySQL and Doris timestamp function"""
     return mysql_function(elements, compiler, **kwargs)
 
 

--- a/ingestion/tests/unit/observability/profiler/test_datetime_dialect.py
+++ b/ingestion/tests/unit/observability/profiler/test_datetime_dialect.py
@@ -1,0 +1,91 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Tests that dialect-specific @compiles overrides for TimestampAddFn / DatetimeAddFn
+produce valid SQL for each engine.
+
+Doris does not accept TIMESTAMP as a CAST target type; it requires DATETIME
+(or DATETIMEV2). The generic fallback produces AS TIMESTAMP, so Doris needs
+its own override.  This module exercises the compiled SQL without requiring
+a live database connection.
+"""
+
+import unittest
+from unittest import TestCase
+
+from sqlalchemy import literal, text
+from sqlalchemy.engine.default import DefaultDialect
+
+from metadata.profiler.orm.functions.datetime import DatetimeAddFn, TimestampAddFn
+
+
+class _FakeDialect(DefaultDialect):
+    """Minimal SQLAlchemy dialect stub — only name matters for @compiles dispatch."""
+
+    supports_statement_cache = True
+
+    def __init__(self, dialect_name: str):
+        super().__init__()
+        self.name = dialect_name
+
+
+class TestDatetimeDialectCompilation(TestCase):
+    """Verify that TimestampAddFn / DatetimeAddFn compile to dialect-correct SQL."""
+
+    def _compile(self, fn_cls, dialect_name: str, interval: int = 1, unit: str = "DAY") -> str:
+        dialect = _FakeDialect(dialect_name)
+        fn = fn_cls(literal(interval), text(unit))
+        return fn.compile(dialect=dialect).string
+
+    # ── Generic / fallback ────────────────────────────────────────────────────
+
+    def test_generic_timestamp_uses_as_timestamp(self):
+        sql = self._compile(TimestampAddFn, "generic")
+        self.assertIn("AS TIMESTAMP", sql.upper())
+
+    def test_generic_datetime_uses_as_timestamp(self):
+        sql = self._compile(DatetimeAddFn, "generic")
+        self.assertIn("AS TIMESTAMP", sql.upper())
+
+    # ── MySQL ─────────────────────────────────────────────────────────────────
+
+    def test_mysql_timestamp_uses_as_datetime(self):
+        sql = self._compile(TimestampAddFn, "mysql")
+        self.assertIn("AS DATETIME", sql.upper())
+        self.assertNotIn("AS TIMESTAMP", sql.upper())
+
+    # ── Doris (pydoris dialect) ───────────────────────────────────────────────
+
+    def test_doris_timestamp_uses_as_datetime(self):
+        """
+        Doris rejects CAST(... AS TIMESTAMP); it requires CAST(... AS DATETIME).
+        Before this fix, Doris fell through to generic_function → AS TIMESTAMP,
+        causing 'mismatched input TIMESTAMP' errors on time-partitioned tables.
+        """
+        sql = self._compile(TimestampAddFn, "pydoris")
+        self.assertIn("AS DATETIME", sql.upper(), msg=f"Doris SQL was: {sql}")
+        self.assertNotIn("AS TIMESTAMP", sql.upper(), msg=f"Doris SQL was: {sql}")
+
+    def test_doris_datetime_uses_as_datetime(self):
+        sql = self._compile(DatetimeAddFn, "pydoris")
+        self.assertIn("AS DATETIME", sql.upper(), msg=f"Doris DatetimeAddFn SQL was: {sql}")
+        self.assertNotIn("AS TIMESTAMP", sql.upper(), msg=f"Doris DatetimeAddFn SQL was: {sql}")
+
+    def test_doris_timestamp_contains_coalesce_interval(self):
+        """Interval value and unit are preserved in the Doris SQL."""
+        sql = self._compile(TimestampAddFn, "pydoris", interval=3, unit="HOUR")
+        self.assertIn("3", sql)
+        self.assertIn("HOUR", sql.upper())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Closes #32787

When a Doris table has a time-based partition column configured in the profiler, OpenMetadata generates:

```sql
CAST(CURRENT_TIMESTAMP - interval '1' DAY AS TIMESTAMP)
```

Doris does **not** accept `TIMESTAMP` as a `CAST` target. It expects `DATETIME` or `DATETIMEV2`, and rejects the query with:

```
mismatched input 'TIMESTAMP'
expecting {... 'DATE', 'DATETIME', 'DATETIMEV2', ...}
```

This is distinct from #32442 (identifier quoting). The failure is in the data-type word inside the `CAST`.

## What

`TimestampAddFn` and `DatetimeAddFn` both fell through to `generic_function`, which hard-codes `AS TIMESTAMP`. MySQL has its own override (`mysql_function`) that already emits `AS DATETIME`. Since Doris is MySQL-protocol-compatible for this expression, the fix is to register the same `@compiles` override for `Dialects.Doris`.

**Changed file:** `ingestion/src/metadata/profiler/orm/functions/datetime.py`

```python
# Before
@compiles(DatetimeAddFn, Dialects.MySQL)
def _(elements, compiler, **kwargs):
    return mysql_function(elements, compiler, **kwargs)

# After — Doris added on the same decorator stack
@compiles(DatetimeAddFn, Dialects.MySQL)
@compiles(DatetimeAddFn, Dialects.Doris)
def _(elements, compiler, **kwargs):
    return mysql_function(elements, compiler, **kwargs)
```

Same change applied to `TimestampAddFn`.

## Test

`ingestion/tests/unit/observability/profiler/test_datetime_dialect.py` — 6 unit tests; no live database required. A `_FakeDialect` stub sets `name = "pydoris"` so `@compiles` dispatch resolves correctly.

Key assertions:
- Generic dialect → `AS TIMESTAMP` (unchanged)
- MySQL dialect → `AS DATETIME` (unchanged)
- Doris dialect → `AS DATETIME` (fixed; was `AS TIMESTAMP`)

All tests pass locally.

## Checklist

- [x] PR title follows the [commit convention](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md)
- [x] Covers both `TimestampAddFn` and `DatetimeAddFn`
- [x] Unit test added that exercises the dialect dispatch without a live Doris connection
- [x] No impact on other dialects (MySQL, BigQuery, Redshift, Snowflake, ClickHouse, SQLite, DB2/IbmDbSa, AzureSQL, MSSQL — all retain their existing overrides)