### PR TITLE
fix(ci): dispatch the resolver by filename, not display name

### DIFF
--- a/.github/workflows/backport-labeled-prs.yaml
+++ b/.github/workflows/backport-labeled-prs.yaml
@@ -172,7 +172,11 @@ jobs:
         id: dispatch
         uses: benc-uk/workflow-dispatch@v1.3.2
         with:
-          workflow: Resolve an OpenMetadata backport conflict
+          # By filename, not display name. This was `Resolve an OpenMetadata
+          # backport conflict` and broke the moment that workflow was renamed —
+          # a dispatch by display name is a cross-repo reference with nothing
+          # checking it. The filename is stable across renames.
+          workflow: oss-backport-resolve.yaml
           repo: open-metadata/openmetadata-collate
           ref: main
           token: ${{ secrets.COLLATE_PAT }}


### PR DESCRIPTION
Every backport from here fails at the handover — [run 34329850382](https://github.com/open-metadata/OpenMetadata/actions/runs/34329850382). `plan` passes (label authorised, release branches resolved), then both `dispatch` jobs fail.

## Cause

They name a workflow that no longer exists. `openmetadata-collate` renamed `Resolve an OpenMetadata backport conflict` → `Backport a labeled OpenMetadata PR` when it took over driving the whole backport rather than only conflicts. This side still asked for the old name.

That's my mistake, and the ordering advice I gave ("merge Collate first") couldn't have helped — the reference itself was wrong, not the sequence.

## Fix

`benc-uk/workflow-dispatch` accepts a filename as well as a display name. A filename doesn't move when a workflow is renamed:

```yaml
workflow: oss-backport-resolve.yaml
```

The underlying problem was that a dispatch by display name is a **cross-repository reference with nothing checking it** — no linter sees it, and it breaks silently on a rename in another repo. Confirmed `oss-backport-resolve.yaml` exists on `openmetadata-collate@main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)