### PR TITLE
ci(playwright): retry shard-results upload under -retry name to sidestep 409 conflict

### DIFF
--- a/.github/scripts/render_playwright_summary.cjs
+++ b/.github/scripts/render_playwright_summary.cjs
@@ -309,12 +309,32 @@ async function renderPlaywrightSummary({ github, context, core }) {
     }
   }
 
+  // The shard-side upload step has a fallback that re-uploads under
+  // `<baseName>-retry` so a first-attempt FinalizeArtifact 403 (leaving a
+  // ghost reservation that would 409 a same-name retry) can still land the
+  // results. Collapse each shardId's primary + retry back to a single
+  // shardId here, preferring the `-retry` copy when both are present (a
+  // successful retry means the primary was incomplete or its finalize
+  // failed).
   if (fs.existsSync(resultsDir)) {
+    const dirsByShard = new Map();
     for (const dir of fs.readdirSync(resultsDir).sort()) {
+      if (!dir.startsWith('playwright-results-json-')) continue;
       const jsonPath = path.join(resultsDir, dir, 'results.json');
       if (!fs.existsSync(jsonPath)) continue;
-
-      const shardNum = dir.replace('playwright-results-json-', '');
+      const suffix = dir.replace('playwright-results-json-', '');
+      const isRetry = suffix.endsWith('-retry');
+      const shardNum = isRetry ? suffix.slice(0, -'-retry'.length) : suffix;
+      const existing = dirsByShard.get(shardNum);
+      // Retry beats primary; otherwise first-writer wins for stable ordering.
+      if (!existing || (isRetry && !existing.isRetry)) {
+        dirsByShard.set(shardNum, { dir, isRetry });
+      }
+    }
+    for (const [shardNum, { dir }] of Array.from(dirsByShard.entries()).sort(
+      ([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)
+    )) {
+      const jsonPath = path.join(resultsDir, dir, 'results.json');
       let report;
       try {
         report = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
@@ -406,15 +426,26 @@ async function renderPlaywrightSummary({ github, context, core }) {
     }
   }
 
+  // ci-status.json is bundled into the same artifact as results.json, so the
+  // primary + retry collapse rule above applies here too — pick the retry
+  // when both are present.
   const statusByShard = new Map();
+  const statusIsRetryByShard = new Map();
   if (fs.existsSync(resultsDir)) {
     for (const dir of fs.readdirSync(resultsDir).sort()) {
+      if (!dir.startsWith('playwright-results-json-')) continue;
       const statusPath = path.join(resultsDir, dir, 'ci-status.json');
       if (!fs.existsSync(statusPath)) continue;
-      const shardNum = dir.replace('playwright-results-json-', '');
+      const suffix = dir.replace('playwright-results-json-', '');
+      const isRetry = suffix.endsWith('-retry');
+      const shardNum = isRetry ? suffix.slice(0, -'-retry'.length) : suffix;
+      if (statusByShard.has(shardNum) && !isRetry && statusIsRetryByShard.get(shardNum)) {
+        continue;
+      }
       try {
         const status = JSON.parse(fs.readFileSync(statusPath, 'utf8'));
         statusByShard.set(shardNum, status);
+        statusIsRetryByShard.set(shardNum, isRetry);
       } catch (error) {
         addInfrastructureIssue(`Shard ${shardNum} uploaded invalid execution status JSON: ${error.message}`);
       }

--- a/.github/scripts/tests/test_playwright_ci_planning.py
+++ b/.github/scripts/tests/test_playwright_ci_planning.py
@@ -3083,6 +3083,116 @@ def test_playwright_summary_merge_group_fails_when_matrix_not_success(tmp_path):
         )
 
 
+def test_playwright_summary_prefers_retry_artifact_over_primary(tmp_path):
+    # The shard-side upload has a `-retry` fallback (added after run
+    # 34244326002 to sidestep the FinalizeArtifact 403 / CreateArtifact 409
+    # ghost-reservation cycle). When both `playwright-results-json-<shardId>`
+    # and `playwright-results-json-<shardId>-retry` land in the summary's
+    # download directory, the render script must:
+    #   * collapse them to a single canonical <shardId> (no
+    #     "Unexpected shard <shardId>-retry uploaded results" issue),
+    #   * prefer the retry copy (the primary is the reason we retried).
+    helper = SCRIPTS / "render_playwright_summary.cjs"
+
+    def write_shard(name, statuses):
+        d = tmp_path / "results" / f"playwright-results-json-{name}"
+        d.mkdir(parents=True)
+        (d / "results.json").write_text(
+            json.dumps(
+                {
+                    "suites": [
+                        {
+                            "file": "playwright/e2e/example.spec.ts",
+                            "specs": [
+                                {
+                                    "title": f"case-{i}",
+                                    "tests": [{"status": status, "results": [{}]}],
+                                }
+                                for i, status in enumerate(statuses)
+                            ],
+                        }
+                    ]
+                }
+            )
+        )
+        (d / "ci-status.json").write_text(
+            json.dumps({"steps": {"tests": "success"}})
+        )
+
+    # Primary reports 3 tests, one flaky; retry reports the full 5 passing
+    # (canonical "primary was incomplete, retry salvaged it" shape).
+    write_shard("chromium-01", ["expected", "flaky", "expected"])
+    write_shard("chromium-01-retry", ["expected"] * 5)
+
+    payload_path = tmp_path / "playwright-pr-comment/summary.json"
+    harness = f"""
+const {{ renderPlaywrightSummary }} = require({json.dumps(str(helper))});
+let failure = null;
+let summaryBody = '';
+const summary = {{
+  addRaw(body) {{ summaryBody = body; return summary; }},
+  async write() {{}},
+}};
+const core = {{
+  summary,
+  warning() {{}},
+  setFailed(message) {{ failure = message; }},
+}};
+(async () => {{
+  await renderPlaywrightSummary({{
+    github: {{}},
+    context: {{
+      eventName: 'pull_request',
+      payload: {{}},
+      repo: {{ owner: 'open-metadata', repo: 'OpenMetadata' }},
+    }},
+    core,
+  }});
+  process.stdout.write(JSON.stringify({{ failure, summaryBody }}));
+}})().catch(e => {{ console.error(e.stack || e.message); process.exitCode = 1; }});
+"""
+    env = os.environ.copy()
+    env.update(
+        {
+            "CHECK_CHANGES_RESULT": "success",
+            "CACHE_KEYS_RESULT": "success",
+            "BUILD_RESULT": "success",
+            "DETECT_CHANGES_RESULT": "success",
+            "PLAN_RESULT": "success",
+            "FIXTURE_RESTORE_RESULT": "success",
+            "FIXTURE_RESULT": "success",
+            "PLAYWRIGHT_RESULT": "success",
+            "EXPECTED_MATRIX": json.dumps({"include": [{"shardId": "chromium-01"}]}),
+            "RUNNER_TEMP": str(tmp_path),
+            "COMMENT_PAYLOAD_PATH": str(payload_path),
+            "GITHUB_RUN_ID": "12345",
+        }
+    )
+    completed = subprocess.run(
+        ["node", "-e", harness],
+        cwd=tmp_path,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    rendered = json.loads(completed.stdout)
+    payload = json.loads(payload_path.read_text())
+
+    # Retry wins: totals reflect the 5-passing retry, not the 3-with-flaky primary.
+    assert payload["totals"]["passed"] == 5, payload["totals"]
+    assert payload["totals"]["flaky"] == 0, payload["totals"]
+
+    # Shard was reported once under the canonical id, not twice.
+    shard_ids = [s["id"] for s in payload["shards"] if s["present"]]
+    assert shard_ids == ["chromium-01"], shard_ids
+
+    # No "Unexpected shard chromium-01-retry" noise.
+    assert "chromium-01-retry" not in rendered["summaryBody"]
+    assert rendered["failure"] is None, rendered["failure"]
+
+
 def test_normal_vite_build_keeps_hashed_entry_assets():
     vite_config = (
         SCRIPTS.parents[1] / "openmetadata-ui/src/main/resources/ui/vite.config.ts"

--- a/.github/workflows/playwright-e2e-reusable.yml
+++ b/.github/workflows/playwright-e2e-reusable.yml
@@ -1799,12 +1799,23 @@ jobs:
           retention-days: 1
           if-no-files-found: ignore
 
+      # The retry uploads to a DIFFERENT name (`-retry` suffix). Reusing the
+      # primary name races an artifact-service failure mode where the first
+      # attempt's blob upload succeeds but `FinalizeArtifact` returns 403
+      # from the intermediary — the name is now a ghost reservation that the
+      # next `CreateArtifact` rejects with `409 Conflict: an artifact with
+      # this name already exists on the workflow run` (run 34244326002:
+      # chromium-09 upload + retry both 403/409 on the same name, results
+      # never landed). `overwrite: true` doesn't help against the ghost.
+      # A unique retry name sidesteps the collision; render_playwright_summary
+      # collapses `<shardId>-retry` back to `<shardId>` and prefers the retry
+      # when both are present.
       - name: Retry upload results JSON for summary
         if: always() && steps.upload-results-json.outcome == 'failure'
         uses: actions/upload-artifact@v6
         continue-on-error: true
         with:
-          name: playwright-results-json-${{ matrix.shardId }}
+          name: playwright-results-json-${{ matrix.shardId }}-retry
           overwrite: true
           path: |
             openmetadata-ui/src/main/resources/ui/playwright/output/results.json


### PR DESCRIPTION
## Summary

Follow-up on merged #33010. That PR relaxed the merge_group gate so infra flakes (artifact upload/download races) don't dissolve otherwise-green batches. This PR attacks the underlying flake — the shard-side retry design that races [`FinalizeArtifact 403` → `CreateArtifact 409 Conflict`](https://github.com/open-metadata/OpenMetadata/actions/runs/34244326002/job/102140455704) — so the retry can actually land the artifact.

Complements #33010 rather than replacing it: retries reduce **how often** an artifact miss happens; the relaxed gate keeps the queue moving when the residual flake still hits. Belt + suspenders.

## The race the retry couldn't survive

Current design uploads the retry under the **same** artifact name as the primary:

```yaml
- name: Upload results JSON for summary       # name: playwright-results-json-<shardId>
- name: Retry upload results JSON for summary # name: playwright-results-json-<shardId>  ← same
```

When GitHub's artifact-service hits its known 403/409 hiccup:

1. Primary: blob upload succeeds → `FinalizeArtifact` returns **403 Forbidden** from an intermediary. Blob is in storage, but the name-slot is left as a **ghost reservation** — not visible in the run's artifact list.
2. Retry: same name → `CreateArtifact` returns **`409 Conflict: an artifact with this name already exists on the workflow run`** (the ghost holds the slot).
3. Both steps `continue-on-error: true` → shard reports success but no artifact ever finalizes.

`overwrite: true` doesn't help — the ghost isn't a listable artifact for overwrite to target.

## Fix

Retry uploads under `<baseName>-retry`, a fresh name-slot the ghost can't touch:

```yaml
- name: Retry upload results JSON for summary
  with:
    name: playwright-results-json-${{ matrix.shardId }}-retry  # NEW: -retry suffix
```

`render_playwright_summary.cjs` collapses `<shardId>-retry` back to the canonical `<shardId>` when walking the download directory, preferring the retry when both are present (a successful retry means the primary was incomplete or its finalize failed). No `"Unexpected shard <shardId>-retry uploaded results"` noise; totals reflect the retry payload.

## Files

- `.github/workflows/playwright-e2e-reusable.yml` — 3-line rename of the retry step's artifact name + a comment explaining the 403/409 ghost mechanic.
- `.github/scripts/render_playwright_summary.cjs` — shard-discovery loop now normalises `<shardId>-retry` → `<shardId>` and picks the retry over the primary. Same normalisation applied to `ci-status.json` discovery.
- `.github/scripts/tests/test_playwright_ci_planning.py` — new `test_playwright_summary_prefers_retry_artifact_over_primary` writes both a partial primary (3 tests, 1 flaky) and a full retry (5 passing) into the results dir, asserts totals reflect the retry, only one canonical shard id is emitted, and no `-retry`-suffixed shard leaks into the summary body.

## Test plan

- [x] `python3 -m pytest .github/scripts/tests/test_playwright_ci_planning.py -k playwright_summary` — all 7 pass (the 6 kept from #33010 + this PR's collapse-retry case).
- [ ] Merge to observe: next `merge_group` / PR run that hits an artifact-upload 403 should now have a `playwright-results-json-<shardId>-retry` artifact land, and the summary should render the retry's results without an "Unexpected shard" note.

## Non-goals

- Doesn't touch the merge_group gate (that landed in #33010).
- Doesn't attempt to fix the GitHub Actions `FinalizeArtifact 403` itself — that's an Azure/Actions-side flake outside our control. This PR just gives the retry a fair chance to succeed when the primary hits it.
- Doesn't address the **summary-side** download flake (run [34312746335](https://github.com/open-metadata/OpenMetadata/actions/runs/34312746335) — the whole `Download all results JSON` step returned failure globally). #33010's relaxed gate covers that already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
