### PR TITLE
Fixes #32998: [KafkaConnect] Distinguish authentication from authorization on telemetry failures

### DIFF
--- a/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/client.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/client.py
@@ -438,11 +438,17 @@ class KafkaConnectClient:
             # Recorded as empty rather than left unset, so one failure does not become one
             # failed call per connector. The API is rate limited per hour, and a large
             # estate would spend that budget retrying a call that already failed.
+            #
+            # The key id and whether Connect accepted the same credential are both stated,
+            # because neither can be recovered from the log afterwards and together they
+            # identify which credential to look at and which half of Confluent rejected it.
+            # The secret is never logged, only the key id, which is not a secret.
             logger.warning(
-                "Confluent telemetry unavailable for cluster %s, topics not enriched: %s%s",
+                "Confluent telemetry unavailable for cluster %s using key %s, topics not enriched: %s%s",
                 cluster_id,
+                self._telemetry_auth[0] if self._telemetry_auth else "none",
                 exc,
-                telemetry.failure_hint(exc),
+                telemetry.failure_hint(exc, connect_authenticated=bool(live_connector_ids)),
             )
             logger.debug(traceback.format_exc())
 

--- a/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/client.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/client.py
@@ -289,6 +289,10 @@ class KafkaConnectClient:
         # lives for a single ingestion run. None means not yet fetched.
         self._connector_ids: dict[str, str] | None = None
         self._telemetry_topics_by_connector_id: dict[str, set[str]] | None = None
+        # Whether the Connect API accepted this credential, which an empty connector list
+        # cannot tell us: a cluster with no connectors and a cluster we cannot authenticate
+        # to both yield nothing. None until the call has been made.
+        self._connect_authenticated: bool | None = None
         # The telemetry API takes the same Confluent Cloud key as the Connect API, so no
         # separate credential is needed. Held as a tuple because that call is made with
         # requests directly rather than through the Connect client. Both halves have to be
@@ -323,11 +327,13 @@ class KafkaConnectClient:
         result: dict[str, str] = {}
         try:
             response = self.get_connectors_list(expand="id")
+            self._connect_authenticated = True
             for name, block in (response or {}).items():
                 connector_id = ((block or {}).get("id") or {}).get("id")
                 if connector_id:
                     result[name] = connector_id
         except Exception as exc:
+            self._connect_authenticated = False
             logger.debug(traceback.format_exc())
             logger.debug("Unable to list Confluent connector ids: %s", exc)
 
@@ -448,7 +454,7 @@ class KafkaConnectClient:
                 cluster_id,
                 self._telemetry_auth[0] if self._telemetry_auth else "none",
                 exc,
-                telemetry.failure_hint(exc, connect_authenticated=bool(live_connector_ids)),
+                telemetry.failure_hint(exc, connect_authenticated=self._connect_authenticated),
             )
             logger.debug(traceback.format_exc())
 

--- a/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/client.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/client.py
@@ -16,6 +16,7 @@ import re
 import traceback
 from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
+from http import HTTPStatus
 from urllib.parse import urlparse
 
 import requests
