### PR TITLE
Backport 2.0: Data Quality dropdown deflakes (#32506, #32969)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts
@@ -1480,15 +1480,22 @@ test.describe(
           const pageSizeDropdown = page.getByTestId(
             'page-size-selection-dropdown'
           );
-          const pageSizeMenu = page.locator(
-            '.ant-dropdown:not(.ant-dropdown-hidden) .ant-dropdown-menu'
-          );
+          const pageSizeMenu = page
+            .getByRole('menu')
+            .filter({ hasText: '/ Page' });
 
           await expect(pageSizeDropdown).toBeVisible();
-          // NextPrevious inherits Ant Dropdown's hover trigger; clicking this
-          // button only runs its preventDefault handler and may not open the menu.
-          await pageSizeDropdown.hover();
-          await expect(pageSizeMenu).toBeVisible();
+
+          // Ant Dropdown opens on hover, so a re-render that shifts the footer out
+          // from under the pointer leaves the menu closed for good.
+          await expect(async () => {
+            await pageSizeDropdown.hover();
+            if (!(await pageSizeMenu.isVisible())) {
+              await pageSizeDropdown.click();
+            }
+            await expect(pageSizeMenu).toBeVisible({ timeout: 2_000 });
+          }).toPass({ timeout: 15_000, intervals: [500, 1_000, 2_000] });
+
           await expect(pageSizeMenu.getByRole('menuitem')).toHaveCount(3);
         });
       } finally {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestLibrary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestLibrary.spec.ts
@@ -754,13 +754,26 @@ test.describe(
 
         // Add a DQ Dimension — verifies that editing a test definition with existing
         // parameters does not prevent the dimension from being saved correctly.
-        await page.getByTestId('data-quality-dimension').click();
+        const dimensionField = page.getByTestId('data-quality-dimension');
         const accuracyOption = page.getByRole('option', {
           name: 'Accuracy',
           exact: true,
         });
-        await expect(accuracyOption).toBeVisible();
-        await accuracyOption.click();
+
+        // The listbox is a non-modal React Aria popover, so it is dismissed by any
+        // scroll of the pane holding the trigger — including the one Playwright
+        // emits to bring this field into view, delivered a frame after the popup
+        // opened. Reopen on each attempt; nothing else reopens it.
+        await expect(async () => {
+          if (!(await accuracyOption.isVisible())) {
+            await dimensionField.getByRole('button').click();
+            await expect(accuracyOption).toBeVisible({ timeout: 2_000 });
+          }
+          await selectOptionWithMouse(page, accuracyOption);
+          await expect(dimensionField).toContainText('Accuracy', {
+            timeout: 2_000,
+          });
+        }).toPass({ timeout: 20_000, intervals: [500, 1_000, 2_000] });
 
         // Save without providing parameter dataType or description — both are optional.
         const patchResponse = page.waitForResponse(

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestLibrary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestLibrary.spec.ts
@@ -43,6 +43,28 @@ const selectOptionWithMouse = async (page: Page, option: Locator) => {
   );
 };
 
+// React Aria's listbox is a non-modal popover, and a press on a trigger that
+// does not already hold focus both opens it and — via the focus transition that
+// same press produces — dismisses it a frame later. That leaves roughly 160ms to
+// pick an option, and nothing reopens the listbox afterwards, so a loaded runner
+// that misses the window retries the option click until the test times out.
+// Focusing the trigger first removes the transition, and with it the window.
+const selectEntityType = async (page: Page, entityType: string) => {
+  const entityTypeSelect = page.getByTestId('entity-type');
+  const entityTypeTrigger = entityTypeSelect.getByRole('button');
+
+  await entityTypeTrigger.focus();
+  await expect(entityTypeTrigger).toBeFocused();
+  await entityTypeTrigger.click();
+
+  await selectOptionWithMouse(
+    page,
+    page.getByRole('option', { name: entityType, exact: true })
+  );
+
+  await expect(entityTypeSelect).toContainText(entityType);
+};
+
 test.use({ storageState: 'playwright/.auth/admin.json' });
 
 test.describe(
@@ -147,9 +169,7 @@ test.describe(
           .locator('textarea')
           .fill(TEST_DEFINITION_DESCRIPTION);
 
-        // Select entity type (react-aria Select: click the field, pick option)
-        await page.locator('[id="root/entityType"]').click();
-        await page.getByRole('option', { name: 'TABLE', exact: true }).click();
+        await selectEntityType(page, 'TABLE');
 
         // Supported data types (multi-select combobox: type to populate the
         // options, then pick — required while the OpenMetadata platform is set).
@@ -357,10 +377,7 @@ test.describe(
             .getByTestId('test-definition-name')
             .locator('input')
             .fill(`validation-test-${uuid()}`);
-          await page.getByTestId('entity-type').click();
-          await page
-            .getByRole('option', { name: 'TABLE', exact: true })
-            .click();
+          await selectEntityType(page, 'TABLE');
 
           // Submit the form
           await page.getByTestId('save-test-definition').click();
@@ -620,22 +637,7 @@ test.describe(
           .locator('textarea')
           .fill('External test for read-only validation');
 
-        const entityTypeSelect = page.getByTestId('entity-type');
-        const entityTypeTrigger = entityTypeSelect.getByRole('button');
-
-        // The documentation panel reacts to focus and rerenders the form. Let
-        // that update settle before the mouse press so React Aria does not
-        // cancel the press when CI is under load.
-        await entityTypeTrigger.focus();
-        await expect(entityTypeTrigger).toBeFocused();
-        await entityTypeTrigger.click();
-        const tableOption = page.getByRole('option', {
-          name: 'TABLE',
-          exact: true,
-        });
-        await selectOptionWithMouse(page, tableOption);
-
-        await expect(entityTypeSelect).toContainText('TABLE');
+        await selectEntityType(page, 'TABLE');
 
         // OpenMetadata is selected by default. Remove its chip (the chip is a
         // span with the label and an unlabeled remove button) and add dbt so the
@@ -857,13 +859,7 @@ test.describe(
           .locator('textarea')
           .fill('Test definition to validate supported services filtering');
 
-        await page.getByTestId('entity-type').click();
-        const entityTypeOption = page.getByRole('option', {
-          name: 'TABLE',
-          exact: true,
-        });
-        await expect(entityTypeOption).toBeVisible();
-        await entityTypeOption.click();
+        await selectEntityType(page, 'TABLE');
 
         // Select supported data types (required when OpenMetadata platform is selected)
         await page.getByTestId('supported-data-types').click();
@@ -1201,8 +1197,7 @@ test.describe(
           .locator('textarea')
           .fill('Test definition for pagination behavior testing');
 
-        await page.getByTestId('entity-type').click();
-        await page.getByRole('option', { name: 'TABLE', exact: true }).click();
+        await selectEntityType(page, 'TABLE');
 
         // Select supported data types (required when OpenMetadata platform is selected)
         await page.getByTestId('supported-data-types').click();


### PR DESCRIPTION
## Describe your changes

Backports the two Data Quality dropdown deflakes from `main` to `2.0`. Both sites exist unhardened on `2.0`; one is failing the nightly upgrade suite today, the other is latent.

| Commit | Backport of | Site | Status on `2.0` |
|---|---|---|---|
| 1 | #32506 | `DataQuality.spec.ts` page-size dropdown + `TestLibrary.spec.ts` DQ Dimension select | **failing the nightly** |
| 2 | #32969 (`Fixes #32968`) | `TestLibrary.spec.ts` entity-type select, 5 call sites | latent — not seen in the nightly, but the same merge-queue exposure `main` had |

#
## 1. `DataQuality.spec.ts` — page-size dropdown (#32506)

One of the hard (non-flaky) failures in run [34296793051](https://github.com/open-metadata/openmetadata-nightly/actions/runs/34296793051) (`kind / postgresql / full`, `1.11.13 ➡ 2.0`) — lost all 3 attempts:

```
Locator: .ant-dropdown:not(.ant-dropdown-hidden) .ant-dropdown-menu
Expected: visible
Timeout: 15000ms — element(s) not found
  1490 | await pageSizeDropdown.hover();
> 1491 | await expect(pageSizeMenu).toBeVisible();
```

`element(s) not found`, not "hidden" — Ant only mounts the dropdown portal on first open, so the menu never opened at all.

### Root cause

`NextPrevious` renders the page-size control as an Ant `Dropdown` with no `trigger` prop (antd default is `['hover']`) over a button that swallows its own click:

```tsx
<Dropdown menu={{ items: pageSizeOptions.map(...) }}>
  <Button data-testid="page-size-selection-dropdown" onClick={(e) => e.preventDefault()}>
```

The menu therefore opens on `mouseenter` only. The preceding step navigates next → previous, and the resulting list re-render shifts the footer out from under the pointer that `hover()` just parked there. No new `mouseenter` fires, and a single un-retried `hover()` has nothing left to reopen it.

`NextPrevious.tsx` is identical on `main` and `2.0` apart from an unrelated a11y attribute — this is a test-hardening gap, not a product difference.

### Why `main` is green and `2.0` is not

#32506 fixed exactly this call site on `main` on 2026-09-03 and was never backported. Nightly history for this test:

| Date | 2.0 (pg / mysql) | main (pg / mysql) |
|---|---|---|
| 09-05 | flaky / **fail** | — |
| 09-06 | **fail** / **fail** | — |
| 09-07 | pass / pass | pass / pass |
| 09-08 | flaky / pass | pass / pass |
| 09-09 | **fail** / pass | — |

6 of the last 10 `2.0` full runs affected; `main` clean on the first attempt in every run since the fix landed.

### Why PR checks never caught it

- PR-time Playwright runs a **targeted** plan (only specs affected by the changed files); the nightly runs the **full** suite, so a spec outside a PR's change set never runs at PR time.
- The failing lane is PostgreSQL + kind + a `1.11.13 ➡ 2.0` migration at full parallelism. A hover-to-open Ant Dropdown is load-sensitive and survives the lighter PR environment.

### Why the hover-then-click retry rather than a plain `click()`

`2.0` already carries this exact pattern for this same control in `playwright/utils/common.ts` (two call sites) — only this inline site was left unconverted. Keeping the backport identical to `main` stops the branches drifting further; a bare `click()` would add a third variant of the same interaction.

#
## 2. `TestLibrary.spec.ts` — entity-type select (#32969)

React Aria's listbox is a non-modal popover, and a press on a trigger that does not already hold focus both opens it and — via the focus transition that same press produces — dismisses it a frame later. That leaves ~160ms to pick an option, with nothing to reopen the listbox afterwards, so a loaded runner that misses the window retries the option click until the test times out. Focusing the trigger first removes the transition.

`2.0` has all five call sites in the pre-fix form; the backport collapses them onto the same `selectEntityType()` helper `main` now uses. **Honest framing:** this one is *not* what is failing the 2.0 nightly — the only two `TestLibrary` flakes in the last 10 AUT runs (one per branch) were `add-test-definition-button` page-load timeouts, an unrelated issue. It is included because the latent defect is identical, because `2.0` PRs go through the same merge queue where this blocked #32524 on `main`, and because both commits touch `TestLibrary.spec.ts` — landing them separately would just create a conflict between two open 2.0 PRs.

### Conflict resolution

Commit 1 cherry-picked clean. Commit 2 hit three conflicts, all the same shape: `2.0` spells the pre-fix entity-type click slightly differently at each site (`page.locator('[id="root/entityType"]')` at one, `getByTestId('entity-type')` at the others). Resolved by taking the incoming `selectEntityType(page, 'TABLE')` at all three — which is what #32969 did to those same sites on `main`, including the `[id="root/entityType"]` one. The resulting helper block is byte-identical to `main`'s, and all five call sites now match.

#
## Type of change

- [x] Bug fix

#
## High-level design

N/A — test-only backport, two files.

#
## Tests

### Use cases covered

Test-only change; no product code touched. Verification for the underlying fixes is in #32506 and #32969 — notably, #32506 proved the page-size open by neutralising the `hover()` so only the click fallback could open the menu, and #32969 measured the listbox lifetime (~160ms on a cold click vs ~1.3s focus-first).

### Unit tests
Not applicable.

### Backend integration tests
Not applicable (no backend changes).

### Ingestion integration tests
Not applicable (no ingestion changes).

### Playwright (UI) tests
This PR *is* the Playwright change.
- `playwright/e2e/Features/DataQuality/DataQuality.spec.ts`
- `playwright/e2e/Features/DataQuality/TestLibrary.spec.ts`

### Manual testing performed

Static gates run against `2.0`'s own toolchain (not borrowed from `main` — `2.0` pins eslint `^9.18` vs `main`'s `^9.39`):

| Check | Result |
|---|---|
| `eslint` (2.0 config) | 0 errors, 0 warnings on both files |
| `prettier --check` | pass |
| `tsc -p playwright/tsconfig.json` | 0 errors in the two changed files; total unchanged at 169 pre-existing baseline errors elsewhere |

The E2E itself was not re-run locally — reproducing needs the full migrated stack, which is the point of the bug. The fixes are field-proven upstream: `main` has been green on the page-size test in every nightly since #32506 landed.

#
## UI screen recording / screenshots:

Not applicable — test-only change.

#
## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
