### PR TITLE
Backport 2.0: MCP and search fixes (#32226, #32552, #32460, #32553, #32342)

### DIFF
--- a/ingestion/src/metadata/ingestion/source/mcp/client.py
+++ b/ingestion/src/metadata/ingestion/source/mcp/client.py
@@ -12,14 +12,13 @@
 MCP (Model Context Protocol) Client
 
 This module provides a client for communicating with MCP servers using
-the JSON-RPC 2.0 protocol over various transports (Stdio, SSE, HTTP).
+the JSON-RPC 2.0 protocol over HTTP transports (SSE, Streamable HTTP).
+
+The Stdio transport (spawning a local subprocess) is not supported; MCP servers
+are reached over HTTP by URL instead.
 """
 
 import json
-import os
-import shutil
-import subprocess
-import threading
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -32,13 +31,20 @@ from metadata.utils.logger import ingestion_logger
 logger = ingestion_logger()
 
 # MCP Protocol Version
-MCP_PROTOCOL_VERSION = "2024-11-05"
+MCP_PROTOCOL_VERSION = "2025-03-26"
 
 # Client info sent during initialization
 CLIENT_INFO = {
     "name": "openmetadata-ingestion",
     "version": "1.0.0",
 }
+
+# Guidance surfaced when a server is configured with the unsupported Stdio transport.
+STDIO_TRANSPORT_REMOVED_MSG = (
+    "Stdio transport is no longer supported. "
+    "Run the MCP server over HTTP (StreamableHTTP or SSE) and set its 'url'. "
+    "To wrap a stdio server, use a stdio-to-HTTP proxy such as mcp-proxy."
+)
 
 
 @dataclass
@@ -66,194 +72,6 @@ class McpProtocolError(Exception):
 _CLIENT_NOT_INITIALIZED = "Client not initialized"
 
 
-class StdioTransport:
-    """Transport for communicating with MCP server via stdin/stdout"""
-
-    def __init__(
-        self,
-        command: str,
-        args: Optional[List[str]] = None,  # noqa: UP006, UP045
-        env: Optional[Dict[str, str]] = None,  # noqa: UP006, UP045
-        timeout: int = 30,
-    ):
-        self.command = command
-        self.args = args or []
-        self.env = env
-        self.timeout = timeout
-        self.process: Optional[subprocess.Popen] = None  # noqa: UP045
-        self._message_id = 0
-        self._lock = threading.Lock()
-        self._responses: Dict[int, Dict] = {}  # noqa: UP006
-        self._response_events: Dict[int, threading.Event] = {}  # noqa: UP006
-        self._reader_thread: Optional[threading.Thread] = None  # noqa: UP045
-        self._stderr_thread: Optional[threading.Thread] = None  # noqa: UP045
-        self._running = False
-
-    def _get_next_id(self) -> int:
-        with self._lock:
-            self._message_id += 1
-            return self._message_id
-
-    _SENSITIVE_ENV_VARS = {  # noqa: RUF012
-        "PATH",
-        "LD_PRELOAD",
-        "LD_LIBRARY_PATH",
-        "DYLD_INSERT_LIBRARIES",
-    }
-
-    @staticmethod
-    def _validate_command(command: str) -> str:
-        """Validate and resolve the MCP server command to an absolute path."""
-        resolved = shutil.which(command)
-        if resolved is None:
-            raise McpProtocolError(
-                f"Command not found: {command}. Ensure the MCP server command is installed and in PATH."
-            )
-        return resolved
-
-    def connect(self) -> None:
-        """Start the MCP server subprocess"""
-        resolved_command = self._validate_command(self.command)
-        full_env = os.environ.copy()
-        if self.env:
-            overridden = self._SENSITIVE_ENV_VARS & self.env.keys()
-            if overridden:
-                logger.warning(f"MCP server '{self.command}' overrides sensitive env vars: {overridden}")
-            full_env.update(self.env)
-
-        try:
-            self.process = subprocess.Popen(  # noqa: RUF100, S603
-                [resolved_command] + self.args,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                env=full_env,
-                text=True,
-                bufsize=1,
-            )
-            self._running = True
-            self._reader_thread = threading.Thread(target=self._read_responses)
-            self._reader_thread.daemon = True
-            self._reader_thread.start()
-            self._stderr_thread = threading.Thread(target=self._drain_stderr)
-            self._stderr_thread.daemon = True
-            self._stderr_thread.start()
-        except Exception as e:
-            raise McpProtocolError(f"Failed to start MCP server: {e}")  # noqa: B904
-
-    def _handle_response_line(self, line: str) -> None:
-        """Parse a single JSON-RPC response line and dispatch it."""
-        try:
-            response = json.loads(line)
-        except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse MCP response: {e}")
-            return
-        msg_id = response.get("id")
-        if msg_id is None:
-            return
-        with self._lock:
-            self._responses[msg_id] = response
-            if msg_id in self._response_events:
-                self._response_events[msg_id].set()
-
-    def _read_responses(self) -> None:
-        """Background thread to read responses from the server"""
-        while self._running and self.process and self.process.stdout:
-            try:
-                line = self.process.stdout.readline()
-                if not line:
-                    break
-                line = line.strip()
-                if line:
-                    self._handle_response_line(line)
-            except Exception as e:
-                if self._running:
-                    logger.error(f"Error reading from MCP server: {e}")
-                break
-
-    def _drain_stderr(self) -> None:
-        """Background thread to drain stderr and prevent buffer deadlock"""
-        while self._running and self.process and self.process.stderr:
-            try:
-                line = self.process.stderr.readline()
-                if not line:
-                    break
-                logger.debug(f"MCP server stderr: {line.strip()}")
-            except Exception:
-                break
-
-    def send_notification(self, method: str, params: Optional[Dict] = None) -> None:  # noqa: UP006, UP045
-        """Send a JSON-RPC notification (no id, no response expected)"""
-        if not self.process or not self.process.stdin:
-            raise McpProtocolError("Transport not connected")
-        notification = {"jsonrpc": "2.0", "method": method}
-        if params:
-            notification["params"] = params
-        try:
-            self.process.stdin.write(json.dumps(notification) + "\n")
-            self.process.stdin.flush()
-        except Exception as e:
-            raise McpProtocolError(f"Failed to send notification: {e}")  # noqa: B904
-
-    def send_request(self, method: str, params: Optional[Dict] = None) -> Dict[str, Any]:  # noqa: UP006, UP045
-        """Send a JSON-RPC request and wait for response"""
-        if not self.process or not self.process.stdin:
-            raise McpProtocolError("Transport not connected")
-
-        msg_id = self._get_next_id()
-        event = threading.Event()
-        with self._lock:
-            self._response_events[msg_id] = event
-
-        request = {
-            "jsonrpc": "2.0",
-            "id": msg_id,
-            "method": method,
-        }
-        if params:
-            request["params"] = params
-
-        try:
-            self.process.stdin.write(json.dumps(request) + "\n")
-            self.process.stdin.flush()
-        except Exception as e:
-            with self._lock:
-                self._response_events.pop(msg_id, None)
-            raise McpProtocolError(f"Failed to send request: {e}")  # noqa: B904
-
-        if event.wait(timeout=self.timeout):
-            with self._lock:
-                self._response_events.pop(msg_id, None)
-                response = self._responses.pop(msg_id, {})
-            if "error" in response:
-                raise McpProtocolError(f"MCP error: {response['error'].get('message', 'Unknown error')}")
-            return response.get("result", {})
-
-        with self._lock:
-            self._response_events.pop(msg_id, None)
-            self._responses.pop(msg_id, None)
-        raise McpProtocolError(f"Timeout waiting for response to {method}")
-
-    def close(self) -> None:
-        """Close the transport and terminate the subprocess"""
-        self._running = False
-        if self.process:
-            try:
-                if self.process.stdin:
-                    self.process.stdin.close()
-                try:
-                    self.process.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    self.process.kill()
-                    self.process.wait()
-            except Exception:
-                pass
-        if self._reader_thread and self._reader_thread.is_alive():
-            self._reader_thread.join(timeout=2)
-        if self._stderr_thread and self._stderr_thread.is_alive():
-            self._stderr_thread.join(timeout=2)
-
-
 class HttpTransport:
     """Transport for communicating with MCP server via HTTP (SSE or Streamable HTTP)"""
 
@@ -267,13 +85,57 @@ class HttpTransport:
         self.api_key = api_key
         self.timeout = timeout
         self.session = requests.Session()
-        self._session_id: Optional[str] = None  # noqa: UP045
+        self._session_id: str | None = None
+        self._protocol_version: str | None = None
 
     def connect(self) -> None:
         """Initialize HTTP session"""
         if self.api_key:
             self.session.headers["Authorization"] = f"Bearer {self.api_key}"
         self.session.headers["Content-Type"] = "application/json"
+        # StreamableHTTP servers may reply with either JSON or an SSE stream.
+        self.session.headers["Accept"] = "application/json, text/event-stream"
+
+    def _post(self, payload: dict[str, Any]) -> requests.Response:
+        """POST a JSON-RPC payload, carrying the MCP session id once the server assigns one."""
+        headers = {}
+        if self._session_id:
+            headers["Mcp-Session-Id"] = self._session_id
+        if self._protocol_version:
+            headers["MCP-Protocol-Version"] = self._protocol_version
+        response = self.session.post(
+            self.url,
+            json=payload,  # pyright: ignore[reportArgumentType]
+            headers=headers,
+            timeout=self.timeout,
+        )
+        session_id = response.headers.get("Mcp-Session-Id")
+        if session_id:
+            self._session_id = session_id
+        return response
+
+    @staticmethod
+    def _parse_jsonrpc(response: requests.Response) -> dict[str, Any]:
+        """Parse a JSON-RPC response that is plain JSON or an SSE stream.
+
+        An SSE stream may carry notifications before the response, and a single
+        event's payload can span multiple ``data:`` lines, so events are
+        reassembled and the first actual JSON-RPC response (carrying ``result``
+        or ``error``) is returned.
+        """
+        content_type = response.headers.get("Content-Type", "")
+        if "text/event-stream" not in content_type:
+            return response.json()
+
+        events = response.text.replace("\r\n", "\n").replace("\r", "\n").split("\n\n")
+        for event in events:
+            data = "\n".join(line[5:].lstrip() for line in event.splitlines() if line.startswith("data:"))
+            if not data:
+                continue
+            message = json.loads(data)
+            if "result" in message or "error" in message:
+                return message
+        raise McpProtocolError("No data in MCP event-stream response")
 
     def send_notification(self, method: str, params: Optional[Dict] = None) -> None:  # noqa: UP006, UP045
         """Send a JSON-RPC notification via HTTP POST (no response expected)"""
@@ -281,11 +143,7 @@ class HttpTransport:
         if params:
             notification["params"] = params
         try:
-            self.session.post(
-                f"{self.url}/mcp",
-                json=notification,  # pyright: ignore[reportArgumentType]
-                timeout=self.timeout,
-            )
+            self._post(notification)
         except Exception as e:
             logger.error(f"Failed to send notification '{method}': {e}")
 
@@ -300,19 +158,15 @@ class HttpTransport:
             request["params"] = params
 
         try:
-            response = self.session.post(
-                f"{self.url}/mcp",
-                json=request,  # pyright: ignore[reportArgumentType]
-                timeout=self.timeout,
-            )
+            response = self._post(request)
             response.raise_for_status()
-            result = response.json()
-
-            if "error" in result:
-                raise McpProtocolError(f"MCP error: {result['error'].get('message', 'Unknown error')}")
-            return result.get("result", {})
+            result = self._parse_jsonrpc(response)
         except (requests.RequestException, ValueError) as e:
             raise McpProtocolError(f"HTTP request failed: {e}")  # noqa: B904
+
+        if "error" in result:
+            raise McpProtocolError(f"MCP error: {result['error'].get('message', 'Unknown error')}")
+        return result.get("result", {})
 
     def close(self) -> None:
         """Close the HTTP session"""
@@ -321,12 +175,13 @@ class HttpTransport:
 
 class McpClient:
     """
-    Client for communicating with MCP servers.
+    Client for communicating with MCP servers over HTTP.
 
-    Supports multiple transport types:
-    - Stdio: Spawns a subprocess and communicates via stdin/stdout
+    Supported transport types:
     - SSE: Uses Server-Sent Events over HTTP
     - StreamableHTTP: Uses HTTP POST for requests
+
+    Stdio transport is not supported (see STDIO_TRANSPORT_REMOVED_MSG).
     """
 
     def __init__(
@@ -338,23 +193,14 @@ class McpClient:
         self.server_config = server_config
         self.connection_timeout = connection_timeout
         self.initialization_timeout = initialization_timeout
-        self._transport: Optional[StdioTransport | HttpTransport] = None  # noqa: UP045
+        self._transport: HttpTransport | None = None
         self._initialized = False
 
     def connect(self) -> None:
         """Connect to the MCP server"""
         transport_type = self.server_config.transport.lower()
 
-        if transport_type == "stdio":
-            if not self.server_config.command:
-                raise McpProtocolError("Command required for Stdio transport")
-            self._transport = StdioTransport(
-                command=self.server_config.command,
-                args=self.server_config.args,
-                env=self.server_config.env,
-                timeout=self.connection_timeout,
-            )
-        elif transport_type in ("sse", "streamablehttp"):
+        if transport_type in ("sse", "streamablehttp"):
             if not self.server_config.url:
                 raise McpProtocolError(f"URL required for {transport_type} transport")
             self._transport = HttpTransport(
@@ -362,6 +208,8 @@ class McpClient:
                 api_key=self.server_config.api_key,
                 timeout=self.connection_timeout,
             )
+        elif transport_type == "stdio":
+            raise McpProtocolError(STDIO_TRANSPORT_REMOVED_MSG)
         else:
             raise McpProtocolError(f"Unsupported transport type: {transport_type}")
 
@@ -388,6 +236,7 @@ class McpClient:
 
         self.server_config.server_info = result.get("serverInfo", {})
         self.server_config.capabilities = result.get("capabilities", {})
+        self._transport._protocol_version = result.get("protocolVersion", MCP_PROTOCOL_VERSION)
 
         self._transport.send_notification("notifications/initialized", {})
         self._initialized = True
@@ -476,12 +325,14 @@ def parse_claude_desktop_config(config_path: str, config: Optional[Dict] = None)
     mcp_servers = config.get("mcpServers", {})
 
     for name, server_config in mcp_servers.items():
+        transport = _get_transport(server_config)
         server_info = McpServerInfo(
             name=name,
-            transport="Stdio",
+            transport=transport,
             command=server_config.get("command"),
             args=server_config.get("args", []),
             env=server_config.get("env", {}),
+            url=server_config.get("url"),
         )
         servers.append(server_info)
         logger.debug(f"Found MCP server '{name}' in config")
@@ -523,7 +374,7 @@ def parse_vscode_config(config_path: str, config: Optional[Dict] = None) -> List
     for name, server_config in mcp_servers.items():
         server_info = McpServerInfo(
             name=name,
-            transport=server_config.get("transport", "Stdio"),
+            transport=_get_transport(server_config),
             command=server_config.get("command"),
             args=server_config.get("args", []),
             env=server_config.get("env", {}),
@@ -533,6 +384,13 @@ def parse_vscode_config(config_path: str, config: Optional[Dict] = None) -> List
         logger.debug(f"Found MCP server '{name}' in VS Code config")
 
     return servers
+
+
+def _get_transport(server_config: dict[str, Any]) -> str:
+    """Map client configuration transport names to OpenMetadata's schema values."""
+    transport = server_config.get("transport") or server_config.get("type") or "Stdio"
+    normalized = transport.lower()
+    return {"http": "StreamableHTTP", "sse": "SSE", "streamablehttp": "StreamableHTTP"}.get(normalized, transport)
 
 
 def discover_servers_from_config_files(

--- a/ingestion/src/metadata/ingestion/source/mcp/connection.py
+++ b/ingestion/src/metadata/ingestion/source/mcp/connection.py
@@ -172,19 +172,30 @@ def _test_discover_servers(manager: McpConnectionManager) -> None:
 
 
 def _test_connect_to_servers(manager: McpConnectionManager) -> None:
-    """Test step: Connect to at least one MCP server"""
-    servers = manager.discover_servers()
-    connected = False
+    """Test step: Connect to at least one connectable MCP server.
 
-    for server in servers[:3]:
+    Stdio servers are cataloging-only: the transport is not supported, so they are
+    no longer connection targets. If every
+    discovered server is Stdio there is nothing to connect to and the step passes
+    - the servers are still cataloged by the ingestion step.
+    """
+    servers = manager.discover_servers()
+    connectable = [server for server in servers if server.transport.lower() != "stdio"]
+
+    if not connectable:
+        logger.warning(
+            "Only Stdio MCP servers were discovered. Stdio transport is no longer supported; "
+            "these servers will be cataloged but not connected. Use an HTTP (SSE / StreamableHTTP) URL to connect."
+        )
+        return
+
+    for server in connectable[:3]:
         if manager.test_server_connection(server):
             logger.info(f"Successfully connected to MCP server '{server.name}'")
-            connected = True
-            break
+            return
         logger.warning(f"Could not connect to MCP server '{server.name}'")
 
-    if not connected:
-        raise SourceConnectionException("Could not connect to any discovered MCP servers")
+    raise SourceConnectionException("Could not connect to any discovered MCP servers")
 
 
 def test_connection(

--- a/ingestion/tests/integration/mcp/test_mcp_integration.py
+++ b/ingestion/tests/integration/mcp/test_mcp_integration.py
@@ -42,6 +42,7 @@ from metadata.generated.schema.entity.services.mcpService import (
     McpServiceType,
 )
 from metadata.generated.schema.type.basic import EntityName
+from metadata.ingestion.source.mcp.client import McpProtocolError
 from metadata.ingestion.source.mcp.connection import McpConnectionManager
 
 
@@ -225,6 +226,39 @@ class TestMcpConnectionManagerIntegration:
         assert "filesystem" in server_names
         assert "memory" in server_names
 
+    def test_stdio_direct_connection_rejected(self):
+        """Stdio servers are still discovered/cataloged but never connected.
+
+        Stdio (local subprocess) transport is not supported; the connector does
+        not start a local process for a discovered server.
+        """
+        connection = McpConnection(
+            type=McpType.Mcp,
+            discoveryMethod=DiscoveryMethod.DirectConnection,
+            servers=[
+                McpServerConfig(
+                    name="local-stdio",
+                    transport=TransportType.Stdio,
+                    command="npx",
+                    args=["-y", "@modelcontextprotocol/server-memory"],
+                ),
+            ],
+        )
+        manager = McpConnectionManager(connection)
+
+        # Discovery still yields the record (governance cataloging is retained).
+        servers = manager.discover_servers()
+        assert len(servers) == 1
+        assert servers[0].transport == "Stdio"
+
+        # Connecting is refused with an actionable migration message.
+        with pytest.raises(McpProtocolError) as exc_info:
+            manager.connect_to_server(servers[0])
+        assert "no longer supported" in str(exc_info.value)
+
+        # The graceful test path reports the failure rather than executing.
+        assert manager.test_server_connection(servers[0]) is False
+
 
 class TestMcpIngestionWorkflow:
     """Tests for MCP ingestion workflow execution"""
@@ -287,13 +321,16 @@ class TestMcpIngestionWorkflow:
         assert created_service.name.root == self.service_name
 
 
-@pytest.mark.skip(reason="Requires running MCP server")
+@pytest.mark.skip(reason="Requires running HTTP MCP server")
 class TestMcpE2EWithRealServer:
     """
     End-to-end tests with a real MCP server.
 
-    To run these tests:
-    1. Start an MCP server (e.g., npx -y @modelcontextprotocol/server-memory)
+    Stdio transport is not supported, so MCP servers are reached over HTTP by
+    URL. The client POSTs JSON-RPC to ``<url>/mcp``. To run these tests:
+    1. Expose an MCP server over StreamableHTTP at an HTTP URL. A stdio-only
+       server can be fronted with a stdio-to-HTTP proxy (e.g. mcp-proxy) that
+       serves the StreamableHTTP endpoint; set ``url`` to that base URL.
     2. Run with: pytest -v tests/integration/mcp/test_mcp_integration.py::TestMcpE2EWithRealServer
     """
 
@@ -322,10 +359,12 @@ class TestMcpE2EWithRealServer:
 
     def test_e2e_with_memory_server(self):
         """
-        Test full E2E flow with the MCP memory server.
+        Test full E2E flow with an HTTP-exposed MCP memory server.
 
-        Requires: npx -y @modelcontextprotocol/server-memory
+        Requires an HTTP MCP endpoint, e.g.:
+          mcp-proxy --sse-port 8096 -- npx -y @modelcontextprotocol/server-memory
         """
+        server_url = "http://localhost:8096"
         service_request = CreateMcpServiceRequest(
             name=EntityName(self.service_name),
             serviceType=McpServiceType.Mcp,
@@ -336,9 +375,8 @@ class TestMcpE2EWithRealServer:
                     servers=[
                         McpServerConfig(
                             name="memory-server",
-                            transport=TransportType.Stdio,
-                            command="npx",
-                            args=["-y", "@modelcontextprotocol/server-memory"],
+                            transport=TransportType.StreamableHTTP,
+                            url=server_url,
                         ),
                     ],
                     fetchTools=True,
@@ -357,9 +395,8 @@ class TestMcpE2EWithRealServer:
             servers=[
                 McpServerConfig(
                     name="memory-server",
-                    transport=TransportType.Stdio,
-                    command="npx",
-                    args=["-y", "@modelcontextprotocol/server-memory"],
+                    transport=TransportType.StreamableHTTP,
+                    url=server_url,
                 ),
             ],
         )

--- a/ingestion/tests/unit/source/mcp/test_mcp_client.py
+++ b/ingestion/tests/unit/source/mcp/test_mcp_client.py
@@ -14,16 +14,16 @@ Unit tests for MCP client module
 
 import json
 import tempfile
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
 from metadata.ingestion.source.mcp.client import (
+    STDIO_TRANSPORT_REMOVED_MSG,
     HttpTransport,
     McpClient,
     McpProtocolError,
     McpServerInfo,
-    StdioTransport,
     discover_servers_from_config_files,
     parse_claude_desktop_config,
     parse_vscode_config,
@@ -65,41 +65,36 @@ class TestMcpServerInfo:
         assert server.api_key == "test-api-key-00000"  # NOSONAR
 
 
-class TestStdioTransport:
-    """Tests for StdioTransport class"""
+class TestStdioTransportRemoved:
+    """Stdio transport is not supported; connecting to a stdio server is rejected."""
 
-    def test_initialization(self):
-        transport = StdioTransport(
-            command="python",
-            args=["-m", "mcp_server"],
-            env={"DEBUG": "true"},
-            timeout=60,
+    def test_stdio_connect_rejected(self):
+        """A stdio server must fail to connect with a clear migration message."""
+        server = McpServerInfo(
+            name="local-stdio",
+            transport="Stdio",
+            command="npx",
+            args=["-y", "@modelcontextprotocol/server-memory"],
         )
-        assert transport.command == "python"
-        assert transport.args == ["-m", "mcp_server"]
-        assert transport.env == {"DEBUG": "true"}
-        assert transport.timeout == 60
-
-    def test_get_next_id_increments(self):
-        transport = StdioTransport(command="echo")
-        id1 = transport._get_next_id()
-        id2 = transport._get_next_id()
-        id3 = transport._get_next_id()
-        assert id1 == 1
-        assert id2 == 2
-        assert id3 == 3
-
-    def test_connect_command_not_found(self):
-        transport = StdioTransport(command="nonexistent_command_12345")
+        client = McpClient(server_config=server)
         with pytest.raises(McpProtocolError) as exc_info:
-            transport.connect()
-        assert "Command not found" in str(exc_info.value)
+            client.connect()
+        message = str(exc_info.value)
+        assert message == STDIO_TRANSPORT_REMOVED_MSG
+        assert "no longer supported" in message
+        assert "mcp-proxy" in message
 
-    def test_send_request_not_connected(self):
-        transport = StdioTransport(command="echo")
+    def test_stdio_transport_class_gone(self):
+        """StdioTransport must no longer be importable."""
+        import metadata.ingestion.source.mcp.client as client_module
+
+        assert not hasattr(client_module, "StdioTransport")
+
+    def test_unsupported_transport_rejected(self):
+        client = McpClient(server_config=McpServerInfo(name="s", transport="carrier"))
         with pytest.raises(McpProtocolError) as exc_info:
-            transport.send_request("test/method")
-        assert "not connected" in str(exc_info.value).lower()
+            client.connect()
+        assert "Unsupported transport" in str(exc_info.value)
 
 
 class TestHttpTransport:
@@ -128,10 +123,13 @@ class TestHttpTransport:
         assert "Authorization" in transport.session.headers
         assert transport.session.headers["Authorization"] == "Bearer test-api-key-00000"
         assert transport.session.headers["Content-Type"] == "application/json"
+        # StreamableHTTP servers may reply with JSON or an SSE stream.
+        assert "text/event-stream" in transport.session.headers["Accept"]
 
     @patch("requests.Session.post")
     def test_send_request_success(self, mock_post):
         mock_response = MagicMock()
+        mock_response.headers = {"Content-Type": "application/json"}
         mock_response.json.return_value = {
             "jsonrpc": "2.0",
             "id": "123",
@@ -145,11 +143,17 @@ class TestHttpTransport:
         result = transport.send_request("tools/list")
 
         assert result == {"tools": []}
-        mock_post.assert_called_once()
+        mock_post.assert_called_once_with(
+            "http://localhost:8080",
+            json=ANY,
+            headers={},
+            timeout=30,
+        )
 
     @patch("requests.Session.post")
     def test_send_request_error_response(self, mock_post):
         mock_response = MagicMock()
+        mock_response.headers = {"Content-Type": "application/json"}
         mock_response.json.return_value = {
             "jsonrpc": "2.0",
             "id": "123",
@@ -164,6 +168,94 @@ class TestHttpTransport:
         with pytest.raises(McpProtocolError) as exc_info:
             transport.send_request("invalid/method")
         assert "Invalid Request" in str(exc_info.value)
+
+    @patch("requests.Session.post")
+    def test_send_request_parses_event_stream(self, mock_post):
+        """A StreamableHTTP server may reply with an SSE-framed JSON-RPC message."""
+        mock_response = MagicMock()
+        mock_response.headers = {"Content-Type": "text/event-stream"}
+        mock_response.text = 'event: message\ndata: {"jsonrpc": "2.0", "id": "1", "result": {"ok": true}}\n\n'
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        transport = HttpTransport(url="http://localhost:8080")
+        transport.connect()
+        result = transport.send_request("initialize")
+
+        assert result == {"ok": True}
+
+    @patch("requests.Session.post")
+    def test_event_stream_skips_leading_notification(self, mock_post):
+        """An SSE stream may emit notifications before the response; skip them."""
+        mock_response = MagicMock()
+        mock_response.headers = {"Content-Type": "text/event-stream"}
+        mock_response.text = (
+            'data: {"jsonrpc": "2.0", "method": "notifications/progress"}\n\n'
+            'data: {"jsonrpc": "2.0", "id": "1", "result": {"ok": true}}\n\n'
+        )
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        transport = HttpTransport(url="http://localhost:8080")
+        transport.connect()
+        result = transport.send_request("initialize")
+
+        assert result == {"ok": True}
+
+    @patch("requests.Session.post")
+    def test_event_stream_parses_crlf_multiline_data(self, mock_post):
+        """SSE data fields use CRLF framing and preserve newlines between fields."""
+        mock_response = MagicMock()
+        mock_response.headers = {"Content-Type": "text/event-stream"}
+        mock_response.text = 'data: {"jsonrpc": "2.0",\r\ndata: "id": "1",\r\ndata: "result": {"ok": true}}\r\n\r\n'
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        transport = HttpTransport(url="http://localhost:8080/mcp")
+        transport.connect()
+
+        assert transport.send_request("initialize") == {"ok": True}
+        assert mock_post.call_args.args[0] == "http://localhost:8080/mcp"
+
+    @patch("requests.Session.post")
+    def test_session_id_captured_and_resent(self, mock_post):
+        """The Mcp-Session-Id from the first response is echoed on later requests."""
+        first = MagicMock()
+        first.headers = {"Content-Type": "application/json", "Mcp-Session-Id": "sess-123"}
+        first.json.return_value = {"result": {}}
+        first.raise_for_status = MagicMock()
+        second = MagicMock()
+        second.headers = {"Content-Type": "application/json"}
+        second.json.return_value = {"result": {}}
+        second.raise_for_status = MagicMock()
+        mock_post.side_effect = [first, second]
+
+        transport = HttpTransport(url="http://localhost:8080")
+        transport.connect()
+        transport.send_request("initialize")
+        assert transport._session_id == "sess-123"
+        transport._protocol_version = "2025-03-26"
+
+        transport.send_request("tools/list")
+        sent_headers = mock_post.call_args.kwargs.get("headers")
+        assert sent_headers is not None
+        assert sent_headers.get("Mcp-Session-Id") == "sess-123"
+        assert sent_headers.get("MCP-Protocol-Version") == "2025-03-26"
+
+    def test_client_sends_negotiated_protocol_version_after_initialization(self):
+        transport = MagicMock(spec=HttpTransport)
+        transport.send_request.return_value = {
+            "protocolVersion": "2025-03-26",
+            "serverInfo": {},
+            "capabilities": {},
+        }
+        client = McpClient(McpServerInfo(name="server", transport="StreamableHTTP", url="http://server/mcp"))
+        client._transport = transport
+
+        client.initialize()
+
+        assert transport._protocol_version == "2025-03-26"
+        transport.send_notification.assert_called_once_with("notifications/initialized", {})
 
     @patch("requests.Session.post")
     def test_send_notification_logs_on_failure(self, mock_post):
@@ -263,6 +355,15 @@ class TestParseClaudeDesktopConfig:
 
         assert servers == []
 
+    def test_parse_http_server(self):
+        servers = parse_claude_desktop_config(
+            "unused",
+            {"mcpServers": {"remote": {"type": "http", "url": "https://example.com/mcp"}}},
+        )
+
+        assert servers[0].transport == "StreamableHTTP"
+        assert servers[0].url == "https://example.com/mcp"
+
     def test_parse_nonexistent_file(self):
         servers = parse_claude_desktop_config("/nonexistent/path/config.json")
         assert servers == []
@@ -303,6 +404,15 @@ class TestParseVscodeConfig:
     def test_parse_nonexistent_file(self):
         servers = parse_vscode_config("/nonexistent/settings.json")
         assert servers == []
+
+    def test_parse_http_type(self):
+        servers = parse_vscode_config(
+            "unused",
+            {"mcp.servers": {"remote": {"type": "http", "url": "https://example.com/mcp"}}},
+        )
+
+        assert servers[0].transport == "StreamableHTTP"
+        assert servers[0].url == "https://example.com/mcp"
 
 
 class TestDiscoverServersFromConfigFiles:

--- a/ingestion/tests/unit/source/mcp/test_mcp_connection.py
+++ b/ingestion/tests/unit/source/mcp/test_mcp_connection.py
@@ -23,9 +23,11 @@ from metadata.generated.schema.entity.services.connections.mcp.mcpConnection imp
     McpType,
     TransportType,
 )
+from metadata.ingestion.connections.test_connections import SourceConnectionException
 from metadata.ingestion.source.mcp.client import McpProtocolError, McpServerInfo
 from metadata.ingestion.source.mcp.connection import (
     McpConnectionManager,
+    _test_connect_to_servers,
     get_connection,
 )
 
@@ -175,7 +177,8 @@ class TestMcpConnectionManager:
         mock_client_class.return_value = mock_client
 
         manager = McpConnectionManager(direct_connection)
-        server = McpServerInfo(name="test", command="echo")
+        # Only HTTP transports can connect; Stdio is not supported.
+        server = McpServerInfo(name="test", transport="StreamableHTTP", url="http://localhost:8080")
 
         result = manager.test_server_connection(server)
 
@@ -201,12 +204,69 @@ class TestMcpConnectionManager:
         mock_client_class.return_value = mock_client
 
         manager = McpConnectionManager(direct_connection)
-        server = McpServerInfo(name="test", command="echo")
+        # Only HTTP transports can connect; Stdio is not supported.
+        server = McpServerInfo(name="test", transport="StreamableHTTP", url="http://localhost:8080")
 
         result = manager.test_server_connection(server)
 
         assert result is True
         mock_client.close.assert_called_once()
+
+
+class TestConnectToServersStep:
+    """Tests for the ConnectToServers test-connection step.
+
+    Stdio servers are cataloging-only (the transport is not supported), so
+    an all-Stdio config must pass this mandatory step (and go on to be cataloged),
+    while an unreachable HTTP server must still fail it.
+    """
+
+    @staticmethod
+    def _direct(*servers: McpServerConfig) -> McpConnection:
+        return McpConnection(
+            type=McpType.Mcp,
+            discoveryMethod=DiscoveryMethod.DirectConnection,
+            servers=list(servers),
+        )
+
+    def test_all_stdio_passes_without_connecting(self):
+        """All-Stdio config: nothing to connect to, step passes, no McpClient built."""
+        connection = self._direct(
+            McpServerConfig(name="a", transport=TransportType.Stdio, command="npx", args=["x"]),
+            McpServerConfig(name="b", transport=TransportType.Stdio, command="uvx", args=["y"]),
+        )
+        manager = McpConnectionManager(connection)
+        manager.test_server_connection = MagicMock()
+
+        _test_connect_to_servers(manager)  # must not raise
+
+        manager.test_server_connection.assert_not_called()
+
+    def test_unreachable_http_still_fails(self):
+        """A non-Stdio (HTTP) server that cannot connect must fail the step."""
+        connection = self._direct(
+            McpServerConfig(name="http", transport=TransportType.StreamableHTTP, url="http://localhost:9"),
+        )
+        manager = McpConnectionManager(connection)
+        manager.test_server_connection = MagicMock(return_value=False)
+
+        with pytest.raises(SourceConnectionException):
+            _test_connect_to_servers(manager)
+
+    def test_mixed_passes_when_http_connects(self):
+        """Stdio servers are skipped; a reachable HTTP server satisfies the step."""
+        connection = self._direct(
+            McpServerConfig(name="stdio", transport=TransportType.Stdio, command="npx", args=["x"]),
+            McpServerConfig(name="http", transport=TransportType.SSE, url="http://localhost:8080"),
+        )
+        manager = McpConnectionManager(connection)
+        manager.test_server_connection = MagicMock(return_value=True)
+
+        _test_connect_to_servers(manager)  # must not raise
+
+        # Only the connectable (HTTP) server is tested, never the Stdio one.
+        tested = [call.args[0].name for call in manager.test_server_connection.call_args_list]
+        assert tested == ["http"]
 
 
 class TestGetConnection:

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DomainIsolationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DomainIsolationIT.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,15 +32,22 @@ import org.openmetadata.schema.api.data.CreateDatabaseSchema;
 import org.openmetadata.schema.api.data.CreateTable;
 import org.openmetadata.schema.api.domains.CreateDomain;
 import org.openmetadata.schema.api.lineage.AddLineage;
+import org.openmetadata.schema.api.policies.CreatePolicy;
 import org.openmetadata.schema.api.search.SearchSettings;
+import org.openmetadata.schema.api.teams.CreateRole;
 import org.openmetadata.schema.api.teams.CreateUser;
 import org.openmetadata.schema.api.tests.CreateTestCase;
 import org.openmetadata.schema.api.tests.CreateTestCaseResolutionStatus;
+import org.openmetadata.schema.auth.JWTAuthMechanism;
+import org.openmetadata.schema.auth.JWTTokenExpiry;
 import org.openmetadata.schema.entity.data.Database;
 import org.openmetadata.schema.entity.data.DatabaseSchema;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.entity.domains.Domain;
+import org.openmetadata.schema.entity.policies.Policy;
+import org.openmetadata.schema.entity.policies.accessControl.Rule;
 import org.openmetadata.schema.entity.services.DatabaseService;
+import org.openmetadata.schema.entity.teams.AuthenticationMechanism;
 import org.openmetadata.schema.entity.teams.Role;
 import org.openmetadata.schema.settings.Settings;
 import org.openmetadata.schema.settings.SettingsType;
@@ -49,6 +57,7 @@ import org.openmetadata.schema.tests.type.TestCaseResolutionStatusTypes;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.ColumnDataType;
 import org.openmetadata.schema.type.EntitiesEdge;
+import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.network.HttpMethod;
@@ -218,6 +227,140 @@ public class DomainIsolationIT {
                     searchNames.contains(d2Fqn),
                     "Foreign domain hidden in search. Saw: " + searchNames);
               });
+    } finally {
+      drain(cleanup);
+    }
+  }
+
+  @Test
+  void test_assetSearch_botIsNarrowedByItsOwnPolicy(TestNamespace ns) throws Exception {
+    // #30023: SearchUtils#shouldApplyRbacConditions skipped policy injection whenever the caller
+    // was a bot, and a skipped injection leaves the query matching everything rather than failing
+    // closed. Bot-authenticated tokens are the standard MCP wiring, so search_metadata ignored the
+    // caller's policies entirely.
+    //
+    // Neither bot here has any domain. That is deliberate: asset and domain search are both
+    // narrowed by a separate, domain-field-driven mechanism that applies even to a caller whose
+    // RBAC allow side compiles to match_all, so any domain-based assertion would pass with or
+    // without this fix.
+    //
+    // The narrowing is a DENY rather than a resource-scoped allow because OpenMetadata attaches
+    // DefaultBotRole to every bot user, and its DataConsumerPolicy grants an unconditioned ViewAll
+    // on All resources. Allow rules are OR'd, so every bot's allow side is match_all and an extra
+    // allow rule can never narrow one. Denies are AND'd as mustNot regardless of the allow side,
+    // which is also why the seeded, deny-based DomainOnlyAccessRole works where a hand-written
+    // allow-only domain role would not.
+    OpenMetadataClient admin = SdkClients.adminClient();
+    Deque<Runnable> cleanup = new ArrayDeque<>();
+    try {
+      String p = ns.shortPrefix();
+      DatabaseSchema schema = createSchema(ns, cleanup);
+      Table table = createTable(admin, p + "_scoped_asset", schema, null, cleanup);
+      String tableFqn = table.getFullyQualifiedName();
+
+      Role tableDenyRole = createResourceDenyRole(admin, p, "table", cleanup);
+      OpenMetadataClient scopedBot =
+          createBotClient(admin, p + "_tabdeny", null, List.of(tableDenyRole.getId()), cleanup);
+      OpenMetadataClient unscopedBot =
+          createBotClient(admin, p + "_norole", null, List.of(), cleanup);
+
+      boolean originalAccessControl = enableSearchAccessControl(admin);
+      cleanup.push(() -> restoreSearchAccessControl(admin, originalAccessControl));
+
+      // Control: the table is indexed and visible to a bot whose policies do not restrict it.
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(60))
+          .pollInterval(Duration.ofSeconds(2))
+          .untilAsserted(
+              () -> {
+                assertTrue(
+                    tableSearchFqns(admin, p).contains(tableFqn), "Admin must see the table");
+                assertTrue(
+                    tableSearchFqns(unscopedBot, p).contains(tableFqn),
+                    "A bot with no role compiles to match_all and must see the table");
+              });
+
+      Set<String> scopedBotTables = tableSearchFqns(scopedBot, p);
+      assertFalse(
+          scopedBotTables.contains(tableFqn),
+          "A bot denied ViewAll on tables must not see them in search. Seeing it means the "
+              + "caller's policies were never compiled into the query. Saw: "
+              + scopedBotTables);
+    } finally {
+      drain(cleanup);
+    }
+  }
+
+  @Test
+  void test_assetSearch_stockBotIsUnaffected(TestNamespace ns) throws Exception {
+    // The seeded bots carry an unconditioned ViewAll on All resources, which compiles to match_all,
+    // so applying their policies must not narrow anything.
+    OpenMetadataClient admin = SdkClients.adminClient();
+    Deque<Runnable> cleanup = new ArrayDeque<>();
+    try {
+      String p = ns.shortPrefix();
+      Domain d1 = createDomain(admin, p + "_stockd1", cleanup);
+      Domain d2 = createDomain(admin, p + "_stockd2", cleanup);
+      DatabaseSchema schema = createSchema(ns, cleanup);
+      Table t1 = createTable(admin, p + "_stock_t1", schema, d1, cleanup);
+      Table t2 = createTable(admin, p + "_stock_t2", schema, d2, cleanup);
+
+      boolean originalAccessControl = enableSearchAccessControl(admin);
+      cleanup.push(() -> restoreSearchAccessControl(admin, originalAccessControl));
+
+      OpenMetadataClient ingestionBot = SdkClients.ingestionBotClient();
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(60))
+          .pollInterval(Duration.ofSeconds(2))
+          .untilAsserted(
+              () -> {
+                Set<String> botTables = tableSearchFqns(ingestionBot, p);
+                assertTrue(
+                    botTables.containsAll(
+                        List.of(t1.getFullyQualifiedName(), t2.getFullyQualifiedName())),
+                    "A stock bot keeps its full view. Saw: " + botTables);
+              });
+    } finally {
+      drain(cleanup);
+    }
+  }
+
+  @Test
+  void test_lineage_restrictedBotSeesOnlyOwnDomainNodes(TestNamespace ns) throws Exception {
+    // Deliberately does NOT enable search access control: the lineage prune is gated on the role
+    // alone (DomainAccessFilter#shouldApply), independently of the search RBAC setting.
+    OpenMetadataClient admin = SdkClients.adminClient();
+    Deque<Runnable> cleanup = new ArrayDeque<>();
+    try {
+      String p = ns.shortPrefix();
+      Domain d1 = createDomain(admin, p + "_lbotd1", cleanup);
+      Domain d2 = createDomain(admin, p + "_lbotd2", cleanup);
+      DatabaseSchema schema = createSchema(ns, cleanup);
+
+      Table t1 = createTable(admin, p + "_lbot_t1", schema, d1, cleanup);
+      Table t2 = createTable(admin, p + "_lbot_t2", schema, d2, cleanup);
+      addLineage(admin, t1, t2);
+
+      String t1Fqn = t1.getFullyQualifiedName();
+      String t2Fqn = t2.getFullyQualifiedName();
+      OpenMetadataClient restrictedBot = createRestrictedBotClient(admin, p, d1, cleanup);
+
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(60))
+          .pollInterval(Duration.ofSeconds(2))
+          .untilAsserted(
+              () -> {
+                Set<String> adminNodes = nodeFqns(searchLineage(admin, t1Fqn));
+                assertTrue(
+                    adminNodes.containsAll(List.of(t1Fqn, t2Fqn)),
+                    "Admin should see the full chain first. Saw: " + adminNodes);
+              });
+
+      Set<String> botNodes = nodeFqns(searchLineage(restrictedBot, t1Fqn));
+      assertTrue(botNodes.contains(t1Fqn), "Domain-scoped bot sees its own-domain root");
+      assertFalse(
+          botNodes.contains(t2Fqn),
+          "Foreign-domain node must be pruned for a domain-scoped bot. Saw: " + botNodes);
     } finally {
       drain(cleanup);
     }
