### PR TITLE
Backport 2.0: AI context trust signals (#32261) + prerequisite MCP context-memory visibility (#32465)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpContextMemoryVisibilityIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpContextMemoryVisibilityIT.java
@@ -1,0 +1,184 @@
+package org.openmetadata.it.tests.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.it.auth.JwtAuthProvider;
+import org.openmetadata.service.Entity;
+
+/**
+ * A context memory's visibility comes from its own {@code shareConfig} rather than from a role or
+ * policy. These tests pin the MCP paths that reach a memory by name - the entity read, its content
+ * section, the Company Context lookup and a patch - to that rule, so each answers the way the REST
+ * endpoint on {@code /v1/contextCenter/memories} does.
+ */
+class McpContextMemoryVisibilityIT extends McpTestBase {
+
+  private static final String SECRET_ANSWER = "the-forecast-is-locked-to-its-owner";
+  private static final String SHARED_PILL_ANSWER = "the-pill-body-is-for-its-principals";
+
+  private static String memoryFqn;
+  private static String memoryId;
+  private static String sharedPillFqn;
+  private static String ownerToken;
+  private static String intruderToken;
+
+  @BeforeAll
+  static void setup() throws Exception {
+    initAuth();
+    String suffix = UUID.randomUUID().toString().substring(0, 8);
+    JsonNode owner = createUser("mcp_vis_owner_" + suffix);
+    JsonNode intruder = createUser("mcp_vis_intruder_" + suffix);
+    ownerToken = bearerFor(owner);
+    intruderToken = bearerFor(intruder);
+
+    JsonNode memory =
+        post(
+            "contextCenter/memories",
+            Map.of(
+                "name",
+                "mcp_vis_note_" + suffix,
+                "description",
+                "MCP visibility IT",
+                "question",
+                "What is the forecast?",
+                "answer",
+                SECRET_ANSWER,
+                "owners",
+                List.of(Map.of("id", owner.get("id").asText(), "type", Entity.USER)),
+                "shareConfig",
+                Map.of("visibility", "Private")),
+            JsonNode.class);
+    memoryFqn = memory.get("fullyQualifiedName").asText();
+    memoryId = memory.get("id").asText();
+    sharedPillFqn = createSharedPill(suffix, owner);
+  }
+
+  /**
+   * A file-extracted pill owned by the admin who created it and shared with one principal, so
+   * access comes from the sharedWith list rather than from ownership.
+   */
+  private static String createSharedPill(String suffix, JsonNode sharedPrincipal) throws Exception {
+    String name = sharedPrincipal.get("name").asText();
+    Map<String, Object> principal =
+        Map.of(
+            "principal",
+            Map.of(
+                "id",
+                sharedPrincipal.get("id").asText(),
+                "type",
+                Entity.USER,
+                "name",
+                name,
+                "fullyQualifiedName",
+                name));
+    JsonNode pill =
+        post(
+            "contextCenter/memories",
+            Map.of(
+                "name",
+                "mcp_vis_pill_" + suffix,
+                "description",
+                "MCP visibility IT pill",
+                "question",
+                "What does the pill say?",
+                "answer",
+                SHARED_PILL_ANSWER,
+                "sourceType",
+                "FileExtraction",
+                "shareConfig",
+                Map.of("visibility", "Shared", "sharedWith", List.of(principal))),
+            JsonNode.class);
+    return pill.get("fullyQualifiedName").asText();
+  }
+
+  @Test
+  void plainRead_deniesAnotherUsersPrivateMemory() throws Exception {
+    Map<String, Object> call =
+        McpTestUtils.createGetEntityToolCall(Entity.CONTEXT_MEMORY, memoryFqn);
+
+    // The owner reading their own memory is the barrier: it proves the denial below is the
+    // visibility rule and not a fetch that fails for everyone.
+    assertThat(executeMcpRequest(call, ownerToken).toString()).contains(SECRET_ANSWER);
+
+    JsonNode denied = executeMcpRequest(call, intruderToken);
+    assertThat(denied.toString()).doesNotContain(SECRET_ANSWER);
+    assertThat(denied.path("result").path("isError").asBoolean(false)).isTrue();
+  }
+
+  @Test
+  void contentRead_deniesAnotherUsersPrivateMemory() throws Exception {
+    Map<String, Object> call =
+        McpTestUtils.createToolCallRequest(
+            "get_entity_details",
+            Map.of(
+                "entityType",
+                Entity.CONTEXT_MEMORY,
+                "fqn",
+                memoryFqn,
+                "include",
+                List.of("content")));
+
+    assertThat(executeMcpRequest(call, ownerToken).toString()).contains(SECRET_ANSWER);
+
+    JsonNode denied = executeMcpRequest(call, intruderToken);
+    assertThat(denied.toString()).doesNotContain(SECRET_ANSWER);
+    assertThat(denied.path("result").path("isError").asBoolean(false)).isTrue();
+  }
+
+  /**
+   * The Company Context scope is a file-extracted pill shared with the caller, which is what the
+   * tool's search half filters on. Reading one by name applies the same rule.
+   */
+  @Test
+  void companyContextByName_answersOnlyAPrincipalThePillIsSharedWith() throws Exception {
+    Map<String, Object> call =
+        McpTestUtils.createToolCallRequest("company_context", Map.of("fqn", sharedPillFqn));
+
+    assertThat(executeMcpRequest(call, ownerToken).toString()).contains(SHARED_PILL_ANSWER);
+
+    JsonNode withheld = executeMcpRequest(call, intruderToken);
+    assertThat(withheld.toString()).doesNotContain(SHARED_PILL_ANSWER);
+    assertThat(withheld.toString()).contains("not a shared Company Context knowledge pill");
+  }
+
+  /**
+   * A patch answers with the patched entity, so an authorized write is also a read - and
+   * EditDescription is granted on every resource by DataConsumerPolicy.
+   */
+  @Test
+  void patch_deniesAnotherUsersPrivateMemory() throws Exception {
+    Map<String, Object> call =
+        McpTestUtils.createToolCallRequest(
+            "patch_entity",
+            Map.of(
+                "entityType",
+                Entity.CONTEXT_MEMORY,
+                "fqn",
+                memoryFqn,
+                "patch",
+                "[{\"op\":\"replace\",\"path\":\"/description\",\"value\":\"touched\"}]"));
+
+    JsonNode denied = executeMcpRequest(call, intruderToken);
+    assertThat(denied.toString()).doesNotContain(SECRET_ANSWER);
+    assertThat(denied.path("result").path("isError").asBoolean(false)).isTrue();
+
+    JsonNode unchanged = get("contextCenter/memories/" + memoryId, JsonNode.class);
+    assertThat(unchanged.path("description").asText()).isEqualTo("MCP visibility IT");
+  }
+
+  private static JsonNode createUser(String name) throws Exception {
+    return post(
+        "users", Map.of("name", name, "email", name + "@test.openmetadata.org"), JsonNode.class);
+  }
+
+  private static String bearerFor(JsonNode user) {
+    String email = user.get("email").asText();
+    return "Bearer " + JwtAuthProvider.tokenFor(email, email, new String[] {}, 3_600);
+  }
+}

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CommonUtils.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CommonUtils.java
@@ -1,5 +1,6 @@
 package org.openmetadata.mcp.tools;
 
+import jakarta.ws.rs.core.SecurityContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -20,6 +21,7 @@ import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.jdbi3.TeamRepository;
 import org.openmetadata.service.jdbi3.UserRepository;
+import org.openmetadata.service.resources.context.ContextMemoryVisibility;
 import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.security.auth.CatalogSecurityContext;
 import org.openmetadata.service.security.policyevaluator.OperationContext;
@@ -27,6 +29,38 @@ import org.openmetadata.service.security.policyevaluator.ResourceContext;
 
 @Slf4j
 public class CommonUtils {
+
+  /**
+   * Reads an entity for a caller and applies that entity's own visibility rule before handing it
+   * back. Rules like a context memory's {@code shareConfig} sit outside the policy model, so the
+   * {@code authorizer.authorize(...)} a tool makes cannot see them - binding the check to the fetch
+   * is what stops a read path from holding an entity it is not allowed to answer with. The rule is
+   * a no-op for entity types that have none, so callers need no per-type knowledge.
+   */
+  public static EntityInterface readEntityForCaller(
+      String entityType,
+      String fqn,
+      String fields,
+      Include include,
+      SecurityContext securityContext) {
+    EntityInterface entity =
+        Entity.getEntityByName(
+            entityType, fqn, ContextMemoryVisibility.guardFields(entityType, fields), include);
+    ContextMemoryVisibility.enforceVisibility(entity, securityContext);
+    return entity;
+  }
+
+  /**
+   * The same guard for a write whose response carries the entity back, which makes it a read too.
+   * Reads the entity only when its type has visibility rules, so an ordinary patch keeps its single
+   * repository fetch.
+   */
+  public static void enforceEntityVisibility(
+      String entityType, String fqn, SecurityContext securityContext) {
+    if (ContextMemoryVisibility.hasVisibilityRules(entityType)) {
+      readEntityForCaller(entityType, fqn, "", Include.NON_DELETED, securityContext);
+    }
+  }
 
   public static <T extends CreateEntity> void setOwners(T entity, Map<String, Object> params) {
 

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CompanyContextTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CompanyContextTool.java
@@ -1,5 +1,6 @@
 package org.openmetadata.mcp.tools;
 
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.schema.type.MetadataOperation.VIEW_ALL;
 
 import java.io.IOException;
@@ -19,6 +20,7 @@ import org.openmetadata.schema.entity.context.MemoryVisibility;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.limits.Limits;
+import org.openmetadata.service.resources.context.ContextMemoryVisibility;
 import org.openmetadata.service.search.vector.OpenSearchVectorService;
 import org.openmetadata.service.search.vector.utils.DTOs.VectorSearchResponse;
 import org.openmetadata.service.security.Authorizer;
@@ -56,12 +58,17 @@ public class CompanyContextTool implements McpTool {
   public Map<String, Object> execute(
       Authorizer authorizer, CatalogSecurityContext securityContext, Map<String, Object> params)
       throws IOException {
+    String query = CommonUtils.optString(params, QUERY_PARAM);
+    String fqn = CommonUtils.optString(params, FQN_PARAM);
+    // Scoped to the pill when the caller named one, so entity-level tag/owner/domain policies are
+    // evaluated and not just the resource-type permission.
     authorizer.authorize(
         securityContext,
         new OperationContext(Entity.CONTEXT_MEMORY, VIEW_ALL),
-        new ResourceContext<>(Entity.CONTEXT_MEMORY));
-    String query = CommonUtils.optString(params, QUERY_PARAM);
-    String fqn = CommonUtils.optString(params, FQN_PARAM);
+        nullOrEmpty(fqn)
+            ? new ResourceContext<>(Entity.CONTEXT_MEMORY)
+            : new ResourceContext<>(
+                Entity.CONTEXT_MEMORY, null, FullyQualifiedName.quoteName(fqn)));
     return route(query, fqn, params, securityContext);
   }
 
@@ -80,7 +87,7 @@ public class CompanyContextTool implements McpTool {
               "Pass either 'query' to search knowledge pills or 'fqn' to read one by name, not"
                   + " both and not neither.");
     } else if (hasFqn) {
-      result = lookupPill(fqn);
+      result = lookupPill(fqn, securityContext);
     } else {
       result = runSearch(query, params, securityContext);
     }
@@ -89,12 +96,15 @@ public class CompanyContextTool implements McpTool {
 
   // --- by name ----------------------------------------------------------------------------------
 
-  private static Map<String, Object> lookupPill(String fqn) {
+  private static Map<String, Object> lookupPill(
+      String fqn, CatalogSecurityContext securityContext) {
     Map<String, Object> result;
     try {
       ContextMemory memory = fetchPill(fqn);
       result =
-          isExposablePill(memory) ? projectPill(memory) : errorResponse(NOT_A_SHARED_PILL_ERROR);
+          isExposablePill(memory, securityContext)
+              ? projectPill(memory)
+              : errorResponse(NOT_A_SHARED_PILL_ERROR);
     } catch (EntityNotFoundException e) {
       result = errorResponse("No Company Context knowledge pill found for '" + fqn + "'");
     }
@@ -115,11 +125,18 @@ public class CompanyContextTool implements McpTool {
         Entity.CONTEXT_MEMORY, normalizedFqn, "sourceFile,owners,tags,domains", null);
   }
 
-  /** The by-name scope, kept identical to {@link #searchFilters()} by construction now. */
-  private static boolean isExposablePill(ContextMemory memory) {
+  /**
+   * The by-name scope: a file-extracted pill, and one this caller may see - the same shareConfig
+   * question {@code ContextMemorySearchVisibility} asks of every hit on the search half. The two
+   * halves are not identical sets: {@link #searchFilters()} additionally pins {@code visibility} to
+   * {@code Shared}, so a pill this caller may see for another reason (an org-wide one, or their own)
+   * is readable by name but will not appear in a query. A pill outside the scope is reported as
+   * not-a-shared-pill rather than denied, which keeps the answer the same whether or not it exists.
+   */
+  private static boolean isExposablePill(
+      ContextMemory memory, CatalogSecurityContext securityContext) {
     return memory.getSourceType() == ContextMemorySourceType.FILE_EXTRACTION
-        && memory.getShareConfig() != null
-        && memory.getShareConfig().getVisibility() == MemoryVisibility.SHARED;
+        && !ContextMemoryVisibility.filterByVisibility(List.of(memory), securityContext).isEmpty();
   }
 
   static Map<String, Object> projectPill(ContextMemory memory) {

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetEntityTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetEntityTool.java
@@ -263,7 +263,8 @@ public class GetEntityTool implements McpTool {
     int columnLimit = McpParams.getInt(params, COLUMN_LIMIT_PARAM, NO_COLUMN_LIMIT);
     // Kept as the entity, not just its map: the content section needs the object, and reading it
     // a second time for that would be the same fetch twice in one request.
-    EntityInterface entity = Entity.getEntityByName(entityType, fqn, "*", null);
+    EntityInterface entity =
+        CommonUtils.readEntityForCaller(entityType, fqn, "*", null, securityContext);
     Map<String, Object> entityData = JsonUtils.getMap(entity);
 
     // Clean response to optimize LLM context usage, then bound the columns array so a wide entity
@@ -287,7 +288,8 @@ public class GetEntityTool implements McpTool {
     IncludeContext authorizationContext =
         new IncludeContext(authorizer, securityContext, entityType, fqn, null, options(params));
     authorizeKnowledge(authorizationContext);
-    EntityInterface entity = Entity.getEntityByName(entityType, fqn, "", Include.NON_DELETED);
+    EntityInterface entity =
+        CommonUtils.readEntityForCaller(entityType, fqn, "", Include.NON_DELETED, securityContext);
     IncludeContext contentContext =
         new IncludeContext(
             authorizer, securityContext, entityType, fqn, entity, authorizationContext.options());

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/PatchEntityTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/PatchEntityTool.java
@@ -70,6 +70,11 @@ public class PatchEntityTool implements McpTool {
         new OperationContext(entityType, jsonPatch),
         new ResourceContext<>(entityType, null, fqn));
 
+    // The response carries the patched entity, so this write answers a read as well: apply the
+    // per-entity visibility rules the authorize() above cannot see, since they live outside the
+    // policy model.
+    CommonUtils.enforceEntityVisibility(entityType, fqn, securityContext);
+
     EntityRepository<? extends EntityInterface> repository = Entity.getEntityRepository(entityType);
     String userName = securityContext.getUserPrincipal().getName();
     RestUtil.PatchResponse<? extends EntityInterface> response =

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/CompanyContextToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/CompanyContextToolTest.java
@@ -1,6 +1,7 @@
 package org.openmetadata.mcp.tools;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -16,10 +17,12 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.security.Principal;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,7 +34,10 @@ import org.openmetadata.mcp.util.PageCursor;
 import org.openmetadata.schema.entity.context.ContextMemory;
 import org.openmetadata.schema.entity.context.ContextMemorySourceType;
 import org.openmetadata.schema.entity.context.MemoryShareConfig;
+import org.openmetadata.schema.entity.context.MemorySharedPrincipal;
 import org.openmetadata.schema.entity.context.MemoryVisibility;
+import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.jdbi3.ContextMemoryRepository;
@@ -260,30 +266,66 @@ class CompanyContextToolTest {
   }
 
   @Test
-  void sharedFilePillIsProjected() throws Exception {
+  void sharedFilePillIsProjectedToAPrincipalItIsSharedWith() throws Exception {
     stubMemory(
         "pill-fqn",
-        memory("pill-fqn", ContextMemorySourceType.FILE_EXTRACTION, MemoryVisibility.SHARED));
+        sharedWith(
+            memory("pill-fqn", ContextMemorySourceType.FILE_EXTRACTION, MemoryVisibility.SHARED),
+            "bob"));
+    CatalogSecurityContext securityContext = securityContextFor("bob");
 
     Map<String, Object> result =
-        tool.execute(
-            mock(Authorizer.class), mock(CatalogSecurityContext.class), Map.of("fqn", "pill-fqn"));
+        withSubject(
+            securityContext,
+            "bob",
+            () -> tool.execute(mock(Authorizer.class), securityContext, Map.of("fqn", "pill-fqn")));
 
     assertEquals("Q", result.get("question"));
     assertEquals("A", result.get("answer"));
+  }
+
+  /**
+   * Shared means shared with someone: the pill's own shareConfig names the principals, and the
+   * search half of this tool already filters on them. Reading by name must answer the same
+   * question, or one lookup exposes what the other hides.
+   */
+  @Test
+  void sharedFilePillIsWithheldFromAPrincipalItIsNotSharedWith() throws Exception {
+    stubMemory(
+        "pill-fqn",
+        sharedWith(
+            memory("pill-fqn", ContextMemorySourceType.FILE_EXTRACTION, MemoryVisibility.SHARED),
+            "alice"));
+    CatalogSecurityContext securityContext = securityContextFor("bob");
+
+    Map<String, Object> result =
+        withSubject(
+            securityContext,
+            "bob",
+            () -> tool.execute(mock(Authorizer.class), securityContext, Map.of("fqn", "pill-fqn")));
+
+    assertEquals(
+        "Requested entity is not a shared Company Context knowledge pill", result.get("error"));
+    assertFalse(result.containsKey("answer"), "the pill body must not be returned: " + result);
   }
 
   @Test
   void unquotedDottedFqnResolvesToQuotedPill() throws Exception {
     stubMemory(
         "\"report.md_hash\"",
-        memory("report.md_hash", ContextMemorySourceType.FILE_EXTRACTION, MemoryVisibility.SHARED));
+        sharedWith(
+            memory(
+                "report.md_hash", ContextMemorySourceType.FILE_EXTRACTION, MemoryVisibility.SHARED),
+            "bob"));
 
+    CatalogSecurityContext securityContext = securityContextFor("bob");
     Map<String, Object> result =
-        tool.execute(
-            mock(Authorizer.class),
-            mock(CatalogSecurityContext.class),
-            Map.of("fqn", "report.md_hash"));
+        withSubject(
+            securityContext,
+            "bob",
+            () ->
+                tool.execute(
+                    mock(Authorizer.class), securityContext, Map.of("fqn", "report.md_hash")));
 
     assertEquals("Q", result.get("question"));
     assertEquals("A", result.get("answer"));
@@ -340,6 +382,38 @@ class CompanyContextToolTest {
         .when(
             () -> Entity.getEntityByName(eq(Entity.CONTEXT_MEMORY), eq(fqn), anyString(), isNull()))
         .thenReturn(memory);
+  }
+
+  private ContextMemory sharedWith(ContextMemory memory, String userName) {
+    memory
+        .getShareConfig()
+        .withSharedWith(
+            List.of(
+                new MemorySharedPrincipal()
+                    .withPrincipal(
+                        new EntityReference()
+                            .withType(Entity.USER)
+                            .withName(userName)
+                            .withFullyQualifiedName(userName))));
+    return memory;
+  }
+
+  private CatalogSecurityContext securityContextFor(String userName) {
+    Principal principal = mock(Principal.class);
+    when(principal.getName()).thenReturn(userName);
+    CatalogSecurityContext securityContext = mock(CatalogSecurityContext.class);
+    when(securityContext.getUserPrincipal()).thenReturn(principal);
+    return securityContext;
+  }
+
+  private <T> T withSubject(
+      CatalogSecurityContext securityContext, String userName, Callable<T> body) throws Exception {
+    try (MockedStatic<DefaultAuthorizer> subjects = mockStatic(DefaultAuthorizer.class)) {
+      subjects
+          .when(() -> DefaultAuthorizer.getSubjectContext(securityContext))
+          .thenReturn(new SubjectContext(new User().withName(userName), null, null));
+      return body.call();
+    }
   }
 
   private ContextMemory memory(

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/GetEntityToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/GetEntityToolTest.java
@@ -16,12 +16,18 @@ package org.openmetadata.mcp.tools;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import jakarta.ws.rs.ForbiddenException;
+import java.security.Principal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -30,15 +36,22 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.openmetadata.mcp.util.McpResponseTrim;
+import org.openmetadata.schema.entity.context.ContextMemory;
+import org.openmetadata.schema.entity.context.MemoryShareConfig;
+import org.openmetadata.schema.entity.context.MemoryVisibility;
 import org.openmetadata.schema.entity.data.Page;
+import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.security.Authorizer;
+import org.openmetadata.service.security.DefaultAuthorizer;
 import org.openmetadata.service.security.auth.CatalogSecurityContext;
 import org.openmetadata.service.security.policyevaluator.OperationContext;
 import org.openmetadata.service.security.policyevaluator.ResourceContextInterface;
+import org.openmetadata.service.security.policyevaluator.SubjectContext;
 
 /**
  * Pins {@link GetEntityTool#cleanEntityResponse}. The entity-level description must always be
@@ -85,6 +98,136 @@ class GetEntityToolTest {
     assertEquals(fqn, result.get("fullyQualifiedName"));
     assertThat(castMap(result.get("content")).get("content")).isEqualTo("full article body");
     assertThat(result).doesNotContainKey("description");
+  }
+
+  /**
+   * A context memory's visibility comes from its own shareConfig rather than from a role or policy,
+   * so a read by name applies that rule on top of the operation check - the same answer the REST
+   * endpoint gives.
+   */
+  @Test
+  void plainReadDeniesAnotherUsersPrivateMemory() {
+    String fqn = "alices-private-note";
+    ContextMemory memory = privateMemoryOwnedBy("alice", fqn);
+    CatalogSecurityContext securityContext = securityContextFor("bob");
+
+    try (MockedStatic<Entity> entities = mockStatic(Entity.class);
+        MockedStatic<DefaultAuthorizer> subjects = mockStatic(DefaultAuthorizer.class)) {
+      entities
+          .when(
+              () -> Entity.getEntityByName(eq(Entity.CONTEXT_MEMORY), eq(fqn), anyString(), any()))
+          .thenReturn(memory);
+      subjects
+          .when(() -> DefaultAuthorizer.getSubjectContext(securityContext))
+          .thenReturn(new SubjectContext(new User().withName("bob"), null, null));
+
+      assertThrows(
+          ForbiddenException.class,
+          () ->
+              new GetEntityTool()
+                  .execute(
+                      mock(Authorizer.class),
+                      securityContext,
+                      Map.of("entityType", Entity.CONTEXT_MEMORY, "fqn", fqn)));
+    }
+  }
+
+  @Test
+  void contentReadDeniesAnotherUsersPrivateMemory() {
+    String fqn = "alices-private-note";
+    ContextMemory memory = privateMemoryOwnedBy("alice", fqn);
+    CatalogSecurityContext securityContext = securityContextFor("bob");
+
+    try (MockedStatic<Entity> entities = mockStatic(Entity.class);
+        MockedStatic<DefaultAuthorizer> subjects = mockStatic(DefaultAuthorizer.class)) {
+      entities
+          .when(
+              () -> Entity.getEntityByName(eq(Entity.CONTEXT_MEMORY), eq(fqn), anyString(), any()))
+          .thenReturn(memory);
+      subjects
+          .when(() -> DefaultAuthorizer.getSubjectContext(securityContext))
+          .thenReturn(new SubjectContext(new User().withName("bob"), null, null));
+
+      assertThrows(
+          ForbiddenException.class,
+          () ->
+              new GetEntityTool()
+                  .execute(
+                      mock(Authorizer.class),
+                      securityContext,
+                      Map.of(
+                          "entityType",
+                          Entity.CONTEXT_MEMORY,
+                          "fqn",
+                          fqn,
+                          "include",
+                          List.of("content"))));
+    }
+  }
+
+  /**
+   * The regression guard for the fetch itself: owners is a relationship field, absent unless the
+   * read asks for it, and an ownerless memory reads as nobody's - which would deny the owner their
+   * own private memory.
+   */
+  @Test
+  void contentReadFetchesOwnersSoTheOwnerKeepsReadingTheirOwnPrivateMemory() throws Exception {
+    String fqn = "alices-private-note";
+    ContextMemory memory = privateMemoryOwnedBy("alice", fqn);
+    CatalogSecurityContext securityContext = securityContextFor("alice");
+    Map<String, Object> result;
+
+    try (MockedStatic<Entity> entities = mockStatic(Entity.class);
+        MockedStatic<DefaultAuthorizer> subjects = mockStatic(DefaultAuthorizer.class)) {
+      entities
+          .when(
+              () ->
+                  Entity.getEntityByName(
+                      Entity.CONTEXT_MEMORY, fqn, Entity.FIELD_OWNERS, Include.NON_DELETED))
+          .thenReturn(memory);
+      subjects
+          .when(() -> DefaultAuthorizer.getSubjectContext(securityContext))
+          .thenReturn(new SubjectContext(new User().withName("alice"), null, null));
+
+      result =
+          new GetEntityTool()
+              .execute(
+                  mock(Authorizer.class),
+                  securityContext,
+                  Map.of(
+                      "entityType",
+                      Entity.CONTEXT_MEMORY,
+                      "fqn",
+                      fqn,
+                      "include",
+                      List.of("content")));
+    }
+
+    assertThat(castMap(result.get("content")).get("content")).isEqualTo("the secret answer");
+  }
+
+  private static ContextMemory privateMemoryOwnedBy(String owner, String fqn) {
+    return new ContextMemory()
+        .withId(java.util.UUID.randomUUID())
+        .withName(fqn)
+        .withFullyQualifiedName(fqn)
+        .withAnswer("the secret answer")
+        .withOwners(
+            List.of(
+                new EntityReference()
+                    .withId(java.util.UUID.randomUUID())
+                    .withType(Entity.USER)
+                    .withName(owner)
+                    .withFullyQualifiedName(owner)))
+        .withShareConfig(new MemoryShareConfig().withVisibility(MemoryVisibility.PRIVATE));
+  }
+
+  private static CatalogSecurityContext securityContextFor(String userName) {
+    Principal principal = mock(Principal.class);
+    when(principal.getName()).thenReturn(userName);
+    CatalogSecurityContext securityContext = mock(CatalogSecurityContext.class);
+    when(securityContext.getUserPrincipal()).thenReturn(principal);
+    return securityContext;
   }
 
   private static Map<String, Object> column(String name, String description) {

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/PatchEntityToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/PatchEntityToolTest.java
@@ -3,17 +3,22 @@ package org.openmetadata.mcp.tools;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.core.Response;
 import java.security.Principal;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,14 +27,21 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.entity.context.ContextMemory;
+import org.openmetadata.schema.entity.context.MemoryShareConfig;
+import org.openmetadata.schema.entity.context.MemoryVisibility;
+import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.EventType;
 import org.openmetadata.schema.type.change.ChangeSource;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.EntityRepository;
 import org.openmetadata.service.security.Authorizer;
+import org.openmetadata.service.security.DefaultAuthorizer;
 import org.openmetadata.service.security.ImpersonationContext;
 import org.openmetadata.service.security.auth.CatalogSecurityContext;
+import org.openmetadata.service.security.policyevaluator.SubjectContext;
 import org.openmetadata.service.util.RestUtil;
 
 /**
@@ -54,6 +66,56 @@ class PatchEntityToolTest {
   @AfterEach
   void clearImpersonationContext() {
     ImpersonationContext.clear();
+  }
+
+  /**
+   * A patch answers with the patched entity, which makes it a read too, so the per-entity
+   * visibility rule runs before the write.
+   */
+  @Test
+  void execute_refusesToPatchAnotherUsersPrivateMemory() {
+    @SuppressWarnings("unchecked")
+    EntityRepository<EntityInterface> repository = mock(EntityRepository.class);
+    ContextMemory memory =
+        new ContextMemory()
+            .withId(UUID.randomUUID())
+            .withName("bobs-private-note")
+            .withFullyQualifiedName("bobs-private-note")
+            .withAnswer("the secret answer")
+            .withOwners(
+                List.of(
+                    new EntityReference()
+                        .withId(UUID.randomUUID())
+                        .withType(Entity.USER)
+                        .withName("bob")
+                        .withFullyQualifiedName("bob")))
+            .withShareConfig(new MemoryShareConfig().withVisibility(MemoryVisibility.PRIVATE));
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("entityType", Entity.CONTEXT_MEMORY);
+    params.put("fqn", "bobs-private-note");
+    params.put("patch", "[{\"op\": \"replace\", \"path\": \"/description\", \"value\": \"x\"}]");
+
+    try (MockedStatic<Entity> entityMock = mockStatic(Entity.class);
+        MockedStatic<DefaultAuthorizer> subjects = mockStatic(DefaultAuthorizer.class)) {
+      entityMock
+          .when(() -> Entity.getEntityRepository(Entity.CONTEXT_MEMORY))
+          .thenReturn(repository);
+      entityMock
+          .when(
+              () ->
+                  Entity.getEntityByName(
+                      eq(Entity.CONTEXT_MEMORY), eq("bobs-private-note"), anyString(), any()))
+          .thenReturn(memory);
+      subjects
+          .when(() -> DefaultAuthorizer.getSubjectContext(securityContext))
+          .thenReturn(new SubjectContext(new User().withName("alice"), null, null));
+
+      assertThatThrownBy(() -> new PatchEntityTool().execute(authorizer, securityContext, params))
+          .isInstanceOf(ForbiddenException.class);
+    }
+
+    verify(repository, never()).patch(any(), anyString(), any(), any(), any(), any(), any());
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AIContextBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AIContextBuilder.java
@@ -31,6 +31,7 @@ import org.apache.commons.text.StringEscapeUtils;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.api.data.MetricExpression;
 import org.openmetadata.schema.entity.context.ContextMemory;
+import org.openmetadata.schema.entity.context.ContextMemoryStatus;
 import org.openmetadata.schema.entity.data.GlossaryTerm;
 import org.openmetadata.schema.entity.data.Metric;
 import org.openmetadata.schema.entity.data.Page;
@@ -86,7 +87,7 @@ import org.openmetadata.service.security.policyevaluator.SubjectContext;
  * Assembles the {@link AIContext} (Context Profile) for a data asset: the common knowledge envelope
  * (attached glossary terms and Context Center articles) that applies to every entity type, plus the
  * type-specific structural {@link AssetContext} (schema, primary/foreign keys, frequent joins for
- * tables). It is the server-side, permission-agnostic core behind the {@code get_asset_context} MCP
+ * tables). It is the server-side core behind the {@code get_asset_context} MCP
  * tool and REST endpoint, so any agent can pull an asset's full context in a single call.
  *
  * <p>The structural transforms ({@link #buildTableContext}, {@link #extractForeignKeys}, etc.) are
@@ -126,6 +127,9 @@ public class AIContextBuilder {
   /** Max query-relevant vector lookups per bundle; items beyond it use the structural preview. */
   private static final int MAX_QUERY_EXCERPTS = 5;
 
+  /** Max upstream edges whose data-quality standing is checked for staleness stamping. */
+  static final int MAX_UPSTREAM_DQ_CHECKS = 3;
+
   private final String entityType;
   private final String fqn;
   private Authorizer authorizer;
@@ -133,6 +137,12 @@ public class AIContextBuilder {
   private int knowledgeBudgetChars = DEFAULT_KNOWLEDGE_BUDGET_CHARS;
   private String query;
   private int queryExcerptsRemaining = MAX_QUERY_EXCERPTS;
+  private Long assetUpdatedAt;
+  private DataQuality assetDataQuality;
+  private EntityLineage lineage;
+  private List<Edge> upstreamEdgeList;
+  private DataQuality upstreamDataQuality;
+  private boolean upstreamDataQualityResolved;
 
   public AIContextBuilder(String entityType, String fqn) {
     this.entityType = entityType;
@@ -180,6 +190,11 @@ public class AIContextBuilder {
     EntityLineage lineage = fetchLineage(entity);
     List<LineageEdgeContext> upstreamEdges = edgeContexts(lineage, true);
     List<LineageEdgeContext> downstreamEdges = edgeContexts(lineage, false);
+    DataQuality dataQuality = resolveDataQuality(entity);
+    this.assetUpdatedAt = entity.getUpdatedAt();
+    this.assetDataQuality = dataQuality;
+    this.lineage = lineage;
+    this.upstreamEdgeList = lineage == null ? null : lineage.getUpstreamEdges();
     AIContext context =
         new AIContext()
             .withId(entity.getId())
@@ -200,7 +215,7 @@ public class AIContextBuilder {
             .withDownstream(edgeFqns(downstreamEdges))
             .withDownstreamEdges(downstreamEdges)
             .withAssetContext(buildAssetContext(entity))
-            .withObservability(resolveObservability(entity))
+            .withObservability(resolveObservability(entity, dataQuality))
             .withGeneratedAt(System.currentTimeMillis());
     applyKnowledgeBudget(context);
     return context;
@@ -234,13 +249,20 @@ public class AIContextBuilder {
     String content = item.getContent();
     int budget = remaining;
     if (!nullOrEmpty(content)) {
-      if (content.length() <= MAX_ITEM_CHARS && content.length() <= remaining) {
-        budget = remaining - content.length();
-      } else if (remaining >= MIN_EXCERPT_CHARS) {
-        String lead = buildExcerpt(item, content, Math.min(EXCERPT_CHARS, remaining));
+      // Stale items render a trust cue next to their excerpt in Compact Markdown; the cue's exact
+      // rendered length is charged to the shared budget so later items can never overrun it.
+      int cueChars =
+          Boolean.TRUE.equals(item.getStale()) ? AIContextMarkdown.staleCue(item).length() : 0;
+      int effective = remaining - cueChars;
+      if (content.length() <= MAX_ITEM_CHARS && content.length() <= effective) {
+        budget = remaining - content.length() - cueChars;
+      } else if (effective >= MIN_EXCERPT_CHARS) {
+        String lead = buildExcerpt(item, content, Math.min(EXCERPT_CHARS, effective));
         item.withContent(lead).withContentTruncated(true);
-        budget = remaining - lead.length();
+        budget = remaining - lead.length() - cueChars;
       } else {
+        // Budget exhausted: content is omitted, and with it the cue (the cue renders only
+        // alongside visible content, see AIContextMarkdown) — so nothing is charged.
         item.withContent(null).withContentTruncated(true);
       }
     }
@@ -308,19 +330,27 @@ public class AIContextBuilder {
 
   /**
    * A relevance-judgeable preview of long content: the lead paragraph plus a {@code Sections:}
-   * outline of the body's markdown headings, so an agent sees what the document covers (not just its
-   * opening) before deciding to fetch the full body.
+   * outline of the body's markdown headings, so an agent sees what the document covers (not just
+   * its opening) before deciding to fetch the full body. The result never exceeds {@code limit}:
+   * when the outline alone fills the share, it is rendered bounded and the lead is elided, so the
+   * item's exact-length budget charge in {@link #fitItem} can never go negative.
    */
   static String structuralPreview(String content, int limit) {
+    if (nullOrEmpty(content)) {
+      return "";
+    }
     List<String> headings = extractHeadings(content);
     String outline =
         headings.size() >= 2
             ? "\n\nSections: " + String.join(" · ", capList(headings, MAX_OUTLINE_HEADINGS))
             : "";
-    // Reserve room for the outline so lead + Sections together stay within limit and the item
-    // never overruns its share of the knowledge budget.
-    String lead = excerpt(leadParagraph(content), Math.max(0, limit - outline.length()));
-    return lead + outline;
+    String result;
+    if (outline.length() >= limit) {
+      result = excerpt(outline.strip(), limit);
+    } else {
+      result = excerpt(leadParagraph(content), limit - outline.length()) + outline;
+    }
+    return result;
   }
 
   private static List<String> extractHeadings(String content) {
@@ -350,12 +380,23 @@ public class AIContextBuilder {
     return result;
   }
 
-  /** A lead excerpt bounded to {@code limit} characters, cut on a word boundary. */
+  /**
+   * A lead excerpt bounded to {@code limit} characters, cut on a word boundary. The ellipsis is
+   * counted inside the limit so budget accounting that charges {@code excerpt.length()} can never
+   * overrun the share it was sized against, and a non-positive limit yields an empty excerpt
+   * (the structural-preview path passes 0 when its heading outline consumes the whole allowance).
+   */
   static String excerpt(String content, int limit) {
+    if (content == null) {
+      return null;
+    }
+    if (limit <= 0) {
+      return "";
+    }
     String result = content;
-    if (content != null && content.length() > limit) {
-      int boundary = content.lastIndexOf(' ', limit);
-      int cut = boundary < limit / 2 ? limit : boundary;
+    if (content.length() > limit) {
+      int boundary = content.lastIndexOf(' ', limit - 1);
+      int cut = boundary < limit / 2 ? limit - 1 : boundary;
       result = content.substring(0, cut).stripTrailing() + "…";
     }
     return result;
@@ -393,10 +434,10 @@ public class AIContextBuilder {
     return serviceType;
   }
 
-  private Observability resolveObservability(EntityInterface entity) {
+  private Observability resolveObservability(EntityInterface entity, DataQuality dataQuality) {
     Observability observability = null;
     if (entity instanceof Table) {
-      observability = new Observability().withDataQuality(resolveDataQuality((Table) entity));
+      observability = new Observability().withDataQuality(dataQuality);
       applyProfile(observability, entity);
       if (isEmpty(observability)) {
         observability = null;
@@ -459,18 +500,119 @@ public class AIContextBuilder {
         .withCardinalityDistribution(columnProfile.getCardinalityDistribution());
   }
 
-  private DataQuality resolveDataQuality(Table table) {
+  private DataQuality resolveDataQuality(EntityInterface entity) {
     DataQuality dataQuality = null;
-    EntityReference testSuiteRef = table.getTestSuite();
-    if (testSuiteRef != null) {
-      try {
-        TestSuite testSuite = Entity.getEntity(testSuiteRef, "summary", Include.NON_DELETED);
-        dataQuality = toDataQuality(testSuite.getSummary());
-      } catch (Exception e) {
-        LOG.warn("AIContext: failed to load data quality for {}: {}", fqn, e.getMessage());
+    if (entity instanceof Table table) {
+      EntityReference testSuiteRef = table.getTestSuite();
+      if (testSuiteRef != null) {
+        try {
+          TestSuite testSuite = Entity.getEntity(testSuiteRef, "summary", Include.NON_DELETED);
+          dataQuality = toDataQuality(testSuite.getSummary());
+        } catch (Exception e) {
+          LOG.warn("AIContext: failed to load data quality for {}: {}", fqn, e.getMessage());
+        }
       }
     }
     return dataQuality;
+  }
+
+  /**
+   * Data-quality standing of the asset's direct upstream, lazily computed once per bundle and
+   * capped at {@link #MAX_UPSTREAM_DQ_CHECKS} edges. Returns a minimal {@link DataQuality} carrying
+   * the first upstream's failed-test count, or null when no checked upstream is failing. A pill
+   * describing data that is currently failing its tests is a trust signal, not a content change.
+   */
+  private DataQuality upstreamDataQuality() {
+    if (upstreamDataQualityResolved) {
+      return upstreamDataQuality;
+    }
+    upstreamDataQualityResolved = true;
+    // Upstream test status is caller-relative: without a caller to authorize there is nobody to
+    // check VIEW_TESTS for, so the signal is not computed rather than disclosed. The only caller
+    // without security is persona materialization (PersonaContextBuilder builds shared, persona-
+    // keyed documents — threading a requester in would bake one member's permissions into
+    // everyone's cached doc), and persona docs exclude pills anyway, so the stamped value would be
+    // discarded; the guard still removes the unauthorized upstream reads that computation performs.
+    if (authorizer == null || securityContext == null) {
+      return null;
+    }
+    Map<UUID, EntityReference> nodeRefs = new HashMap<>();
+    for (EntityReference node : listOrEmpty(lineage == null ? null : lineage.getNodes())) {
+      nodeRefs.put(node.getId(), node);
+    }
+    int checked = 0;
+    for (Edge edge : listOrEmpty(upstreamEdgeList)) {
+      if (checked >= MAX_UPSTREAM_DQ_CHECKS) {
+        break;
+      }
+      EntityReference ref = nodeRefs.get(edge.getFromEntity());
+      if (ref == null || !Entity.TABLE.equals(ref.getType())) {
+        continue;
+      }
+      // Being allowed to view this asset does not imply access to its upstreams. The only datum
+      // read from the upstream is its test-suite summary, which the platform field-gates behind
+      // VIEW_TESTS (TableResource), so VIEW_BASIC is not sufficient. The asset's own DQ needs no
+      // such check on the direct path: AI-context endpoints require VIEW_ALL on the requested
+      // asset, which subsumes VIEW_TESTS. Persona documents are different — they are admin-curated
+      // shared artifacts whose boundary is the persona's rule set, not a requesting caller — which
+      // is exactly why the caller-relative upstream signal above is suppressed there.
+      if (!canViewKnowledge(
+          Entity.TABLE, ref.getFullyQualifiedName(), MetadataOperation.VIEW_TESTS)) {
+        continue;
+      }
+      checked++;
+      try {
+        Table upstream = (Table) Entity.getEntity(ref, "testSuite", Include.NON_DELETED);
+        if (upstream.getTestSuite() != null) {
+          TestSuite suite =
+              Entity.getEntity(upstream.getTestSuite(), "summary", Include.NON_DELETED);
+          TestSummary summary = suite.getSummary();
+          if (summary != null && summary.getFailed() != null && summary.getFailed() > 0) {
+            upstreamDataQuality = new DataQuality().withFailed(summary.getFailed());
+            break;
+          }
+        }
+      } catch (Exception e) {
+        LOG.warn(
+            "AIContext: failed to load upstream data quality for {}: {}",
+            ref.getName(),
+            e.getMessage());
+      }
+    }
+    return upstreamDataQuality;
+  }
+
+  /**
+   * Read-time trust stamping (issue #32260): a knowledge item is marked stale when the asset it is
+   * attached to was updated after the knowledge was last touched, or when the asset's (or a direct
+   * upstream's) data-quality tests are failing. Purely informational — never removes the item —
+   * so agents can weigh the signal instead of silently losing context.
+   */
+  static void stampStaleness(
+      KnowledgeItem item,
+      Long knowledgeUpdatedAt,
+      Long assetUpdatedAt,
+      DataQuality assetDataQuality,
+      DataQuality upstreamDataQuality) {
+    List<String> reasons = new ArrayList<>();
+    if (knowledgeUpdatedAt != null
+        && assetUpdatedAt != null
+        && assetUpdatedAt > knowledgeUpdatedAt) {
+      reasons.add("assetUpdatedAfterKnowledge");
+    }
+    if (isFailing(assetDataQuality)) {
+      reasons.add("dataQualityFailing");
+    }
+    if (isFailing(upstreamDataQuality)) {
+      reasons.add("upstreamDataQualityFailing");
+    }
+    if (!reasons.isEmpty()) {
+      item.withStale(true).withStaleReasons(reasons);
+    }
+  }
+
+  private static boolean isFailing(DataQuality dataQuality) {
+    return dataQuality != null && dataQuality.getFailed() != null && dataQuality.getFailed() > 0;
   }
 
   static DataQuality toDataQuality(TestSummary summary) {
@@ -623,12 +765,36 @@ public class AIContextBuilder {
    * callers (no security context) are not filtered.
    */
   private boolean canViewKnowledge(String knowledgeType, String knowledgeFqn) {
+    return canViewKnowledge(
+        authorizer, securityContext, knowledgeType, knowledgeFqn, MetadataOperation.VIEW_BASIC);
+  }
+
+  private boolean canViewKnowledge(
+      String knowledgeType, String knowledgeFqn, MetadataOperation operation) {
+    return canViewKnowledge(authorizer, securityContext, knowledgeType, knowledgeFqn, operation);
+  }
+
+  /**
+   * Per-item PBAC, parameterized by the operation the datum requires: glossary/metric/page
+   * knowledge needs VIEW_BASIC, while a table's test-suite summary is a VIEW_TESTS-protected field
+   * (TableResource maps {@code testSuite} to VIEW_TESTS), so upstream data-quality stamping checks
+   * that operation instead. Server-internal callers (authorizer == null, e.g. persona
+   * materialization) are not filtered here — the same fail-open convention as the other per-item
+   * checks in this builder. {@link #upstreamDataQuality()} is the deliberate exception: it is a
+   * caller-relative signal, so it is suppressed rather than computed without a caller.
+   */
+  static boolean canViewKnowledge(
+      Authorizer authorizer,
+      SecurityContext securityContext,
+      String knowledgeType,
+      String knowledgeFqn,
+      MetadataOperation operation) {
     boolean visible = true;
     if (authorizer != null && securityContext != null) {
       try {
         authorizer.authorize(
             securityContext,
-            new OperationContext(knowledgeType, MetadataOperation.VIEW_BASIC),
+            new OperationContext(knowledgeType, operation),
             new ResourceContext<>(knowledgeType, null, knowledgeFqn));
       } catch (AuthorizationException e) {
         LOG.debug(
@@ -725,7 +891,9 @@ public class AIContextBuilder {
     KnowledgeItem item = null;
     try {
       ContextMemory pill = Entity.getEntity(ref, "", Include.NON_DELETED);
-      if (canViewPill(pill)) {
+      // Mirror the glossary path's approval gating: Draft/Archived memories are not settled
+      // knowledge and must not reach agents as current context (issue #32260).
+      if (isActivePill(pill) && canViewPill(pill)) {
         item =
             new KnowledgeItem()
                 .withId(pill.getId())
@@ -734,11 +902,22 @@ public class AIContextBuilder {
                 .withDisplayName(pill.getDisplayName())
                 .withFullyQualifiedName(pill.getFullyQualifiedName())
                 .withContent(pillContent(pill));
+        stampStaleness(
+            item, pill.getUpdatedAt(), assetUpdatedAt, assetDataQuality, upstreamDataQuality());
       }
     } catch (Exception e) {
       LOG.warn("AIContext: failed to fetch knowledge pill {}: {}", ref.getName(), e.getMessage());
     }
     return item;
+  }
+
+  /**
+   * Pills with no lifecycle status (pre-lifecycle memories) are treated as active, matching how
+   * {@link #isApproved(GlossaryTerm)} treats a missing glossary review status.
+   */
+  static boolean isActivePill(ContextMemory pill) {
+    ContextMemoryStatus status = pill.getStatus();
+    return status == null || status == ContextMemoryStatus.ACTIVE;
   }
 
   private static String pillContent(ContextMemory pill) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AIContextMarkdown.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AIContextMarkdown.java
@@ -556,6 +556,11 @@ public final class AIContextMarkdown {
     if (!nullOrEmpty(promptContent)) {
       String content = promptContent.strip();
       markdown.append('\n').append(truncateContent ? truncate(content) : content).append('\n');
+      // The cue only rides alongside visible content (it is charged to the item's budget share in
+      // fitItem); a reference-only item renders the fetch hint below instead.
+      if (Boolean.TRUE.equals(item.getStale())) {
+        markdown.append(staleCue(item));
+      }
     }
     if (Boolean.TRUE.equals(item.getContentTruncated())) {
       markdown
@@ -571,6 +576,18 @@ public final class AIContextMarkdown {
     if (!nullOrEmpty(fqn)) {
       markdown.append('`').append(fqn).append("`\n");
     }
+  }
+
+  /**
+   * The stale trust cue rendered for a knowledge item in Compact Markdown. Its exact length is
+   * charged to the item's budget share in {@code AIContextBuilder.fitItem}, so cue + excerpt can
+   * never push a bundle past the caller's knowledge budget.
+   */
+  static String staleCue(KnowledgeItem item) {
+    List<String> reasons = listOrEmpty(item.getStaleReasons());
+    return "\n_⚠ Stale"
+        + (reasons.isEmpty() ? "" : " — " + String.join(", ", reasons))
+        + ". Weigh this against the asset's current state before relying on it for decisions._\n";
   }
 
   private static String labelOf(KnowledgeItem item) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/context/ContextMemoryVisibility.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/context/ContextMemoryVisibility.java
@@ -14,12 +14,15 @@
 package org.openmetadata.service.resources.context;
 
 import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.core.SecurityContext;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.entity.context.ContextMemory;
 import org.openmetadata.schema.entity.context.MemoryVisibility;
 import org.openmetadata.schema.entity.teams.User;
@@ -36,10 +39,19 @@ import org.slf4j.LoggerFactory;
  * through this check so a non-admin user cannot read another user's PRIVATE memory via the public
  * API. Visibility is independent of the OSS policy/authorizer model because it is driven by the
  * per-memory {@code shareConfig} (visibility + sharedWith) rather than role/policy.
+ *
+ * <p>Because it sits outside the policy model, no {@code authorizer.authorize(...)} call can ever
+ * enforce it: a read path that authorizes and fetches is not yet a read path that is allowed to
+ * answer. Callers that reach a memory without knowing they have (the MCP entity tools read any
+ * type by name) use the type-blind {@link #enforceVisibility(EntityInterface, SecurityContext)}
+ * together with {@link #guardFields(String, String)}.
  */
 public final class ContextMemoryVisibility {
 
   private static final Logger LOG = LoggerFactory.getLogger(ContextMemoryVisibility.class);
+
+  /** The field selection that already asks for every allowed field, owners included. */
+  private static final String ALL_FIELDS = "*";
 
   private ContextMemoryVisibility() {}
 
@@ -70,11 +82,45 @@ public final class ContextMemoryVisibility {
   }
 
   public static void enforceVisibility(ContextMemory memory, SecurityContext securityContext) {
-    if (memory == null || securityContext == null || securityContext.getUserPrincipal() == null) {
-      return;
+    if (memory != null) {
+      enforceVisibility(memory, callerName(securityContext), isAdmin(securityContext));
     }
-    SubjectContext subject = DefaultAuthorizer.getSubjectContext(securityContext);
-    enforceVisibility(memory, securityContext.getUserPrincipal().getName(), subject.isAdmin());
+  }
+
+  /**
+   * The type-blind guard, for read paths that hold an entity without knowing its type. Applies the
+   * rule when {@code entity} is a memory and does nothing for every other entity type, so a caller
+   * needs no per-type knowledge to be safe.
+   */
+  public static void enforceVisibility(EntityInterface entity, SecurityContext securityContext) {
+    if (entity instanceof ContextMemory memory) {
+      enforceVisibility(memory, securityContext);
+    }
+  }
+
+  /** Whether reads of {@code entityType} are governed by a per-entity visibility rule. */
+  public static boolean hasVisibilityRules(String entityType) {
+    return Entity.CONTEXT_MEMORY.equals(entityType);
+  }
+
+  /**
+   * Merges the fields the decision reads into a caller's field selection. Owners is a relationship
+   * field, null unless the fetch asked for it, so a read that omits it hands the guard an ownerless
+   * memory - denying the owner their own private memory. Field selections that already cover owners
+   * ({@code *}, or an explicit {@code owners}) are returned unchanged.
+   */
+  public static String guardFields(String entityType, String requestedFields) {
+    String fields = requestedFields;
+    if (hasVisibilityRules(entityType) && !ALL_FIELDS.equals(requestedFields)) {
+      Set<String> requested = new LinkedHashSet<>(splitFields(requestedFields));
+      requested.add(Entity.FIELD_OWNERS);
+      fields = String.join(",", requested);
+    }
+    return fields;
+  }
+
+  private static List<String> splitFields(String fields) {
+    return nullOrEmpty(fields) ? List.of() : List.of(fields.split(","));
   }
 
   public static List<ContextMemory> filterByVisibility(
@@ -87,12 +133,28 @@ public final class ContextMemoryVisibility {
     if (memories == null || memories.isEmpty()) {
       return memories;
     }
-    if (securityContext == null || securityContext.getUserPrincipal() == null) {
-      return memories;
+    return filterByVisibility(memories, callerName(securityContext), isAdmin(securityContext));
+  }
+
+  /**
+   * A caller too anonymous to decide from is treated as one, not waved through: {@link
+   * #isVisibleToUser} then matches no owner and no shared principal, leaving the org-wide ({@code
+   * ENTITY}) memories - the same fallback {@code ContextMemorySearchVisibility} applies to an
+   * unresolvable search subject.
+   */
+  private static String callerName(SecurityContext securityContext) {
+    return securityContext == null || securityContext.getUserPrincipal() == null
+        ? null
+        : securityContext.getUserPrincipal().getName();
+  }
+
+  private static boolean isAdmin(SecurityContext securityContext) {
+    boolean admin = false;
+    if (callerName(securityContext) != null) {
+      SubjectContext subject = DefaultAuthorizer.getSubjectContext(securityContext);
+      admin = subject != null && subject.isAdmin();
     }
-    SubjectContext subject = DefaultAuthorizer.getSubjectContext(securityContext);
-    return filterByVisibility(
-        memories, securityContext.getUserPrincipal().getName(), subject.isAdmin());
+    return admin;
   }
 
   public static boolean isOwnedBy(ContextMemory memory, String userName) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/aicontext/AIContextBuilderTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/aicontext/AIContextBuilderTest.java
@@ -13,9 +13,16 @@
 package org.openmetadata.service.aicontext;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 
+import jakarta.ws.rs.core.SecurityContext;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -25,6 +32,8 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.api.data.MetricExpression;
 import org.openmetadata.schema.api.services.CreateDatabaseService;
+import org.openmetadata.schema.entity.context.ContextMemory;
+import org.openmetadata.schema.entity.context.ContextMemoryStatus;
 import org.openmetadata.schema.entity.data.Metric;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.tests.type.TestSummary;
@@ -42,6 +51,7 @@ import org.openmetadata.schema.type.EntityLineage;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.JoinedWith;
 import org.openmetadata.schema.type.LineageDetails;
+import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.PartitionColumnDetails;
 import org.openmetadata.schema.type.TableConstraint;
 import org.openmetadata.schema.type.TableJoins;
@@ -58,6 +68,10 @@ import org.openmetadata.schema.type.aicontext.LineageEdgeContext;
 import org.openmetadata.schema.type.aicontext.Observability;
 import org.openmetadata.schema.type.aicontext.TableContext;
 import org.openmetadata.schema.type.aicontext.TableDataModel;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.security.AuthorizationException;
+import org.openmetadata.service.security.Authorizer;
+import org.openmetadata.service.security.policyevaluator.OperationContext;
 
 /**
  * Unit tests for the pure structural transforms of {@link AIContextBuilder}. These verify that the
@@ -159,6 +173,72 @@ class AIContextBuilderTest {
   }
 
   @Test
+  void excerpt_zeroOrNegativeLimitYieldsEmptyWithoutCrashing() {
+    assertEquals("", AIContextBuilder.excerpt("lead paragraph", 0));
+    assertEquals("", AIContextBuilder.excerpt("lead paragraph", -3));
+  }
+
+  @Test
+  void structuralPreview_outlineExhaustingTheLimitDoesNotCrash() {
+    String body = "Lead paragraph.\n\n## Recognition timing\n\n## Refund exclusions";
+    // Limit exactly at the outline's length: the lead's excerpt allowance drops to 0.
+    String preview = AIContextBuilder.structuralPreview(body, 40);
+    assertTrue(preview.contains("Sections:"), "outline still renders when the lead is elided");
+  }
+
+  @Test
+  void structuralPreview_neverExceedsTheLimit() {
+    String body =
+        "Lead paragraph about revenue recognition.\n\n"
+            + "## Recognition timing\n\n## Refund exclusions\n\n"
+            + "## Territory rules\n\n## Reseller margins";
+    for (int limit : new int[] {20, 40, 120, 800}) {
+      String preview = AIContextBuilder.structuralPreview(body, limit);
+      assertTrue(
+          preview.length() <= limit,
+          "preview must respect the limit (" + limit + "), was " + preview.length());
+    }
+    String bounded = AIContextBuilder.structuralPreview(body, 20);
+    assertTrue(bounded.contains("Sections:"), "bounded outline still names the section list");
+  }
+
+  @Test
+  void canViewKnowledge_failsClosedAndAllowsInternalCallers() {
+    Authorizer authorizer = mock(Authorizer.class);
+    SecurityContext securityContext = mock(SecurityContext.class);
+
+    doThrow(new AuthorizationException("denied"))
+        .when(authorizer)
+        .authorize(eq(securityContext), any(OperationContext.class), any());
+    assertFalse(
+        AIContextBuilder.canViewKnowledge(
+            authorizer,
+            securityContext,
+            Entity.TABLE,
+            "svc.db.sch.upstream",
+            MetadataOperation.VIEW_TESTS),
+        "authorization denial hides the upstream");
+
+    reset(authorizer);
+    doThrow(new IllegalStateException("policy store hiccup"))
+        .when(authorizer)
+        .authorize(any(), any(), any());
+    assertFalse(
+        AIContextBuilder.canViewKnowledge(
+            authorizer,
+            securityContext,
+            Entity.TABLE,
+            "svc.db.sch.upstream",
+            MetadataOperation.VIEW_TESTS),
+        "non-authorization errors fail closed");
+
+    assertTrue(
+        AIContextBuilder.canViewKnowledge(
+            authorizer, null, Entity.TABLE, "svc.db.sch.upstream", MetadataOperation.VIEW_TESTS),
+        "server-internal callers (no security context) are not filtered");
+  }
+
+  @Test
   void applyKnowledgeBudget_keepsShortItemsFullAndExcerptsOversized() {
     KnowledgeItem term = knowledgeItem("term", "x".repeat(100));
     KnowledgeItem metric = knowledgeItem("metric", "y".repeat(100));
@@ -194,6 +274,138 @@ class AIContextBuilderTest {
     assertTrue(
         Boolean.TRUE.equals(second.getContentTruncated()), "second article marked truncated");
     assertTrue(second.getContent() == null, "second article content omitted (reference-only)");
+  }
+
+  @Test
+  void isActivePill_gatesNonActiveStatusesButTreatsMissingStatusAsActive() {
+    assertTrue(
+        AIContextBuilder.isActivePill(new ContextMemory()),
+        "pre-lifecycle memories (no status) stay visible");
+    assertTrue(
+        AIContextBuilder.isActivePill(new ContextMemory().withStatus(ContextMemoryStatus.ACTIVE)));
+    assertFalse(
+        AIContextBuilder.isActivePill(new ContextMemory().withStatus(ContextMemoryStatus.DRAFT)),
+        "Draft memories are not settled knowledge");
+    assertFalse(
+        AIContextBuilder.isActivePill(new ContextMemory().withStatus(ContextMemoryStatus.ARCHIVED)),
+        "Archived memories must not reach agents as current context");
+  }
+
+  @Test
+  void stampStaleness_flagsNothingWhenSignalsHealthy() {
+    KnowledgeItem item = knowledgeItem("NPI", "definition");
+    AIContextBuilder.stampStaleness(item, 1000L, 900L, null, null);
+    assertFalse(Boolean.TRUE.equals(item.getStale()), "fresh knowledge on a healthy asset");
+    assertTrue(item.getStaleReasons().isEmpty(), "no reasons when nothing is flagged");
+  }
+
+  @Test
+  void stampStaleness_flagsAssetUpdatedAfterKnowledge() {
+    KnowledgeItem item = knowledgeItem("NPI", "definition");
+    AIContextBuilder.stampStaleness(item, 1000L, 2000L, null, null);
+    assertTrue(Boolean.TRUE.equals(item.getStale()));
+    assertEquals(List.of("assetUpdatedAfterKnowledge"), item.getStaleReasons());
+  }
+
+  @Test
+  void stampStaleness_flagsFailingAssetAndUpstreamDataQuality() {
+    KnowledgeItem item = knowledgeItem("NPI", "definition");
+    AIContextBuilder.stampStaleness(
+        item, null, null, new DataQuality().withFailed(3), new DataQuality().withFailed(1));
+    assertTrue(Boolean.TRUE.equals(item.getStale()));
+    assertEquals(
+        List.of("dataQualityFailing", "upstreamDataQualityFailing"), item.getStaleReasons());
+  }
+
+  @Test
+  void stampStaleness_zeroFailuresAndMissingTimestampsAreNotStale() {
+    KnowledgeItem item = knowledgeItem("NPI", "definition");
+    AIContextBuilder.stampStaleness(
+        item, null, null, new DataQuality().withFailed(0), new DataQuality().withFailed(0));
+    assertFalse(Boolean.TRUE.equals(item.getStale()));
+  }
+
+  @Test
+  void applyKnowledgeBudget_reservesCueRoomForStaleItems() {
+    KnowledgeItem fresh = knowledgeItem("fresh", "z".repeat(4000));
+    KnowledgeItem stale =
+        knowledgeItem("stale", "z".repeat(4000))
+            .withStale(true)
+            .withStaleReasons(List.of("assetUpdatedAfterKnowledge"));
+    AIContextBuilder builder =
+        new AIContextBuilder("table", "svc.db.sch.orders")
+            .withKnowledgeBudget(AIContextBuilder.EXCERPT_CHARS);
+
+    AIContext freshContext = new AIContext().withArticles(List.of(fresh));
+    AIContext staleContext = new AIContext().withArticles(List.of(stale));
+    builder.applyKnowledgeBudget(freshContext);
+    builder.applyKnowledgeBudget(staleContext);
+
+    assertTrue(Boolean.TRUE.equals(fresh.getContentTruncated()));
+    assertTrue(Boolean.TRUE.equals(stale.getContentTruncated()));
+    // Invariant: rendered cue + excerpt stays within the fresh item's budget share (exact sizing,
+    // not an estimate).
+    assertTrue(
+        stale.getContent().length() + AIContextMarkdown.staleCue(stale).length()
+            <= fresh.getContent().length() + 1,
+        "stale excerpt plus its rendered cue stays within the budget share");
+  }
+
+  @Test
+  void applyKnowledgeBudget_chargesStaleCueAgainstTheSharedPool() {
+    // Two stale items share a small budget: the cue of item 1 must be charged to the pool, or the
+    // bundle's rendered total (content + cues) exceeds the configured budget.
+    KnowledgeItem first =
+        knowledgeItem("first", "z".repeat(4000))
+            .withStale(true)
+            .withStaleReasons(List.of("assetUpdatedAfterKnowledge"));
+    KnowledgeItem second =
+        knowledgeItem("second", "z".repeat(4000))
+            .withStale(true)
+            .withStaleReasons(List.of("assetUpdatedAfterKnowledge"));
+    AIContext context = new AIContext().withArticles(List.of(first, second));
+
+    new AIContextBuilder("table", "svc.db.sch.orders")
+        .withKnowledgeBudget(AIContextBuilder.EXCERPT_CHARS)
+        .applyKnowledgeBudget(context);
+
+    String renderedFirst = AIContextMarkdown.staleCue(first);
+    assertTrue(Boolean.TRUE.equals(first.getContentTruncated()));
+    assertTrue(
+        first.getContent().length() + renderedFirst.length() <= AIContextBuilder.EXCERPT_CHARS,
+        "first stale item's excerpt + cue fits the budget");
+    assertTrue(Boolean.TRUE.equals(second.getContentTruncated()));
+    assertTrue(
+        second.getContent() == null,
+        "second item omitted once the first item's excerpt + cue consumed the pool");
+    // The omitted item renders no cue (it is only charged/rendered alongside visible content).
+    StringBuilder markdown = new StringBuilder();
+    AIContextMarkdown.appendKnowledgeSection(
+        markdown, "Knowledge", List.of(first, second), "#", true);
+    assertEquals(
+        1,
+        markdown.toString().split("⚠ Stale", -1).length - 1,
+        "exactly one cue renders — the omitted item carries no unbudgeted cue");
+  }
+
+  @Test
+  void appendKnowledgeSection_rendersTrustCueOnlyForStaleItems() {
+    KnowledgeItem stale =
+        knowledgeItem("NPI", "definition")
+            .withStale(true)
+            .withStaleReasons(List.of("assetUpdatedAfterKnowledge"));
+    KnowledgeItem fresh = knowledgeItem("MRR", "metric definition");
+    StringBuilder markdown = new StringBuilder();
+
+    AIContextMarkdown.appendKnowledgeSection(
+        markdown, "Knowledge", List.of(stale, fresh), "#", true);
+
+    String rendered = markdown.toString();
+    assertTrue(
+        rendered.contains("⚠ Stale — assetUpdatedAfterKnowledge"),
+        "stale item carries a trust cue naming the reasons");
+    assertEquals(
+        1, rendered.split("⚠ Stale", -1).length - 1, "cue is rendered for stale items only");
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/context/ContextMemoryVisibilityTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/context/ContextMemoryVisibilityTest.java
@@ -22,6 +22,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 
 import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.core.SecurityContext;
+import java.security.Principal;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
@@ -29,13 +31,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.entity.context.ContextMemory;
 import org.openmetadata.schema.entity.context.MemoryShareConfig;
 import org.openmetadata.schema.entity.context.MemorySharedPrincipal;
 import org.openmetadata.schema.entity.context.MemoryVisibility;
+import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.service.Entity;
+import org.openmetadata.service.security.DefaultAuthorizer;
+import org.openmetadata.service.security.policyevaluator.SubjectContext;
 
 /**
  * Tests user-isolation semantics enforced by {@link ContextMemoryVisibility}. These rules back
@@ -197,6 +203,104 @@ class ContextMemoryVisibilityTest {
     ContextMemory memory = new ContextMemory().withOwners(List.of());
 
     assertFalse(ContextMemoryVisibility.isOwnedBy(memory, ALICE));
+  }
+
+  /**
+   * The type-blind overload the entity read paths call: a read tool holds an {@link
+   * EntityInterface} and does not know which types carry visibility rules, so it must be able to
+   * ask without naming contextMemory.
+   */
+  @Test
+  void testEnforceVisibility_onEntityInterface_deniesAnotherUsersPrivateMemory() {
+    EntityInterface privateOwnedByAlice = memoryOwnedBy(ALICE, MemoryVisibility.PRIVATE);
+    SecurityContext bob = securityContextFor(BOB);
+
+    withSubject(
+        bob,
+        BOB,
+        () ->
+            assertThrows(
+                ForbiddenException.class,
+                () -> ContextMemoryVisibility.enforceVisibility(privateOwnedByAlice, bob)));
+  }
+
+  @Test
+  void testEnforceVisibility_onEntityInterface_allowsTheOwnersOwnPrivateMemory() {
+    EntityInterface privateOwnedByAlice = memoryOwnedBy(ALICE, MemoryVisibility.PRIVATE);
+    SecurityContext alice = securityContextFor(ALICE);
+
+    withSubject(
+        alice,
+        ALICE,
+        () ->
+            assertDoesNotThrow(
+                () -> ContextMemoryVisibility.enforceVisibility(privateOwnedByAlice, alice)));
+  }
+
+  @Test
+  void testEnforceVisibility_onEntityInterface_ignoresTypesWithoutVisibilityRules() {
+    EntityInterface table = new Table().withName("orders").withFullyQualifiedName("s.d.orders");
+
+    assertDoesNotThrow(
+        () -> ContextMemoryVisibility.enforceVisibility(table, securityContextFor(BOB)));
+  }
+
+  @Test
+  void testEnforceVisibility_onEntityInterface_letsAnAdminReadEveryMemory() {
+    EntityInterface privateOwnedByAlice = memoryOwnedBy(ALICE, MemoryVisibility.PRIVATE);
+    SecurityContext admin = securityContextFor(BOB);
+
+    try (MockedStatic<DefaultAuthorizer> authorizer = Mockito.mockStatic(DefaultAuthorizer.class)) {
+      authorizer
+          .when(() -> DefaultAuthorizer.getSubjectContext(admin))
+          .thenReturn(new SubjectContext(new User().withName(BOB).withIsAdmin(true), null, null));
+
+      assertDoesNotThrow(
+          () -> ContextMemoryVisibility.enforceVisibility(privateOwnedByAlice, admin));
+    }
+  }
+
+  @Test
+  void testHasVisibilityRules_onlyForContextMemory() {
+    assertTrue(ContextMemoryVisibility.hasVisibilityRules(Entity.CONTEXT_MEMORY));
+    assertFalse(ContextMemoryVisibility.hasVisibilityRules(Entity.TABLE));
+    assertFalse(ContextMemoryVisibility.hasVisibilityRules(null));
+  }
+
+  /**
+   * Owners is a relationship field, null unless the fetch asked for it. A read path that fetches a
+   * memory without owners hands the guard an ownerless memory and denies the owner their own
+   * private memory - so the guard states the fields its own decision reads.
+   */
+  @Test
+  void testGuardFields_addsOwnersForMemoriesOnly() {
+    assertEquals(
+        Entity.FIELD_OWNERS, ContextMemoryVisibility.guardFields(Entity.CONTEXT_MEMORY, ""));
+    assertEquals(
+        Entity.FIELD_OWNERS, ContextMemoryVisibility.guardFields(Entity.CONTEXT_MEMORY, null));
+    assertEquals("tags,owners", ContextMemoryVisibility.guardFields(Entity.CONTEXT_MEMORY, "tags"));
+    assertEquals(
+        "sourceFile,owners",
+        ContextMemoryVisibility.guardFields(Entity.CONTEXT_MEMORY, "sourceFile,owners"));
+    assertEquals("*", ContextMemoryVisibility.guardFields(Entity.CONTEXT_MEMORY, "*"));
+    assertEquals("", ContextMemoryVisibility.guardFields(Entity.TABLE, ""));
+  }
+
+  private SecurityContext securityContextFor(String userName) {
+    Principal principal = Mockito.mock(Principal.class);
+    Mockito.when(principal.getName()).thenReturn(userName);
+    SecurityContext securityContext = Mockito.mock(SecurityContext.class);
+    Mockito.when(securityContext.getUserPrincipal()).thenReturn(principal);
+    return securityContext;
+  }
+
+  private void withSubject(SecurityContext securityContext, String userName, Runnable assertions) {
+    try (MockedStatic<DefaultAuthorizer> authorizer = Mockito.mockStatic(DefaultAuthorizer.class)) {
+      authorizer
+          .when(() -> DefaultAuthorizer.getSubjectContext(securityContext))
+          .thenReturn(new SubjectContext(new User().withName(userName), null, null));
+      assertions.run();
+    }
   }
 
   private ContextMemory memoryOwnedBy(String userName, MemoryVisibility visibility) {

--- a/openmetadata-spec/src/main/resources/json/schema/type/aiContext.json
+++ b/openmetadata-spec/src/main/resources/json/schema/type/aiContext.json
@@ -37,6 +37,18 @@
                     "description": "True when content is a lead excerpt or has been omitted to fit the context budget; fetch the full body via the get_knowledge_content tool using this item's fullyQualifiedName.",
                     "type": "boolean",
                     "default": false
+                },
+                "stale": {
+                    "description": "True when read-time trust signals indicate this item may no longer reflect the asset it is attached to (e.g. the asset changed after the knowledge was last updated, or the asset's data-quality tests are failing). Absent means no staleness signal.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "staleReasons": {
+                    "description": "Machine-readable reasons for the stale flag (e.g. assetUpdated, dataQualityFailing).",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             },
             "additionalProperties": false

--- a/openmetadata-ui/src/main/resources/ui/src/generated/type/aiContext.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/type/aiContext.ts
@@ -132,6 +132,16 @@ export interface KnowledgeItem {
     id?:   string;
     name?: string;
     /**
+     * True when read-time trust signals indicate this item may no longer reflect the asset it
+     * is attached to (e.g. the asset changed after the knowledge was last updated, or the
+     * asset's data-quality tests are failing). Absent means no staleness signal.
+     */
+    stale?: boolean;
+    /**
+     * Machine-readable reasons for the stale flag (e.g. assetUpdated, dataQualityFailing).
+     */
+    staleReasons?: string[];
+    /**
      * The entity type of the knowledge item.
      */
     type?: Type;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/type/personaContext.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/type/personaContext.ts
@@ -230,6 +230,16 @@ export interface KnowledgeItem {
     id?:   string;
     name?: string;
     /**
+     * True when read-time trust signals indicate this item may no longer reflect the asset it
+     * is attached to (e.g. the asset changed after the knowledge was last updated, or the
+     * asset's data-quality tests are failing). Absent means no staleness signal.
+     */
+    stale?: boolean;
+    /**
+     * Machine-readable reasons for the stale flag (e.g. assetUpdated, dataQualityFailing).
+     */
+    staleReasons?: string[];
+    /**
      * The entity type of the knowledge item.
      */
     type?: Type;


### PR DESCRIPTION
### Describe your changes:

Two backports to `2.0`, cherry-picked in dependency order:

| # | Upstream | SHA | Why |
|---|----------|-----|-----|
| 1 | #32261 — trust signals for AI context (Fixes #32260) | `c3d6c03` | The backport that was asked for |
| 2 | #32465 — Apply context memory visibility rules on MCP entity reads | `d3ab545` | **Prerequisite.** `2.0` did not compile without it — see below |

#### Why #32465 is in this PR

`2.0` was broken at HEAD before this branch. `1f7813f0b0` (the `2.0` backport of #32858, *fix(context): hydrate owners for memory reads*) added two call sites of `ContextMemoryVisibility.guardFields(entityType, fieldsParam)` in `ContextMemoryResource.java` (lines 400 and 438), but #32465 — the PR that **defines** `guardFields` on `ContextMemoryVisibility` — was never backported:

```
[ERROR] .../resources/context/ContextMemoryResource.java:[400,36] cannot find symbol
[ERROR]   symbol:   method guardFields(java.lang.String,java.lang.String)
[ERROR]   location: class org.openmetadata.service.resources.context.ContextMemoryVisibility
```

Nothing on push-to-`2.0` compiles Java (only CodeQL runs), which is why this went unnoticed. Picking #32465 here both restores the branch and lets this PR's CI actually validate the #32261 backport instead of failing on a pre-existing break.

#### What #32261 does

Knowledge pills (ContextMemory items) attached to an asset flowed into AI context bundles (`get_asset_context`, persona documents) regardless of lifecycle state, and the bundle never told an agent whether the knowledge it received was still current.

1. **Active-only pill gating** — `toPillKnowledgeItem` mirrors the glossary path's approval gating: pills in `Draft` or `Archived` state with a live `APPLIED_TO` edge are no longer served to agents as current context. Pre-lifecycle memories (no status) remain visible, matching how `isApproved` treats a missing glossary review status.
2. **Read-time staleness stamping** — `KnowledgeItem` gains additive `stale` + `staleReasons` fields, stamped by `AIContextBuilder` from two deterministic, pure-function signals:
   - `assetUpdatedAfterKnowledge` — the attached asset's `updatedAt` is newer than the knowledge item's last update;
   - `dataQualityFailing` / `upstreamDataQualityFailing` — the asset's (or a direct upstream's, capped at 3 edges, gated behind `VIEW_TESTS` and memoized per bundle) data-quality tests are failing.

   Stamping is informational only — items are never removed, so agents can weigh the signal instead of silently losing context.
3. **Compact Markdown trust cue** — stale items render a one-line cue naming the reasons, only when stale; the cue's exact rendered length is charged to the existing knowledge budget (`fitItem`) so it can never push a bundle past the caller's budget.

No new status vocabulary, no new provenance model, no relational migration (additive fields on the `KnowledgeItem` JSON type; `ContextMemory` schema untouched).

#### What #32465 does

Applies the per-entity ContextMemory visibility rules on MCP entity reads: `CommonUtils.readEntityForCaller` / `enforceEntityVisibility`, wired into `GetEntityTool`, `PatchEntityTool` and `CompanyContextTool`, plus the `guardFields` / `hasVisibilityRules` helpers on `ContextMemoryVisibility` that merge `owners` into the caller's field selection (a read that omits `owners` hands the guard an ownerless memory and denies the owner their own private memory).

### Type of change:
- [x] Bug fix
- [x] Improvement

### Backport fidelity:

Both picks were diffed line-by-line against their upstream commits, comparing only added/removed content lines (ignoring blob hashes and hunk offsets):

- **#32261** — `496` changed lines, identical to upstream. Applied with zero conflicts.
- **#32465** — `747` changed lines, identical to upstream. One conflict, in `PatchEntityToolTest.java`, confined to the import block (2.0's copy of that file has drifted from `main`); resolved by taking the incoming imports, then `spotless:apply` dropped the three that are unused on the 2.0 base (`java.util.Set`, `ResourceContextInterface`, `EntityUtil.Fields`). No logic was touched.

Also checked: `ContextMemoryStatus` (`Draft`/`Active`/`Archived`) exists on `2.0` with the same vocabulary, so the pill gate keeps its meaning.

### Tests:

#### Use cases covered
- Archived/Draft pill attached to a table is excluded from `get_asset_context` output
- Pill on an asset updated after the pill's last update is flagged stale with `assetUpdatedAfterKnowledge`
- Pill on an asset (or upstream) with failing DQ tests is flagged with the corresponding reason
- Fresh pill on a healthy asset carries no stale flag or reasons
- A stale item's markdown excerpt shrinks so cue + excerpt fit the caller's knowledge budget
- Trust cue renders in Compact Markdown exactly once, only for stale items
- MCP `get_entity` / `patch_entity` / company-context reads honour ContextMemory visibility; `guardFields` merges `owners` into the caller's field selection

#### Unit tests
Both upstream test suites come across with the picks. Green on this branch:

```
Tests run: 46, Failures: 0, Errors: 0, Skipped: 0 -- AIContextBuilderTest
Tests run: 17, Failures: 0, Errors: 0, Skipped: 0 -- ContextMemoryVisibilityTest
Tests run: 16, Failures: 0, Errors: 0, Skipped: 0 -- CompanyContextToolTest
Tests run: 29, Failures: 0, Errors: 0, Skipped: 0 -- GetEntityToolTest
Tests run: 17, Failures: 0, Errors: 0, Skipped: 0 -- PatchEntityToolTest
```

#### Backend integration tests
- [x] `McpContextMemoryVisibilityIT` comes across with #32465 and compiles on this branch.
- [ ] No new IT for #32261 — same as the original PR; the gating and stamping paths are exercised end-to-end by the existing `AIContextMcpIT` harness.

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI behavior change; generated TS types only).

#### Manual testing performed
```
mvn -pl openmetadata-service,openmetadata-mcp,openmetadata-integration-tests -am install -DskipTests   -> BUILD SUCCESS
mvn -pl openmetadata-service,openmetadata-mcp,openmetadata-integration-tests spotless:check            -> BUILD SUCCESS
```

### UI screen recording / screenshots:

Not applicable.

### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My PR is linked to the original PRs and issue above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: additive JSON-type fields only; entity JSON column storage means no migration is required.
- [x] For UI changes: N/A — generated types only.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
