### PR TITLE
fix(tableau): collapse auto-titled mirror columnsp [Backport #32301 - 1.13]

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
@@ -13,6 +13,7 @@ Tableau source module
 """
 
 # pylint: disable=too-many-lines
+import re
 import traceback
 from collections import defaultdict
 from datetime import datetime
@@ -102,6 +103,18 @@ logger = ingestion_logger()
 
 TABLEAU_TAG_CATEGORY = "TableauTags"
 TABLEAU_FIELD_TYPE_DISPLAY = "Tableau Field"
+# Tableau titles database column names when it builds fields (`order_date` becomes
+# `Order Date`), so separators and casing carry no meaning when comparing the two.
+# `\w` is Unicode-aware, and `_` is listed explicitly because `\w` matches it: a name made
+# only of non-ASCII letters must normalize to itself rather than to an empty string, or a
+# CJK column would never collapse onto the field mirroring it.
+NON_ALPHANUMERIC = re.compile(r"[\W_]")
+
+
+def normalize_column_name(name: str) -> str:
+    """Strip separators and casing so a Tableau field name can be compared to the physical
+    column it wraps (``Order Date`` vs ``order_date``)."""
+    return NON_ALPHANUMERIC.sub("", name.casefold())
 
 
 class TableauSource(DashboardServiceSource):
@@ -1187,14 +1200,18 @@ class TableauSource(DashboardServiceSource):
         column: its value is a transformation, so the physical column stays visible as a child and
         its ``remoteType`` must not be reported as the field's own type. ``formula`` is only
         populated by the ``... on CalculatedField`` fragment, which makes it the field-type marker.
+
+        Names are compared normalized: Tableau titles database column names when it builds the
+        field, so a Databricks column ``order_date`` surfaces as a field named ``Order Date``.
+        Those are still the same column, and comparing them raw would leave the mirror nested.
         """
         mirrored_column = None
         upstream_columns = [column for column in field.upstreamColumns or [] if column]
         if not field.formula and len(upstream_columns) == 1:
             upstream_column = upstream_columns[0]
-            field_name = field.name or field.id
-            upstream_column_name = upstream_column.name or upstream_column.id
-            if field_name.casefold() == upstream_column_name.casefold():
+            field_name = normalize_column_name(field.name or field.id)
+            upstream_column_name = normalize_column_name(upstream_column.name or upstream_column.id)
+            if field_name and field_name == upstream_column_name:
                 mirrored_column = upstream_column
         return mirrored_column
 
@@ -1222,6 +1239,10 @@ class TableauSource(DashboardServiceSource):
                     "name": truncate_column_name(field.id),
                     "displayName": field.name if field.name else field.id,
                     "description": description or None,
+                    # Always set explicitly, even when empty: the patch path merges each column
+                    # onto the stored one and only overlays fields present in `model_fields_set`,
+                    # so leaving `children` unset would resurrect children ingested previously.
+                    "children": [],
                 }
                 mirrored_column = self._get_mirrored_upstream_column(field=field)
                 if mirrored_column:
@@ -1234,9 +1255,7 @@ class TableauSource(DashboardServiceSource):
                     if mirrored_column.remoteType == DataType.ARRAY.value:
                         parsed_fields["arrayDataType"] = DataType.UNKNOWN
                 else:
-                    child_columns = self.get_child_columns(field=field)
-                    if child_columns:
-                        parsed_fields["children"] = child_columns
+                    parsed_fields["children"] = self.get_child_columns(field=field)
                 datasource_columns.append(Column(**parsed_fields))
             except Exception as exc:
                 logger.debug(traceback.format_exc())

--- a/ingestion/tests/unit/topology/dashboard/test_tableau.py
+++ b/ingestion/tests/unit/topology/dashboard/test_tableau.py
@@ -27,6 +27,11 @@ from metadata.generated.schema.type.entityReferenceList import EntityReferenceLi
 from metadata.generated.schema.type.filterPattern import FilterPattern
 from metadata.generated.schema.type.usageDetails import UsageDetails, UsageStats
 from metadata.generated.schema.type.usageRequest import UsageRequest
