### PR TITLE
Fixes #32680: [Detail Bug] Data Quality API: `/testCaseResults/search/latest` returns 400 for any non-empty `fields` value

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -89,6 +89,8 @@ import org.slf4j.LoggerFactory;
 public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
   private static final Logger LOG = LoggerFactory.getLogger(TestCaseResourceIT.class);
   private static final ObjectMapper MAPPER = new ObjectMapper();
+  // The `fields` example documented on the testCaseResults search endpoints
+  private static final String TEST_CASE_RESULT_FIELDS = "testCase,testDefinition";
   private static final RetryConfig DEADLOCK_RETRY_CONFIG =
       RetryConfig.custom()
           .maxAttempts(3)
@@ -2632,6 +2634,70 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
             "/v1/dataQuality/testCases/testCaseResults" + path,
             null,
             RequestOptions.builder().queryParam("q", query).queryParam("limit", "10").build());
+  }
+
+  /**
+   * {@code testCaseResults/search/latest} validated its {@code fields} param against a placeholder
+   * allowed-fields set, so every real field name — including the endpoint's own documented example
+   * {@code testCase,testDefinition} — came back as HTTP 400. Pins the parity with the sibling
+   * {@code /search/list}, which resolves the allowed fields from the repository.
+   */
+  @Test
+  void test_testCaseResultSearchLatestWithFields(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Table table = createTable(ns);
+    TestCase testCase =
+        TestCaseBuilder.create(client)
+            .name(ns.prefix("result_latest_fields"))
+            .forTable(table)
+            .testDefinition("tableRowCountToEqual")
+            .parameter("value", "100")
+            .create();
+
+    CreateTestCaseResult result = new CreateTestCaseResult();
+    result.setTimestamp(System.currentTimeMillis());
+    result.setTestCaseStatus(TestCaseStatus.Failed);
+    result.setResult("failed");
+    client.testCaseResults().create(testCase.getFullyQualifiedName(), result);
+
+    String testCaseFQN = testCase.getFullyQualifiedName();
+    // Independent of search convergence: the documented `fields` example must not be rejected.
+    assertDoesNotThrow(
+        () -> searchLatestTestCaseResult(testCaseFQN, TEST_CASE_RESULT_FIELDS),
+        "testCaseResults/search/latest must accept fields=" + TEST_CASE_RESULT_FIELDS);
+
+    Awaitility.await()
+        .atMost(SEARCH_CONVERGENCE_TIMEOUT)
+        .pollInterval(Duration.ofSeconds(2))
+        .untilAsserted(
+            () -> {
+              String response = searchLatestTestCaseResult(testCaseFQN, TEST_CASE_RESULT_FIELDS);
+              assertTrue(
+                  response != null && !response.isBlank(),
+                  "latest test case result must be returned once indexed");
+              JsonNode latest = JsonUtils.readTree(response);
+              assertEquals(testCaseFQN, latest.path("testCaseFQN").asText());
+              assertEquals(
+                  testCase.getId().toString(),
+                  latest.path("testCase").path("id").asText(),
+                  "the requested `testCase` field must be resolved, got: " + response);
+              assertFalse(
+                  latest.path("testDefinition").path("id").asText().isEmpty(),
+                  "the requested `testDefinition` field must be resolved, got: " + response);
+            });
+  }
+
+  private String searchLatestTestCaseResult(String testCaseFQN, String fields) {
+    return SdkClients.adminClient()
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.GET,
+            "/v1/dataQuality/testCases/testCaseResults/search/latest",
+            null,
+            RequestOptions.builder()
+                .queryParam("testCaseFQN", testCaseFQN)
+                .queryParam("fields", fields)
+                .build());
   }
 
   /**

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResultResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResultResource.java
@@ -36,7 +36,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.api.tests.CreateTestCaseResult;
@@ -409,7 +408,7 @@ public class TestCaseResultResource
           @QueryParam("q")
           String q)
       throws IOException {
-    EntityUtil.Fields fields = new EntityUtil.Fields(Set.of(""), fieldParams);
+    EntityUtil.Fields fields = repository.getFields(fieldParams);
     SearchListFilter searchListFilter = new SearchListFilter();
     Optional.ofNullable(testCaseStatus)
         .ifPresent(tcs -> searchListFilter.addQueryParam("testCaseStatus", tcs.toString()));


### PR DESCRIPTION
> **This pull request was opened by an olivaw agent.** It is an input to review, not an approved change — read the diff, not this description.
>
> Fixes #32680

## What olivaw checked (machine-observed, §8.2/A.1)

- diff: non-empty
- build: not_run
- tests: not_run
- base: `b88ec9fd75cce20196a4a362d80f9aeb206465f8`
- head: `f0561d0d8fa348535aae6c0dd0e442cc9b672f5c`

**No build or test command is configured for this workspace**, so only the diff's existence was checked. Set `run_config.build_cmd`/`test_cmd` to have olivaw verify its own work.

## What the agent says it did (unverified)

> Done. Committed as `f0561d0d8f` on `agent/issue-32680`.
> 
> **The fix** — `openmetadata-service/.../dqtests/TestCaseResultResource.java:411`:
> 
> ```java
> -    EntityUtil.Fields fields = new EntityUtil.Fields(Set.of(""), fieldParams);
> +    EntityUtil.Fields fields = repository.getFields(fieldParams);
> ```
> 
> `Set.of("")` as the allowed-fields set made `EntityUtil.Fields`' validation loop reject every non-empty token, so any real `fields` value on `/search/latest` — including the endpoint's own documented example `testCase,testDefinition` — returned HTTP 400. `repository.getFields()` resolves the real allowed set, matching the sibling `/search/list`. The now-unused `java.util.Set` import was dropped.
> 
> **Regression test** — `openmetadata-integration-tests/.../TestCaseResourceIT.java`: `test_testCaseResultSearchLatestWithFields` creates a test case plus a result, asserts `GET /testCaseResults/search/latest?testCaseFQN=…&fields=testCase,testDefinition` doesn't fail (the 400 pin, independent of index convergence), then awaits search convergence and asserts the returned result carries the resolved `testCase` and `testDefinition` references.
> 
> **Verification**: `mvn spotless:apply` on both touched modules (no reformatting needed), and `install` of `openmetadata-service` + `test-compile` of `openmetadata-integration-tests` both BUILD SUCCESS. I did not run the integration test itself — it needs a live server and search backend, which isn't available in this environment.
