### PR TITLE
Fixes #33040: run ConversationSchemaMigrationIT in the global-state lane

### DIFF
--- a/openmetadata-integration-tests/pom.xml
+++ b/openmetadata-integration-tests/pom.xml
@@ -21,7 +21,7 @@
     <integrationTests.skipIsolated>false</integrationTests.skipIsolated>
     <integrationTests.skipParallel>false</integrationTests.skipParallel>
     <integrationTests.forkTimeoutSeconds>3600</integrationTests.forkTimeoutSeconds>
-    <integrationTests.globalStateTests>TagRecognizerFeedbackIT,WorkflowDefinitionResourceIT,AppsResourceIT,SystemResourceIT,VectorEmbeddingIntegrationIT,PatchTableEmbeddingIT,GlossaryOntologyExportIT,UserMetricsResourceIT</integrationTests.globalStateTests>
+    <integrationTests.globalStateTests>TagRecognizerFeedbackIT,WorkflowDefinitionResourceIT,AppsResourceIT,SystemResourceIT,VectorEmbeddingIntegrationIT,PatchTableEmbeddingIT,GlossaryOntologyExportIT,UserMetricsResourceIT,ConversationSchemaMigrationIT</integrationTests.globalStateTests>
     <integrationTests.multiNodeTests>SessionMultiNodeIT,SessionRedisMultiNodeIT,CsvExportMultiNodeIT</integrationTests.multiNodeTests>
     <integrationTests.retryQueueTests>SearchIndexRetryQueueIT</integrationTests.retryQueueTests>
     <!-- Tags excluded from the ui-it profile. Override on the CLI to include them, e.g.
@@ -419,6 +419,7 @@
                     <include>**/VectorEmbeddingIntegrationIT.java</include>
                     <include>**/PatchTableEmbeddingIT.java</include>
                     <include>**/GlossaryOntologyExportIT.java</include>
+                    <include>**/ConversationSchemaMigrationIT.java</include>
                     <include>**/SessionMultiNodeIT.java</include>
                     <include>**/SessionRedisMultiNodeIT.java</include>
                     <include>**/SearchIndexRetryQueueIT.java</include>
@@ -463,6 +464,7 @@
                     <exclude>**/VectorEmbeddingIntegrationIT.java</exclude>
                     <exclude>**/PatchTableEmbeddingIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
+                    <exclude>**/ConversationSchemaMigrationIT.java</exclude>
                     <exclude>**/SessionMultiNodeIT.java</exclude>
                     <exclude>**/SessionRedisMultiNodeIT.java</exclude>
                     <exclude>**/SearchIndexRetryQueueIT.java</exclude>
@@ -530,6 +532,7 @@
                     <include>**/VectorEmbeddingIntegrationIT.java</include>
                     <include>**/PatchTableEmbeddingIT.java</include>
                     <include>**/GlossaryOntologyExportIT.java</include>
+                    <include>**/ConversationSchemaMigrationIT.java</include>
                     <include>**/SessionMultiNodeIT.java</include>
                     <include>**/SessionRedisMultiNodeIT.java</include>
                     <include>**/SearchIndexRetryQueueIT.java</include>
@@ -574,6 +577,7 @@
                     <exclude>**/VectorEmbeddingIntegrationIT.java</exclude>
                     <exclude>**/PatchTableEmbeddingIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
+                    <exclude>**/ConversationSchemaMigrationIT.java</exclude>
                     <exclude>**/SessionMultiNodeIT.java</exclude>
                     <exclude>**/SessionRedisMultiNodeIT.java</exclude>
                     <exclude>**/SearchIndexRetryQueueIT.java</exclude>
@@ -641,6 +645,7 @@
                     <include>**/VectorEmbeddingIntegrationIT.java</include>
                     <include>**/PatchTableEmbeddingIT.java</include>
                     <include>**/GlossaryOntologyExportIT.java</include>
+                    <include>**/ConversationSchemaMigrationIT.java</include>
                     <include>**/SessionMultiNodeIT.java</include>
                     <include>**/SessionRedisMultiNodeIT.java</include>
                     <include>**/SearchIndexRetryQueueIT.java</include>
@@ -686,6 +691,7 @@
                     <exclude>**/VectorEmbeddingIntegrationIT.java</exclude>
                     <exclude>**/PatchTableEmbeddingIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
