### PR TITLE
fix(ui): show original casing for tag-like options in Advanced Search

### DIFF
--- a/.github/playwright/impact-map.generated.json
+++ b/.github/playwright/impact-map.generated.json
@@ -1975,6 +1975,7 @@
         "playwright/e2e/Features/Permissions/GlossaryPermissions.spec.ts",
         "playwright/e2e/Pages/DomainUIInteractions.spec.ts",
         "playwright/e2e/Pages/Glossary.spec.ts",
+        "playwright/e2e/Pages/Tag.spec.ts",
         "playwright/e2e/Pages/Tags.spec.ts",
         "playwright/e2e/Pages/Users.spec.ts"
       ]
@@ -2357,8 +2358,6 @@
         "openmetadata-ui/src/main/resources/ui/src/components/Modals/StyleModal/StyleModal.component.tsx"
       ],
       "specs": [
-        "playwright/e2e/Features/Glossary/GlossaryAdvancedOperations.spec.ts",
-        "playwright/e2e/Features/Glossary/GlossaryTermDetails.spec.ts",
         "playwright/e2e/Pages/DomainUIInteractions.spec.ts"
       ]
     },

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AdvancedSearch.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AdvancedSearch.spec.ts
@@ -1218,9 +1218,9 @@ test.describe(
       await test.step('Filter chip reflects the applied column tag', async () => {
         await expect(
           page.getByTestId('advance-search-filter-container')
-        ).toContainText(
-          columnTag1.responseData.fullyQualifiedName.toLowerCase()
-        );
+        ).toContainText(columnTag1.responseData.fullyQualifiedName, {
+          ignoreCase: true,
+        });
       });
 
       await test.step('table1 (tagged with tag1) is visible', async () => {
@@ -1268,9 +1268,9 @@ test.describe(
       await test.step('Filter chip reflects the applied column tag', async () => {
         await expect(
           page.getByTestId('advance-search-filter-container')
-        ).toContainText(
-          columnTag2.responseData.fullyQualifiedName.toLowerCase()
-        );
+        ).toContainText(columnTag2.responseData.fullyQualifiedName, {
+          ignoreCase: true,
+        });
       });
 
       await test.step('table2 (tagged with tag2) is visible', async () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CuratedAssets.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CuratedAssets.spec.ts
@@ -586,7 +586,7 @@ test.describe('Curated Assets Widget', () => {
     await selectOption(
       page,
       ruleLocator3.locator('.rule--value'),
-      'tier.tier5',
+      'Tier.Tier5',
       true
     );
 
@@ -597,7 +597,7 @@ test.describe('Curated Assets Widget', () => {
       (response) =>
         response.url().includes('/api/v1/search/query') &&
         response.url().includes('index=all') &&
-        response.url().includes('tier.tier5')
+        response.url().toLowerCase().includes('tier.tier5')
     );
 
     await page.locator('[data-testid="saveButton"]').click();

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/advancedSearch.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/advancedSearch.ts
@@ -360,6 +360,22 @@ export const fillRule = async (
   }
 };
 
+// Tag-like fields (tags, tier, certification, glossary) now apply the
+// original-cased value while other fields still apply the lowercased
+// aggregation key, so URL and chip expectations must be case-insensitive.
+const waitForSearchQueryWithValues = (page: Page, values: string[]) =>
+  page.waitForResponse((response) => {
+    const url = response.url().toLowerCase();
+
+    return (
+      url.includes('/api/v1/search/query') &&
+      url.includes('index=dataasset&from=0&size=15') &&
+      values.every((value) =>
+        url.includes(getEncodedFqn(value, true).toLowerCase())
+      )
+    );
+  });
+
 export const checkMustPaths = async (
   page: Page,
   {
@@ -383,17 +399,14 @@ export const checkMustPaths = async (
     index,
   });
 
-  const searchRes = page.waitForResponse(
-    `/api/v1/search/query?*index=dataAsset&from=0&size=15*${getEncodedFqn(
-      searchData,
-      true
-    )}*`
-  );
+  const searchRes = waitForSearchQueryWithValues(page, [searchData]);
   await page.getByTestId('apply-btn').click();
 
   const res = await searchRes;
 
-  expect(res.request().url()).toContain(getEncodedFqn(searchData, true));
+  expect(res.request().url().toLowerCase()).toContain(
+    getEncodedFqn(searchData, true).toLowerCase()
+  );
 
   const json = await res.json();
 
@@ -401,7 +414,7 @@ export const checkMustPaths = async (
 
   await expect(
     page.getByTestId('advance-search-filter-container')
-  ).toContainText(searchData);
+  ).toContainText(searchData, { ignoreCase: true });
 };
 
 export const checkMustNotPaths = async (
@@ -427,16 +440,13 @@ export const checkMustNotPaths = async (
     index,
   });
 
-  const searchRes = page.waitForResponse(
-    `/api/v1/search/query?*index=dataAsset&from=0&size=15*${getEncodedFqn(
-      searchData,
-      true
-    )}*`
-  );
+  const searchRes = waitForSearchQueryWithValues(page, [searchData]);
   await page.getByTestId('apply-btn').click();
   const res = await searchRes;
 
-  expect(res.request().url()).toContain(getEncodedFqn(searchData, true));
+  expect(res.request().url().toLowerCase()).toContain(
+    getEncodedFqn(searchData, true).toLowerCase()
+  );
 
   if (!['columns.name.keyword'].includes(field.name)) {
     const json = await res.json();
@@ -446,7 +456,7 @@ export const checkMustNotPaths = async (
 
   await expect(
     page.getByTestId('advance-search-filter-container')
-  ).toContainText(searchData);
+  ).toContainText(searchData, { ignoreCase: true });
 };
 
 export const checkNullPaths = async (
@@ -621,12 +631,10 @@ export const checkAddRuleOrGroupWithOperator = async (
   if (field.id === 'Column') {
     await page.getByTestId('apply-btn').click();
   } else {
-    const searchRes = page.waitForResponse(
-      `/api/v1/search/query?*index=dataAsset&from=0&size=15*${getEncodedFqn(
-        searchCriteria1.toLowerCase(),
-        true
-      )}*${getEncodedFqn(searchCriteria2.toLowerCase(), true)}*`
-    );
+    const searchRes = waitForSearchQueryWithValues(page, [
+      searchCriteria1,
+      searchCriteria2,
+    ]);
     await page.getByTestId('apply-btn').click();
     const res = await searchRes;
     const json = await res.json();

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.test.ts
@@ -20,6 +20,7 @@ import {
 import { EntityFields } from '../enums/AdvancedSearch.enum';
 import { SearchIndex } from '../enums/search.enum';
 import { CustomPropertySummary } from '../rest/metadataTypeAPI.interface';
+import { getAggregateFieldOptions } from '../rest/miscAPI';
 import { AdvancedSearchClassBase } from './AdvancedSearchClassBase';
 import { getCustomPropertyAdvanceSearchEnumOptions } from './AdvancedSearchPureUtils';
 import { getEntityName } from './EntityNameUtils';
@@ -1244,5 +1245,65 @@ describe('buildEnumAsyncFetch', () => {
 
     expect(result.values).toHaveLength(2);
     expect(result.values.map((v) => v.value)).toEqual(['Active', 'ACTIVE']);
+  });
+});
+
+describe('tag-like field autocomplete casing (#31999)', () => {
+  // Terms aggregations on lowercase_normalizer fields return lowercased bucket
+  // keys; without a sourceFields top-hits sub-aggregation the option label falls
+  // back to that lowercased key. These configs must request fullyQualifiedName.
+  let advancedSearchClassBase: AdvancedSearchClassBase;
+
+  beforeEach(() => {
+    advancedSearchClassBase = new AdvancedSearchClassBase();
+    jest.useFakeTimers();
+    (getAggregateFieldOptions as jest.Mock).mockClear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const expectSourceFieldsRequested = (field: {
+    fieldSettings?: { asyncFetch?: unknown };
+  }) => {
+    const asyncFetch = field.fieldSettings?.asyncFetch as (
+      search: string
+    ) => Promise<unknown>;
+    asyncFetch('pii');
+    jest.advanceTimersByTime(300);
+
+    expect(getAggregateFieldOptions).toHaveBeenCalledWith(
+      expect.anything(),
+      EntityFields.FULLY_QUALIFIED_NAME,
+      'pii',
+      expect.anything(),
+      'fullyQualifiedName'
+    );
+  };
+
+  it.each([
+    EntityFields.TAG,
+    EntityFields.GLOSSARY_TERMS,
+    EntityFields.CERTIFICATION,
+    EntityFields.TIER,
+  ])('%s config should request fullyQualifiedName source field', (key) => {
+    const config = advancedSearchClassBase.getCommonConfig({});
+
+    expectSourceFieldsRequested(
+      config[key] as { fieldSettings?: { asyncFetch?: unknown } }
+    );
+  });
+
+  it('column tag config should request fullyQualifiedName source field', () => {
+    const config = advancedSearchClassBase.getColumnTagConfig([
+      SearchIndex.TABLE,
+    ]);
+
+    expectSourceFieldsRequested(
+      config[EntityFields.COLUMN_TAG] as {
+        fieldSettings?: { asyncFetch?: unknown };
+      }
+    );
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
@@ -956,6 +956,7 @@ class AdvancedSearchClassBase {
           asyncFetch: this.autocomplete({
             searchIndex: [SearchIndex.TAG, SearchIndex.GLOSSARY_TERM],
             entityField: EntityFields.FULLY_QUALIFIED_NAME,
+            sourceFields: 'fullyQualifiedName',
             q: buildTermQuery(
               [
                 {
@@ -984,6 +985,7 @@ class AdvancedSearchClassBase {
           asyncFetch: this.autocomplete({
             searchIndex: SearchIndex.GLOSSARY_TERM,
             entityField: EntityFields.FULLY_QUALIFIED_NAME,
+            sourceFields: 'fullyQualifiedName',
           }),
           useAsyncSearch: true,
         },
@@ -997,6 +999,7 @@ class AdvancedSearchClassBase {
           asyncFetch: this.autocomplete({
             searchIndex: [SearchIndex.TAG],
             entityField: EntityFields.FULLY_QUALIFIED_NAME,
+            sourceFields: 'fullyQualifiedName',
             q: buildTermQuery(
               {
                 field: CLASSIFICATION_NAME_KEYWORD,
@@ -1017,6 +1020,7 @@ class AdvancedSearchClassBase {
           asyncFetch: this.autocomplete({
             searchIndex: [SearchIndex.TAG],
             entityField: EntityFields.FULLY_QUALIFIED_NAME,
+            sourceFields: 'fullyQualifiedName',
             q: buildTermQuery(
               {
                 field: CLASSIFICATION_NAME_KEYWORD,
@@ -1172,6 +1176,7 @@ class AdvancedSearchClassBase {
               asyncFetch: this.autocomplete({
                 searchIndex: [SearchIndex.TAG, SearchIndex.GLOSSARY_TERM],
                 entityField: EntityFields.FULLY_QUALIFIED_NAME,
+                sourceFields: 'fullyQualifiedName',
               }),
               useAsyncSearch: true,
             },


### PR DESCRIPTION
## Describe your changes

Fixes #31999 (Advanced Search half).

Terms aggregations on `lowercase_normalizer` keyword fields return lowercased bucket keys, so the Advanced Search query builder displayed tag, glossary term, tier and certification options in lowercase (e.g. `advanced shipment notification` instead of `Advanced Shipment Notification`).

This threads `sourceFields: 'fullyQualifiedName'` into the five aggregation-based `autocomplete()` field configs (`TAG`, `GLOSSARY_TERMS`, `CERTIFICATION`, `TIER`, `COLUMN_TAG`) so the request adds a `top_hits` sub-aggregation and the option label is resolved from `_source` with its original casing — the same mechanism `NAME_KEYWORD` already uses, built on the `parseBucketsData`/`extractSourceValue` plumbing from #32190.

### Why this does not change query results

The target fields (`tags.tagFQN`, `columns.tags.tagFQN`, `tier.tagFQN`, `certification.tagLabel.tagFQN`) are all `keyword` with `lowercase_normalizer`; Elasticsearch applies the normalizer to term-level query input, so an original-cased value matches exactly what the lowercased value matched. Previously-saved filters with lowercase values keep working unchanged.

The JSONLogic query builder is unaffected: its tag/glossary fields use `searchAutocomplete` (search API over real `_source`), which already returns original casing.

Before:

<img width="1512" height="910" alt="Screenshot 2026-09-10 at 1 29 13 PM" src="https://github.com/user-attachments/assets/2f1e8d38-cc9c-4fb3-a4d1-6f2678cde870" />


After:

<img width="1512" height="910" alt="Screenshot 2026-09-10 at 1 29 02 PM" src="https://github.com/user-attachments/assets/1866cfee-e4c6-4a25-9460-cc1d2589e73d" />


### Testing

- 5 new regression tests pin the `sourceFields` argument per field config (`AdvancedSearchClassBase.test.ts`), 61/61 pass.
- ESLint and Prettier clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)