### PR TITLE
fix(test): increase data contract validation timeout in ingestion shard

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataContracts.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataContracts.ts
@@ -86,7 +86,11 @@ export const saveAndTriggerDataContractValidation = async (
   // reloading the page. Without this, the UI status check immediately after
   // the reload is racy: the backend may still be processing the result.
   if (responseData?.id) {
-    await pollContractStatus(page, responseData.id);
+    await waitForContractExecutionWithFallback(
+      page,
+      responseData.id,
+      responseData.name
+    );
   }
 
   await page.reload();


### PR DESCRIPTION
## Summary

- Replaces the 180-second `pollContractStatus` call inside `saveAndTriggerDataContractValidation` with `waitForContractExecutionWithFallback`, which uses a 600-second timeout and falls back to verifying results on the DQ Bundle Suites page when `latestResult` is not updated in time.
- Fixes a consistent failure in the `ingestion-01` CI shard where the contract validation job was still `Running` when the 3-minute timeout expired (failed on both initial run and retry).

## Root Cause

The `ingestion-01` shard runs the full ingestion stack. Contract validation in that environment takes longer than 3 minutes to complete, exceeding the `pollContractStatus` timeout. The longer `waitForContractExecutionWithFallback` path (600s + fallback) already exists and is designed for exactly this case.

**Failing run**: https://github.com/open-metadata/OpenMetadata/actions/runs/34258372543/job/102178662011

## Test plan

- [ ] CI ingestion shard passes `DataContracts.spec.ts › Create Data Contract and validate for Table`

🤖 Generated with [Claude Code](https://claude.com/claude-code)