### PR TITLE
ci(playwright): relax playwright-summary gate on merge_group

### DIFF
--- a/.github/scripts/render_playwright_summary.cjs
+++ b/.github/scripts/render_playwright_summary.cjs
@@ -845,22 +845,32 @@ async function renderPlaywrightSummary({ github, context, core }) {
   //     infrastructure issue fails the check. Authors have to fix drift,
   //     invalid results JSON, missing artifacts, etc. before a PR can
   //     enter the merge queue.
-  //   * merge_group (RELAXED): only real test failures — or a fully
-  //     collapsed shard matrix, or a run that produced zero test results
-  //     — fail the check. Every strict validation already ran on the PR
-  //     before it entered the queue; infra flakes on the tentative merge
-  //     (artifact-upload 403/409 races, coverage misses caused by those
-  //     missing artifacts, missing ci-status.json, etc.) should not
-  //     dequeue an otherwise-green PR (with the repo's ALLGREEN grouping
-  //     strategy, any failing check dissolves the whole batch). All
-  //     infrastructure issues are still enumerated in the rendered job
-  //     summary above for debuggability — they just don't fail the
-  //     check on merge_group.
+  //   * merge_group (RELAXED): trust the shard matrix's own result. Fail
+  //     only on a real test failure, or when PLAYWRIGHT_RESULT itself is
+  //     not 'success' (matrix failure / skipped / cancelled). Every
+  //     strict validation already ran on the PR before it entered the
+  //     queue; infra flakes on the tentative merge (artifact-upload
+  //     403/409 races, summary-side download failures that lose ALL
+  //     per-shard results, coverage misses cascading from those, missing
+  //     ci-status.json, etc.) should not dequeue an otherwise-green PR
+  //     (with the repo's ALLGREEN grouping strategy, any failing check
+  //     dissolves the whole batch).
+  //
+  //   PLAYWRIGHT_RESULT === 'success' is authoritative: it means every
+  //   shard job succeeded, which means every shard's Playwright test
+  //   step passed. That signal is safe even when the summary job's
+  //   download-artifact step later flakes and leaves us with zero
+  //   per-shard results (see run 34312746335: 37/37 shards succeeded,
+  //   summary's Download-all-results-JSON returned failure, 75 infra
+  //   issues cascaded — the merge_group check must trust the matrix).
+  //
+  //   All infrastructure issues are still enumerated in the rendered
+  //   job summary above for debuggability — they just don't fail the
+  //   check on merge_group.
   const isMergeGroup = context.eventName === 'merge_group';
-  const shardMatrixCollapsed = upstreamResult === 'failure';
-  const noTestsReported = totalPassed === 0 && totalFailed === 0;
+  const upstreamGreen = upstreamResult === 'success';
   const shouldFail = isMergeGroup
-    ? (totalFailed > 0 || shardMatrixCollapsed || noTestsReported)
+    ? (totalFailed > 0 || !upstreamGreen)
     : (totalFailed > 0 || infrastructureIssues.length > 0);
 
   if (shouldFail) {
@@ -869,10 +879,8 @@ async function renderPlaywrightSummary({ github, context, core }) {
     let verdict;
     if (totalFailed > 0) {
       verdict = 'test failures — author action needed';
-    } else if (isMergeGroup && shardMatrixCollapsed) {
-      verdict = 'shard matrix collapsed on merge_group — refusing synthetic green';
-    } else if (isMergeGroup && noTestsReported) {
-      verdict = 'no tests reported on merge_group — refusing synthetic green';
+    } else if (isMergeGroup && !upstreamGreen) {
+      verdict = `shard matrix not green on merge_group (PLAYWRIGHT_RESULT=${upstreamResult || 'unset'}) — refusing synthetic green`;
     } else {
       verdict = 'no test failures — CI infrastructure/reporting problem, not this change';
     }

--- a/.github/scripts/render_playwright_summary.cjs
+++ b/.github/scripts/render_playwright_summary.cjs
@@ -840,13 +840,42 @@ async function renderPlaywrightSummary({ github, context, core }) {
     core.warning(`Could not write the Playwright job summary: ${error.message}`);
   }
 
-  if (totalFailed > 0 || infrastructureIssues.length > 0) {
+  // Gate policy:
+  //   * PR / dispatch / schedule (STRICT): any test failure OR any
+  //     infrastructure issue fails the check. Authors have to fix drift,
+  //     invalid results JSON, missing artifacts, etc. before a PR can
+  //     enter the merge queue.
+  //   * merge_group (RELAXED): only real test failures — or a fully
+  //     collapsed shard matrix, or a run that produced zero test results
+  //     — fail the check. Every strict validation already ran on the PR
+  //     before it entered the queue; infra flakes on the tentative merge
+  //     (artifact-upload 403/409 races, coverage misses caused by those
+  //     missing artifacts, missing ci-status.json, etc.) should not
+  //     dequeue an otherwise-green PR (with the repo's ALLGREEN grouping
+  //     strategy, any failing check dissolves the whole batch). All
+  //     infrastructure issues are still enumerated in the rendered job
+  //     summary above for debuggability — they just don't fail the
+  //     check on merge_group.
+  const isMergeGroup = context.eventName === 'merge_group';
+  const shardMatrixCollapsed = upstreamResult === 'failure';
+  const noTestsReported = totalPassed === 0 && totalFailed === 0;
+  const shouldFail = isMergeGroup
+    ? (totalFailed > 0 || shardMatrixCollapsed || noTestsReported)
+    : (totalFailed > 0 || infrastructureIssues.length > 0);
+
+  if (shouldFail) {
     // Tell the author which kind of red this is: test failures need their
     // action; infrastructure-only failures explicitly do not.
-    const verdict =
-      totalFailed > 0
-        ? 'test failures — author action needed'
-        : 'no test failures — CI infrastructure/reporting problem, not this change';
+    let verdict;
+    if (totalFailed > 0) {
+      verdict = 'test failures — author action needed';
+    } else if (isMergeGroup && shardMatrixCollapsed) {
+      verdict = 'shard matrix collapsed on merge_group — refusing synthetic green';
+    } else if (isMergeGroup && noTestsReported) {
+      verdict = 'no tests reported on merge_group — refusing synthetic green';
+    } else {
+      verdict = 'no test failures — CI infrastructure/reporting problem, not this change';
+    }
     core.setFailed(
       `${totalFailed} Playwright test failure(s); ${infrastructureIssues.length} CI/reporting failure(s) (${verdict}).`
     );

--- a/.github/scripts/tests/test_playwright_ci_planning.py
+++ b/.github/scripts/tests/test_playwright_ci_planning.py
@@ -2979,12 +2979,16 @@ const core = {{
     assert "author action needed" in rendered["failure"]
 
 
-def test_playwright_summary_merge_group_fails_when_no_tests_reported(tmp_path):
-    # Refuse synthetic green: if not a single test result reached the summary
-    # (e.g., every shard's upload flake'd, or the matrix job silently produced
-    # no results), fail the merge_group check even though there are no
-    # explicit test failures. Prevents an all-flake run from being counted
-    # as a green tentative merge.
+def _run_playwright_summary_bare(
+    tmp_path, *, event_name, playwright_result, expected_shards
+):
+    """Run renderPlaywrightSummary with an empty results directory — no per-
+    shard result files at all. Simulates the summary job's own download step
+    flaking (run 34312746335: 37/37 shards succeeded upstream but
+    REPORT_DOWNLOAD_RESULTS_OUTCOME=failure lost every per-shard results.json,
+    producing 75 infrastructure issues and totals.passed=0 / totals.failed=0).
+    Callers vary PLAYWRIGHT_RESULT to model matrix outcomes.
+    """
     helper = SCRIPTS / "render_playwright_summary.cjs"
     payload_path = tmp_path / "playwright-pr-comment/summary.json"
     harness = f"""
@@ -3000,7 +3004,7 @@ const core = {{
   await renderPlaywrightSummary({{
     github: {{}},
     context: {{
-      eventName: 'merge_group',
+      eventName: {json.dumps(event_name)},
       payload: {{}},
       repo: {{ owner: 'open-metadata', repo: 'OpenMetadata' }},
     }},
@@ -3019,8 +3023,10 @@ const core = {{
             "PLAN_RESULT": "success",
             "FIXTURE_RESTORE_RESULT": "success",
             "FIXTURE_RESULT": "success",
-            "PLAYWRIGHT_RESULT": "success",
-            "EXPECTED_MATRIX": json.dumps({"include": [{"shardId": "chromium-01"}]}),
+            "PLAYWRIGHT_RESULT": playwright_result,
+            "EXPECTED_MATRIX": json.dumps(
+                {"include": [{"shardId": s} for s in expected_shards]}
+            ),
             "RUNNER_TEMP": str(tmp_path),
             "COMMENT_PAYLOAD_PATH": str(payload_path),
             "GITHUB_RUN_ID": "12345",
@@ -3035,9 +3041,46 @@ const core = {{
         text=True,
     )
     assert completed.returncode == 0, completed.stderr
-    rendered = json.loads(completed.stdout)
-    assert rendered["failure"] is not None
-    assert "no tests reported" in rendered["failure"]
+    return json.loads(completed.stdout)
+
+
+def test_playwright_summary_merge_group_passes_when_summary_download_flakes(tmp_path):
+    # Reproduces run 34312746335: all shard jobs succeeded (PLAYWRIGHT_RESULT=
+    # success) but the summary job's Download-all-results-JSON step flaked and
+    # returned nothing, so the render script sees zero per-shard results. On
+    # merge_group we trust the matrix's own result — passing shards mean
+    # passing tests, even when we can't fetch the per-shard artifacts.
+    rendered = _run_playwright_summary_bare(
+        tmp_path,
+        event_name="merge_group",
+        playwright_result="success",
+        expected_shards=["chromium-01", "chromium-02"],
+    )
+    assert rendered["failure"] is None, (
+        "merge_group must trust PLAYWRIGHT_RESULT=success when the summary "
+        f"can't see per-shard artifacts, got: {rendered['failure']}"
+    )
+
+
+def test_playwright_summary_merge_group_fails_when_matrix_not_success(tmp_path):
+    # Refuse synthetic green when the matrix itself didn't succeed. Covers
+    # failure/skipped/cancelled — any state that isn't an authoritative
+    # "tests passed" signal from GitHub's own matrix aggregation.
+    for state in ("failure", "cancelled", "skipped", ""):
+        rendered = _run_playwright_summary_bare(
+            tmp_path,
+            event_name="merge_group",
+            playwright_result=state,
+            expected_shards=["chromium-01"],
+        )
+        assert rendered["failure"] is not None, (
+            f"merge_group must fail when PLAYWRIGHT_RESULT={state!r}, "
+            f"got: {rendered['failure']}"
+        )
+        assert "shard matrix not green" in rendered["failure"], (
+            f"expected 'shard matrix not green' verdict for state {state!r}, "
+            f"got: {rendered['failure']}"
+        )
 
 
 def test_normal_vite_build_keeps_hashed_entry_assets():

--- a/.github/scripts/tests/test_playwright_ci_planning.py
+++ b/.github/scripts/tests/test_playwright_ci_planning.py
@@ -2755,6 +2755,291 @@ const core = {{
     assert payload["shards"][0]["id"] == "chromium-01"
 
 
+def _run_playwright_summary_harness(tmp_path, *, event_name, extra_env, expected_shards):
+    """Run renderPlaywrightSummary with a single passing shard and a matrix
+    that expects TWO shards, so the second is always "missing" — a canonical
+    infrastructure-issue setup (see run 34244326002 — chromium-09 and
+    advanced-search-01 uploaded blob but 403'd on FinalizeArtifact, so their
+    results.json never landed and the summary counted 149 missing tests +
+    4 per-shard "did not upload" issues). Returns the parsed harness result.
+    """
+    helper = SCRIPTS / "render_playwright_summary.cjs"
+    results_dir = tmp_path / "results/playwright-results-json-chromium-01"
+    results_dir.mkdir(parents=True)
+    (results_dir / "results.json").write_text(
+        json.dumps(
+            {
+                "suites": [
+                    {
+                        "file": "playwright/e2e/example.spec.ts",
+                        "specs": [
+                            {
+                                "title": "passes",
+                                "tests": [
+                                    {
+                                        "status": "expected",
+                                        "results": [{}],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+    )
+    (results_dir / "ci-status.json").write_text(
+        json.dumps({"steps": {"tests": "success"}})
+    )
+    payload_path = tmp_path / "playwright-pr-comment/summary.json"
+    harness = f"""
+const {{ renderPlaywrightSummary }} = require({json.dumps(str(helper))});
+let summaryBody = '';
+let failure = null;
+const summary = {{
+  addRaw(body) {{
+    summaryBody = body;
+    return summary;
+  }},
+  async write() {{}},
+}};
+const core = {{
+  summary,
+  warning() {{}},
+  setFailed(message) {{
+    failure = message;
+  }},
+}};
+
+(async () => {{
+  await renderPlaywrightSummary({{
+    github: {{}},
+    context: {{
+      eventName: {json.dumps(event_name)},
+      payload: {{}},
+      repo: {{ owner: 'open-metadata', repo: 'OpenMetadata' }},
+    }},
+    core,
+  }});
+  process.stdout.write(JSON.stringify({{ summaryBody, failure }}));
+}})().catch(error => {{
+  console.error(error.stack || error.message);
+  process.exitCode = 1;
+}});
+"""
+    env = os.environ.copy()
+    env.update(
+        {
+            "CHECK_CHANGES_RESULT": "success",
+            "CACHE_KEYS_RESULT": "success",
+            "BUILD_RESULT": "success",
+            "DETECT_CHANGES_RESULT": "success",
+            "PLAN_RESULT": "success",
+            "FIXTURE_RESTORE_RESULT": "success",
+            "FIXTURE_RESULT": "success",
+            "PLAYWRIGHT_RESULT": "success",
+            "EXPECTED_MATRIX": json.dumps(
+                {"include": [{"shardId": shard} for shard in expected_shards]}
+            ),
+            "RUNNER_TEMP": str(tmp_path),
+            "COMMENT_PAYLOAD_PATH": str(payload_path),
+            "GITHUB_RUN_ID": "12345",
+        }
+    )
+    env.update(extra_env)
+
+    completed = subprocess.run(
+        ["node", "-e", harness],
+        cwd=tmp_path,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return json.loads(completed.stdout), json.loads(payload_path.read_text())
+
+
+def test_playwright_summary_pr_fails_when_expected_shard_is_missing(tmp_path):
+    rendered, payload = _run_playwright_summary_harness(
+        tmp_path,
+        event_name="pull_request",
+        extra_env={},
+        expected_shards=["chromium-01", "chromium-99"],
+    )
+    assert rendered["failure"] is not None, (
+        "PR runs must gate on missing-shard infrastructure issues so authors "
+        "regenerate / re-upload before the PR enters the queue."
+    )
+    assert "CI/reporting failure(s)" in rendered["failure"]
+    assert payload["infrastructureIssueCount"] >= 1
+
+
+def test_playwright_summary_merge_group_passes_when_only_infra_issues(tmp_path):
+    # Merge-queue tentative merges must NOT fail on infra-only issues. The
+    # repo's merge-queue grouping strategy is ALLGREEN — a failing non-required
+    # check still dissolves the whole batch — so an artifact-upload race on
+    # one shard (run 34244326002) is enough to eject a green batch. The strict
+    # checks already ran on the PR before it entered the queue.
+    rendered, payload = _run_playwright_summary_harness(
+        tmp_path,
+        event_name="merge_group",
+        extra_env={},
+        expected_shards=["chromium-01", "chromium-99"],
+    )
+    assert rendered["failure"] is None, (
+        f"merge_group check should ignore infra-only issues, got: {rendered['failure']}"
+    )
+    # The issues are still rendered in the summary body / payload — the check
+    # just doesn't fail on them.
+    assert payload["infrastructureIssueCount"] >= 1
+    assert "did not upload" in rendered["summaryBody"]
+
+
+def test_playwright_summary_merge_group_fails_on_real_test_failure(tmp_path):
+    # Real test failures still gate the merge_group check — this is the only
+    # signal that the tentative merge broke something on `main`.
+    helper = SCRIPTS / "render_playwright_summary.cjs"
+    results_dir = tmp_path / "results/playwright-results-json-chromium-01"
+    results_dir.mkdir(parents=True)
+    (results_dir / "results.json").write_text(
+        json.dumps(
+            {
+                "suites": [
+                    {
+                        "file": "playwright/e2e/example.spec.ts",
+                        "specs": [
+                            {
+                                "title": "fails",
+                                "tests": [
+                                    {"status": "unexpected", "results": [{}]},
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+    )
+    (results_dir / "ci-status.json").write_text(
+        json.dumps({"steps": {"tests": "failure"}})
+    )
+    payload_path = tmp_path / "playwright-pr-comment/summary.json"
+    harness = f"""
+const {{ renderPlaywrightSummary }} = require({json.dumps(str(helper))});
+let failure = null;
+const summary = {{ addRaw() {{ return summary; }}, async write() {{}} }};
+const core = {{
+  summary,
+  warning() {{}},
+  setFailed(message) {{ failure = message; }},
+}};
+(async () => {{
+  await renderPlaywrightSummary({{
+    github: {{}},
+    context: {{
+      eventName: 'merge_group',
+      payload: {{}},
+      repo: {{ owner: 'open-metadata', repo: 'OpenMetadata' }},
+    }},
+    core,
+  }});
+  process.stdout.write(JSON.stringify({{ failure }}));
+}})().catch(e => {{ console.error(e.stack || e.message); process.exitCode = 1; }});
+"""
+    env = os.environ.copy()
+    env.update(
+        {
+            "CHECK_CHANGES_RESULT": "success",
+            "CACHE_KEYS_RESULT": "success",
+            "BUILD_RESULT": "success",
+            "DETECT_CHANGES_RESULT": "success",
+            "PLAN_RESULT": "success",
+            "FIXTURE_RESTORE_RESULT": "success",
+            "FIXTURE_RESULT": "success",
+            "PLAYWRIGHT_RESULT": "success",
+            "EXPECTED_MATRIX": json.dumps({"include": [{"shardId": "chromium-01"}]}),
+            "RUNNER_TEMP": str(tmp_path),
+            "COMMENT_PAYLOAD_PATH": str(payload_path),
+            "GITHUB_RUN_ID": "12345",
+        }
+    )
+    completed = subprocess.run(
+        ["node", "-e", harness],
+        cwd=tmp_path,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    rendered = json.loads(completed.stdout)
+    assert rendered["failure"] is not None
+    assert "1 Playwright test failure(s)" in rendered["failure"]
+    assert "author action needed" in rendered["failure"]
+
+
+def test_playwright_summary_merge_group_fails_when_no_tests_reported(tmp_path):
+    # Refuse synthetic green: if not a single test result reached the summary
+    # (e.g., every shard's upload flake'd, or the matrix job silently produced
+    # no results), fail the merge_group check even though there are no
+    # explicit test failures. Prevents an all-flake run from being counted
+    # as a green tentative merge.
+    helper = SCRIPTS / "render_playwright_summary.cjs"
+    payload_path = tmp_path / "playwright-pr-comment/summary.json"
+    harness = f"""
+const {{ renderPlaywrightSummary }} = require({json.dumps(str(helper))});
+let failure = null;
+const summary = {{ addRaw() {{ return summary; }}, async write() {{}} }};
+const core = {{
+  summary,
+  warning() {{}},
+  setFailed(message) {{ failure = message; }},
+}};
+(async () => {{
+  await renderPlaywrightSummary({{
+    github: {{}},
+    context: {{
+      eventName: 'merge_group',
+      payload: {{}},
+      repo: {{ owner: 'open-metadata', repo: 'OpenMetadata' }},
+    }},
+    core,
+  }});
+  process.stdout.write(JSON.stringify({{ failure }}));
+}})().catch(e => {{ console.error(e.stack || e.message); process.exitCode = 1; }});
+"""
+    env = os.environ.copy()
+    env.update(
+        {
+            "CHECK_CHANGES_RESULT": "success",
+            "CACHE_KEYS_RESULT": "success",
+            "BUILD_RESULT": "success",
+            "DETECT_CHANGES_RESULT": "success",
+            "PLAN_RESULT": "success",
+            "FIXTURE_RESTORE_RESULT": "success",
+            "FIXTURE_RESULT": "success",
+            "PLAYWRIGHT_RESULT": "success",
+            "EXPECTED_MATRIX": json.dumps({"include": [{"shardId": "chromium-01"}]}),
+            "RUNNER_TEMP": str(tmp_path),
+            "COMMENT_PAYLOAD_PATH": str(payload_path),
+            "GITHUB_RUN_ID": "12345",
+        }
+    )
+    completed = subprocess.run(
+        ["node", "-e", harness],
+        cwd=tmp_path,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    rendered = json.loads(completed.stdout)
+    assert rendered["failure"] is not None
+    assert "no tests reported" in rendered["failure"]
+
+
 def test_normal_vite_build_keeps_hashed_entry_assets():
     vite_config = (
         SCRIPTS.parents[1] / "openmetadata-ui/src/main/resources/ui/vite.config.ts"


### PR DESCRIPTION
## Summary

The `playwright-summary` required check treats any of ~12 infrastructure-issue categories as batch-dissolving on merge_group runs — even when zero tests actually failed. Combined with the repo's `grouping_strategy: ALLGREEN` merge-queue policy (any failing check on a tentative merge dissolves the whole batch), a single transient infra flake ejects an otherwise-green PR.

**Gate change** (only for `merge_group`; PR runs stay strict):

```js
isMergeGroup
  ? (totalFailed > 0 || !upstreamGreen)                       // trust the matrix
  : (totalFailed > 0 || infrastructureIssues.length > 0);     // unchanged

// upstreamGreen = PLAYWRIGHT_RESULT === 'success'
```

On `merge_group`, only two things fail the check:

1. A **real test failure** (`totalFailed > 0`).
2. The **shard matrix itself isn't green** (`PLAYWRIGHT_RESULT !== 'success'` — covers `failure` / `cancelled` / `skipped` / unset).

PR / dispatch / schedule runs are unchanged: every infrastructure issue still fails the check strictly. Authors fix drift, invalid results JSON, missing artifacts, etc. before a PR enters the queue.

All infrastructure issues are **still enumerated** in the rendered job summary and PR-comment payload for debuggability — the merge_group check just doesn't fail on them.

## Why trust `PLAYWRIGHT_RESULT`

It's GitHub's own matrix aggregation. `PLAYWRIGHT_RESULT === 'success'` means every shard job succeeded, which means every shard's Playwright test step passed. That signal is authoritative and independent of whether the summary job can later download the per-shard result artifacts. The whole downstream chain (coverage validator, per-shard artifact checks, ci-status.json presence, …) is *derived* from artifacts that may not survive GitHub Actions infra flakes.

## Motivating incidents

### Run [34244326002](https://github.com/open-metadata/OpenMetadata/actions/runs/34244326002/job/102140455704) — 2 shards' uploads flaked

- **4200 tests passed** · 0 failed · 5 flaky (all retried green)
- 2 shards (`chromium-09`, `advanced-search-01`) hit `FinalizeArtifact 403` → retry hit `409 Conflict` → artifacts never landed
- 5 infrastructure issues: 1 coverage validator + 2 "did not upload results" + 2 "did not upload execution status"
- **playwright-summary FAILED**, batch dissolved, PR ejected

### Run [34312746335](https://github.com/open-metadata/OpenMetadata/actions/runs/34312746335/job/102355002407) — summary's own download flaked

- **All 37 shard jobs succeeded** (`PLAYWRIGHT_RESULT: success`)
- 32/37 result artifacts landed (5 shard-side upload flakes) — but the summary job's `Download all results JSON` step **returned failure globally**
- Render script saw **zero** per-shard results on disk → `totals.passed=0`, `totals.failed=0`
- 75 infrastructure issues (2 per each of 37 shards + the download-failure)
- **playwright-summary FAILED**

Both cases have identical signals from GitHub's own matrix (`PLAYWRIGHT_RESULT: success`) and identical merge-safety (nothing actually broke). The new gate correctly passes both.

## Infrastructure-issue categories still enumerated (but no longer merge_group-fatal)

Verified by auditing `render_playwright_summary.cjs`:

1. Upstream matrix precursor jobs (checkChanges / cacheKeys / build / detectChanges / plan / fixtureRestore / fixture) not `success`
2. Matrix cancelled/skipped (still fails via `!upstreamGreen`)
3. Summary-job step outcomes not `success` (download / setup / install / merge / upload)
4. Coverage validation mismatch
5. Performance evaluation outcome not `success`
6. Expected shard didn't upload a results artifact
7. Expected shard didn't upload a ci-status.json
8. Shard uploaded invalid results / ci-status JSON
9. Shard reported zero tests / unknown-status tests / duplicate testIds
10. Shard failed during a lifecycle test
11. Shard failed during a setup step (per its ci-status)
12. Unexpected shard uploaded results

All 12 remain in the rendered summary; none of them fail the merge_group check.

## Tests

Five subprocess-driven cases in `.github/scripts/tests/test_playwright_ci_planning.py`:

- `test_playwright_summary_pr_fails_when_expected_shard_is_missing` — PR run with a missing shard **fails** (strict path).
- `test_playwright_summary_merge_group_passes_when_only_infra_issues` — same setup on `merge_group` **passes**, issues still rendered.
- `test_playwright_summary_merge_group_fails_on_real_test_failure` — a real `unexpected` test still fails the merge_group check.
- `test_playwright_summary_merge_group_passes_when_summary_download_flakes` — matrix=success + zero per-shard results (reproduces run 34312746335) → **passes**.
- `test_playwright_summary_merge_group_fails_when_matrix_not_success` — parametrised over `PLAYWRIGHT_RESULT ∈ {failure, cancelled, skipped, ''}` → **fails** with "shard matrix not green" verdict.

All 5 new + all existing render-script tests pass locally.

## Test plan

- [x] Unit tests pass (`python3 -m pytest .github/scripts/tests/test_playwright_ci_planning.py -k playwright_summary`)
- [ ] Merge to observe: next `merge_group` run with a transient upload/download flake should pass the check with issues rendered in the summary.
- [ ] Regression: PR CI runs still fail loudly when an author forgets to regenerate `impact-map.generated.json` / uploads invalid results / etc.

## Non-goals

- Doesn't touch the required-check list or the merge-queue grouping strategy.
- Doesn't skip the `Verify Playwright timing coverage` workflow step on merge_group (moot — its outcome is now ignored on merge_group anyway; skipping it is a ~1 min CI optimisation left as a follow-up).
- Doesn't attempt to fix the underlying GitHub Actions artifact-service flakes — outside our control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
