### PR TITLE
Fixes 32021: Attach SQL to native Unity Catalog lineage edges

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py
@@ -17,7 +17,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, cast
 
-from sqlalchemy import text
+from sqlalchemy import bindparam, text
 
 from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.entity.data.container import ContainerDataModel
@@ -30,6 +30,7 @@ from metadata.generated.schema.entity.services.connections.database.unityCatalog
 from metadata.generated.schema.metadataIngestion.workflow import (
     Source as WorkflowSource,
 )
+from metadata.generated.schema.type.basic import SqlQuery
 from metadata.generated.schema.type.entityLineage import (
     ColumnLineage,
     EntitiesEdge,
@@ -50,6 +51,7 @@ from metadata.ingestion.source.connections import (
 from metadata.ingestion.source.database.unitycatalog.queries import (
     UNITY_CATALOG_COLUMN_LINEAGE,
     UNITY_CATALOG_EXTERNAL_TABLES,
+    UNITY_CATALOG_LINEAGE_SQL,
     UNITY_CATALOG_TABLE_LINEAGE,
 )
 from metadata.utils import fqn
@@ -58,12 +60,16 @@ from metadata.utils.helpers import retry_with_docker_host
 from metadata.utils.logger import ingestion_logger
 
 if TYPE_CHECKING:
+    from metadata.generated.schema.metadataIngestion.databaseServiceQueryLineagePipeline import (
+        DatabaseServiceQueryLineagePipeline,
+    )
     from metadata.ingestion.source.database.unitycatalog.connection import (
         UnityCatalogConnection as UnityCatalogConnectionHandler,
     )
 
 
 logger = ingestion_logger()
+LINEAGE_SQL_BATCH_SIZE = 100
 
 
 class UnitycatalogLineageSource(Source):
@@ -81,7 +87,7 @@ class UnitycatalogLineageSource(Source):
         self.config = config
         self.metadata = metadata
         self.service_connection = self.config.serviceConnection.root.config
-        self.source_config = self.config.sourceConfig.config
+        self.source_config = cast("DatabaseServiceQueryLineagePipeline", self.config.sourceConfig.config)
         self._connection = create_connection(self.service_connection)
         connection = cast("UnityCatalogConnectionHandler", self._connection)
         self.connection_obj = connection.client
@@ -89,6 +95,7 @@ class UnitycatalogLineageSource(Source):
         self.table_lineage_map: dict[str, set[str]] = defaultdict(set)
         self.column_lineage_map: dict[tuple[str, str], list[tuple[str, str]]] = defaultdict(list)
         self.external_location_map: dict[str, str] = {}
+        self._query_history_available = True
         with close_on_failure(self._connection):
             self.test_connection()
 
@@ -114,7 +121,7 @@ class UnitycatalogLineageSource(Source):
         """
         Bulk-fetch all table and column lineage from system tables into memory.
         """
-        query_log_duration = self.source_config.queryLogDuration or 1  # pyright: ignore[reportAttributeAccessIssue]
+        query_log_duration = self.source_config.queryLogDuration or 1
         logger.info(f"Caching lineage from system tables (lookback: {query_log_duration} days)")
 
         try:
@@ -273,10 +280,42 @@ class UnitycatalogLineageSource(Source):
             logger.debug(f"Error processing external location lineage for {databricks_table_fqn}: {exc}")
             logger.debug(traceback.format_exc())
 
-    def _process_table_lineage(self, table: Table, databricks_table_fqn: str) -> Iterable[Either[AddLineageRequest]]:
-        upstream_tables = self.table_lineage_map.get(databricks_table_fqn, set())
+    def _enrich_lineage_batch(
+        self, batch: list[tuple[str, str, AddLineageRequest]]
+    ) -> Iterable[Either[AddLineageRequest]]:
+        """Attach available SQL to a batch of native edges."""
+        if not batch:
+            return
+        queries = {}
+        if self._query_history_available:
+            query_log_duration = self.source_config.queryLogDuration or 1
+            statement = text(UNITY_CATALOG_LINEAGE_SQL.format(query_log_duration=query_log_duration)).bindparams(
+                bindparam("table_pairs", expanding=True)
+            )
+            try:
+                with self.engine.connect() as conn:
+                    rows = conn.execute(statement, {"table_pairs": [(source, target) for source, target, _ in batch]})
+                    queries = {
+                        (row.source_table_full_name, row.target_table_full_name): row.statement_text for row in rows
+                    }
+            except Exception as exc:
+                self._query_history_available = False
+                logger.debug(traceback.format_exc())
+                logger.warning(
+                    "Could not retrieve native lineage SQL from system.query.history; "
+                    "continuing without SQL enrichment for this run. Check query history access: %s",
+                    exc,
+                )
+        for source, target, request in batch:
+            sql_query = queries.get((source, target))
+            if sql_query and request.edge.lineageDetails is not None:
+                request.edge.lineageDetails.sqlQuery = SqlQuery(sql_query)
+            yield Either(left=None, right=request)
 
-        for source_table_full_name in upstream_tables:
+    def _process_table_lineage(
+        self, table: Table, databricks_table_fqn: str
+    ) -> Iterable[tuple[str, AddLineageRequest]]:
+        for source_table_full_name in self.table_lineage_map.get(databricks_table_fqn, set()):
             try:
                 parts = source_table_full_name.split(".")
                 if len(parts) != 3:
@@ -303,10 +342,10 @@ class UnitycatalogLineageSource(Source):
                     to_table=table,
                     source_table_fqn=source_table_full_name,
                     target_table_fqn=databricks_table_fqn,
-                )
-
-                yield Either(
-                    right=AddLineageRequest(
+                ) or LineageDetails(source=LineageSource.QueryLineage)
+                yield (
+                    source_table_full_name,
+                    AddLineageRequest(
                         edge=EntitiesEdge(
                             toEntity=EntityReference(id=table.id, type="table"),
                             fromEntity=EntityReference(id=from_entity.id, type="table"),
@@ -325,6 +364,7 @@ class UnitycatalogLineageSource(Source):
         """
         self._cache_lineage()
         self._cache_external_locations()
+        batch: list[tuple[str, str, AddLineageRequest]] = []
 
         for database in self.metadata.list_all_entities(entity=Database, params={"service": self.config.serviceName}):
             if filter_by_database(self.source_config.databaseFilterPattern, database.name.root):  # pyright: ignore[reportAttributeAccessIssue]
@@ -356,9 +396,15 @@ class UnitycatalogLineageSource(Source):
 
                     databricks_table_fqn = f"{table.database.name}.{table.databaseSchema.name}.{table.name.root}"
 
-                    yield from self._process_table_lineage(table, databricks_table_fqn)
+                    for source_table_fqn, request in self._process_table_lineage(table, databricks_table_fqn):
+                        batch.append((source_table_fqn, databricks_table_fqn, request))
+                        if len(batch) == LINEAGE_SQL_BATCH_SIZE:
+                            yield from self._enrich_lineage_batch(batch)
+                            batch.clear()
 
                     yield from self._process_external_location_lineage(table, databricks_table_fqn)
+
+        yield from self._enrich_lineage_batch(batch)
 
     def test_connection(self) -> None:
         if self._connection is not None:

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/queries.py
@@ -86,6 +86,38 @@ UNITY_CATALOG_COLUMN_LINEAGE = textwrap.dedent(
     """
 )
 
+UNITY_CATALOG_LINEAGE_SQL = textwrap.dedent(
+    """
+    WITH lineage_events AS (
+        SELECT source_table_full_name, target_table_full_name, statement_id, workspace_id, event_time
+        FROM system.access.table_lineage
+        WHERE event_date >= current_date() - INTERVAL {query_log_duration} DAYS
+            AND event_time >= current_date() - INTERVAL {query_log_duration} DAYS
+            AND (source_table_full_name, target_table_full_name) IN :table_pairs
+            AND statement_id IS NOT NULL
+    ), ranked_queries AS (
+        SELECT
+            lineage.source_table_full_name,
+            lineage.target_table_full_name,
+            history.statement_text,
+            ROW_NUMBER() OVER (
+                PARTITION BY lineage.source_table_full_name, lineage.target_table_full_name
+                ORDER BY lineage.event_time DESC, lineage.statement_id DESC, lineage.workspace_id DESC
+            ) AS query_rank
+        FROM lineage_events lineage
+        JOIN system.query.history history
+            ON lineage.statement_id = history.statement_id
+            AND lineage.workspace_id = history.workspace_id
+        WHERE history.statement_text IS NOT NULL
+            AND TRIM(history.statement_text) <> ''
+            AND UPPER(TRIM(history.statement_text)) <> '<REDACTED>'
+    )
+    SELECT source_table_full_name, target_table_full_name, statement_text
+    FROM ranked_queries
+    WHERE query_rank = 1
+    """
+)
+
 UNITY_CATALOG_EXTERNAL_TABLES = textwrap.dedent(
     """
     SELECT

--- a/ingestion/tests/unit/topology/database/test_unity_catalog_lineage.py
+++ b/ingestion/tests/unit/topology/database/test_unity_catalog_lineage.py
@@ -180,10 +180,11 @@ class TestProcessTableLineage:
         results = list(lineage_source._process_table_lineage(target_table, "cat.schema.target"))
 
         assert len(results) == 1
-        assert isinstance(results[0], Either)
-        assert isinstance(results[0].right, AddLineageRequest)
-        assert results[0].right.edge.fromEntity.id == source_table.id
-        assert results[0].right.edge.toEntity.id == target_table.id
+        source_name, request = results[0]
+        assert source_name == "cat.schema.source"
+        assert isinstance(request, AddLineageRequest)
+        assert request.edge.fromEntity.id == source_table.id
+        assert request.edge.toEntity.id == target_table.id
 
     def test_process_table_lineage_with_column_lineage(self, lineage_source):
         lineage_source.table_lineage_map = {"cat.schema.target": {"cat.schema.source"}}
@@ -220,7 +221,11 @@ class TestProcessTableLineage:
         results = list(lineage_source._process_table_lineage(target_table, "cat.schema.target"))
 
         assert len(results) == 1
-        lineage_details = results[0].right.edge.lineageDetails
+        source_name, request = results[0]
+        assert source_name == "cat.schema.source"
+        assert request.edge.fromEntity.id == source_table.id
+        assert request.edge.toEntity.id == target_table.id
+        lineage_details = request.edge.lineageDetails
         assert lineage_details is not None
         assert len(lineage_details.columnsLineage) == 1
         assert lineage_details.columnsLineage[0].fromColumns[0].root == "local_unitycatalog.cat.schema.source.col_a"

--- a/ingestion/tests/unit/topology/database/test_unitycatalog_lineage_sql.py
+++ b/ingestion/tests/unit/topology/database/test_unitycatalog_lineage_sql.py
@@ -1,0 +1,478 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Native lineage SQL enrichment, executing the connector queries against SQLite."""
+
+import json
+import re
+from collections import defaultdict
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from uuid import uuid4
+
+import jsonpatch
+import pytest
+from sqlalchemy import bindparam, create_engine, event, text
+from sqlalchemy.exc import OperationalError
+
+from metadata.generated.schema.entity.data.database import Database
+from metadata.generated.schema.entity.data.databaseSchema import DatabaseSchema
+from metadata.generated.schema.entity.data.table import Column, DataType, Table
+from metadata.generated.schema.type.entityLineage import Source as LineageSource
+from metadata.generated.schema.type.entityReference import EntityReference
+from metadata.generated.schema.type.filterPattern import FilterPattern
+from metadata.ingestion.api.status import Status
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.ingestion.ometa.utils import model_str
+from metadata.ingestion.source.database.unitycatalog.lineage import UnitycatalogLineageSource
+from metadata.ingestion.source.database.unitycatalog.queries import UNITY_CATALOG_LINEAGE_SQL
+
+SOURCE = "my_catalog.my_schema.my_source"
+TARGET = "my_catalog.my_schema.my_target"
+SQL = "INSERT INTO my_catalog.my_schema.my_target SELECT id FROM my_catalog.my_schema.my_source"
+
+
+@pytest.fixture
+def warehouse():
+    engine = create_engine("sqlite://")
+    state = SimpleNamespace(engine=engine, batches=[], history_error=None, fail_batch=1)
+    with engine.begin() as conn:
+        conn.execute(text("ATTACH DATABASE ':memory:' AS access"))
+        conn.execute(text("ATTACH DATABASE ':memory:' AS query"))
+        conn.execute(text("ATTACH DATABASE ':memory:' AS information_schema"))
+        conn.execute(
+            text(
+                "CREATE TABLE information_schema.tables (table_catalog TEXT, table_schema TEXT, table_name TEXT, storage_path TEXT, table_type TEXT)"
+            )
+        )
+        conn.execute(
+            text("""
+            CREATE TABLE access.table_lineage (
+                source_table_full_name TEXT, target_table_full_name TEXT,
+                statement_id TEXT, workspace_id TEXT, event_time TEXT, event_date TEXT
+            )
+        """)
+        )
+        conn.execute(
+            text("""
+            CREATE TABLE access.column_lineage (
+                source_table_full_name TEXT, target_table_full_name TEXT,
+                source_column_name TEXT, target_column_name TEXT, event_time TEXT
+            )
+        """)
+        )
+        conn.execute(text("CREATE TABLE query.history (statement_id TEXT, workspace_id TEXT, statement_text TEXT)"))
+        state.today = datetime.fromisoformat(conn.execute(text("SELECT current_date")).scalar_one())
+
+    @event.listens_for(engine, "before_cursor_execute", retval=True)
+    def execute_databricks_sql(_conn, _cursor, statement, parameters, _context, _executemany):
+        if "system.query.history" in statement:
+            state.batches.append(len(parameters) // 2)
+            if state.history_error and len(state.batches) >= state.fail_batch:
+                raise OperationalError(None, None, state.history_error)
+        # Adapt only catalog qualification and date syntax; execute joins, ranking and bindings unchanged.
+        statement = (
+            statement.replace("system.access.", "access.")
+            .replace("system.query.", "query.")
+            .replace("system.information_schema.", "information_schema.")
+        )
+        statement = re.sub(r"current_date\(\) - INTERVAL (\d+) DAYS", r"date('now', '-\1 days')", statement)
+        return statement, parameters
+
+    yield state
+    engine.dispose()
+
+
+def add_event(warehouse, statement_id="my_statement", source=SOURCE, target=TARGET, days_ago=0, hour=1):
+    timestamp = warehouse.today - timedelta(days=days_ago) + timedelta(hours=hour)
+    with warehouse.engine.begin() as conn:
+        conn.execute(
+            text("INSERT INTO access.table_lineage VALUES (:source, :target, :id, :workspace, :time, :date)"),
+            {
+                "source": source,
+                "target": target,
+                "id": statement_id,
+                "workspace": "my_workspace",
+                "time": timestamp.isoformat(sep=" "),
+                "date": timestamp.date().isoformat(),
+            },
+        )
+
+
+def add_query(warehouse, statement_id="my_statement", sql=SQL, workspace="my_workspace"):
+    with warehouse.engine.begin() as conn:
+        conn.execute(
+            text("INSERT INTO query.history VALUES (:id, :workspace, :sql)"),
+            {"id": statement_id, "workspace": workspace, "sql": sql},
+        )
+
+
+def make_table(native_name):
+    catalog, schema, name = native_name.split(".")
+    return Table(
+        id=uuid4(),
+        name=name,
+        fullyQualifiedName=f"my_service.{native_name}",
+        columns=[Column(name="id", dataType=DataType.INT, fullyQualifiedName=f"my_service.{native_name}.id")],
+        database=EntityReference(id=uuid4(), type="database", name=catalog),
+        databaseSchema=EntityReference(id=uuid4(), type="databaseSchema", name=schema),
+    )
+
+
+def make_source(warehouse, upstream_names=(SOURCE,)):
+    source = UnitycatalogLineageSource.__new__(UnitycatalogLineageSource)
+    source.engine = warehouse.engine
+    source.table_lineage_map = defaultdict(set)
+    source.column_lineage_map = defaultdict(list)
+    source.external_location_map = {}
+    source.source_config = SimpleNamespace(
+        queryLogDuration=1, databaseFilterPattern=None, schemaFilterPattern=None, tableFilterPattern=None
+    )
+    source.status = Status()
+    source.config = SimpleNamespace(serviceName="my_service")
+    source._query_history_available = True
+    tables = {f"my_service.{name}": make_table(name) for name in upstream_names}
+    source.metadata = SimpleNamespace(
+        get_by_name=lambda entity, fqn: tables.get(fqn),
+        es_search_from_fqn=lambda **kwargs: None,
+        tables=tables,
+    )
+    return source
+
+
+def requests(source, target=TARGET):
+    targets = [target] if isinstance(target, str) else target
+    for name in targets:
+        source.metadata.tables.setdefault(f"my_service.{name}", make_table(name))
+    databases = {}
+    schemas = {}
+    for name in source.metadata.tables:
+        service, catalog, schema, _ = name.split(".")
+        database_fqn = f"{service}.{catalog}"
+        schema_fqn = f"{database_fqn}.{schema}"
+        databases.setdefault(
+            database_fqn,
+            SimpleNamespace(name=SimpleNamespace(root=catalog), fullyQualifiedName=SimpleNamespace(root=database_fqn)),
+        )
+        schemas.setdefault(
+            schema_fqn,
+            SimpleNamespace(name=SimpleNamespace(root=schema), fullyQualifiedName=SimpleNamespace(root=schema_fqn)),
+        )
+
+    def list_entities(entity, params):
+        if entity is Database:
+            return iter(databases.values())
+        if entity is DatabaseSchema:
+            return (schema for name, schema in schemas.items() if name.rsplit(".", 1)[0] == params["database"])
+        assert entity is Table
+        return (
+            table
+            for name, table in source.metadata.tables.items()
+            if name.rsplit(".", 1)[0] == params["databaseSchema"]
+        )
+
+    source.metadata.list_all_entities = list_entities
+    results = list(source._iter())
+    assert all(result.right is not None and result.left is None for result in results)
+    return [result.right for result in results]
+
+
+@pytest.mark.parametrize("column_name", [None, "id", "missing_column"])
+def test_sql_is_attached_with_or_without_resolved_columns(warehouse, column_name):
+    add_event(warehouse)
+    add_query(warehouse)
+    if column_name:
+        with warehouse.engine.begin() as conn:
+            conn.execute(
+                text("INSERT INTO access.column_lineage VALUES (:source, :target, :column, :column, :time)"),
+                {"source": SOURCE, "target": TARGET, "column": column_name, "time": warehouse.today.isoformat()},
+            )
+    [request] = requests(make_source(warehouse))
+    details = request.edge.lineageDetails
+    assert model_str(details.sqlQuery) == SQL
+    assert details.source == LineageSource.QueryLineage
+    assert request.model_dump(mode="json")["edge"]["lineageDetails"]["sqlQuery"] == SQL
+    if column_name == "id":
+        [mapping] = details.columnsLineage
+        assert [model_str(column) for column in mapping.fromColumns] == ["my_service.my_catalog.my_schema.my_source.id"]
+        assert model_str(mapping.toColumn) == "my_service.my_catalog.my_schema.my_target.id"
+    else:
+        assert not details.columnsLineage
+
+
+@pytest.mark.parametrize("unavailable_sql", [None, "", "  ", "<REDACTED>", " <redacted> "])
+def test_latest_unavailable_text_does_not_hide_an_older_query(warehouse, unavailable_sql):
+    add_event(warehouse, "older_statement", hour=1)
+    add_query(warehouse, "older_statement")
+    add_event(warehouse, "newer_statement", hour=2)
+    add_query(warehouse, "newer_statement", sql=unavailable_sql)
+    [request] = requests(make_source(warehouse))
+    assert model_str(request.edge.lineageDetails.sqlQuery) == SQL
+
+
+def test_latest_event_wins_with_deterministic_statement_ties(warehouse):
+    for statement_id, hour, sql in [
+        ("statement_z", 1, "SELECT 1"),
+        ("statement_b", 2, "SELECT 2"),
+        ("statement_a", 2, "SELECT 3"),
+    ]:
+        add_event(warehouse, statement_id, hour=hour)
+        add_query(warehouse, statement_id, sql=sql)
+    [request] = requests(make_source(warehouse))
+    assert model_str(request.edge.lineageDetails.sqlQuery) == "SELECT 2"
+
+
+@pytest.mark.parametrize(
+    "missing", ["statement_id", "history_row", "text", "workspace", "history_table", "statement_column"]
+)
+def test_missing_query_information_preserves_native_edges_and_columns(warehouse, missing):
+    add_event(warehouse, statement_id=None if missing == "statement_id" else "my_statement")
+    if missing == "text":
+        add_query(warehouse, sql="<REDACTED>")
+    if missing == "workspace":
+        add_query(warehouse, workspace="other_workspace")
+    with warehouse.engine.begin() as conn:
+        conn.execute(
+            text("INSERT INTO access.column_lineage VALUES (:source, :target, 'id', 'id', :time)"),
+            {"source": SOURCE, "target": TARGET, "time": warehouse.today.isoformat()},
+        )
+        if missing == "history_table":
+            conn.execute(text("DROP TABLE query.history"))
+        if missing == "statement_column":
+            conn.execute(text("ALTER TABLE access.table_lineage DROP COLUMN statement_id"))
+    [request] = requests(make_source(warehouse))
+    details = request.edge.lineageDetails
+    assert details.sqlQuery is None
+    [mapping] = details.columnsLineage
+    assert [model_str(column) for column in mapping.fromColumns] == ["my_service.my_catalog.my_schema.my_source.id"]
+    assert model_str(mapping.toColumn) == "my_service.my_catalog.my_schema.my_target.id"
+
+
+def test_query_selection_is_scoped_to_table_pair_and_lookback(warehouse):
+    add_event(warehouse)
+    add_query(warehouse)
+    add_event(warehouse, "old_statement", days_ago=2)
+    add_query(warehouse, "old_statement", sql="SELECT 2")
+    add_event(warehouse, "other_target", target="my_catalog.my_schema.other_target", hour=3)
+    add_query(warehouse, "other_target", sql="SELECT 3")
+    add_event(warehouse, "other_source", source="my_catalog.my_schema.other_source", hour=3)
+    add_query(warehouse, "other_source", sql="SELECT 4")
+    [request] = requests(make_source(warehouse))
+    assert model_str(request.edge.lineageDetails.sqlQuery) == SQL
+
+
+def test_lookback_configuration_controls_sql_selection(warehouse):
+    add_event(warehouse, days_ago=2)
+    add_query(warehouse)
+    source = make_source(warehouse)
+    assert requests(source) == []
+    source.source_config.queryLogDuration = 3
+    source._cache_lineage()
+    [request] = requests(source)
+    assert model_str(request.edge.lineageDetails.sqlQuery) == SQL
+
+
+@pytest.mark.parametrize("history_denied", [False, True])
+def test_all_edges_survive_batch_boundaries_and_history_access_failure(warehouse, history_denied):
+    names = [f"my_catalog.my_schema.my_source_{index}" for index in range(205)]
+    for index, name in enumerate(names):
+        add_event(warehouse, statement_id=f"my_statement_{index}", source=name)
+        add_query(warehouse, statement_id=f"my_statement_{index}", sql=f"SELECT {index}")
+    if history_denied:
+        warehouse.history_error = PermissionError("Query history access denied")
+    results = requests(make_source(warehouse, names))
+    assert len(results) == 205
+    assert len({model_str(request.edge.fromEntity.id) for request in results}) == 205
+    if history_denied:
+        assert all(request.edge.lineageDetails.sqlQuery is None for request in results)
+        assert warehouse.batches == [100]
+    else:
+        assert {model_str(request.edge.lineageDetails.sqlQuery) for request in results} == {
+            f"SELECT {index}" for index in range(205)
+        }
+        assert warehouse.batches == [100, 100, 5]
+
+
+@pytest.mark.parametrize(
+    "edge_count,expected_batches", [(0, []), (100, [100]), (101, [100, 1]), (205, [100, 100, 5]), (1000, [100] * 10)]
+)
+def test_batches_span_targets_schemas_and_catalogs(warehouse, edge_count, expected_batches):
+    targets = [f"my_catalog_{index % 2}.my_schema_{index % 3}.my_target_{index}" for index in range(edge_count)]
+    for index, target in enumerate(targets):
+        add_event(warehouse, statement_id=f"statement_{index}", target=target)
+        add_query(warehouse, statement_id=f"statement_{index}", sql=f"SELECT {index}")
+    source = make_source(warehouse)
+    results = requests(source, targets)
+    expected = {
+        model_str(source.metadata.tables[f"my_service.{target}"].id): f"SELECT {index}"
+        for index, target in enumerate(targets)
+    }
+    assert len(results) == edge_count
+    assert {
+        model_str(result.edge.toEntity.id): model_str(result.edge.lineageDetails.sqlQuery) for result in results
+    } == expected
+    assert warehouse.batches == expected_batches
+
+
+def test_sql_query_selects_only_requested_pairs(warehouse):
+    other_source = "my_catalog.my_schema.other_source"
+    other_target = "my_catalog.my_schema.other_target"
+    for index, (source, target) in enumerate(
+        [(SOURCE, TARGET), (other_source, other_target), (SOURCE, other_target), (other_source, TARGET)]
+    ):
+        add_event(warehouse, statement_id=f"statement_{index}", source=source, target=target)
+        add_query(warehouse, statement_id=f"statement_{index}", sql=f"SELECT {index}")
+    statement = text(UNITY_CATALOG_LINEAGE_SQL.format(query_log_duration=1)).bindparams(
+        bindparam("table_pairs", expanding=True)
+    )
+    with warehouse.engine.connect() as conn:
+        rows = conn.execute(statement, {"table_pairs": [(SOURCE, TARGET), (other_source, other_target)]}).all()
+    assert {(row.source_table_full_name, row.target_table_full_name, row.statement_text) for row in rows} == {
+        (SOURCE, TARGET, "SELECT 0"),
+        (other_source, other_target, "SELECT 1"),
+    }
+
+
+@pytest.mark.parametrize("fail_batch", [1, 2])
+def test_history_failure_preserves_all_target_edges_and_column_mappings(warehouse, fail_batch):
+    targets = [f"my_catalog.my_schema.my_target_{index}" for index in range(205)]
+    for index, target in enumerate(targets):
+        add_event(warehouse, statement_id=f"statement_{index}", target=target)
+        add_query(warehouse, statement_id=f"statement_{index}", sql=f"SELECT {index}")
+        with warehouse.engine.begin() as conn:
+            conn.execute(
+                text("INSERT INTO access.column_lineage VALUES (:source, :target, 'id', 'id', :time)"),
+                {"source": SOURCE, "target": target, "time": warehouse.today.isoformat()},
+            )
+    warehouse.history_error = PermissionError("Query history access denied")
+    warehouse.fail_batch = fail_batch
+    results = requests(make_source(warehouse), targets)
+    assert len(results) == 205
+    assert len({model_str(result.edge.toEntity.id) for result in results}) == 205
+    assert sum(result.edge.lineageDetails.sqlQuery is not None for result in results) == (0 if fail_batch == 1 else 100)
+    assert all(len(result.edge.lineageDetails.columnsLineage) == 1 for result in results)
+    assert warehouse.batches == ([100] if fail_batch == 1 else [100, 100])
+
+
+@pytest.mark.parametrize("filter_name", ["databaseFilterPattern", "schemaFilterPattern", "tableFilterPattern"])
+def test_filtered_targets_are_not_enriched(warehouse, filter_name):
+    add_event(warehouse)
+    add_query(warehouse)
+    source = make_source(warehouse)
+    setattr(source.source_config, filter_name, FilterPattern(includes=["^excluded$"]))
+    assert requests(source) == []
+    assert warehouse.batches == []
+
+
+def test_unresolved_upstream_is_not_enriched(warehouse):
+    add_event(warehouse)
+    add_query(warehouse)
+    assert requests(make_source(warehouse, [])) == []
+    assert warehouse.batches == []
+
+
+def test_only_eligible_pairs_consume_batch_slots(warehouse):
+    targets = [f"my_catalog.my_schema.my_target_{index}" for index in range(101)]
+    excluded_targets = [
+        "other_catalog.my_schema.my_target_excluded",
+        "my_catalog.other_schema.my_target_excluded",
+        "my_catalog.my_schema.other_target",
+    ]
+    for index, target in enumerate(targets + excluded_targets):
+        add_event(warehouse, statement_id=f"statement_{index}", target=target)
+        add_query(warehouse, statement_id=f"statement_{index}", sql=f"SELECT {index}")
+        add_event(
+            warehouse, statement_id=f"unresolved_{index}", source="my_catalog.my_schema.missing_source", target=target
+        )
+        add_query(warehouse, statement_id=f"unresolved_{index}", sql="SELECT 999")
+    source = make_source(warehouse)
+    source.source_config.databaseFilterPattern = FilterPattern(includes=["^my_catalog$"])
+    source.source_config.schemaFilterPattern = FilterPattern(includes=["^my_schema$"])
+    source.source_config.tableFilterPattern = FilterPattern(includes=["^my_target_"])
+    results = requests(source, targets + excluded_targets)
+    assert len(results) == 101
+    assert {model_str(result.edge.lineageDetails.sqlQuery) for result in results} == {
+        f"SELECT {index}" for index in range(101)
+    }
+    assert warehouse.batches == [100, 1]
+
+
+def test_missing_history_for_one_pair_does_not_hide_another_pairs_sql(warehouse):
+    other_target = "my_catalog.my_schema.other_target"
+    add_event(warehouse)
+    add_query(warehouse)
+    add_event(warehouse, statement_id="missing_statement", target=other_target)
+    source = make_source(warehouse)
+    results = requests(source, [TARGET, other_target])
+    assert {
+        model_str(result.edge.toEntity.id): model_str(result.edge.lineageDetails.sqlQuery)
+        if result.edge.lineageDetails.sqlQuery
+        else None
+        for result in results
+    } == {
+        model_str(source.metadata.tables[f"my_service.{TARGET}"].id): SQL,
+        model_str(source.metadata.tables[f"my_service.{other_target}"].id): None,
+    }
+    assert warehouse.batches == [2]
+
+
+def test_external_location_lineage_is_preserved_alongside_batched_native_edges(warehouse):
+    add_event(warehouse)
+    add_query(warehouse)
+    with warehouse.engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO information_schema.tables VALUES ('my_catalog', 'my_schema', 'my_target', 's3://bucket/path', 'EXTERNAL')"
+            )
+        )
+    source = make_source(warehouse)
+    container_id = uuid4()
+    source.metadata.es_search_container_by_path = lambda **kwargs: [SimpleNamespace(id=container_id, dataModel=None)]
+    results = requests(source)
+    [native] = [result for result in results if result.edge.fromEntity.type == "table"]
+    [external] = [result for result in results if result.edge.fromEntity.type == "container"]
+    assert model_str(native.edge.lineageDetails.sqlQuery) == SQL
+    assert model_str(external.edge.fromEntity.id) == str(container_id)
+    assert external.edge.toEntity.id == native.edge.toEntity.id
+    assert warehouse.batches == [1]
+
+
+def test_table_names_are_bound_as_values(warehouse):
+    source_name = "my_catalog.my_schema.my_source's_table"
+    target_name = "my_catalog.my_schema.my_target's_table"
+    add_event(warehouse, source=source_name, target=target_name)
+    add_query(warehouse)
+    [request] = requests(make_source(warehouse, [source_name]), target_name)
+    assert model_str(request.edge.lineageDetails.sqlQuery) == SQL
+
+
+@pytest.mark.parametrize(
+    "stored_sql,incoming_sql,expected_sql",
+    [(None, SQL, SQL), ("SELECT 0", SQL, SQL), ("SELECT 0", None, "SELECT 0")],
+)
+def test_table_only_requests_backfill_update_and_preserve_stored_sql(warehouse, stored_sql, incoming_sql, expected_sql):
+    add_event(warehouse)
+    if incoming_sql:
+        add_query(warehouse, sql=incoming_sql)
+    [request] = requests(make_source(warehouse))
+    stored = {"sqlQuery": stored_sql, "columnsLineage": []}
+
+    def put(_path, data):
+        stored.clear()
+        stored.update(json.loads(data)["edge"]["lineageDetails"] or {})
+
+    metadata = OpenMetadata.__new__(OpenMetadata)
+    metadata.client = SimpleNamespace(
+        get=lambda _path: {"edge": stored.copy()},
+        patch=lambda _path, data: jsonpatch.JsonPatch(json.loads(data)).apply(stored, in_place=True),
+        put=put,
+    )
+    metadata.add_lineage(request, check_patch=True, return_lineage=False)
+    assert stored.get("sqlQuery") == expected_sql

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/UnityCatalog.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/UnityCatalog.md
@@ -74,9 +74,26 @@ $$
 
 ### Usage & Lineage
 
-$$note
-To get Query Usage and Lineage details, you need a Databricks Premium account, since we will be extracting this information from your SQL Warehouse's history API.
-$$
+Query usage and SQL text for native lineage edges are read from `system.query.history`.
+To include SQL on lineage edges, grant the ingestion principal access:
+
+```sql
+GRANT USE CATALOG ON CATALOG system TO `<user_or_service_principal>`;
+GRANT USE SCHEMA ON SCHEMA system.query TO `<user_or_service_principal>`;
+GRANT SELECT ON TABLE system.query.history TO `<user_or_service_principal>`;
+```
+
+The SQL Query section displays the latest available statement for each source–target
+table pair within the lineage lookback window. Column mappings still include all
+native mappings from that window; a single displayed statement may not explain every mapping.
+
+Databricks populates the lineage `statement_id` used to retrieve SQL only for queries
+run on SQL warehouses. Query history can arrive later than lineage, and SQL text can
+be empty or `<REDACTED>` depending on the principal's access and encryption settings.
+See the [Databricks query history reference](https://docs.databricks.com/aws/en/admin/system-tables/query-history)
+for statement-text access requirements. Native lineage is still ingested when SQL
+is unavailable. If query history cannot be read, SQL enrichment is skipped for the
+rest of that ingestion run and a warning is logged.
 
 ### Profiler & Data Quality
 


### PR DESCRIPTION
### Describe your changes:

Fixes #32021

Native Unity Catalog lineage edges can currently appear without SQL even when the originating statement is available. Attach the latest readable statement for each source–target pair by joining `system.access.table_lineage` to `system.query.history` on statement and workspace IDs. Table edges and column mappings continue to come from native lineage.

Enrichment runs in batches of 100 eligible edges across targets, schemas, and catalogs. Missing or redacted statements preserve native lineage; a history access failure disables enrichment for the rest of the run. Document the optional history permissions and SQL availability limits.

### Type of change:

- [x] Bug fix

### High-level design:

Batch only resolved edges that pass ingestion filters. Bind exact source–target pairs and return at most one SQL row per pair. This bounds enrichment batches and round trips, but does not bound warehouse scan bytes or change the existing native-lineage caches.

### Tests:

- Added `ingestion/tests/unit/topology/database/test_unitycatalog_lineage_sql.py`: 38 cases covering SQL selection, workspace isolation, missing/redacted history, batch boundaries across catalogs and schemas, filters, access failures, external lineage, and SDK backfill/update/preservation of stored SQL.
- Relevant ingestion and SDK suite: **170 passed**. The 38 new cases also passed in the deployed Airflow Python 3.12 environment.
- Coverage: **94% (34/36)** of changed executable lines in `lineage.py`; full-module coverage is **68%**. `queries.py` is **100%**. The tests execute joins, ranking, and bindings against SQLite with catalog/date syntax adapted; Databricks dialect compilation was checked separately.
- Python formatting, lint, and scoped type checks passed. A mutation that flushed per target failed the batching regression as expected.
- Backend integration and Playwright tests: not applicable; no backend API or UI behavior changes. No automated live-Databricks integration test was added; live connector validation is described below.

Manual testing performed:

1. Created source/target tables in a Databricks SQL warehouse and populated the target with a standalone `INSERT ... SELECT`. Ingested metadata and native lineage through the local UI.
2. Compared deployed baseline and patched ingestion code, removing the test edge before the baseline rerun. Baseline recreated the native edge and column mappings without SQL; patched ingestion attached SQL.
3. Created 205 targets from five sources using a SQL loop. The ingestion processed 444 total edges without warnings or errors in approximately 85 seconds.
4. Queried the OpenMetadata API: all 444 edges had SQL, including all 410 source–target edges in the bulk fixture. Each bulk target had its expected two sources; those edges retained 615 column mappings.

The bulk fixture stored the same whole `BEGIN ... END` block on its edges, so it verifies SQL presence and native mappings, not distinct expanded SQL per target. Distinct per-edge assignment is covered by automated tests. Warehouse scan cost was not measured.

### UI screen recording / screenshots:

Not applicable; only connector help text changed.

### Checklist:

- [x] PR title follows `Fixes <issue-number>: <short explanation>`.
- [x] Linked issue above.
- [x] Regression tests and verification results included.
- [x] Connector documentation updated.
- Comments: existing code structure expresses the implementation; the test adapter documents its non-obvious constraint.
- JSON Schema migrations: not applicable; no schema changes.
- UI recording: not applicable; no UI behavior changes.
