### PR TITLE
docs: say why quoteName only quotes names containing a dot

### DIFF
--- a/openmetadata-spec/src/main/java/org/openmetadata/schema/utils/EntityInterfaceUtil.java
+++ b/openmetadata-spec/src/main/java/org/openmetadata/schema/utils/EntityInterfaceUtil.java
@@ -1,5 +1,10 @@
 package org.openmetadata.schema.utils;
 
+/**
+ * Quoting helpers for entity names. A name is quoted only when it contains a {@code .}, because an
+ * unquoted dot would otherwise be read as a separator when the name is composed into a fully
+ * qualified name.
+ */
 public final class EntityInterfaceUtil {
   /** Adds quotes to name as required */
   // TODO change this FullyQualifiedName


### PR DESCRIPTION
One javadoc block on `EntityInterfaceUtil`. The `name.contains(".")` condition reads as arbitrary without the reason: an unquoted dot is taken as a separator once the name is composed into a fully qualified name, so only those names need quoting.

---

### 🧪 Also a smoke test for the backport pipeline

This is deliberately a **comment-only change to a file that is byte-identical on `main`, `1.13` and `2.0`**, so the cherry-pick applies cleanly to both release branches and exercises the happy path end to end.

**Do not label this until #32985 has merged** — the pipeline it tests doesn't exist yet.

Then add `To release` and merge. Expected:

1. `To release` is authorised against org membership ✅
2. Two backport PRs open, against `1.13` and `2.0`, each assigned to you and marked "Clean cherry-pick"
3. CI runs on both
4. Both merge themselves; each comments "All checks passed — merged automatically"

Nothing should need a human.

**Note for this repo:** `Validate PR Metadata` will fail on *this* PR because no issue is linked. Backport PRs skip that check (they're bot-authored), but this one isn't — link an issue or add `skip-pr-checks` before merging.

Sibling smoke tests: open-metadata/openmetadata-collate#6471 and open-metadata/ai-platform#1284, so all three repos can be exercised from one label each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)