### PR TITLE
Backport #31441 to 1.13: report Tableau source tables whose names are hidden from the ingestion account

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/client.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/client.py
@@ -46,6 +46,13 @@ from metadata.utils.ssl_manager import SSLManager
 
 logger = ometa_logger()
 
+# GetSourceTables samples a few workbooks rather than reading the whole site. Every test
+# connection step shares one timeout, so the sample is capped. Breadth matters more than
+# depth here: the first workbook is often a sample one over a spreadsheet, whose names are
+# readable even when every database asset is withheld.
+SOURCE_TABLE_SAMPLE_PAGE_SIZE = 50
+MAX_SAMPLED_WORKBOOKS = 3
+
 
 class TableauWorkBookException(Exception):
     """
@@ -68,6 +75,16 @@ class TableauOwnersNotFound(Exception):
 class TableauDataModelsException(Exception):
     """
     Raise when Data Source information is not retrieved from the Tableau Graphql Query
+    """
+
+
+class TableauUpstreamTablesRedacted(Exception):  # noqa: N818
+    """
+    Raise when the Metadata API returns a source table with its name withheld.
+
+    Tableau does not omit assets the account may not read. It returns them with the table
+    and database names nulled and only the identifiers left, so the table cannot be
+    resolved and its lineage is silently dropped for the whole run.
     """
 
 
@@ -317,6 +334,65 @@ class TableauClient:
             "https://help.tableau.com/current/api/metadata_api/en-us/docs/meta_api_start.html"
             "#enable-the-tableau-metadata-api-for-tableau-server\n"
         )
+
+    def _withheld_source_tables(self, workbook_id: str) -> List[str]:  # noqa: UP006
+        """
+        Names of the data sources on a workbook whose upstream tables cannot be resolved.
+
+        Mirrors _get_database_tables: a table with no name is still resolved through its
+        referencedByQueries, so only a table with neither is lineage that cannot be built.
+        """
+        datasources = self._query_datasources(
+            dashboard_id=workbook_id,
+            entities_per_page=SOURCE_TABLE_SAMPLE_PAGE_SIZE,
+            offset=0,
+        )
+        withheld = []
+        for datasource in (datasources.nodes if datasources else None) or []:
+            withheld.extend(
+                datasource.name or datasource.id
+                for table in datasource.upstreamTables or []
+                if not table.name and not table.referencedByQueries
+            )
+        return withheld
+
+    def test_get_source_tables(self):
+        """
+        Check that the Metadata API returns usable source tables.
+
+        Tableau withholds table and database names from accounts without Catalog
+        permissions on external assets, returning the table objects with only their
+        identifiers. Lineage to those tables cannot be built, so this is worth catching at
+        connection time instead of after a run that looks successful.
+
+        View is granted per external asset, so one withheld table is already lost lineage
+        even when others are readable. Reports the first sampled workbook that has one.
+
+        Passes when there is nothing to judge, meaning no sampled workbook declares a
+        source table at all, which is normal for file backed data sources.
+        """
+        sampled = 0
+
+        for workbook in Pager(self.tableau_server.workbooks):
+            if sampled >= MAX_SAMPLED_WORKBOOKS:
+                break
+            if workbook.id is None:
+                continue
+            sampled += 1
+
+            withheld = self._withheld_source_tables(workbook.id)
+            if withheld:
+                raise TableauUpstreamTablesRedacted(
+                    f"Tableau returned {len(withheld)} source table(s) with no name in workbook "
+                    f"[{workbook.name}], for data source(s): {', '.join(sorted(set(withheld))[:5])}"
+                )
+
+        if not sampled:
+            raise TableauWorkBookException(
+                "Unable to fetch Dashboards from tableau\n"
+                "Please check if the user has permissions to access the Dashboards information"
+            )
+        return True
 
     def _query_datasources(
         self, dashboard_id: str, entities_per_page: int, offset: int

--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/connection.py
@@ -126,6 +126,7 @@ def test_connection(
         "GetViews": client.test_get_workbook_views,
         "GetOwners": client.test_get_owners,
         "GetDataModels": client.test_get_datamodels,
+        "GetSourceTables": client.test_get_source_tables,
     }
 
     return test_connection_steps(

--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
@@ -526,6 +526,19 @@ class TableauSource(DashboardServiceSource):
             )
             for table in datamodel.upstreamTables or []:
                 om_tables = self._get_database_tables(db_service_prefix, table)
+                if not om_tables and not table.name:
+                    # Tableau withholds table and database names from accounts without
+                    # Catalog permissions and leaves only the identifiers, so there is
+                    # nothing left to look the table up by. The GetSourceTables check
+                    # runs at the start of every ingestion as well as from Test Connection,
+                    # and reports the cause once per run, so this only records which data
+                    # models lost their upstream.
+                    logger.debug(
+                        "Could not build lineage for data model [%s]. Tableau did not return a "
+                        "name for its source table [%s].",
+                        model_str(upstream_data_model_entity.fullyQualifiedName),
+                        table.luid or table.id,
+                    )
                 for om_table_and_query in om_tables or []:
                     column_lineage = self._get_column_lineage(
                         table,

--- a/ingestion/tests/unit/topology/dashboard/test_tableau_redacted_upstream.py
+++ b/ingestion/tests/unit/topology/dashboard/test_tableau_redacted_upstream.py
@@ -1,0 +1,195 @@
+#  Copyright 2026 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Tableau withholds source table metadata from accounts without Catalog permissions.
+
+The Metadata API still returns the `upstreamTables` objects and keeps `id` and `luid`, but
+nulls `name`, `fullName`, `schema` and `database.name`. Nothing can be resolved from that,
+so lineage is empty for those tables while the run itself reports complete success.
+
+The payloads below were captured from Tableau for one workbook and table, queried once as a
+site admin and once as an Explorer.
+"""
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from metadata.ingestion.source.dashboard.tableau.client import (
+    MAX_SAMPLED_WORKBOOKS,
+    TableauClient,
+    TableauUpstreamTablesRedacted,
+    TableauWorkBookException,
+)
+from metadata.ingestion.source.dashboard.tableau.models import (
+    DataSource,
+    TableauDatasources,
+)
+
+CLIENT_MODULE = "metadata.ingestion.source.dashboard.tableau.client"
+
+# Captured live: what a site admin sees.
+VISIBLE_TABLE = {
+    "id": "b3ef7314-b9e5-900e-2869-41d858ab17a8",
+    "luid": "b127038f-754c-48d0-892a-0ced6335f710",
+    "name": "rpt_repro_transfer_out_mv",
+    "fullName": "[reporting_prod].[finance].[rpt_repro_transfer_out_mv]",
+    "schema": "finance",
+    "database": {"id": "0f9b1efd-b968-d24c-f5e1-b3788b993cbe", "name": "reporting_prod"},
+}
+
+# Captured live: the same table, same workbook, seen by a restricted account.
+REDACTED_TABLE = {
+    "id": "b3ef7314-b9e5-900e-2869-41d858ab17a8",
+    "luid": "b127038f-754c-48d0-892a-0ced6335f710",
+    "name": None,
+    "fullName": None,
+    "schema": None,
+    "database": {"id": "0f9b1efd-b968-d24c-f5e1-b3788b993cbe", "name": None},
+}
+
+# A custom SQL data source. The name is withheld the same way, but the query survives, and
+# _get_database_tables resolves the table from it, so no lineage is lost.
+QUERY_BACKED_TABLE = {
+    **REDACTED_TABLE,
+    "referencedByQueries": [
+        {"id": "0f5a1c22-9d3e-4b71-8c6a-2e4f7b90d135", "name": "Custom SQL Query", "query": "SELECT 1"}
+    ],
+}
+
+# Captured live: a sample workbook over a spreadsheet. An Explorer reads these names even
+# when every database asset on the same site is withheld.
+SPREADSHEET_TABLE = {
+    "id": "5c9d2e77-1f4a-4a55-9a41-2a6f0b8d3c11",
+    "luid": "7a1c3f90-6d2b-4e88-b0f4-95c7e2a41d63",
+    "name": "Orders",
+    "fullName": "[Sample - Superstore.xlsx].[Orders]",
+    "schema": None,
+    "database": {"id": "c41a7f65-3b2e-4d19-8f7a-1e5b9c0d2a48", "name": "Sample - Superstore.xlsx"},
+}
+
+
+@contextmanager
+def fake_site(workbooks):
+    """A TableauClient over a fake site. `workbooks` is [(name, datasources)] in Pager order."""
+    with patch.object(TableauClient, "__init__", return_value=None):
+        client = TableauClient()
+    client.tableau_server = MagicMock()
+    client._query_datasources = MagicMock(side_effect=[datasources for _, datasources in workbooks])
+
+    items = []
+    for index, (workbook_name, _) in enumerate(workbooks):
+        item = MagicMock(id=f"wb-{index}")
+        item.name = workbook_name
+        items.append(item)
+
+    with patch(f"{CLIENT_MODULE}.Pager", return_value=items):
+        yield client
+
+
+def datasources_with(tables, name="rpt_repro_transfer_out_mv (reporting_prod.finance)"):
+    return TableauDatasources(
+        nodes=[DataSource(id="ds-1", name=name, upstreamTables=tables)],
+        totalCount=1,
+    )
+
+
+class TestGetSourceTablesCheck:
+    def test_withheld_name_fails_the_check(self):
+        """
+        The whole point: lineage that cannot be built must not look healthy. The message
+        has to name the data source and workbook, because the table has nothing left to
+        identify it by.
+        """
+        with (
+            fake_site([("Repro Databricks Lineage", datasources_with([REDACTED_TABLE]))]) as client,
+            pytest.raises(TableauUpstreamTablesRedacted) as excinfo,
+        ):
+            client.test_get_source_tables()
+
+        message = str(excinfo.value)
+        assert "no name" in message
+        assert "Repro Databricks Lineage" in message
+        assert "rpt_repro_transfer_out_mv (reporting_prod.finance)" in message, (
+            "an operator needs to know which data source is affected"
+        )
+
+    def test_named_tables_pass(self):
+        with fake_site([("Repro", datasources_with([VISIBLE_TABLE]))]) as client:
+            assert client.test_get_source_tables() is True
+
+    def test_a_withheld_name_with_a_query_fallback_passes(self):
+        """
+        _get_database_tables resolves a nameless table through its referencedByQueries and
+        the SQL lineage parser, so that table is not lost and there is nothing to report.
+        """
+        with fake_site([("Custom SQL", datasources_with([QUERY_BACKED_TABLE]))]) as client:
+            assert client.test_get_source_tables() is True
+
+    def test_no_upstream_tables_passes(self):
+        """
+        A workbook over an extract declares no source tables. There is nothing to judge,
+        so this must not be reported as a permissions problem.
+        """
+        with fake_site([("Extract only", datasources_with([]))]) as client:
+            assert client.test_get_source_tables() is True
+
+    def test_a_readable_name_does_not_excuse_a_withheld_one(self):
+        """
+        View is granted per external asset, so a readable table proves nothing about the
+        one next to it. The withheld table is lost lineage either way.
+        """
+        with (
+            fake_site([("Mixed", datasources_with([VISIBLE_TABLE, REDACTED_TABLE]))]) as client,
+            pytest.raises(TableauUpstreamTablesRedacted),
+        ):
+            client.test_get_source_tables()
+
+    def test_a_spreadsheet_workbook_does_not_hide_a_later_blackout(self):
+        """
+        Observed live: an Explorer passed this check because the first workbook the API
+        returned was a sample one over a spreadsheet, whose names it could read, while the
+        Databricks backed workbook behind it was fully withheld. Sampling only the first
+        workbook reported a healthy connection for an account that builds no lineage.
+        """
+        with (
+            fake_site(
+                [
+                    ("Superstore", datasources_with([SPREADSHEET_TABLE], name="Sample - Superstore")),
+                    ("Repro Databricks Lineage", datasources_with([REDACTED_TABLE])),
+                ]
+            ) as client,
+            pytest.raises(TableauUpstreamTablesRedacted) as excinfo,
+        ):
+            client.test_get_source_tables()
+
+        assert "Repro Databricks Lineage" in str(excinfo.value)
+
+    def test_the_sample_is_capped(self):
+        """
+        Every test connection step shares one timeout, so a large site must not be read to
+        the end just to confirm a healthy connection.
+        """
+        healthy = [(f"wb-{n}", datasources_with([VISIBLE_TABLE])) for n in range(50)]
+
+        with fake_site(healthy) as client:
+            assert client.test_get_source_tables() is True
+            assert client._query_datasources.call_count == MAX_SAMPLED_WORKBOOKS
+
+    def test_no_datasources_passes(self):
+        with fake_site([("Empty", None)]) as client:
+            assert client.test_get_source_tables() is True
+
+    def test_no_workbooks_raises(self):
+        with fake_site([]) as client, pytest.raises(TableauWorkBookException):
+            client.test_get_source_tables()

