### PR TITLE
Fixes #32981: let the class base suppress the shared test-result graph

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTab.component.tsx
@@ -45,6 +45,7 @@ import {
   getSidePanelColSpanClass,
   hasAdditionalComponents,
   resolveIsSidePanelVisible,
+  shouldRenderTestSummary,
   shouldShowAILearningBanner,
   shouldShowEditParameterButton,
   shouldShowSqlParamsSection,
@@ -212,6 +213,7 @@ const TestCaseResultTab = ({
     isTabExpanded,
     AlertComponent,
     additionalComponents,
+    shouldRenderDefaultGraph,
   } = useTestCaseResultTab();
   const { entityRules, isRulesLoaded } = useEntityRules(EntityType.TEST_CASE);
   const isSidePanelVisible = resolveIsSidePanelVisible(
@@ -396,7 +398,7 @@ const TestCaseResultTab = ({
                 <AlertComponent />
               </div>
             )}
-          {testCaseData && (
+          {shouldRenderTestSummary(testCaseData, shouldRenderDefaultGraph) && (
             <div className="test-case-result-tab-graph tw:w-full">
               <TestSummary data={testCaseData} />
             </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTab.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTab.test.tsx
@@ -95,9 +95,15 @@ jest.mock(
   })
 );
 const mockBannerComponent = () => <div>BannerComponent</div>;
+const mockShouldRenderDefaultGraph = jest.fn().mockReturnValue(true);
 jest.mock('./TestCaseResultTabClassBase', () => ({
   getAdditionalComponents: jest.fn().mockReturnValue([]),
   getAlertBanner: jest.fn().mockImplementation(() => mockBannerComponent),
+  shouldRenderDefaultGraph: jest
+    .fn()
+    .mockImplementation((...args: unknown[]) =>
+      mockShouldRenderDefaultGraph(...args)
+    ),
 }));
 jest.mock('../../../common/EntityDescription/Description', () => {
   return jest.fn().mockImplementation(() => <div>Description</div>);
@@ -183,6 +189,7 @@ describe('TestCaseResultTab', () => {
     mockUseTestCaseStore.testCase.useDynamicAssertion = undefined;
     mockUseTestCaseStore.testCase.computePassedFailedRowCount = undefined;
     mockUseTestCaseStore.testCase.deleted = undefined;
+    mockShouldRenderDefaultGraph.mockReturnValue(true);
   });
 
   it('Should render component', async () => {
@@ -199,6 +206,17 @@ describe('TestCaseResultTab', () => {
     ).toBeInTheDocument();
     expect(await screen.findByText('Description')).toBeInTheDocument();
     expect(await screen.findByText('TestSummary')).toBeInTheDocument();
+  });
+
+  it('should not mount the default graph when the class base suppresses it', async () => {
+    mockShouldRenderDefaultGraph.mockReturnValue(false);
+
+    render(<TestCaseResultTab />);
+
+    expect(
+      await screen.findByTestId('test-case-result-tab-container')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('TestSummary')).not.toBeInTheDocument();
   });
 
   it("EditTestCaseModal should be rendered when 'Edit' button is clicked", async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTab.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTab.test.tsx
@@ -97,13 +97,16 @@ jest.mock(
 const mockBannerComponent = () => <div>BannerComponent</div>;
 const mockShouldRenderDefaultGraph = jest.fn().mockReturnValue(true);
 jest.mock('./TestCaseResultTabClassBase', () => ({
-  getAdditionalComponents: jest.fn().mockReturnValue([]),
-  getAlertBanner: jest.fn().mockImplementation(() => mockBannerComponent),
-  shouldRenderDefaultGraph: jest
-    .fn()
-    .mockImplementation((...args: unknown[]) =>
-      mockShouldRenderDefaultGraph(...args)
-    ),
+  __esModule: true,
+  default: {
+    getAdditionalComponents: jest.fn().mockReturnValue([]),
+    getAlertBanner: jest.fn().mockImplementation(() => mockBannerComponent),
+    shouldRenderDefaultGraph: jest
+      .fn()
+      .mockImplementation((...args: unknown[]) =>
+        mockShouldRenderDefaultGraph(...args)
+      ),
+  },
 }));
 jest.mock('../../../common/EntityDescription/Description', () => {
   return jest.fn().mockImplementation(() => <div>Description</div>);

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTab.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTab.utils.ts
@@ -45,6 +45,16 @@ export const hasAdditionalComponents = (
   additionalComponents: unknown[]
 ): boolean => !isEmpty(additionalComponents);
 
+/**
+ * A type predicate so the caller can pass `testCaseData` straight to
+ * `TestSummary`, which requires a defined test case.
+ */
+export const shouldRenderTestSummary = (
+  testCaseData: TestCase | undefined,
+  shouldRenderDefaultGraph: boolean
+): testCaseData is TestCase =>
+  !isUndefined(testCaseData) && shouldRenderDefaultGraph;
+
 export const canEditTestCaseParameters = (
   hasEditPermission: boolean | undefined,
   isParameterEdit: boolean

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTabClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTabClassBase.test.ts
@@ -120,6 +120,18 @@ describe('TestCaseResultTabClassBase', () => {
     });
   });
 
+  describe('shouldRenderDefaultGraph', () => {
+    it('should render the shared graph by default', () => {
+      expect(testCaseResultTabClassBase.shouldRenderDefaultGraph()).toBe(true);
+      expect(
+        testCaseResultTabClassBase.shouldRenderDefaultGraph(undefined)
+      ).toBe(true);
+      expect(
+        testCaseResultTabClassBase.shouldRenderDefaultGraph(mockTestCase)
+      ).toBe(true);
+    });
+  });
+
   describe('extended class functionality', () => {
     it('should allow extending the class to add custom components', () => {
       const MockComponent = () => null;
@@ -165,6 +177,29 @@ describe('TestCaseResultTabClassBase', () => {
       const result = extendedInstance.getAlertBanner();
 
       expect(result).toBe(MockBanner);
+    });
+
+    it('should allow extending the class to suppress the default graph per test type', () => {
+      class ExtendedClass extends TestCaseResultTabClassBase {
+        public shouldRenderDefaultGraph(testCaseData?: TestCase): boolean {
+          return testCaseData?.testDefinition?.name !== 'tableDataToBeFresh';
+        }
+      }
+
+      const extendedInstance = new ExtendedClass();
+
+      expect(extendedInstance.shouldRenderDefaultGraph(mockTestCase)).toBe(
+        true
+      );
+      expect(
+        extendedInstance.shouldRenderDefaultGraph({
+          ...mockTestCase,
+          testDefinition: {
+            ...mockTestCase.testDefinition,
+            name: 'tableDataToBeFresh',
+          },
+        })
+      ).toBe(false);
     });
 
     it('should allow extending the class with conditional banner logic', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTabClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTabClassBase.ts
@@ -28,6 +28,20 @@ class TestCaseResultTabClassBase {
   public getAlertBanner(): React.FC | null {
     return null;
   }
+
+  /**
+   * Whether the tab renders the shared `TestSummary` chart for this test case.
+   *
+   * A downstream build can plot a test type the shared chart reads wrongly — a
+   * freshness result stores signed slack rather than a delay, so the shared
+   * chart draws it as a descending line into negative durations. Returning
+   * `false` here unmounts that chart so a replacement supplied through
+   * {@link getAdditionalComponents} stands in its place, rather than sitting
+   * beside it and paying for the same `getListTestCaseResults` twice.
+   */
+  public shouldRenderDefaultGraph(_testCaseData?: TestCase): boolean {
+    return true;
+  }
 }
 
 const testCaseResultTabClassBase = new TestCaseResultTabClassBase();

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/useTestCaseResultTab.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/useTestCaseResultTab.test.tsx
@@ -56,11 +56,18 @@ jest.mock('../../../../rest/testAPI', () => ({
     ),
 }));
 
+const mockShouldRenderDefaultGraph = jest.fn().mockReturnValue(true);
+
 jest.mock('./TestCaseResultTabClassBase', () => ({
   __esModule: true,
   default: {
     getAdditionalComponents: jest.fn().mockReturnValue([]),
     getAlertBanner: jest.fn().mockReturnValue(null),
+    shouldRenderDefaultGraph: jest
+      .fn()
+      .mockImplementation((...args: unknown[]) =>
+        mockShouldRenderDefaultGraph(...args)
+      ),
   },
 }));
 
@@ -95,6 +102,7 @@ describe('useTestCaseResultTab', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockParams = {};
+    mockShouldRenderDefaultGraph.mockReturnValue(true);
     mockUseTestCaseStore.testCase = MOCK_TEST_CASE_DATA as unknown as TestCase;
     mockUseTestCaseStore.testCasePermission = MOCK_PERMISSIONS;
   });
@@ -293,5 +301,22 @@ describe('useTestCaseResultTab', () => {
     });
 
     expect(result.current.isParameterEdit).toBe(false);
+  });
+
+  it('should surface the class base default-graph decision for the current test case', () => {
+    const { result } = renderHook(() => useTestCaseResultTab());
+
+    expect(result.current.shouldRenderDefaultGraph).toBe(true);
+    expect(mockShouldRenderDefaultGraph).toHaveBeenCalledWith(
+      MOCK_TEST_CASE_DATA
+    );
+  });
+
+  it('should surface a suppressed default graph', () => {
+    mockShouldRenderDefaultGraph.mockReturnValue(false);
+
+    const { result } = renderHook(() => useTestCaseResultTab());
+
+    expect(result.current.shouldRenderDefaultGraph).toBe(false);
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/useTestCaseResultTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/useTestCaseResultTab.tsx
@@ -87,6 +87,7 @@ export interface UseTestCaseResultTabResult {
   isTabExpanded: boolean;
   AlertComponent: FC | null;
   additionalComponents: AdditionalComponentInterface[];
+  shouldRenderDefaultGraph: boolean;
 }
 
 /**
@@ -113,6 +114,8 @@ export const useTestCaseResultTab = (): UseTestCaseResultTabResult => {
 
   const additionalComponents =
     testCaseResultTabClassBase.getAdditionalComponents(testCaseData);
+  const shouldRenderDefaultGraph =
+    testCaseResultTabClassBase.shouldRenderDefaultGraph(testCaseData);
 
   // The test-case page mounts no GenericProvider, so the description
   // attribution must be fetched directly instead of read from context.
@@ -408,5 +411,6 @@ export const useTestCaseResultTab = (): UseTestCaseResultTabResult => {
     isTabExpanded,
     AlertComponent,
     additionalComponents,
+    shouldRenderDefaultGraph,
   };
 };


### PR DESCRIPTION
### Describe your changes:

Fixes #32981

`TestCaseResultTab` renders the shared `TestSummary` chart for every test case, and `TestCaseResultTabClassBase` exposes no way to say otherwise — only `getAdditionalComponents` and `getAlertBanner`, neither of which can suppress that render.

A downstream build that needs to plot a test type the shared chart reads wrongly (a freshness result stores signed slack rather than a measured delay, so the shared chart draws it as a descending line into negative durations) can therefore append its own chart, but cannot take the wrong one off the page. The only lever left is a CSS `:has()` rule, which does not unmount `TestSummary` — so the page issues `getListTestCaseResults` twice, renders a full recharts tree into a `display: none` container, and couples to class names owned by this repo.

This adds `shouldRenderDefaultGraph(testCaseData)` to the class base, defaulting to `true` so OSS behaviour is unchanged, surfaces it through `useTestCaseResultTab`, and gates the `TestSummary` block on it. An override that returns `false` unmounts the chart rather than hiding it, so its fetch never fires.

The gate goes through `shouldRenderTestSummary` in `TestCaseResultTab.utils` rather than inline. It is a type predicate, so `TestSummary` still receives a narrowed `TestCase`, and it keeps `TestCaseResultTab` under the `sonarjs/cyclomatic-complexity` ceiling of 10 — the inline `testCaseData && shouldRenderDefaultGraph &&` form pushed it to 11 and failed lint.

**Downstream consumer:** openmetadata-collate#6385 overrides this hook in `TestCaseResultTabClassCollate` to return `false` for `tableDataToBeFresh`, where it supplies a replacement `FreshnessGraph`. That PR is blocked on this one — its override is inert until this lands and the submodule pointer moves.

#
### Type of change:
- [x] Improvement

#
### High-level design:

N/A — small change. Three files touched plus their tests; the hook is additive with a `true` default, so no existing caller changes behaviour.

#
### Tests:

#### Use cases covered
- A test case renders the shared `TestSummary` chart (unchanged default)
- A class base that returns `false` for a test type unmounts the chart, so it neither renders nor fetches

#### Unit tests
- [x] `TestCaseResultTabClassBase.test.ts` — the default returns `true` for no argument, `undefined`, and a real test case; a subclass can suppress per test type
- [x] `useTestCaseResultTab.test.tsx` — the hook calls the class base with the current test case and surfaces both `true` and `false`
- [x] `TestCaseResultTab.test.tsx` — `TestSummary` is not in the document when the class base suppresses it

Verified locally: `yarn test --testPathPattern TestCaseResultTab` → 53 passed, and the new tab assertion fails on `main` without the gate (checked by reverting the condition). `npx tsc --noEmit` reports nothing on the changed files; `ui-checkstyle` sequence (organize-imports → eslint --fix → prettier) leaves them clean with 0 errors.

#### Integration tests
N/A — UI-only change.

#### Playwright tests
N/A — no user-visible change in OSS; the default keeps the current behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Z6H2Crk88aujoBtrELGJK