### PR TITLE
Fixes #32976: Omni owners and lineage resolution

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/omni/client.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/omni/client.py
@@ -38,7 +38,9 @@ from metadata.ingestion.source.dashboard.omni.models import (
     OmniModel,
     OmniQuery,
     OmniTopic,
+    OmniUser,
     QueryPresentation,
+    UsersResponse,
 )
 from metadata.utils.constants import AUTHORIZATION_HEADER
 from metadata.utils.helpers import clean_uri
@@ -47,6 +49,10 @@ from metadata.utils.logger import ingestion_logger
 logger = ingestion_logger()
 
 PAGE_SIZE = 100
+# The user directory is only exposed over SCIM, which is mounted next to the
+# versioned REST API rather than under it.
+SCIM_API_VERSION = "scim/v2"
+SCIM_PAGE_SIZE = 100
 # Only the shared semantic-layer model(s) carry the real views/topics. The other
 # model kinds (QUERY, WORKBOOK, BRANCH, SCHEMA) are per-document and would explode
 # the number of API calls against the 60 req/min rate limit.
@@ -59,10 +65,24 @@ _TABLE_KEYS = ("sql_table_name", "table_name", "table", "sql_table")
 _SCHEMA_KEYS = ("schema", "schema_name")
 
 
+def canonical_ref(ref: str) -> str:
+    """
+    Canonicalize an Omni object reference so every spelling compares equal.
+
+    Omni qualifies a reference with ``.``, ``/`` or ``__`` and always spells the
+    schema part in lower case (``revenues__all_revenues``), while the model YAML
+    paths carry the warehouse's own casing (``REVENUES/all_revenues.view``). A
+    single underscore is a valid identifier character, so only the double
+    underscore is treated as a separator.
+    """
+    return ref.replace("__", ".").replace("/", ".").casefold()
+
+
 class OmniApiClient:
     """REST client wrapper for the Omni API."""
 
     client: TrackedREST
+    scim_client: TrackedREST
 
     def __init__(self, config: OmniConnection, verify_ssl: bool | str | None = None):
         self.config = config
@@ -73,10 +93,14 @@ class OmniApiClient:
         base_url = clean_uri(str(config.hostPort)).rstrip("/")
         base_url = re.sub(r"/api(/v\d+)?$", "", base_url)
         base_url = f"{base_url}/api"
