### PR TITLE
Fixes #33050: stop reporting search-engine timeouts as EntityShapeIT shape rejections

### DIFF
--- a/openmetadata-integration-tests/pom.xml
+++ b/openmetadata-integration-tests/pom.xml
@@ -21,7 +21,7 @@
     <integrationTests.skipIsolated>false</integrationTests.skipIsolated>
     <integrationTests.skipParallel>false</integrationTests.skipParallel>
     <integrationTests.forkTimeoutSeconds>3600</integrationTests.forkTimeoutSeconds>
-    <integrationTests.globalStateTests>TagRecognizerFeedbackIT,WorkflowDefinitionResourceIT,AppsResourceIT,SystemResourceIT,VectorEmbeddingIntegrationIT,PatchTableEmbeddingIT,GlossaryOntologyExportIT,UserMetricsResourceIT,ConversationSchemaMigrationIT</integrationTests.globalStateTests>
+    <integrationTests.globalStateTests>TagRecognizerFeedbackIT,WorkflowDefinitionResourceIT,AppsResourceIT,SystemResourceIT,VectorEmbeddingIntegrationIT,PatchTableEmbeddingIT,GlossaryOntologyExportIT,UserMetricsResourceIT,ConversationSchemaMigrationIT,EntityShapeIT</integrationTests.globalStateTests>
     <integrationTests.multiNodeTests>SessionMultiNodeIT,SessionRedisMultiNodeIT,CsvExportMultiNodeIT</integrationTests.multiNodeTests>
     <integrationTests.retryQueueTests>SearchIndexRetryQueueIT</integrationTests.retryQueueTests>
     <!-- Tags excluded from the ui-it profile. Override on the CLI to include them, e.g.
@@ -420,6 +420,7 @@
                     <include>**/PatchTableEmbeddingIT.java</include>
                     <include>**/GlossaryOntologyExportIT.java</include>
                     <include>**/ConversationSchemaMigrationIT.java</include>
+                    <include>**/EntityShapeIT.java</include>
                     <include>**/SessionMultiNodeIT.java</include>
                     <include>**/SessionRedisMultiNodeIT.java</include>
                     <include>**/SearchIndexRetryQueueIT.java</include>
@@ -465,6 +466,7 @@
                     <exclude>**/PatchTableEmbeddingIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
                     <exclude>**/ConversationSchemaMigrationIT.java</exclude>
+                    <exclude>**/EntityShapeIT.java</exclude>
                     <exclude>**/SessionMultiNodeIT.java</exclude>
                     <exclude>**/SessionRedisMultiNodeIT.java</exclude>
                     <exclude>**/SearchIndexRetryQueueIT.java</exclude>
@@ -533,6 +535,7 @@
                     <include>**/PatchTableEmbeddingIT.java</include>
                     <include>**/GlossaryOntologyExportIT.java</include>
                     <include>**/ConversationSchemaMigrationIT.java</include>
+                    <include>**/EntityShapeIT.java</include>
                     <include>**/SessionMultiNodeIT.java</include>
                     <include>**/SessionRedisMultiNodeIT.java</include>
                     <include>**/SearchIndexRetryQueueIT.java</include>
@@ -578,6 +581,7 @@
                     <exclude>**/PatchTableEmbeddingIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
                     <exclude>**/ConversationSchemaMigrationIT.java</exclude>
+                    <exclude>**/EntityShapeIT.java</exclude>
                     <exclude>**/SessionMultiNodeIT.java</exclude>
                     <exclude>**/SessionRedisMultiNodeIT.java</exclude>
                     <exclude>**/SearchIndexRetryQueueIT.java</exclude>
@@ -646,6 +650,7 @@
                     <include>**/PatchTableEmbeddingIT.java</include>
                     <include>**/GlossaryOntologyExportIT.java</include>
                     <include>**/ConversationSchemaMigrationIT.java</include>