@@ -433,6 +576,79 @@ public class DomainIsolationIT {
     return SdkClients.createClient(email, email, new String[] {});
   }
 
+  private OpenMetadataClient createRestrictedBotClient(
+      OpenMetadataClient admin, String prefix, Domain allowedDomain, Deque<Runnable> cleanup) {
+    Role domainOnlyRole = admin.roles().getByName("DomainOnlyAccessRole");
+    return createBotClient(
+        admin, prefix + "_restricted", allowedDomain, List.of(domainOnlyRole.getId()), cleanup);
+  }
+
+  /**
+   * Creates a bot user and a client for it. Roles are assigned directly to the bot rather than
+   * through a team, because {@code SubjectCache#loadPoliciesForUser} skips team policies for bots,
+   * so a team-inherited role would never reach the compiled search query.
+   */
+  private OpenMetadataClient createBotClient(
+      OpenMetadataClient admin,
+      String prefix,
+      Domain allowedDomain,
+      List<UUID> roleIds,
+      Deque<Runnable> cleanup) {
+    String name = prefix + "_bot";
+    String email = name + "@test.openmetadata.org";
+    CreateUser request =
+        new CreateUser()
+            .withName(name)
+            .withEmail(email)
+            .withIsBot(true)
+            .withAuthenticationMechanism(
+                new AuthenticationMechanism()
+                    .withAuthType(AuthenticationMechanism.AuthType.JWT)
+                    .withConfig(
+                        new JWTAuthMechanism().withJWTTokenExpiry(JWTTokenExpiry.Unlimited)))
+            .withDomains(
+                allowedDomain == null ? List.of() : List.of(allowedDomain.getFullyQualifiedName()))
+            .withRoles(roleIds);
+    org.openmetadata.schema.entity.teams.User bot = admin.users().create(request);
+    cleanup.push(() -> admin.users().delete(bot.getId()));
+    return SdkClients.createClient(email, email, new String[] {});
+  }
+
+  /**
+   * A role that denies ViewAll on one resource. A deny is used rather than a narrow allow because
+   * every bot inherits DefaultBotRole's unconditioned ViewAll, which makes its allow side match_all.
+   */
+  private Role createResourceDenyRole(
+      OpenMetadataClient admin, String prefix, String resource, Deque<Runnable> cleanup) {
+    Rule rule =
+        new Rule()
+            .withName("denyViewOneResource")
+            .withDescription("Deny viewing a single resource type")
+            .withEffect(Rule.Effect.DENY)
+            .withOperations(List.of(MetadataOperation.VIEW_ALL))
+            .withResources(List.of(resource));
+    Policy policy =
+        admin
+            .policies()
+            .create(
+                new CreatePolicy()
+                    .withName(prefix + "_" + resource + "DenyPolicy")
+                    .withDescription("Resource-deny policy for search RBAC coverage")
+                    .withRules(List.of(rule)));
+    cleanup.push(() -> admin.policies().delete(policy.getId()));
+
+    Role role =
+        admin
+            .roles()
+            .create(
+                new CreateRole()
+                    .withName(prefix + "_" + resource + "DenyRole")
+                    .withDescription("Resource-deny role for search RBAC coverage")
+                    .withPolicies(List.of(policy.getFullyQualifiedName())));
+    cleanup.push(() -> admin.roles().delete(role.getId()));
+    return role;
+  }
+
   private OpenMetadataClient createPlainUserClient(
       OpenMetadataClient admin, String prefix, Deque<Runnable> cleanup) {
     String name = prefix + "_plain";
@@ -512,6 +728,24 @@ public class DomainIsolationIT {
       }
     }
     return names;