+                    <exclude>**/ConversationSchemaMigrationIT.java</exclude>
                     <exclude>**/SessionMultiNodeIT.java</exclude>
                     <exclude>**/SessionRedisMultiNodeIT.java</exclude>
                     <exclude>**/SearchIndexRetryQueueIT.java</exclude>
@@ -753,6 +759,7 @@
                     <include>**/VectorEmbeddingIntegrationIT.java</include>
                     <include>**/PatchTableEmbeddingIT.java</include>
                     <include>**/GlossaryOntologyExportIT.java</include>
+                    <include>**/ConversationSchemaMigrationIT.java</include>
                     <include>**/SessionMultiNodeIT.java</include>
                     <include>**/SessionRedisMultiNodeIT.java</include>
                     <include>**/SearchIndexRetryQueueIT.java</include>
@@ -797,6 +804,7 @@
                     <exclude>**/VectorEmbeddingIntegrationIT.java</exclude>
                     <exclude>**/PatchTableEmbeddingIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
+                    <exclude>**/ConversationSchemaMigrationIT.java</exclude>
                     <exclude>**/SessionMultiNodeIT.java</exclude>
                     <exclude>**/SessionRedisMultiNodeIT.java</exclude>
                     <exclude>**/SearchIndexRetryQueueIT.java</exclude>
@@ -863,6 +871,7 @@
                     <include>**/VectorEmbeddingIntegrationIT.java</include>
                     <include>**/PatchTableEmbeddingIT.java</include>
                     <include>**/GlossaryOntologyExportIT.java</include>
+                    <include>**/ConversationSchemaMigrationIT.java</include>
                     <include>**/SessionMultiNodeIT.java</include>
                     <include>**/SessionRedisMultiNodeIT.java</include>
                     <include>**/SearchIndexRetryQueueIT.java</include>
@@ -907,6 +916,7 @@
                     <exclude>**/VectorEmbeddingIntegrationIT.java</exclude>
                     <exclude>**/PatchTableEmbeddingIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
+                    <exclude>**/ConversationSchemaMigrationIT.java</exclude>
                     <exclude>**/SessionMultiNodeIT.java</exclude>
                     <exclude>**/SessionRedisMultiNodeIT.java</exclude>
                     <exclude>**/SearchIndexRetryQueueIT.java</exclude>
@@ -972,6 +982,7 @@
                     <include>**/VectorEmbeddingIntegrationIT.java</include>
                     <include>**/PatchTableEmbeddingIT.java</include>
                     <include>**/GlossaryOntologyExportIT.java</include>
+                    <include>**/ConversationSchemaMigrationIT.java</include>
                     <include>**/SessionMultiNodeIT.java</include>
                     <include>**/SessionRedisMultiNodeIT.java</include>
                     <include>**/SearchIndexRetryQueueIT.java</include>
@@ -1017,6 +1028,7 @@
                     <exclude>**/VectorEmbeddingIntegrationIT.java</exclude>
                     <exclude>**/PatchTableEmbeddingIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
+                    <exclude>**/ConversationSchemaMigrationIT.java</exclude>
                     <exclude>**/SessionMultiNodeIT.java</exclude>
                     <exclude>**/SessionRedisMultiNodeIT.java</exclude>
                     <exclude>**/SearchIndexRetryQueueIT.java</exclude>
@@ -1099,6 +1111,7 @@
                     <include>**/VectorEmbeddingIntegrationIT.java</include>
                     <include>**/PatchTableEmbeddingIT.java</include>
                     <include>**/GlossaryOntologyExportIT.java</include>
+                    <include>**/ConversationSchemaMigrationIT.java</include>
                     <include>**/SessionMultiNodeIT.java</include>
                     <include>**/SessionRedisMultiNodeIT.java</include>
                     <include>**/SearchIndexRetryQueueIT.java</include>
@@ -1145,6 +1158,7 @@
                     <exclude>**/VectorEmbeddingIntegrationIT.java</exclude>
                     <exclude>**/PatchTableEmbeddingIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
+                    <exclude>**/ConversationSchemaMigrationIT.java</exclude>
                     <exclude>**/SessionMultiNodeIT.java</exclude>
                     <exclude>**/SessionRedisMultiNodeIT.java</exclude>
                     <exclude>**/SearchIndexRetryQueueIT.java</exclude>