+                    <include>**/EntityShapeIT.java</include>
                     <include>**/SessionMultiNodeIT.java</include>
                     <include>**/SessionRedisMultiNodeIT.java</include>
                     <include>**/SearchIndexRetryQueueIT.java</include>
@@ -692,6 +697,7 @@
                     <exclude>**/PatchTableEmbeddingIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
                     <exclude>**/ConversationSchemaMigrationIT.java</exclude>
+                    <exclude>**/EntityShapeIT.java</exclude>
                     <exclude>**/SessionMultiNodeIT.java</exclude>
                     <exclude>**/SessionRedisMultiNodeIT.java</exclude>
                     <exclude>**/SearchIndexRetryQueueIT.java</exclude>
@@ -760,6 +766,7 @@
                     <include>**/PatchTableEmbeddingIT.java</include>
                     <include>**/GlossaryOntologyExportIT.java</include>
                     <include>**/ConversationSchemaMigrationIT.java</include>
+                    <include>**/EntityShapeIT.java</include>
                     <include>**/SessionMultiNodeIT.java</include>
                     <include>**/SessionRedisMultiNodeIT.java</include>
                     <include>**/SearchIndexRetryQueueIT.java</include>
@@ -805,6 +812,7 @@
                     <exclude>**/PatchTableEmbeddingIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
                     <exclude>**/ConversationSchemaMigrationIT.java</exclude>
+                    <exclude>**/EntityShapeIT.java</exclude>
                     <exclude>**/SessionMultiNodeIT.java</exclude>
                     <exclude>**/SessionRedisMultiNodeIT.java</exclude>
                     <exclude>**/SearchIndexRetryQueueIT.java</exclude>
@@ -872,6 +880,7 @@
                     <include>**/PatchTableEmbeddingIT.java</include>
                     <include>**/GlossaryOntologyExportIT.java</include>
                     <include>**/ConversationSchemaMigrationIT.java</include>
+                    <include>**/EntityShapeIT.java</include>
                     <include>**/SessionMultiNodeIT.java</include>
                     <include>**/SessionRedisMultiNodeIT.java</include>
                     <include>**/SearchIndexRetryQueueIT.java</include>
@@ -917,6 +926,7 @@
                     <exclude>**/PatchTableEmbeddingIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
                     <exclude>**/ConversationSchemaMigrationIT.java</exclude>
+                    <exclude>**/EntityShapeIT.java</exclude>
                     <exclude>**/SessionMultiNodeIT.java</exclude>
                     <exclude>**/SessionRedisMultiNodeIT.java</exclude>
                     <exclude>**/SearchIndexRetryQueueIT.java</exclude>
@@ -983,6 +993,7 @@
                     <include>**/PatchTableEmbeddingIT.java</include>
                     <include>**/GlossaryOntologyExportIT.java</include>
                     <include>**/ConversationSchemaMigrationIT.java</include>
+                    <include>**/EntityShapeIT.java</include>
                     <include>**/SessionMultiNodeIT.java</include>
                     <include>**/SessionRedisMultiNodeIT.java</include>
                     <include>**/SearchIndexRetryQueueIT.java</include>
@@ -1029,6 +1040,7 @@
                     <exclude>**/PatchTableEmbeddingIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
                     <exclude>**/ConversationSchemaMigrationIT.java</exclude>
+                    <exclude>**/EntityShapeIT.java</exclude>
                     <exclude>**/SessionMultiNodeIT.java</exclude>
                     <exclude>**/SessionRedisMultiNodeIT.java</exclude>
                     <exclude>**/SearchIndexRetryQueueIT.java</exclude>
@@ -1112,6 +1124,7 @@
                     <include>**/PatchTableEmbeddingIT.java</include>
                     <include>**/GlossaryOntologyExportIT.java</include>
                     <include>**/ConversationSchemaMigrationIT.java</include>
+                    <include>**/EntityShapeIT.java</include>
                     <include>**/SessionMultiNodeIT.java</include>
                     <include>**/SessionRedisMultiNodeIT.java</include>
                     <include>**/SearchIndexRetryQueueIT.java</include>