--- a/openmetadata-service/src/main/resources/json/data/testConnections/dashboard/tableau.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/dashboard/tableau.json
@@ -45,6 +45,12 @@
       "description": "Validate if the Data Sources(Data Models) information is retrieved for Workbooks",
       "errorMessage": "Failed to fetch Workbook Data Sources, please validate if user has access to fetch Data Sources and Metadata API is enabled for tableau server",
       "mandatory": false
+    },
+    {
+      "name": "GetSourceTables",
+      "description": "Validate if the source tables behind a Data Source are named. Tableau hides table and database names from accounts without Tableau Catalog permissions, which drops the lineage for those tables.",
+      "errorMessage": "Failed to read the names of one or more source tables, please validate if user has the View capability on those external assets in Tableau Catalog. Data Sources and Dashboards are still ingested, but lineage cannot be built for the tables the account cannot see",
+      "mandatory": false
     }
   ]
 }


### PR DESCRIPTION
Backport of #31441.

Tableau returns `upstreamTables` with `name`, `fullName`, `schema` and `database.name` nulled when the account cannot read those assets in Tableau Catalog. Nothing can be resolved from that, so table to data model lineage is empty for the whole run while the run reports 100% success and logs nothing.

Adds a `GetSourceTables` test connection step that reports source tables whose names are withheld, so the cause is visible before an ingestion is ever run, plus a debug log naming the data model that lost its upstream.