+  }
+
+  /**
+   * Asset-index search, scoped to this test's namespace. Unlike the domain index, table search is
+   * narrowed by search RBAC alone, so it is the right probe for the bot policy injection in #30023.
+   */
+  private Set<String> tableSearchFqns(OpenMetadataClient client, String prefix) throws Exception {
+    String response =
+        client.search().query(prefix + "*").index("table_search_index").size(1000).execute();
+    JsonNode hits = MAPPER.readTree(response).path("hits").path("hits");
+    Set<String> fqns = new HashSet<>();
+    for (JsonNode hit : hits) {
+      JsonNode source = hit.path("_source");
+      if (source.hasNonNull("fullyQualifiedName")) {
+        fqns.add(source.get("fullyQualifiedName").asText());
+      }
+    }
+    return fqns;
   }
 
   private Set<String> domainSearchFqns(OpenMetadataClient client) throws Exception {

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/PatchEntityTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/PatchEntityTool.java
@@ -12,6 +12,7 @@ import jakarta.json.JsonValue;
 import java.io.StringReader;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.type.change.ChangeSource;
@@ -23,6 +24,7 @@ import org.openmetadata.service.security.ImpersonationContext;
 import org.openmetadata.service.security.auth.CatalogSecurityContext;
 import org.openmetadata.service.security.policyevaluator.OperationContext;
 import org.openmetadata.service.security.policyevaluator.ResourceContext;
+import org.openmetadata.service.security.policyevaluator.ResourceContextInterface;
 import org.openmetadata.service.util.RestUtil;
 
 /**
@@ -44,6 +46,37 @@ public class PatchEntityTool implements McpTool {
   private static final String VALUE_KEY = "value";
   private static final String FROM_KEY = "from";
 
+  // Resources that do lifecycle work outside EntityRepository.patch(), which a direct repository
+  // patch would skip. Derived by auditing every @PATCH endpoint under openmetadata-service for a
+  // body that is not a bare patchInternal() delegation - re-run that audit before adding an entry
+  // here or dropping one. What each entry protects:
+  //   app                  system-app guard, scheduler teardown/reinstall
+  //   document             requirePublic - private doc types are not editable
+  //   eventsubscription    scheduler re-registration
+  //   ingestionPipeline    secret decryptOrNullify on the response
+  //   intakeForm           authorizeAdmin
+  //   notificationTemplate provider-aware EDIT_ALL authorization
+  //   persona              authorizeAdmin
+  //   testCase             table-or-testCase authorization, sample cleanup
+  //   testSuite            getAuthRequestsForUpdate authorization
+  //   task                 restricted-field diff validation
+  //   user                 isAdmin / isBot / roles / teams authorization
+  //   workflow             connection-secret decryptOrNullify
+  private static final Set<String> DEDICATED_PATCH_LIFECYCLES =
+      Set.of(
+          Entity.APPLICATION,
+          Entity.DOCUMENT,
+          Entity.EVENT_SUBSCRIPTION,
+          Entity.INGESTION_PIPELINE,
+          Entity.INTAKE_FORM,
+          Entity.NOTIFICATION_TEMPLATE,
+          Entity.PERSONA,
+          Entity.TEST_CASE,
+          Entity.TEST_SUITE,
+          Entity.TASK,
+          Entity.USER,
+          Entity.WORKFLOW);
+
   /** The members RFC 6902 requires for each operation, beyond {@code op} itself. */
   private static final Map<String, List<String>> REQUIRED_MEMBERS =
       Map.of(
@@ -60,6 +93,7 @@ public class PatchEntityTool implements McpTool {
     String entityType = (String) params.get("entityType");
     String fqn = (String) params.get("fqn");
     requireTarget(entityType, fqn);
+    requireGenericPatchLifecycle(entityType);
 
     JsonPatch jsonPatch = parsePatch((String) params.get(PATCH_PARAM));
 
@@ -68,7 +102,7 @@ public class PatchEntityTool implements McpTool {
     authorizer.authorize(
         securityContext,
         new OperationContext(entityType, jsonPatch),
-        new ResourceContext<>(entityType, null, fqn));
+        new ResourceContext<>(entityType, null, fqn, ResourceContextInterface.Operation.PATCH));
 
     // The response carries the patched entity, so this write answers a read as well: apply the
     // per-entity visibility rules the authorize() above cannot see, since they live outside the
@@ -97,6 +131,25 @@ public class PatchEntityTool implements McpTool {
   private static void requireTarget(String entityType, String fqn) {
     if (nullOrEmpty(entityType) || nullOrEmpty(fqn)) {
       throw new IllegalArgumentException("Parameters 'entityType' and 'fqn' are required");
+    }
+  }
+
+  private static void requireGenericPatchLifecycle(String entityType) {
+    if (DEDICATED_PATCH_LIFECYCLES.contains(entityType)) {
+      throw new IllegalArgumentException(
+          "entityType '"
+              + entityType
+              + "' cannot be patched through patch_entity because its resource performs"
+              + " additional authorization, scheduling, cleanup, or secret handling. Use its"
+              + " dedicated OpenMetadata REST PATCH API. Nothing was changed.");
+    }
+    if (Entity.isTimeSeriesEntity(entityType)) {
+      throw new IllegalArgumentException(
+          "entityType '"
+              + entityType
+              + "' cannot be patched through patch_entity because time-series entities use"
+              + " dedicated repositories and authorization. Use the entity's dedicated"
+              + " OpenMetadata API. Nothing was changed.");
     }
   }
 

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
@@ -120,12 +120,15 @@ public class SearchMetadataTool implements McpTool {
               McpResponseTrim.VECTOR_NOISE_FIELDS.stream())
           .toList();
 
+  /** Lucene match-anything query, mirroring the {@code @DefaultValue("*")} on the REST search API. */
+  private static final String MATCH_ANY_QUERY = "*";
+
   @Override
   public Map<String, Object> execute(
       Authorizer authorizer, CatalogSecurityContext securityContext, Map<String, Object> params)
       throws IOException {
-    LOG.info("Executing searchMetadata with params: {}", params);
-    String query = stringParam(params, "query", "*");
+    LOG.debug("Executing searchMetadata with params: {}", params);
+    String query = stringParam(params, "query", MATCH_ANY_QUERY);
     String entityType = stringParam(params, "entityType", null);
     String index = resolveIndex(entityType);
 
@@ -241,47 +244,32 @@ public class SearchMetadataTool implements McpTool {
     // (OpenSearchSearchManager.applyQueryFilter), so the engine applies it and the page backfills.
     String exclusionFilter = queryFilter == null ? excludeOnlyFilter(excludedTypes) : null;
 
-    LOG.info(
+    LOG.debug(
         "Search query: {}, index: {}, limit: {}, includeDeleted: {}",
         queryFilter,
         index,
         size,
         includeDeleted);
 
-    SearchRequest searchRequest;
-    if (!nullOrEmpty(queryFilter)) {
-      // When queryFilter is provided, use it directly as it's already a transformed OpenSearch
-      // query
-      searchRequest =
-          new SearchRequest()
-              .withIndex(Entity.getSearchRepository().getIndexOrAliasName(index))
-              .withQueryFilter(queryFilter)
-              .withSize(size)
-              .withFrom(from)
-              .withFetchSource(true)
-              .withDeleted(includeDeleted);
-    } else {
-      // Fallback to basic query when no queryFilter is provided
-      searchRequest =
-          new SearchRequest()
-              .withQuery(query)
-              .withIndex(Entity.getSearchRepository().getIndexOrAliasName(index))
-              .withQueryFilter(exclusionFilter)
-              .withSize(size)
-              .withFrom(from)
-              .withFetchSource(true)
-              .withDeleted(includeDeleted);
-    }
+    // One request shape for both cases. A caller-supplied queryFilter used to be sent through
+    // searchWithDirectQuery, which reads neither the text query nor the deleted flag, so both were
+    // silently dropped whenever a filter was present. The standard search path ANDs the filter
+    // under
+    // the text query (OpenSearchSearchManager#applyQueryFilter) and additionally applies the
+    // deleted
+    // filter, ranked scoring, and the search preference.
+    SearchRequest searchRequest =
+        new SearchRequest()
+            .withQuery(nullOrEmpty(query) ? MATCH_ANY_QUERY : query)
+            .withIndex(Entity.getSearchRepository().getIndexOrAliasName(index))
+            .withQueryFilter(nullOrEmpty(queryFilter) ? exclusionFilter : queryFilter)
+            .withSize(size)
+            .withFrom(from)
+            .withFetchSource(true)
+            .withDeleted(includeDeleted);
 
     SubjectContext subjectContext = getSubjectContext(securityContext);
-    Response response;
-    if (!nullOrEmpty(queryFilter)) {
-      // Use direct query method when queryFilter is provided since it's already a transformed query
-      response = Entity.getSearchRepository().searchWithDirectQuery(searchRequest, subjectContext);
-    } else {
-      // Use regular search for basic queries
-      response = Entity.getSearchRepository().search(searchRequest, subjectContext);
-    }
+    Response response = Entity.getSearchRepository().search(searchRequest, subjectContext);
 
     Map<String, Object> searchResponse;
     if (response.getEntity() instanceof String responseStr) {

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/PatchEntityToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/PatchEntityToolTest.java
@@ -6,10 +6,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.ForbiddenException;
@@ -18,6 +20,7 @@ import java.security.Principal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,7 +44,9 @@ import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.security.DefaultAuthorizer;
 import org.openmetadata.service.security.ImpersonationContext;
 import org.openmetadata.service.security.auth.CatalogSecurityContext;
+import org.openmetadata.service.security.policyevaluator.ResourceContextInterface;
 import org.openmetadata.service.security.policyevaluator.SubjectContext;
+import org.openmetadata.service.util.EntityUtil.Fields;
 import org.openmetadata.service.util.RestUtil;
 
 /**
@@ -233,6 +238,92 @@ class PatchEntityToolTest {
               McpChangeEventUtil.publishChangeEvent(
                   eq(mockEntity), eq(EventType.ENTITY_UPDATED), eq("alice")));
     }
+  }
+
+  @Test
+  void execute_authorizesWithPatchResourceContext() {
+    @SuppressWarnings("unchecked")
+    EntityRepository<EntityInterface> mockRepo = mock(EntityRepository.class);
+    EntityInterface mockEntity = mock(EntityInterface.class);
+    when(mockRepo.getPatchFields()).thenReturn(new Fields(Set.of()));
+    when(mockRepo.patch(any(), any(String.class), any(), any(), any(), any(), any()))
+        .thenReturn(
+            new RestUtil.PatchResponse<>(Response.Status.OK, mockEntity, EventType.ENTITY_UPDATED));
+    doAnswer(
+            invocation -> {
+              ResourceContextInterface resourceContext = invocation.getArgument(2);
+              resourceContext.getEntity();
+              return null;
+            })
+        .when(authorizer)
+        .authorize(eq(securityContext), any(), any());
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("entityType", "table");
+    params.put("fqn", "db.schema.test_table");
+    params.put("patch", "[]");
+
+    try (MockedStatic<Entity> entityMock = mockStatic(Entity.class);
+        MockedStatic<McpChangeEventUtil> changeEventMock = mockStatic(McpChangeEventUtil.class);
+        MockedStatic<JsonUtils> jsonMock = mockStatic(JsonUtils.class)) {
+      entityMock.when(() -> Entity.getEntityRepository("table")).thenReturn(mockRepo);
+      jsonMock.when(() -> JsonUtils.convertValue(any(), eq(Map.class))).thenReturn(Map.of());
+
+      new PatchEntityTool().execute(authorizer, securityContext, params);
+    }
+
+    verify(mockRepo).getPatchFields();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "app",
+        "document",
+        "eventsubscription",
+        "ingestionPipeline",
+        "intakeForm",
+        "notificationTemplate",
+        "persona",
+        "testCase",
+        "testSuite",
+        "task",
+        "user",
+        "workflow"
+      })
+  void execute_rejectsEntitiesWhoseResourceOwnsThePatchLifecycle(String entityType) {
+    Map<String, Object> params = new HashMap<>();
+    params.put("entityType", entityType);
+    params.put("fqn", "target");
+    params.put("patch", "[]");
+
+    assertThatThrownBy(() -> new PatchEntityTool().execute(authorizer, securityContext, params))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("entityType '" + entityType + "'")
+        .hasMessageContaining("dedicated OpenMetadata REST PATCH API")
+        .hasMessageContaining("Nothing was changed");
+    verifyNoInteractions(authorizer);
+  }
+
+  @Test
+  void execute_rejectsTimeSeriesEntitiesBeforeAuthorization() {
+    Map<String, Object> params = new HashMap<>();
+    params.put("entityType", Entity.TEST_CASE_RESOLUTION_STATUS);
+    params.put("fqn", "target");
+    params.put("patch", "[]");
+
+    try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
+      entityMock
+          .when(() -> Entity.isTimeSeriesEntity(Entity.TEST_CASE_RESOLUTION_STATUS))
+          .thenReturn(true);
+
+      assertThatThrownBy(() -> new PatchEntityTool().execute(authorizer, securityContext, params))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("time-series entities")
+          .hasMessageContaining("dedicated OpenMetadata API")
+          .hasMessageContaining("Nothing was changed");
+    }
+    verifyNoInteractions(authorizer);
   }
 
   @ParameterizedTest

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SearchMetadataToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SearchMetadataToolTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -209,21 +210,63 @@ class SearchMetadataToolTest {
       params.put("queryFilter", Map.of("query", Map.of("term", Map.of("entityType", "table"))));
 
       when(searchRepository.getIndexOrAliasName("dataAsset")).thenReturn("dataAsset");
-      Response mockResponse = mock(Response.class);
-      when(mockResponse.getEntity()).thenReturn("{\"hits\":{\"hits\":[],\"total\":{\"value\":0}}}");
-      when(searchRepository.searchWithDirectQuery(any(), any(SubjectContext.class)))
-          .thenReturn(mockResponse);
+      stubEmptySearch();
 
       Map<String, Object> result = searchMetadataTool.execute(authorizer, securityContext, params);
 
       assertNotNull(result);
       ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
-      verify(searchRepository).searchWithDirectQuery(captor.capture(), any(SubjectContext.class));
+      verify(searchRepository).search(captor.capture(), any(SubjectContext.class));
       assertEquals(
           "table",
           JsonUtils.readTree(captor.getValue().getQueryFilter())
               .at("/query/term/entityType")
               .asText());
+    }
+  }
+
+  @Test
+  void testQueryFilterKeepsTextQueryAndDeletedFlag() throws Exception {
+    // A caller-supplied queryFilter used to route through searchWithDirectQuery, which reads
+    // neither the text query nor the deleted flag, so both were silently dropped.
+    try (MockedStatic<SubjectCache> subjectCacheMock = mockStatic(SubjectCache.class)) {
+      subjectCacheMock.when(() -> SubjectCache.getUserContext("test-user")).thenReturn(mockUser);
+
+      Map<String, Object> params = new HashMap<>();
+      params.put("query", "customer orders");
+      params.put("includeDeleted", true);
+      params.put("queryFilter", Map.of("query", Map.of("term", Map.of("entityType", "table"))));
+
+      when(searchRepository.getIndexOrAliasName("dataAsset")).thenReturn("dataAsset");
+      stubEmptySearch();
+
+      searchMetadataTool.execute(authorizer, securityContext, params);
+
+      ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+      verify(searchRepository).search(captor.capture(), any(SubjectContext.class));
+      assertEquals("customer orders", captor.getValue().getQuery());
+      assertEquals(true, captor.getValue().getDeleted());
+      verify(searchRepository, never()).searchWithDirectQuery(any(), any(SubjectContext.class));
+    }
+  }
+
+  @Test
+  void testMissingQueryDefaultsToMatchAnything() throws Exception {
+    try (MockedStatic<SubjectCache> subjectCacheMock = mockStatic(SubjectCache.class)) {
+      subjectCacheMock.when(() -> SubjectCache.getUserContext("test-user")).thenReturn(mockUser);
+
+      Map<String, Object> params = new HashMap<>();
+      params.put("queryFilter", Map.of("query", Map.of("term", Map.of("entityType", "table"))));
+
+      when(searchRepository.getIndexOrAliasName("dataAsset")).thenReturn("dataAsset");
+      stubEmptySearch();
+
+      searchMetadataTool.execute(authorizer, securityContext, params);
+
+      ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+      verify(searchRepository).search(captor.capture(), any(SubjectContext.class));
+      assertEquals(
+          "*", captor.getValue().getQuery(), "a filter-only call must still match anything");
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchUtils.java
@@ -355,6 +355,14 @@ public final class SearchUtils {
     return aggregationJson.getString("key");
   }
 
+  /**
+   * Decides whether the caller's policy conditions are compiled into the search query. Bots are
+   * evaluated exactly like humans: they used to be exempt, which left every bot-authenticated search
+   * unfiltered even with access control on, because a skipped injection leaves the query matching
+   * everything rather than failing closed. {@code DefaultAuthorizer#authorize} already evaluates the
+   * same policies on a bot's REST reads, so exempting search made it the laxer of the two. Admins
+   * stay exempt because their compiled query would match everything anyway.
+   */
   public static boolean shouldApplyRbacConditions(
       SubjectContext subjectContext, RBACConditionEvaluator rbacConditionEvaluator) {
     return Boolean.TRUE.equals(
@@ -363,7 +371,6 @@ public final class SearchUtils {
                 .getEnableAccessControl())
         && subjectContext != null
         && !subjectContext.isAdmin()
-        && !subjectContext.isBot()
         && rbacConditionEvaluator != null;
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchAggregationManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchAggregationManager.java
@@ -89,8 +89,8 @@ public class ElasticSearchAggregationManager implements AggregationManagementCli
   /**
    * ANDs the caller's policy conditions into an aggregation query. Aggregations run over whole
    * indexes, so without this a caller can read documents they are denied on the corresponding
-   * listing. A {@code null} or exempt subject (admin, bot, access control disabled) is left
-   * unfiltered.
+   * listing. A {@code null} or exempt subject (admin, or access control disabled) is left
+   * unfiltered. Bots are not exempt: they are policy-evaluated like any other caller.
    */
   private Query applyRbacQuery(Query query, SubjectContext subjectContext) {
     if (!SearchUtils.shouldApplyRbacConditions(subjectContext, rbacConditionEvaluator)) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchAggregationManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchAggregationManager.java
@@ -88,8 +88,8 @@ public class OpenSearchAggregationManager implements AggregationManagementClient
   /**
    * ANDs the caller's policy conditions into an aggregation query. Aggregations run over whole
    * indexes, so without this a caller can read documents they are denied on the corresponding
-   * listing. A {@code null} or exempt subject (admin, bot, access control disabled) is left
-   * unfiltered.
+   * listing. A {@code null} or exempt subject (admin, or access control disabled) is left
+   * unfiltered. Bots are not exempt: they are policy-evaluated like any other caller.
    */
   private Query applyRbacQuery(Query query, SubjectContext subjectContext) {
     if (!SearchUtils.shouldApplyRbacConditions(subjectContext, rbacConditionEvaluator)) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
@@ -1,6 +1,7 @@
 package org.openmetadata.service.search.opensearch;
 
 import static jakarta.ws.rs.core.Response.Status.OK;
+import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.service.Entity.DOMAIN;
 import static org.openmetadata.service.Entity.GLOSSARY_TERM;
@@ -47,6 +48,7 @@ import org.openmetadata.schema.api.search.SearchSettings;
 import org.openmetadata.schema.entity.data.EntityHierarchy;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.settings.SettingsType;
+import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.sdk.exception.SearchException;
@@ -1029,6 +1031,31 @@ public class OpenSearchSearchManager implements SearchManagementClient {
   }
 
   /**
+   * Keys a compiled RBAC query by the subject fields that end up embedded in it as literal ids.
+   * Roles select the policies; {@code hasDomain()} compiles domain ids into term clauses; {@code
+   * isOwner()}, {@code isReviewer()} and {@code inAnyTeam()} compile team ids the same way. Nothing
+   * invalidates this cache, so any field left out of the key is served stale for the remainder of
+   * the TTL after it changes. Keep this in step with {@link RBACConditionEvaluator} whenever a new
+   * condition starts reading another subject field.
+   */
+  static String rbacCacheKey(SubjectContext subjectContext) {
+    return subjectContext.user().getId()
+        + ":"
+        + sortedIds(subjectContext.user().getRoles())
+        + ":"
+        + sortedIds(subjectContext.user().getDomains())
+        + ":"
+        + sortedIds(subjectContext.user().getTeams());
+  }
+
+  private static String sortedIds(List<EntityReference> references) {
+    return listOrEmpty(references).stream()
+        .map(reference -> reference.getId().toString())
+        .sorted()
+        .collect(Collectors.joining(","));
+  }
+
+  /**
    * Applies RBAC query constraints with caching to the request builder.
    *
    * @param subjectContext the subject context containing user and role information
@@ -1040,14 +1067,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
       return;
     }
 
-    // Create cache key from user ID and roles
-    String cacheKey =
-        subjectContext.user().getId()
-            + ":"
-            + subjectContext.user().getRoles().stream()
-                .map(r -> r.getId().toString())
-                .sorted()
-                .collect(Collectors.joining(","));
+    String cacheKey = rbacCacheKey(subjectContext);
 
     try {
       // Guava Cache forbids null values, so we check getIfPresent first, then build and cache.

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/ElasticSearchVectorService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/ElasticSearchVectorService.java
@@ -110,7 +110,10 @@ public class ElasticSearchVectorService implements VectorIndexService {
       SubjectContext subjectContext) {
     long start = System.currentTimeMillis();
     try {
-      float[] queryVector = embeddingClient.embed(query);
+      // embedQuery, not embed: providers that distinguish the two (Cohere's search_query vs
+      // search_document input type) produce a worse vector for a question embedded as a
+      // document. The OpenSearch path already does this.
+      float[] queryVector = embeddingClient.embedQuery(query);
       LinkedHashMap<String, List<Map<String, Object>>> byParent = new LinkedHashMap<>();
       int rawOffset = 0;
       long totalHits = -1L;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/client/BedrockEmbeddingClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/client/BedrockEmbeddingClient.java
@@ -36,6 +36,7 @@ public final class BedrockEmbeddingClient extends EmbeddingClient implements Aut
   private static final String FIELD_EMBEDDING = "embedding";
   private static final String FIELD_EMBEDDINGS = "embeddings";
   private static final String FIELD_FLOAT = "float";
+  private static final String FIELD_INPUT_TEXT_TOKEN_COUNT = "inputTextTokenCount";
   private static final String COHERE_INPUT_TYPE_SEARCH_DOCUMENT = "search_document";
   private static final String COHERE_INPUT_TYPE_SEARCH_QUERY = "search_query";
   private static final String COHERE_TRUNCATE_END = "END";
@@ -91,6 +92,11 @@ public final class BedrockEmbeddingClient extends EmbeddingClient implements Aut
       JsonNode extractEmbedding(JsonNode root) {
         return root.get(FIELD_EMBEDDING);
       }
+
+      @Override
+      EmbeddingUsage extractUsage(JsonNode root) {
+        return titanUsage(root);
+      }
     },
     TITAN_V2(OptionalInt.empty(), TITAN_MAX_INPUT_CHARS) {
       @Override
@@ -105,6 +111,11 @@ public final class BedrockEmbeddingClient extends EmbeddingClient implements Aut
       @Override
       JsonNode extractEmbedding(JsonNode root) {
         return root.get(FIELD_EMBEDDING);
+      }
+
+      @Override
+      EmbeddingUsage extractUsage(JsonNode root) {
+        return titanUsage(root);
       }
     },
     COHERE(OptionalInt.of(COHERE_FIXED_DIMENSION), COHERE_MAX_INPUT_CHARS) {
@@ -136,6 +147,20 @@ public final class BedrockEmbeddingClient extends EmbeddingClient implements Aut
     abstract ObjectNode buildRequest(String text, int dimension, boolean isQuery);
 
     abstract JsonNode extractEmbedding(JsonNode root);
+
+    /**
+     * Input tokens the family's response reports, or {@code null} when it reports none. Cohere on
+     * Bedrock returns no count at all, so consumers that need a number must estimate one.
+     */
+    EmbeddingUsage extractUsage(JsonNode root) {
+      return null;
+    }
+
+    /** Titan families both report the count under the same field. */
+    static EmbeddingUsage titanUsage(JsonNode root) {
+      JsonNode tokens = root.get(FIELD_INPUT_TEXT_TOKEN_COUNT);
+      return tokens != null && tokens.isNumber() ? new EmbeddingUsage(tokens.asLong()) : null;
+    }
 
     OptionalInt fixedDimension() {
       return fixedDimension;
@@ -207,17 +232,27 @@ public final class BedrockEmbeddingClient extends EmbeddingClient implements Aut
 
   @Override
   protected float[] doEmbed(String text) {
-    return invokeEmbedding(text, false);
+    return invokeEmbedding(text, false).vector();
   }
 
   @Override
   protected float[] doEmbedQuery(String text) {
-    return invokeEmbedding(text, true);
+    return invokeEmbedding(text, true).vector();
   }
 
-  private float[] invokeEmbedding(String text, boolean isQuery) {
+  @Override
+  protected EmbeddingResult doEmbedWithUsage(String text, boolean query) {
+    return invokeEmbedding(text, query);
+  }
+
+  /**
+   * Usage reflects the call that succeeded. An oversized input that AWS rejects with a
+   * ValidationException is not a billable invocation, so the halving retries below contribute
+   * nothing to the count.
+   */
+  private EmbeddingResult invokeEmbedding(String text, boolean isQuery) {
     String input = family.cap(text);
-    float[] embedding = null;
+    EmbeddingResult embedding = null;
     int attempt = 0;
     while (embedding == null) {
       try {
@@ -237,7 +272,7 @@ public final class BedrockEmbeddingClient extends EmbeddingClient implements Aut
     return embedding;
   }
 
-  private float[] invokeOnce(String text, boolean isQuery) throws IOException {
+  private EmbeddingResult invokeOnce(String text, boolean isQuery) throws IOException {
     String body = buildRequestBody(family, text, dimension, isQuery);
     InvokeModelRequest request =
         InvokeModelRequest.builder()
@@ -247,7 +282,8 @@ public final class BedrockEmbeddingClient extends EmbeddingClient implements Aut
             .body(SdkBytes.fromUtf8String(body))
             .build();
     InvokeModelResponse response = bedrockClient.invokeModel(request);
-    return parseEmbeddingResponse(family, response.body().asUtf8String());
+    // `text` here is already capped and possibly halved, so it is what the provider received.
+    return parseEmbeddingResult(family, response.body().asUtf8String(), text);
   }
 
   /**
@@ -340,6 +376,11 @@ public final class BedrockEmbeddingClient extends EmbeddingClient implements Aut
   }
 
   static float[] parseEmbeddingResponse(BedrockEmbeddingFamily family, String responseBody) {
+    return parseEmbeddingResult(family, responseBody, null).vector();
+  }
+
+  static EmbeddingResult parseEmbeddingResult(
+      BedrockEmbeddingFamily family, String responseBody, String submittedText) {
     try {
       JsonNode root = MAPPER.readTree(responseBody);
       JsonNode embeddingNode = family.extractEmbedding(root);
@@ -350,7 +391,7 @@ public final class BedrockEmbeddingClient extends EmbeddingClient implements Aut
       for (int i = 0; i < embeddingNode.size(); i++) {
         embedding[i] = (float) embeddingNode.get(i).asDouble();
       }
-      return embedding;
+      return new EmbeddingResult(embedding, family.extractUsage(root), submittedText);
     } catch (IOException e) {
       throw new RuntimeException("Failed to parse Bedrock embedding response", e);
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/client/EmbeddingClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/client/EmbeddingClient.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.configuration.LLMConfiguration;
 import org.openmetadata.schema.configuration.LLMEmbeddingsConfig;
@@ -25,7 +24,55 @@ public abstract class EmbeddingClient {
     HALF_OPEN
   }
 
+  /**
+   * Token usage the provider reported for a single embedding call. An embedding call has no output
+   * tokens — it returns a vector, not generated text — so the input count is the whole of it.
+   */
+  public record EmbeddingUsage(long inputTokens) {}
+
+  /**
+   * A vector plus the usage of the call that produced it. {@code usage} is {@code null} when the
+   * provider does not report token counts (Google's {@code :embedContent} and Cohere on Bedrock
+   * never do), so consumers that need a number must estimate one from the submitted text.
+   *
+   * <p>{@code submittedText} is what actually went to the provider, which is not always what the
+   * caller passed in: providers with a hard input limit truncate first (Cohere on Bedrock at 2048
+   * chars, well under a normal chunk). Estimating from the caller's string would then overstate
+   * every truncated call — and Cohere is precisely the family that reports no usage, so estimation
+   * is the only option there. {@code null} means the input went through unchanged.
+   *
+   * <p>A carrier only: the generated {@code equals}/{@code hashCode} compare {@code vector} by
+   * identity, so do not use this record as a map key or in equality assertions.
+   */
+  public record EmbeddingResult(float[] vector, EmbeddingUsage usage, String submittedText) {
+
+    /** For providers that submit the caller's input unchanged. */
+    public EmbeddingResult(float[] vector, EmbeddingUsage usage) {
+      this(vector, usage, null);
+    }
+  }
+
+  /**
+   * Notified after each successful embedding call, so a deployment can meter its own embedding
+   * traffic without this class knowing anything about how that metering works.
+   *
+   * <p>Called off the concurrency permit and after the circuit breaker has settled, and any
+   * exception it throws is logged and swallowed — a listener is observability and must never fail
+   * an embedding or open the circuit.
+   *
+   * <p>Runs synchronously on the calling thread, once per embedded chunk on the indexing path, so
+   * an implementation must not block. Accumulate and report out of band.
+   *
+   * @param text what the provider received, after any provider-side truncation — not necessarily
+   *     what the caller passed in. Estimating a token count from anything else overstates a
+   *     truncated call.
+   */
+  public interface UsageListener {
+    void onUsage(String modelId, String text, EmbeddingUsage usage, boolean query);
+  }
+
   private final Semaphore concurrencyLimiter;
+  private volatile UsageListener usageListener;
   private final Object circuitLock = new Object();
   private CircuitState circuitState = CircuitState.CLOSED;
   private int consecutiveFailures = 0;
@@ -70,23 +117,50 @@ public abstract class EmbeddingClient {
     return doEmbed(text);
   }
 
+  /**
+   * Embed {@code text} and report whatever token usage the provider returned alongside the vector.
+   *
+   * <p>Defaults to the plain {@link #doEmbed}/{@link #doEmbedQuery} pair with no usage, so a client
+   * that overrides only those keeps working unchanged. Providers whose response carries a token
+   * count (Bedrock Titan's {@code inputTextTokenCount}, OpenAI's {@code usage.prompt_tokens})
+   * override this to surface it instead of discarding it.
+   */
+  protected EmbeddingResult doEmbedWithUsage(String text, boolean query) {
+    float[] vector = query ? doEmbedQuery(text) : doEmbed(text);
+    return new EmbeddingResult(vector, null);
+  }
+
+  /** Register the listener notified after each successful call. {@code null} disables reporting. */
+  public void setUsageListener(UsageListener usageListener) {
+    this.usageListener = usageListener;
+  }
+
   public final float[] embed(String text) {
-    return embedWithLimit(() -> doEmbed(text));
+    return embedWithLimit(text, false);
   }
 
   public final float[] embedQuery(String text) {
-    return embedWithLimit(() -> doEmbedQuery(text));
+    return embedWithLimit(text, true);
   }
 
-  private float[] embedWithLimit(Supplier<float[]> embedder) {
+  private float[] embedWithLimit(String text, boolean query) {
     guardCircuit();
+    EmbeddingResult result = invokeProvider(text, query);
+    // Deliberately outside invokeProvider: the permit is released and the circuit has settled by
+    // now, so a slow listener cannot starve other callers and a throwing one cannot open the
+    // circuit.
+    notifyUsage(submittedOr(result, text), result.usage(), query);
+    return result.vector();
+  }
+
+  private EmbeddingResult invokeProvider(String text, boolean query) {
     boolean permitAcquired = false;
     try {
       acquirePermit();
       permitAcquired = true;
-      float[] embedding = embedder.get();
+      EmbeddingResult result = doEmbedWithUsage(text, query);
       recordSuccess();
-      return embedding;
+      return result;
     } catch (RuntimeException failure) {
       // Record even a permit-acquisition failure so a promoted HALF_OPEN probe always resolves
       // (success -> closed, failure -> reopened) and never wedges the circuit half-open forever.
@@ -95,6 +169,23 @@ public abstract class EmbeddingClient {
     } finally {
       if (permitAcquired) {
         concurrencyLimiter.release();
+      }
+    }
+  }
+
+  /** What the provider received: the truncated form when one was reported, else the input. */
+  private static String submittedOr(EmbeddingResult result, String text) {
+    return result.submittedText() != null ? result.submittedText() : text;
+  }
+
+  private void notifyUsage(String text, EmbeddingUsage usage, boolean query) {
+    UsageListener listener = usageListener;
+    if (listener != null) {
+      try {
+        listener.onUsage(getModelId(), text, usage, query);
+      } catch (RuntimeException e) {
+        LOG.warn(
+            "Embedding usage listener failed for model {}: {}", getModelId(), e.getMessage(), e);
       }
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/client/OpenAIEmbeddingClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/client/OpenAIEmbeddingClient.java
@@ -18,6 +18,8 @@ import org.openmetadata.schema.configuration.LLMOpenAIEmbeddingConfig;
 @Slf4j
 public final class OpenAIEmbeddingClient extends EmbeddingClient {
   private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final String FIELD_USAGE = "usage";
+  private static final String FIELD_PROMPT_TOKENS = "prompt_tokens";
 
   private final HttpClient httpClient;
   private final String apiKey;
@@ -122,6 +124,16 @@ public final class OpenAIEmbeddingClient extends EmbeddingClient {
 
   @Override
   protected float[] doEmbed(String text) {
+    return invokeEmbedding(text).vector();
+  }
+
+  /** OpenAI embeddings do not distinguish query from document input, so {@code query} is unused. */
+  @Override
+  protected EmbeddingResult doEmbedWithUsage(String text, boolean query) {
+    return invokeEmbedding(text);
+  }
+
+  private EmbeddingResult invokeEmbedding(String text) {
     if (text == null || text.isBlank()) {
       throw new IllegalArgumentException("Input text must not be null or blank");
     }
@@ -155,7 +167,7 @@ public final class OpenAIEmbeddingClient extends EmbeddingClient {
             "OpenAI API returned status " + response.statusCode() + ": " + errorMsg);
       }
 
-      return parseEmbeddingResponse(response.body());
+      return parseEmbeddingResult(response.body());
     } catch (IOException e) {
       LOG.error("IO error calling OpenAI API: {}", e.getMessage(), e);
       throw new RuntimeException("OpenAI embedding generation failed due to IO error", e);
@@ -175,7 +187,7 @@ public final class OpenAIEmbeddingClient extends EmbeddingClient {
     return modelId;
   }
 
-  private float[] parseEmbeddingResponse(String responseBody) {
+  private EmbeddingResult parseEmbeddingResult(String responseBody) {
     try {
       JsonNode root = MAPPER.readTree(responseBody);
       JsonNode data = root.get("data");
@@ -190,10 +202,19 @@ public final class OpenAIEmbeddingClient extends EmbeddingClient {
       for (int i = 0; i < embeddingNode.size(); i++) {
         embedding[i] = (float) embeddingNode.get(i).asDouble();
       }
-      return embedding;
+      return new EmbeddingResult(embedding, extractUsage(root));
     } catch (IOException e) {
       throw new RuntimeException("Failed to parse OpenAI embedding response", e);
     }
+  }
+
+  /** Input tokens from the response's {@code usage} block, or {@code null} if absent. */
+  private static EmbeddingUsage extractUsage(JsonNode root) {
+    JsonNode usage = root.get(FIELD_USAGE);
+    JsonNode promptTokens = usage != null ? usage.get(FIELD_PROMPT_TOKENS) : null;
+    return promptTokens != null && promptTokens.isNumber()
+        ? new EmbeddingUsage(promptTokens.asLong())
+        : null;
   }
 
   private String extractErrorMessage(String responseBody) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/DomainAccessFilter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/DomainAccessFilter.java
@@ -38,11 +38,14 @@ public final class DomainAccessFilter {
 
   private DomainAccessFilter() {}
 
-  /** Returns true when the subject's view must be narrowed to its own domain hierarchy. */
+  /**
+   * Returns true when the subject's view must be narrowed to its own domain hierarchy. A bot holding
+   * the role is narrowed like any other subject; exempting bots here left a bot-authenticated caller
+   * seeing every domain's lineage and incidents even though the role had been assigned to it.
+   */
   public static boolean shouldApply(SubjectContext subjectContext) {
     return subjectContext != null
         && !subjectContext.isAdmin()
-        && !subjectContext.isBot()
         && subjectContext.hasDomainOnlyAccessRole();
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchUtilsTest.java
@@ -282,9 +282,19 @@ class SearchUtilsTest {
 
       when(subjectContext.isAdmin()).thenReturn(true);
       assertFalse(SearchUtils.shouldApplyRbacConditions(subjectContext, evaluator));
+
+      // A bot is policy-evaluated exactly like a human (#30023): exempting bots left every
+      // bot-authenticated search unfiltered, because a skipped injection matches everything.
       when(subjectContext.isAdmin()).thenReturn(false);
       when(subjectContext.isBot()).thenReturn(true);
+      assertTrue(SearchUtils.shouldApplyRbacConditions(subjectContext, evaluator));
+
+      // Being a bot does not defeat the other exemptions.
+      when(subjectContext.isAdmin()).thenReturn(true);
       assertFalse(SearchUtils.shouldApplyRbacConditions(subjectContext, evaluator));
+      when(subjectContext.isAdmin()).thenReturn(false);
+      assertFalse(SearchUtils.shouldApplyRbacConditions(subjectContext, null));
+
       when(subjectContext.isBot()).thenReturn(false);
       assertFalse(SearchUtils.shouldApplyRbacConditions(subjectContext, null));
       assertFalse(SearchUtils.shouldApplyRbacConditions(null, evaluator));
@@ -292,6 +302,8 @@ class SearchUtilsTest {
       settingsCache
           .when(() -> SettingsCache.getSetting(SettingsType.SEARCH_SETTINGS, SearchSettings.class))
           .thenReturn(disabledSettings);
+      assertFalse(SearchUtils.shouldApplyRbacConditions(subjectContext, evaluator));
+      when(subjectContext.isBot()).thenReturn(true);
       assertFalse(SearchUtils.shouldApplyRbacConditions(subjectContext, evaluator));
     }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/lineage/LineageDomainFilterTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/lineage/LineageDomainFilterTest.java
@@ -59,7 +59,7 @@ class LineageDomainFilterTest {
   }
 
   @Test
-  @DisplayName("shouldApply: only for non-admin non-bot users holding DomainOnlyAccessRole")
+  @DisplayName("shouldApply: only for non-admin users holding DomainOnlyAccessRole")
   void testShouldApply() {
     assertFalse(LineageDomainFilter.shouldApply(null));
     assertTrue(LineageDomainFilter.shouldApply(restricted));
@@ -68,13 +68,30 @@ class LineageDomainFilterTest {
     when(admin.isAdmin()).thenReturn(true);
     assertFalse(LineageDomainFilter.shouldApply(admin));
 
-    SubjectContext bot = mock(SubjectContext.class);
-    when(bot.isBot()).thenReturn(true);
-    assertFalse(LineageDomainFilter.shouldApply(bot));
-
     SubjectContext noRole = mock(SubjectContext.class);
     when(noRole.hasDomainOnlyAccessRole()).thenReturn(false);
     assertFalse(LineageDomainFilter.shouldApply(noRole));
+  }
+
+  @Test
+  @DisplayName("shouldApply: a bot is narrowed when it holds the role, untouched when it does not")
+  void testShouldApplyToBots() {
+    SubjectContext restrictedBot = mock(SubjectContext.class);
+    when(restrictedBot.isBot()).thenReturn(true);
+    when(restrictedBot.hasDomainOnlyAccessRole()).thenReturn(true);
+    assertTrue(
+        LineageDomainFilter.shouldApply(restrictedBot),
+        "a bot assigned DomainOnlyAccessRole must be narrowed, not exempted (#30023)");
+
+    SubjectContext plainBot = mock(SubjectContext.class);
+    when(plainBot.isBot()).thenReturn(true);
+    assertFalse(
+        LineageDomainFilter.shouldApply(plainBot),
+        "a bot without the role is untouched, so stock bots keep their current view");
+
+    SubjectContext adminBot = mock(SubjectContext.class);
+    when(adminBot.isAdmin()).thenReturn(true);
+    assertFalse(LineageDomainFilter.shouldApply(adminBot));
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchRbacCacheKeyTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchRbacCacheKeyTest.java
@@ -1,0 +1,96 @@
+package org.openmetadata.service.search.opensearch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.security.policyevaluator.SubjectContext;
+
+/**
+ * The compiled RBAC query is cached for five minutes with no invalidation hook, so the key has to
+ * cover every input {@code RBACConditionEvaluator} reads. {@code hasDomain()} compiles the subject's
+ * domain ids into literal term clauses, which is why domains sit in the key alongside roles.
+ */
+class OpenSearchRbacCacheKeyTest {
+
+  private static final UUID USER_ID = UUID.randomUUID();
+  private static final UUID ROLE_ID = UUID.randomUUID();
+
+  @Test
+  @DisplayName("Two subjects sharing roles but not domains do not share a cached query")
+  void testDomainsChangeTheKey() {
+    SubjectContext financeSubject = subject(List.of(ROLE_ID), List.of(UUID.randomUUID()));
+    SubjectContext marketingSubject = subject(List.of(ROLE_ID), List.of(UUID.randomUUID()));
+
+    assertNotEquals(
+        OpenSearchSearchManager.rbacCacheKey(financeSubject),
+        OpenSearchSearchManager.rbacCacheKey(marketingSubject));
+  }
+
+  @Test
+  @DisplayName("Role order does not change the key, so equivalent subjects share one cached query")
+  void testKeyIsStableAcrossOrdering() {
+    UUID secondRoleId = UUID.randomUUID();
+    UUID domainId = UUID.randomUUID();
+
+    assertEquals(
+        OpenSearchSearchManager.rbacCacheKey(
+            subject(List.of(ROLE_ID, secondRoleId), List.of(domainId))),
+        OpenSearchSearchManager.rbacCacheKey(
+            subject(List.of(secondRoleId, ROLE_ID), List.of(domainId))));
+  }
+
+  @Test
+  @DisplayName("Two subjects sharing roles and domains but not teams do not share a cached query")
+  void testTeamsChangeTheKey() {
+    UUID domainId = UUID.randomUUID();
+    SubjectContext engineering =
+        subject(List.of(ROLE_ID), List.of(domainId), List.of(UUID.randomUUID()));
+    SubjectContext marketing =
+        subject(List.of(ROLE_ID), List.of(domainId), List.of(UUID.randomUUID()));
+
+    assertNotEquals(
+        OpenSearchSearchManager.rbacCacheKey(engineering),
+        OpenSearchSearchManager.rbacCacheKey(marketing),
+        "isOwner, isReviewer and inAnyTeam compile team ids into the query");
+  }
+
+  @Test
+  @DisplayName("A subject with no roles, domains or teams keys cleanly rather than throwing")
+  void testKeyToleratesNullCollections() {
+    SubjectContext bareSubject = subject(null, null, null);
+
+    assertEquals(USER_ID + ":::", OpenSearchSearchManager.rbacCacheKey(bareSubject));
+  }
+
+  private static SubjectContext subject(List<UUID> roleIds, List<UUID> domainIds) {
+    return subject(roleIds, domainIds, null);
+  }
+
+  private static SubjectContext subject(
+      List<UUID> roleIds, List<UUID> domainIds, List<UUID> teamIds) {
+    User user = mock(User.class);
+    when(user.getId()).thenReturn(USER_ID);
+    when(user.getRoles()).thenReturn(references(roleIds, Entity.ROLE));
+    when(user.getDomains()).thenReturn(references(domainIds, Entity.DOMAIN));
+    when(user.getTeams()).thenReturn(references(teamIds, Entity.TEAM));
+
+    SubjectContext subjectContext = mock(SubjectContext.class);
+    when(subjectContext.user()).thenReturn(user);
+    return subjectContext;
+  }
+
+  private static List<EntityReference> references(List<UUID> ids, String type) {
+    return ids == null
+        ? null
+        : ids.stream().map(id -> new EntityReference().withId(id).withType(type)).toList();
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/security/BotPolicySearchScopeTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/security/BotPolicySearchScopeTest.java
@@ -1,0 +1,150 @@
+package org.openmetadata.service.search.security;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.MetadataOperation;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.search.SearchRepository;
+import org.openmetadata.service.search.opensearch.queries.OpenSearchQueryBuilder;
+import org.openmetadata.service.search.opensearch.queries.OpenSearchQueryBuilderFactory;
+import org.openmetadata.service.search.queries.OMQueryBuilder;
+import org.openmetadata.service.security.policyevaluator.CompiledRule;
+import org.openmetadata.service.security.policyevaluator.SubjectContext;
+import os.org.opensearch.client.opensearch._types.query_dsl.Query;
+
+/**
+ * Pins what each seeded bot's policy compiles to now that bots are no longer exempt from search RBAC
+ * (#30023). Bots skip team policies entirely ({@code SubjectCache#loadPoliciesForUser}), so a bot
+ * compiles from its directly-assigned role alone and never picks up the Organization {@code ViewAll}
+ * that makes every human's allow side {@code match_all}. That makes the per-policy shape the whole
+ * story for blast radius, so a change to any seeded bot policy should fail here rather than in
+ * production.
+ */
+class BotPolicySearchScopeTest {
+
+  private static final String ALL_RESOURCES = "All";
+  private static final String INGESTION_PIPELINE_RESOURCE = "ingestionPipeline";
+  private static final String MATCH_ALL = "match_all";
+
+  private RBACConditionEvaluator evaluator;
+  private User botUser;
+  private SubjectContext botSubject;
+
+  @BeforeEach
+  void setUp() {
+    evaluator = new RBACConditionEvaluator(new OpenSearchQueryBuilderFactory());
+  }
+
+  @Test
+  @DisplayName("A bot on an All/ViewAll policy still sees everything, so stock bots are unaffected")
+  void testUnrestrictedBotPolicyCompilesToMatchAll() {
+    // IngestionBotPolicy, ProfilerBotPolicy, QualityBotPolicy, LineageBotPolicy, UsageBotPolicy,
+    // ApplicationBotPolicy and DataConsumerPolicy (via DefaultBotRole) all have this shape.
+    givenBotWithRules(allowRule(List.of(ALL_RESOURCES), null));
+
+    String query = compiledQuery();
+
+    assertTrue(query.contains(MATCH_ALL), "an unconditioned ViewAll on All resources matches all");
+    assertFalse(query.contains("_index"), "resources 'All' must not add an index filter");
+  }
+
+  @Test
+  @DisplayName(
+      "A bot whose policy names resources is scoped to them, matching its REST permissions")
+  void testResourceScopedBotPolicyCompilesToIndexFilter() {
+    // GovernanceBotRole carries only DefaultBotPolicy, whose sole search-relevant allow is ViewAll
+    // on ingestionPipeline. This is the one seeded bot whose search results narrow.
+    givenBotWithRules(allowRule(List.of(INGESTION_PIPELINE_RESOURCE), null));
+
+    String query = compiledQuery();
+
+    assertTrue(query.contains("_index"), "a named resource compiles to an index filter");
+    assertTrue(query.contains(INGESTION_PIPELINE_RESOURCE.toLowerCase()));
+  }
+
+  @Test
+  @DisplayName("A bot holding the domain-scoped policy is filtered to its own domains (#30023)")
+  void testDomainScopedBotPolicyCompilesToDomainTerms() {
+    UUID ownDomainId = UUID.randomUUID();
+    givenBotWithRules(
+        denyRule(List.of(ALL_RESOURCES), "!hasDomain()"),
+        allowRule(List.of(ALL_RESOURCES), "hasDomain()"));
+    when(botUser.getDomains()).thenReturn(List.of(domainRef(ownDomainId)));
+
+    String query = compiledQuery();
+
+    assertTrue(query.contains("domains.id"), "the subject's domains must reach the query");
+    assertTrue(
+        query.contains(ownDomainId.toString()), "only the subject's own domain id is allowed");
+  }
+
+  private void givenBotWithRules(CompiledRule... rules) {
+    botUser = mock(User.class);
+    EntityReference userReference = mock(EntityReference.class);
+    when(userReference.getId()).thenReturn(UUID.randomUUID());
+    when(botUser.getEntityReference()).thenReturn(userReference);
+    when(botUser.getId()).thenReturn(UUID.randomUUID());
+    when(botUser.getName()).thenReturn("test-bot");
+    when(botUser.getIsBot()).thenReturn(true);
+
+    SubjectContext.PolicyContext policyContext = mock(SubjectContext.PolicyContext.class);
+    when(policyContext.getPolicyName()).thenReturn("TestBotPolicy");
+    when(policyContext.getRules()).thenReturn(List.of(rules));
+
+    botSubject = mock(SubjectContext.class);
+    when(botSubject.isBot()).thenReturn(true);
+    when(botSubject.user()).thenReturn(botUser);
+    when(botSubject.getPolicies(any())).thenReturn(List.of(policyContext).iterator());
+  }
+
+  private String compiledQuery() {
+    try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
+      SearchRepository searchRepository = mock(SearchRepository.class);
+      when(searchRepository.getIndexOrAliasName(anyString()))
+          .thenAnswer(invocation -> invocation.getArgument(0).toString().toLowerCase());
+      when(searchRepository.getChildIndexAliases(anyString())).thenReturn(Collections.emptyList());
+      entityMock.when(Entity::getSearchRepository).thenReturn(searchRepository);
+
+      OMQueryBuilder compiled = evaluator.evaluateConditions(botSubject);
+      Query query = ((OpenSearchQueryBuilder) compiled).build();
+      return query.toJsonString();
+    }
+  }
+
+  private static CompiledRule allowRule(List<String> resources, String condition) {
+    return rule(resources, condition, CompiledRule.Effect.ALLOW);
+  }
+
+  private static CompiledRule denyRule(List<String> resources, String condition) {
+    return rule(resources, condition, CompiledRule.Effect.DENY);
+  }
+
+  private static CompiledRule rule(
+      List<String> resources, String condition, CompiledRule.Effect effect) {
+    CompiledRule compiledRule = mock(CompiledRule.class);
+    when(compiledRule.getResources()).thenReturn(resources);
+    when(compiledRule.getOperations()).thenReturn(List.of(MetadataOperation.VIEW_ALL));
+    when(compiledRule.getCondition()).thenReturn(condition);
+    when(compiledRule.getEffect()).thenReturn(effect);
+    return compiledRule;
+  }
+
+  private static EntityReference domainRef(UUID id) {
+    return new EntityReference().withId(id).withType(Entity.DOMAIN);
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/ElasticSearchVectorServiceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/ElasticSearchVectorServiceTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import es.co.elastic.clients.elasticsearch.ElasticsearchClient;
@@ -47,8 +49,23 @@ class ElasticSearchVectorServiceTest {
 
     mockEmbeddingClient = mock(EmbeddingClient.class);
     when(mockEmbeddingClient.embed(any(String.class))).thenReturn(new float[] {0.1f, 0.2f, 0.3f});
+    when(mockEmbeddingClient.embedQuery(any(String.class)))
+        .thenReturn(new float[] {0.1f, 0.2f, 0.3f});
 
     vectorService = new ElasticSearchVectorService(mockEsClient, mockEmbeddingClient);
+  }
+
+  @Test
+  void searchEmbedsTheQueryAsAQueryNotADocument() throws Exception {
+    // Providers that distinguish the two (Cohere on Bedrock: search_query vs search_document)
+    // return a worse vector for a question embedded as a document, so the query path must not
+    // fall back to embed(). The OpenSearch path has always used embedQuery.
+    mockRestClientResponse(EMPTY_HITS_RESPONSE);
+
+    vectorService.search("test query", Map.of(), 10, 0, 100, 0.0);
+
+    verify(mockEmbeddingClient).embedQuery("test query");
+    verify(mockEmbeddingClient, never()).embed("test query");
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/EmbeddingClientTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/EmbeddingClientTest.java
@@ -3,6 +3,7 @@ package org.openmetadata.service.search.vector;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -14,8 +15,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.service.search.vector.client.EmbeddingClient;
+import org.openmetadata.service.search.vector.client.EmbeddingClient.EmbeddingResult;
+import org.openmetadata.service.search.vector.client.EmbeddingClient.EmbeddingUsage;
 import org.openmetadata.service.search.vector.client.EmbeddingUnavailableException;
 
 class EmbeddingClientTest {
@@ -254,6 +258,230 @@ class EmbeddingClientTest {
         providerCalls.get(),
         "exactly one recovery probe may reach the provider while half-open");
     assertTrue(client.isAvailable());
+  }
+
+  @Test
+  void testUsageListenerDistinguishesQueryFromDocument() {
+    EmbeddingClient client = new MockEmbeddingClient(8);
+    List<Boolean> queryFlags = new ArrayList<>();
+    client.setUsageListener((modelId, text, usage, query) -> queryFlags.add(query));
+
+    client.embed("a document");
+    client.embedQuery("a question");
+
+    assertEquals(List.of(false, true), queryFlags);
+  }
+
+  @Test
+  void testUsageListenerReceivesModelAndText() {
+    EmbeddingClient client = new MockEmbeddingClient(8);
+    AtomicReference<String> seenModel = new AtomicReference<>();
+    AtomicReference<String> seenText = new AtomicReference<>();
+    client.setUsageListener(
+        (modelId, text, usage, query) -> {
+          seenModel.set(modelId);
+          seenText.set(text);
+        });
+
+    client.embed("the exact input");
+
+    assertEquals("mock-model", seenModel.get());
+    assertEquals("the exact input", seenText.get());
+  }
+
+  @Test
+  void testSubclassOverridingOnlyDoEmbedReportsNoUsage() {
+    // Backward compatibility: an existing client that never heard of doEmbedWithUsage still works,
+    // and reports null usage so consumers know to estimate.
+    EmbeddingClient client = new MockEmbeddingClient(8);
+    AtomicReference<EmbeddingUsage> seen = new AtomicReference<>(new EmbeddingUsage(-1L));
+    client.setUsageListener((modelId, text, usage, query) -> seen.set(usage));
+
+    assertEquals(8, client.embed("text").length);
+
+    assertNull(seen.get(), "a client that reports no usage must surface null, not a fabricated 0");
+  }
+
+  @Test
+  void testUsageListenerReceivesProviderReportedUsage() {
+    EmbeddingClient client =
+        new EmbeddingClient() {
+          @Override
+          protected float[] doEmbed(String text) {
+            return new float[] {1.0f};
+          }
+
+          @Override
+          protected EmbeddingResult doEmbedWithUsage(String text, boolean query) {
+            return new EmbeddingResult(new float[] {2.0f}, new EmbeddingUsage(42L));
+          }
+
+          @Override
+          public int getDimension() {
+            return 1;
+          }
+
+          @Override
+          public String getModelId() {
+            return "usage-test";
+          }
+        };
+    AtomicReference<EmbeddingUsage> seen = new AtomicReference<>();
+    client.setUsageListener((modelId, text, usage, query) -> seen.set(usage));
+
+    float[] vector = client.embed("text");
+
+    assertNotNull(seen.get());
+    assertEquals(42L, seen.get().inputTokens());
+    assertEquals(
+        2.0f, vector[0], "the usage-aware path must supply the vector, not the legacy doEmbed");
+  }
+
+  @Test
+  void testUsageListenerNotNotifiedOnFailure() {
+    AtomicInteger calls = new AtomicInteger(0);
+    EmbeddingClient client = failingClient(calls, false);
+    AtomicInteger notifications = new AtomicInteger(0);
+    client.setUsageListener((modelId, text, usage, query) -> notifications.incrementAndGet());
+
+    assertThrows(RuntimeException.class, () -> client.embed("text"));
+
+    assertEquals(0, notifications.get(), "a failed call bills nothing");
+  }
+
+  @Test
+  void testThrowingUsageListenerNeitherFailsEmbedNorOpensCircuit() {
+    // A listener is observability. If a metering bug throws on every call it must not take
+    // embeddings down with it, and must not be mistaken for a provider failure.
+    EmbeddingClient client = new MockEmbeddingClient(8);
+    client.setUsageListener(
+        (modelId, text, usage, query) -> {
+          throw new IllegalStateException("listener is broken");
+        });
+
+    for (int i = 0; i < 6; i++) {
+      assertEquals(8, client.embed("text").length);
+    }
+
+    assertTrue(client.isAvailable(), "listener failures must not count toward the circuit breaker");
+  }
+
+  @Test
+  void embedQueryStillReachesADoEmbedQueryOverride() {
+    // The compatibility guarantee the whole usage hook rests on. Without this, collapsing the
+    // dispatch in embedWithLimit onto doEmbed would pass every other test in this file.
+    EmbeddingClient client =
+        new EmbeddingClient() {
+          @Override
+          protected float[] doEmbed(String text) {
+            return new float[] {1.0f};
+          }
+
+          @Override
+          protected float[] doEmbedQuery(String text) {
+            return new float[] {2.0f};
+          }
+
+          @Override
+          public int getDimension() {
+            return 1;
+          }
+
+          @Override
+          public String getModelId() {
+            return "dispatch-test";
+          }
+        };
+
+    assertEquals(1.0f, client.embed("a document")[0]);
+    assertEquals(
+        2.0f, client.embedQuery("a question")[0], "embedQuery must not collapse onto doEmbed");
+  }
+
+  @Test
+  void listenerSeesTheSubmittedTextNotTheCallersInput() {
+    // Cohere on Bedrock truncates at 2048 chars and reports no usage, so it is the one family that
+    // must be estimated from text — and the one where the caller's string is the wrong string.
+    EmbeddingClient client =
+        new EmbeddingClient() {
+          @Override
+          protected float[] doEmbed(String text) {
+            return new float[] {1.0f};
+          }
+
+          @Override
+          protected EmbeddingResult doEmbedWithUsage(String text, boolean query) {
+            return new EmbeddingResult(new float[] {1.0f}, null, text.substring(0, 2048));
+          }
+
+          @Override
+          public int getDimension() {
+            return 1;
+          }
+
+          @Override
+          public String getModelId() {
+            return "truncating-test";
+          }
+        };
+    AtomicReference<String> seen = new AtomicReference<>();
+    client.setUsageListener((modelId, text, usage, query) -> seen.set(text));
+
+    client.embed("x".repeat(5000));
+
+    assertEquals(
+        2048, seen.get().length(), "estimating from 5000 chars would bill 2952 never sent");
+  }
+
+  @Test
+  void aBlockingListenerDoesNotHoldTheConcurrencyPermit() throws InterruptedException {
+    // The design claim behind notifyUsage living outside invokeProvider. Move it back inside and
+    // this deadlocks on a one-permit client.
+    CountDownLatch listenerEntered = new CountDownLatch(1);
+    CountDownLatch releaseListener = new CountDownLatch(1);
+    AtomicInteger listenerCalls = new AtomicInteger(0);
+    EmbeddingClient client =
+        new EmbeddingClient(1) {
+          @Override
+          protected float[] doEmbed(String text) {
+            return new float[] {1.0f};
+          }
+
+          @Override
+          public int getDimension() {
+            return 1;
+          }
+
+          @Override
+          public String getModelId() {
+            return "permit-test";
+          }
+        };
+    client.setUsageListener(
+        (modelId, text, usage, query) -> {
+          if (listenerCalls.incrementAndGet() == 1) {
+            listenerEntered.countDown();
+            try {
+              releaseListener.await();
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            }
+          }
+        });
+
+    ExecutorService pool = Executors.newSingleThreadExecutor();
+    try {
+      CompletableFuture<float[]> blocked =
+          CompletableFuture.supplyAsync(() -> client.embed("first"), pool);
+      assertTrue(listenerEntered.await(2, TimeUnit.SECONDS), "the listener should be reached");
+
+      assertNotNull(client.embed("second"), "a blocked listener must not hold the only permit");
+
+      releaseListener.countDown();
+      assertNotNull(blocked.join());
+    } finally {
+      pool.shutdown();
+    }
   }
 
   private static EmbeddingClient failingClient(AtomicInteger calls, boolean permanent) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/client/BedrockEmbeddingClientTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/client/BedrockEmbeddingClientTest.java
@@ -3,6 +3,8 @@ package org.openmetadata.service.search.vector.client;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -15,6 +17,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.service.search.vector.client.BedrockEmbeddingClient.BedrockEmbeddingFamily;
+import org.openmetadata.service.search.vector.client.EmbeddingClient.EmbeddingResult;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelRequest;
@@ -227,6 +230,51 @@ class BedrockEmbeddingClientTest {
         BedrockEmbeddingClient.parseEmbeddingResponse(
             BedrockEmbeddingFamily.COHERE, "{\"embeddings\":{\"float\":[[0.4,0.5]]}}");
     assertArrayEquals(new float[] {0.4f, 0.5f}, embedding, DELTA);
+  }
+
+  @Test
+  void titanResponseReportsInputTokens() {
+    EmbeddingResult result =
+        BedrockEmbeddingClient.parseEmbeddingResult(
+            BedrockEmbeddingFamily.TITAN_V2,
+            "{\"embedding\":[0.6,0.7],\"inputTextTokenCount\":2}",
+            null);
+
+    assertArrayEquals(new float[] {0.6f, 0.7f}, result.vector(), DELTA);
+    assertNotNull(result.usage());
+    assertEquals(2L, result.usage().inputTokens());
+  }
+
+  @Test
+  void titanV1ResponseReportsInputTokens() {
+    EmbeddingResult result =
+        BedrockEmbeddingClient.parseEmbeddingResult(
+            BedrockEmbeddingFamily.TITAN_V1,
+            "{\"embedding\":[0.1],\"inputTextTokenCount\":17}",
+            null);
+
+    assertNotNull(result.usage());
+    assertEquals(17L, result.usage().inputTokens());
+  }
+
+  @Test
+  void titanResponseWithoutTokenCountReportsNoUsage() {
+    EmbeddingResult result =
+        BedrockEmbeddingClient.parseEmbeddingResult(
+            BedrockEmbeddingFamily.TITAN_V2, "{\"embedding\":[0.6,0.7]}", null);
+
+    assertNull(result.usage(), "an absent count must stay absent rather than becoming 0");
+  }
+
+  @Test
+  void cohereResponseReportsNoUsage() {
+    // Cohere on Bedrock returns no token count at all, so consumers must estimate one.
+    EmbeddingResult result =
+        BedrockEmbeddingClient.parseEmbeddingResult(
+            BedrockEmbeddingFamily.COHERE, "{\"embeddings\":[[0.1,0.2,0.3]]}", null);
+
+    assertArrayEquals(new float[] {0.1f, 0.2f, 0.3f}, result.vector(), DELTA);
+    assertNull(result.usage());
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/client/OpenAIEmbeddingClientTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/client/OpenAIEmbeddingClientTest.java
@@ -2,6 +2,7 @@ package org.openmetadata.service.search.vector.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -19,12 +20,14 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLSession;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.configuration.LLMConfiguration;
 import org.openmetadata.schema.configuration.LLMEmbeddingsConfig;
 import org.openmetadata.schema.configuration.LLMOpenAIConfig;
 import org.openmetadata.schema.configuration.LLMOpenAIEmbeddingConfig;
+import org.openmetadata.service.search.vector.client.EmbeddingClient.EmbeddingUsage;
 
 class OpenAIEmbeddingClientTest {
 
@@ -530,6 +533,38 @@ class OpenAIEmbeddingClientTest {
     assertEquals(0.1f, embedding[0], 0.001f);
     assertEquals(0.2f, embedding[1], 0.001f);
     assertEquals(0.3f, embedding[2], 0.001f);
+  }
+
+  @Test
+  void testUsageListenerReceivesPromptTokens() {
+    String response =
+        "{\"data\":[{\"embedding\":[0.1]}],\"model\":\"test\",\"usage\":{\"prompt_tokens\":7}}";
+    StubHttpClient httpClient = new StubHttpClient(response, 200);
+    OpenAIEmbeddingClient client =
+        new OpenAIEmbeddingClient(
+            httpClient, "test-key", "test-model", 1, "http://localhost/v1/embeddings", false);
+    AtomicReference<EmbeddingUsage> seen = new AtomicReference<>();
+    client.setUsageListener((modelId, text, usage, query) -> seen.set(usage));
+
+    client.embed("hello world");
+
+    assertNotNull(seen.get());
+    assertEquals(7L, seen.get().inputTokens());
+  }
+
+  @Test
+  void testEmptyUsageBlockReportsNoUsage() {
+    String response = "{\"data\":[{\"embedding\":[0.1]}],\"model\":\"test\",\"usage\":{}}";
+    StubHttpClient httpClient = new StubHttpClient(response, 200);
+    OpenAIEmbeddingClient client =
+        new OpenAIEmbeddingClient(
+            httpClient, "test-key", "test-model", 1, "http://localhost/v1/embeddings", false);
+    AtomicReference<EmbeddingUsage> seen = new AtomicReference<>(new EmbeddingUsage(-1L));
+    client.setUsageListener((modelId, text, usage, query) -> seen.set(usage));
+
+    client.embed("hello world");
+
+    assertNull(seen.get(), "an empty usage block must not become a fabricated 0");
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/DomainAccessFilterTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/DomainAccessFilterTest.java
@@ -40,7 +40,7 @@ class DomainAccessFilterTest {
   private static final String FOREIGN_DOMAIN = "Finance";
 
   @Test
-  @DisplayName("shouldApply: only non-admin, non-bot subjects holding DomainOnlyAccessRole")
+  @DisplayName("shouldApply: only non-admin subjects holding DomainOnlyAccessRole")
   void testShouldApply() {
     assertFalse(DomainAccessFilter.shouldApply(null), "a null subject narrows nothing");
     assertTrue(DomainAccessFilter.shouldApply(restrictedSubject(OWN_DOMAIN)));
@@ -48,9 +48,23 @@ class DomainAccessFilterTest {
 
     User admin = restrictedUser(OWN_DOMAIN).withIsAdmin(true);
     assertFalse(DomainAccessFilter.shouldApply(new SubjectContext(admin, null)));
+  }
 
-    User bot = restrictedUser(OWN_DOMAIN).withIsBot(true);
-    assertFalse(DomainAccessFilter.shouldApply(new SubjectContext(bot, null)));
+  @Test
+  @DisplayName("shouldApply: a bot holding the role is narrowed like any other subject (#30023)")
+  void testShouldApplyToBots() {
+    User restrictedBot = restrictedUser(OWN_DOMAIN).withIsBot(true);
+    assertTrue(
+        DomainAccessFilter.shouldApply(new SubjectContext(restrictedBot, null)),
+        "a bot assigned DomainOnlyAccessRole must be narrowed, not exempted");
+
+    User plainBot = userWithoutRole().withIsBot(true);
+    assertFalse(
+        DomainAccessFilter.shouldApply(new SubjectContext(plainBot, null)),
+        "a bot without the role is untouched, so stock bots keep their current view");
+
+    User adminBot = restrictedUser(OWN_DOMAIN).withIsBot(true).withIsAdmin(true);
+    assertFalse(DomainAccessFilter.shouldApply(new SubjectContext(adminBot, null)));
   }
 
   @Test
@@ -144,7 +158,11 @@ class DomainAccessFilterTest {
   }
 
   private SubjectContext subjectWithoutRole() {
-    return new SubjectContext(new User().withName("plain").withDomains(List.of()), null);
+    return new SubjectContext(userWithoutRole(), null);
+  }
+
+  private User userWithoutRole() {
+    return new User().withName("plain").withDomains(List.of());
   }
 
   private User restrictedUser(String... domains) {

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/mcp/mcpConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/mcp/mcpConnection.json
@@ -27,7 +27,7 @@
       "type": "string",
       "enum": ["Stdio", "SSE", "StreamableHTTP"],
       "javaEnums": [
-        {"name": "Stdio", "description": "Standard input/output transport - spawns a subprocess"},
+        {"name": "Stdio", "description": "Deprecated and unsupported. Stdio transport has been removed; use SSE or StreamableHTTP with a URL."},
         {"name": "SSE", "description": "Server-Sent Events transport over HTTP"},
         {"name": "StreamableHTTP", "description": "Streamable HTTP transport"}
       ]
@@ -46,17 +46,17 @@
         },
         "command": {
           "type": "string",
-          "description": "Command to execute for Stdio transport (e.g., 'npx', 'uvx', 'python')"
+          "description": "Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url' instead."
         },
         "args": {
           "type": "array",
           "items": {"type": "string"},
-          "description": "Arguments to pass to the command"
+          "description": "Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url' instead."
         },
         "env": {
           "type": "object",
           "additionalProperties": {"type": "string"},
-          "description": "Environment variables for the server process"
+          "description": "Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url' instead."
         },
         "url": {
           "type": "string",

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createMcpService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createMcpService.ts
@@ -146,15 +146,18 @@ export interface MCPServerConfig {
      */
     apiKey?: string;
     /**
-     * Arguments to pass to the command
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     args?: string[];
     /**
-     * Command to execute for Stdio transport (e.g., 'npx', 'uvx', 'python')
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     command?: string;
     /**
-     * Environment variables for the server process
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     env?: { [key: string]: string };
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
@@ -7653,15 +7653,18 @@ export interface MCPServerConfig {
      */
     apiKey?: string;
     /**
-     * Arguments to pass to the command
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     args?: string[];
     /**
-     * Command to execute for Stdio transport (e.g., 'npx', 'uvx', 'python')
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     command?: string;
     /**
-     * Environment variables for the server process
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     env?: { [key: string]: string };
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/mcp/mcpConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/mcp/mcpConnection.ts
@@ -99,15 +99,18 @@ export interface MCPServerConfig {
      */
     apiKey?: string;
     /**
-     * Arguments to pass to the command
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     args?: string[];
     /**
-     * Command to execute for Stdio transport (e.g., 'npx', 'uvx', 'python')
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     command?: string;
     /**
-     * Environment variables for the server process
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     env?: { [key: string]: string };
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
@@ -4878,15 +4878,18 @@ export interface MCPServerConfig {
      */
     apiKey?: string;
     /**
-     * Arguments to pass to the command
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     args?: string[];
     /**
-     * Command to execute for Stdio transport (e.g., 'npx', 'uvx', 'python')
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     command?: string;
     /**
-     * Environment variables for the server process
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     env?: { [key: string]: string };
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
@@ -8121,15 +8121,18 @@ export interface MCPServerConfig {
      */
     apiKey?: string;
     /**
-     * Arguments to pass to the command
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     args?: string[];
     /**
-     * Command to execute for Stdio transport (e.g., 'npx', 'uvx', 'python')
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     command?: string;
     /**
-     * Environment variables for the server process
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     env?: { [key: string]: string };
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/serviceProgressEvent.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/serviceProgressEvent.ts
@@ -8252,15 +8252,18 @@ export interface MCPServerConfig {
      */
     apiKey?: string;
     /**
-     * Arguments to pass to the command
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     args?: string[];
     /**
-     * Command to execute for Stdio transport (e.g., 'npx', 'uvx', 'python')
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     command?: string;
     /**
-     * Environment variables for the server process
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     env?: { [key: string]: string };
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/mcpService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/mcpService.ts
@@ -267,15 +267,18 @@ export interface MCPServerConfig {
      */
     apiKey?: string;
     /**
-     * Arguments to pass to the command
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     args?: string[];
     /**
-     * Command to execute for Stdio transport (e.g., 'npx', 'uvx', 'python')
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     command?: string;
     /**
-     * Environment variables for the server process
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     env?: { [key: string]: string };
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
@@ -4976,15 +4976,18 @@ export interface MCPServerConfig {
      */
     apiKey?: string;
     /**
-     * Arguments to pass to the command
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     args?: string[];
     /**
-     * Command to execute for Stdio transport (e.g., 'npx', 'uvx', 'python')
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     command?: string;
     /**
-     * Environment variables for the server process
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     env?: { [key: string]: string };
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
@@ -4999,15 +4999,18 @@ export interface MCPServerConfig {
      */
     apiKey?: string;
     /**
-     * Arguments to pass to the command
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     args?: string[];
     /**
-     * Command to execute for Stdio transport (e.g., 'npx', 'uvx', 'python')
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     command?: string;
     /**
-     * Environment variables for the server process
+     * Deprecated: Stdio transport has been removed; run the server over HTTP and set 'url'
+     * instead.
      */
     env?: { [key: string]: string };
     /**


### PR DESCRIPTION
### Describe your changes:

Backport of 5 already-merged `main` commits to `2.0`. No new code.

Original PRs: #32226, #32552, #32460 (Fixes #30023), #32553, #32342

| Commit | Original | What it does |
|---|---|---|
| `e2f258207e` | #32226 | Fix MCP entity patch lifecycle handling |
| `c5b69338f8` | #32552 | Report embedding token usage instead of discarding it |
| `756547db49` | #32460 | Apply the caller's policies to bot searches |
| `7b79ff8f84` | #32553 | Embed ElasticSearch semantic search queries as queries, not documents |
| `7f2b4b3863` | #32342 | Use HTTP transport for the MCP connector |

Notes:

- #32465 is not here, it already landed on `2.0` in #32973.
- `PatchEntityToolTest.java` had an import-only conflict (#32465 landed before #32226 on this branch). Resolved file is byte-identical to `main`.
- `client.py` keeps `2.0`'s existing `Optional[...]` typing style rather than pulling in the unrelated ruff modernization that only `main` has.
- 5 files from #32342 were dropped, they are generated at build time on `2.0` and not tracked: `ingestion/.ruff-g004-baseline.json`, `public/jsons/connectionSchemas/{mcp/mcpConnection,serviceConnection}.json`, `src/jsons/ingestionSchemas/{testSuitePipeline,workflow}.json`.
- The `mcpConnection.json` change is description text only, no migration needed.

### Type of change:

- [x] Bug fix

### Tests:

Tests came with the backported commits. Run on this branch: 317 pass, 0 fail (52 in `openmetadata-mcp`, 265 in `openmetadata-service`). `mvn spotless:check` clean, `ruff check` and `ruff format --check` clean on the changed ingestion files. `DomainIsolationIT` compiles but was not executed locally. Python unit tests not run locally, CI is the gate.

No UI changes beyond generated TypeScript types, so no Playwright tests or screen recording.
