### PR TITLE
ci: fan the Collate check out to Playwright and the UI unit tests

### DIFF
--- a/.github/workflows/maven-build-collate.yml
+++ b/.github/workflows/maven-build-collate.yml
@@ -141,10 +141,20 @@ jobs:
       # the Collate change is backported to the live release branches.
       - name: Skip — suite not wired on this release branch
         if: ${{ matrix.main_only && (github.event.pull_request.base.ref || github.ref_name) != 'main' }}
+        env:
+          SUITE: ${{ matrix.suite }}
         run: |
-          echo "::notice::${{ matrix.suite }} runs for main PRs only — the Collate branch this PR targets does not accept the OpenMetadata sha input yet."
+          echo "::notice::${SUITE} runs for main PRs only — the Collate branch this PR targets does not accept the OpenMetadata sha input yet."
+          {
+            echo "### ${SUITE} — not run"
+            echo ""
+            echo "Dispatched for \`main\` PRs only: the Collate branch this PR targets does not"
+            echo "accept the OpenMetadata \`sha\` input yet, and the dispatch API rejects the whole"
+            echo "call when an input is undeclared."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Dispatch ${{ matrix.file }} & wait
+        id: dispatch
         if: ${{ !matrix.main_only || (github.event.pull_request.base.ref || github.ref_name) == 'main' }}
         uses: benc-uk/workflow-dispatch@v1.3.2
         timeout-minutes: ${{ matrix.timeout_minutes }}
@@ -165,3 +175,43 @@ jobs:
           wait-timeout-seconds: ${{ matrix.wait_seconds }}
           wait-interval-seconds: 60
           inputs: '{ "sha": "${{ env.SHA }}", "event": "${{ github.event_name }}" }'
+
+      # Two reasons this step exists rather than trusting `sync-status`:
+      #
+      #   It fails the dispatch step only on a `failure` or `cancelled` conclusion.
+      #   When the wait budget expires the action logs a warning and re-reads a
+      #   conclusion that is still `null`, which lands in its success branch — so
+      #   the leg went green while the Collate run was still going. A false pass on
+      #   exactly the suites this fan-out exists to surface.
+      #
+      #   openmetadata-collate is private, so a contributor cannot open the run
+      #   URL. Naming the jobs that failed here puts them in this repo's run
+      #   summary, which anyone reading the red check can see.
+      - name: Report the Collate run's conclusion
+        if: ${{ always() && steps.dispatch.outputs.runId != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.COLLATE_PAT }}
+          COLLATE_REPO: open-metadata/openmetadata-collate
+          RUN_ID: ${{ steps.dispatch.outputs.runId }}
+          RUN_URL: ${{ steps.dispatch.outputs.runUrlHtml }}
+          SUITE: ${{ matrix.suite }}
+        run: |
+          conclusion=$(gh api "repos/${COLLATE_REPO}/actions/runs/${RUN_ID}" \
+            --jq '.conclusion // "still running (wait budget expired)"')
+          failed=$(gh api --paginate "repos/${COLLATE_REPO}/actions/runs/${RUN_ID}/jobs" \
+            --jq '.jobs[] | select(.conclusion != "success" and .conclusion != "skipped")
+                  | "- `\(.name)` — \(.conclusion // "still running")"' || true)
+          {
+            echo "### ${SUITE} — ${conclusion}"
+            echo ""
+            if [ -n "$failed" ]; then
+              echo "$failed"
+              echo ""
+            fi
+            echo "[Collate run ${RUN_ID}](${RUN_URL}) · needs openmetadata-collate access"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$conclusion" != "success" ]; then
+            echo "::error::${SUITE} did not pass on the Collate side (${conclusion}). The run summary lists the jobs that failed."
+            exit 1
+          fi

--- a/.github/workflows/maven-build-collate.yml
+++ b/.github/workflows/maven-build-collate.yml
@@ -126,7 +126,7 @@ jobs:
             wait_seconds: 8100
             timeout_minutes: 140
           # Collate's Jest suite — the only leg that fails on an OpenMetadata UI
-          # change that breaks a Collate unit test. ~50 min, Collate cap 90.
+          # change that breaks a Collate unit test. 16-20 min, Collate cap 90.
           - suite: Collate UI unit tests
             file: collate-ui-coverage.yml
             main_only: true

--- a/.github/workflows/maven-build-collate.yml
+++ b/.github/workflows/maven-build-collate.yml
@@ -40,6 +40,15 @@ on:
       - "!openmetadata-ui/src/main/resources/ui/src/test/**"
       - "!openmetadata-ui/src/main/resources/ui/src/**/*.test.ts"
       - "!openmetadata-ui/src/main/resources/ui/src/**/*.test.tsx"
+      # collate-ui mirrors ui/playwright and builds against this package.json, so
+      # a change here breaks the Collate Playwright and Jest suites the fan-out
+      # below now runs. Both were outside this filter while only the backend
+      # build ran.
+      - "openmetadata-ui/src/main/resources/ui/playwright/**"
+      - "!openmetadata-ui/src/main/resources/ui/playwright/doc-generator/**"
+      - "!openmetadata-ui/src/main/resources/ui/playwright/docs/**"
+      - "openmetadata-ui/src/main/resources/ui/package.json"
+      - "openmetadata-ui/src/main/resources/ui/yarn.lock"
       - "openmetadata-spec/src/main/resources/json/schema/**"
       - "openmetadata-integration-tests/**"
       - "openmetadata-mcp/**"
@@ -52,7 +61,10 @@ concurrency:
   group: maven-build-collate-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name != 'pull_request_target' || github.event.action != 'labeled' || (github.event.label.name == 'safe to test' && github.event.pull_request.head.repo.full_name != github.repository) }}
 jobs:
-  maven-collate-ci:
+  # Gate once, not per matrix leg: the label check fails the job when the label is
+  # missing, and running it inside the matrix would paint one red check per Collate
+  # workflow on every unlabelled fork PR.
+  gate:
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft && (github.event_name != 'pull_request_target' || github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
     steps:
@@ -74,22 +86,72 @@ jobs:
           pull-request-number: "${{ github.event.pull_request.number }}"
           disable-reviews: true # To not auto approve changes
 
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          allow-unsafe-pr-checkout: true
-          persist-credentials: false
-      - name: Trigger Collate build & wait
+  # One leg per Collate suite, all dispatched in parallel and each reported as its
+  # own check so a red one names the suite that broke. Every leg sends the same
+  # payload; the Collate side pins its OpenMetadata submodule to `sha`, so all of
+  # them test this PR's code rather than the submodule tip.
+  #
+  # `file`, not the display name: Collate has a paths-ignore "skip" twin for some
+  # of these that carries the *same* `name:`, and the action takes the first match
+  # of (name | id | filename). Dispatching "Collate UI Coverage" is a coin flip
+  # between the real suite and a no-op; the filename is unambiguous.
+  #
+  # Two ordering rules for the budgets, both learned the hard way:
+  #   timeout_minutes > wait_seconds — the step timeout kills the action outright,
+  #     so when it is the smaller of the two the action can never reach its own
+  #     wait budget and reports a bare "has timed out" with no conclusion.
+  #   wait_seconds > the Collate job's own `timeout-minutes` — waiting past that
+  #     point is what guarantees we report the run's real conclusion instead of
+  #     giving up first. A budget that sits inside the Collate cap expires
+  #     mid-build and fails this check while the run it watches goes on to pass.
+  collate-ci:
+    needs: gate
+    name: ${{ matrix.suite }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Build + AI Platform + Collate unit tests + MySQL/Elasticsearch ITs.
+          # 58-68 min typical, Collate cap 120.
+          - suite: Collate build & integration tests
+            file: openmetadata-dispatch.yml
+            wait_seconds: 7500
+            timeout_minutes: 130
+          # Playwright: 3 shards plus the local-webserver suite, itself parallel.
+          # ~70 min typical, Collate cap 120 per job.
+          - suite: Collate Playwright (Postgres)
+            file: e2e-postgres.yml
+            main_only: true
+            wait_seconds: 8100
+            timeout_minutes: 140
+          # Collate's Jest suite — the only leg that fails on an OpenMetadata UI
+          # change that breaks a Collate unit test. ~50 min, Collate cap 90.
+          - suite: Collate UI unit tests
+            file: collate-ui-coverage.yml
+            main_only: true
+            wait_seconds: 5700
+            timeout_minutes: 100
+    steps:
+      # Collate's release branches still carry a bare `workflow_dispatch:` for the
+      # suites added here, and the dispatch API rejects the whole call with 422
+      # "Unexpected inputs provided" when the target branch does not declare an
+      # input. Without this guard every release-branch PR gets two red legs for a
+      # reason that has nothing to do with the PR. Drop `main_only` from a leg once
+      # the Collate change is backported to the live release branches.
+      - name: Skip — suite not wired on this release branch
+        if: ${{ matrix.main_only && (github.event.pull_request.base.ref || github.ref_name) != 'main' }}
+        run: |
+          echo "::notice::${{ matrix.suite }} runs for main PRs only — the Collate branch this PR targets does not accept the OpenMetadata sha input yet."
+
+      - name: Dispatch ${{ matrix.file }} & wait
+        if: ${{ !matrix.main_only || (github.event.pull_request.base.ref || github.ref_name) == 'main' }}
         uses: benc-uk/workflow-dispatch@v1.3.2
-        # Must stay above wait-timeout-seconds below. The step timeout kills the action
-        # outright, so when it is the smaller of the two the action can never reach its own
-        # wait budget and reports a bare "has timed out" with no downstream conclusion.
-        timeout-minutes: 100
+        timeout-minutes: ${{ matrix.timeout_minutes }}
         env:
           SHA: ${{ github.event_name == 'push' && github.event.after || github.event.pull_request.head.sha || github.sha }}
         with:
-          workflow: OpenMetadata Collate Test
+          workflow: ${{ matrix.file }}
           # Collate mirrors each OpenMetadata release line on an identically
           # named branch, so build the Collate branch matching the PR base.
           # Dispatching main for a 1.13 PR builds main-only Collate code
@@ -100,11 +162,6 @@ jobs:
           token: ${{ secrets.COLLATE_PAT }}
           wait-for-completion: true
           sync-status: true
-          # The Collate job caps itself at timeout-minutes: 90, so waiting past that point is
-          # what guarantees we report its real conclusion instead of giving up first. Successful
-          # main builds run 58-68 min, which the previous 61-min budget sat inside: the wait
-          # expired mid-build and failed this check on nearly every PR while the Collate run it
-          # was watching went on to pass.
-          wait-timeout-seconds: 5700
+          wait-timeout-seconds: ${{ matrix.wait_seconds }}
           wait-interval-seconds: 60
           inputs: '{ "sha": "${{ env.SHA }}", "event": "${{ github.event_name }}" }'


### PR DESCRIPTION
## Why

`maven-build-collate.yml` runs on every PR here, but all it ever got back was the Collate build plus one MySQL/Elasticsearch integration run. Collate's Playwright suite and its Jest suite both compile the mirrored `openmetadata-ui` tree, and neither ever saw the change — so a UI or API break in a PR here surfaced only after merge, on somebody's Collate PR.

Companion: open-metadata/openmetadata-collate#6466. **That one has to merge first** — it adds the `sha` input each leg sends, and the dispatch API rejects the whole call with 422 *Unexpected inputs provided* against a branch that does not declare it.

## What

Single dispatch → a `gate` job plus a 3-leg `collate-ci` matrix, `fail-fast: false`, all legs dispatched in parallel and each reported as its own check:

| Leg | Collate workflow | Covers |
|---|---|---|
| Collate build & integration tests | `openmetadata-dispatch.yml` | build, AI Platform, Collate unit tests (new there), MySQL/ES ITs |
| Collate Playwright (Postgres) | `e2e-postgres.yml` | 3 shards + the local-webserver suite, themselves parallel |
| Collate UI unit tests | `collate-ui-coverage.yml` | Jest against the mirrored OSS UI |

Collate pins its `OpenMetadata` submodule to the dispatched sha, so every leg tests this PR's code rather than the submodule tip.

Also:

- **Dispatch by filename, not display name.** Collate keeps a `paths-ignore` "skip" twin for some of these carrying the *same* `name:`, and the action takes the first match of (name | id | filename) — so `Collate UI Coverage` is a coin flip between the real suite and a no-op.
- **Widen the `pull_request_target` paths** to `ui/playwright/**`, `ui/package.json` and `ui/yarn.lock`. `collate-ui` mirrors the first and builds against the others; none of them mattered while only the backend built, so a dependency bump or a shared-fixture change skipped this check entirely.
- **Gate the two new legs to `main`.** Collate's release branches still carry a bare `workflow_dispatch:` for these files, so a release-branch PR would get two red legs for a reason that has nothing to do with the PR. Drop `main_only` from a leg once the Collate change is backported.
- **Drop the dead `actions/checkout`.** Nothing read the working tree — and it was checking out untrusted PR code with `allow-unsafe-pr-checkout: true` inside a `pull_request_target`.
- The label wait moves into `gate` so an unlabelled fork PR gets one red check instead of three.

## Budgets

Two ordering rules, both documented inline: `timeout_minutes > wait_seconds` (the step timeout kills the action outright), and `wait_seconds >` the Collate job's own `timeout-minutes` (waiting past that point is what reports the run's real conclusion instead of giving up first). The companion PR adds the Collate-side caps these budgets sit above.

## Testing

`actionlint` clean. Cross-checked programmatically that every input sent here is declared on all three Collate targets and that each leg's budget clears the corresponding Collate job cap. Confirmed `maven-collate-ci` is not a required check in either the `merge-rules` or `2.0.x-protection` ruleset, so renaming the job breaks nothing.

## Not included

AskCollate e2e (burns AI credits — a cost call), Collate's postgres-opensearch ITs, and `-P hybrid-it`. Each is one matrix entry plus the same input plumbing. `e2e-mysql.yml` is `disabled_manually` on the Collate side, so it is excluded deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)