@@ -1213,6 +1227,7 @@
                     <include>**/VectorEmbeddingIntegrationIT.java</include>
                     <include>**/PatchTableEmbeddingIT.java</include>
                     <include>**/GlossaryOntologyExportIT.java</include>
+                    <include>**/ConversationSchemaMigrationIT.java</include>
                     <include>**/SessionMultiNodeIT.java</include>
                     <include>**/SessionRedisMultiNodeIT.java</include>
                     <include>**/SearchIndexRetryQueueIT.java</include>
@@ -1259,6 +1274,7 @@
                     <exclude>**/VectorEmbeddingIntegrationIT.java</exclude>
                     <exclude>**/PatchTableEmbeddingIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
+                    <exclude>**/ConversationSchemaMigrationIT.java</exclude>
                     <exclude>**/SessionMultiNodeIT.java</exclude>
                     <exclude>**/SessionRedisMultiNodeIT.java</exclude>
                     <exclude>**/SearchIndexRetryQueueIT.java</exclude>


### PR DESCRIPTION
### Describe your changes:

Fixes #33040

`ConversationSchemaMigrationIT.conversationV2DdlIsIdempotentAndIndexedChildrenCascade` runs the shipped 2.1.0 migration DDL against the **live, shared** integration-test database (`TestSuiteBootstrap.getJdbi()`) — three times over, plus an `ALTER TABLE conversation_entity ADD COLUMN activityTimestamp ... STORED`.

`junit-platform.properties` sets `junit.jupiter.execution.parallel.mode.classes.default = concurrent`, so in the `parallel` lane that DDL executes while every other IT is live. MySQL bumps the table definition version and any transaction holding an older snapshot of `conversation_entity` dies with `ER_TABLE_DEF_CHANGED` (1412):

```
[ERROR] ChartResourceIT>BaseEntityIT.delete_entityAsAdmin_hardDelete_200 » Api
An exception with message [java.sql.SQLException: Table definition has changed, please retry transaction
[statement:"/* ConversationDAO.deleteByEntity */ DELETE FROM conversation_entity ...
```

([failing run](https://github.com/open-metadata/OpenMetadata/runs/102390432413))

Chart is incidental. `EntityRepository` calls `ConversationRepository.deleteByEntity` on the hard-delete path, so `BaseEntityIT.delete_entityAsAdmin_hardDelete_200` is exposed for all ~40 `*ResourceIT` subclasses — whichever one is mid-delete when the DDL lands is the one that fails.

Worth noting the test already guards the *other* table it touches: `thread_entity` is created as `CREATE TEMPORARY TABLE` so it stays session-local. `conversation_entity` can't get the same treatment, because the DDL under test names the real table.

**Fix:** move the class to the `global-state` lane, which exists for exactly this — its own job, its own MySQL, `junit.jupiter.execution.parallel.enabled=false`. The test itself is untouched; it still runs the real migration against a real database, just without company.

- `integrationTests.globalStateTests` (the lane's single source of truth) gains the class
- the 8 duplicated `isolated-tests` `<includes>` / `parallel-tests` `<excludes>` lists are kept in sync with it

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- The conversation V2 DDL idempotency test keeps running against a real MySQL/Postgres, in a lane where no other test shares the connection
- Entity hard-delete tests in the `parallel` lane no longer race schema changes to `conversation_entity`

#### Unit tests
- [x] Not applicable — build configuration only, no production or test code changed.

#### Backend integration tests
- [x] Not applicable — no new endpoints. `ConversationSchemaMigrationIT` still runs on every backend PR, in the `global-state` lane instead of `parallel`.

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. Parsed the pom and asserted lane membership structurally: the class is in the `<includes>` of all 8 `isolated-tests` executions and the `<excludes>` of all 8 `parallel-tests` executions, across every DB/search profile
2. `mvn -pl openmetadata-integration-tests -DintegrationTests.lane=global-state help:evaluate -Dexpression=it.test` → resolves to the global-state list now ending in `ConversationSchemaMigrationIT`
3. `mvn -pl openmetadata-integration-tests -DintegrationTests.lane=parallel help:evaluate -Dexpression=integrationTests.skipIsolated` → `true`, so the parallel lane skips the isolated execution entirely

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. (No schema changes.)
- [x] For UI changes: I attached a screen recording and/or screenshots above. (No UI changes.)
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above. (Build config only — the affected test already exists and is unchanged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