+from metadata.ingestion.models.patch_request import (
+    ARRAY_ENTITY_FIELDS,
+    RESTRICT_UPDATE_LIST,
+    _sort_array_entity_fields,
+)
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.dashboard.dashboard_service import DashboardUsage
 from metadata.ingestion.source.dashboard.tableau.metadata import (
@@ -1156,7 +1161,8 @@ class TableauUnitTest(TestCase):
         columns = self.tableau.get_column_info(data_source)
 
         assert len(columns) == 1
-        assert columns[0].children is None
+        assert columns[0].children == []
+        assert "children" in columns[0].model_fields_set
         assert columns[0].displayName == "revenue"
         assert columns[0].dataTypeDisplay == "NUMERIC"
         assert columns[0].dataType == DataType.NUMERIC
@@ -1180,11 +1186,68 @@ class TableauUnitTest(TestCase):
         columns = self.tableau.get_column_info(data_source)
 
         assert len(columns) == 1
-        assert columns[0].children is None
+        assert columns[0].children == []
+        assert "children" in columns[0].model_fields_set
         assert columns[0].dataType == DataType.STRING
 
-    def test_renamed_column_field_keeps_child(self):
-        """A renamed field no longer mirrors the column, so the physical column stays visible."""
+    def test_tableau_titled_column_collapses(self):
+        """
+        Tableau titles database column names when it builds fields, so a Databricks column
+        `order_date` surfaces as a field named `Order Date`. Those are the same column, so the
+        mirror must still collapse -- raw comparison would leave a near-duplicate row nested.
+        """
+        data_source = DataSource(
+            id="ds-databricks-001",
+            name="lineage_destination",
+            fields=[
+                DatasourceField(
+                    id="fld-order-date",
+                    name="Order Date",
+                    upstreamColumns=[UpstreamColumn(id="col-order-date", name="order_date", remoteType="DATE")],
+                ),
+                DatasourceField(
+                    id="fld-order-amount",
+                    name="Order Amount",
+                    upstreamColumns=[
+                        UpstreamColumn(
+                            id="col-order-amount",
+                            name="order_amount",
+                            remoteType="NUMERIC",
+                        )
+                    ],
+                ),
+            ],
+        )
+
+        columns = self.tableau.get_column_info(data_source)
+
+        assert [column.children for column in columns] == [[], []]
+        assert [column.dataTypeDisplay for column in columns] == ["DATE", "NUMERIC"]
+
+    def test_differently_named_field_keeps_child(self):
+        """Normalization must not collapse a field genuinely renamed to something else."""
+        data_source = DataSource(
+            id="ds-renamed-002",
+            name="Sales",
+            fields=[
+                DatasourceField(
+                    id="fld-revenue-usd",
+                    name="Revenue (USD)",
+                    upstreamColumns=[UpstreamColumn(id="col-revenue", name="revenue", remoteType="R8")],
+                ),
+            ],
+        )
+
+        columns = self.tableau.get_column_info(data_source)
+
+        assert len(columns[0].children) == 1
+        assert columns[0].dataTypeDisplay == "Tableau Field"
+
+    def test_uppercase_snake_case_column_collapses(self):
+        """
+        `SIGNUP_DATE` surfacing as a field named `Signup Date` is Tableau's own titling of the
+        physical column, not a user rename, so it collapses like any other mirror.
+        """
         data_source = DataSource(
             id="ds-renamed-001",
             name="Customer Facts",
@@ -1204,10 +1267,56 @@ class TableauUnitTest(TestCase):
         columns = self.tableau.get_column_info(data_source)
 
         assert len(columns) == 1
-        assert columns[0].dataTypeDisplay == "Tableau Field"
-        assert columns[0].dataType == DataType.RECORD
+        assert columns[0].children == []
+        assert columns[0].dataTypeDisplay == "DATE"
+        assert columns[0].dataType == DataType.DATE
+
+    def test_non_ascii_column_collapses(self):
+        """
+        Stripping to `[0-9a-z]` normalized an all-CJK name to an empty string, which the mirror
+        guard reads as "no name" and never collapses. Unicode letters have to survive
+        normalization so a Japanese column collapses like an ASCII one.
+        """
+        data_source = DataSource(
+            id="ds-cjk-001",
+            name="売上データ",
+            fields=[
+                DatasourceField(
+                    id="fld-uriage",
+                    name="売上",
+                    upstreamColumns=[UpstreamColumn(id="col-uriage", name="売上", remoteType="NUMERIC")],
+                ),
+                DatasourceField(
+                    id="fld-kokyaku",
+                    name="顧客 名",
+                    upstreamColumns=[UpstreamColumn(id="col-kokyaku", name="顧客_名", remoteType="STRING")],
+                ),
+            ],
+        )
+
+        columns = self.tableau.get_column_info(data_source)
+
+        assert [column.children for column in columns] == [[], []]
+        assert [column.dataTypeDisplay for column in columns] == ["NUMERIC", "STRING"]
+
+    def test_non_ascii_differently_named_field_keeps_child(self):
+        """Unicode-aware normalization must still tell genuinely different CJK names apart."""
+        data_source = DataSource(
+            id="ds-cjk-002",
+            name="売上データ",
+            fields=[
+                DatasourceField(
+                    id="fld-uriage-daka",
+                    name="売上",
+                    upstreamColumns=[UpstreamColumn(id="col-uriage-daka", name="売上高", remoteType="NUMERIC")],
+                ),
+            ],
+        )
+
+        columns = self.tableau.get_column_info(data_source)
+
         assert len(columns[0].children) == 1
-        assert columns[0].children[0].displayName == "SIGNUP_DATE"
+        assert columns[0].dataTypeDisplay == "Tableau Field"
 
     def test_calculated_field_keeps_children(self):
         """A field fanning out to several columns keeps them all: they are not duplicates."""
@@ -1283,7 +1392,8 @@ class TableauUnitTest(TestCase):
         columns = self.tableau.get_column_info(data_source)
 
         assert len(columns) == 1
-        assert columns[0].children is None
+        assert columns[0].children == []
+        assert "children" in columns[0].model_fields_set
         assert columns[0].dataTypeDisplay == "Tableau Field"
         assert columns[0].dataType == DataType.RECORD
 
@@ -1506,6 +1616,62 @@ class TableauUnitTest(TestCase):
         assert len(column_lineage) == 1
         assert column_lineage[0].fromColumns[0].root == "db.schema.sales.revenue"
         assert column_lineage[0].toColumn.root == "svc.model.Sales.fld-revenue"
+
+    def test_collapsed_column_clears_previously_ingested_children(self):
+        """
+        Issue #30639: the patch path merges each incoming column onto the stored one via
+        `source_attr.model_copy(update=...)`, overlaying only fields present in
+        `model_fields_set`. Leaving `children` unset therefore resurrects children ingested
+        before the collapse, leaving the duplicate row visible in the UI forever.
+        """
+        data_source = DataSource(
+            id="ds-mirror-003",
+            name="Sales",
+            fields=[
+                DatasourceField(
+                    id="047ffe96",
+                    name="revenue_provision",
+                    upstreamColumns=[UpstreamColumn(id="610f77a9", name="revenue_provision", remoteType="NUMERIC")],
+                ),
+            ],
+        )
+        stored_entity = DashboardDataModel(
+            id=uuid.uuid4(),
+            name="Sales",
+            service=EntityReference(id=uuid.uuid4(), type="dashboardService"),
+            dataModelType="TableauDataModel",
+            columns=[
+                Column(
+                    name="047ffe96",
+                    displayName="revenue_provision",
+                    dataType=DataType.RECORD,
+                    dataTypeDisplay="Tableau Field",
+                    fullyQualifiedName="svc.model.Sales.047ffe96",
+                    children=[
+                        Column(
+                            name="610f77a9",
+                            displayName="revenue_provision",
+                            dataType=DataType.NUMERIC,
+                            dataTypeDisplay="NUMERIC",
+                            fullyQualifiedName="svc.model.Sales.047ffe96.610f77a9",
+                        )
+                    ],
+                )
+            ],
+        )
+        incoming_entity = stored_entity.model_copy(update={"columns": self.tableau.get_column_info(data_source)})
+
+        _sort_array_entity_fields(
+            source=stored_entity,
+            destination=incoming_entity,
+            array_entity_fields=ARRAY_ENTITY_FIELDS,
+            restrict_update_fields=RESTRICT_UPDATE_LIST,
+            override_metadata=False,
+        )
+
+        merged_column = incoming_entity.columns[0]
+        assert merged_column.children == []
+        assert merged_column.dataTypeDisplay == "NUMERIC"
 
     def test_column_lineage_skips_upstream_column_without_name(self):
         """A nameless physical column cannot be resolved to a table column FQN."""


### PR DESCRIPTION
backport of https://github.com/open-metadata/OpenMetadata/commit/17c459142d5d456c4d035934153eed9f927c5a57 on 1.13