-        client_config = ClientConfig(
+        self.client = TrackedREST(self._client_config(base_url, "v1", verify_ssl), source_name="omni")
+        self.scim_client = TrackedREST(self._client_config(base_url, SCIM_API_VERSION, verify_ssl), source_name="omni")
+
+    def _client_config(self, base_url: str, api_version: str, verify_ssl: bool | str | None) -> ClientConfig:
+        return ClientConfig(
             base_url=base_url,
-            api_version="v1",
-            auth_token=lambda: (config.token.get_secret_value(), 0),
+            api_version=api_version,
+            auth_token=lambda: (self.config.token.get_secret_value(), 0),
             auth_header=AUTHORIZATION_HEADER,
             auth_token_mode="Bearer",
             extra_headers={"Content-Type": "application/json"},
@@ -87,13 +111,13 @@ class OmniApiClient:
             retry_codes=[429, 500, 502, 503],
             limit_codes=[],
         )
-        self.client = TrackedREST(client_config, source_name="omni")
 
     def close(self) -> None:
-        """Close the underlying HTTP session, if the REST client exposes one."""
-        close_fn = getattr(self.client, "close", None)
-        if callable(close_fn):
-            close_fn()
+        """Close the underlying HTTP sessions, if the REST clients expose one."""
+        for client in (self.client, self.scim_client):
+            close_fn = getattr(client, "close", None)
+            if callable(close_fn):
+                close_fn()
 
     # -- pagination ---------------------------------------------------------
 
@@ -248,22 +272,24 @@ class OmniApiClient:
                 leaf = base[: -len(".view")]
                 parsed = cls._parse_view(content)
                 view_records.append((leaf, parsed))
-                # Full and dotted-qualified keys are unique; the bare leaf is only
-                # keyed while unambiguous. If two view files share a leaf, drop the
-                # bare key so a bare reference misses (skipping lineage) instead of
-                # resolving to the wrong physical view.
-                view_lookup[full] = parsed
-                view_lookup[full.replace("/", ".")] = parsed
-                if leaf in leaf_seen:
-                    view_lookup.pop(leaf, None)
+                # Keys are canonicalized so a reference resolves regardless of the
+                # separator or the casing the model YAML path happens to use. The
+                # qualified key is unique; the bare leaf is only keyed while
+                # unambiguous. If two view files share a leaf, drop the bare key so
+                # a bare reference misses (skipping lineage) instead of resolving to
+                # the wrong physical view.
+                leaf_key = canonical_ref(leaf)
+                view_lookup[canonical_ref(full)] = parsed
+                if leaf_key in leaf_seen:
+                    view_lookup.pop(leaf_key, None)
                     logger.debug(
                         "View leaf %r is ambiguous in model %s; a qualified reference is required",
                         leaf,
                         model.id,
                     )
                 else:
-                    leaf_seen.add(leaf)
-                    view_lookup[leaf] = parsed
+                    leaf_seen.add(leaf_key)
+                    view_lookup.setdefault(leaf_key, parsed)
             elif filename.endswith(".topic"):
                 topic_defs[base[: -len(".topic")]] = content
 
@@ -279,13 +305,10 @@ class OmniApiClient:
                 continue
             seen_names.add(topic_name)
             base_view = cls._first(topic_def, _BASE_VIEW_KEYS) or topic_name
-            # ``base_view`` may be bare or schema-qualified with ``.``, ``/`` or
-            # ``__`` (per Omni's data-lineage docs); try the raw value and a
-            # separator-normalized form. We never strip a qualifier down to a bare
-            # leaf, so a qualified reference cannot bind to an unrelated view -- it
-            # is left unresolved instead. (A single underscore is a valid
-            # identifier character, so only ``__`` is treated as a separator.)
-            view = view_lookup.get(base_view) or view_lookup.get(base_view.replace("__", ".").replace("/", ".")) or {}
+            # We never strip a qualifier down to a bare leaf, so a qualified
+            # reference cannot bind to an unrelated view -- it is left unresolved
+            # instead.
+            view = view_lookup.get(canonical_ref(base_view)) or {}
             topics.append(
                 OmniTopic(
                     model_id=model.id,
@@ -323,6 +346,29 @@ class OmniApiClient:
                 )
             )
         return topics
+
+    # -- users --------------------------------------------------------------
+
+    def get_users(self) -> list[OmniUser]:
+        """List the instance's users over SCIM, following its index pagination."""
+        users: list[OmniUser] = []
+        start_index = 1
+        try:
+            while True:
+                payload = self.scim_client.get("/Users", data={"startIndex": start_index, "count": SCIM_PAGE_SIZE})
+                if payload is None:
+                    break
+                result = UsersResponse.model_validate(payload)
+                page = result.Resources or []
+                users.extend(page)
+                total = result.totalResults or 0
+                start_index += result.itemsPerPage or len(page) or SCIM_PAGE_SIZE
+                if not page or start_index > total:
+                    break
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.debug(traceback.format_exc())
+            logger.warning("Error fetching Omni users: %s", exc)
+        return users
 
     # -- documents / dashboards --------------------------------------------
 

--- a/ingestion/src/metadata/ingestion/source/dashboard/omni/client.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/omni/client.py
@@ -361,9 +361,16 @@ class OmniApiClient:
                 result = UsersResponse.model_validate(payload)
                 page = result.Resources or []
                 users.extend(page)
-                total = result.totalResults or 0
-                start_index += result.itemsPerPage or len(page) or SCIM_PAGE_SIZE
-                if not page or start_index > total:
+                if not page:
+                    break
+                # ``startIndex`` is the 1-based index of the first result, so advance
+                # by what this page actually returned. ``totalResults`` is optional:
+                # without it, keep paging while the server hands back full pages.
+                start_index += len(page)
+                if result.totalResults is not None:
+                    if start_index > result.totalResults:
+                        break
+                elif len(page) < SCIM_PAGE_SIZE:
                     break
         except Exception as exc:  # pylint: disable=broad-except
             logger.debug(traceback.format_exc())

--- a/ingestion/src/metadata/ingestion/source/dashboard/omni/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/omni/metadata.py
@@ -53,11 +53,13 @@ from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.models.barrier import Barrier
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.dashboard.dashboard_service import DashboardServiceSource
+from metadata.ingestion.source.dashboard.omni.client import canonical_ref
 from metadata.ingestion.source.dashboard.omni.models import (
     OmniDashboardDocument,
     OmniDocument,
     OmniField,
     OmniTopic,
+    QueryPresentation,
 )
 from metadata.ingestion.source.database.column_helpers import truncate_column_name
 from metadata.utils import fqn
@@ -99,6 +101,11 @@ OMNI_DATATYPE_MAP = {
 }
 
 
+def _fold_display_name(name: str | None) -> str:
+    """Fold a user display name for matching between the two Omni directories."""
+    return (name or "").strip().casefold()
+
+
 class OmniDashboardDetails(BaseModel):
     """Wrapper pairing a document with its expanded dashboard payload."""
 
@@ -125,10 +132,16 @@ class OmniSource(DashboardServiceSource):
     def __init__(self, config: WorkflowSource, metadata: OpenMetadata):
         super().__init__(config, metadata)
         self.topics: list[OmniTopic] = []
-        # Maps a tile reference (view or topic name) -> list of matching topics.
-        # A list, not a single value, so we can detect cross-model name collisions
-        # and avoid silently misrouting lineage to the wrong model's data model.
-        self._topic_index: dict = defaultdict(list)
+        # Maps a tile reference -> list of matching topics. A list, not a single
+        # value, so we can detect cross-model name collisions and avoid silently
+        # misrouting lineage to the wrong model's data model. The two indexes are
+        # kept apart so a reference that names a data model outright wins over one
+        # that only matches another data model's base view.
+        self._topic_name_index: dict = defaultdict(list)
+        self._topic_alias_index: dict = defaultdict(list)
+        # Owner email by folded display name, and the resolved owner references.
+        self._owner_email_by_name: dict = {}
+        self._owner_ref_cache: dict = {}
         # Track which db-service prefixes have had table lineage emitted, so each
         # configured dbServicePrefix is attempted exactly once.
         self._datamodel_table_lineage_prefixes: set = set()
@@ -149,40 +162,42 @@ class OmniSource(DashboardServiceSource):
                     self.status.filter(datamodel_name, "Data model (Topic) filtered out.")
                     continue
                 self.topics.append(topic)
-                for key in self._topic_index_keys(topic):
-                    self._topic_index[key].append(topic)
+                for key in self._topic_name_keys(topic):
+                    self._topic_name_index[key].append(topic)
+                for key in self._topic_alias_keys(topic):
+                    self._topic_alias_index[key].append(topic)
         logger.info("Fetched %d Omni topics across models", len(self.topics))
-
-    @staticmethod
-    def _normalize_ref(ref: str) -> str:
-        """Canonicalize a reference's qualifier separator.
-
-        Omni qualifies references with ``.``, ``/`` or ``__`` (see the data-lineage
-        integration docs), so collapse them to a single ``.`` form. A single
-        underscore is a valid identifier character, so only the double underscore
-        is treated as a separator.
-        """
-        return ref.replace("__", ".").replace("/", ".")
+        if self.source_config.includeOwners:
+            self._load_owner_emails()
 
     @classmethod
-    def _topic_index_keys(cls, topic: OmniTopic) -> set[str]:
-        """Reference keys a tile/base-view may use to point at this topic.
+    def _topic_name_keys(cls, topic: OmniTopic) -> set[str]:
+        """Reference keys that name this topic/view itself.
 
-        Includes the bare view/topic name and, when the base schema is known, the
-        canonical schema-qualified form (``schema.name``). Indexing the qualified
-        form lets a qualified reference resolve to the correct schema's topic
-        instead of being stripped to a bare leaf that could match an unrelated
-        model/schema. Callers normalize the reference separator before lookup.
+        Includes the bare name and, when the base schema is known, the
+        schema-qualified form (``schema.name``). Indexing the qualified form lets a
+        qualified reference resolve to the correct schema's topic instead of being
+        stripped to a bare leaf that could match an unrelated model/schema.
         """
-        keys: set[str] = set()
-        names = {topic.name}
-        if topic.base_view:
-            names.add(topic.base_view)
-        for name in names:
-            keys.add(name)
-            if topic.base_schema:
-                keys.add(cls._normalize_ref(f"{topic.base_schema}.{name}"))
+        keys = {canonical_ref(topic.name)}
+        if topic.base_schema:
+            keys.add(canonical_ref(f"{topic.base_schema}.{topic.name}"))
         return keys
+
+    @classmethod
+    def _topic_alias_keys(cls, topic: OmniTopic) -> set[str]:
+        """Reference keys that point at this topic's base view rather than itself.
+
+        A curated topic and the physical view it sits on are both ingested as data
+        models, so a reference naming that view must not be treated as ambiguous
+        between the two -- it belongs to the view.
+        """
+        if not topic.base_view:
+            return set()
+        keys = {canonical_ref(topic.base_view)}
+        if topic.base_schema:
+            keys.add(canonical_ref(f"{topic.base_schema}.{topic.base_view}"))
+        return keys - cls._topic_name_keys(topic)
 
     # -- data models (topics) ----------------------------------------------
 
@@ -210,25 +225,23 @@ class OmniSource(DashboardServiceSource):
         """
         if not table_ref:
             return None
-        # Try the reference as given, then with the qualifier separator swapped
-        # (Omni may use ``.`` or ``/``). Both bare and schema-qualified forms are
-        # indexed in prepare(), so a qualified reference matches the correct
-        # schema's topic. We deliberately do NOT strip a qualifier down to its
-        # bare leaf: that could match an unrelated topic and misroute lineage, so
-        # an unmatched qualified reference is left unresolved instead.
-        matches: list[OmniTopic] = []
-        for candidate in (table_ref, self._normalize_ref(table_ref)):
-            matches = self._topic_index.get(candidate) or []
-            if matches:
-                break
-        if len(matches) == 1:
-            return matches[0]
-        if len(matches) > 1:
-            logger.warning(
-                "Ambiguous tile reference %r across %d models; skipping lineage",
-                table_ref,
-                len(matches),
-            )
+        # Both bare and schema-qualified forms are indexed in prepare(), so a
+        # qualified reference matches the correct schema's topic. We deliberately do
+        # NOT strip a qualifier down to its bare leaf: that could match an unrelated
+        # topic and misroute lineage, so an unmatched qualified reference is left
+        # unresolved instead.
+        key = canonical_ref(table_ref)
+        for index in (self._topic_name_index, self._topic_alias_index):
+            matches: list[OmniTopic] = index.get(key) or []
+            if len(matches) == 1:
+                return matches[0]
+            if len(matches) > 1:
+                logger.warning(
+                    "Ambiguous tile reference %r across %d models; skipping lineage",
+                    table_ref,
+                    len(matches),
+                )
+                return None
         return None
 
     def _get_columns(self, fields: list[OmniField]) -> list[Column]:
@@ -383,6 +396,7 @@ class OmniSource(DashboardServiceSource):
         if not dashboard_details:
             return
         document = dashboard_details.document
+        owners = self.get_owner_ref(dashboard_details=dashboard_details)
         for idx, tile in enumerate(dashboard_details.dashboard.queryPresentations or []):
             try:
                 chart_display = tile.name or f"Tile {idx}"
@@ -395,6 +409,7 @@ class OmniSource(DashboardServiceSource):
                     chartType=get_standard_chart_type(tile.chartType) if tile.chartType else None,
                     service=FullyQualifiedEntityName(self.context.get().dashboard_service),
                     sourceUrl=SourceUrl(document.url) if document.url else None,
+                    owners=owners,
                 )
                 yield Either(right=chart_request)
                 self.register_record_chart(chart_request=chart_request)