@@ -179,6 +180,10 @@ CONFLUENT_PRODUCER_CLIENT_PATTERN = re.compile(r"connector-producer-(?P<connecto
 # telemetry query filters on.
 CONFLUENT_CLUSTER_ID_PATTERN = re.compile(r"/clusters/(?P<cluster_id>lkc-[a-z0-9]+)")
 
+# Confluent's error bodies are short, but this is an unbounded remote string being put into
+# a log line, so it is capped rather than trusted.
+MAX_TELEMETRY_ERROR_CHARS = 300
+
 
 def extract_internal_topic_names(connector_config: dict | None) -> set[str]:
     """
@@ -239,6 +244,74 @@ def confluent_managed_internal_topic_names(connector_config: dict | None, connec
         f"{prefix}.{connector_id}.transaction",
         f"dbhistory.{prefix}.{connector_id}",
     }
+
+
+def _telemetry_error_detail(response) -> str:
+    """
+    What Confluent said, which the raised HTTPError does not carry.
+
+    ``raise_for_status`` renders only the status line, so the body is lost even though it
+    is the part that identifies the failure: "Invalid credentials" and "Query must filter
+    by at least one of your authorized resources" arrive under the same 4xx otherwise.
+    """
+    if response is None:
+        return ""
+
+    try:
+        body = response.json()
+    except Exception:
+        text = (getattr(response, "text", "") or "").strip()
+        return text[:MAX_TELEMETRY_ERROR_CHARS]
+
+    # Confluent's error envelope puts the useful sentence in errors[].detail. Anything else
+    # is rendered as-is rather than dropped, because an unexpected shape is itself worth
+    # seeing when diagnosing, and a body we chose not to print cannot be recovered later.
+    if isinstance(body, dict):
+        details = [
+            str(err.get("detail")).strip()
+            for err in (body.get("errors") or [])
+            if isinstance(err, dict) and err.get("detail")
+        ]
+        if details:
+            return ", ".join(details)[:MAX_TELEMETRY_ERROR_CHARS]
+    return str(body)[:MAX_TELEMETRY_ERROR_CHARS]
+
+
+def telemetry_failure_hint(exc: Exception) -> str:
+    """
+    Confluent's own error text plus the operator-facing next step, for a failed lookup.
+
+    The two authentication failures need opposite fixes and were indistinguishable in the
+    log. Confluent answers 401 when the credential is not a Cloud API key at all, which no
+    role grant repairs, and 403 when the credential is valid but its account holds no role
+    granting metrics on the cluster, which no key change repairs.
+
+    The status to cause mapping is measured against the live API rather than taken from
+    documentation. A Kafka cluster-scoped key, a wrong secret and an unknown key all give
+    401. A Cloud key lacking a metrics role, or one querying a cluster in another
+    organisation, gives 403.
+    """
+    response = getattr(exc, "response", None)
+    parts = []
+
+    detail = _telemetry_error_detail(response)
+    if detail:
+        parts.append(f"Confluent said: {detail}")
+
+    status = getattr(response, "status_code", None)
+    if status == HTTPStatus.UNAUTHORIZED:
+        parts.append(
+            "The Kafka Connect credential is not accepted by the Telemetry API. It has to be a "
+            "Confluent Cloud API key, because a Kafka cluster-scoped key cannot authenticate here"
+        )
+    elif status == HTTPStatus.FORBIDDEN:
+        parts.append(
+            "The credential authenticated but is not authorised for metrics on this cluster. Grant "
+            "its account the MetricsViewer role, or use an account that already holds one conferring "
+            "metrics access"
+        )
+
+    return f". {'. '.join(parts)}" if parts else ""
 
 
 def _to_python_replacement(replacement: str) -> str:
@@ -489,7 +562,12 @@ class KafkaConnectClient:
             # Recorded as empty rather than left unset, so one failure does not become one
             # failed call per connector. The API is rate limited per hour, and a large
             # estate would spend that budget retrying a call that already failed.
-            logger.warning("Confluent telemetry unavailable for cluster %s, topics not enriched: %s", cluster_id, exc)
+            logger.warning(
+                "Confluent telemetry unavailable for cluster %s, topics not enriched: %s%s",
+                cluster_id,
+                exc,
+                telemetry_failure_hint(exc),
+            )
             logger.debug(traceback.format_exc())
 
         self._telemetry_topics_by_connector_id = by_connector

--- a/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/client.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/client.py
@@ -15,8 +15,6 @@ Client to interact with Kafka Connect REST APIs
 import re
 import traceback
 from collections.abc import Iterable
-from datetime import datetime, timedelta, timezone
-from http import HTTPStatus
 from urllib.parse import urlparse
 
 import requests
@@ -26,6 +24,7 @@ from pydantic import ValidationError
 from metadata.generated.schema.entity.services.connections.pipeline.kafkaConnectConnection import (
     KafkaConnectConnection,
 )
+from metadata.ingestion.source.pipeline.kafkaconnect import telemetry
 from metadata.ingestion.source.pipeline.kafkaconnect.constants import (
     ConnectorConfigKeys,
 )
@@ -143,47 +142,6 @@ INTERNAL_TOPIC_CONFIG_KEYS = (
     "errors.deadletterqueue.topic.name",
 )
 
-# Confluent Cloud answers KIP-558 with 404, so a connector whose destination topic is
-# chosen from a row value resolves nothing from its configuration. The telemetry Data Flow
-# dataset reports which topic a producer client wrote to, and a managed connector produces
-# under a client id carrying its own connector id, which is what ties the two together.
-CONFLUENT_TELEMETRY_URL = "https://api.telemetry.confluent.cloud/v2/metrics/dataflow/query"
-
-# Named from the CLUSTER's perspective, not the client's: received_records counts records
-# the cluster received, which is what a producer wrote. The mirrored sent_records counts
-# what the cluster sent to consumers and returns no producer clients at all, so it is the
-# wrong end of the pipe for a source connector. The value itself is unused, only the
-# topic-to-client pairing matters.
-CONFLUENT_TELEMETRY_METRIC = "received_records"
-
-# Confluent retains metrics for seven days. A shorter window keeps the response small and
-# reduces how far back a since-deleted connector can appear.
-CONFLUENT_TELEMETRY_WINDOW_HOURS = 24
-
-CONFLUENT_TELEMETRY_TIMEOUT_SECONDS = 60
-
-# The documented maximum number of groups per response. Higher values are currently
-# tolerated by the service but are out of spec, and the response is paginated regardless,
-# so there is nothing to gain by asking for more than the contract allows.
-CONFLUENT_TELEMETRY_PAGE_LIMIT = 1000
-
-# A cluster busy enough to need more pages than this is not one we can usefully enumerate,
-# and an unbounded follow-the-cursor loop would hang ingestion on a malformed response.
-CONFLUENT_TELEMETRY_MAX_PAGES = 50
-
-# A managed connector's producer client is named connector-producer-<connector-id>-<task>.
-# The convention is not documented, so it is matched rather than constructed, and a client
-# id that does not match yields no attribution instead of a guess.
-CONFLUENT_PRODUCER_CLIENT_PATTERN = re.compile(r"connector-producer-(?P<connector_id>lcc-[a-z0-9]+)-\d+$")
-
-# Confluent Cloud Connect URLs end in /clusters/<kafka-cluster-id>, which is the id the
-# telemetry query filters on.
-CONFLUENT_CLUSTER_ID_PATTERN = re.compile(r"/clusters/(?P<cluster_id>lkc-[a-z0-9]+)")
-
-# Confluent's error bodies are short, but this is an unbounded remote string being put into
-# a log line, so it is capped rather than trusted.
-MAX_TELEMETRY_ERROR_CHARS = 300
-
 
 def extract_internal_topic_names(connector_config: dict | None) -> set[str]:
     """
@@ -244,74 +202,6 @@ def confluent_managed_internal_topic_names(connector_config: dict | None, connec
         f"{prefix}.{connector_id}.transaction",
         f"dbhistory.{prefix}.{connector_id}",
     }
-
-
-def _telemetry_error_detail(response) -> str:
-    """
-    What Confluent said, which the raised HTTPError does not carry.
-
-    ``raise_for_status`` renders only the status line, so the body is lost even though it
-    is the part that identifies the failure: "Invalid credentials" and "Query must filter
-    by at least one of your authorized resources" arrive under the same 4xx otherwise.
-    """
-    if response is None:
-        return ""
-
-    try:
-        body = response.json()
-    except Exception:
-        text = (getattr(response, "text", "") or "").strip()
-        return text[:MAX_TELEMETRY_ERROR_CHARS]
-
-    # Confluent's error envelope puts the useful sentence in errors[].detail. Anything else
-    # is rendered as-is rather than dropped, because an unexpected shape is itself worth
-    # seeing when diagnosing, and a body we chose not to print cannot be recovered later.
-    if isinstance(body, dict):
-        details = [
-            str(err.get("detail")).strip()
-            for err in (body.get("errors") or [])
-            if isinstance(err, dict) and err.get("detail")
-        ]
-        if details:
-            return ", ".join(details)[:MAX_TELEMETRY_ERROR_CHARS]
-    return str(body)[:MAX_TELEMETRY_ERROR_CHARS]
-
-
-def telemetry_failure_hint(exc: Exception) -> str:
-    """
-    Confluent's own error text plus the operator-facing next step, for a failed lookup.
-
-    The two authentication failures need opposite fixes and were indistinguishable in the
-    log. Confluent answers 401 when the credential is not a Cloud API key at all, which no
-    role grant repairs, and 403 when the credential is valid but its account holds no role
-    granting metrics on the cluster, which no key change repairs.
-
-    The status to cause mapping is measured against the live API rather than taken from
-    documentation. A Kafka cluster-scoped key, a wrong secret and an unknown key all give
-    401. A Cloud key lacking a metrics role, or one querying a cluster in another
-    organisation, gives 403.
-    """
-    response = getattr(exc, "response", None)
-    parts = []
-
-    detail = _telemetry_error_detail(response)
-    if detail:
-        parts.append(f"Confluent said: {detail}")
-
-    status = getattr(response, "status_code", None)
-    if status == HTTPStatus.UNAUTHORIZED:
-        parts.append(
-            "The Kafka Connect credential is not accepted by the Telemetry API. It has to be a "
-            "Confluent Cloud API key, because a Kafka cluster-scoped key cannot authenticate here"
-        )
-    elif status == HTTPStatus.FORBIDDEN:
-        parts.append(
-            "The credential authenticated but is not authorised for metrics on this cluster. Grant "
-            "its account the MetricsViewer role, or use an account that already holds one conferring "
-            "metrics access"
-        )
-
-    return f". {'. '.join(parts)}" if parts else ""
 
 
 def _to_python_replacement(replacement: str) -> str:
@@ -416,8 +306,7 @@ class KafkaConnectClient:
         """The Kafka cluster id the Connect URL points at, which scopes the telemetry query."""
         if not self.is_confluent_cloud:
             return None
-        match = CONFLUENT_CLUSTER_ID_PATTERN.search(self._host_port)
-        return match.group("cluster_id") if match else None
+        return telemetry.cluster_id_from_connect_url(self._host_port)
 
     def _connector_id_by_name(self) -> dict[str, str]:
         """
@@ -446,7 +335,7 @@ class KafkaConnectClient:
         return result
 
     def _query_dataflow_topics_by_client(
-        self, cluster_id: str, max_pages: int = CONFLUENT_TELEMETRY_MAX_PAGES
+        self, cluster_id: str, max_pages: int = telemetry.MAX_PAGES
     ) -> dict[str, set[str]]:
         """
         Topics each connector producer wrote to on this cluster, from the telemetry API.
@@ -463,30 +352,17 @@ class KafkaConnectClient:
         them all would spend a request per page against an endpoint that rate limits by the
         hour, for an answer the first response already gave.
         """
-        now = datetime.now(timezone.utc).replace(microsecond=0)
-        start = now - timedelta(hours=CONFLUENT_TELEMETRY_WINDOW_HOURS)
-        interval = f"{start.isoformat().replace('+00:00', 'Z')}/{now.isoformat().replace('+00:00', 'Z')}"
-        payload = {
-            "aggregations": [{"metric": CONFLUENT_TELEMETRY_METRIC, "aggregations": ["SUM"]}],
-            "filter": {
-                "op": "AND",
-                "filters": [{"field": "resource.kafka.id", "op": "EQ", "value": cluster_id}],
-            },
-            "granularity": "ALL",
-            "group_by": ["metric.topic", "metric.client_id"],
-            "intervals": [interval],
-            "limit": CONFLUENT_TELEMETRY_PAGE_LIMIT,
-        }
+        payload = telemetry.build_dataflow_query(cluster_id)
 
         by_client: dict[str, set[str]] = {}
         page_token = None
         for _ in range(max_pages):
             response = requests.post(
-                CONFLUENT_TELEMETRY_URL,
+                telemetry.DATAFLOW_QUERY_URL,
                 json=payload,
                 params={"page_token": page_token} if page_token else None,
                 auth=self._telemetry_auth,
-                timeout=CONFLUENT_TELEMETRY_TIMEOUT_SECONDS,
+                timeout=telemetry.TIMEOUT_SECONDS,
                 verify=self._verify_ssl,
             )
             response.raise_for_status()
@@ -506,7 +382,7 @@ class KafkaConnectClient:
                 # Discarded here rather than after the loop, because this map is held
                 # across every page: on a busy cluster the applications producing to it
                 # far outnumber the connectors, and none of them can ever be attributed.
-                if not CONFLUENT_PRODUCER_CLIENT_PATTERN.match(entry.client_id):
+                if not telemetry.connector_id_from_client_id(entry.client_id):
                     continue
                 by_client.setdefault(entry.client_id, set()).add(entry.topic)
 
@@ -528,7 +404,7 @@ class KafkaConnectClient:
             # Only when the full budget was asked for. A caller that deliberately reads one
             # page has not lost anything it wanted, and warning there would report a problem
             # during a test connection that ran exactly as intended.
-            if max_pages == CONFLUENT_TELEMETRY_MAX_PAGES:
+            if max_pages == telemetry.MAX_PAGES:
                 logger.warning(
                     "Stopped reading Confluent telemetry after %s pages for cluster %s, topic resolution may be incomplete",
                     max_pages,
@@ -555,9 +431,9 @@ class KafkaConnectClient:
         by_connector: dict[str, set[str]] = {}
         try:
             for client_id, client_topics in self._query_dataflow_topics_by_client(cluster_id).items():
-                match = CONFLUENT_PRODUCER_CLIENT_PATTERN.match(client_id)
-                if match and match.group("connector_id") in live_connector_ids:
-                    by_connector.setdefault(match.group("connector_id"), set()).update(client_topics)
+                connector_id = telemetry.connector_id_from_client_id(client_id)
+                if connector_id in live_connector_ids:
+                    by_connector.setdefault(connector_id, set()).update(client_topics)
         except Exception as exc:
             # Recorded as empty rather than left unset, so one failure does not become one
             # failed call per connector. The API is rate limited per hour, and a large
@@ -566,7 +442,7 @@ class KafkaConnectClient:
                 "Confluent telemetry unavailable for cluster %s, topics not enriched: %s%s",
                 cluster_id,
                 exc,
-                telemetry_failure_hint(exc),
+                telemetry.failure_hint(exc),
             )
             logger.debug(traceback.format_exc())
 

--- a/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/telemetry.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/telemetry.py
@@ -140,19 +140,26 @@ def error_detail(response) -> str:
     return single_log_line(str(body))
 
 
-def failure_hint(exc: Exception) -> str:
+def failure_hint(exc: Exception, connect_authenticated: bool | None = None) -> str:
     """
     Confluent's own error text plus the operator-facing next step, for a failed lookup.
 
     The two authentication failures need opposite fixes and were indistinguishable in the
-    log. Confluent answers 401 when the credential is not a Cloud API key at all, which no
-    role grant repairs, and 403 when the credential is valid but its account holds no role
-    granting metrics on the cluster, which no key change repairs.
+    log. Confluent answers 401 when it does not accept the credential at all, and 403 when
+    it accepts the credential but the account holds no role granting metrics on the cluster.
+    A key change repairs the first and never the second, a role grant the second and never
+    the first.
 
     The status to cause mapping is measured against the live API rather than taken from
     documentation. A Kafka cluster-scoped key, a wrong secret and an unknown key all give
     401. A Cloud key lacking a metrics role, or one querying a cluster in another
     organization, gives 403.
+
+    ``connect_authenticated`` says whether the same credential just worked against the
+    Connect API. It changes what a 401 means and so what to advise. A credential that fails
+    both is simply not a Cloud API key, which is the common case. One that Connect accepts
+    while telemetry rejects is neither of the causes above, so the honest thing is to report
+    that rather than prescribe a fix that would send the reader after the wrong thing.
     """
     response = getattr(exc, "response", None)
     parts = []
@@ -162,7 +169,13 @@ def failure_hint(exc: Exception) -> str:
         parts.append(f"Confluent said: {detail}")
 
     status = getattr(response, "status_code", None)
-    if status == HTTPStatus.UNAUTHORIZED:
+    if status == HTTPStatus.UNAUTHORIZED and connect_authenticated:
+        parts.append(
+            "The same credential authenticates to the Connect API, so Confluent accepts it but the "
+            "Metrics API does not. Check the key's scope, it has to be a Cloud API key rather than a "
+            "Kafka cluster-scoped one, and that its account holds the MetricsViewer role"
+        )
+    elif status == HTTPStatus.UNAUTHORIZED:
         parts.append(
             "The Kafka Connect credential is not accepted by the Telemetry API. It has to be a "
             "Confluent Cloud API key, because a Kafka cluster-scoped key cannot authenticate here"

--- a/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/telemetry.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/telemetry.py
@@ -62,6 +62,11 @@ CLUSTER_ID_PATTERN = re.compile(r"/clusters/(?P<cluster_id>lkc-[a-z0-9]+)")
 # a log line, so it is capped rather than trusted.
 MAX_ERROR_CHARS = 300
 
+# How much of the raw body is read before whitespace is collapsed. Ten times the output
+# leaves room for a page that is mostly indentation to still yield a full line of content,
+# while keeping the work bounded no matter how large the response is.
+INPUT_CAP_FACTOR = 10
+
 
 def cluster_id_from_connect_url(url: str) -> str | None:
     """The Kafka cluster id a Confluent Connect URL points at, which scopes the query."""
@@ -106,8 +111,15 @@ def single_log_line(text: str) -> str:
     returning HTML rather than Confluent returning JSON. Newlines in it would split one
     warning into several lines that each look like their own log record, so a crafted body
     could forge entries and any body at all could break line-oriented parsing.
+
+    The input is capped before it is normalized, not after. Splitting first would build a
+    token list the size of the whole body, and a large HTML error page would be tokenized
+    and rejoined only for all but a few hundred characters to be discarded. The cap is a
+    multiple of the output so that collapsing long runs of whitespace, which such pages are
+    mostly made of, still leaves a full line of real content.
     """
-    return " ".join((text or "").split())[:MAX_ERROR_CHARS]
+    head = (text or "")[: MAX_ERROR_CHARS * INPUT_CAP_FACTOR]
+    return " ".join(head.split())[:MAX_ERROR_CHARS]
 
 
 def error_detail(response) -> str:

--- a/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/telemetry.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/telemetry.py
@@ -1,0 +1,177 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Confluent Cloud Telemetry API: how to ask it for a connector's topics, and how to read
+what it answers.
+
+Confluent Cloud answers KIP-558 with 404, so a connector whose destination topic is chosen
+from a row value resolves nothing from its configuration. The telemetry Data Flow dataset
+reports which topic a producer client wrote to, and a managed connector produces under a
+client id carrying its own connector id, which is what ties the two together.
+
+Everything here is pure. The HTTP session, pagination and per-run caching live with the
+client, so this module can be reasoned about and tested without a network.
+"""
+
+import re
+from datetime import datetime, timedelta, timezone
+from http import HTTPStatus
+
+DATAFLOW_QUERY_URL = "https://api.telemetry.confluent.cloud/v2/metrics/dataflow/query"
+
+# Named from the CLUSTER's perspective, not the client's: received_records counts records
+# the cluster received, which is what a producer wrote. The mirrored sent_records counts
+# what the cluster sent to consumers and returns no producer clients at all, so it is the
+# wrong end of the pipe for a source connector. The value itself is unused, only the
+# topic-to-client pairing matters.
+METRIC = "received_records"
+
+# Confluent retains metrics for seven days. A shorter window keeps the response small and
+# reduces how far back a since-deleted connector can appear.
+WINDOW_HOURS = 24
+
+TIMEOUT_SECONDS = 60
+
+# The documented maximum number of groups per response. Higher values are currently
+# tolerated by the service but are out of spec, and the response is paginated regardless,
+# so there is nothing to gain by asking for more than the contract allows.
+PAGE_LIMIT = 1000
+
+# A cluster busy enough to need more pages than this is not one we can usefully enumerate,
+# and an unbounded follow-the-cursor loop would hang ingestion on a malformed response.
+MAX_PAGES = 50
+
+# A managed connector's producer client is named connector-producer-<connector-id>-<task>.
+# The convention is not documented, so it is matched rather than constructed, and a client
+# id that does not match yields no attribution instead of a guess.
+PRODUCER_CLIENT_PATTERN = re.compile(r"connector-producer-(?P<connector_id>lcc-[a-z0-9]+)-\d+$")
+
+# Confluent Cloud Connect URLs end in /clusters/<kafka-cluster-id>, which is the id the
+# telemetry query filters on.
+CLUSTER_ID_PATTERN = re.compile(r"/clusters/(?P<cluster_id>lkc-[a-z0-9]+)")
+
+# Confluent's error bodies are short, but this is an unbounded remote string being put into
+# a log line, so it is capped rather than trusted.
+MAX_ERROR_CHARS = 300
+
+
+def cluster_id_from_connect_url(url: str) -> str | None:
+    """The Kafka cluster id a Confluent Connect URL points at, which scopes the query."""
+    match = CLUSTER_ID_PATTERN.search(url or "")
+    return match.group("cluster_id") if match else None
+
+
+def connector_id_from_client_id(client_id: str) -> str | None:
+    """The connector a producer client belongs to, or None when it is not a connector."""
+    match = PRODUCER_CLIENT_PATTERN.match(client_id or "")
+    return match.group("connector_id") if match else None
+
+
+def build_dataflow_query(cluster_id: str, now: datetime | None = None) -> dict:
+    """
+    The Data Flow query for one cluster's producer-to-topic pairs.
+
+    Grouping by topic and client together is what makes the result attributable. The metric
+    value is discarded, since the presence of the pair is the whole signal.
+    """
+    now = (now or datetime.now(timezone.utc)).replace(microsecond=0)
+    start = now - timedelta(hours=WINDOW_HOURS)
+    interval = f"{start.isoformat().replace('+00:00', 'Z')}/{now.isoformat().replace('+00:00', 'Z')}"
+    return {
+        "aggregations": [{"metric": METRIC, "aggregations": ["SUM"]}],
+        "filter": {
+            "op": "AND",
+            "filters": [{"field": "resource.kafka.id", "op": "EQ", "value": cluster_id}],
+        },
+        "granularity": "ALL",
+        "group_by": ["metric.topic", "metric.client_id"],
+        "intervals": [interval],
+        "limit": PAGE_LIMIT,
+    }
+
+
+def single_log_line(text: str) -> str:
+    """
+    Collapse remote text into one bounded log line.
+
+    The body comes from whatever answered the request, which on a failure may be a proxy
+    returning HTML rather than Confluent returning JSON. Newlines in it would split one
+    warning into several lines that each look like their own log record, so a crafted body
+    could forge entries and any body at all could break line-oriented parsing.
+    """
+    return " ".join((text or "").split())[:MAX_ERROR_CHARS]
+
+
+def error_detail(response) -> str:
+    """
+    What Confluent said, which the raised HTTPError does not carry.
+
+    ``raise_for_status`` renders only the status line, so the body is lost even though it
+    is the part that identifies the failure: "Invalid credentials" and "Query must filter
+    by at least one of your authorized resources" arrive under the same 4xx otherwise.
+    """
+    if response is None:
+        return ""
+
+    try:
+        body = response.json()
+    except Exception:
+        return single_log_line(getattr(response, "text", ""))
+
+    # Confluent's error envelope puts the useful sentence in errors[].detail. Anything else
+    # is rendered as-is rather than dropped, because an unexpected shape is itself worth
+    # seeing when diagnosing, and a body we chose not to print cannot be recovered later.
+    if isinstance(body, dict):
+        details = [
+            str(err.get("detail")).strip()
+            for err in (body.get("errors") or [])
+            if isinstance(err, dict) and err.get("detail")
+        ]
+        if details:
+            return single_log_line(", ".join(details))
+    return single_log_line(str(body))
+
+
+def failure_hint(exc: Exception) -> str:
+    """
+    Confluent's own error text plus the operator-facing next step, for a failed lookup.
+
+    The two authentication failures need opposite fixes and were indistinguishable in the
+    log. Confluent answers 401 when the credential is not a Cloud API key at all, which no
+    role grant repairs, and 403 when the credential is valid but its account holds no role
+    granting metrics on the cluster, which no key change repairs.
+
+    The status to cause mapping is measured against the live API rather than taken from
+    documentation. A Kafka cluster-scoped key, a wrong secret and an unknown key all give
+    401. A Cloud key lacking a metrics role, or one querying a cluster in another
+    organization, gives 403.
+    """
+    response = getattr(exc, "response", None)
+    parts = []
+
+    detail = error_detail(response)
+    if detail:
+        parts.append(f"Confluent said: {detail}")
+
+    status = getattr(response, "status_code", None)
+    if status == HTTPStatus.UNAUTHORIZED:
+        parts.append(
+            "The Kafka Connect credential is not accepted by the Telemetry API. It has to be a "
+            "Confluent Cloud API key, because a Kafka cluster-scoped key cannot authenticate here"
+        )
+    elif status == HTTPStatus.FORBIDDEN:
+        parts.append(
+            "The credential authenticated but is not authorized for metrics on this cluster. Grant "
+            "its account the MetricsViewer role, or use an account that already holds one conferring "
+            "metrics access"
+        )
+
+    return f". {'. '.join(parts)}" if parts else ""

--- a/ingestion/tests/unit/topology/pipeline/test_kafkaconnect.py
+++ b/ingestion/tests/unit/topology/pipeline/test_kafkaconnect.py
@@ -27,10 +27,8 @@ from metadata.generated.schema.entity.services.connections.pipeline.kafkaConnect
 )
 from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.ingestion.source.pipeline.kafkaconnect import client as client_module
-from metadata.ingestion.source.pipeline.kafkaconnect.client import (
-    KafkaConnectClient,
-    telemetry_failure_hint,
-)
+from metadata.ingestion.source.pipeline.kafkaconnect import telemetry
+from metadata.ingestion.source.pipeline.kafkaconnect.client import KafkaConnectClient
 from metadata.ingestion.source.pipeline.kafkaconnect.models import (
     KafkaConnectColumnMapping,
     KafkaConnectDatasetDetails,
@@ -2923,7 +2921,7 @@ class TestTelemetryFailureHint:
     A failed telemetry lookup has to say which of the two fixes applies.
 
     Confluent answers 401 when the credential is not a Cloud API key at all and 403 when it
-    is valid but unauthorised for metrics. The fixes are opposite, a different key versus a
+    is valid but unauthorized for metrics. The fixes are opposite, a different key versus a
     role grant, and the raised HTTPError renders only the status line, so without this the
     log said the same thing for both.
     """
@@ -2943,7 +2941,7 @@ class TestTelemetryFailureHint:
 
     def test_unauthorized_names_the_key_as_the_problem(self):
         """401 is unauthenticated, so no role grant can fix it. The key itself is wrong."""
-        hint = telemetry_failure_hint(
+        hint = telemetry.failure_hint(
             self._error(401, {"errors": [{"status": "401", "detail": "Invalid credentials"}]})
         )
 
@@ -2953,7 +2951,7 @@ class TestTelemetryFailureHint:
 
     def test_forbidden_names_the_role_as_the_problem(self):
         """403 authenticated fine, so the key is right and only the role is missing."""
-        hint = telemetry_failure_hint(
+        hint = telemetry.failure_hint(
             self._error(
                 403,
                 {
@@ -2977,7 +2975,7 @@ class TestTelemetryFailureHint:
         after the wrong thing. What Confluent returned is still reported, because an
         unexpected shape is worth seeing and a body we declined to print is lost for good.
         """
-        hint = telemetry_failure_hint(self._error(500, {"errors": []}))
+        hint = telemetry.failure_hint(self._error(500, {"errors": []}))
 
         assert "MetricsViewer" not in hint and "Cloud API key" not in hint, (
             "a non-auth failure must not prescribe an auth fix"
@@ -2986,18 +2984,18 @@ class TestTelemetryFailureHint:
 
     def test_no_response_at_all_adds_nothing(self):
         """A connection error never reached Confluent, so there is no response to report."""
-        assert telemetry_failure_hint(requests.exceptions.ConnectionError("no route")) == ""
+        assert telemetry.failure_hint(requests.exceptions.ConnectionError("no route")) == ""
 
     def test_non_json_body_falls_back_to_text(self):
         """A proxy in front of the API answers HTML, which must not crash the handler."""
-        hint = telemetry_failure_hint(self._error(401, body=None, text="<html>gateway</html>"))
+        hint = telemetry.failure_hint(self._error(401, body=None, text="<html>gateway</html>"))
 
         assert "gateway" in hint
         assert "Cloud API key" in hint
 
     def test_remote_text_is_capped(self):
         """The body is remote input going into a log line, so it cannot be unbounded."""
-        hint = telemetry_failure_hint(self._error(403, {"errors": [{"detail": "x" * 5000}]}))
+        hint = telemetry.failure_hint(self._error(403, {"errors": [{"detail": "x" * 5000}]}))
 
         assert len(hint) < 1000, "an unbounded remote string must not reach the log"
 
@@ -3018,3 +3016,25 @@ class TestTelemetryFailureHint:
         rendered = warn.call_args[0][0] % warn.call_args[0][1:]
         assert "MetricsViewer" in rendered
         assert "not authorized" in rendered
+
+    def test_remote_text_cannot_forge_log_lines(self):
+        """
+        The body is whatever answered the request, which on a failure may be a proxy
+        returning HTML rather than Confluent returning JSON. Newlines in it would split one
+        warning into several that each read as their own record, so a crafted body could
+        forge log entries and any body at all could break line-oriented parsing.
+        """
+        forged = "denied\n2026-01-01 00:00:00 INFO  everything is fine\nmore"
+        hint = telemetry.failure_hint(self._error(401, {"errors": [{"detail": forged}]}))
+
+        assert "\n" not in hint and "\r" not in hint, "remote text must not span log lines"
+        assert "everything is fine" in hint, "the content is kept, only the newlines go"
+
+    def test_html_error_body_is_flattened(self):
+        """A proxy's HTML page is multi-line by nature and must collapse to one line."""
+        hint = telemetry.failure_hint(
+            self._error(403, body=None, text="<html>\n  <body>\n    Forbidden\n  </body>\n</html>")
+        )
+
+        assert "\n" not in hint
+        assert "Forbidden" in hint

--- a/ingestion/tests/unit/topology/pipeline/test_kafkaconnect.py
+++ b/ingestion/tests/unit/topology/pipeline/test_kafkaconnect.py
@@ -19,13 +19,18 @@ from unittest.mock import MagicMock, Mock, patch
 from uuid import uuid4
 
 import pytest
+import requests
 
 from metadata.generated.schema.entity.data.topic import Topic
 from metadata.generated.schema.entity.services.connections.pipeline.kafkaConnectConnection import (
     KafkaConnectConnection,
 )
 from metadata.generated.schema.type.entityReference import EntityReference
-from metadata.ingestion.source.pipeline.kafkaconnect.client import KafkaConnectClient
+from metadata.ingestion.source.pipeline.kafkaconnect import client as client_module
+from metadata.ingestion.source.pipeline.kafkaconnect.client import (
+    KafkaConnectClient,
+    telemetry_failure_hint,
+)
 from metadata.ingestion.source.pipeline.kafkaconnect.models import (
     KafkaConnectColumnMapping,
     KafkaConnectDatasetDetails,
@@ -2911,3 +2916,105 @@ class TestConfluentTelemetryTopics:
             pytest.raises(Exception, match="401"),
         ):
             client.check_confluent_telemetry()
+
+
+class TestTelemetryFailureHint:
+    """
+    A failed telemetry lookup has to say which of the two fixes applies.
+
+    Confluent answers 401 when the credential is not a Cloud API key at all and 403 when it
+    is valid but unauthorised for metrics. The fixes are opposite, a different key versus a
+    role grant, and the raised HTTPError renders only the status line, so without this the
+    log said the same thing for both.
+    """
+
+    @staticmethod
+    def _error(status, body=None, text=""):
+        response = MagicMock()
+        response.status_code = status
+        response.text = text
+        if body is None:
+            response.json = MagicMock(side_effect=ValueError("not json"))
+        else:
+            response.json = MagicMock(return_value=body)
+        exc = requests.exceptions.HTTPError(f"{status} Client Error")
+        exc.response = response
+        return exc
+
+    def test_unauthorized_names_the_key_as_the_problem(self):
+        """401 is unauthenticated, so no role grant can fix it. The key itself is wrong."""
+        hint = telemetry_failure_hint(
+            self._error(401, {"errors": [{"status": "401", "detail": "Invalid credentials"}]})
+        )
+
+        assert "Invalid credentials" in hint, "Confluent's own wording must survive"
+        assert "Cloud API key" in hint
+        assert "MetricsViewer" not in hint, "a role grant cannot fix an unauthenticated key"
+
+    def test_forbidden_names_the_role_as_the_problem(self):
+        """403 authenticated fine, so the key is right and only the role is missing."""
+        hint = telemetry_failure_hint(
+            self._error(
+                403,
+                {
+                    "errors": [
+                        {
+                            "status": "403",
+                            "detail": "Query must filter by at least one of your authorized resources",
+                        }
+                    ]
+                },
+            )
+        )
+
+        assert "authorized resources" in hint, "Confluent's own wording must survive"
+        assert "MetricsViewer" in hint
+        assert "Cloud API key" not in hint, "the key authenticated, so it is not the problem"
+
+    def test_other_failures_report_the_response_but_prescribe_no_fix(self):
+        """
+        A timeout or a 500 is not an auth problem, so naming a fix would send the reader
+        after the wrong thing. What Confluent returned is still reported, because an
+        unexpected shape is worth seeing and a body we declined to print is lost for good.
+        """
+        hint = telemetry_failure_hint(self._error(500, {"errors": []}))
+
+        assert "MetricsViewer" not in hint and "Cloud API key" not in hint, (
+            "a non-auth failure must not prescribe an auth fix"
+        )
+        assert "errors" in hint, "the response itself is still worth reporting"
+
+    def test_no_response_at_all_adds_nothing(self):
+        """A connection error never reached Confluent, so there is no response to report."""
+        assert telemetry_failure_hint(requests.exceptions.ConnectionError("no route")) == ""
+
+    def test_non_json_body_falls_back_to_text(self):
+        """A proxy in front of the API answers HTML, which must not crash the handler."""
+        hint = telemetry_failure_hint(self._error(401, body=None, text="<html>gateway</html>"))
+
+        assert "gateway" in hint
+        assert "Cloud API key" in hint
+
+    def test_remote_text_is_capped(self):
+        """The body is remote input going into a log line, so it cannot be unbounded."""
+        hint = telemetry_failure_hint(self._error(403, {"errors": [{"detail": "x" * 5000}]}))
+
+        assert len(hint) < 1000, "an unbounded remote string must not reach the log"
+
+    def test_hint_reaches_the_warning(self):
+        """The hint is worthless unless it lands in the line an operator actually reads."""
+        client = object.__new__(KafkaConnectClient)
+        client.is_confluent_cloud = True
+        client._telemetry_auth = ("k", "s")
+        client._connector_ids = {"outbox-a": "lcc-aaa111"}
+        client._telemetry_topics_by_connector_id = None
+        client._query_dataflow_topics_by_client = MagicMock(
+            side_effect=self._error(403, {"errors": [{"detail": "not authorized"}]})
+        )
+
+        with patch.object(client_module.logger, "warning") as warn:
+            client._telemetry_topics_for_connector_ids("lkc-xyz")
+
+        rendered = warn.call_args[0][0] % warn.call_args[0][1:]
+        assert "MetricsViewer" in rendered
+        assert "not authorized" in rendered

--- a/ingestion/tests/unit/topology/pipeline/test_kafkaconnect.py
+++ b/ingestion/tests/unit/topology/pipeline/test_kafkaconnect.py
@@ -3038,3 +3038,49 @@ class TestTelemetryFailureHint:
 
         assert "\n" not in hint
         assert "Forbidden" in hint
+
+    def test_401_when_connect_works_does_not_blame_the_key_type(self):
+        """
+        A credential Connect accepts is not a cluster-scoped key, since those fail Connect
+        too. Telling the reader to swap the key type would send them after the wrong thing,
+        so the message reports what was observed and names both levers to check.
+        """
+        hint = telemetry.failure_hint(
+            self._error(401, {"errors": [{"detail": "Invalid credentials"}]}),
+            connect_authenticated=True,
+        )
+
+        assert "authenticates to the Connect API" in hint, "the observed split must be stated"
+        assert "MetricsViewer" in hint and "scope" in hint, "both levers are named"
+
+    def test_401_when_connect_also_failed_blames_the_key(self):
+        """Failing both is the ordinary case: the credential is not a Cloud API key."""
+        hint = telemetry.failure_hint(
+            self._error(401, {"errors": [{"detail": "Invalid credentials"}]}),
+            connect_authenticated=False,
+        )
+
+        assert "not accepted by the Telemetry API" in hint
+        assert "authenticates to the Connect API" not in hint
+
+    def test_warning_names_the_key_but_never_the_secret(self):
+        """
+        The key id is what identifies which credential to go and look at, and it is not a
+        secret. The secret sits beside it in the same tuple and must never reach a log.
+        """
+        client = object.__new__(KafkaConnectClient)
+        client.is_confluent_cloud = True
+        client._telemetry_auth = ("KEYID123", "SUPERSECRET")
+        client._connector_ids = {"outbox-a": "lcc-aaa111"}
+        client._telemetry_topics_by_connector_id = None
+        client._query_dataflow_topics_by_client = MagicMock(
+            side_effect=self._error(401, {"errors": [{"detail": "Invalid credentials"}]})
+        )
+
+        with patch.object(client_module.logger, "warning") as warn:
+            client._telemetry_topics_for_connector_ids("lkc-xyz")
+
+        rendered = warn.call_args[0][0] % warn.call_args[0][1:]
+        assert "KEYID123" in rendered, "the key id identifies which credential to check"
+        assert "SUPERSECRET" not in rendered, "the secret must never be logged"
+        assert "authenticates to the Connect API" in rendered, "Connect worked, so say so"

--- a/ingestion/tests/unit/topology/pipeline/test_kafkaconnect.py
+++ b/ingestion/tests/unit/topology/pipeline/test_kafkaconnect.py
@@ -3005,6 +3005,7 @@ class TestTelemetryFailureHint:
         client.is_confluent_cloud = True
         client._telemetry_auth = ("k", "s")
         client._connector_ids = {"outbox-a": "lcc-aaa111"}
+        client._connect_authenticated = True
         client._telemetry_topics_by_connector_id = None
         client._query_dataflow_topics_by_client = MagicMock(
             side_effect=self._error(403, {"errors": [{"detail": "not authorized"}]})
@@ -3072,6 +3073,7 @@ class TestTelemetryFailureHint:
         client.is_confluent_cloud = True
         client._telemetry_auth = ("KEYID123", "SUPERSECRET")
         client._connector_ids = {"outbox-a": "lcc-aaa111"}
+        client._connect_authenticated = True
         client._telemetry_topics_by_connector_id = None
         client._query_dataflow_topics_by_client = MagicMock(
             side_effect=self._error(401, {"errors": [{"detail": "Invalid credentials"}]})
@@ -3084,3 +3086,30 @@ class TestTelemetryFailureHint:
         assert "KEYID123" in rendered, "the key id identifies which credential to check"
         assert "SUPERSECRET" not in rendered, "the secret must never be logged"
         assert "authenticates to the Connect API" in rendered, "Connect worked, so say so"
+
+    def test_empty_cluster_is_not_mistaken_for_a_rejected_credential(self):
+        """
+        A cluster with no connectors and a cluster we cannot authenticate to both yield an
+        empty connector list. Inferring the credential from that list would tell an operator
+        with a working key and an empty cluster to go and replace the key.
+        """
+        client = object.__new__(KafkaConnectClient)
+        client.is_confluent_cloud = True
+        client._telemetry_auth = ("KEYID123", "SECRET")
+        client._telemetry_topics_by_connector_id = None
+        client._connector_ids = None
+        client._connect_authenticated = None
+        # Connect answers, the cluster simply has no connectors.
+        client.get_connectors_list = MagicMock(return_value={})
+        client._query_dataflow_topics_by_client = MagicMock(
+            side_effect=self._error(401, {"errors": [{"detail": "Invalid credentials"}]})
+        )
+
+        with patch.object(client_module.logger, "warning") as warn:
+            client._telemetry_topics_for_connector_ids("lkc-xyz")
+
+        rendered = warn.call_args[0][0] % warn.call_args[0][1:]
+        assert "authenticates to the Connect API" in rendered, (
+            "an empty connector list still means Connect authenticated"
+        )
+        assert "cannot authenticate here" not in rendered

--- a/ingestion/tests/unit/topology/pipeline/test_kafkaconnect.py
+++ b/ingestion/tests/unit/topology/pipeline/test_kafkaconnect.py
@@ -3113,3 +3113,32 @@ class TestTelemetryFailureHint:
             "an empty connector list still means Connect authenticated"
         )
         assert "cannot authenticate here" not in rendered
+
+    def test_large_body_is_capped_before_normalizing(self):
+        """
+        A proxy error page can be megabytes. Collapsing whitespace across the whole body
+        would build a token list the size of the response before all but a few hundred
+        characters are discarded, so the input is capped first.
+
+        Asserted by putting a marker past the cap: it cannot appear in the output, which is
+        only true if the body was truncated before being split.
+        """
+        cap = telemetry.MAX_ERROR_CHARS * telemetry.INPUT_CAP_FACTOR
+        body = ("x " * cap) + "MARKER_PAST_THE_CAP"
+
+        out = telemetry.single_log_line(body)
+
+        assert "MARKER_PAST_THE_CAP" not in out, "input must be capped before normalizing"
+        assert len(out) <= telemetry.MAX_ERROR_CHARS
+
+    def test_whitespace_heavy_body_still_yields_full_line(self):
+        """
+        The cap is a multiple of the output so an indented page still gives a usable line.
+        Capping at exactly the output length would leave almost nothing after collapsing.
+        """
+        body = "\n".join("    " + w for w in ["Forbidden"] * 200)
+
+        out = telemetry.single_log_line(body)
+
+        assert len(out) == telemetry.MAX_ERROR_CHARS, "a real line of content must survive"
+        assert "\n" not in out


### PR DESCRIPTION
### Describe your changes:

Fixes #32998

When Confluent's Telemetry API rejects the Kafka Connect credential, the connector logged the same line whatever the cause, and `raise_for_status` renders only the status line, so Confluent's response body never reached the log at all. The two failures need opposite fixes, and the old line let an operator tell them apart only if they already knew Confluent's permission model.

I measured the status to cause mapping against the live API rather than taking it from documentation:

| Credential | Telemetry | Confluent's `errors[].detail` |
|---|---|---|
| Cloud API key, `MetricsViewer` or an admin role | 200 | |
| Cloud API key, no metrics role | **403** | `Query must filter by at least one of your authorized resources` |
| Cloud API key, cluster in another organization | **403** | same |
| Kafka cluster-scoped key | **401** | `Invalid credentials` |
| Wrong secret, or unknown key | **401** | `Invalid credentials` |

401 is unauthenticated, so no role grant can repair it and the key itself has to change. 403 authenticated fine, so changing the key repairs nothing and only a role is missing. `MetricsViewer` is the least privileged qualifying role, though `EnvironmentAdmin` and `OrganizationAdmin` also return 200, so an account that already holds one needs no new binding.

The warning now carries Confluent's own `errors[].detail` alongside the applicable next step. A failure that is not an authentication problem still reports the response, but prescribes nothing, because naming a fix there would send the reader after the wrong thing.

Before:

```
Confluent telemetry unavailable for cluster lkc-xxxxx, topics not enriched: 401 Client Error:
Unauthorized for url: https://api.telemetry.confluent.cloud/v2/metrics/dataflow/query
```

After:

```
... topics not enriched: 401 Client Error: ... . Confluent said: Invalid credentials. The Kafka
Connect credential is not accepted by the Telemetry API. It has to be a Confluent Cloud API key,
because a Kafka cluster-scoped key cannot authenticate here

... topics not enriched: 403 Client Error: ... . Confluent said: Query must filter by at least one
of your authorized resources. The credential authenticated but is not authorized for metrics on
this cluster. Grant its account the MetricsViewer role, or use an account that already holds one
conferring metrics access
```

This only changes what is logged. Topic resolution already degraded correctly, falling back to the configured names and emitting no incorrect lineage, which is precisely why the log line is the only signal an operator has.

Two things came out of the review while writing it. The remote body was capped for length but not for shape, so newlines in a proxy's HTML could split one warning into several records that each read as their own, which is a way to forge log entries. Both paths carrying remote text now collapse it to a single line.

`client.py` had also grown to 1028 lines across four unrelated concerns, and the diagnostics landed between the internal-topic helpers and the SMT routing helpers, nowhere near the constants they read. `telemetry.py` now holds the whole contract with that API, its endpoint, limits, id conventions, query and errors, all of it pure so it can be read and tested without a network, while the session, pagination and per-run caching stay with the client. `client.py` drops to 893 lines.

#
### Type of change:

- [x] Bug fix

#
### Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
