### PR TITLE
Fixes 31512: Ingest SQL Server synonyms as Table.aliases [1.13]

### DIFF
--- a/ingestion/src/metadata/ingestion/lineage/sql_lineage.py
+++ b/ingestion/src/metadata/ingestion/lineage/sql_lineage.py
@@ -97,6 +97,46 @@ def get_column_fqn(
 
 search_cache = LRUCache(LRU_CACHE_SIZE)
 database_service_type_cache = LRUCache(LRU_CACHE_SIZE)
+alias_resolution_cache = LRUCache(LRU_CACHE_SIZE)
+
+# Connection field a connector sets to opt into alias resolution. Read by name
+# rather than by service type so any connector exposing alternate names (SQL
+# Server synonyms today, Oracle synonyms later) participates without this
+# service-agnostic module learning connector names.
+ALIAS_OPT_IN_FIELD = "includeSynonyms"
+
+
+def service_resolves_aliases(metadata: OpenMetadata, service_name: str) -> bool:
+    """
+    Whether this service's connection opts into resolving alternate table names.
+
+    Resolving an alias costs an extra exact-match search per unresolved name, so
+    connectors that cannot produce aliases must not pay for it. Absent field
+    means no.
+    """
+    if service_name in alias_resolution_cache:
+        return bool(alias_resolution_cache.get(service_name))
+
+    resolves = False
+    try:
+        service: DatabaseService | None = metadata.get_by_name(
+            entity=DatabaseService, fqn=service_name
+        )
+        if service:
+            resolves = bool(
+                getattr(service.connection.config, ALIAS_OPT_IN_FIELD, False)
+            )
+    except Exception as exc:
+        logger.debug(traceback.format_exc())
+        logger.warning(
+            "Could not read alias opt-in for service '%s', assuming disabled: %s",
+            service_name,
+            exc,
+        )
+
+    alias_resolution_cache.put(service_name, resolves)
+
+    return resolves
 
 
 def get_database_service_type(
@@ -179,6 +219,38 @@ def normalize_table_params_by_service(
     return database, database_schema
 
 
+def resolve_table_entities_from_alias(
+    metadata: OpenMetadata,
+    service_name: str,
+    database: Optional[str],
+    database_schema: Optional[str],
+    table: str,
+) -> Optional[List[Table]]:
+    """
+    Resolve a name that is an alternate name (alias) of a table to that table.
+
+    Matching is exact on the stored alias FQN: a fuzzy hit would silently attach
+    a lineage edge to the wrong table. Gated per service so connectors that
+    cannot produce aliases never pay for the extra search.
+    """
+    if not service_resolves_aliases(metadata, service_name):
+        return None
+
+    alias_fqn = fqn.build(
+        metadata,
+        entity_type=Table,
+        service_name=service_name,
+        database_name=database,
+        schema_name=database_schema,
+        table_name=table,
+        skip_es_search=True,
+    )
+    if not alias_fqn:
+        return None
+
+    return metadata.es_search_from_alias(entity_type=Table, alias_fqn=alias_fqn)
+
+
 def search_table_entities(
     metadata: OpenMetadata,
     service_names: Union[str, List[str]],
@@ -251,6 +323,11 @@ def search_table_entities(
                     table_entity: Table = metadata.get_by_name(Table, fqn=table_fqn)
                     if table_entity:
                         table_entities.append(table_entity)
+
+            if not table_entities:
+                table_entities = resolve_table_entities_from_alias(
+                    metadata, service_name, normalized_db, normalized_schema, table
+                )
 
             # added the search tuple to the cache
             search_cache.put(search_tuple, table_entities)

--- a/ingestion/src/metadata/ingestion/ometa/mixins/es_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/es_mixin.py
@@ -229,6 +229,29 @@ class ESMixin(Generic[T]):
             fields=fields,
         )
 
+    def es_search_from_alias(
+        self,
+        entity_type: type[T],
+        alias_fqn: str,
+        from_count: int = 0,
+        size: int = 10,
+        fields: str | None = None,
+    ) -> list[T] | None:
+        """
+        Find entities carrying an exact alternate FQN in their aliases field.
+
+        Matches on the keyword subfield only: an alias is resolved for lineage,
+        where a fuzzy hit would silently attach an edge to the wrong table.
+        """
+        return self._es_search_entity(
+            entity_type=entity_type,
+            field_value=alias_fqn,
+            field_name="aliases.keyword",
+            from_count=from_count,
+            size=size,
+            fields=fields,
+        )
+
     def es_search_container_by_path(
         self,
         full_path: str,

--- a/ingestion/src/metadata/ingestion/source/database/common_db_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/common_db_source.py
@@ -584,6 +584,19 @@ class CommonDbSourceService(
         Method to fetch the extensions of the table
         """
 
+    def get_table_aliases(
+        self,
+        table_name: str,  # pyright: ignore[reportUnusedParameter]
+        schema_name: str,  # pyright: ignore[reportUnusedParameter]
+    ) -> Optional[List[str]]:
+        """
+        Alternate fully qualified SQL names that resolve to this table.
+
+        Connectors that expose database-native alternate names for a table
+        override this. The list is source-managed: it is recomputed from the
+        source on every run and replaces whatever is stored.
+        """
+
     def yield_table(
         self, table_name_and_type: Tuple[str, TableType]
     ) -> Iterable[Either[CreateTableRequest]]:
@@ -637,6 +650,13 @@ class CommonDbSourceService(
                 else None
             )
 
+            # `or []` normalizes the base hook's implicit None for connectors that
+            # do not expose alternate names.
+            table_aliases = (
+                self.get_table_aliases(table_name=table_name, schema_name=schema_name)
+                or []
+            )
+
             table_request = CreateTableRequest(
                 name=EntityName(table_name),
                 tableType=table_type,
@@ -668,6 +688,11 @@ class CommonDbSourceService(
                 ),
                 extension=self.get_table_extensions(
                     table_name=table_name, table_type=table_type
+                ),
+                aliases=(
+                    [FullyQualifiedEntityName(alias) for alias in table_aliases]
+                    if table_aliases
+                    else None
                 ),
             )
 

--- a/ingestion/src/metadata/ingestion/source/database/mssql/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/metadata.py
@@ -22,6 +22,7 @@ from metadata.generated.schema.api.data.createStoredProcedure import (
 from metadata.generated.schema.entity.data.database import Database
 from metadata.generated.schema.entity.data.databaseSchema import DatabaseSchema
 from metadata.generated.schema.entity.data.storedProcedure import StoredProcedureCode
+from metadata.generated.schema.entity.data.table import Table
 from metadata.generated.schema.entity.services.connections.database.mssqlConnection import (
     MssqlConnection,
 )
@@ -47,6 +48,10 @@ from metadata.ingestion.source.database.mssql.queries import (
     MSSQL_GET_SCHEMA_COMMENTS,
     MSSQL_GET_STORED_PROCEDURE_COMMENTS,
     MSSQL_GET_STORED_PROCEDURES,
+)
+from metadata.ingestion.source.database.mssql.synonyms import (
+    SynonymMap,
+    build_synonym_map,
 )
 from metadata.ingestion.source.database.mssql.utils import (
     get_columns,
@@ -109,6 +114,7 @@ class MssqlSource(CommonDbSourceService, MultiDBSource):
         self.database_desc_map = {}
         self.stored_procedure_desc_map = {}
         self.encrypted_procedures_cache: dict[tuple[str, str], set[str]] = {}
+        self.synonym_map = SynonymMap()
 
     @classmethod
     def create(
@@ -271,6 +277,84 @@ class MssqlSource(CommonDbSourceService, MultiDBSource):
                         )
                     )
 
+    def _in_scope_database_names(self) -> list[str]:
+        """
+        In-scope databases for the synonym sweep, resolved without touching the
+        topology. prepare() runs before get_database_names(), so the filter has
+        to be reapplied here rather than reused from it.
+        """
+        if not self.service_connection.ingestAllDatabases:
+            return [self.service_connection.database]
+
+        database_names = []
+        for database_name in self.get_database_names_raw():
+            database_fqn = fqn.build(
+                self.metadata,
+                entity_type=Database,
+                service_name=self.config.serviceName,
+                database_name=database_name,
+            )
+            if filter_by_database(
+                self.source_config.databaseFilterPattern,
+                (
+                    database_fqn
+                    if self.source_config.useFqnForFiltering
+                    else database_name
+                ),  # pyright: ignore[reportArgumentType]
+            ):
+                continue
+            database_names.append(database_name)
+        return database_names
+
+    def _build_table_fqn(
+        self, database_name: str, schema_name: str, table_name: str
+    ) -> str:
+        return fqn.build(  # pyright: ignore[reportReturnType]
+            self.metadata,
+            entity_type=Table,
+            service_name=self.config.serviceName,
+            database_name=database_name,
+            schema_name=schema_name,
+            table_name=table_name,
+            skip_es_search=True,
+        )
+
+    def prepare(self):
+        """
+        Sweep synonyms before the topology runs.
+
+        Synonym discovery is optional metadata: a failure here must not abort the
+        run, so it is logged and ingestion continues with an empty map.
+        """
+        super().prepare()
+        if not self.service_connection.includeSynonyms:
+            logger.info("includeSynonyms is disabled; skipping MSSQL synonym discovery")
+
+            return
+        try:
+            self.synonym_map = build_synonym_map(
+                engine=self.engine,
+                database_names=self._in_scope_database_names(),
+                fqn_builder=self._build_table_fqn,
+            )
+        except Exception as exc:
+            logger.debug(traceback.format_exc())
+            logger.warning(
+                "Could not discover MSSQL synonyms, continuing without aliases: %s", exc
+            )
+
+    def get_table_aliases(self, table_name: str, schema_name: str) -> list[str] | None:
+        """Aliases from sys.synonyms whose target is the table being produced"""
+        if self.synonym_map.is_empty():
+            return None
+        return self.synonym_map.aliases_for(
+            self._build_table_fqn(
+                self.context.get().database,  # pyright: ignore[reportAttributeAccessIssue]
+                schema_name,
+                table_name,
+            )
+        )
+
     def get_stored_procedures(self) -> Iterable[MssqlStoredProcedure]:
         """List Snowflake stored procedures"""
         if self.source_config.includeStoredProcedures:
@@ -344,3 +428,9 @@ class MssqlSource(CommonDbSourceService, MultiDBSource):
                     stackTrace=traceback.format_exc(),
                 )
             )
+
+    def close(self):
+        """Report synonyms that never resolved to an ingested table"""
+        for alias_fqn, reason in self.synonym_map.unresolved():
+            self.status.warning(alias_fqn, f"Synonym target unresolved: {reason}")
+        super().close()

--- a/ingestion/src/metadata/ingestion/source/database/mssql/models.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/models.py
@@ -10,7 +10,7 @@
 #  limitations under the License.
 """MSSQL models"""
 
-from enum import IntEnum
+from enum import Enum, IntEnum
 from typing import Optional
 
 from pydantic import BaseModel, Field
@@ -39,3 +39,27 @@ class MssqlStoredProcedure(BaseModel):
     owner: Optional[str] = Field(None)
     language: str = Field(Language.SQL)
     definition: Optional[str] = Field(None)
+
+
+class SynonymUnresolvedReason(str, Enum):
+    """Why a discovered synonym could not be attached to a canonical table"""
+
+    UNRESOLVED = "Unresolved"
+    UNSUPPORTED_TARGET_TYPE = "UnsupportedTargetType"
+    REMOTE_TARGET_UNMAPPED = "RemoteTargetUnmapped"
+
+
+class MssqlSynonym(BaseModel):
+    """A row from sys.synonyms joined to sys.schemas"""
+
+    synonym_schema: str = Field(...)
+    synonym_name: str = Field(...)
+    base_object_name: str = Field(...)
+
+
+class MssqlSynonymTarget(BaseModel):
+    """The parsed three-part target a synonym resolves to"""
+
+    database: str = Field(...)
+    schema_name: str = Field(...)
+    table: str = Field(...)

--- a/ingestion/src/metadata/ingestion/source/database/mssql/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/queries.py
@@ -466,3 +466,15 @@ ORDER BY PROCEDURE_START_TIME DESC
 )
 
 GET_DB_CONFIGS = textwrap.dedent("DBCC USEROPTIONS;")
+
+MSSQL_GET_SYNONYMS = textwrap.dedent(
+    """
+SELECT
+    sch.name AS synonym_schema,
+    syn.name AS synonym_name,
+    syn.base_object_name AS base_object_name
+FROM [{database_name}].sys.synonyms syn
+JOIN [{database_name}].sys.schemas sch
+    ON syn.schema_id = sch.schema_id
+"""
+)

--- a/ingestion/src/metadata/ingestion/source/database/mssql/synonyms.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/synonyms.py
@@ -1,0 +1,260 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""MSSQL synonym discovery, identifier parsing, and target mapping"""
+
+import traceback
+from collections.abc import Callable
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from metadata.ingestion.source.database.mssql.models import (
+    MssqlSynonym,
+    MssqlSynonymTarget,
+    SynonymUnresolvedReason,
+)
+from metadata.ingestion.source.database.mssql.queries import MSSQL_GET_SYNONYMS
+from metadata.utils.logger import ingestion_logger
+
+logger = ingestion_logger()
+
+DEFAULT_MSSQL_SCHEMA = "dbo"
+
+MAX_SYNONYM_ENTRIES = 5000
+
+
+def split_sql_server_identifier(raw: str) -> list[str]:
+    """
+    Split a possibly bracket-quoted T-SQL identifier on unquoted '.' separators.
+
+    Splitting naively on '.' would tear apart a quoted component that legitimately
+    contains a dot, which SQL Server permits: [my.db].[dbo].[order.items] is three
+    parts, not five. Inside brackets, ']]' is an escaped literal ']'.
+    """
+    parts: list[str] = []
+    current: list[str] = []
+    in_bracket = False
+    index = 0
+
+    while index < len(raw):
+        char = raw[index]
+        if in_bracket:
+            if char == "]":
+                if index + 1 < len(raw) and raw[index + 1] == "]":
+                    current.append("]")
+                    index += 2
+                    continue
+                in_bracket = False
+            else:
+                current.append(char)
+        elif char == "[":
+            in_bracket = True
+        elif char == ".":
+            parts.append("".join(current))
+            current = []
+        else:
+            current.append(char)
+        index += 1
+
+    parts.append("".join(current))
+    return parts
+
+
+def parse_base_object_name(
+    base_object_name: str,
+    synonym_database: str,
+) -> tuple[MssqlSynonymTarget | None, SynonymUnresolvedReason | None]:
+    """
+    Normalize sys.synonyms.base_object_name into a three-part target.
+
+    Returns exactly one of (target, None) or (None, reason).
+
+    An omitted schema resolves at runtime to the calling user's default schema,
+    which is not knowable at ingestion time; 'dbo' is assumed because it is the
+    default for the overwhelming majority of SQL Server principals.
+    """
+    if not base_object_name or not base_object_name.strip():
+        return None, SynonymUnresolvedReason.UNRESOLVED
+
+    parts = split_sql_server_identifier(base_object_name.strip())
+
+    if len(parts) == 4:
+        if parts[0] == "":
+            parts = parts[1:]
+        else:
+            return None, SynonymUnresolvedReason.REMOTE_TARGET_UNMAPPED
+
+    if len(parts) == 3:
+        database, schema_name, table = parts
+    elif len(parts) == 2:
+        database, (schema_name, table) = synonym_database, parts
+    elif len(parts) == 1:
+        database, schema_name, table = synonym_database, DEFAULT_MSSQL_SCHEMA, parts[0]
+    else:
+        return None, SynonymUnresolvedReason.UNRESOLVED
+
+    if not table:
+        return None, SynonymUnresolvedReason.UNRESOLVED
+
+    return (
+        MssqlSynonymTarget(
+            database=database or synonym_database,
+            schema_name=schema_name or DEFAULT_MSSQL_SCHEMA,
+            table=table,
+        ),
+        None,
+    )
+
+
+class SynonymMap:
+    """
+    Target FQN -> alias FQNs, with consumption tracking.
+
+    Bounded by an explicit target cap: the map is built from a whole-service
+    sys.synonyms snapshot, so on a pathological catalog it would otherwise grow
+    without limit and exhaust memory mid-run.
+    """
+
+    def __init__(self, max_entries: int = MAX_SYNONYM_ENTRIES):
+        self._max_entries = max_entries
+        # Keyed on the case-folded target FQN: SQL Server's default collation is
+        # case-insensitive, so `base_object_name` casing routinely disagrees with
+        # the target table's actual stored casing, but the FQNs we compare here
+        # are case-preserving strings. Folding only the key -- never the alias
+        # values stored below -- keeps lookups collation-correct without
+        # mangling what actually lands in aliases[].
+        self._targets: dict[str, set[str]] = {}
+        self._consumed: set[str] = set()
+        self._explicit_unresolved: list[tuple[str, str]] = []
+        self._cap_warned = False
+        self._unresolved_cap_warned = False
+
+    def add(self, target_fqn: str, alias_fqn: str) -> bool:
+        key = target_fqn.casefold()
+        if key not in self._targets and len(self._targets) >= self._max_entries:
+            if not self._cap_warned:
+                logger.warning(
+                    "Synonym map reached its cap of %d targets; further synonyms are ignored for this run",
+                    self._max_entries,
+                )
+                self._cap_warned = True
+            return False
+        self._targets.setdefault(key, set()).add(alias_fqn)
+        return True
+
+    def aliases_for(self, target_fqn: str) -> list[str] | None:
+        """
+        Return sorted aliases for a target; marks target as consumed.
+
+        Calling this method signals that the target was ingested and will exclude
+        it from unresolved() reporting. Meant to be called exactly once per target
+        when it is successfully discovered and added to the catalog.
+        """
+        key = target_fqn.casefold()
+        aliases = self._targets.get(key)
+        if not aliases:
+            return None
+        self._consumed.add(key)
+        return sorted(aliases)
+
+    def record_unresolved(
+        self, alias_fqn: str, reason: SynonymUnresolvedReason
+    ) -> None:
+        if len(self._explicit_unresolved) >= self._max_entries:
+            if not self._unresolved_cap_warned:
+                logger.warning(
+                    "Unresolved synonym list reached its cap of %d; "
+                    "further unresolved entries are ignored for this run",
+                    self._max_entries,
+                )
+                self._unresolved_cap_warned = True
+            return
+        self._explicit_unresolved.append((alias_fqn, reason.value))
+
+    def unresolved(self) -> list[tuple[str, str]]:
+        never_consumed = [
+            (alias_fqn, SynonymUnresolvedReason.UNRESOLVED.value)
+            for target_fqn, aliases in self._targets.items()
+            if target_fqn not in self._consumed
+            for alias_fqn in sorted(aliases)
+        ]
+        return self._explicit_unresolved + never_consumed
+
+    def is_empty(self) -> bool:
+        return not self._targets
+
+
+def build_synonym_map(
+    engine: Engine,
+    database_names: list[str],
+    fqn_builder: Callable[[str, str, str], str],
+    max_entries: int = MAX_SYNONYM_ENTRIES,
+) -> SynonymMap:
+    """
+    Sweep sys.synonyms across every in-scope database and index by target FQN.
+
+    Runs before any table is produced, because a synonym's target commonly lives
+    in a different database than the synonym itself and the alias has to be
+    attached to the target's create request.
+
+    A database that cannot be read (dropped mid-run, offline, or no VIEW
+    DEFINITION grant) is logged and skipped: partial synonym coverage is better
+    than no metadata at all.
+    """
+    synonym_map = SynonymMap(max_entries=max_entries)
+
+    for database_name in database_names:
+        escaped_database = database_name.replace("]", "]]")
+        try:
+            with engine.connect() as connection:
+                result = connection.execute(
+                    text(MSSQL_GET_SYNONYMS.format(database_name=escaped_database))
+                )
+                # SQLAlchemy's stubs type Connection.execute as Optional on this
+                # branch; every other MSSQL query in the connector does the same.
+                rows = result.all()  # pyright: ignore[reportOptionalMemberAccess]
+        except Exception as exc:
+            logger.debug(traceback.format_exc())
+            logger.warning(
+                "Could not read synonyms from database [%s]: %s", database_name, exc
+            )
+            continue
+
+        for row in rows:
+            synonym = MssqlSynonym(
+                synonym_schema=row.synonym_schema,
+                synonym_name=row.synonym_name,
+                base_object_name=row.base_object_name,
+            )
+            alias_fqn = fqn_builder(
+                database_name, synonym.synonym_schema, synonym.synonym_name
+            )
+
+            target, reason = parse_base_object_name(
+                synonym.base_object_name, database_name
+            )
+            if reason is not None or target is None:
+                # parse_base_object_name guarantees exactly one of (target, reason) is set;
+                # the `target is None` check is here purely so type narrowing lets us treat
+                # `target` as non-optional below.
+                synonym_map.record_unresolved(
+                    alias_fqn, reason or SynonymUnresolvedReason.UNRESOLVED
+                )
+                continue
+
+            synonym_map.add(
+                target_fqn=fqn_builder(
+                    target.database, target.schema_name, target.table
+                ),
+                alias_fqn=alias_fqn,
+            )
+
+    return synonym_map

--- a/ingestion/src/metadata/utils/source_hash.py
+++ b/ingestion/src/metadata/utils/source_hash.py
@@ -26,7 +26,7 @@ import hashlib
 import json
 import re
 import traceback
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, cast
 
 from metadata.ingestion.ometa.ometa_api import C
 from metadata.utils.logger import utils_logger
@@ -133,10 +133,14 @@ def _normalize_for_hash(data: Dict[str, Any]) -> Dict[str, Any]:
     2. Sorts tags by tagFQN
     3. Sorts tableConstraints by type and columns
     4. Sorts owners by FQN/name/id
-    5. Removes volatile EntityReference fields (href, deleted, inherited)
-    6. Normalizes schemaDefinition whitespace
+    5. Sorts aliases lexicographically
+    6. Removes volatile EntityReference fields (href, deleted, inherited)
+    7. Normalizes schemaDefinition whitespace
     """
-    result = _remove_volatile_fields(data)
+    # _remove_volatile_fields is `Dict | List | Any` because it recurses into nested
+    # lists, but called here on a top-level create-request dict it always returns a dict
+    # (see its `isinstance(obj, dict)` branch); cast narrows for the string-keyed lookups below.
+    result = cast(Dict[str, Any], _remove_volatile_fields(data))
 
     if "columns" in result and isinstance(result["columns"], list):
         result["columns"] = _sort_columns(result["columns"])
@@ -152,6 +156,9 @@ def _normalize_for_hash(data: Dict[str, Any]) -> Dict[str, Any]:
     if "owners" in result and isinstance(result["owners"], list):
         result["owners"] = sorted(result["owners"], key=_get_entity_reference_sort_key)
 
+    if "aliases" in result and isinstance(result["aliases"], list):
+        result["aliases"] = sorted(result["aliases"], key=str)
+
     if "schemaDefinition" in result and result["schemaDefinition"]:
         result["schemaDefinition"] = _normalize_whitespace(result["schemaDefinition"])
 
@@ -166,7 +173,7 @@ def generate_source_hash(
     and generate a stable hash value.
 
     The normalization process ensures hash stability by:
-    - Sorting lists (columns, tags, constraints, owners) by deterministic keys
+    - Sorting lists (columns, tags, constraints, owners, aliases) by deterministic keys
     - Removing volatile fields (href, deleted, inherited) from entity references
     - Normalizing whitespace in DDL/SQL definitions
     """

--- a/ingestion/tests/unit/lineage/test_alias_resolution.py
+++ b/ingestion/tests/unit/lineage/test_alias_resolution.py
@@ -1,0 +1,177 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Lineage resolution falls back to an exact alias match"""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.generated.schema.entity.data.table import Table
+from metadata.ingestion.lineage.sql_lineage import (
+    search_table_entities,
+    service_resolves_aliases,
+)
+
+
+def _table(table_fqn):
+    table = MagicMock(spec=Table)
+    table.fullyQualifiedName = table_fqn
+    return table
+
+
+def test_canonical_match_does_not_consult_aliases():
+    metadata = MagicMock()
+    metadata.es_search_from_fqn.return_value = [
+        _table("svc.analytics_master.dbo.orders")
+    ]
+
+    with patch(
+        "metadata.ingestion.lineage.sql_lineage.search_cache",
+        MagicMock(get=lambda _: None),
+    ):
+        result = search_table_entities(
+            metadata=metadata,
+            service_names="svc",
+            database="analytics_master",
+            database_schema="dbo",
+            table="orders",
+        )
+
+    assert result is not None
+    metadata.es_search_from_alias.assert_not_called()
+
+
+def test_alias_match_resolves_to_the_canonical_table():
+    metadata = MagicMock()
+    metadata.es_search_from_fqn.return_value = None
+    metadata.get_by_name.return_value = None
+    metadata.es_search_from_alias.return_value = [
+        _table("svc.analytics_master.dbo.orders")
+    ]
+
+    with (
+        patch(
+            "metadata.ingestion.lineage.sql_lineage.search_cache",
+            MagicMock(get=lambda _: None),
+        ),
+        patch(
+            "metadata.ingestion.lineage.sql_lineage.service_resolves_aliases",
+            return_value=True,
+        ),
+    ):
+        result = search_table_entities(
+            metadata=metadata,
+            service_names="svc",
+            database="analytics_core",
+            database_schema="dbo",
+            table="orders",
+        )
+
+    assert [entity.fullyQualifiedName for entity in result] == [
+        "svc.analytics_master.dbo.orders"
+    ]
+    metadata.es_search_from_alias.assert_called_once()
+
+
+def test_no_match_returns_none():
+    metadata = MagicMock()
+    metadata.es_search_from_fqn.return_value = None
+    metadata.get_by_name.return_value = None
+    metadata.es_search_from_alias.return_value = None
+
+    with (
+        patch(
+            "metadata.ingestion.lineage.sql_lineage.search_cache",
+            MagicMock(get=lambda _: None),
+        ),
+        patch(
+            "metadata.ingestion.lineage.sql_lineage.service_resolves_aliases",
+            return_value=True,
+        ),
+    ):
+        result = search_table_entities(
+            metadata=metadata,
+            service_names="svc",
+            database="analytics_core",
+            database_schema="dbo",
+            table="orders",
+        )
+
+    assert result is None
+
+
+class TestAliasOptInGate:
+    """The alias lookup must be per-service opt-in, not paid by every connector."""
+
+    def setup_method(self):
+        from metadata.ingestion.lineage import sql_lineage
+
+        sql_lineage.alias_resolution_cache.clear()
+
+    def _service(self, **connection_fields):
+        service = MagicMock()
+        service.connection.config = MagicMock(spec_set=list(connection_fields))
+        for key, value in connection_fields.items():
+            setattr(service.connection.config, key, value)
+
+        return service
+
+    def test_opted_in_service_resolves_aliases(self):
+        metadata = MagicMock()
+        metadata.get_by_name.return_value = self._service(includeSynonyms=True)
+
+        assert service_resolves_aliases(metadata, "svc") is True
+
+    def test_opted_out_service_does_not(self):
+        metadata = MagicMock()
+        metadata.get_by_name.return_value = self._service(includeSynonyms=False)
+
+        assert service_resolves_aliases(metadata, "svc") is False
+
+    def test_connector_without_the_field_does_not(self):
+        metadata = MagicMock()
+        metadata.get_by_name.return_value = self._service(hostPort="localhost:5432")
+
+        assert service_resolves_aliases(metadata, "svc") is False
+
+    def test_result_is_cached_so_the_service_is_fetched_once(self):
+        metadata = MagicMock()
+        metadata.get_by_name.return_value = self._service(includeSynonyms=True)
+
+        service_resolves_aliases(metadata, "svc")
+        service_resolves_aliases(metadata, "svc")
+
+        assert metadata.get_by_name.call_count == 1
+
+    def test_unreadable_service_defaults_to_disabled(self):
+        metadata = MagicMock()
+        metadata.get_by_name.side_effect = RuntimeError("boom")
+
+        assert service_resolves_aliases(metadata, "svc") is False
+
+    def test_opted_out_service_never_issues_the_alias_search(self):
+        metadata = MagicMock()
+        metadata.es_search_from_fqn.return_value = None
+        metadata.get_by_name.return_value = None
+        metadata.es_search_from_alias.return_value = [_table("svc.master.dbo.orders")]
+
+        with patch(
+            "metadata.ingestion.lineage.sql_lineage.search_cache",
+            MagicMock(get=lambda _: None),
+        ):
+            result = search_table_entities(
+                metadata=metadata,
+                service_names="svc",
+                database="core",
+                database_schema="dbo",
+                table="orders",
+            )
+
+        assert result is None
+        metadata.es_search_from_alias.assert_not_called()

--- a/ingestion/tests/unit/test_db_utils.py
+++ b/ingestion/tests/unit/test_db_utils.py
@@ -61,6 +61,11 @@ class TestDbUtils(TestCase):
         search_cache.clear()
 
         self.metadata = MagicMock()
+        # Default to "no alias match": an unconfigured MagicMock call returns a
+        # truthy MagicMock, which search_table_entities' alias fallback would
+        # otherwise mistake for a real resolved alias. Individual tests override
+        # this when they intend to exercise the alias-match path.
+        self.metadata.es_search_from_alias.return_value = None
         self.service_name = "test_service"
         self.connection_type = "postgres"
         self.timeout_seconds = 30

--- a/ingestion/tests/unit/test_source_hash.py
+++ b/ingestion/tests/unit/test_source_hash.py
@@ -1,0 +1,44 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Tests for source hash generation"""
+
+from metadata.generated.schema.api.data.createTable import CreateTableRequest
+from metadata.utils.source_hash import generate_source_hash
+
+
+def _request(aliases):
+    return CreateTableRequest(
+        name="orders",
+        databaseSchema="mssql_service.analytics_master.dbo",
+        columns=[],
+        aliases=aliases,
+    )
+
+
+def test_source_hash_is_stable_across_alias_ordering():
+    first = generate_source_hash(
+        _request(["svc.db_a.dbo.orders", "svc.db_b.dbo.orders"])
+    )
+    second = generate_source_hash(
+        _request(["svc.db_b.dbo.orders", "svc.db_a.dbo.orders"])
+    )
+
+    assert first == second
+
+
+def test_source_hash_changes_when_an_alias_is_added():
+    without = generate_source_hash(_request(["svc.db_a.dbo.orders"]))
+    with_extra = generate_source_hash(
+        _request(["svc.db_a.dbo.orders", "svc.db_b.dbo.orders"])
+    )
+
+    assert without != with_extra

--- a/ingestion/tests/unit/test_table_aliases_schema.py
+++ b/ingestion/tests/unit/test_table_aliases_schema.py
@@ -1,0 +1,42 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Validate that the generated Table models expose the aliases field"""
+
+from metadata.generated.schema.api.data.createTable import CreateTableRequest
+from metadata.generated.schema.entity.data.table import Table
+from metadata.ingestion.ometa.utils import model_str
+
+
+def test_create_table_request_accepts_aliases():
+    request = CreateTableRequest(
+        name="orders",
+        databaseSchema="mssql_service.analytics_master.dbo",
+        columns=[],
+        aliases=["mssql_service.analytics_core.dbo.orders"],
+    )
+
+    assert [model_str(alias) for alias in request.aliases] == [
+        "mssql_service.analytics_core.dbo.orders"
+    ]
+
+
+def test_aliases_defaults_to_none():
+    request = CreateTableRequest(
+        name="orders",
+        databaseSchema="mssql_service.analytics_master.dbo",
+        columns=[],
+    )
+
+    assert request.aliases is None
+
+
+def test_table_entity_exposes_aliases():
+    assert "aliases" in Table.model_fields

--- a/ingestion/tests/unit/topology/database/test_common_db_source_aliases.py
+++ b/ingestion/tests/unit/topology/database/test_common_db_source_aliases.py
@@ -1,0 +1,96 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""The generic table producer must pass connector-supplied aliases into the create request"""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.generated.schema.api.data.createTable import CreateTableRequest
+from metadata.generated.schema.entity.data.table import TableType
+from metadata.ingestion.ometa.utils import model_str
+from metadata.ingestion.source.database.common_db_source import CommonDbSourceService
+
+
+def test_get_table_aliases_defaults_to_none():
+    assert (
+        CommonDbSourceService.get_table_aliases(
+            None, table_name="orders", schema_name="dbo"
+        )
+        is None
+    )
+
+
+def test_create_table_request_carries_aliases():
+    request = CreateTableRequest(
+        name="orders",
+        databaseSchema="svc.analytics_master.dbo",
+        columns=[],
+        aliases=["svc.analytics_core.dbo.orders"],
+    )
+
+    assert [model_str(alias) for alias in request.aliases] == [
+        "svc.analytics_core.dbo.orders"
+    ]
+
+
+def test_yield_table_includes_aliases_from_hook():
+    """Verify that the aliases returned by get_table_aliases are included in the yielded CreateTableRequest."""
+    # Expected aliases to be returned by the hook
+    expected_aliases = ["svc.analytics_core.dbo.orders"]
+
+    # Create a mock source with get_table_aliases returning the expected aliases
+    source = MagicMock(spec=CommonDbSourceService)
+    source.get_table_aliases.return_value = expected_aliases
+    source.metadata = MagicMock()  # Need to mock metadata for fqn.build
+
+    # Stub all the collaborators that yield_table calls
+    source.get_columns_and_constraints.return_value = ([], [], {})
+    source.get_schema_definition.return_value = None
+    source.update_table_constraints.return_value = []
+    source.normalize_table_constraints.return_value = []
+    source.get_table_description.return_value = None
+    source.get_tag_labels.return_value = []
+    source.get_source_url.return_value = None
+    source.get_owner_ref.return_value = None
+    source.get_location_path.return_value = None
+    source.get_table_extensions.return_value = None
+    source.get_table_partition_details.return_value = (False, None)
+    source.register_record.return_value = None
+    source.inspector = MagicMock()
+
+    # Stub context.get() to return required fields
+    mock_context_value = MagicMock()
+    mock_context_value.database = "test_db"
+    mock_context_value.database_service = "test_service"
+    mock_context_value.database_schema = "dbo"
+    source.context.get.return_value = mock_context_value
+
+    # Patch fqn.build to avoid needing a real metadata client
+    with patch(
+        "metadata.ingestion.source.database.common_db_source.fqn.build"
+    ) as mock_fqn_build:
+        mock_fqn_build.return_value = "test_service.test_db.dbo"
+
+        # Call yield_table
+        results = list(
+            CommonDbSourceService.yield_table(source, ("orders", TableType.Regular))
+        )
+
+    # Should have exactly one result (the CreateTableRequest)
+    assert len(results) == 1
+    result = results[0]
+
+    # Result should be a right-hand Either (successful case)
+    assert result.right is not None
+    request = result.right
+
+    # Verify that the aliases from the hook are in the request
+    # Schema wraps aliases in FullyQualifiedEntityName, so we use model_str to extract the values
+    assert [model_str(alias) for alias in request.aliases] == expected_aliases

--- a/ingestion/tests/unit/topology/database/test_mssql_synonyms.py
+++ b/ingestion/tests/unit/topology/database/test_mssql_synonyms.py
@@ -1,0 +1,608 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""MSSQL synonym discovery unit tests"""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.generated.schema.entity.services.connections.database.mssqlConnection import (
+    MssqlConnection,
+)
+from metadata.generated.schema.type.filterPattern import FilterPattern
+from metadata.ingestion.api.status import Status
+from metadata.ingestion.source.database.mssql.metadata import MssqlSource
+from metadata.ingestion.source.database.mssql.models import (
+    MssqlSynonym,
+    MssqlSynonymTarget,
+    SynonymUnresolvedReason,
+)
+from metadata.ingestion.source.database.mssql.queries import MSSQL_GET_SYNONYMS
+from metadata.ingestion.source.database.mssql.synonyms import (
+    SynonymMap,
+    build_synonym_map,
+    parse_base_object_name,
+    split_sql_server_identifier,
+)
+
+
+def test_synonym_query_targets_a_named_database():
+    rendered = MSSQL_GET_SYNONYMS.format(database_name="analytics_core")
+
+    assert "[analytics_core].sys.synonyms" in rendered
+    assert "base_object_name" in rendered
+
+
+def test_synonym_model_fields():
+    synonym = MssqlSynonym(
+        synonym_schema="dbo",
+        synonym_name="orders",
+        base_object_name="[analytics_master].[dbo].[orders]",
+    )
+
+    assert synonym.synonym_schema == "dbo"
+    assert synonym.base_object_name == "[analytics_master].[dbo].[orders]"
+
+
+def test_unresolved_reason_values():
+    assert (
+        SynonymUnresolvedReason.REMOTE_TARGET_UNMAPPED.value == "RemoteTargetUnmapped"
+    )
+    assert (
+        SynonymUnresolvedReason.UNSUPPORTED_TARGET_TYPE.value == "UnsupportedTargetType"
+    )
+    assert SynonymUnresolvedReason.UNRESOLVED.value == "Unresolved"
+
+
+def test_synonym_target_fields():
+    target = MssqlSynonymTarget(
+        database="analytics_master", schema_name="dbo", table="orders"
+    )
+
+    assert (target.database, target.schema_name, target.table) == (
+        "analytics_master",
+        "dbo",
+        "orders",
+    )
+
+
+class TestSplitSqlServerIdentifier:
+    def test_plain_three_part(self):
+        assert split_sql_server_identifier("db.dbo.orders") == ["db", "dbo", "orders"]
+
+    def test_bracket_quoted(self):
+        assert split_sql_server_identifier("[db].[dbo].[orders]") == [
+            "db",
+            "dbo",
+            "orders",
+        ]
+
+    def test_dot_inside_brackets_is_not_a_separator(self):
+        assert split_sql_server_identifier("[my.db].[dbo].[order.items]") == [
+            "my.db",
+            "dbo",
+            "order.items",
+        ]
+
+    def test_escaped_closing_bracket(self):
+        assert split_sql_server_identifier("[we[ird]]name]") == ["we[ird]name"]
+
+    def test_omitted_middle_part_yields_empty_string(self):
+        assert split_sql_server_identifier("db..orders") == ["db", "", "orders"]
+
+    def test_mixed_quoting(self):
+        assert split_sql_server_identifier("db.[dbo].orders") == ["db", "dbo", "orders"]
+
+
+class TestParseBaseObjectName:
+    def test_three_part_name(self):
+        target, reason = parse_base_object_name(
+            "[analytics_master].[dbo].[orders]", "analytics_core"
+        )
+
+        assert reason is None
+        assert (target.database, target.schema_name, target.table) == (
+            "analytics_master",
+            "dbo",
+            "orders",
+        )
+
+    def test_two_part_name_inherits_the_synonym_database(self):
+        target, reason = parse_base_object_name("[sales].[orders]", "analytics_core")
+
+        assert reason is None
+        assert (target.database, target.schema_name, target.table) == (
+            "analytics_core",
+            "sales",
+            "orders",
+        )
+
+    def test_one_part_name_inherits_database_and_defaults_schema(self):
+        target, reason = parse_base_object_name("orders", "analytics_core")
+
+        assert reason is None
+        assert (target.database, target.schema_name, target.table) == (
+            "analytics_core",
+            "dbo",
+            "orders",
+        )
+
+    def test_omitted_schema_defaults_to_dbo(self):
+        target, reason = parse_base_object_name(
+            "[analytics_master]..[orders]", "analytics_core"
+        )
+
+        assert reason is None
+        assert (target.database, target.schema_name, target.table) == (
+            "analytics_master",
+            "dbo",
+            "orders",
+        )
+
+    def test_four_part_name_is_remote(self):
+        target, reason = parse_base_object_name(
+            "[LINKED].[analytics_master].[dbo].[orders]", "analytics_core"
+        )
+
+        assert target is None
+        assert reason is SynonymUnresolvedReason.REMOTE_TARGET_UNMAPPED
+
+    def test_four_part_name_with_empty_server_is_local(self):
+        target, reason = parse_base_object_name(
+            "[].[analytics_master].[dbo].[orders]", "analytics_core"
+        )
+
+        assert reason is None
+        assert target.database == "analytics_master"
+
+    def test_case_is_preserved(self):
+        target, reason = parse_base_object_name(
+            "[Analytics_Master].[DBO].[Orders]", "analytics_core"
+        )
+
+        assert reason is None
+        assert (target.database, target.schema_name, target.table) == (
+            "Analytics_Master",
+            "DBO",
+            "Orders",
+        )
+
+    def test_empty_name_is_unresolved(self):
+        target, reason = parse_base_object_name("", "analytics_core")
+
+        assert target is None
+        assert reason is SynonymUnresolvedReason.UNRESOLVED
+
+    def test_too_many_parts_is_unresolved(self):
+        target, reason = parse_base_object_name("a.b.c.d.e", "analytics_core")
+
+        assert target is None
+        assert reason is SynonymUnresolvedReason.UNRESOLVED
+
+    def test_empty_table_name_is_unresolved(self):
+        target, reason = parse_base_object_name("[db].[dbo].[]", "analytics_core")
+
+        assert target is None
+        assert reason is SynonymUnresolvedReason.UNRESOLVED
+
+
+class TestSynonymMap:
+    def test_aliases_are_returned_sorted(self):
+        synonym_map = SynonymMap()
+        synonym_map.add("svc.master.dbo.orders", "svc.z_core.dbo.orders")
+        synonym_map.add("svc.master.dbo.orders", "svc.a_core.dbo.orders")
+
+        assert synonym_map.aliases_for("svc.master.dbo.orders") == [
+            "svc.a_core.dbo.orders",
+            "svc.z_core.dbo.orders",
+        ]
+
+    def test_unknown_target_returns_none(self):
+        assert SynonymMap().aliases_for("svc.master.dbo.orders") is None
+
+    def test_duplicate_alias_is_stored_once(self):
+        synonym_map = SynonymMap()
+        synonym_map.add("svc.master.dbo.orders", "svc.core.dbo.orders")
+        synonym_map.add("svc.master.dbo.orders", "svc.core.dbo.orders")
+
+        assert synonym_map.aliases_for("svc.master.dbo.orders") == [
+            "svc.core.dbo.orders"
+        ]
+
+    def test_consumed_target_is_not_reported_unresolved(self):
+        synonym_map = SynonymMap()
+        synonym_map.add("svc.master.dbo.orders", "svc.core.dbo.orders")
+        synonym_map.aliases_for("svc.master.dbo.orders")
+
+        assert synonym_map.unresolved() == []
+
+    def test_unconsumed_target_is_reported_unresolved(self):
+        synonym_map = SynonymMap()
+        synonym_map.add("svc.master.dbo.orders", "svc.core.dbo.orders")
+
+        assert synonym_map.unresolved() == [
+            ("svc.core.dbo.orders", SynonymUnresolvedReason.UNRESOLVED.value)
+        ]
+
+    def test_explicitly_recorded_unresolved_is_reported(self):
+        synonym_map = SynonymMap()
+        synonym_map.record_unresolved(
+            "svc.core.dbo.remote_orders", SynonymUnresolvedReason.REMOTE_TARGET_UNMAPPED
+        )
+
+        assert synonym_map.unresolved() == [
+            ("svc.core.dbo.remote_orders", "RemoteTargetUnmapped")
+        ]
+
+    def test_cap_rejects_further_entries(self):
+        synonym_map = SynonymMap(max_entries=2)
+
+        assert synonym_map.add("svc.master.dbo.a", "svc.core.dbo.a") is True
+        assert synonym_map.add("svc.master.dbo.b", "svc.core.dbo.b") is True
+        assert synonym_map.add("svc.master.dbo.c", "svc.core.dbo.c") is False
+        assert synonym_map.aliases_for("svc.master.dbo.c") is None
+
+    def test_cap_counts_targets_not_aliases(self):
+        synonym_map = SynonymMap(max_entries=1)
+
+        assert synonym_map.add("svc.master.dbo.a", "svc.core.dbo.a") is True
+        assert synonym_map.add("svc.master.dbo.a", "svc.other.dbo.a") is True
+
+    def test_is_empty(self):
+        synonym_map = SynonymMap()
+
+        assert synonym_map.is_empty() is True
+        synonym_map.add("svc.master.dbo.orders", "svc.core.dbo.orders")
+        assert synonym_map.is_empty() is False
+
+    def test_lookup_is_case_insensitive_regardless_of_which_case_was_added_first(self):
+        # SQL Server's default collation is case-insensitive, so base_object_name
+        # casing routinely disagrees with the target table's real stored casing.
+        added_mixed_case = SynonymMap()
+        added_mixed_case.add("svc.db.dbo.Orders", "svc.core.dbo.orders_alias")
+        assert added_mixed_case.aliases_for("svc.db.dbo.orders") == [
+            "svc.core.dbo.orders_alias"
+        ]
+
+        added_lower_case = SynonymMap()
+        added_lower_case.add("svc.db.dbo.orders", "svc.core.dbo.orders_alias")
+        assert added_lower_case.aliases_for("svc.db.dbo.Orders") == [
+            "svc.core.dbo.orders_alias"
+        ]
+
+    def test_aliases_for_retains_original_alias_casing(self):
+        synonym_map = SynonymMap()
+        synonym_map.add("svc.db.dbo.Orders", "svc.core.dbo.CustOrdersAlias")
+
+        # The lookup key is folded, but the stored alias FQN must not be -- OpenMetadata
+        # FQNs are case-preserving, so folding the value would corrupt aliases[].
+        assert synonym_map.aliases_for("svc.db.dbo.orders") == [
+            "svc.core.dbo.CustOrdersAlias"
+        ]
+
+    def test_target_consumed_via_differently_cased_lookup_is_not_unresolved(self):
+        synonym_map = SynonymMap()
+        synonym_map.add("svc.db.dbo.Orders", "svc.core.dbo.orders_alias")
+
+        synonym_map.aliases_for("svc.db.dbo.orders")
+
+        assert synonym_map.unresolved() == []
+
+    def test_unresolved_cap_bounds_explicit_entries(self):
+        synonym_map = SynonymMap(max_entries=2)
+
+        synonym_map.record_unresolved(
+            "svc.core.dbo.a", SynonymUnresolvedReason.REMOTE_TARGET_UNMAPPED
+        )
+        synonym_map.record_unresolved(
+            "svc.core.dbo.b", SynonymUnresolvedReason.REMOTE_TARGET_UNMAPPED
+        )
+        synonym_map.record_unresolved(
+            "svc.core.dbo.c", SynonymUnresolvedReason.REMOTE_TARGET_UNMAPPED
+        )
+
+        # Only the first 2 entries should be stored (capped at max_entries)
+        assert len(synonym_map.unresolved()) == 2
+        stored_fqns = [u[0] for u in synonym_map.unresolved()]
+        assert "svc.core.dbo.a" in stored_fqns
+        assert "svc.core.dbo.b" in stored_fqns
+        assert "svc.core.dbo.c" not in stored_fqns
+
+
+def _fqn_builder(database, schema, table):
+    return f"svc.{database}.{schema}.{table}"
+
+
+def _engine_returning(rows_by_database):
+    """Mock a SQLAlchemy engine whose execute() returns per-database synonym rows"""
+    engine = MagicMock()
+    connection = engine.connect.return_value.__enter__.return_value
+
+    def execute(statement, *_args, **_kwargs):
+        rendered = str(statement)
+        for database, rows in rows_by_database.items():
+            if f"[{database}]" in rendered:
+                result = MagicMock()
+                result.all.return_value = rows
+                return result
+        result = MagicMock()
+        result.all.return_value = []
+        return result
+
+    connection.execute.side_effect = execute
+    return engine
+
+
+def _row(synonym_schema, synonym_name, base_object_name):
+    row = MagicMock()
+    row.synonym_schema = synonym_schema
+    row.synonym_name = synonym_name
+    row.base_object_name = base_object_name
+    return row
+
+
+class TestBuildSynonymMap:
+    def test_cross_database_synonym_maps_to_its_target(self):
+        engine = _engine_returning(
+            {
+                "analytics_core": [
+                    _row("dbo", "orders", "[analytics_master].[dbo].[orders]")
+                ]
+            }
+        )
+
+        synonym_map = build_synonym_map(
+            engine=engine,
+            database_names=["analytics_core"],
+            fqn_builder=_fqn_builder,
+        )
+
+        assert synonym_map.aliases_for("svc.analytics_master.dbo.orders") == [
+            "svc.analytics_core.dbo.orders"
+        ]
+
+    def test_remote_target_is_recorded_unresolved(self):
+        engine = _engine_returning(
+            {"analytics_core": [_row("dbo", "orders", "[LINK].[db].[dbo].[orders]")]}
+        )
+
+        synonym_map = build_synonym_map(
+            engine=engine,
+            database_names=["analytics_core"],
+            fqn_builder=_fqn_builder,
+        )
+
+        assert synonym_map.unresolved() == [
+            ("svc.analytics_core.dbo.orders", "RemoteTargetUnmapped")
+        ]
+
+    def test_a_failing_database_does_not_abort_the_sweep(self):
+        engine = MagicMock()
+        connection = engine.connect.return_value.__enter__.return_value
+
+        def execute(statement, *_args, **_kwargs):
+            if "[broken]" in str(statement):
+                raise RuntimeError("permission denied")
+            result = MagicMock()
+            result.all.return_value = [
+                _row("dbo", "orders", "[master_db].[dbo].[orders]")
+            ]
+            return result
+
+        connection.execute.side_effect = execute
+
+        synonym_map = build_synonym_map(
+            engine=engine,
+            database_names=["broken", "good"],
+            fqn_builder=_fqn_builder,
+        )
+
+        assert synonym_map.aliases_for("svc.master_db.dbo.orders") is not None
+
+    def test_database_name_with_bracket_is_escaped(self):
+        engine = _engine_returning({})
+
+        build_synonym_map(
+            engine=engine,
+            database_names=["we]ird"],
+            fqn_builder=_fqn_builder,
+        )
+
+        connection = engine.connect.return_value.__enter__.return_value
+        rendered = str(connection.execute.call_args[0][0])
+        assert "[we]]ird].sys.synonyms" in rendered
+
+
+class TestMssqlSourceAliases:
+    def test_get_table_aliases_returns_none_for_an_empty_map(self):
+        source = MagicMock(spec=MssqlSource)
+        source.synonym_map = SynonymMap()
+
+        assert (
+            MssqlSource.get_table_aliases(
+                source, table_name="orders", schema_name="dbo"
+            )
+            is None
+        )
+
+    def test_get_table_aliases_resolves_the_current_table(self):
+        source = MagicMock(spec=MssqlSource)
+        source.synonym_map = SynonymMap()
+        source.synonym_map.add(
+            "svc.analytics_master.dbo.orders", "svc.analytics_core.dbo.orders"
+        )
+        source.context.get.return_value.database = "analytics_master"
+        source._build_table_fqn.side_effect = _fqn_builder
+
+        aliases = MssqlSource.get_table_aliases(
+            source, table_name="orders", schema_name="dbo"
+        )
+
+        assert aliases == ["svc.analytics_core.dbo.orders"]
+
+    def test_close_warns_for_each_unresolved_synonym(self):
+        source = MagicMock(spec=MssqlSource)
+        source.status = Status()
+        source.synonym_map = SynonymMap()
+        source.synonym_map.record_unresolved(
+            "svc.analytics_core.dbo.orders",
+            SynonymUnresolvedReason.REMOTE_TARGET_UNMAPPED,
+        )
+
+        MssqlSource.close(source)
+
+        assert source.status.warnings == [
+            {
+                "svc.analytics_core.dbo.orders": "Synonym target unresolved: RemoteTargetUnmapped"
+            }
+        ]
+
+    def test_close_reports_no_warnings_when_nothing_is_unresolved(self):
+        source = MagicMock(spec=MssqlSource)
+        source.status = Status()
+        source.synonym_map = SynonymMap()
+
+        MssqlSource.close(source)
+
+        assert source.status.warnings == []
+
+
+class TestInScopeDatabaseNames:
+    """
+    _in_scope_database_names() is the sweep's routing logic: it decides which
+    databases prepare() sweeps at all. prepare() wraps the sweep in a broad
+    except, so a regression here would silently produce an empty synonym map
+    rather than fail loudly.
+    """
+
+    def test_returns_only_the_configured_database_when_not_ingesting_all(self):
+        source = MagicMock(spec=MssqlSource)
+        source.service_connection = MagicMock(
+            ingestAllDatabases=False, database="analytics_core"
+        )
+
+        result = MssqlSource._in_scope_database_names(source)
+
+        assert result == ["analytics_core"]
+        source.get_database_names_raw.assert_not_called()
+
+    def test_excludes_a_database_matching_the_filter_pattern(self):
+        # Covers the plain-name filtering path (useFqnForFiltering=False). The
+        # useFqnForFiltering=True branch is not covered here: exercising it
+        # would require asserting against fqn.build's/quote_name's exact output
+        # format, coupling this test to internals unrelated to the routing
+        # logic under test.
+        source = MagicMock(spec=MssqlSource)
+        source.service_connection = MagicMock(ingestAllDatabases=True)
+        source.metadata = MagicMock()
+        source.config = MagicMock(serviceName="svc")
+        source.source_config = MagicMock(
+            useFqnForFiltering=False,
+            databaseFilterPattern=FilterPattern(excludes=["^analytics_master$"]),
+        )
+        source.get_database_names_raw.return_value = [
+            "analytics_core",
+            "analytics_master",
+        ]
+
+        result = MssqlSource._in_scope_database_names(source)
+
+        assert result == ["analytics_core"]
+
+
+class TestMssqlSourcePrepare:
+    def test_prepare_wires_the_sweep_into_synonym_map(self):
+        source = MagicMock(spec=MssqlSource)
+        source.engine = MagicMock()
+        source.service_connection = MagicMock(includeSynonyms=True)
+        source._in_scope_database_names.return_value = ["analytics_core"]
+        expected_map = SynonymMap()
+        expected_map.add(
+            "svc.analytics_master.dbo.orders", "svc.analytics_core.dbo.orders"
+        )
+
+        with patch(
+            "metadata.ingestion.source.database.mssql.metadata.build_synonym_map",
+            return_value=expected_map,
+        ) as mock_build:
+            MssqlSource.prepare(source)
+
+        mock_build.assert_called_once_with(
+            engine=source.engine,
+            database_names=["analytics_core"],
+            fqn_builder=source._build_table_fqn,
+        )
+        assert source.synonym_map is expected_map
+
+    def test_prepare_leaves_the_existing_synonym_map_untouched_when_the_sweep_fails(
+        self,
+    ):
+        source = MagicMock(spec=MssqlSource)
+        source.engine = MagicMock()
+        source.service_connection = MagicMock(includeSynonyms=True)
+        # What __init__ would have set before prepare() ever ran.
+        source.synonym_map = SynonymMap()
+        source._in_scope_database_names.return_value = ["analytics_core"]
+
+        with patch(
+            "metadata.ingestion.source.database.mssql.metadata.build_synonym_map",
+            side_effect=RuntimeError("permission denied"),
+        ):
+            MssqlSource.prepare(source)
+
+        assert source.synonym_map is not None
+        assert source.synonym_map.is_empty() is True
+        assert source.synonym_map.aliases_for("svc.analytics_master.dbo.orders") is None
+
+        source.status = Status()
+        MssqlSource.close(source)
+
+        assert source.status.warnings == []
+
+
+class TestIncludeSynonymsFlag:
+    """includeSynonyms gates the sweep so an opted-out service runs no synonym queries."""
+
+    def test_defaults_to_disabled(self):
+        # Synonym discovery is opt-in: a service configured before the field existed, or by
+        # anyone who never touched the toggle, must not start paying for the sweep.
+        assert (
+            MssqlConnection(hostPort="localhost:1433", database="db").includeSynonyms
+            is False
+        )
+
+    def test_disabled_skips_the_sweep_entirely(self):
+        source = MagicMock(spec=MssqlSource)
+        source.service_connection = MagicMock(includeSynonyms=False)
+        source.synonym_map = SynonymMap()
+
+        with patch(
+            "metadata.ingestion.source.database.mssql.metadata.build_synonym_map"
+        ) as sweep:
+            MssqlSource.prepare(source)
+
+        sweep.assert_not_called()
+        assert source.synonym_map.is_empty() is True
+
+    def test_enabled_runs_the_sweep(self):
+        source = MagicMock(spec=MssqlSource)
+        source.engine = MagicMock()
+        source.service_connection = MagicMock(includeSynonyms=True)
+        source._in_scope_database_names.return_value = ["analytics_core"]
+        built = SynonymMap()
+        built.add("svc.master.dbo.orders", "svc.core.dbo.orders")
+
+        with patch(
+            "metadata.ingestion.source.database.mssql.metadata.build_synonym_map",
+            return_value=built,
+        ) as sweep:
+            MssqlSource.prepare(source)
+
+        sweep.assert_called_once()
+        assert source.synonym_map is built

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableResourceIT.java
@@ -2183,6 +2183,54 @@ public class TableResourceIT extends BaseEntityIT<Table, CreateTable> {
     assertEquals("select * from test;", afterUpdate.getDataModel().getSql());
   }
 
+  /**
+   * The mssql synonym-aliases design assumes the connector recomputes the full {@code aliases}
+   * list from {@code sys.synonyms} on every run and ships it inside the {@code CreateTable}
+   * request, so created/dropped/retargeted synonyms reconcile through plain PUT upsert semantics
+   * with no diffing stage. That only holds if PUT replaces {@code aliases} wholesale rather than
+   * merging it (as tags do). This test is the gate on that assumption.
+   */
+  @Test
+  void put_tableAliases_replaceNotMerge(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    CreateTable createRequest =
+        createRequest(ns.prefix("aliases_replace_table"), ns)
+            .withAliases(List.of("svc.core_a.dbo.orders"));
+    Table created = createEntity(createRequest);
+    assertEquals(
+        List.of("svc.core_a.dbo.orders"),
+        created.getAliases(),
+        "create response should echo the requested aliases");
+
+    // Re-fetch from the server (rather than trusting the create/PUT response's in-memory echo) so
+    // every assertion below reflects what was actually persisted, not just what the request or
+    // response object carried. A mapper that dropped aliases at store time only on create, for
+    // example, would still pass an echo-only assertion here.
+    Table table = client.tables().get(created.getId().toString());
+    assertEquals(
+        List.of("svc.core_a.dbo.orders"),
+        table.getAliases(),
+        "initial aliases from the create request must be persisted, not just echoed");
+
+    // Retarget: the connector re-sends the full list, so the old alias must be gone.
+    createRequest.setAliases(List.of("svc.core_b.dbo.orders"));
+    client.tables().createOrUpdate(createRequest);
+    Table retargeted = client.tables().get(table.getId().toString());
+    assertEquals(
+        List.of("svc.core_b.dbo.orders"),
+        retargeted.getAliases(),
+        "aliases must be replaced wholesale, not merged with the previous run's list");
+
+    // Synonym dropped at the source: SynonymMap.aliases_for (ingestion/.../mssql/synonyms.py)
+    // returns None, not an empty list, on a miss, so the real connector clear path sends
+    // aliases=null rather than aliases=[]. Test that exact production path.
+    createRequest.setAliases(null);
+    client.tables().createOrUpdate(createRequest);
+    Table cleared = client.tables().get(table.getId().toString());
+    assertNull(cleared.getAliases(), "dropping every synonym must clear aliases");
+  }
+
   // ===================================================================
   // COLUMN GET VALIDATION TESTS
   // ===================================================================

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
@@ -2414,6 +2414,7 @@ public class TableRepository extends EntityRepository<Table> {
       compareAndUpdate(
           "sourceUrl",
           () -> recordChange("sourceUrl", original.getSourceUrl(), updated.getSourceUrl()));
+      compareAndUpdate("aliases", () -> updateAliases(origTable, updatedTable));
       compareAndUpdate(
           "retentionPeriod",
           () ->
@@ -2470,6 +2471,16 @@ public class TableRepository extends EntityRepository<Table> {
           && !origTable.getSchemaDefinition().equals(updatedTable.getSchemaDefinition())) {
         updatedTable.setProcessedLineage(false);
       }
+    }
+
+    private void updateAliases(Table origTable, Table updatedTable) {
+      List<String> origAliases = listOrEmpty(origTable.getAliases());
+      List<String> updatedAliases = listOrEmpty(updatedTable.getAliases());
+
+      List<String> added = new ArrayList<>();
+      List<String> deleted = new ArrayList<>();
+      recordListChange(
+          "aliases", origAliases, updatedAliases, added, deleted, EntityUtil.stringMatch);
     }
 
     private void updateTableConstraints(Table origTable, Table updatedTable, Operation operation) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1136/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1136/Migration.java
@@ -1,0 +1,28 @@
+package org.openmetadata.service.migration.mysql.v1136;
+
+import static org.openmetadata.service.migration.utils.v1136.TableAliasesSearchSettingsMigration.addAliasesSearchSettings;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.service.migration.api.MigrationProcessImpl;
+import org.openmetadata.service.migration.utils.MigrationFile;
+
+@Slf4j
+public class Migration extends MigrationProcessImpl {
+
+  public Migration(MigrationFile migrationFile) {
+    super(migrationFile);
+  }
+
+  @Override
+  @SneakyThrows
+  public void runDataMigration() {
+    // Log and continue rather than abort: alias search degrades to not matching synonyms, which
+    // is not worth failing an upgrade over.
+    try {
+      addAliasesSearchSettings();
+    } catch (Exception e) {
+      LOG.error("v1136: failed to backfill the table 'aliases' search settings", e);
+    }
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1136/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1136/Migration.java
@@ -1,0 +1,28 @@
+package org.openmetadata.service.migration.postgres.v1136;
+
+import static org.openmetadata.service.migration.utils.v1136.TableAliasesSearchSettingsMigration.addAliasesSearchSettings;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.service.migration.api.MigrationProcessImpl;
+import org.openmetadata.service.migration.utils.MigrationFile;
+
+@Slf4j
+public class Migration extends MigrationProcessImpl {
+
+  public Migration(MigrationFile migrationFile) {
+    super(migrationFile);
+  }
+
+  @Override
+  @SneakyThrows
+  public void runDataMigration() {
+    // Log and continue rather than abort: alias search degrades to not matching synonyms, which
+    // is not worth failing an upgrade over.
+    try {
+      addAliasesSearchSettings();
+    } catch (Exception e) {
+      LOG.error("v1136: failed to backfill the table 'aliases' search settings", e);
+    }
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1136/TableAliasesSearchSettingsMigration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1136/TableAliasesSearchSettingsMigration.java
@@ -20,8 +20,13 @@ import org.openmetadata.service.migration.utils.SearchSettingsMergeUtil;
  *
  * <p>searchSettings.json is seed data: the additive merge that runs on startup only adds whole
  * missing asset types, so a cluster upgrading from an older baseline keeps its own {@code table}
- * entry forever and alias search silently returns zero results even though the index document and
- * the mapping already carry the field.
+ * entry forever and never picks the alias fields up.
+ *
+ * <p>Without this backfill an alias is still *findable* — the query falls through to an all-fields
+ * match that reaches {@code aliases} because the index mapping carries it. What the operator loses
+ * is relevance and presentation: measured on a single-table index, an alias hit scores 5.50 instead
+ * of 6.41 (the 5.0 / 10.0 boosts never apply), and the result carries no {@code aliases} highlight
+ * snippet, so the UI cannot show *which* alias matched.
  *
  * <p>Only the alias fields are added, so an operator's own boosts and highlight fields survive.
  */

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1136/TableAliasesSearchSettingsMigration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1136/TableAliasesSearchSettingsMigration.java
@@ -1,0 +1,130 @@
+package org.openmetadata.service.migration.utils.v1136;
+
+import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.api.search.AssetTypeConfiguration;
+import org.openmetadata.schema.api.search.FieldBoost;
+import org.openmetadata.schema.api.search.SearchSettings;
+import org.openmetadata.schema.settings.Settings;
+import org.openmetadata.service.migration.utils.SearchSettingsMergeUtil;
+
+/**
+ * Backfills the {@code aliases} / {@code aliases.keyword} searchFields and the {@code aliases}
+ * highlightField onto the {@code table} assetTypeConfiguration of an already-installed instance's
+ * stored searchSettings.
+ *
+ * <p>searchSettings.json is seed data: the additive merge that runs on startup only adds whole
+ * missing asset types, so a cluster upgrading from an older baseline keeps its own {@code table}
+ * entry forever and alias search silently returns zero results even though the index document and
+ * the mapping already carry the field.
+ *
+ * <p>Only the alias fields are added, so an operator's own boosts and highlight fields survive.
+ */
+@Slf4j
+public class TableAliasesSearchSettingsMigration {
+
+  private static final String TABLE_ASSET_TYPE = "table";
+  private static final String ALIASES_FIELD = "aliases";
+  private static final String ALIASES_KEYWORD_FIELD = "aliases.keyword";
+
+  private TableAliasesSearchSettingsMigration() {}
+
+  /** Idempotent; safe to call on every reprocessing pass. */
+  public static void addAliasesSearchSettings() {
+    Settings searchSettings = SearchSettingsMergeUtil.getSearchSettingsFromDatabase();
+    if (searchSettings == null) {
+      LOG.warn(
+          "Search settings not found in database. "
+              + "Default settings will be loaded on next startup which includes table aliases.");
+      return;
+    }
+
+    SearchSettings currentSettings = SearchSettingsMergeUtil.loadSearchSettings(searchSettings);
+    SearchSettings defaultSettings = SearchSettingsMergeUtil.loadSearchSettingsFromFile();
+    if (defaultSettings == null) {
+      LOG.error("Failed to load default search settings from file, skipping aliases migration");
+      return;
+    }
+
+    if (mergeAliasesIntoTableConfiguration(currentSettings, defaultSettings)) {
+      SearchSettingsMergeUtil.saveSearchSettings(searchSettings, currentSettings);
+      LOG.info("Added 'aliases' search field and highlight field to table search settings");
+    } else {
+      LOG.info("Table search settings already include 'aliases'; no updates needed");
+    }
+  }
+
+  static boolean mergeAliasesIntoTableConfiguration(
+      SearchSettings currentSettings, SearchSettings defaultSettings) {
+    boolean changed = false;
+    AssetTypeConfiguration currentTableConfig = findTableConfiguration(currentSettings);
+    AssetTypeConfiguration defaultTableConfig = findTableConfiguration(defaultSettings);
+    if (currentTableConfig != null && defaultTableConfig != null) {
+      changed |= mergeMissingAliasSearchFields(currentTableConfig, defaultTableConfig);
+      changed |= mergeMissingAliasHighlightField(currentTableConfig, defaultTableConfig);
+    }
+    return changed;
+  }
+
+  private static AssetTypeConfiguration findTableConfiguration(SearchSettings settings) {
+    AssetTypeConfiguration match = null;
+    if (settings != null) {
+      for (AssetTypeConfiguration config : listOrEmpty(settings.getAssetTypeConfigurations())) {
+        if (TABLE_ASSET_TYPE.equals(config.getAssetType())) {
+          match = config;
+          break;
+        }
+      }
+    }
+    return match;
+  }
+
+  private static boolean mergeMissingAliasSearchFields(
+      AssetTypeConfiguration currentConfig, AssetTypeConfiguration defaultConfig) {
+    boolean added = false;
+    List<FieldBoost> currentFields = currentConfig.getSearchFields();
+    if (currentFields == null) {
+      currentFields = new ArrayList<>();
+      currentConfig.setSearchFields(currentFields);
+    }
+
+    Set<String> existingFieldNames = new HashSet<>();
+    for (FieldBoost field : currentFields) {
+      existingFieldNames.add(field.getField());
+    }
+
+    for (FieldBoost defaultField : listOrEmpty(defaultConfig.getSearchFields())) {
+      boolean isAliasField =
+          ALIASES_FIELD.equals(defaultField.getField())
+              || ALIASES_KEYWORD_FIELD.equals(defaultField.getField());
+      if (isAliasField && !existingFieldNames.contains(defaultField.getField())) {
+        currentFields.add(defaultField);
+        existingFieldNames.add(defaultField.getField());
+        added = true;
+      }
+    }
+    return added;
+  }
+
+  private static boolean mergeMissingAliasHighlightField(
+      AssetTypeConfiguration currentConfig, AssetTypeConfiguration defaultConfig) {
+    boolean added = false;
+    List<String> currentHighlights = currentConfig.getHighlightFields();
+    if (currentHighlights == null) {
+      currentHighlights = new ArrayList<>();
+      currentConfig.setHighlightFields(currentHighlights);
+    }
+
+    if (!currentHighlights.contains(ALIASES_FIELD)
+        && listOrEmpty(defaultConfig.getHighlightFields()).contains(ALIASES_FIELD)) {
+      currentHighlights.add(ALIASES_FIELD);
+      added = true;
+    }
+    return added;
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/TableMapper.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/TableMapper.java
@@ -24,6 +24,7 @@ public class TableMapper implements EntityMapper<Table, CreateTable> {
                 .withFileFormat(create.getFileFormat())
                 .withSchemaDefinition(create.getSchemaDefinition())
                 .withTableProfilerConfig(create.getTableProfilerConfig())
+                .withAliases(create.getAliases())
                 .withDatabaseSchema(
                     getEntityReference(Entity.DATABASE_SCHEMA, create.getDatabaseSchema())))
         .withDatabaseSchema(getEntityReference(Entity.DATABASE_SCHEMA, create.getDatabaseSchema()))

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TableIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TableIndex.java
@@ -94,6 +94,7 @@ public record TableIndex(Table table) implements ColumnIndex, DataAssetIndex {
     }
 
     doc.put("locationPath", table.getLocationPath());
+    doc.put("aliases", table.getAliases());
     doc.put("schemaDefinition", table.getSchemaDefinition());
     doc.put("database", getEntityWithDisplayName(table.getDatabase()));
     doc.put("processedLineage", table.getProcessedLineage());

--- a/openmetadata-service/src/main/resources/json/data/settings/searchSettings.json
+++ b/openmetadata-service/src/main/resources/json/data/settings/searchSettings.json
@@ -338,6 +338,16 @@
           "field": "columnNamesFuzzy",
           "boost": 1.5,
           "matchType": "standard"
+        },
+        {
+          "field": "aliases",
+          "boost": 5.0,
+          "matchType": "standard"
+        },
+        {
+          "field": "aliases.keyword",
+          "boost": 10.0,
+          "matchType": "exact"
         }
       ],
       "aggregations": [
@@ -357,7 +367,8 @@
       "highlightFields": [
         "name",
         "description",
-        "displayName"
+        "displayName",
+        "aliases"
       ],
       "fieldValueBoosts": [
         {
@@ -2462,6 +2473,14 @@
         {
           "name": "columns.description",
           "description": "Full-text search on column descriptions to find tables based on specific column purposes or contents."
+        },
+        {
+          "name": "aliases",
+          "description": "Alternate SQL names such as SQL Server synonyms that resolve to this table. Searching an alias returns the canonical table."
+        },
+        {
+          "name": "aliases.keyword",
+          "description": "Exact match on an alternate SQL name (alias) for precise FQN-style lookups."
         }
       ]
     },

--- a/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v1136/MigrationWiringTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v1136/MigrationWiringTest.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.migration.utils.v1136;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.openmetadata.service.OpenMetadataApplicationConfig;
+import org.openmetadata.service.jdbi3.MigrationDAO;
+import org.openmetadata.service.jdbi3.locator.ConnectionType;
+import org.openmetadata.service.migration.utils.MigrationFile;
+
+/**
+ * MigrationFile resolves a version directory to its Migration class by package-name convention and
+ * falls back to the no-op default when the class is absent, so a mismatch between the SQL directory
+ * name and the Java package silently skips the whole data migration with no error. Pin the wiring
+ * for 1.13.6 instead of finding out on an upgrade.
+ */
+class MigrationWiringTest {
+
+  private static final Path MIGRATIONS_ROOT =
+      Paths.get("..", "bootstrap", "sql", "migrations", "native");
+
+  private File versionDir() {
+    File dir = MIGRATIONS_ROOT.resolve("1.13.6").toFile();
+    assertTrue(dir.isDirectory(), "missing native migration directory: " + dir);
+    return dir;
+  }
+
+  @ParameterizedTest
+  @EnumSource(ConnectionType.class)
+  void theVersionDirectoryResolvesToTheV1136MigrationClass(ConnectionType connectionType) {
+    MigrationFile file =
+        new MigrationFile(
+            versionDir(),
+            mock(MigrationDAO.class),
+            connectionType,
+            mock(OpenMetadataApplicationConfig.class),
+            false);
+
+    String dbPackage = connectionType == ConnectionType.MYSQL ? "mysql" : "postgres";
+    assertEquals(
+        "org.openmetadata.service.migration." + dbPackage + ".v1136.Migration",
+        file.getMigrationProcessClassName(),
+        "1.13.6 fell back to the default no-op migration class; the data migration would not run");
+  }
+
+  @Test
+  void bothDialectsShipASchemaChangesFile() {
+    // The runner reads schemaChanges.sql per dialect; a missing one is a startup-time surprise.
+    for (String dialect : new String[] {"mysql", "postgres"}) {
+      assertTrue(
+          MIGRATIONS_ROOT
+              .resolve("1.13.6")
+              .resolve(dialect)
+              .resolve("schemaChanges.sql")
+              .toFile()
+              .isFile(),
+          "missing " + dialect + "/schemaChanges.sql for 1.13.6");
+      assertTrue(
+          MIGRATIONS_ROOT
+              .resolve("1.13.6")
+              .resolve(dialect)
+              .resolve("postDataMigrationSQLScript.sql")
+              .toFile()
+              .isFile(),
+          "missing " + dialect + "/postDataMigrationSQLScript.sql for 1.13.6");
+    }
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v1136/TableAliasesSearchSettingsMigrationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v1136/TableAliasesSearchSettingsMigrationTest.java
@@ -1,0 +1,122 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.migration.utils.v1136;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.api.search.AssetTypeConfiguration;
+import org.openmetadata.schema.api.search.FieldBoost;
+import org.openmetadata.schema.api.search.SearchSettings;
+
+/**
+ * Covers the merge the 1.13.6 migration applies to a stored search-settings document: the alias
+ * fields have to reach an existing {@code table} configuration without disturbing what an operator
+ * already put there.
+ */
+class TableAliasesSearchSettingsMigrationTest {
+
+  private FieldBoost fieldBoost(String field, double boost, FieldBoost.MatchType matchType) {
+    FieldBoost fieldBoost = new FieldBoost();
+    fieldBoost.setField(field);
+    fieldBoost.setBoost(boost);
+    fieldBoost.setMatchType(matchType);
+    return fieldBoost;
+  }
+
+  private AssetTypeConfiguration tableConfig(
+      List<FieldBoost> searchFields, List<String> highlightFields) {
+    AssetTypeConfiguration config = new AssetTypeConfiguration();
+    config.setAssetType("table");
+    config.setSearchFields(new ArrayList<>(searchFields));
+    config.setHighlightFields(new ArrayList<>(highlightFields));
+    return config;
+  }
+
+  private SearchSettings settingsWithTableConfig(AssetTypeConfiguration tableConfig) {
+    SearchSettings settings = new SearchSettings();
+    settings.setAssetTypeConfigurations(new ArrayList<>(List.of(tableConfig)));
+    return settings;
+  }
+
+  @Test
+  void addsMissingAliasSearchFieldsAndHighlightField() {
+    SearchSettings currentSettings =
+        settingsWithTableConfig(
+            tableConfig(
+                new ArrayList<>(List.of(fieldBoost("name", 10.0, FieldBoost.MatchType.PHRASE))),
+                new ArrayList<>(List.of("name", "description"))));
+    SearchSettings defaultSettings =
+        settingsWithTableConfig(
+            tableConfig(
+                List.of(
+                    fieldBoost("name", 10.0, FieldBoost.MatchType.PHRASE),
+                    fieldBoost("aliases", 5.0, FieldBoost.MatchType.STANDARD),
+                    fieldBoost("aliases.keyword", 10.0, FieldBoost.MatchType.EXACT)),
+                List.of("name", "description", "aliases")));
+
+    boolean changed =
+        TableAliasesSearchSettingsMigration.mergeAliasesIntoTableConfiguration(
+            currentSettings, defaultSettings);
+
+    assertTrue(changed);
+    AssetTypeConfiguration mergedConfig = currentSettings.getAssetTypeConfigurations().getFirst();
+    assertTrue(
+        mergedConfig.getSearchFields().stream().anyMatch(f -> "aliases".equals(f.getField())));
+    assertTrue(
+        mergedConfig.getSearchFields().stream()
+            .anyMatch(f -> "aliases.keyword".equals(f.getField())));
+    assertTrue(mergedConfig.getHighlightFields().contains("aliases"));
+    // The operator's own field must survive the merge.
+    assertTrue(mergedConfig.getSearchFields().stream().anyMatch(f -> "name".equals(f.getField())));
+  }
+
+  @Test
+  void isIdempotentWhenAliasesAlreadyPresent() {
+    List<FieldBoost> fields =
+        List.of(
+            fieldBoost("name", 10.0, FieldBoost.MatchType.PHRASE),
+            fieldBoost("aliases", 5.0, FieldBoost.MatchType.STANDARD),
+            fieldBoost("aliases.keyword", 10.0, FieldBoost.MatchType.EXACT));
+    SearchSettings currentSettings =
+        settingsWithTableConfig(tableConfig(fields, List.of("name", "aliases")));
+    SearchSettings defaultSettings =
+        settingsWithTableConfig(tableConfig(fields, List.of("name", "aliases")));
+
+    boolean changed =
+        TableAliasesSearchSettingsMigration.mergeAliasesIntoTableConfiguration(
+            currentSettings, defaultSettings);
+
+    assertFalse(changed);
+  }
+
+  @Test
+  void doesNothingWhenTableConfigurationMissing() {
+    SearchSettings currentSettings = new SearchSettings();
+    currentSettings.setAssetTypeConfigurations(new ArrayList<>());
+    SearchSettings defaultSettings =
+        settingsWithTableConfig(
+            tableConfig(
+                List.of(fieldBoost("aliases", 5.0, FieldBoost.MatchType.STANDARD)),
+                List.of("aliases")));
+
+    boolean changed =
+        TableAliasesSearchSettingsMigration.mergeAliasesIntoTableConfiguration(
+            currentSettings, defaultSettings);
+
+    assertFalse(changed);
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/indexes/TableIndexTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/indexes/TableIndexTest.java
@@ -1,0 +1,107 @@
+package org.openmetadata.service.search.indexes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.openmetadata.common.utils.CommonUtil;
+import org.openmetadata.schema.api.search.AssetTypeConfiguration;
+import org.openmetadata.schema.api.search.FieldBoost;
+import org.openmetadata.schema.api.search.SearchSettings;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.jdbi3.EntityRepository;
+import org.openmetadata.service.search.SearchRepository;
+import org.openmetadata.service.util.EntityUtil;
+
+class TableIndexTest {
+
+  private static MockedStatic<Entity> entityStaticMock;
+
+  @BeforeAll
+  static void setUp() {
+    SearchRepository mockSearchRepo = mock(SearchRepository.class, Mockito.RETURNS_DEEP_STUBS);
+    entityStaticMock = Mockito.mockStatic(Entity.class);
+    entityStaticMock.when(Entity::getSearchRepository).thenReturn(mockSearchRepo);
+  }
+
+  @AfterAll
+  static void tearDown() {
+    entityStaticMock.close();
+  }
+
+  @Test
+  void aliasesArePutOnTheSearchDocument() {
+    Table table =
+        new Table()
+            .withName("orders")
+            .withFullyQualifiedName("svc.analytics_master.dbo.orders")
+            .withAliases(List.of("svc.analytics_core.dbo.orders"));
+
+    Map<String, Object> doc = new TableIndex(table).buildSearchIndexDocInternal(new HashMap<>());
+
+    assertEquals(List.of("svc.analytics_core.dbo.orders"), doc.get("aliases"));
+  }
+
+  /**
+   * TableIndex.getFields() is never consulted by the ES/OS source-builder factories for table
+   * search (only a handful of other indexes use that mechanism); the actual data-asset query is
+   * built from assetTypeConfigurations[assetType=table].searchFields in searchSettings.json. This
+   * test asserts on that settings-driven path instead of the dead getFields() map so alias
+   * searchability is verified where it is actually enforced.
+   */
+  @Test
+  void aliasesAreSearchableWithABoostInSearchSettings() throws IOException {
+    AssetTypeConfiguration tableConfig =
+        findAssetConfig(loadDefaultSearchSettingsFromFile(), "table");
+    assertNotNull(tableConfig, "searchSettings.json must contain a table assetTypeConfiguration");
+
+    FieldBoost aliasesField =
+        tableConfig.getSearchFields().stream()
+            .filter(field -> "aliases".equals(field.getField()))
+            .findFirst()
+            .orElse(null);
+    assertNotNull(aliasesField, "table searchFields must include 'aliases'");
+    assertEquals(5.0, aliasesField.getBoost());
+
+    Set<String> fieldNames =
+        tableConfig.getSearchFields().stream()
+            .map(FieldBoost::getField)
+            .collect(Collectors.toSet());
+    assertTrue(
+        fieldNames.contains("aliases.keyword"),
+        "table searchFields must include 'aliases.keyword' for exact-FQN ranking");
+    assertTrue(
+        tableConfig.getHighlightFields().contains("aliases"),
+        "table highlightFields must include 'aliases' so matched-alias text is returned");
+  }
+
+  private SearchSettings loadDefaultSearchSettingsFromFile() throws IOException {
+    List<String> jsonDataFiles =
+        EntityUtil.getJsonDataResources(".*json/data/settings/searchSettings.json$");
+    String json =
+        CommonUtil.getResourceAsStream(
+            EntityRepository.class.getClassLoader(), jsonDataFiles.get(0));
+    return JsonUtils.readValue(json, SearchSettings.class);
+  }
+
+  private AssetTypeConfiguration findAssetConfig(SearchSettings settings, String assetType) {
+    return settings.getAssetTypeConfigurations().stream()
+        .filter(config -> assetType.equalsIgnoreCase(config.getAssetType()))
+        .findFirst()
+        .orElse(null);
+  }
+}

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/table_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/table_index_mapping.json
@@ -649,6 +649,20 @@
       "locationPath": {
         "type": "keyword"
       },
+      "aliases": {
+        "type": "text",
+        "analyzer": "om_analyzer",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "normalizer": "lowercase_normalizer"
+          },
+          "ngram": {
+            "type": "text",
+            "analyzer": "om_ngram"
+          }
+        }
+      },
       "usageSummary": {
         "properties": {
           "dailyStats": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/table_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/table_index_mapping.json
@@ -803,6 +803,20 @@
       "locationPath": {
         "type": "keyword"
       },
+      "aliases": {
+        "type": "text",
+        "analyzer": "om_analyzer",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "normalizer": "lowercase_normalizer"
+          },
+          "ngram": {
+            "type": "text",
+            "analyzer": "om_ngram"
+          }
+        }
+      },
       "usageSummary": {
         "properties": {
           "dailyStats": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/table_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/table_index_mapping.json
@@ -659,6 +659,20 @@
       "locationPath": {
         "type": "keyword"
       },
+      "aliases": {
+        "type": "text",
+        "analyzer": "om_analyzer",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "normalizer": "lowercase_normalizer"
+          },
+          "ngram": {
+            "type": "text",
+            "analyzer": "om_ngram"
+          }
+        }
+      },
       "usageSummary": {
         "properties": {
           "dailyStats": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/table_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/table_index_mapping.json
@@ -800,6 +800,20 @@
       "locationPath": {
         "type": "keyword"
       },
+      "aliases": {
+        "type": "text",
+        "analyzer": "om_analyzer",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "normalizer": "lowercase_normalizer"
+          },
+          "ngram": {
+            "type": "text",
+            "analyzer": "om_ngram"
+          }
+        }
+      },
       "usageSummary": {
         "properties": {
           "dailyStats": {

--- a/openmetadata-spec/src/main/resources/json/schema/api/data/createTable.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/data/createTable.json
@@ -45,6 +45,14 @@
       },
       "default": null
     },
+    "aliases": {
+      "description": "Alternate fully qualified SQL names that resolve to this table, such as SQL Server synonyms. Source-managed: the ingestion connector recomputes and overwrites this list on every run.",
+      "type": "array",
+      "items": {
+        "$ref": "../../type/basic.json#/definitions/fullyQualifiedEntityName"
+      },
+      "default": null
+    },
     "tablePartition": {
       "$ref": "../../entity/data/table.json#/definitions/tablePartition"
     },

--- a/openmetadata-spec/src/main/resources/json/schema/entity/data/table.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/data/table.json
@@ -1105,6 +1105,14 @@
       },
       "default": null
     },
+    "aliases": {
+      "description": "Alternate fully qualified SQL names that resolve to this table, such as SQL Server synonyms. Source-managed: the ingestion connector recomputes and overwrites this list on every run.",
+      "type": "array",
+      "items": {
+        "$ref": "../../type/basic.json#/definitions/fullyQualifiedEntityName"
+      },
+      "default": null
+    },
     "tablePartition": {
       "$ref": "#/definitions/tablePartition"
     },

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/mssqlConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/mssqlConnection.json
@@ -88,6 +88,12 @@
       "type": "boolean",
       "default": false
     },
+    "includeSynonyms": {
+      "title": "Include Synonyms",
+      "description": "Discover SQL Server synonyms and record them as alternate names (aliases) on the table they resolve to. Also enables alias resolution when building lineage.",
+      "type": "boolean",
+      "default": false
+    },
     "schemaFilterPattern": {
       "title": "Default Schema Filter Pattern",
       "description": "Regex to only include/exclude schemas that matches the pattern.",

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TableAliases.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TableAliases.spec.ts
@@ -1,0 +1,93 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { expect } from '@playwright/test';
+import { DOMAIN_TAGS } from '../../constant/config';
+import { TableClass } from '../../support/entity/TableClass';
+import { performAdminLogin } from '../../utils/admin';
+import { redirectToHomePage, uuid } from '../../utils/common';
+import { waitForAllLoadersToDisappear } from '../../utils/entity';
+import { test } from '../fixtures/pages';
+
+// Shaped like the FQNs the MSSQL synonym sweep writes to Table.aliases, so the
+// assertion mirrors what the connector actually produces rather than an
+// arbitrary label.
+const ALIAS_NAMES = [`legacy_customers_${uuid()}`, `legacy_orders_${uuid()}`];
+const ALIASES = ALIAS_NAMES.map((name) => `mssql_synonym_svc.dbo.${name}`);
+
+test.describe('Table Aliases widget', { tag: [DOMAIN_TAGS.DISCOVERY] }, () => {
+  const tableWithAliases = new TableClass();
+  const tableWithoutAliases = new TableClass();
+
+  test.beforeAll('Create tables', async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+
+    await tableWithAliases.create(apiContext);
+    // aliases is source-managed (no create-time UI field), so it is written
+    // the same way ingestion would apply it: a PATCH after creation.
+    await tableWithAliases.patch({
+      apiContext,
+      patchData: [{ op: 'add', path: '/aliases', value: ALIASES }],
+    });
+
+    await tableWithoutAliases.create(apiContext);
+
+    await afterAction();
+  });
+
+  test.afterAll('Cleanup tables', async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+
+    await tableWithAliases.delete(apiContext);
+    await tableWithoutAliases.delete(apiContext);
+
+    await afterAction();
+  });
+
+  test('renders each alias and offers no edit affordance', async ({ page }) => {
+    await redirectToHomePage(page);
+    await tableWithAliases.visitEntityPage(page);
+    await waitForAllLoadersToDisappear(page);
+
+    const aliasesWidget = page.getByTestId('table-aliases-table');
+
+    await expect(aliasesWidget).toBeVisible();
+
+    // The widget shows only the trailing alias name; the service, database and
+    // schema are already implied by the page, and the full FQN stays available
+    // as the cell's title attribute.
+    for (const [index, name] of ALIAS_NAMES.entries()) {
+      const cell = aliasesWidget.getByText(name, { exact: true });
+
+      await expect(cell).toBeVisible();
+      await expect(cell).toHaveAttribute('title', ALIASES[index]);
+    }
+
+    await expect(aliasesWidget.getByText(ALIASES[0])).toHaveCount(0);
+
+    // Deliberately no edit affordance: the MSSQL connector overwrites
+    // aliases on every ingestion run, so an editable control would silently
+    // discard user input (Task 11 design decision).
+    await expect(aliasesWidget.getByRole('button')).toHaveCount(0);
+  });
+
+  test('hides the widget entirely when the table has no aliases', async ({
+    page,
+  }) => {
+    await redirectToHomePage(page);
+    await tableWithoutAliases.visitEntityPage(page);
+    await waitForAllLoadersToDisappear(page);
+
+    await expect(page.getByTestId('table-aliases-table')).not.toBeVisible();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/searchSettingUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/searchSettingUtils.ts
@@ -42,8 +42,10 @@ export const mockEntitySearchConfig = {
     { field: 'columns.name.keyword', boost: 2, matchType: 'exact' },
     { field: 'columns.displayName.keyword', boost: 2, matchType: 'exact' },
     { field: 'columnNamesFuzzy', boost: 1.5, matchType: 'standard' },
+    { field: 'aliases', boost: 5, matchType: 'standard' },
+    { field: 'aliases.keyword', boost: 10, matchType: 'exact' },
   ],
-  highlightFields: ['name', 'description', 'displayName'],
+  highlightFields: ['name', 'description', 'displayName', 'aliases'],
   matchTypeBoostMultipliers: {
     exactMatchMultiplier: 2,
     fuzzyMatchMultiplier: 1,

--- a/openmetadata-ui/src/main/resources/ui/src/enums/CustomizeDetailPage.enum.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/enums/CustomizeDetailPage.enum.ts
@@ -35,6 +35,7 @@ export enum DetailPageWidgetKeys {
   TABLE_CONSTRAINTS = 'KnowledgePanel.TableConstraints',
   EMPTY_WIDGET_PLACEHOLDER = 'ExtraWidget.EmptyWidgetPlaceholder',
   PARTITIONED_KEYS = 'KnowledgePanel.PartitionedKeys',
+  TABLE_ALIASES = 'KnowledgePanel.TableAliases',
   STORED_PROCEDURE_CODE = 'KnowledgePanel.StoredProcedureCode',
   DATA_MODEL = 'KnowledgePanel.DataModel',
   CONTAINER_CHILDREN = 'KnowledgePanel.ContainerChildren',

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/automations/createWorkflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/automations/createWorkflow.ts
@@ -1253,6 +1253,11 @@ export interface ConfigObject {
      */
     encrypt?: boolean;
     /**
+     * Discover SQL Server synonyms and record them as alternate names (aliases) on the table
+     * they resolve to. Also enables alias resolution when building lineage.
+     */
+    includeSynonyms?: boolean;
+    /**
      * Trust the server certificate without validation. Set to false in production to validate
      * server certificates against the certificate authority.
      */
@@ -4233,6 +4238,11 @@ export interface DatabaseConnectionClass {
      * Host and port of the MSSQL service.
      */
     hostPort?: string;
+    /**
+     * Discover SQL Server synonyms and record them as alternate names (aliases) on the table
+     * they resolve to. Also enables alias resolution when building lineage.
+     */
+    includeSynonyms?: boolean;
     /**
      * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/data/bulkCreateTable.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/data/bulkCreateTable.ts
@@ -29,6 +29,12 @@ export interface BulkCreateTable {
  */
 export interface CreateTableRequest {
     /**
+     * Alternate fully qualified SQL names that resolve to this table, such as SQL Server
+     * synonyms. Source-managed: the ingestion connector recomputes and overwrites this list on
+     * every run.
+     */
+    aliases?: string[];
+    /**
      * Name of the tables in the database
      */
     columns: Column[];

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/data/createTable.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/data/createTable.ts
@@ -15,6 +15,12 @@
  */
 export interface CreateTable {
     /**
+     * Alternate fully qualified SQL names that resolve to this table, such as SQL Server
+     * synonyms. Source-managed: the ingestion connector recomputes and overwrites this list on
+     * every run.
+     */
+    aliases?: string[];
+    /**
      * Name of the tables in the database
      */
     columns: Column[];

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createDatabaseService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createDatabaseService.ts
@@ -774,6 +774,11 @@ export interface Connection {
      */
     encrypt?: boolean;
     /**
+     * Discover SQL Server synonyms and record them as alternate names (aliases) on the table
+     * they resolve to. Also enables alias resolution when building lineage.
+     */
+    includeSynonyms?: boolean;
+    /**
      * Trust the server certificate without validation. Set to false in production to validate
      * server certificates against the certificate authority.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createPipelineService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createPipelineService.ts
@@ -1287,6 +1287,11 @@ export interface DatabaseConnectionClass {
      */
     hostPort?: string;
     /**
+     * Discover SQL Server synonyms and record them as alternate names (aliases) on the table
+     * they resolve to. Also enables alias resolution when building lineage.
+     */
+    includeSynonyms?: boolean;
+    /**
      * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */
     ingestAllDatabases?: boolean;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
@@ -4368,6 +4368,11 @@ export interface ConfigObject {
      */
     encrypt?: boolean;
     /**
+     * Discover SQL Server synonyms and record them as alternate names (aliases) on the table
+     * they resolve to. Also enables alias resolution when building lineage.
+     */
+    includeSynonyms?: boolean;
+    /**
      * Trust the server certificate without validation. Set to false in production to validate
      * server certificates against the certificate authority.
      */
@@ -6793,6 +6798,11 @@ export interface DatabaseConnectionClass {
      * Host and port of the MSSQL service.
      */
     hostPort?: string;
+    /**
+     * Discover SQL Server synonyms and record them as alternate names (aliases) on the table
+     * they resolve to. Also enables alias resolution when building lineage.
+     */
+    includeSynonyms?: boolean;
     /**
      * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/testServiceConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/testServiceConnection.ts
@@ -1135,6 +1135,11 @@ export interface ConfigObject {
      */
     encrypt?: boolean;
     /**
+     * Discover SQL Server synonyms and record them as alternate names (aliases) on the table
+     * they resolve to. Also enables alias resolution when building lineage.
+     */
+    includeSynonyms?: boolean;
+    /**
      * Trust the server certificate without validation. Set to false in production to validate
      * server certificates against the certificate authority.
      */
@@ -4115,6 +4120,11 @@ export interface DatabaseConnectionClass {
      * Host and port of the MSSQL service.
      */
     hostPort?: string;
+    /**
+     * Discover SQL Server synonyms and record them as alternate names (aliases) on the table
+     * they resolve to. Also enables alias resolution when building lineage.
+     */
+    includeSynonyms?: boolean;
     /**
      * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/workflow.ts
@@ -1797,6 +1797,11 @@ export interface ConfigObject {
      */
     encrypt?: boolean;
     /**
+     * Discover SQL Server synonyms and record them as alternate names (aliases) on the table
+     * they resolve to. Also enables alias resolution when building lineage.
+     */
+    includeSynonyms?: boolean;
+    /**
      * Trust the server certificate without validation. Set to false in production to validate
      * server certificates against the certificate authority.
      */
@@ -4614,6 +4619,11 @@ export interface DatabaseConnectionClass {
      * Host and port of the MSSQL service.
      */
     hostPort?: string;
+    /**
+     * Discover SQL Server synonyms and record them as alternate names (aliases) on the table
+     * they resolve to. Also enables alias resolution when building lineage.
+     */
+    includeSynonyms?: boolean;
     /**
      * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/data/table.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/data/table.ts
@@ -14,6 +14,12 @@
  * A `Table` entity organizes data in rows and columns and is defined in a `Database Schema`.
  */
 export interface Table {
+    /**
+     * Alternate fully qualified SQL names that resolve to this table, such as SQL Server
+     * synonyms. Source-managed: the ingestion connector recomputes and overwrites this list on
+     * every run.
+     */
+    aliases?:       string[];
     certification?: AssetCertification;
     /**
      * Change that lead to this version of the entity.

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/mssqlConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/mssqlConnection.ts
@@ -40,6 +40,11 @@ export interface MssqlConnection {
      */
     hostPort?: string;
     /**
+     * Discover SQL Server synonyms and record them as alternate names (aliases) on the table
+     * they resolve to. Also enables alias resolution when building lineage.
+     */
+    includeSynonyms?: boolean;
+    /**
      * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */
     ingestAllDatabases?: boolean;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/ssisConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/ssisConnection.ts
@@ -61,6 +61,11 @@ export interface MssqlConnection {
      */
     hostPort?: string;
     /**
+     * Discover SQL Server synonyms and record them as alternate names (aliases) on the table
+     * they resolve to. Also enables alias resolution when building lineage.
+     */
+    includeSynonyms?: boolean;
+    /**
      * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */
     ingestAllDatabases?: boolean;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/wherescapeConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/wherescapeConnection.ts
@@ -61,6 +61,11 @@ export interface Connection {
      */
     hostPort?: string;
     /**
+     * Discover SQL Server synonyms and record them as alternate names (aliases) on the table
+     * they resolve to. Also enables alias resolution when building lineage.
+     */
+    includeSynonyms?: boolean;
+    /**
      * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */
     ingestAllDatabases?: boolean;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
@@ -1420,6 +1420,11 @@ export interface ConfigObject {
      */
     encrypt?: boolean;
     /**
+     * Discover SQL Server synonyms and record them as alternate names (aliases) on the table
+     * they resolve to. Also enables alias resolution when building lineage.
+     */
+    includeSynonyms?: boolean;
+    /**
      * Trust the server certificate without validation. Set to false in production to validate
      * server certificates against the certificate authority.
      */
@@ -4144,6 +4149,11 @@ export interface DatabaseConnectionClass {
      * Host and port of the MSSQL service.
      */
     hostPort?: string;
+    /**
+     * Discover SQL Server synonyms and record them as alternate names (aliases) on the table
+     * they resolve to. Also enables alias resolution when building lineage.
+     */
+    includeSynonyms?: boolean;
     /**
      * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/databaseService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/databaseService.ts
@@ -905,6 +905,11 @@ export interface Connection {
      */
     encrypt?: boolean;
     /**
+     * Discover SQL Server synonyms and record them as alternate names (aliases) on the table
+     * they resolve to. Also enables alias resolution when building lineage.
+     */
+    includeSynonyms?: boolean;
+    /**
      * Trust the server certificate without validation. Set to false in production to validate
      * server certificates against the certificate authority.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
@@ -4958,6 +4958,11 @@ export interface ConfigObject {
      */
     encrypt?: boolean;
     /**
+     * Discover SQL Server synonyms and record them as alternate names (aliases) on the table
+     * they resolve to. Also enables alias resolution when building lineage.
+     */
+    includeSynonyms?: boolean;
+    /**
      * Trust the server certificate without validation. Set to false in production to validate
      * server certificates against the certificate authority.
      */
@@ -7306,6 +7311,11 @@ export interface DatabaseConnectionClass {
      * Host and port of the MSSQL service.
      */
     hostPort?: string;
+    /**
+     * Discover SQL Server synonyms and record them as alternate names (aliases) on the table
+     * they resolve to. Also enables alias resolution when building lineage.
+     */
+    includeSynonyms?: boolean;
     /**
      * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/pipelineService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/pipelineService.ts
@@ -1409,6 +1409,11 @@ export interface DatabaseConnectionClass {
      */
     hostPort?: string;
     /**
+     * Discover SQL Server synonyms and record them as alternate names (aliases) on the table
+     * they resolve to. Also enables alias resolution when building lineage.
+     */
+    includeSynonyms?: boolean;
+    /**
      * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */
     ingestAllDatabases?: boolean;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
@@ -1518,6 +1518,11 @@ export interface ConfigObject {
      */
     encrypt?: boolean;
     /**
+     * Discover SQL Server synonyms and record them as alternate names (aliases) on the table
+     * they resolve to. Also enables alias resolution when building lineage.
+     */
+    includeSynonyms?: boolean;
+    /**
      * Trust the server certificate without validation. Set to false in production to validate
      * server certificates against the certificate authority.
      */
@@ -4242,6 +4247,11 @@ export interface DatabaseConnectionClass {
      * Host and port of the MSSQL service.
      */
     hostPort?: string;
+    /**
+     * Discover SQL Server synonyms and record them as alternate names (aliases) on the table
+     * they resolve to. Also enables alias resolution when building lineage.
+     */
+    includeSynonyms?: boolean;
     /**
      * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
@@ -1509,6 +1509,11 @@ export interface ConfigObject {
      */
     encrypt?: boolean;
     /**
+     * Discover SQL Server synonyms and record them as alternate names (aliases) on the table
+     * they resolve to. Also enables alias resolution when building lineage.
+     */
+    includeSynonyms?: boolean;
+    /**
      * Trust the server certificate without validation. Set to false in production to validate
      * server certificates against the certificate authority.
      */
@@ -4253,6 +4258,11 @@ export interface DatabaseConnectionClass {
      * Host and port of the MSSQL service.
      */
     hostPort?: string;
+    /**
+     * Discover SQL Server synonyms and record them as alternate names (aliases) on the table
+     * they resolve to. Also enables alias resolution when building lineage.
+     */
+    includeSynonyms?: boolean;
     /**
      * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableAliases/TableAliases.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableAliases/TableAliases.component.tsx
@@ -1,0 +1,112 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { ColumnsType } from 'antd/lib/table';
+import { isEmpty } from 'lodash';
+import { useEffect, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import ExpandableCard from '../../../components/common/ExpandableCard/ExpandableCard';
+import Table from '../../../components/common/Table/Table';
+import { useGenericContext } from '../../../components/Customization/GenericProvider/GenericContext';
+import { DetailPageWidgetKeys } from '../../../enums/CustomizeDetailPage.enum';
+import { Table as TableType } from '../../../generated/entity/data/table';
+import Fqn from '../../../utils/Fqn';
+
+interface AliasRow {
+  key: string;
+  name: string;
+  fqn: string;
+}
+
+// Aliases are stored as fully qualified names, but the service, database and
+// schema are already established by the page the widget sits on, so only the
+// trailing name carries new information. Fqn.split is quote-aware: a name part
+// may legitimately contain a dot, which a plain split would tear in half.
+// Fqn.split retains quoting on each part and Fqn.unquoteName throws on a
+// malformed name, so fall back to the raw value rather than letting one odd
+// alias take down the whole table page.
+const getAliasName = (fqn: string): string => {
+  try {
+    const parts = Fqn.split(fqn);
+
+    return parts.length > 0 ? Fqn.unquoteName(parts[parts.length - 1]) : fqn;
+  } catch {
+    return fqn;
+  }
+};
+
+export const TableAliases = ({
+  renderAsExpandableCard = true,
+}: {
+  renderAsExpandableCard?: boolean;
+}) => {
+  const { data, filterWidgets } = useGenericContext<TableType>();
+  const { t } = useTranslation();
+
+  const aliasRows = useMemo<AliasRow[]>(
+    () =>
+      (data?.aliases ?? []).map((alias) => ({
+        key: alias,
+        name: getAliasName(alias),
+        fqn: alias,
+      })),
+    [data?.aliases]
+  );
+
+  const columns = useMemo<ColumnsType<AliasRow>>(
+    () => [
+      {
+        title: t('label.name'),
+        dataIndex: 'name',
+        key: 'name',
+        ellipsis: true,
+        render: (name: string, record: AliasRow) => (
+          <span title={record.fqn}>{name}</span>
+        ),
+      },
+    ],
+    [t]
+  );
+
+  useEffect(() => {
+    if (isEmpty(aliasRows)) {
+      filterWidgets?.([DetailPageWidgetKeys.TABLE_ALIASES]);
+    }
+  }, [aliasRows]);
+
+  if (isEmpty(aliasRows)) {
+    return null;
+  }
+
+  const content = (
+    <Table
+      columns={columns}
+      data-testid="table-aliases-table"
+      dataSource={aliasRows}
+      pagination={false}
+      rowKey="key"
+      size="small"
+    />
+  );
+
+  return renderAsExpandableCard ? (
+    <ExpandableCard
+      cardProps={{
+        title: t('label.alias-plural'),
+      }}
+      isExpandDisabled={isEmpty(aliasRows)}>
+      {content}
+    </ExpandableCard>
+  ) : (
+    content
+  );
+};

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableAliases/TableAliases.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableAliases/TableAliases.test.tsx
@@ -1,0 +1,108 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+import { TableAliases } from './TableAliases.component';
+
+const mockUseGenericContext = jest.fn();
+
+jest.mock(
+  '../../../components/Customization/GenericProvider/GenericContext',
+  () => ({
+    useGenericContext: () => mockUseGenericContext(),
+  })
+);
+
+jest.mock('../../../components/common/ExpandableCard/ExpandableCard', () => ({
+  __esModule: true,
+  default: ({
+    children,
+    cardProps,
+  }: {
+    children: React.ReactNode;
+    cardProps: { title: string };
+  }) => (
+    <div data-testid="expandable-card">
+      <span>{cardProps.title}</span>
+      {children}
+    </div>
+  ),
+}));
+
+describe('TableAliases', () => {
+  it('renders only the alias name, not the fully qualified name', () => {
+    mockUseGenericContext.mockReturnValue({
+      data: {
+        aliases: [
+          'svc.analytics_core.dbo.mayur',
+          'svc.analytics_core.dbo.apple',
+        ],
+      },
+      filterWidgets: jest.fn(),
+    });
+
+    render(<TableAliases />);
+
+    expect(screen.getByText('mayur')).toBeInTheDocument();
+    expect(screen.getByText('apple')).toBeInTheDocument();
+    expect(
+      screen.queryByText('svc.analytics_core.dbo.mayur')
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the full fully qualified name available on hover', () => {
+    mockUseGenericContext.mockReturnValue({
+      data: { aliases: ['svc.analytics_core.dbo.mayur'] },
+      filterWidgets: jest.fn(),
+    });
+
+    render(<TableAliases />);
+
+    expect(screen.getByText('mayur')).toHaveAttribute(
+      'title',
+      'svc.analytics_core.dbo.mayur'
+    );
+  });
+
+  it('does not split a quoted name part that contains a dot', () => {
+    mockUseGenericContext.mockReturnValue({
+      data: { aliases: ['svc.analytics_core.dbo."order.items"'] },
+      filterWidgets: jest.fn(),
+    });
+
+    render(<TableAliases />);
+
+    expect(screen.getByText('order.items')).toBeInTheDocument();
+  });
+
+  it('renders nothing when there are no aliases', () => {
+    mockUseGenericContext.mockReturnValue({
+      data: { aliases: [] },
+      filterWidgets: jest.fn(),
+    });
+
+    const { container } = render(<TableAliases />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('offers no edit control, because aliases are source-managed', () => {
+    mockUseGenericContext.mockReturnValue({
+      data: { aliases: ['svc.analytics_core.dbo.mayur'] },
+      filterWidgets: jest.fn(),
+    });
+
+    render(<TableAliases />);
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/GenericWidget/GenericWidgetUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/GenericWidget/GenericWidgetUtils.tsx
@@ -172,6 +172,14 @@ const TableConstraints = withSuspenseFallback(
   )
 );
 
+const TableAliases = withSuspenseFallback(
+  lazy(() =>
+    import(
+      '../../pages/TableDetailsPageV1/TableAliases/TableAliases.component'
+    ).then((m) => ({ default: m.TableAliases }))
+  )
+);
+
 export const WIDGET_COMPONENTS = {
   [DetailPageWidgetKeys.GLOSSARY_TERMS]: () => (
     <TagsViewer
@@ -307,6 +315,9 @@ export const WIDGET_COMPONENTS = {
   ),
   [DetailPageWidgetKeys.PARTITIONED_KEYS]: () => (
     <PartitionedKeys renderAsExpandableCard={false} />
+  ),
+  [DetailPageWidgetKeys.TABLE_ALIASES]: () => (
+    <TableAliases renderAsExpandableCard={false} />
   ),
   [DetailPageWidgetKeys.MARKETPLACE_DATA_PRODUCTS]: () => (
     <MarketplaceDataProductsWidget

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableClassBase.test.ts
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { DetailPageWidgetKeys } from '../enums/CustomizeDetailPage.enum';
+import tableClassBase from './TableClassBase';
+
+describe('TableClassBase.getWidgetHeight', () => {
+  it.each([
+    [DetailPageWidgetKeys.DESCRIPTION, 2],
+    [DetailPageWidgetKeys.TABLE_SCHEMA, 8.5],
+    [DetailPageWidgetKeys.FREQUENTLY_JOINED_TABLES, 2],
+    [DetailPageWidgetKeys.DATA_PRODUCTS, 2],
+    [DetailPageWidgetKeys.TAGS, 2],
+    [DetailPageWidgetKeys.GLOSSARY_TERMS, 2],
+    [DetailPageWidgetKeys.TABLE_CONSTRAINTS, 2],
+    [DetailPageWidgetKeys.PARTITIONED_KEYS, 2],
+    [DetailPageWidgetKeys.TABLE_ALIASES, 2],
+  ])('should return the configured height for %s', (widgetKey, height) => {
+    expect(tableClassBase.getWidgetHeight(widgetKey)).toBe(height);
+  });
+
+  it.each([
+    DetailPageWidgetKeys.CUSTOM_PROPERTIES,
+    DetailPageWidgetKeys.ANNOUNCEMENTS,
+    DetailPageWidgetKeys.DIRECTORY_CHILDREN,
+    '',
+    'unknown-widget',
+  ])('should fall back to height 1 for %s', (widgetKey) => {
+    expect(tableClassBase.getWidgetHeight(widgetKey)).toBe(1);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableClassBase.ts
@@ -68,7 +68,22 @@ type TableWidgetKeys =
   | DetailPageWidgetKeys.GLOSSARY_TERMS
   | DetailPageWidgetKeys.CUSTOM_PROPERTIES
   | DetailPageWidgetKeys.TABLE_CONSTRAINTS
-  | DetailPageWidgetKeys.PARTITIONED_KEYS;
+  | DetailPageWidgetKeys.PARTITIONED_KEYS
+  | DetailPageWidgetKeys.TABLE_ALIASES;
+
+// Widgets whose height comes from `defaultWidgetHeight`; every other widget is
+// laid out at height 1.
+const SIZEABLE_WIDGET_KEYS: TableWidgetKeys[] = [
+  DetailPageWidgetKeys.DESCRIPTION,
+  DetailPageWidgetKeys.TABLE_SCHEMA,
+  DetailPageWidgetKeys.FREQUENTLY_JOINED_TABLES,
+  DetailPageWidgetKeys.DATA_PRODUCTS,
+  DetailPageWidgetKeys.TAGS,
+  DetailPageWidgetKeys.GLOSSARY_TERMS,
+  DetailPageWidgetKeys.TABLE_CONSTRAINTS,
+  DetailPageWidgetKeys.PARTITIONED_KEYS,
+  DetailPageWidgetKeys.TABLE_ALIASES,
+];
 
 class TableClassBase {
   defaultWidgetHeight: Record<TableWidgetKeys, number>;
@@ -84,6 +99,7 @@ class TableClassBase {
       [DetailPageWidgetKeys.CUSTOM_PROPERTIES]: 4,
       [DetailPageWidgetKeys.TABLE_CONSTRAINTS]: 2,
       [DetailPageWidgetKeys.PARTITIONED_KEYS]: 2,
+      [DetailPageWidgetKeys.TABLE_ALIASES]: 2,
     };
   }
 
@@ -210,6 +226,14 @@ class TableClassBase {
         y: 6,
         static: false,
       },
+      {
+        h: this.defaultWidgetHeight[DetailPageWidgetKeys.TABLE_ALIASES],
+        i: DetailPageWidgetKeys.TABLE_ALIASES,
+        w: 2,
+        x: 6,
+        y: 9,
+        static: false,
+      },
     ];
   }
 
@@ -257,28 +281,9 @@ class TableClassBase {
   }
 
   public getWidgetHeight(widgetName: string) {
-    switch (widgetName) {
-      case DetailPageWidgetKeys.DESCRIPTION:
-        return this.defaultWidgetHeight[DetailPageWidgetKeys.DESCRIPTION];
-      case DetailPageWidgetKeys.TABLE_SCHEMA:
-        return this.defaultWidgetHeight[DetailPageWidgetKeys.TABLE_SCHEMA];
-      case DetailPageWidgetKeys.FREQUENTLY_JOINED_TABLES:
-        return this.defaultWidgetHeight[
-          DetailPageWidgetKeys.FREQUENTLY_JOINED_TABLES
-        ];
-      case DetailPageWidgetKeys.DATA_PRODUCTS:
-        return this.defaultWidgetHeight[DetailPageWidgetKeys.DATA_PRODUCTS];
-      case DetailPageWidgetKeys.TAGS:
-        return this.defaultWidgetHeight[DetailPageWidgetKeys.TAGS];
-      case DetailPageWidgetKeys.GLOSSARY_TERMS:
-        return this.defaultWidgetHeight[DetailPageWidgetKeys.GLOSSARY_TERMS];
-      case DetailPageWidgetKeys.TABLE_CONSTRAINTS:
-        return this.defaultWidgetHeight[DetailPageWidgetKeys.TABLE_CONSTRAINTS];
-      case DetailPageWidgetKeys.PARTITIONED_KEYS:
-        return this.defaultWidgetHeight[DetailPageWidgetKeys.PARTITIONED_KEYS];
-      default:
-        return 1;
-    }
+    return SIZEABLE_WIDGET_KEYS.includes(widgetName as TableWidgetKeys)
+      ? this.defaultWidgetHeight[widgetName as TableWidgetKeys]
+      : 1;
   }
 }
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableTabsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableTabsUtils.tsx
@@ -167,6 +167,15 @@ const PartitionedKeys = withSuspenseFallback(
   TAB_CONTENT_FALLBACK
 );
 
+const TableAliases = withSuspenseFallback(
+  lazy(() =>
+    import(
+      '../pages/TableDetailsPageV1/TableAliases/TableAliases.component'
+    ).then((module) => ({ default: module.TableAliases }))
+  ),
+  TAB_CONTENT_FALLBACK
+);
+
 export const getTableDetailPageBaseTabs = ({
   queryCount,
   isQueryCountLoading,
@@ -483,6 +492,8 @@ export const getTableWidgetFromKey = (
     return <FrequentlyJoinedTables />;
   } else if (widgetConfig.i.startsWith(DetailPageWidgetKeys.PARTITIONED_KEYS)) {
     return <PartitionedKeys />;
+  } else if (widgetConfig.i.startsWith(DetailPageWidgetKeys.TABLE_ALIASES)) {
+    return <TableAliases />;
   } else {
     return (
       <CommonWidgets


### PR DESCRIPTION
### Describe your changes:

Fixes #31512

Backport of #31829 to the **1.13** release train. It ingests SQL Server synonyms as source-managed `Table.aliases`, indexes them for exact and partial search, resolves alias FQNs to their canonical table when building lineage, and shows a read-only Aliases widget on the table detail page.

See #31829 for the full design write-up (embedded-aliases model, the up-front `sys.synonyms` sweep in `prepare()`, and why the lineage fallback lives in the generic resolver).

#
### Type of change:
- [x] New feature

#
### Differences from the main PR

- **The migration moves from `2.0.2` to `1.13.6.`** 1.13.5 is already released, and a data-migration slot in a shipped version is never reprocessed, so the search-settings backfill lives in `migration/mysql/v1136`, `migration/postgres/v1136` and `migration/utils/v1136`. `MigrationWiringTest` pins the version-directory → `v1136.Migration` resolution for both dialects so a package/directory mismatch cannot silently skip the backfill.
- **The Aliases widget uses this branch's UI stack** — `ExpandableCard` and antd `ColumnsType` rather than main's `WidgetCard`. `DetailPageWidgetKeys.ASSET_HEALTH` does not exist on 1.13 and is dropped from `TableWidgetKeys` / `SIZEABLE_WIDGET_KEYS`.
- **Python follows 1.13's toolchain** — `Optional[...]`/`List[...]` typing, black 22.3.0 formatting, and the alias lookup extracted into `resolve_table_entities_from_alias` so `search_table_entities` stays inside pylint's branch budget. `pycln`/`isort`/`black`/`pylint` report no new findings versus `origin/1.13`, and `basedpyright --baselinemode=discard` shows no new errors in the changed files.
- The main-only trees (`public/jsons/connectionSchemas`, `src/jsons/ingestionSchemas`, `serviceProgressEvent.ts`) do not exist here, so only the generated TS under `src/generated/` is regenerated.

#
### Tests

| Suite | Result |
|---|---|
| `MigrationWiringTest` | 3 passed |
| `TableAliasesSearchSettingsMigrationTest` | 3 passed |
| `TableIndexTest` | 2 passed |
| ingestion unit tests (alias resolution, MSSQL synonyms, `common_db_source` aliases, `source_hash`, schema) | 77 passed |
| UI jest (`TableAliases`, `TableClassBase`) | 19 passed |
| `openmetadata-integration-tests` (`TableResourceIT`) | compiles |

Also run: `mvn spotless:apply`, UI prettier + ESLint + `license-header-check` (clean), `tsc --noEmit` (no errors in changed files).

Playwright coverage for the widget ships in `playwright/e2e/Pages/TableAliases.spec.ts`.

#
### Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) document.
- [x] My PR title is of the format `Fixes <issue-number>: <short description>`.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