@@ -477,35 +492,87 @@ class OmniSource(DashboardServiceSource):
         # for the tiles of this dashboard.
         seen_topics = set()
         for tile in dashboard_details.dashboard.queryPresentations or []:
-            table_ref = tile.query.table if tile.query else None
-            topic = self._resolve_topic(table_ref)
-            if not topic or self._datamodel_name(topic) in seen_topics:
-                continue
-            seen_topics.add(self._datamodel_name(topic))
-            try:
-                datamodel_entity = self._get_datamodel_entity(topic)
-                if datamodel_entity and dashboard_entity:
-                    lineage = self._get_add_lineage_request(to_entity=dashboard_entity, from_entity=datamodel_entity)
-                    if lineage:
-                        yield lineage
-            except Exception as exc:  # pylint: disable=broad-except
-                yield Either(
-                    left=StackTraceError(
-                        name=f"{dashboard_details.document.identifier} Lineage",
-                        error=f"Error yielding lineage for topic {topic.name}: {exc}",
-                        stackTrace=traceback.format_exc(),
+            for topic in self._tile_topics(tile):
+                if self._datamodel_name(topic) in seen_topics:
+                    continue
+                seen_topics.add(self._datamodel_name(topic))
+                try:
+                    datamodel_entity = self._get_datamodel_entity(topic)
+                    if datamodel_entity and dashboard_entity:
+                        lineage = self._get_add_lineage_request(
+                            to_entity=dashboard_entity, from_entity=datamodel_entity
+                        )
+                        if lineage:
+                            yield lineage
+                except Exception as exc:  # pylint: disable=broad-except
+                    yield Either(
+                        left=StackTraceError(
+                            name=f"{dashboard_details.document.identifier} Lineage",
+                            error=f"Error yielding lineage for topic {topic.name}: {exc}",
+                            stackTrace=traceback.format_exc(),
+                        )
                     )
-                )
+
+    def _tile_topics(self, tile: QueryPresentation) -> Iterable[OmniTopic]:
+        """Resolve every data model a tile reads.
+
+        A tile's ``query.table`` can name a workbook-local query view that is absent
+        from the shared model, while the tile's field references
+        (``<schema>__<view>.<field>``) still name real views. Reading both keeps a
+        dashboard connected to the views it queries through joins, as the Looker
+        connector does when it walks an explore's joins.
+        """
+        if not tile.query:
+            return
+        refs = [tile.query.table]
+        refs.extend(field.split(".")[0] for field in tile.query.fields or [] if "." in field)
+        # Distinct references can resolve to the same data model (a bare view name
+        # and its schema-qualified handle), so dedupe on what they resolve to.
+        seen: set[str] = set()
+        for ref in refs:
+            topic = self._resolve_topic(ref) if ref else None
+            if not topic or self._datamodel_name(topic) in seen:
+                continue
+            seen.add(self._datamodel_name(topic))
+            yield topic
 
     # -- owners -------------------------------------------------------------
 
+    def _load_owner_emails(self) -> None:
+        """Index user emails by display name, dropping names shared by several users.
+
+        The document payload identifies an owner by ``id`` and ``name`` only, and
+        that ``id`` is not the SCIM user id, so the display name is the only key
+        the two directories share.
+        """
+        emails: dict[str, str | None] = {}
+        for user in self.client.get_users() or []:
+            name = _fold_display_name(user.displayName)
+            email = user.primary_email
+            if not name or not email:
+                continue
+            if name in emails and emails[name] != email:
+                emails[name] = None
+                logger.debug("Omni display name %r maps to several users; ignoring it", user.displayName)
+                continue
+            emails[name] = email
+        self._owner_email_by_name = {name: email for name, email in emails.items() if email}
+        logger.info("Resolved %d Omni owner emails", len(self._owner_email_by_name))
+
     def get_owner_ref(self, dashboard_details: OmniDashboardDetails) -> EntityReferenceList | None:
         try:
-            if not self.source_config.includeOwners:
+            if not self.source_config.includeOwners or not dashboard_details:
                 return None
             owner = dashboard_details.document.owner
-            if owner and owner.email:
-                return self.metadata.get_reference_by_email(owner.email)
+            if not owner:
+                return None
+            email = self._owner_email_by_name.get(_fold_display_name(owner.name))
+            if not email:
+                logger.debug("No email found for Omni owner %r", owner.name)
+                return None
+            if email not in self._owner_ref_cache:
+                self._owner_ref_cache[email] = self.metadata.get_reference_by_email(email)
+            return self._owner_ref_cache[email]
         except Exception as exc:  # pylint: disable=broad-except
             logger.debug(traceback.format_exc())
             logger.warning("Could not fetch owner: %s", exc)

--- a/ingestion/src/metadata/ingestion/source/dashboard/omni/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/omni/metadata.py
@@ -51,6 +51,7 @@ from metadata.generated.schema.type.entityReferenceList import EntityReferenceLi
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.models.barrier import Barrier
+from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.dashboard.dashboard_service import DashboardServiceSource
 from metadata.ingestion.source.dashboard.omni.client import canonical_ref
@@ -71,12 +72,16 @@ from metadata.utils.filters import (
 from metadata.utils.fqn import build_es_fqn_search_string
 from metadata.utils.helpers import get_standard_chart_type
 from metadata.utils.logger import ingestion_logger
+from metadata.utils.tag_utils import get_ometa_tag_and_classification, get_tag_labels
 
 logger = ingestion_logger()
 
 # Project name for documents that don't live in a folder. Must be non-null so the
 # base class does not filter folderless dashboards out via projectFilterPattern.
 DEFAULT_PROJECT = "default"
+
+# Classification holding the labels Omni documents carry.
+OMNI_TAG_CATEGORY = "OmniLabels"
 
 # Bound the data model entity cache so it cannot grow unbounded on large catalogs.
 DATAMODEL_CACHE_SIZE = 1000
@@ -380,6 +385,12 @@ class OmniSource(DashboardServiceSource):
                 service=FullyQualifiedEntityName(self.context.get().dashboard_service),
                 sourceUrl=SourceUrl(document.url) if document.url else None,
                 owners=self.get_owner_ref(dashboard_details=dashboard_details),
+                tags=get_tag_labels(
+                    metadata=self.metadata,
+                    tags=document.label_names,
+                    classification_name=OMNI_TAG_CATEGORY,
+                    include_tags=self.source_config.includeTags,
+                ),
             )
             yield Either(right=dashboard_request)
             self.register_record(dashboard_request=dashboard_request)
@@ -421,6 +432,20 @@ class OmniSource(DashboardServiceSource):
                         stackTrace=traceback.format_exc(),
                     )
                 )
