### PR TITLE
fix(security): bump stream-json 1.7.5 → 3.5.0 (backport 2.0 #33008)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "resolutions": {
     "brace-expansion": "1.1.18",
-    "lodash": "4.18.1"
+    "lodash": "4.18.1",
+    "stream-json": "3.5.0"
   },
   "scripts": {
     "preinstall": "yarn global add node-gyp@10.0.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,14 @@
     "lodash": "4.18.1",
     "stream-json": "3.5.0"
   },
+  "//": [
+    "resolutions.stream-json: forces 3.5.0 (GHSA-528h-pc64-c93x DoS fix) over quicktype's exact 1.7.5 pin,",
+    "two majors ahead. Safe because this repo only runs `quicktype -s schema` (json2ts.sh,",
+    "json2ts-generate-all.sh), which does not exercise the changed stream-json API; quicktype's",
+    "JSON-sample input mode DOES break under 3.5.0 (`Parser is not a constructor`) — do not use it.",
+    "Re-verify schema codegen (and drop this override if quicktype ships stream-json >= 3.5.0,",
+    "as quicktype 26+ does) whenever quicktype is upgraded."
+  ],
   "scripts": {
     "preinstall": "yarn global add node-gyp@10.0.1",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -562,17 +562,17 @@ safe-stable-stringify@^2.2.0:
   resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz#4ca2f8e385f2831c432a719b108a3bf7af42a1dd"
   integrity sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==
 
-stream-chain@^2.2.5:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/stream-chain/-/stream-chain-2.2.5.tgz#b30967e8f14ee033c5b9a19bbe8a2cba90ba0d09"
-  integrity sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==
+stream-chain@^4.2.5:
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/stream-chain/-/stream-chain-4.2.5.tgz#9061d29573ab79c49258b2cbe2f72bed7629c79f"
+  integrity sha512-Wtyq3bNE3ggLR0v2vftqvuhltym3WbZAkZpfIrkr5F/6vpeUmWmwTgXa16zD87gpahwJ/Qulq3zVfUlgIc0J2A==
 
-stream-json@1.7.5:
-  version "1.7.5"
-  resolved "https://registry.yarnpkg.com/stream-json/-/stream-json-1.7.5.tgz#2ff0563011f22cea4f6a28dbfc0344a53c761fe4"
-  integrity sha512-NSkoVduGakxZ8a+pTPUlcGEeAGQpWL9rKJhOFCV+J/QtdQUEU5vtBgVg6eJXn8JB8RZvpbJWZGvXkhz70MLWoA==
+stream-json@1.7.5, stream-json@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/stream-json/-/stream-json-3.5.0.tgz#5cedd64fca7e8dcd226a5e22e5f11722a5376e91"
+  integrity sha512-dobB7zipGW8o11PvdRljQSWuyMxifADLvoHeA4elwNWOTbZo6+BlNa+P6aCq7Y9jRiWTy2Ucu2xSv0Y2/T+/kQ==
   dependencies:
-    stream-chain "^2.2.5"
+    stream-chain "^4.2.5"
 
 string-to-stream@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Backport of #33008 to `2.0` — stream-json part only.

**Applied:** stream-json 1.7.5 → 3.5.0 via root `resolutions` (GHSA-528h-pc64-c93x, O(depth²) DoS). Verified on this branch: `yarn install` clean, `quicktype -s schema` codegen works (the only quicktype mode this repo uses).

**Not applicable on 2.0:** the other #33008 bumps target deps that don't exist on this branch — `tooling/antd-codemods` (js-yaml) is absent, and `ui-core-components` has no vitest/svgo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)