### PR TITLE
fix(service): carry column tags forward when a column dataType changes [Backport #32810 - 1.13]

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BaseEntityIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BaseEntityIT.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.openmetadata.it.auth.JwtAuthProvider;
 import org.openmetadata.it.bootstrap.SharedEntities;
+import org.openmetadata.it.util.BulkApi;
 import org.openmetadata.it.util.EntityValidation;
 import org.openmetadata.it.util.SdkClients;
 import org.openmetadata.it.util.TestNamespace;
@@ -4965,6 +4966,30 @@ public abstract class BaseEntityIT<T extends EntityInterface, K> {
       throw new IllegalStateException(
           "Failed to strip DefaultBotRole: " + resp.statusCode() + " " + resp.body());
     }
+  }
+
+  /**
+   * Bulk-upsert the requests via raw HTTP using the ingestion-bot JWT. The bot identity is what
+   * activates the "preserve user-curated description/displayName" rules in EntityRepository.
+   */
+  protected BulkOperationResult executeBulkAsBot(List<K> requests, boolean overrideMetadata) {
+    try {
+      return BulkApi.upsert(getBulkCollection(), requests, overrideMetadata, BulkApi.botToken());
+    } catch (Exception e) {
+      throw new RuntimeException("Bulk upsert as bot failed: " + e.getMessage(), e);
+    }
+  }
+
+  /** Derives the v1 collection name (e.g. {@code "tables"}) from {@link #getResourcePath()}. */
+  private String getBulkCollection() {
+    String path = getResourcePath();
+    if (path.startsWith("/v1/")) {
+      path = path.substring(4);
+    }
+    if (path.endsWith("/")) {
+      path = path.substring(0, path.length() - 1);
+    }
+    return path;
   }
 
   private String getBotToken() {

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DashboardDataModelResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DashboardDataModelResourceIT.java
@@ -838,4 +838,85 @@ public class DashboardDataModelResourceIT
     request.setName(ns.prefix("invalid_data_model"));
     return request;
   }
+
+  /**
+   * Issue #30639: a column whose dataType changes is recorded as deleted + re-added rather than
+   * updated, because EntityUtil.columnMatch compares dataType. updateColumns then removes the
+   * deleted column's tag_usage rows, so the carry-forward must move user-applied tags onto the
+   * re-added column, which occupies the same FQN. The Tableau connector hits this when it promotes
+   * a physical column's type onto the field it mirrors (RECORD -> STRING).
+   */
+  @Test
+  void test_columnTagsSurviveDataTypeChange(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    String shortId = ns.shortPrefix();
+
+    Classification classification =
+        client
+            .classifications()
+            .create(
+                new CreateClassification()
+                    .withName("cls_" + shortId)
+                    .withDescription("Test classification"));
+    Tag columnTag =
+        client
+            .tags()
+            .create(
+                new CreateTag()
+                    .withName("ct_" + shortId)
+                    .withClassification(classification.getName())
+                    .withDescription("Column level tag"));
+    TagLabel columnTagLabel =
+        new TagLabel()
+            .withTagFQN(columnTag.getFullyQualifiedName())
+            .withSource(TagLabel.TagSource.CLASSIFICATION);
+
+    DashboardService service = DashboardServiceTestFactory.createLooker(ns);
+    String name = ns.prefix("dm_coltype");
+
+    DashboardDataModel created =
+        createEntity(
+            new CreateDashboardDataModel()
+                .withName(name)
+                .withService(service.getFullyQualifiedName())
+                .withDataModelType(DataModelType.LookMlView)
+                .withColumns(
+                    List.of(
+                        new Column()
+                            .withName("customer_name")
+                            .withDataType(ColumnDataType.RECORD)
+                            .withTags(List.of(columnTagLabel)))));
+
+    String entityId = created.getId().toString();
+    DashboardDataModel tagged = getEntityWithFields(entityId, "columns,tags");
+    assertEquals(
+        1,
+        tagged.getColumns().get(0).getTags().size(),
+        "Column tag should be present after create");
+
+    // Re-ingest the same column with the physical type promoted onto it and no tags in the
+    // payload, which is what a connector sends.
+    BulkOperationResult result =
+        executeBulkAsBot(
+            List.of(
+                new CreateDashboardDataModel()
+                    .withName(name)
+                    .withService(service.getFullyQualifiedName())
+                    .withDataModelType(DataModelType.LookMlView)
+                    .withColumns(
+                        List.of(
+                            new Column()
+                                .withName("customer_name")
+                                .withDataType(ColumnDataType.STRING)))),
+            false);
+    assertNotNull(result);
+
+    DashboardDataModel afterTypeChange = getEntityWithFields(entityId, "columns,tags");
+    Column column = afterTypeChange.getColumns().get(0);
+    assertEquals(ColumnDataType.STRING, column.getDataType(), "dataType should have changed");
+    assertNotNull(column.getTags(), "Column tags must survive a dataType change");
+    assertEquals(
+        1, column.getTags().size(), "User-applied column tag must survive a dataType change");
+    assertEquals(columnTag.getFullyQualifiedName(), column.getTags().get(0).getTagFQN());
+  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -9982,7 +9982,11 @@ public abstract class EntityRepository<T extends EntityInterface> {
           if (nullOrEmpty(addedColumn.getDescription())) {
             addedColumn.setDescription(deleted.getDescription());
           }
-          if (nullOrEmpty(addedColumn.getTags()) && nullOrEmpty(deleted.getTags())) {
+          // Carry the tags forward only when the re-added column has none of its own and the
+          // deleted one actually had some. A column is re-added rather than updated whenever its
+          // dataType changes (see EntityUtil.columnMatch), and the deleteTagsByTarget below would
+          // otherwise drop user-applied tags from a column that still exists under the same FQN.
+          if (nullOrEmpty(addedColumn.getTags()) && !nullOrEmpty(deleted.getTags())) {
             addedColumn.setTags(deleted.getTags());
           }
         }


### PR DESCRIPTION
backport of https://github.com/open-metadata/OpenMetadata/commit/39055fe6bae8959bb8f9b310cdc7450ddb064804 on 1.13

----
## Summary by Gitar

- **Bug fix:**
    - Fixed tag carry-forward logic in `EntityRepository` when column `dataType` changes
- **Testing:**
    - Added integration test `test_columnTagsSurviveDataTypeChange` in `DashboardDataModelResourceIT`

<sub>This will update automatically on new commits.</sub>