+
+    # -- tags ---------------------------------------------------------------
+
+    def yield_tags(self, dashboard_details: OmniDashboardDetails) -> Iterable[Either[OMetaTagAndClassification]]:
+        """Yield the classification and tags for a document's labels."""
+        if not dashboard_details or not self.source_config.includeTags:
+            return
+        yield from get_ometa_tag_and_classification(
+            tags=dashboard_details.document.label_names,
+            classification_name=OMNI_TAG_CATEGORY,
+            tag_description="Omni Label",
+            classification_description="Labels associated with Omni documents",
+            include_tags=self.source_config.includeTags,
+        )
 
     # -- lineage ------------------------------------------------------------
 

--- a/ingestion/src/metadata/ingestion/source/dashboard/omni/models.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/omni/models.py
@@ -90,14 +90,60 @@ class OmniTopic(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Users (SCIM)
+# ---------------------------------------------------------------------------
+
+
+class ScimEmail(BaseModel):
+    """One entry of a SCIM user's ``emails`` array."""
+
+    value: str | None = None
+    primary: bool | None = False
+
+
+class OmniUser(BaseModel):
+    """A SCIM user resource. ``id`` is the SCIM id, not a document owner id."""
+
+    id: str | None = None
+    displayName: str | None = None  # noqa: N815
+    userName: str | None = None  # noqa: N815
+    emails: list[ScimEmail] = Field(default_factory=list)
+
+    @property
+    def primary_email(self) -> str | None:
+        """Preferred email: the primary entry, else the first, else the username."""
+        for email in self.emails:
+            if email.primary and email.value:
+                return email.value
+        for email in self.emails:
+            if email.value:
+                return email.value
+        return self.userName
+
+
+class UsersResponse(BaseModel):
+    """SCIM ListResponse envelope returned by ``/scim/v2/Users``."""
+
+    Resources: list[OmniUser] | None = Field(default_factory=list)
+    totalResults: int | None = None  # noqa: N815
+    itemsPerPage: int | None = None  # noqa: N815
+    startIndex: int | None = None  # noqa: N815
+
+
+# ---------------------------------------------------------------------------
 # Documents (workbooks / dashboards)
 # ---------------------------------------------------------------------------
 
 
 class OmniOwner(BaseModel):
+    """A document owner as the documents API reports it: an id and a display name.
+
+    The id is not the owner's SCIM user id, so ``name`` is the only key shared
+    with the user directory.
+    """
+
     id: str | None = None
     name: str | None = None
-    email: str | None = None
 
 
 class OmniFolder(BaseModel):

--- a/ingestion/src/metadata/ingestion/source/dashboard/omni/models.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/omni/models.py
@@ -152,6 +152,13 @@ class OmniFolder(BaseModel):
     path: str | None = None
 
 
+class OmniLabel(BaseModel):
+    """A document label. The documents API reports these as objects, not strings."""
+
+    name: str | None = None
+    verified: bool | None = None
+
+
 class OmniDocument(BaseModel):
     """An Omni document. Documents with ``hasDashboard`` carry a dashboard."""
 
@@ -166,8 +173,12 @@ class OmniDocument(BaseModel):
     hasDashboard: bool | None = False  # noqa: N815
     url: str | None = None
     deleted: bool | None = False
-    labels: list[str] | None = Field(default_factory=list)
+    labels: list[OmniLabel] | None = Field(default_factory=list)
     updatedAt: str | None = None  # noqa: N815
+
+    @property
+    def label_names(self) -> list[str]:
+        return [label.name for label in self.labels or [] if label.name]
 
 
 class DocumentsResponse(BaseModel):

--- a/ingestion/tests/unit/topology/dashboard/test_omni.py
+++ b/ingestion/tests/unit/topology/dashboard/test_omni.py
@@ -710,3 +710,41 @@ def test_yield_dashboard_lineage_details_uses_field_references(omni_source):
     ]
     assert len(edges) == 1
     assert (edges[0].edge.fromEntity.type, edges[0].edge.toEntity.type) == ("dashboardDataModel", "dashboard")
+
+
+def test_get_users_pages_on_when_total_results_is_absent():
+    """``totalResults`` is optional in a SCIM ListResponse; a server that omits it
+    must not have its later pages silently dropped."""
+    from metadata.generated.schema.entity.services.connections.dashboard.omniConnection import (
+        OmniConnection as OmniConnectionConfig,
+    )
+    from metadata.ingestion.source.dashboard.omni.client import SCIM_PAGE_SIZE, OmniApiClient
+
+    client = OmniApiClient(OmniConnectionConfig(hostPort="https://acme.omniapp.co", token="t"))
+    full = [{"id": str(i), "displayName": f"U{i}"} for i in range(SCIM_PAGE_SIZE)]
+    client.scim_client = MagicMock()
+    client.scim_client.get.side_effect = [
+        {"Resources": full},
+        {"Resources": [{"id": "last", "displayName": "Last"}]},
+    ]
+
+    users = client.get_users()
+    assert len(users) == SCIM_PAGE_SIZE + 1
+    assert users[-1].id == "last"
+    assert [c.kwargs["data"]["startIndex"] for c in client.scim_client.get.call_args_list] == [
+        1,
+        1 + SCIM_PAGE_SIZE,
+    ]
+
+
+def test_get_users_stops_on_an_empty_page():
+    from metadata.generated.schema.entity.services.connections.dashboard.omniConnection import (
+        OmniConnection as OmniConnectionConfig,
+    )
+    from metadata.ingestion.source.dashboard.omni.client import OmniApiClient
+
+    client = OmniApiClient(OmniConnectionConfig(hostPort="https://acme.omniapp.co", token="t"))
+    client.scim_client = MagicMock()
+    client.scim_client.get.side_effect = [{"Resources": [], "totalResults": 0}]
+    assert client.get_users() == []
+    assert client.scim_client.get.call_count == 1