## Conflict resolution

`1.13` predates the test connection refactor, so three files conflicted.

- `ingestion/src/metadata/core/connections/test_connection/checks/dashboard.py` does not exist on this branch, so the `DashboardStep.GetSourceTables` enum entry was dropped.
- `ingestion/tests/unit/source/dashboard/tableau/test_connection.py` does not exist on this branch and was dropped. The new test landed at `ingestion/tests/unit/topology/dashboard/test_tableau_redacted_upstream.py`, which is where Tableau tests live here.
- `connection.py` declares steps as a `test_fn` dict rather than the `@check(DashboardStep...)` decorator used on `main`, and this branch has no `ErrorPack`. It therefore gains a single dict entry, `"GetSourceTables": client.test_get_source_tables`, in place of the `ErrorPack` diagnosis and the `TableauChecks.get_source_tables` method.

The `client.py` and `metadata.py` hunks are byte-identical to `main`, and no formatter was run.

## Tests

Ran in a dedicated worktree with its own venv and generated models.

- `test_tableau_redacted_upstream.py`, `test_tableau.py`, `test_tableau_client.py`: 59 passed
- full `ingestion/tests/unit/topology/dashboard/`: 594 passed

Also verified directly that `GetSourceTables` is wired into `test_fn` and that the seed `tableau.json` step names match the connector, since the test that asserts the step set does not exist on this branch.
