### PR TITLE
fix(ci): preinstall spaCy across shards and pin Python CI actions

### DIFF
--- a/.github/actions/setup-openmetadata-test-environment/action.yml
+++ b/.github/actions/setup-openmetadata-test-environment/action.yml
@@ -72,7 +72,7 @@ runs:
     # ---- Setup Java --------------------------------------------------------------
     - name: Setup JDK ${{ inputs.java-version }}
       if: ${{ inputs.install-server == 'true' && (inputs.fast-mode == 'true' || inputs.lightweight-ingestion != 'true') }}
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         java-version: ${{ inputs.java-version }}
         distribution: 'temurin'
@@ -81,7 +81,7 @@ runs:
     # ---- Setup Node --------------------------------------------------------------
     - name: Use Node.js ${{ inputs.npm-version }}
       if: ${{ inputs.install-server == 'true' && inputs.fast-mode != 'true' && inputs.lightweight-ingestion != 'true' }}
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: ${{ inputs.npm-version }}
 
@@ -95,7 +95,7 @@ runs:
     - name: Setup Python ${{ inputs.python-version }}
       id: setup-python
       if: ${{ inputs.fast-mode != 'true' && inputs.lightweight-ingestion != 'true' }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
       with:
         python-version: ${{ inputs.python-version }}
 
@@ -116,7 +116,7 @@ runs:
     # gates in playwright-e2e-reusable.yml; see #32613.
     - name: Install uv
       if: ${{ inputs.fast-mode != 'true' && inputs.lightweight-ingestion != 'true' }}
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       with:
         enable-cache: ${{ github.event_name != 'merge_group' }}
 
@@ -141,7 +141,7 @@ runs:
     - name: Restore ingestion Python venv
       id: cache-python-venv
       if: ${{ inputs.fast-mode != 'true' && inputs.lightweight-ingestion != 'true' }}
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: env
         key: ${{ steps.venv-cache-key.outputs.key }}
@@ -182,7 +182,7 @@ runs:
         !(github.event_name == 'pull_request_target' &&
           github.event.pull_request.head.repo.full_name != github.repository) }}
       continue-on-error: true
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: env
         key: ${{ steps.venv-cache-key.outputs.key }}
@@ -199,7 +199,7 @@ runs:
 
     - name: Start Server and Ingest Sample Data
       if: ${{ inputs.install-server == 'true' && inputs.fast-mode != 'true' }}
-      uses: nick-fields/retry@v4
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
       env:
         INGESTION_DEPENDENCY: ${{ inputs.ingestion_dependency }}
       with:

--- a/.github/workflows/py-tests-shared.yml
+++ b/.github/workflows/py-tests-shared.yml
@@ -65,13 +65,13 @@ jobs:
       python: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.python }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         if: ${{ github.event_name == 'merge_group' }}
         with:
           fetch-depth: 0
           filter: blob:none
           persist-credentials: false
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         id: filter
         if: ${{ github.event_name == 'pull_request_target' || github.event_name == 'merge_group' }}
         with:
@@ -87,7 +87,7 @@ jobs:
               - 'openmetadata-service/src/main/java/org/openmetadata/service/ResourceRegistry.java'
 
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.7.0
+        uses: lewagon/wait-on-check-action@9312864dfbc9fd208e9c0417843430751c042800 # v1.7.0
         if: ${{ github.event_name == 'pull_request_target' && steps.filter.outputs.python == 'true' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -96,7 +96,7 @@ jobs:
           wait-interval: 30
 
       - name: Verify PR labels
-        uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+        uses: jesusvasquez333/verify-pr-label-action@657d111bbbe13e22bbd55870f1813c699bde1401 # v1.4.0
         if: ${{ github.event_name == 'pull_request_target' && steps.filter.outputs.python == 'true' }}
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -113,14 +113,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
           allow-unsafe-pr-checkout: true
           persist-credentials: false
 
       - name: Setup JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -128,7 +128,7 @@ jobs:
       # Restore-only: pull_request_target / merge_group writes are scoped to refs no
       # other run can read, so saving would only consume the repo's cache quota.
       - name: Restore Maven dependencies
-        uses: actions/cache/restore@v6
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.m2
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -143,7 +143,7 @@ jobs:
         shell: bash
 
       - name: Upload backend distribution
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: openmetadata-backend-distribution
           path: openmetadata-dist/target/openmetadata-*.tar.gz
@@ -163,7 +163,7 @@ jobs:
     steps:
       - name: Restore spaCy model wheel
         id: spacy-model-cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: .cache/spacy-model
           key: spacy-model-${{ env.SPACY_MODEL_VERSION }}-${{ env.SPACY_MODEL_SHA256 }}
@@ -180,7 +180,7 @@ jobs:
         shell: bash
 
       - name: Upload spaCy model wheel
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: spacy-en-model
           path: .cache/spacy-model/*.whl
@@ -200,7 +200,7 @@ jobs:
         py-version: ["3.10", "3.11", "3.12"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
           allow-unsafe-pr-checkout: true
@@ -212,7 +212,7 @@ jobs:
           install-server: 'false'
 
       - name: Download spaCy model
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: spacy-en-model
           path: /tmp/spacy-model
@@ -272,7 +272,7 @@ jobs:
       - name: Upload test results
         if: ${{ always() }}
         continue-on-error: true
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ${{ inputs.artifact-prefix }}-unit-test-results-${{ matrix.py-version }}
           path: |
@@ -288,7 +288,7 @@ jobs:
       - name: Upload coverage artifact
         if: ${{ matrix.py-version == env.MAIN_PYTHON_VERSION && !cancelled() }}
         continue-on-error: true
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: coverage-unit
           path: ingestion/.coverage
@@ -356,7 +356,7 @@ jobs:
           docker-images: false
 
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
           allow-unsafe-pr-checkout: true
@@ -367,7 +367,7 @@ jobs:
 
       # Must precede the setup action, which builds the server image from this tarball.
       - name: Download backend distribution
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: openmetadata-backend-distribution
           path: openmetadata-dist/target
@@ -379,7 +379,7 @@ jobs:
           args: ${{ inputs.compose-args }}
 
       - name: Download spaCy model
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: spacy-en-model
           path: /tmp/spacy-model
@@ -437,7 +437,7 @@ jobs:
       - name: Upload coverage artifact
         if: ${{ inputs.run-coverage && matrix.py-version == env.MAIN_PYTHON_VERSION && !cancelled() }}
         continue-on-error: true
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: coverage-integration-${{ matrix.shard.name }}
           path: ingestion/.coverage
@@ -446,7 +446,7 @@ jobs:
       - name: Upload test results
         if: ${{ always() }}
         continue-on-error: true
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ${{ inputs.artifact-prefix }}-integration-test-results-${{ matrix.shard.name }}-${{ matrix.py-version }}
           path: |
@@ -486,7 +486,7 @@ jobs:
       - name: Upload runner and service diagnostics
         if: ${{ failure() || cancelled() }}
         continue-on-error: true
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ${{ inputs.artifact-prefix }}-integration-diagnostics-${{ matrix.shard.name }}-${{ matrix.py-version }}
           path: ${{ runner.temp }}/python-ci-diagnostics/
@@ -554,7 +554,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
           allow-unsafe-pr-checkout: true
@@ -562,7 +562,7 @@ jobs:
           filter: blob:none
           persist-credentials: false
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
@@ -578,7 +578,7 @@ jobs:
         shell: bash
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           pattern: coverage-*
           path: ingestion/coverage-data/
@@ -609,7 +609,7 @@ jobs:
         id: push-to-sonar
         if: ${{ github.event_name == 'pull_request_target'}}
         continue-on-error: true
-        uses: SonarSource/sonarqube-scan-action@v7
+        uses: SonarSource/sonarqube-scan-action@c7ee0f9df90b7aa20e8dcf9695dcfe2e7da5b4f2 # v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.INGESTION_SONAR_SECRET }}

--- a/.github/workflows/py-tests-shared.yml
+++ b/.github/workflows/py-tests-shared.yml
@@ -379,14 +379,12 @@ jobs:
           args: ${{ inputs.compose-args }}
 
       - name: Download spaCy model
-        if: matrix.shard.name == 'shard-1'
         uses: actions/download-artifact@v7
         with:
           name: spacy-en-model
           path: /tmp/spacy-model
 
       - name: Install and verify spaCy model
-        if: matrix.shard.name == 'shard-1'
         run: |
           source env/bin/activate
           uv pip install --no-deps /tmp/spacy-model/*.whl


### PR DESCRIPTION
### Describe your changes:

Python integration shard 2 downloaded the spaCy model during fixture setup because preinstallation was restricted to shard 1. HTTP 500 responses during that download failed the classification tests. Install and verify the existing model artifact in every integration shard before pytest starts.

Pin external actions in the shared Python workflow and its setup composite action to full commit SHAs resolved from the existing upstream tags. Retain the version tags in comments for Dependabot updates. All 32 external action references across these files are now pinned, including the existing free-disk-space pin.

The setup action is shared with other CI workflows, and its file content participates in the Python venv cache key. This update therefore causes a one-time cache miss for affected consumers.

Validated with actionlint, YAML parsing, upstream SHA mapping and reference-only diff checks, and `git diff --check`. Integration tests have not been rerun locally.

### Type of change:

- [x] Bug fix
