### PR TITLE
fix(ingestion): unbreak static-checks on 1.13 for the Astra token read

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/cassandra/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/cassandra/connection.py
@@ -55,7 +55,7 @@ def get_connection(connection: CassandraConnection):
     cluster_config = {}
     if hasattr(connection.authType, "cloudConfig"):
         cloud_config = connection.authType.cloudConfig
-        token = cloud_config.token
+        token = cloud_config.token  # pyright: ignore[reportOptionalMemberAccess]
         cluster_cloud_config = {
             "connect_timeout": cloud_config.connectTimeout,
             "use_default_tempdir": True,


### PR DESCRIPTION
### Describe your changes:

`python / Unit Tests & Static Checks (3.10)` is failing on **every** PR targeting `1.13`, not just one — [#32984](https://github.com/open-metadata/OpenMetadata/pull/32984) and [#32937](https://github.com/open-metadata/OpenMetadata/pull/32937) both report the identical error, and neither touches Cassandra:

```
ingestion/src/metadata/ingestion/source/database/cassandra/connection.py:58:30
  - error: "token" is not a known attribute of "None" (reportOptionalMemberAccess)
Error: 1 error
nox > Session static-checks failed.
```

**Cause.** #32892 ("Improve Domo and Astra connection configuration") added a new line to the Cassandra cloud path:

```python
 cloud_config = connection.authType.cloudConfig
+token = cloud_config.token
```

`CassandraConnection.authType` is `BasicAuth | CloudConfig | None`, and `CloudConfig.cloudConfig` is itself `CloudConfig1 | None` (defaulted to `None`). `hasattr(connection.authType, "cloudConfig")` narrows the *union member* but proves nothing about the *value*, so the access is genuinely `Optional`.

The sibling accesses on the lines just below (`cloud_config.connectTimeout`, `.secureConnectBundle`, `.requestTimeout`) do not fail, because they are already in `.basedpyright/baseline.json`. The baseline matches by `(code, startColumn, endColumn, lineCount)` rather than by line number, so the new read — at a column no existing entry covers — is unbaselined. `--baselinemode=discard` fails on any new error, hence the branch-wide breakage.

**Fix.** Suppress it exactly the way `main` already suppresses this same block — an inline `# pyright: ignore[reportOptionalMemberAccess]`. `main` carries these annotations on every access in this branch of the function; the 1.13 backport dropped them. Porting `main`'s structure wholesale isn't possible (it has since moved this into `BaseConnection._get_client`), so the annotation is the portable part.

`reportUnnecessaryTypeIgnoreComment = false` in `ingestion/pyproject.toml`, so this cannot itself become a finding.

No runtime change — one comment on one line.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — one-line CI unblock.

#
### Tests:

#### Use cases covered
- `nox -s static-checks` passes on `1.13` again, unblocking all open PRs against the branch

#### Unit tests
No new test — the change is a type-checker annotation with no runtime behaviour. The regression is caught by the existing `static-checks` session, which is what this restores.

Verified locally with the exact CI command (`basedpyright -p pyproject.toml --baselinefile .basedpyright/baseline.json --baselinemode=discard`), with `cassandra-driver==3.30.1` installed to match the runner:

```
### BEFORE (fix reverted)
  .../cassandra/connection.py:58:30 - error: "token" is not a known attribute of "None" (reportOptionalMemberAccess)

### AFTER (with fix)
  (no findings for this file)
```

Exactly one error removed, none added. `black==22.3.0` (the pinned version) leaves the file unchanged; the line is 81 chars against pylint's `max-line-length = 120`.

#### Integration tests
N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Z6H2Crk88aujoBtrELGJK