### PR TITLE
test(e2e): pin the classification Users.spec asserts Data Consumer permissions on

### DIFF
--- a/.github/playwright/impact-map.generated.json
+++ b/.github/playwright/impact-map.generated.json
@@ -824,7 +824,8 @@
         "playwright/e2e/Features/ContextCenterPermission.spec.ts",
         "playwright/e2e/Features/DataQuality/TestCaseImportExportBasic.spec.ts",
         "playwright/e2e/Pages/DataContracts.spec.ts",
-        "playwright/e2e/Pages/ODCSImportExport.spec.ts"
+        "playwright/e2e/Pages/ODCSImportExport.spec.ts",
+        "playwright/e2e/Pages/Users.spec.ts"
       ]
     },
     {
@@ -1623,7 +1624,8 @@
         "playwright/e2e/Features/LineageExportPNGSnapshot.spec.ts",
         "playwright/e2e/Features/SampleDataTableOperations.spec.ts",
         "playwright/e2e/Pages/Lineage/DataAssetLineage.spec.ts",
-        "playwright/e2e/Pages/Lineage/LineageFilters.spec.ts"
+        "playwright/e2e/Pages/Lineage/LineageFilters.spec.ts",
+        "playwright/e2e/Pages/Users.spec.ts"
       ]
     },
     {
@@ -3942,7 +3944,8 @@
         "playwright/e2e/Features/ClassificationImportExport.spec.ts",
         "playwright/e2e/Features/DataQuality/TestCaseImportExportBasic.spec.ts",
         "playwright/e2e/Pages/DataContracts.spec.ts",
-        "playwright/e2e/Pages/ODCSImportExport.spec.ts"
+        "playwright/e2e/Pages/ODCSImportExport.spec.ts",
+        "playwright/e2e/Pages/Users.spec.ts"
       ]
     },
     {
@@ -5506,6 +5509,7 @@
         "playwright/e2e/Pages/TasksUIFlow.spec.ts",
         "playwright/e2e/Pages/TeamAssetsRightPanel.spec.ts",
         "playwright/e2e/Pages/Teams.spec.ts",
+        "playwright/e2e/Pages/Users.spec.ts",
         "playwright/e2e/VersionPages/EntityVersionPages.spec.ts",
         "playwright/e2e/VersionPages/GlossaryVersionPage.spec.ts"
       ]
@@ -6050,7 +6054,8 @@
         "playwright/e2e/Pages/Lineage/DataAssetLineage.spec.ts",
         "playwright/e2e/Pages/Lineage/LineageControls.spec.ts",
         "playwright/e2e/Pages/Lineage/LineageRightPanel.spec.ts",
