### PR TITLE
Backport #32366 to 1.13.5: stop catalog.log duplicating every rotated openmetadata.log line

### DIFF
--- a/bin/openmetadata-server-start.sh
+++ b/bin/openmetadata-server-start.sh
@@ -122,6 +122,10 @@ APP_CLASS="org.openmetadata.service.OpenMetadataApplication"
 
 # Launch mode
 if [ "x$DAEMON_MODE" = "xtrue" ]; then
+    # $CONSOLE_OUTPUT_FILE has no rotation, and the console appender in conf/openmetadata.yaml
+    # emits what logback already writes to the rotated logs/openmetadata.log. Silence the console
+    # so this file only collects JVM and pre-logback output. CONSOLE_LOG_LEVEL=TRACE restores it.
+    export CONSOLE_LOG_LEVEL="${CONSOLE_LOG_LEVEL:-OFF}"
     nohup $JAVA $OPENMETADATA_HEAP_OPTS $OPENMETADATA_JVM_PERFORMANCE_OPTS $OPENMETADATA_GC_LOG_OPTS -cp $CLASSPATH $OPENMETADATA_OPTS "$APP_CLASS" "server" "$@" > "$CONSOLE_OUTPUT_FILE" 2>&1 < /dev/null &
 else
     exec $JAVA $OPENMETADATA_HEAP_OPTS $OPENMETADATA_JVM_PERFORMANCE_OPTS $OPENMETADATA_GC_LOG_OPTS -cp $CLASSPATH $OPENMETADATA_OPTS "$APP_CLASS" "server" "$@"

--- a/bin/openmetadata.sh
+++ b/bin/openmetadata.sh
@@ -13,8 +13,6 @@
 # Home Dir
 base_dir=$(dirname $0)/..
 
-CATALOG_HOME=$base_dirbase_dir=$(dirname $0)/..
-
 CATALOG_HOME=$base_dir
 PID_DIR=$base_dir/logs
 LOG_DIR=$base_dir/logs