--- a/ingestion/tests/unit/topology/dashboard/test_omni.py
+++ b/ingestion/tests/unit/topology/dashboard/test_omni.py
@@ -29,6 +29,7 @@ from metadata.generated.schema.metadataIngestion.workflow import (
     OpenMetadataWorkflowConfig,
 )
 from metadata.generated.schema.type.entityReference import EntityReference
+from metadata.generated.schema.type.entityReferenceList import EntityReferenceList
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.models.barrier import Barrier
 from metadata.ingestion.models.ometa_lineage import OMetaLineageRequest
@@ -47,7 +48,9 @@ from metadata.ingestion.source.dashboard.omni.models import (
     OmniOwner,
     OmniQuery,
     OmniTopic,
+    OmniUser,
     QueryPresentation,
+    ScimEmail,
 )
 
 MOCK_CONFIG = {
@@ -109,7 +112,7 @@ MOCK_DOCUMENT = OmniDocument(
     name="Sales Overview",
     description="Monthly sales",
     type="document",
-    owner=OmniOwner(id="u1", name="Jane", email="jane@acme.co"),
+    owner=OmniOwner(id="owner-1", name="Jane Doe"),
     hasDashboard=True,
     url="https://acme.omniapp.co/dashboards/doc-1",
     deleted=False,
@@ -117,6 +120,19 @@ MOCK_DOCUMENT = OmniDocument(
 
 MOCK_ARCHIVED_DOCUMENT = OmniDocument(identifier="doc-2", name="Old", hasDashboard=True, deleted=True)
 MOCK_WORKBOOK_ONLY = OmniDocument(identifier="doc-3", name="Workbook", hasDashboard=False)
+
+MOCK_USERS = [
+    OmniUser(
+        id="scim-1",
+        displayName="Jane Doe",
+        userName="jane.doe@acme.co",
+        emails=[
+            ScimEmail(value="jane.old@acme.co", primary=False),
+            ScimEmail(value="jane.doe@acme.co", primary=True),
+        ],
+    ),
+    OmniUser(id="scim-2", displayName="John Roe", userName="john.roe@acme.co", emails=[]),
+]
 
 MOCK_DASHBOARD_DOC = OmniDashboardDocument(
     identifier="doc-1",
@@ -143,7 +159,7 @@ def omni_source():
             MOCK_CONFIG["source"],
             OpenMetadata(config.workflowConfig.openMetadataServerConfig),
         )
-    source.client = SimpleNamespace()
+    source.client = SimpleNamespace(get_users=lambda *_: [])
     source.context.get().__dict__["dashboard_service"] = "mock_omni"
     return source
 
@@ -179,7 +195,7 @@ def test_resolve_topic_skips_ambiguous_cross_model(omni_source):
     # Two models expose a view with the same name -> must not misroute lineage.
     t1 = MOCK_TOPIC.model_copy(update={"model_id": "m1", "model_name": "a"})
     t2 = MOCK_TOPIC.model_copy(update={"model_id": "m2", "model_name": "b"})
-    omni_source._topic_index = {"orders": [t1, t2]}
+    omni_source._topic_name_index = {"orders": [t1, t2]}
     assert omni_source._resolve_topic("orders") is None
 
 
@@ -255,7 +271,7 @@ def test_yield_dashboard_chart(omni_source):
 def test_yield_dashboard_lineage_details(omni_source):
     """table -> data model (bulk) and dashboard <- data model (per tile)."""
     omni_source.topics = [MOCK_TOPIC]
-    omni_source._topic_index = {"orders": [MOCK_TOPIC]}
+    omni_source._topic_name_index = {"orders": [MOCK_TOPIC]}
 
     datamodel_entity = DashboardDataModel(
         id="550e8400-e29b-41d4-a716-446655440010",
@@ -438,3 +454,259 @@ def test_list_datamodels_respects_include_flag(omni_source):
 
     omni_source.source_config.includeDataModels = False
     assert list(omni_source.list_datamodels()) == []
+
+
+def test_parse_model_yaml_base_view_handle_is_case_insensitive():
+    """Omni spells a base_view handle in lower case (``revenues__all_revenues``)
+    while the model YAML path keeps the warehouse casing (``REVENUES/...``)."""
+    from metadata.ingestion.source.dashboard.omni.client import OmniApiClient
+
+    files = {
+        "REVENUES/all_revenues.view": "schema: REVENUES\ntable_name: ALL_REVENUES\ndimensions:\n  amount:\n    label: Amount\n",
+        "Company North Star/revenue.topic": "base_view: revenues__all_revenues\nlabel: Revenue\n",
+    }
+    result = OmniApiClient._parse_model_yaml(OmniModel(id="m1", name="sales"), files)
+    topic = next(t for t in result if t.name == "revenue")
+    assert topic.base_schema == "REVENUES"
+    assert topic.base_table == "ALL_REVENUES"
+    assert [f.name for f in topic.fields] == ["amount"]
+
+
+def test_resolve_topic_is_case_insensitive(omni_source):
+    """A tile reference must resolve regardless of the casing of the schema part."""
+    omni_source.client.get_models = lambda *_: [OmniModel(id="m1", name="sales")]
+    omni_source.client.get_model_topics = lambda *_: [MOCK_TOPIC]  # base_schema=ANALYTICS
+    omni_source.prepare()
+    assert omni_source._resolve_topic("analytics__orders").base_table == "ORDERS"
+    assert omni_source._resolve_topic("Analytics.Orders").base_table == "ORDERS"
+    assert omni_source._resolve_topic("ORDERS").base_table == "ORDERS"
+
+
+def test_resolve_topic_prefers_the_data_model_named_by_the_reference(omni_source):
+    """A curated topic and the view it sits on are both ingested as data models, so
+    a reference naming that view belongs to the view -- not ambiguous between them."""
+    view = OmniTopic(
+        model_id="m1",
+        model_name="sales",
+        name="clients__fact_lifecycle",
+        base_view="clients__fact_lifecycle",
+        base_schema="CLIENTS",
+        base_table="FACT_LIFECYCLE",
+    )
+    topic = OmniTopic(
+        model_id="m1",
+        model_name="sales",
+        name="Post-Acquisition Lifecycle",
+        base_view="clients__fact_lifecycle",
+        base_schema="CLIENTS",
+        base_table="FACT_LIFECYCLE",
+    )
+    omni_source.client.get_models = lambda *_: [OmniModel(id="m1", name="sales")]
+    omni_source.client.get_model_topics = lambda *_: [topic, view]
+    omni_source.prepare()
+
+    resolved = omni_source._resolve_topic("clients__fact_lifecycle")
+    assert resolved is not None
+    assert resolved.name == "clients__fact_lifecycle"
+    assert omni_source._resolve_topic("Post-Acquisition Lifecycle").name == "Post-Acquisition Lifecycle"
+
+
+def test_get_owner_ref_resolves_via_user_directory(omni_source):
+    """The documents API carries no owner email, so the owner is matched on the
+    display name it does carry against the SCIM user directory."""
+    omni_source.client.get_models = lambda *_: []
+    omni_source.client.get_model_topics = lambda *_: []
+    omni_source.client.get_users = lambda *_: MOCK_USERS
+    omni_source.prepare()
+
+    reference = EntityReferenceList(root=[EntityReference(id="550e8400-e29b-41d4-a716-446655440020", type="user")])
+    omni_source.metadata.get_reference_by_email = MagicMock(return_value=reference)
+
+    assert omni_source.get_owner_ref(MOCK_DASHBOARD_DETAILS) is reference
+    omni_source.metadata.get_reference_by_email.assert_called_once_with("jane.doe@acme.co")
+
+    # A second lookup for the same owner is served from cache.
+    omni_source.get_owner_ref(MOCK_DASHBOARD_DETAILS)
+    assert omni_source.metadata.get_reference_by_email.call_count == 1
+
+
+def test_get_owner_ref_ignores_display_name_shared_by_several_users(omni_source):
+    """Two users with the same display name cannot be told apart, so neither is used."""
+    omni_source.client.get_models = lambda *_: []
+    omni_source.client.get_model_topics = lambda *_: []
+    omni_source.client.get_users = lambda *_: [
+        OmniUser(id="a", displayName="Jane Doe", emails=[ScimEmail(value="jane1@acme.co", primary=True)]),
+        OmniUser(id="b", displayName="Jane Doe", emails=[ScimEmail(value="jane2@acme.co", primary=True)]),
+    ]
+    omni_source.prepare()
+    omni_source.metadata.get_reference_by_email = MagicMock()
+
+    assert omni_source.get_owner_ref(MOCK_DASHBOARD_DETAILS) is None
+    omni_source.metadata.get_reference_by_email.assert_not_called()
+
+
+def test_get_owner_ref_skipped_when_include_owners_disabled(omni_source):
+    omni_source.source_config.includeOwners = False
+    omni_source.client.get_models = lambda *_: []
+    omni_source.client.get_model_topics = lambda *_: []
+    omni_source.client.get_users = MagicMock(return_value=MOCK_USERS)
+    omni_source.prepare()
+
+    omni_source.client.get_users.assert_not_called()
+    assert omni_source.get_owner_ref(MOCK_DASHBOARD_DETAILS) is None
+
+
+def test_yield_dashboard_chart_inherits_the_document_owner(omni_source):
+    omni_source.client.get_models = lambda *_: []
+    omni_source.client.get_model_topics = lambda *_: []
+    omni_source.client.get_users = lambda *_: MOCK_USERS
+    omni_source.prepare()
+
+    reference = EntityReferenceList(root=[EntityReference(id="550e8400-e29b-41d4-a716-446655440021", type="user")])
+    omni_source.metadata.get_reference_by_email = MagicMock(return_value=reference)
+
+    charts = _rights(omni_source.yield_dashboard_chart(MOCK_DASHBOARD_DETAILS))
+    assert len(charts) == 2
+    assert all(c.owners is reference for c in charts)
+
+
+def test_get_users_follows_scim_index_pagination():
+    """SCIM pages by startIndex/itemsPerPage rather than a cursor."""
+    from metadata.generated.schema.entity.services.connections.dashboard.omniConnection import (
+        OmniConnection as OmniConnectionConfig,
+    )
+    from metadata.ingestion.source.dashboard.omni.client import OmniApiClient
+
+    client = OmniApiClient(OmniConnectionConfig(hostPort="https://acme.omniapp.co", token="t"))
+    pages = [
+        {
+            "Resources": [{"id": "1", "displayName": "A", "emails": [{"value": "a@acme.co", "primary": True}]}],
+            "totalResults": 2,
+            "itemsPerPage": 1,
+            "startIndex": 1,
+        },
+        {
+            "Resources": [{"id": "2", "displayName": "B", "emails": [{"value": "b@acme.co", "primary": True}]}],
+            "totalResults": 2,
+            "itemsPerPage": 1,
+            "startIndex": 2,
+        },
+    ]
+    client.scim_client = MagicMock()
+    client.scim_client.get.side_effect = pages
+
+    users = client.get_users()
+    assert [u.id for u in users] == ["1", "2"]
+    assert [u.primary_email for u in users] == ["a@acme.co", "b@acme.co"]
+    assert client.scim_client.get.call_args_list[0].kwargs["data"]["startIndex"] == 1
+    assert client.scim_client.get.call_args_list[1].kwargs["data"]["startIndex"] == 2
+
+
+def test_get_users_uses_the_scim_mount_point():
+    """SCIM sits next to the versioned API, not under it."""
+    from metadata.generated.schema.entity.services.connections.dashboard.omniConnection import (
+        OmniConnection as OmniConnectionConfig,
+    )
+    from metadata.ingestion.source.dashboard.omni.client import OmniApiClient
+
+    client = OmniApiClient(OmniConnectionConfig(hostPort="https://acme.omniapp.co", token="t"))
+    assert client.client._api_version == "v1"
+    assert client.scim_client._api_version == "scim/v2"
+    assert client.scim_client._base_url.rstrip("/") == "https://acme.omniapp.co/api"
+
+
+def test_primary_email_falls_back_to_username():
+    assert OmniUser(id="x", displayName="X", userName="x@acme.co").primary_email == "x@acme.co"
+    assert (
+        OmniUser(id="x", displayName="X", userName="x@acme.co", emails=[ScimEmail(value="y@acme.co")]).primary_email
+        == "y@acme.co"
+    )
+
+
+def test_tile_topics_reads_field_references_as_well_as_the_table(omni_source):
+    """A tile's query.table may name a workbook-local query view absent from the
+    shared model, while its field references still name real views."""
+    accounts = OmniTopic(
+        model_id="m1",
+        model_name="sales",
+        name="clients__accounts",
+        base_view="clients__accounts",
+        base_schema="CLIENTS",
+        base_table="ACCOUNTS",
+    )
+    omni_source.client.get_models = lambda *_: [OmniModel(id="m1", name="sales")]
+    omni_source.client.get_model_topics = lambda *_: [MOCK_TOPIC, accounts]
+    omni_source.prepare()
+
+    tile = QueryPresentation(
+        name="Transactions",
+        query=OmniQuery(
+            table="monthly_active_customers",
+            fields=[
+                "clients__accounts.legal_country",
+                "clients__accounts.count",
+                "monthly_active_customers.total",
+                "omni_period_pivot",
+                "calc_1",
+            ],
+        ),
+    )
+    # The unresolvable table is skipped; the field prefix resolves, once, to its view.
+    assert [t.name for t in omni_source._tile_topics(tile)] == ["clients__accounts"]
+
+    # A resolvable table is still returned, and is not duplicated by its own fields.
+    tile = QueryPresentation(
+        name="Orders", query=OmniQuery(table="orders", fields=["orders.total", "ANALYTICS__orders.country"])
+    )
+    assert [t.name for t in omni_source._tile_topics(tile)] == ["orders"]
+
+
+def test_tile_topics_handles_a_tile_without_a_query(omni_source):
+    assert list(omni_source._tile_topics(QueryPresentation(name="Text tile"))) == []
+
+
+def test_yield_dashboard_lineage_details_uses_field_references(omni_source):
+    """A dashboard whose tiles only reference views through fields still gets edges."""
+    accounts = OmniTopic(
+        model_id="m1",
+        model_name="sales",
+        name="clients__accounts",
+        base_view="clients__accounts",
+        base_schema="CLIENTS",
+        base_table="ACCOUNTS",
+    )
+    omni_source.client.get_models = lambda *_: [OmniModel(id="m1", name="sales")]
+    omni_source.client.get_model_topics = lambda *_: [accounts]
+    omni_source.prepare()
+
+    document = MOCK_DOCUMENT.model_copy()
+    dashboard_doc = OmniDashboardDocument(
+        identifier="doc-1",
+        queryPresentations=[
+            QueryPresentation(
+                name="Tile",
+                query=OmniQuery(table="workbook_only_view", fields=["clients__accounts.legal_country"]),
+            )
+        ],
+    )
+    details = OmniDashboardDetails(document=document, dashboard=dashboard_doc)
+
+    datamodel_entity = DashboardDataModel(
+        id="550e8400-e29b-41d4-a716-446655440030",
+        name="sales.clients__accounts",
+        dataModelType="OmniDataModel",
+        columns=[],
+    )
+    dashboard_entity = Dashboard(
+        id="550e8400-e29b-41d4-a716-446655440031",
+        name="doc-1",
+        service=EntityReference(id="550e8400-e29b-41d4-a716-446655440032", type="dashboardService"),
+    )
+    omni_source._get_datamodel_entity = lambda topic: datamodel_entity
+    omni_source.metadata.get_by_name = MagicMock(return_value=dashboard_entity)
+
+    edges = [
+        r for r in _rights(omni_source.yield_dashboard_lineage_details(details)) if isinstance(r, AddLineageRequest)
+    ]
+    assert len(edges) == 1
+    assert (edges[0].edge.fromEntity.type, edges[0].edge.toEntity.type) == ("dashboardDataModel", "dashboard")

--- a/ingestion/tests/unit/topology/dashboard/test_omni.py
+++ b/ingestion/tests/unit/topology/dashboard/test_omni.py
@@ -44,6 +44,7 @@ from metadata.ingestion.source.dashboard.omni.models import (
     OmniDocument,
     OmniField,
     OmniFolder,
+    OmniLabel,
     OmniModel,
     OmniOwner,
     OmniQuery,
@@ -748,3 +749,74 @@ def test_get_users_stops_on_an_empty_page():
     client.scim_client.get.side_effect = [{"Resources": [], "totalResults": 0}]
     assert client.get_users() == []
     assert client.scim_client.get.call_count == 1
+
+
+def test_documents_response_accepts_object_shaped_labels():
+    """The documents API reports labels as objects. Typing them as plain strings
+    made one labelled document invalidate its whole page, and `get_documents`
+    turns a page failure into an empty list -- dropping every dashboard."""
+    from metadata.ingestion.source.dashboard.omni.models import DocumentsResponse
+
+    page = {
+        "records": [
+            {"identifier": "a", "name": "Unlabelled", "hasDashboard": True, "labels": []},
+            {
+                "identifier": "b",
+                "name": "Company North Star Metrics Executive Overview",
+                "hasDashboard": True,
+                "labels": [{"name": "Company North Star", "verified": True}, {"name": "Executive"}],
+            },
+        ],
+        "pageInfo": {"hasNextPage": False},
+    }
+    response = DocumentsResponse.model_validate(page)
+    assert [d.identifier for d in response.records] == ["a", "b"]
+    assert response.records[0].label_names == []
+    assert response.records[1].label_names == ["Company North Star", "Executive"]
+
+
+def test_yield_tags_emits_document_labels(omni_source):
+    labelled = MOCK_DOCUMENT.model_copy(
+        update={"labels": [OmniLabel(name="Company North Star", verified=True), OmniLabel(name="Executive")]}
+    )
+    details = OmniDashboardDetails(document=labelled, dashboard=MOCK_DASHBOARD_DOC)
+    tags = _rights(omni_source.yield_tags(details))
+    names = {tag.tag_request.name.root for tag in tags}
+    assert names == {"Company North Star", "Executive"}
+    assert all(tag.classification_request.name.root == "OmniLabels" for tag in tags)
+
+
+def test_yield_tags_skipped_when_include_tags_disabled(omni_source):
+    labelled = MOCK_DOCUMENT.model_copy(update={"labels": [OmniLabel(name="Company North Star")]})
+    details = OmniDashboardDetails(document=labelled, dashboard=MOCK_DASHBOARD_DOC)
+    omni_source.source_config.includeTags = False
+    assert list(omni_source.yield_tags(details)) == []
+
+
+def test_yield_dashboard_attaches_label_tags(omni_source):
+    """The dashboard request carries the document's labels, resolved against the
+    Omni classification (tag FQN resolution itself is a server call)."""
+    from metadata.generated.schema.type.tagLabel import (
+        LabelType,
+        State,
+        TagFQN,
+        TagLabel,
+        TagSource,
+    )
+
+    labelled = MOCK_DOCUMENT.model_copy(update={"labels": [OmniLabel(name="Company North Star")]})
+    details = OmniDashboardDetails(document=labelled, dashboard=MOCK_DASHBOARD_DOC)
+    resolved = [
+        TagLabel(
+            tagFQN=TagFQN(root='OmniLabels."Company North Star"'),
+            source=TagSource.Classification,
+            labelType=LabelType.Automated,
+            state=State.Suggested,
+        )
+    ]
+    with patch("metadata.ingestion.source.dashboard.omni.metadata.get_tag_labels", return_value=resolved) as get_labels:
+        dashboard = _rights(omni_source.yield_dashboard(details))[0]
+
+    assert [t.tagFQN.root for t in dashboard.tags] == ['OmniLabels."Company North Star"']
+    assert get_labels.call_args.kwargs["tags"] == ["Company North Star"]
+    assert get_labels.call_args.kwargs["classification_name"] == "OmniLabels"


### PR DESCRIPTION
### Describe your changes:

Fixes #32976

I worked on five defects in the Omni dashboard connector that only surface against a real instance: no entity ever received an owner, and most lineage edges were silently dropped. All three fail through a `return None` or a `logger.debug`, so the workflow reported success with 0 errors.

**1. Owners: resolve through the SCIM user directory instead of a non-existent field**

`get_owner_ref` returned an owner only when `document.owner.email` was set, but `GET /api/v1/documents` reports an owner as `{"id", "name"}` — there is no `email` field, on any document. The guard was never true. The unit fixture invented `email="jane@acme.co"`, which is why CI never caught it.

Resolving by id is not possible either: there is no `/api/v1/users` endpoint, and the SCIM `id` at `/api/scim/v2/Users` is a **different identifier space** from `document.owner.id` (the same user is `802fd5c2-…` in SCIM and `70adb5ab-…` as a document owner; a SCIM `filter=id eq` on the owner id returns 0 results). The display name is the only key the two directories share, so that is what this matches on, and a display name shared by more than one user is discarded rather than guessed at.

`OmniOwner.email` is removed — the field mirrored nothing in the payload, and its plausibility is what produced the bug.

Charts now inherit the document owner. Data models are left without one: an Omni topic/view carries no ownership in the model YAML.

**2. Lineage: match view handles case-insensitively**

Omni refers to a view by a lower-case `<schema>__<view>` handle (`revenues__all_revenues`) while the model YAML paths keep the warehouse's own casing (`REVENUES/all_revenues.view`). Both sides now go through one `canonical_ref()` that folds the separator (`.`, `/`, `__`) *and* the case, replacing the two ad-hoc `replace()` chains that compared case-sensitively.

This is the high-impact half. A topic whose `base_view` did not resolve got **no columns and no `base_table`**, so no `table -> data model` edge was emitted for it — and since dashboards link to *topics*, the `table -> topic -> dashboard` chain broke at exactly the node carrying it.

**3. Lineage: a topic no longer collides with its own base view**

`_topic_index_keys` indexed a topic under both its name and its `base_view`, but that base view is *also* ingested as its own data model under that name. A tile referencing the view therefore matched twice, hit the `len(matches) > 1` branch and was logged as `Ambiguous tile reference` — yet the reference is not ambiguous, it names the view.

The single index is split into a name index and an alias (base-view) index, and `_resolve_topic` consults them in that order: a reference that names a data model outright wins over one that only matches another data model's base view. Genuine cross-model collisions are still detected and still skipped.

**4. Lineage: read a tile's field references, not just its declared table**

Edges were drawn only from a tile's `query.table`, which is frequently a workbook-local query view absent from the shared model — so the tile contributed nothing, even when its `query.fields` named real shared-model views (`clients__omni_qonto_accounts.legal_country`). `_tile_topics` now resolves the declared table *and* every field's `<schema>__<view>` prefix, deduplicating on the data model they resolve to rather than on the raw reference (a bare view name and its qualified handle resolve to the same model).

Fetching the tile's own model would not help and is not worth the rate limit: for four documents referencing such a view, three returned only the shared model's files and the fourth carried a `dimensions`-only stub with no `schema`, `table_name`, `extends` or `sql`. The field references are already in the `/documents/{id}/queries` response, so this costs no extra API calls.

This follows the Looker connector, which walks an explore's `joins` to link every joined view and whose `_get_explore_column_lineage` resolves field references of exactly this shape ("Look for fields with format view_name.col"); Tableau and PowerBI build lineage from field/upstream references too.

**5. Labels: model them as objects, and actually propagate them**

`OmniDocument.labels` was `list[str]`, but the documents API reports a label as `{"name": ..., "verified": ...}`. Pydantic rejects the dict and `_paginate` validates a whole page at a time, so one labelled document invalidated up to 100 documents; `get_documents` turns that into `[]`, which leaves `dashboard_source_state` empty, and with `markDeletedDashboards` enabled `delete_entity_from_source` then marks **every already-ingested dashboard in the service deleted** — while the run still reports success, because the failure is a `logger.error` rather than a `StackTraceError`.

Adds an `OmniLabel` model and a `label_names` helper. And since `include=labels` was already being requested and then discarded, the labels now reach OpenMetadata: a `yield_tags` override emits an `OmniLabels` classification and `yield_dashboard` attaches the tags, following the `TABLEAU_TAG_CATEGORY` pattern. `includeTags: true` previously produced nothing for Omni.

Of the five, this is the one I would prioritise for a patch release: it needs no unusual configuration, a single label anywhere in the instance triggers it, and the consequence is deletion of already-catalogued dashboards rather than absent metadata.

#
### Type of change:
- [x] Bug fix

#
### How was this tested?

`ingestion/tests/unit/topology/dashboard/test_omni.py`: 42 passed. The full `tests/unit/topology/dashboard/` suite goes from 398 to 417 passing with no new failures.

Eighteen tests added, covering each defect: a case-mismatched `base_view` handle resolving to its view with columns and table; `_resolve_topic` folding case and separator; a reference naming a view resolving to the view rather than being reported ambiguous; owner resolution via the user directory, its cache, a display name shared by two users, and `includeOwners: false`; chart owner inheritance; SCIM `startIndex`/`itemsPerPage` pagination and its mount point; and for the tile references, a field prefix resolving where the declared table cannot, no duplicate when a table and its own fields resolve alike, a tile with no query, and a dashboard whose edges come only from fields; and for labels, a page carrying object-shaped labels validating rather than being dropped, `yield_tags` emitting the classification, `includeTags: false`, and the dashboard request carrying the resolved tags. Two existing tests were updated for the split index, and the `OmniOwner` fixture now carries the payload shape the API actually returns.

SCIM pagination and label handling are unit-tested only — I could not re-reach the live instance to confirm them (local credential tooling outage), so those two are the least externally validated parts of this PR.

Verified end-to-end by replaying the patched parser and the real `_topic_name_keys`/`_topic_alias_keys` against a production instance's model YAML and every dashboard's tile references (1 shared model, 164 views, 5 topics, 26 dashboards, 150 tile references):

| | before | after |
|---|---|---|
| topics resolving to a warehouse table | 1/5 | **5/5** |
| data models resolving to a warehouse table | 163/167 | **167/167** |
| dashboards with at least one lineage edge | 9/26 | **18/26** |
| distinct dashboard <- data model edges | 15 | **33** |

The `before` column matches what that instance's OpenMetadata actually holds today (the topic every dashboard points at is stored with `columns: []` and no upstream), which is what makes me confident the replay is faithful.

The 8 dashboards still without an edge reference only workbook-local derived views (`revenue_with_shape`, `card_transactions_base`, `daily_actual_and_target`, ...) whose definitions carry no table, `extends` or `sql` anywhere the API exposes, plus one legacy workbook whose queries endpoint returns `400 "Workbook needs to be migrated"`. I don't think those are recoverable without a new Omni API surface.

Column-level lineage is the natural next step and is deliberately not here: the same field references would support view-to-topic column lineage the way Looker's `_get_explore_column_lineage` does, but that is new behaviour rather than a fix and deserves its own PR.
