### PR TITLE
fix(security): bump jetty to 12.1.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,8 @@
     <jsonpath.version>2.9.0</jsonpath.version>
     <everit.version>1.14.4</everit.version>
     <json-patch.version>1.13</json-patch.version>
-    <jetty.version>12.1.10</jetty.version>
+    <!-- 12.1.12 clears CVE-2026-19203 (jetty-http) and CVE-2026-19204 (jetty-websocket-core-common). -->
+    <jetty.version>12.1.12</jetty.version>
     <jakarta-el.version>5.0.0-M1</jakarta-el.version>
     <mcp-sdk.version>1.1.1</mcp-sdk.version>
     <lettuce.version>6.7.1.RELEASE</lettuce.version>


### PR DESCRIPTION
## Advisory

- **CVE-2026-19203** — `org.eclipse.jetty:jetty-http` 12.1.10 → fixed in 12.0.38 / 12.1.12
- **CVE-2026-19204** — `org.eclipse.jetty.websocket:jetty-websocket-core-common` 12.1.10 → fixed in 12.0.38 / 12.1.12

Both HIGH, fix available.

## Change

Bumped `jetty.version` in the root `pom.xml` from `12.1.10` to `12.1.12` — same 12.1.x line, patch bump only, resolved through the existing `jetty-bom`/`jetty-ee10-bom` import so every module picks it up.