@@ -31,6 +29,12 @@ function catalogStart {
        rm -f ${PID_FILE}
        echo "Starting OpenMetadata"
        APP_CLASS="org.openmetadata.service.OpenMetadataApplication"
+       # ${OUT_FILE} is an append-mode redirect with no rotation. The console appender in
+       # conf/openmetadata.yaml emits the same lines that logback already writes to the rotated
+       # logs/openmetadata.log, so leaving it on makes catalog.log an unbounded duplicate.
+       # Silence it here; catalog.log then only collects JVM and pre-logback output.
+       # Export CONSOLE_LOG_LEVEL=TRACE before starting to get the old behaviour back.
+       export CONSOLE_LOG_LEVEL="${CONSOLE_LOG_LEVEL:-OFF}"
        cd ${CATALOG_HOME}
        nohup ${JAVA} ${CATALOG_HEAP_OPTS} ${CATALOG_JVM_PERF_OPTS} ${CATALOG_DEBUG_OPTS} ${CATALOG_GC_LOG_OPTS} ${CATALOG_JMX_OPTS} -cp ${CLASSPATH} "${APP_CLASS}" "server" "$@" 2>>"${ERR_FILE}" 1>>"${OUT_FILE}" &
        cd - &> /dev/null

--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -215,8 +215,12 @@ logging:
           timeZone: UTC
           maxFileSize: 50MB
   appenders:
+    # Containers keep this on — stdout is how `docker logs` / `kubectl logs` see the server.
+    # `bin/openmetadata.sh start` exports CONSOLE_LOG_LEVEL=OFF instead, because it redirects
+    # stdout into logs/catalog.log, which has no rotation: leaving the console on there duplicates
+    # every rotated logs/openmetadata.log line into a file that grows for the life of the install.
     - type: console
-      threshold: TRACE
+      threshold: ${CONSOLE_LOG_LEVEL:-TRACE}
       timeZone: UTC
       layout:
         type: om-event-layout

--- a/openmetadata-service/src/test/java/org/openmetadata/service/config/LoggingConfigurationYamlTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/config/LoggingConfigurationYamlTest.java
@@ -14,6 +14,9 @@
 package org.openmetadata.service.config;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
@@ -21,10 +24,13 @@ import io.dropwizard.configuration.FileConfigurationSourceProvider;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
+import io.dropwizard.logging.common.ConsoleAppenderFactory;
+import io.dropwizard.logging.common.DefaultLoggingFactory;
 import jakarta.validation.Validation;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.events.AuditExcludeFilterFactory;
@@ -33,9 +39,12 @@ import org.openmetadata.service.logging.SwitchableAccessLayoutFactory;
 import org.openmetadata.service.logging.SwitchableEventLayoutFactory;
 
 class LoggingConfigurationYamlTest {
+  private static final String SHIPPED_CONFIG = "../conf/openmetadata.yaml";
+  private static final String LOG_FORMAT_PLACEHOLDER = "${LOG_FORMAT:-text}";
+  private static final String CONSOLE_LEVEL_PLACEHOLDER = "${CONSOLE_LOG_LEVEL:-TRACE}";
   private static final List<String> CONFIG_PATHS =
       List.of(
-          "../conf/openmetadata.yaml",
+          SHIPPED_CONFIG,
           "../docker/development/distributed-test/local/server1.yaml",
           "../docker/development/distributed-test/local/server2.yaml",
           "../docker/development/distributed-test/local/server3.yaml",
@@ -55,11 +64,51 @@ class LoggingConfigurationYamlTest {
     }
   }
 
+  /**
+   * On bare metal {@code bin/openmetadata.sh start} appends stdout to {@code logs/catalog.log},
+   * which nothing rotates. The console appender emits the same lines logback already writes to the
+   * rotated {@code logs/openmetadata.log}, so leaving the console on makes that file an unbounded
+   * duplicate — one reported install reached 20M lines going back two years.
+   *
+   * <p>The fix is a pair: the yaml reads its console threshold from {@code CONSOLE_LOG_LEVEL} and
+   * the start script exports it. Either half alone is a silent no-op, so assert both. {@code
+   * DefaultLoggingFactory.toLevel} degrades an unrecognised value to INFO without complaint, which
+   * is why the parsed level is asserted rather than the yaml text.
+   */
+  @Test
+  void bareMetalStartScriptSilencesTheConsoleAppender() throws Exception {
+    assumeTrue(
+        System.getenv("CONSOLE_LOG_LEVEL") == null,
+        "CONSOLE_LOG_LEVEL overrides the shipped value");
+
+    assertEquals("TRACE", consoleThreshold(parse(SHIPPED_CONFIG)));
+    assertEquals("OFF", consoleThreshold(parse(SHIPPED_CONFIG, CONSOLE_LEVEL_PLACEHOLDER, "OFF")));
+    assertTrue(
+        Pattern.compile("export\\s+CONSOLE_LOG_LEVEL=.*:-OFF")
+            .matcher(Files.readString(Path.of("../bin/openmetadata.sh")))
+            .find(),
+        "bin/openmetadata.sh must silence the console appender it redirects into catalog.log");
+  }
+
+  private String consoleThreshold(OpenMetadataApplicationConfig config) {
+    return ((DefaultLoggingFactory) config.getLoggingFactory())
+        .getAppenders().stream()
+            .filter(ConsoleAppenderFactory.class::isInstance)
+            .map(appender -> ((ConsoleAppenderFactory<?>) appender).getThreshold())
+            .findFirst()
+            .orElseThrow();
+  }
+
   private OpenMetadataApplicationConfig parse(String path) throws Exception {
-    return parse(path, null);
+    return parse(path, LOG_FORMAT_PLACEHOLDER, null);
   }
 
   private OpenMetadataApplicationConfig parse(String path, String formatOverride) throws Exception {
+    return parse(path, LOG_FORMAT_PLACEHOLDER, formatOverride);
+  }
+
+  private OpenMetadataApplicationConfig parse(String path, String placeholder, String replacement)
+      throws Exception {
     ObjectMapper objectMapper = Jackson.newObjectMapper();
     objectMapper.registerSubtypes(
         AuditExcludeFilterFactory.class,
@@ -73,7 +122,7 @@ class LoggingConfigurationYamlTest {
             objectMapper,
             "dw");
 
-    if (formatOverride == null) {
+    if (replacement == null) {
       return factory.build(
           new SubstitutingSourceProvider(
               new FileConfigurationSourceProvider(), new EnvironmentVariableSubstitutor(false)),
@@ -83,7 +132,7 @@ class LoggingConfigurationYamlTest {
     Path tempFile = Files.createTempFile("logging-config-", ".yaml");
     try {
       Files.writeString(
-          tempFile, Files.readString(Path.of(path)).replace("${LOG_FORMAT:-text}", formatOverride));
+          tempFile, Files.readString(Path.of(path)).replace(placeholder, replacement));
       return factory.build(
           new SubstitutingSourceProvider(
               new FileConfigurationSourceProvider(), new EnvironmentVariableSubstitutor(false)),


### PR DESCRIPTION
Backport of #32366 (issue #32365) to `1.13.5`. Cherry-pick of fcc64e2 — applied cleanly, no conflicts.

## What it does

`catalog.log` is a byte-for-byte duplicate of `logs/openmetadata.log`: the root console appender is `threshold: TRACE`, so every line logback writes to the rotated file also goes to stdout, and `bin/openmetadata.sh start` appends stdout to `logs/catalog.log` — which nothing rotates, so it grows for the life of the deployment.

The console threshold now reads `CONSOLE_LOG_LEVEL`, and the two daemon launch paths that tee stdout into an unrotated file export it as `OFF`:

| Path | Console | Why |
|---|---|---|
| `openmetadata-server-start.sh` (no flags → `exec`) | **on** | stdout is how `docker logs` / `kubectl logs` see the server |
| `openmetadata.sh start` → `1>>logs/catalog.log` | **off** | already captured, rotated, in `openmetadata.log` |
| `openmetadata-server-start.sh -daemon` → `> logs/OpenMetadataServer.out` | **off** | same |

`CONSOLE_LOG_LEVEL=TRACE` restores the old behaviour. `openmetadata.log` and `audit.log` unchanged.

Collate half: open-metadata/openmetadata-collate#6316 → its 1.13.5 backport. The two must stay in step — Collate forks `conf/openmetadata.yaml` and both `bin/` scripts.

## Tests

```
mvn -pl openmetadata-service -Dtest=LoggingConfigurationYamlTest test
→ Tests run: 3, Failures: 0, Errors: 0 — BUILD SUCCESS
```

Includes the backported `bareMetalStartScriptSilencesTheConsoleAppender`, which asserts both halves of the pair (the shipped yaml resolves to `TRACE` by default and `OFF` when the variable is set, *and* `bin/openmetadata.sh` actually exports it) — either half alone is a silent no-op, and `DefaultLoggingFactory.toLevel` degrades an unrecognised level to `INFO` without complaining.

Also verified all three launch paths on this branch against a stub `java` that echoes its environment:

```
openmetadata.sh start                  → CONSOLE_LOG_LEVEL=[OFF]
server-start.sh -daemon                → CONSOLE_LOG_LEVEL=[OFF]
server-start.sh (container exec path)  → CONSOLE_LOG_LEVEL=[<unset>]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)