### PR TITLE
Backport 2.0: bump js-yaml to 5.4.1

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/package.json
+++ b/openmetadata-ui-core-components/src/main/resources/ui/package.json
@@ -149,7 +149,7 @@
     "uuid": "^14.0.0",
     "esbuild": "^0.28.1",
     "ws": "8.21.1",
-    "js-yaml": "^5.2.2"
+    "js-yaml": "^5.4.1"
   },
   "publishConfig": {
     "access": "restricted",

--- a/openmetadata-ui-core-components/src/main/resources/ui/yarn.lock
+++ b/openmetadata-ui-core-components/src/main/resources/ui/yarn.lock
@@ -4245,10 +4245,10 @@ jju@~1.4.0:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^4.1.1, js-yaml@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-5.2.2.tgz#497bfe63f0b0db11c7bbc5ce8bc568e836c8b08c"
-  integrity sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==
+js-yaml@^4.1.1, js-yaml@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-5.4.1.tgz#4629d91d4b4551f300435f0e4127899710f816fb"
+  integrity sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==
   dependencies:
     argparse "^2.0.1"
 

--- a/openmetadata-ui/src/main/resources/ui/package.json
+++ b/openmetadata-ui/src/main/resources/ui/package.json
@@ -124,7 +124,7 @@
     "i18next": "^21.10.0",
     "i18next-browser-languagedetector": "^6.1.6",
     "input-otp": "^1.4.2",
-    "js-yaml": "^5.2.2",
+    "js-yaml": "^5.4.1",
     "jwt-decode": "^3.1.2",
     "katex": "^0.16.21",
     "lodash": "4.18.1",
@@ -308,7 +308,7 @@
     "nanoid": "3.3.17",
     "uuid": "^14.0.0",
     "esbuild": "^0.28.1",
-    "js-yaml": "^5.2.2",
+    "js-yaml": "^5.4.1",
     "postcss": "8.5.23",
     "socket.io-parser": "4.2.7",
     "undici": "^6.28.0"

--- a/openmetadata-ui/src/main/resources/ui/yarn.lock
+++ b/openmetadata-ui/src/main/resources/ui/yarn.lock
@@ -8669,10 +8669,10 @@ js-cookie@^3.0.1:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1, js-yaml@^4.1.0, js-yaml@^4.1.1, js-yaml@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-5.2.2.tgz#497bfe63f0b0db11c7bbc5ce8bc568e836c8b08c"
-  integrity sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==
+js-yaml@^3.13.1, js-yaml@^4.1.0, js-yaml@^4.1.1, js-yaml@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-5.4.1.tgz#4629d91d4b4551f300435f0e4127899710f816fb"
+  integrity sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
Backport of #32913 to `2.0`.

## What it does

Brings the two UI workspaces on `2.0` from js-yaml `^5.2.2` to `^5.4.1`. 5.4.1 carries a CHANGELOG "Security" entry — empty mappings in merge sequences now count toward `maxTotalMergeKeys`, and merge sequence size is hard-limited to 100 — continuing the merge-key CPU-exhaustion hardening that GHSA-pm4m-ph32-ghv5 (patched in 5.2.2) started.

As on main, this is **hardening, not an open advisory**: no GitHub advisory currently lists 5.2.2 as affected, so this is not remediating a filed alert against `2.0`.

The bump crosses 5.3.0 and 5.4.0, both of which declare `[breaking]` changes — grouped constant exports, a flattened low-level AST node representation, a rewritten `sortKeys`, and reworked scalar style selection that can change dump formatting. None apply: `2.0` has the **same five call sites** as main, all of which use only the high-level `dump`/`load` API, `dump` is invoked with no options, and `sortKeys` is unused.

Net diff is version-only across the same 4 files as the original: 3 `package.json` specifiers (`openmetadata-ui` dependency + resolution, `openmetadata-ui-core-components` resolution) and the 2 lockfile entries.

## Adaptation

One conflict, in `openmetadata-ui-core-components/.../yarn.lock`. The incoming side carried main's dependency graph rather than just the version change:

- a `js-tokens@^9.0.1` block that has no requester on `2.0`, and
- a `js-yaml@^4.1.0` specifier in the merged key list, which likewise only exists in main's graph.

Taking the incoming side verbatim would have written a lockfile entry that does not describe `2.0`'s tree. Resolved instead by keeping `2.0`'s own specifier set and changing only the resolution:

```
-js-yaml@^4.1.1, js-yaml@^5.2.2:
-  version "5.2.2"
+js-yaml@^4.1.1, js-yaml@^5.4.1:
+  version "5.4.1"
```

`openmetadata-ui/.../yarn.lock` auto-merged, and that merge was checked rather than assumed — its specifier set (`^3.13.1, ^4.1.0, ^4.1.1`) is byte-identical on `2.0` and main, so the auto-merge there was genuinely version-only.

## Verification

- **`yarn install --frozen-lockfile` clean in both workspaces** — this is the check that matters for a hand-edited lockfile, since it fails if the lockfile no longer satisfies the manifests. Both succeeded, and neither rewrote its lockfile (`git status` clean afterwards).
- **js-yaml resolves to 5.4.1 in both** installed trees, confirmed from `node_modules/js-yaml/package.json`.
- **Jest: 101/101 passing** across the js-yaml-dependent suites — `ContractYaml`, `ODCSImportModal`, `DataContractUtils`.

One correction to the original PR message, which claimed four suites: `ODPSImportModal` has **no test file** — on `2.0` or on main — so it is 3 suites for the same 101 tests. Its `yamlLoad` call site is still covered by the manual read of all five call sites above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
