### PR TITLE
Fixes #32968: focus the entity-type trigger before opening its listbox

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestLibrary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestLibrary.spec.ts
@@ -43,6 +43,28 @@ const selectOptionWithMouse = async (page: Page, option: Locator) => {
   );
 };
 
+// React Aria's listbox is a non-modal popover, and a press on a trigger that
+// does not already hold focus both opens it and — via the focus transition that
+// same press produces — dismisses it a frame later. That leaves roughly 160ms to
+// pick an option, and nothing reopens the listbox afterwards, so a loaded runner
+// that misses the window retries the option click until the test times out.
+// Focusing the trigger first removes the transition, and with it the window.
+const selectEntityType = async (page: Page, entityType: string) => {
+  const entityTypeSelect = page.getByTestId('entity-type');
+  const entityTypeTrigger = entityTypeSelect.getByRole('button');
+
+  await entityTypeTrigger.focus();
+  await expect(entityTypeTrigger).toBeFocused();
+  await entityTypeTrigger.click();
+
+  await selectOptionWithMouse(
+    page,
+    page.getByRole('option', { name: entityType, exact: true })
+  );
+
+  await expect(entityTypeSelect).toContainText(entityType);
+};
+
 test.use({ storageState: 'playwright/.auth/admin.json' });
 
 test.describe(
@@ -147,13 +169,7 @@ test.describe(
           .locator('textarea')
           .fill(TEST_DEFINITION_DESCRIPTION);
 
-        // Select entity type (react-aria Select: click the field, pick option)
-        await page.locator('[id="root/entityType"]').click();
-        const entityTypeOption = page.getByRole('option', {
-          name: 'TABLE',
-          exact: true,
-        });
-        await entityTypeOption.click();
+        await selectEntityType(page, 'TABLE');
 
         // Supported data types (core MultiSelect: type into its combobox input to
         // populate the options, then pick — required while the OpenMetadata
@@ -367,12 +383,7 @@ test.describe(
             .getByTestId('test-definition-name')
             .locator('input')
             .fill(`validation-test-${uuid()}`);
-          await page.getByTestId('entity-type').click();
-          const entityTypeOption = page.getByRole('option', {
-            name: 'TABLE',
-            exact: true,
-          });
-          await entityTypeOption.click();
+          await selectEntityType(page, 'TABLE');
 
           // Submit the form
           await page.getByTestId('save-test-definition').click();
@@ -632,22 +643,7 @@ test.describe(
           .locator('textarea')
           .fill('External test for read-only validation');
 
-        const entityTypeSelect = page.getByTestId('entity-type');
-        const entityTypeTrigger = entityTypeSelect.getByRole('button');
-
-        // The documentation panel reacts to focus and rerenders the form. Let
-        // that update settle before the mouse press so React Aria does not
-        // cancel the press when CI is under load.
-        await entityTypeTrigger.focus();
-        await expect(entityTypeTrigger).toBeFocused();
-        await entityTypeTrigger.click();
-        const tableOption = page.getByRole('option', {
-          name: 'TABLE',
-          exact: true,
-        });
-        await selectOptionWithMouse(page, tableOption);
-
-        await expect(entityTypeSelect).toContainText('TABLE');
+        await selectEntityType(page, 'TABLE');
 
         // OpenMetadata is selected by default. Remove its chip (the chip is a
         // span with the label and an unlabeled remove button) and add dbt so the
@@ -867,13 +863,7 @@ test.describe(
           .locator('textarea')
           .fill('Test definition to validate supported services filtering');
 
-        await page.getByTestId('entity-type').click();
-        const entityTypeOption = page.getByRole('option', {
-          name: 'TABLE',
-          exact: true,
-        });
-        await expect(entityTypeOption).toBeVisible();
-        await entityTypeOption.click();
+        await selectEntityType(page, 'TABLE');
 
         // Select supported data types (required when OpenMetadata platform is selected)
         await page.getByTestId('supported-data-types').click();
@@ -1211,12 +1201,7 @@ test.describe(
           .locator('textarea')
           .fill('Test definition for pagination behavior testing');
 
-        await page.getByTestId('entity-type').click();
-        const entityTypeOption = page.getByRole('option', {
-          name: 'TABLE',
-          exact: true,
-        });
-        await entityTypeOption.click();
+        await selectEntityType(page, 'TABLE');
 
         // Select supported data types (required when OpenMetadata platform is selected)
         await page.getByTestId('supported-data-types').click();


### PR DESCRIPTION
### Describe your changes:

Fixes #32968

`TestLibrary.spec.ts` has been ejecting PRs from the merge queue via `playwright-summary` — most recently #32524 ([run](https://github.com/open-metadata/OpenMetadata/actions/runs/34225148854), shard `chromium-07`), a PR that touches nothing in this path. Two tests fail on the same line, clicking the `TABLE` option in the entity-type dropdown.

**Root cause.** The listbox dismisses itself ~160 ms after it opens, deterministically — no CI load required:

```
295ms  focusin   button#root/entityType   ← the click
306ms  listbox+                           ← options appear
421ms  focusout  div{listbox}
426ms  listbox-                           ← destroyed, and nothing reopens it
```

React Aria's listbox is a non-modal popover. A press on a trigger that does not already hold focus both opens it *and* produces a focus transition, and that transition dismisses it a frame later. The trigger and form nodes are **not** remounted, so this is not an RJSF re-render; it is also unrelated to the doc panel (forcing every programmatic scroll instant changes nothing, and the teardown is identical with no fields filled).

Measured, 3/3 runs each:

| Gesture | Listbox |
|---|---|
| `locator.click()` on an unfocused trigger | **closes after ~160 ms** |
| `focus()` + assert focused + `click()` | **stays open** |
| raw `mouse.click()` on an unfocused trigger | **closes at ~0 ms** |
| `focus()` + `Enter` | **stays open** |

So the four cold-click sites have always had a ~160 ms window. A dev machine wins that race; a loaded 2-core runner does not — and since nothing reopens the listbox, `option.click()` retries until the test timeout.

**The change.** Four sites opened the Select on an unfocused trigger (`:156`, `:375`, `:876`, `:1219`); a fifth (`:635-650`) already focused first and passed in the same CI run that failed the other two. All five collapse into one `selectEntityType` helper built on that working sequence — net **+27 / −42**.

#
### Type of change:
- [x] Bug fix

#
### Checklist:

- [x] I have read the [CONTRIBUTING](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR is adequately covered with tests

#
### Manual test steps / verification:

Page-side CPU throttling does not reproduce this, because CI's lag is on the **driver** side. Injecting a delay between the trigger press and the option click reproduces it exactly:

| Injected driver lag | Before | Signature |
|---|---|---|
| 100 ms | 2/2 fail | `element is not stable` + `element was detached from the DOM` — CI's exact first-attempt text |
| 140 / 170 / 220 / 400 ms | fail | `waiting for getByRole('option', …)` |

With the trigger focused first, the same scenario passes at 400 ms **and at 1500 ms** of injected lag — 10× the window.

Running the spec at 4 workers against a local stack:

| Run | Result |
|---|---|
| `origin/main` unmodified | **2 failed**, 13 passed — incl. `should maintain page on edit and reset to first page on delete`, one of the two CI failures |
| this branch | **1 failed**, 14 passed — only a `platform badges` failure that also fails on unmodified `origin/main` and is unrelated |

The two CI-affected tests, `--repeat-each=3 --workers=4` on this branch: **6/6 passed**.

Lint and types: the CI `ui-checkstyle` playwright sequence (organize-imports → eslint --fix → prettier) is clean and idempotent on the changed file, and `tsc --project playwright/tsconfig.json` reports 0 errors in it (165 pre-existing elsewhere in the project, untouched).

#
### Note for reviewers — possible product bug

With a human-speed press (60 ms hold) rather than Playwright's instantaneous down/up, the listbox closed at ~0 ms on **both** the first and second click, 3/3. If that holds for real hardware input, the entity-type dropdown does not open on a normal mouse click and the real fix belongs in the `ui-core-components` Select. I did not confirm this by hand and CDP-injected press-and-hold may not match real input, so it is captured as a note in #32968 rather than a claim — but there are 118 `getByRole('option')` call sites across 38 spec files sitting on the same behaviour, so it is worth someone clicking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