-        "playwright/e2e/Pages/Lineage/PlatformLineage.spec.ts"
+        "playwright/e2e/Pages/Lineage/PlatformLineage.spec.ts",
+        "playwright/e2e/Pages/Users.spec.ts"
       ]
     },
     {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
@@ -230,6 +230,14 @@ test.describe('Context Center Articles', () => {
     await afterAction();
   });
 
+  test.afterAll(async ({ browser }) => {
+    const { apiContext, afterAction } = await createNewPage(browser);
+    // `cc_classification_*` sorts ahead of every system classification, so a
+    // leaked one becomes the Tags page default for every spec that runs later.
+    await articleTagClassification.delete(apiContext);
+    await afterAction();
+  });
+
   test.beforeEach(async ({ page }) => {
     await redirectToHomePage(page);
   });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Users.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Users.spec.ts
@@ -31,6 +31,7 @@ import { EntityDataClass } from '../../support/entity/EntityDataClass';
 import { TableClass } from '../../support/entity/TableClass';
 import { expect, test as base } from '../../support/fixtures/base';
 import { PersonaClass } from '../../support/persona/PersonaClass';
+import { ClassificationClass } from '../../support/tag/ClassificationClass';
 import { TeamClass } from '../../support/team/TeamClass';
 import { UserClass } from '../../support/user/UserClass';
 import { createAdminApiContext, performAdminLogin } from '../../utils/admin';
@@ -42,6 +43,7 @@ import {
 } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import { settingClick, sidebarClick } from '../../utils/sidebar';
+import { visitClassificationPage } from '../../utils/tag';
 import {
   addUser,
   checkDataConsumerPermissions,
@@ -68,6 +70,8 @@ import {
 } from '../../utils/user';
 
 const userName = `pw-user-${uuid()}`;
+const SYSTEM_CLASSIFICATION = 'Certification';
+
 const expirationTime = [1, 7, 30, 60, 90];
 
 const updatedUserDetails = {
@@ -361,20 +365,58 @@ test.describe('User with Data Consumer Roles', () => {
       await checkEditOwnerButtonPermission(dataConsumerPage);
     }
 
-    // Check CRUD for Tags
-    await sidebarClick(dataConsumerPage, SidebarItem.TAGS);
+    // Check CRUD for Tags. The Tags page lands on whichever classification the
+    // API lists first, so pin the classification instead of relying on order:
+    // a system classification offers a viewer no Manage action at all, while
+    // a user classification offers only Export (gated on ViewAll).
+    await visitClassificationPage(
+      dataConsumerPage,
+      SYSTEM_CLASSIFICATION,
+      SYSTEM_CLASSIFICATION
+    );
 
     await expect(
-      dataConsumerPage.locator('[data-testid="add-classification"]')
+      dataConsumerPage.getByTestId('add-classification')
+    ).not.toBeVisible();
+    await expect(
+      dataConsumerPage.getByTestId('add-new-tag-button')
+    ).not.toBeVisible();
+    await expect(
+      dataConsumerPage.getByTestId('manage-button')
     ).not.toBeVisible();
 
-    await expect(
-      dataConsumerPage.locator('[data-testid="add-new-tag-button"]')
-    ).not.toBeVisible();
+    const classification = new ClassificationClass();
+    const { apiContext, afterAction } = await createAdminApiContext();
+    try {
+      await classification.create(apiContext);
+      await visitClassificationPage(
+        dataConsumerPage,
+        classification.data.name,
+        classification.data.displayName
+      );
 
-    await expect(
-      dataConsumerPage.locator('[data-testid="manage-button"]')
-    ).not.toBeVisible();
+      await expect(
+        dataConsumerPage.getByTestId('add-new-tag-button')
+      ).not.toBeVisible();
+
+      const manageButton = dataConsumerPage.getByTestId('manage-button');
+      await expect(manageButton).toBeVisible();
+      await manageButton.click();
+
+      await expect(dataConsumerPage.getByTestId('export-button')).toBeVisible();
+      await expect(
+        dataConsumerPage.getByTestId('import-button')
+      ).not.toBeVisible();
+      await expect(
+        dataConsumerPage.getByTestId('edit-classification')
+      ).not.toBeVisible();
+      await expect(
+        dataConsumerPage.getByTestId('delete-button')
+      ).not.toBeVisible();
+    } finally {
+      await classification.delete(apiContext);
+      await afterAction();
+    }
   });
 
   test('Operations for settings page for Data Consumer', async ({


### PR DESCRIPTION
## Describe your changes

Fixes the intermittent failure of `Users.spec.ts › User should have only view permission for glossary and tags for Data Consumer` at the Tags-page `manage-button` assertion (seen on the Collate AUT nightly, e.g. https://github.com/open-metadata/openmetadata-nightly/actions/runs/34326261170/job/102384516454).

### Root cause

1. **Assertion went stale in #31938** (`Add export support for classification and tag level`). `ClassificationDetails` now shows the Manage menu when `showExportOption` is true, which needs only `ViewAll` on a non-system classification. `DataConsumerPolicy` grants `ViewAll` on `all`, so a Data Consumer legitimately sees Manage → Export on every user-created classification. The test still asserted the button is never visible.
2. **Masked by list order.** `TagsPage` opens `response.data[0]`; the API lists classifications `ORDER BY name`. On a clean DB `Certification` (system, no Export) is first, so the stale assertion kept passing.
3. **Test-data leak flips it.** `ContextCenterArticles.spec.ts` creates `cc_classification_<uuid>` in `beforeAll` with no `afterAll`. `cc_` sorts before `Ce`, so once that spec has run in the same server the leaked classification is the Tags-page default for everyone. Whether it runs before the Users.spec test depends on worker scheduling → pass/fail alternates run to run.

### Fix

- `Users.spec.ts`: navigate to `Certification` explicitly (`visitClassificationPage`) and assert no Manage button. Then create a user classification via API and assert the Data Consumer sees Manage with **only** `export-button` (no `import-button`, `edit-classification`, `delete-button`). Deletes it in `finally`.
- `ContextCenterArticles.spec.ts`: `afterAll` deletes `articleTagClassification` (recursive → tags too).

Follows `PLAYWRIGHT_DEVELOPER_HANDBOOK.md`: API setup/cleanup, `getByTestId`, reuses existing `visitClassificationPage` util, no positional locators.

### Verification

- `yarn lint:base` on both files: 0 errors (3 pre-existing `no-restricted-syntax` warnings in Users.spec, untouched lines).
- `tsc -p playwright/tsconfig.json`: no new errors (2 pre-existing in Users.spec lines 181/438, present on `main`).
- Not run against a live server locally; relying on CI Playwright.

## Type of change

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>` or a conventional-commit prefix.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: N/A.
- [x] I have added tests around the new logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