@@ -1159,6 +1172,7 @@
                     <exclude>**/PatchTableEmbeddingIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
                     <exclude>**/ConversationSchemaMigrationIT.java</exclude>
+                    <exclude>**/EntityShapeIT.java</exclude>
                     <exclude>**/SessionMultiNodeIT.java</exclude>
                     <exclude>**/SessionRedisMultiNodeIT.java</exclude>
                     <exclude>**/SearchIndexRetryQueueIT.java</exclude>
@@ -1228,6 +1242,7 @@
                     <include>**/PatchTableEmbeddingIT.java</include>
                     <include>**/GlossaryOntologyExportIT.java</include>
                     <include>**/ConversationSchemaMigrationIT.java</include>
+                    <include>**/EntityShapeIT.java</include>
                     <include>**/SessionMultiNodeIT.java</include>
                     <include>**/SessionRedisMultiNodeIT.java</include>
                     <include>**/SearchIndexRetryQueueIT.java</include>
@@ -1275,6 +1290,7 @@
                     <exclude>**/PatchTableEmbeddingIT.java</exclude>
                     <exclude>**/GlossaryOntologyExportIT.java</exclude>
                     <exclude>**/ConversationSchemaMigrationIT.java</exclude>
+                    <exclude>**/EntityShapeIT.java</exclude>
                     <exclude>**/SessionMultiNodeIT.java</exclude>
                     <exclude>**/SessionRedisMultiNodeIT.java</exclude>
                     <exclude>**/SearchIndexRetryQueueIT.java</exclude>

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/search/SearchClient.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/search/SearchClient.java
@@ -40,7 +40,15 @@ public final class SearchClient {
       this.http = null;
       this.base = null;
     } else {
-      this.http = HttpClient.newBuilder().connectTimeout(TIMEOUT).build();
+      // ES/OpenSearch expose HTTP/1.1-only REST over cleartext, but the JDK client defaults to
+      // HTTP_2 and attempts an h2c upgrade on every request. A slow, large exchange has been seen
+      // to leave that connection desynchronised, surfacing as an unreadable
+      // "Frame type(34) ... exceeds MAX_FRAME_SIZE" rather than the real problem.
+      this.http =
+          HttpClient.newBuilder()
+              .connectTimeout(TIMEOUT)
+              .version(HttpClient.Version.HTTP_1_1)
+              .build();
       this.base =
           URI.create(
               server.searchScheme() + "://" + server.searchHost() + ":" + server.searchPort());
@@ -93,13 +101,13 @@ public final class SearchClient {
 
   public JsonNode get(final String path) {
     requireEmbedded("GET " + path);
-    return execute(HttpRequest.newBuilder(base.resolve(path)).GET().build());
+    return execute(request(path).GET().build());
   }
 
   public JsonNode post(final String path, final String jsonBody) {
     requireEmbedded("POST " + path);
     return execute(
-        HttpRequest.newBuilder(base.resolve(path))
+        request(path)
             .header("Content-Type", "application/json")
             .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
             .build());
@@ -108,7 +116,7 @@ public final class SearchClient {
   public JsonNode put(final String path, final String jsonBody) {
     requireEmbedded("PUT " + path);
     return execute(
-        HttpRequest.newBuilder(base.resolve(path))
+        request(path)
             .header("Content-Type", "application/json")
             .PUT(HttpRequest.BodyPublishers.ofString(jsonBody))
             .build());
@@ -118,9 +126,7 @@ public final class SearchClient {
     requireEmbedded("DELETE " + path);
     try {
       final HttpResponse<String> response =
-          http.send(
-              HttpRequest.newBuilder(base.resolve(path)).DELETE().build(),
-              HttpResponse.BodyHandlers.ofString());
+          http.send(request(path).DELETE().build(), HttpResponse.BodyHandlers.ofString());
       final int status = response.statusCode();
       final boolean success = (status >= 200 && status < 300) || status == 404;
       if (!success) {
@@ -202,12 +208,12 @@ public final class SearchClient {
   }
 
   private JsonNode engineGet(final String path) {
-    return execute(HttpRequest.newBuilder(base.resolve(path)).GET().build());
+    return execute(request(path).GET().build());
   }
 
   private JsonNode enginePost(final String path, final String jsonBody) {
     return execute(
-        HttpRequest.newBuilder(base.resolve(path))
+        request(path)
             .header("Content-Type", "application/json")
             .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
             .build());
@@ -217,9 +223,7 @@ public final class SearchClient {
     try {
       final HttpResponse<Void> response =
           http.send(
-              HttpRequest.newBuilder(base.resolve(path))
-                  .method("HEAD", HttpRequest.BodyPublishers.noBody())
-                  .build(),
+              request(path).method("HEAD", HttpRequest.BodyPublishers.noBody()).build(),
               HttpResponse.BodyHandlers.discarding());
       return response.statusCode() >= 200 && response.statusCode() < 300;
     } catch (final InterruptedException e) {
@@ -243,6 +247,15 @@ public final class SearchClient {
               + " requires direct engine access, which is unavailable in external mode "
               + "(the test-support proxy exposes only read-only introspection).");
     }
+  }
+
+  /**
+   * {@link #TIMEOUT} was only ever a connect timeout, so an exchange that stalled after the
+   * handshake ran unbounded -- one shape-canary GET was observed hanging for 80s before it failed.
+   * Every request is built here so it carries a response deadline too.
+   */
+  private HttpRequest.Builder request(final String path) {
+    return HttpRequest.newBuilder(base.resolve(path)).timeout(TIMEOUT);
   }
 
   private JsonNode execute(final HttpRequest request) {

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/search/shape/ShapeCanary.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/search/shape/ShapeCanary.java
@@ -13,6 +13,7 @@
 package org.openmetadata.it.search.shape;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
 import org.openmetadata.it.search.SearchClient;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.utils.JsonUtils;
@@ -48,10 +49,43 @@ public final class ShapeCanary {
           rejection != null
               ? new ShapeResult(Outcome.REJECTED, rejection)
               : verify(freshIndex, docId, probe);
+    } catch (final ShapeTransportException e) {
+      throw e;
+    } catch (final RuntimeException e) {
+      throw isTransportFailure(e)
+          ? new ShapeTransportException(
+              "shape probe against " + freshIndex + " did not complete", e)
+          : e;
     } finally {
       shadowIndex.drop(freshIndex);
     }
     return result;
+  }
+
+  /**
+   * Whether the engine never answered, as opposed to answering "no". A deadline overrun, a dropped
+   * connection or a desynchronised HTTP stream says nothing about whether the shape under test is
+   * indexable, so it must not be reported as {@link Outcome#REJECTED} -- doing so blames the
+   * document for a slow or overloaded cluster.
+   */
+  static boolean isTransportFailure(final Throwable error) {
+    Throwable cursor = error;
+    int depth = 0;
+    while (cursor != null && depth < MAX_CAUSE_DEPTH) {
+      if (cursor instanceof IOException || cursor.getClass().getSimpleName().contains("Timeout")) {
+        return true;
+      }
+      cursor = cursor.getCause();
+      depth++;
+    }
+    return false;
+  }
+
+  /** The engine did not answer; the case was not observed either way. */
+  public static final class ShapeTransportException extends RuntimeException {
+    ShapeTransportException(final String message, final Throwable cause) {
+      super(message, cause);
+    }
   }
 
   /**
@@ -70,13 +104,18 @@ public final class ShapeCanary {
    * PUTs the built doc into the shadow index. Returns the engine's rejection detail when the write
    * fails, or {@code null} when it succeeds. Only this network write is caught — the engine refuses
    * an unindexable doc with varied exception types, and REJECTED plus the raw error chain is the
-   * honest signal. We do NOT classify the cause.
+   * honest signal. The cause is not classified beyond one distinction: an engine that never
+   * answered ({@link #isTransportFailure}) has not refused anything, so it propagates instead of
+   * being recorded as a refusal.
    */
   private String putDoc(final String freshIndex, final String docId, final String doc) {
     String rejection = null;
     try {
       searchRepository.getSearchClient().createEntity(freshIndex, docId, doc);
     } catch (final Exception e) {
+      if (isTransportFailure(e)) {
+        throw new ShapeTransportException("PUT to " + freshIndex + " did not complete", e);
+      }
       rejection = describe(e);
       LOG.warn("REJECTED: PUT to {} failed for doc {}: {}", freshIndex, docId, rejection, e);
     }

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/search/shape/ShapeCanary.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/search/shape/ShapeCanary.java
@@ -40,10 +40,14 @@ public final class ShapeCanary {
   public ShapeResult index(
       final String entityType, final EntityInterface entity, final FieldProbe probe) {
     final String docId = entity.getId().toString();
+    // Built before the try: JsonUtils.pojoToJson reports a serialization bug as a
+    // JsonParsingException caused by a JsonProcessingException, which extends IOException -- so
+    // inside the transport handling below it would read as "the engine never answered" and be
+    // retried and skipped, hiding exactly the harness bug buildDoc's contract says must surface.
+    final String doc = buildDoc(entityType, entity);
     final String freshIndex = shadowIndex.create(entityType);
     ShapeResult result;
     try {
-      final String doc = buildDoc(entityType, entity);
       final String rejection = putDoc(freshIndex, docId, doc);
       result =
           rejection != null

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/search/shape/ShapeCanaryTest.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/search/shape/ShapeCanaryTest.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.it.search.shape;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.ProtocolException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The shape canary reports {@link Outcome#REJECTED} when the engine refuses a document. An engine
+ * that never answered has refused nothing, and calling that REJECTED blames the document under test
+ * for a slow cluster — which is how a deadline overrun once surfaced as
+ * "databaseSchema/tags.count/1k must index + be queryable but got REJECTED".
+ */
+class ShapeCanaryTest {
+
+  /** Stands in for the shaded {@code DeadlineTimeoutException} the OpenSearch transport throws. */
+  private static final class DeadlineTimeoutException extends RuntimeException {
+    private DeadlineTimeoutException() {
+      super("Deadline: 2026-09-09T09:04:05.390+0000, -1339 MILLISECONDS overdue");
+    }
+  }
+
+  @Test
+  @DisplayName("A missed request deadline is a transport failure, however deeply it is wrapped")
+  void deadlineOverrunIsTransport() {
+    assertTrue(
+        ShapeCanary.isTransportFailure(
+            new RuntimeException(
+                "error while performing request", new DeadlineTimeoutException())));
+  }
+
+  @Test
+  @DisplayName("A dropped or desynchronised connection is a transport failure")
+  void ioFailureIsTransport() {
+    assertTrue(ShapeCanary.isTransportFailure(new IOException("connection reset")));
+    assertTrue(
+        ShapeCanary.isTransportFailure(
+            new RuntimeException(
+                "GET failed",
+                new ProtocolException("Frame type(34) length(6627898) exceeds MAX_FRAME_SIZE"))));
+  }
+
+  @Test
+  @DisplayName("An engine refusal is not a transport failure — it is the finding under test")
+  void mappingRejectionIsNotTransport() {
+    assertFalse(
+        ShapeCanary.isTransportFailure(
+            new RuntimeException(
+                "Request failed: [mapper_parsing_exception] The number of nested documents has"
+                    + " exceeded the allowed limit of [10000]",
+                new RuntimeException("Request failed: [mapper_parsing_exception]"))));
+  }
+
+  @Test
+  @DisplayName("A cyclic cause chain terminates instead of spinning")
+  void cyclicCauseChainTerminates() {
+    final Throwable inner = new RuntimeException("inner");
+    final Throwable outer = new RuntimeException("outer", inner);
+    inner.initCause(outer);
+    assertFalse(ShapeCanary.isTransportFailure(outer));
+  }
+}

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/EntityShapeIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/EntityShapeIT.java
@@ -13,6 +13,7 @@
 package org.openmetadata.it.tests;
 
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.abort;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.util.Optional;
@@ -29,6 +30,7 @@ import org.openmetadata.it.search.shape.EntityShapeRegistry;
 import org.openmetadata.it.search.shape.Outcome;
 import org.openmetadata.it.search.shape.PlannedCase;
 import org.openmetadata.it.search.shape.ShapeCanary;
+import org.openmetadata.it.search.shape.ShapeCanary.ShapeTransportException;
 import org.openmetadata.it.search.shape.ShapeResult;
 import org.openmetadata.it.util.OssTestServer;
 import org.openmetadata.it.util.SdkClients;
@@ -63,8 +65,7 @@ class EntityShapeIT {
   @ParameterizedTest(name = "{0}")
   @MethodSource("cases")
   void sweep(final PlannedCase plannedCase) {
-    final ShapeResult result =
-        canary.index(plannedCase.entityType(), plannedCase.entity().get(), plannedCase.probe());
+    final ShapeResult result = indexAllowingOneTransportRetry(plannedCase);
     final Outcome observed = result.outcome();
     final Optional<AcceptedLimits.Accepted> accepted =
         AcceptedLimits.find(
@@ -88,5 +89,32 @@ class EntityShapeIT {
               + (result.detail().isBlank() ? "" : " [" + result.detail() + "]")
               + ". Fix the cause, or opt-in via AcceptedLimits if this limit is acceptable.");
     }
+  }
+
+  /**
+   * Ramped cases push multi-megabyte and 10k-nested-object documents at the engine, and a single
+   * case has been measured at over 80s. When the engine misses its deadline the case was never
+   * observed -- it says nothing about whether the shape is indexable -- so retry once and, if the
+   * engine still cannot answer, skip rather than report a limit the run never actually tested.
+   */
+  private ShapeResult indexAllowingOneTransportRetry(final PlannedCase plannedCase) {
+    try {
+      return index(plannedCase);
+    } catch (final ShapeTransportException first) {
+      LOG.warn("{}: engine did not answer, retrying once — {}", plannedCase.label(), first);
+      try {
+        return index(plannedCase);
+      } catch (final ShapeTransportException second) {
+        return abort(
+            plannedCase.label()
+                + " not observed: the search engine did not answer on either attempt ("
+                + second.getMessage()
+                + ")");
+      }
+    }
+  }
+
+  private ShapeResult index(final PlannedCase plannedCase) {
+    return canary.index(plannedCase.entityType(), plannedCase.entity().get(), plannedCase.probe());
   }
 }


### PR DESCRIPTION
### Describe your changes:

Fixes #33050

`EntityShapeIT` failed 3 times in the merge-queue window GitHub still exposes (2026-09-03 → 09-09, 39 failed `merge_group` runs total), twice on 09-09 alone — with two different symptoms from **two different HTTP stacks**:

```
sweep[233]  databaseSchema/tags.count/1k must index + be queryable but got REJECTED
            [RuntimeException: error while performing request | caused by:
             DeadlineTimeoutException: ... -1339 MILLISECONDS overdue]      ← server-side OS client

sweep[58]   SearchClient GET .../openmetadata_topic_search_index_sc_.../_doc/... failed
            Caused by: java.net.ProtocolException:
              Frame type(34) length(6627898) exceeds MAX_FRAME_SIZE(16384)  ← test-side JDK client
```

Both are **latency**, not shape violations. From the failing job log — no circuit breaker, no OOM, no rejection anywhere in it:

```
sweep(PlannedCase)[58] -- Time elapsed: 80.52 s <<< ERROR!
sweep(PlannedCase)[6]  -- Time elapsed: 83.69 s
sweep(PlannedCase)[26] -- Time elapsed: 71.68 s
Tests run: 55, ... Time elapsed: 898.5 s -- in EntityShapeIT
```

The canary deliberately indexes ramped documents (1k tags, 10k nested objects, oversized keywords) while ~15,000 other tests share the same engine container. Four things turn that slowness into a red build, and this PR fixes each:

**1. `ShapeCanary` called every write failure `REJECTED`.** Its `putDoc` javadoc said outright *"We do NOT classify the cause"* — which is precisely why a `DeadlineTimeoutException` was indistinguishable from a `mapper_parsing_exception`. It now makes exactly one distinction: an engine that never answered has refused nothing, so it propagates as `ShapeTransportException` instead of being recorded as a refusal.

**2. `EntityShapeIT` retries such a case once, then skips it.** A case the engine could not answer was never observed either way; failing on it reports a limit the run never actually tested.

**3. `SearchClient` used the JDK default HTTP/2.** `jdk.internal.net.http.Http2Connection.processFrame` is in the `sweep[58]` stack, so h2 was genuinely in use against OpenSearch's HTTP/1.1-only cleartext REST API. Frame type 34 is not a valid HTTP/2 frame type — the decoder was reading off a desynchronised connection. Pinned to HTTP/1.1, which is all ES and OpenSearch speak; the h2c upgrade bought nothing and made the failure unreadable.

**4. `SearchClient.TIMEOUT` was only a `connectTimeout`.** No request carried a response deadline, so the exchange above ran unbounded for 80s. One `request(path)` builder now applies it to every request.

**Plus: `EntityShapeIT` moves to the `global-state` lane.** It runs in `parallel` today (`grep -c EntityShapeIT pom.xml` → 0), competing for the engine with ~15,000 tests, despite declaring `@Execution(SAME_THREAD)` — which only serialises its own methods. Wall clock is unaffected: lanes are separate jobs, and on run 34338224150 they measured **parallel 30min, multi-node 9min, global-state 8min**, so moving ~15min of canary out of the critical path and into the 8min lane leaves `parallel` longest either way.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- A search-engine deadline overrun during a shape probe is retried, and skipped if it recurs, instead of being reported as a shape rejection
- An engine refusal (`mapper_parsing_exception`) is still reported as `REJECTED` — the finding the suite exists to catch
- A shape probe whose HTTP exchange stalls fails at the 30s deadline with a readable message, not after 80s with a protocol error

#### Unit tests
- [x] Added `openmetadata-integration-tests/.../search/shape/ShapeCanaryTest.java` (4 tests) covering the transport-vs-refusal classification: deadline overrun, dropped/desynchronised connection, `mapper_parsing_exception` (must stay a refusal), and a cyclic cause chain terminating.

```
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0 -- ShapeCanaryTest
```

#### Backend integration tests
- [x] Not applicable — no API or production-code change; this is entirely IT-harness behaviour. `EntityShapeIT` itself is the integration coverage and still runs on every backend PR, in `global-state` instead of `parallel`.

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. `mvn -pl openmetadata-integration-tests test -Dtest=ShapeCanaryTest` → 4/4 pass
2. `mvn -pl openmetadata-integration-tests test-compile` → BUILD SUCCESS (493 sources)
3. `mvn -pl openmetadata-integration-tests spotless:apply` → clean
4. Parsed the pom and asserted lane membership structurally: `EntityShapeIT` is in the `<includes>` of all 8 `isolated-tests` executions and the `<excludes>` of all 8 `parallel-tests` executions, across every DB/search profile
5. `mvn -DintegrationTests.lane=global-state help:evaluate -Dexpression=it.test` → resolves to the global-state list now ending in `EntityShapeIT`

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. (No schema changes.)
- [x] For UI changes: I attached a screen recording and/or screenshots above. (No UI changes.)
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
