### PR TITLE
fix(playwright): stabilize 8 merge-queue flaky tests (last-5h window)

### DIFF
--- a/.github/playwright/impact-map.generated.json
+++ b/.github/playwright/impact-map.generated.json
@@ -1758,7 +1758,8 @@
         "playwright/e2e/Features/Topic.spec.ts",
         "playwright/e2e/Flow/SchemaTable.spec.ts",
         "playwright/e2e/Pages/Entity.spec.ts",
-        "playwright/e2e/Pages/ExploreTree.spec.ts"
+        "playwright/e2e/Pages/ExploreTree.spec.ts",
+        "playwright/e2e/Pages/TasksUIFlow.spec.ts"
       ]
     },
     {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/GlobalPageSize.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/GlobalPageSize.spec.ts
@@ -44,15 +44,25 @@ test.describe('Table & Data Model columns table pagination', () => {
 
     await waitForAllLoadersToDisappear(page);
 
-    // Go to Explore Page
+    // Go to Explore Page — its first search runs at the persisted page size,
+    // so wait for that size=25 response to settle before reading the value
+    // back off the dropdown, otherwise the assertion can race the search and
+    // read the pre-hydration default.
+    const exploreSearchAt25 = page.waitForResponse(
+      (res) =>
+        res.url().includes('/search/query') &&
+        new URL(res.url()).searchParams.get('size') === '25'
+    );
     await sidebarClick(page, SidebarItem.EXPLORE);
+    await exploreSearchAt25;
 
     await waitForAllLoadersToDisappear(page);
 
     const rowsPerPageDropdown = page.getByTestId('rows-per-page-dropdown');
     await expect(rowsPerPageDropdown.locator('p').first()).toHaveText('25');
 
-    // Change page size to 50
+    // Change page size to 50, then wait for the size=50 search to settle so the
+    // persisted globalPageSize is committed before navigating to the next page.
     const option50 = page.getByTestId('rows-per-page-option-50');
     await expect(async () => {
       if (
@@ -62,7 +72,13 @@ test.describe('Table & Data Model columns table pagination', () => {
       }
       await expect(option50).toBeVisible();
     }).toPass({ timeout: 15000 });
+    const exploreSearchAt50 = page.waitForResponse(
+      (res) =>
+        res.url().includes('/search/query') &&
+        new URL(res.url()).searchParams.get('size') === '50'
+    );
     await option50.click();
+    await exploreSearchAt50;
     await waitForAllLoadersToDisappear(page);
 
     // Go to Users Page

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LandingPageWidgets/DomainDataProductsWidgets.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LandingPageWidgets/DomainDataProductsWidgets.spec.ts
@@ -37,7 +37,10 @@ import {
   selectDomain,
 } from '../../../utils/domain';
 import { waitForAllLoadersToDisappear } from '../../../utils/entity';
-import { waitForEntitySearchable } from '../../../utils/search';
+import {
+  waitForDomainAssetCount,
+  waitForEntitySearchable,
+} from '../../../utils/search';
 import { sidebarClick } from '../../../utils/sidebar';
 
 const adminUser = new UserClass();
@@ -203,6 +206,7 @@ test.describe.serial('Domain and Data Product Asset Counts', () => {
   test('Domain asset count should update when assets are removed', async ({
     page,
   }) => {
+    test.slow();
     await redirectToHomePage(page);
     await waitForAllLoadersToDisappear(page);
     await sidebarClick(page, SidebarItem.DOMAIN);
@@ -234,6 +238,16 @@ test.describe.serial('Domain and Data Product Asset Counts', () => {
       .getByTestId('save-button')
       .click();
     await removeRes;
+
+    // The remove mutation returns before Elasticsearch is refreshed, and both
+    // the assets-tab badge and the landing-page widget read the count exactly
+    // once per page load. Wait for the search index to reflect the removal
+    // before reloading so those single-shot reads snapshot the updated count.
+    await waitForDomainAssetCount(
+      page,
+      domain.responseData.fullyQualifiedName ?? domain.data.name,
+      1
+    );
 
     await page.reload();
     await checkAssetsCount(page, 1);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaAIContext.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaAIContext.spec.ts
@@ -13,23 +13,23 @@
 import { Locator, Page, Request, Route } from '@playwright/test';
 import { EntityType } from '../../../src/enums/entity.enum';
 import {
-    CacheState,
-    ContextRule,
-    ContextSection,
-    PersonaContextDefinition
+  CacheState,
+  ContextRule,
+  ContextSection,
+  PersonaContextDefinition,
 } from '../../../src/generated/type/personaContextDefinition';
 import { DatabaseServiceClass } from '../../support/entity/service/DatabaseServiceClass';
 import { expect, test } from '../../support/fixtures/userPages';
 import { PersonaClass } from '../../support/persona/PersonaClass';
 import { selectOption } from '../../utils/advancedSearch';
 import {
-    getDefaultAdminAPIContext,
-    selectOptionWithRetry,
-    toastNotification
+  getDefaultAdminAPIContext,
+  selectOptionWithRetry,
+  toastNotification,
 } from '../../utils/common';
 import {
-    enablePersonaRulePreloading,
-    openPersonaAIContext
+  enablePersonaRulePreloading,
+  openPersonaAIContext,
 } from '../../utils/personaAIContext';
 
 const persona = new PersonaClass();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaAIContext.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaAIContext.spec.ts
@@ -13,22 +13,23 @@
 import { Locator, Page, Request, Route } from '@playwright/test';
 import { EntityType } from '../../../src/enums/entity.enum';
 import {
-  CacheState,
-  ContextRule,
-  ContextSection,
-  PersonaContextDefinition,
+    CacheState,
+    ContextRule,
+    ContextSection,
+    PersonaContextDefinition
 } from '../../../src/generated/type/personaContextDefinition';
 import { DatabaseServiceClass } from '../../support/entity/service/DatabaseServiceClass';
 import { expect, test } from '../../support/fixtures/userPages';
 import { PersonaClass } from '../../support/persona/PersonaClass';
 import { selectOption } from '../../utils/advancedSearch';
 import {
-  getDefaultAdminAPIContext,
-  toastNotification,
+    getDefaultAdminAPIContext,
+    selectOptionWithRetry,
+    toastNotification
 } from '../../utils/common';
 import {
-  enablePersonaRulePreloading,
-  openPersonaAIContext,
+    enablePersonaRulePreloading,
+    openPersonaAIContext
 } from '../../utils/personaAIContext';
 
 const persona = new PersonaClass();
@@ -1503,11 +1504,15 @@ test.describe.serial('Persona AI Context', () => {
     await expect(exploreLink).toHaveAttribute('href', /\/explore\/tables/);
 
     // Switch to Glossary Term — href must change to the glossaries tab.
-    await adminPage.getByTestId('context-rule-entity-type').click();
-    await adminPage
-      .getByRole('listbox')
-      .getByText('Glossary Term', { exact: true })
-      .click();
+    // react-aria can close the listbox mid-click and detach the option, dropping
+    // the selection so the entity type never changes and the href stays on
+    // /explore/tables — the source of this test's flakiness. selectOptionWithRetry
+    // re-resolves the trigger's expanded state and reopens the popover before
+    // retrying the option click.
+    await selectOptionWithRetry(
+      adminPage.getByTestId('context-rule-entity-type'),
+      adminPage.getByRole('listbox').getByText('Glossary Term', { exact: true })
+    );
     await expect(exploreLink).toHaveAttribute('href', /\/explore\/glossaries/);
 
     await adminPage.keyboard.press('Escape');

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaAIContextRules.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaAIContextRules.spec.ts
@@ -37,8 +37,8 @@ import { performAdminLogin } from '../../utils/admin';
 import { selectOption } from '../../utils/advancedSearch';
 import { selectOptionWithRetry, toastNotification } from '../../utils/common';
 import {
-    enablePersonaRulePreloading,
-    openPersonaAIContext
+  enablePersonaRulePreloading,
+  openPersonaAIContext,
 } from '../../utils/personaAIContext';
 
 // ---------------------------------------------------------------------------

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaAIContextRules.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaAIContextRules.spec.ts
@@ -35,10 +35,10 @@ import { PersonaClass } from '../../support/persona/PersonaClass';
 import { AdminClass } from '../../support/user/AdminClass';
 import { performAdminLogin } from '../../utils/admin';
 import { selectOption } from '../../utils/advancedSearch';
-import { toastNotification } from '../../utils/common';
+import { selectOptionWithRetry, toastNotification } from '../../utils/common';
 import {
-  enablePersonaRulePreloading,
-  openPersonaAIContext,
+    enablePersonaRulePreloading,
+    openPersonaAIContext
 } from '../../utils/personaAIContext';
 
 // ---------------------------------------------------------------------------
@@ -337,12 +337,18 @@ test.describe.serial('Persona AI Context — Rule Builder', () => {
       });
 
       await test.step('switch entity type — filter must reset and unblock save', async () => {
-        await page.getByTestId('context-rule-entity-type').click();
-        await page
-          .getByRole('listbox')
-          .getByRole('option', { name: /metric/i })
-          .first()
-          .click();
+        // react-aria can close the listbox mid-click and detach the option,
+        // dropping the selection so the filter is never reset and the save stays
+        // blocked — the source of this test's flakiness. selectOptionWithRetry
+        // re-resolves the trigger's expanded state and reopens the popover before
+        // retrying the option click.
+        await selectOptionWithRetry(
+          page.getByTestId('context-rule-entity-type'),
+          page
+            .getByRole('listbox')
+            .getByRole('option', { name: /metric/i })
+            .first()
+        );
         await saveRule(page);
         await toastNotification(page, /AI context rule saved\./);
       });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/CustomizeWidgets.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/CustomizeWidgets.spec.ts
@@ -463,26 +463,20 @@ test('KPI Widget', async ({ page, persona }) => {
 
     await expect(kpiWidgetContent).toBeVisible();
 
-    // Check if there's either a chart or empty state
-    const hasChart = await widget
-      .locator('.recharts-responsive-container')
-      .isVisible()
-      .catch(() => false);
+    // The KPI widget settles into exactly one terminal state — a rendered chart
+    // or an empty state — and both mount a frame or two after the skeleton
+    // clears (recharts measures its container on a debounced ResizeObserver
+    // tick before it paints). Reading `isVisible()` the instant the skeleton
+    // disappears can observe neither node yet and fail a run that just needed
+    // one more frame, so wait for whichever one arrives with a web-first
+    // assertion instead of a pair of point-in-time reads.
+    const kpiChart = widget.locator('.recharts-responsive-container');
+    const kpiEmptyState = widget.locator('[data-testid="widget-empty-state"]');
 
-    const hasEmptyState = await widget
-      .locator('[data-testid="widget-empty-state"]')
-      .isVisible()
-      .catch(() => false);
+    await expect(kpiChart.or(kpiEmptyState)).toBeVisible();
 
-    expect(hasChart || hasEmptyState).toBeTruthy();
-
-    if (hasChart) {
-      // If chart exists, verify it's rendered properly
-      await expect(
-        widget.locator('.recharts-responsive-container')
-      ).toBeVisible();
-
-      // Verify chart elements are present
+    if (await kpiChart.isVisible()) {
+      // Chart rendered — verify its area path painted too.
       await expect(widget.locator('.recharts-area')).toBeVisible();
     }
   });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/IngestionBot.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/IngestionBot.spec.ts
@@ -15,7 +15,7 @@ import { SidebarItem } from '../../constant/sidebar';
 import { Domain } from '../../support/domain/Domain';
 import { expect, test as base } from '../../support/fixtures/base';
 import { performAdminLogin } from '../../utils/admin';
-import { redirectToHomePage } from '../../utils/common';
+import { getApiContext, redirectToHomePage } from '../../utils/common';
 import {
   addAssetsToDomain,
   addServicesToDomain,
@@ -23,6 +23,7 @@ import {
   setupAssetsForDomain,
 } from '../../utils/domain';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
+import { waitForSearchIndexed } from '../../utils/polling';
 import { visitServiceDetailsPage } from '../../utils/service';
 import { sidebarClick } from '../../utils/sidebar';
 import { setToken } from '../../utils/tokenStorage';
@@ -104,6 +105,24 @@ test.describe('Ingestion Bot ', () => {
     const { assets: domainAsset2, assetCleanup: assetCleanup2 } =
       await setupAssetsForDomain(page);
 
+    // setupAssetsForDomain creates these assets over the REST API, and their
+    // Elasticsearch indexing is eventually consistent. addAssetsToDomain drives
+    // the search-backed asset-selection modal, so gate on indexing first —
+    // otherwise the modal search returns no rows and the row check() waits out
+    // the whole test timeout, ejecting the test from the merge queue.
+    const { apiContext, afterAction: disposeApiContext } = await getApiContext(
+      page
+    );
+    await Promise.all(
+      [...domainAsset1, ...domainAsset2].map((asset) =>
+        waitForSearchIndexed(
+          apiContext,
+          asset.entityResponseData.fullyQualifiedName,
+          'all'
+        )
+      )
+    );
+
     await test.step('Assign assets to domains', async () => {
       // Add assets to domain 1
       await sidebarClick(page, SidebarItem.DOMAIN);
@@ -181,5 +200,6 @@ test.describe('Ingestion Bot ', () => {
 
     await assetCleanup1();
     await assetCleanup2();
+    await disposeApiContext();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/MetricListSearch.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/MetricListSearch.spec.ts
@@ -101,7 +101,6 @@ test.describe('Metric List Page - Search', { tag: ['@Discovery'] }, () => {
     await expect(searchInput).toBeVisible();
 
     await expect(page.getByTestId('metric-name').first()).toBeVisible();
-    const initialCount = await page.getByTestId('metric-name').count();
 
     await test.step('search fires a scoped metric query and narrows the results', async () => {
       // The debounced search must actually reach the API. Regression #29538
@@ -142,13 +141,20 @@ test.describe('Metric List Page - Search', { tag: ['@Discovery'] }, () => {
 
       await searchInput.fill('');
 
-      await clearResponse;
+      const clearHttpResponse = await clearResponse;
+      const clearData: { hits?: { hits?: unknown[] } } =
+        await clearHttpResponse.json();
       await waitForAllLoadersToDisappear(page);
 
-      // The list is paginated — specific names may not be on page 1 after
-      // the full list is restored. Verify restoration by checking the visible
-      // row count on the current page is back to the pre-search count.
-      await expect(page.getByTestId('metric-name')).toHaveCount(initialCount);
+      // Derive the restored row count from the clear response that repopulates
+      // the table, never from a snapshot taken before the search. Parallel
+      // specs mutate the shared metric index, so a pre-search count drifts by
+      // the time the full list is restored — the source of this step's flake.
+      // The table renders exactly the hits this response returns for the
+      // current (first) page.
+      await expect(page.getByTestId('metric-name')).toHaveCount(
+        clearData.hits?.hits?.length ?? 0
+      );
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/PageObject/Explore/OverviewPageObject.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/PageObject/Explore/OverviewPageObject.ts
@@ -700,7 +700,11 @@ export class OverviewPageObject extends RightPanelBase {
 
     await expect(this.selectOwnerTabsLoader).toHaveCount(0);
 
-    return this.page.getByTitle(ownerName);
+    // Scope to the owner selection dropdown, not the whole page: a page-wide
+    // getByTitle also matches the entity's still-assigned owner chip in the
+    // panel, whose removal after the user hard-delete is eventually consistent
+    // and independent of this search-backed dropdown — the deleted-entity flake.
+    return this.selectOwnerTabs.getByTitle(ownerName);
   }
 
   /**
@@ -729,7 +733,11 @@ export class OverviewPageObject extends RightPanelBase {
       .getByTestId('loader')
       .waitFor({ state: 'detached' });
 
-    return this.page.getByTitle(tagName);
+    // Scope to the tag selection dropdown, not the whole page: a page-wide
+    // getByTitle also matches the entity's still-assigned tag chip in the panel,
+    // whose removal after the tag hard-delete is eventually consistent and
+    // independent of this search-backed dropdown — the deleted-entity flake.
+    return this.selectableList.getByTitle(tagName);
   }
 
   /**
@@ -760,7 +768,11 @@ export class OverviewPageObject extends RightPanelBase {
       .getByTestId('loader')
       .waitFor({ state: 'detached' });
 
-    return this.page.getByTitle(termName);
+    // Scope to the glossary-term selection dropdown, not the whole page: a
+    // page-wide getByTitle also matches the entity's still-assigned term chip in
+    // the panel, whose removal after the term hard-delete is eventually
+    // consistent and independent of this search-backed dropdown — the flake.
+    return this.selectableList.getByTitle(termName);
   }
 
   // ============ HELPER METHODS ============

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TasksUIFlow.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TasksUIFlow.spec.ts
@@ -129,11 +129,25 @@ const createTagTaskViaUI = async (
 // task creation navigates it returned false before the card had painted. The
 // click was then skipped and the resolve step ran against whatever panel was
 // open — the source of this spec's intermittent failures. Wait for the card.
+//
+// The remaining race: clicking the card is the ONLY thing that mounts the task
+// detail panel — selectedTask is set solely in ActivityFeedTab's handleTaskClick,
+// there is no auto-selection. A click that lands while the feed list is still
+// re-rendering is dropped, the panel never opens, and the downstream
+// approve/close helpers then wait out their full timeout on buttons that never
+// appear (fails, passes on retry). Retry the click until the detail panel
+// (#task-panel → [data-testid="task-tab"]) is actually mounted before returning.
 const openFirstTaskCard = async (page: Page) => {
   const taskCard = page.locator('[data-testid="task-feed-card"]').first();
+  const taskDetailTab = page.locator('[data-testid="task-tab"]');
 
   await expect(taskCard).toBeVisible({ timeout: 30_000 });
-  await taskCard.click();
+
+  await expect(async () => {
+    await taskCard.click();
+    await expect(taskDetailTab).toBeVisible({ timeout: 5_000 });
+  }).toPass({ timeout: 30_000 });
+
   await waitForPageLoaded(page);
 };
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/search.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/search.ts
@@ -65,3 +65,54 @@ export const waitForEntitySearchable = async (
     await afterAction();
   }
 };
+
+/**
+ * Wait until Elasticsearch reflects a domain's asset count via the same
+ * `/api/v1/domains/assets/counts` aggregation the Domains landing-page widget
+ * and the domain detail assets tab read.
+ *
+ * Asset add/remove mutations return before the search index is refreshed, and
+ * every UI surface that shows the count fetches it exactly once per page load
+ * with no background refetch — so a `page.reload()`/navigation issued too soon
+ * snapshots the stale count and the subsequent DOM poll can never recover.
+ * Gating on this API poll guarantees the index has propagated before any UI
+ * read, making the count assertions deterministic.
+ */
+export const waitForDomainAssetCount = async (
+  page: Page,
+  domainFqn: string,
+  expectedCount: number
+) => {
+  const browser = page.context().browser();
+  if (!browser) {
+    throw new Error('Browser instance is not available for admin API search');
+  }
+
+  const { apiContext, afterAction } = await performAdminLogin(browser);
+
+  try {
+    await expect
+      .poll(
+        async () => {
+          const response = await apiContext.get(
+            '/api/v1/domains/assets/counts'
+          );
+
+          if (!response.ok()) {
+            return null;
+          }
+
+          const payload = (await response.json()) as Record<string, number>;
+
+          return payload[domainFqn] ?? null;
+        },
+        {
+          intervals: [1_000, 2_000, 5_000],
+          timeout: 60_000,
+        }
+      )
+      .toBe(expectedCount);
+  } finally {
+    await afterAction();
+  }
+};


### PR DESCRIPTION
### Describe your changes:

<!-- No existing issue; opening this fix directly. -->

Stabilizes eight Playwright tests that flaked (pass-on-retry) or ejected PRs from the merge queue in the last five hours. These are distinct from the click-intercept flakes already handled in #33022 — that PR is on `main` and this branch builds on it (reuses its `selectOptionWithRetry` helper). Each fix targets the concrete race and stays spec-local except one shared helper (`utils/search.ts::waitForDomainAssetCount`).

| Spec | Signal (24h) | Root cause | Fix |
|---|---|---|---|
| `Pages/TasksUIFlow` | 52 flakes | card click dropped during feed re-render → `selectedTask` unset → detail panel never mounts → approve/close buttons time out | retry click under `toPass` until `[data-testid="task-tab"]` visible (`handleTaskClick` is idempotent on re-click) |
| `Pages/ExplorePageRightPanel` (page object) | 7+ flakes + 1 ejection | deleted-entity verify asserted absence with a page-wide `getByTitle`, matching the still-rendered assigned owner/tag/term chip (host-entity search cleanup is eventually consistent, independent of the entity leaving its own index) | scope locators to the selection dropdown (`selectOwnerTabs` / `selectableList`) |
| `Features/GlobalPageSize` | 7 flakes + 2 ejections | `waitForAllLoadersToDisappear` asserts loader count 0, passing before the Explore search loader mounts; assertion + navigation ran while `/search/query` in flight | hoist two `search/query` waiters keyed on exact `size` param (25, then 50) |
| `Features/PersonaAIContext` + `PersonaAIContextRules` | 9 (+2) flakes | react-aria closes the entity-type listbox mid-click and detaches the option, dropping the selection so `href`/filter never updates | `selectOptionWithRetry` (helper from #33022) at both sites |
| `Flow/CustomizeWidgets` | 6+2 flakes | KPI step read the recharts container with point-in-time `isVisible()` before the debounced `ResponsiveContainer` painted | web-first `expect(chart.or(empty)).toBeVisible()` then a settled read |
| `Features/LandingPageWidgets/DomainDataProductsWidgets` | 2 ejections | asset count fetched once per page load with no background refetch, so assertion polls re-read a frozen stale DOM after the remove mutation | gate on `/domains/assets/counts` via `waitForDomainAssetCount` before reload + restore `test.slow()` (dropped for the "removed" tests in ed9c661f20) |
| `Flow/MetricListSearch` | 1 ejection | clear step asserted a pre-search `initialCount` snapshot that drifts — the shared metric index is mutated by ~15 parallel specs and the total sits near the page-size boundary | derive expected restored count from the clear response body (`hits.hits.length`) |
| `Flow/IngestionBot` | 1 ejection | `setupAssetsForDomain` creates assets over REST and returns before ES indexing; the next step's search-backed add-to-domain modal found no rows and `.check()` burned the timeout | wait for all six assets to be searchable (`waitForSearchIndexed`, index `all`) before the first search interaction |

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — test-infra only. One new shared helper (`waitForDomainAssetCount` in `playwright/utils/search.ts`); everything else is spec-local wait/locator corrections. No product code changed.

#
### Tests:

#### Playwright (UI) tests
- [x] The eight listed tests are the changed tests. Fixes follow `.claude/rules/frontend-playwright.md`: no `waitForTimeout`/`networkidle`/`force`/`waitForSelector`/element-handles/new positional locators; response waiters hoisted above their triggering action.

#### Manual testing performed
- `yarn lint:playwright` → 0 errors (214 pre-existing warnings, none in the changed files).
- `eslint-suppressions.json` unchanged (no baseline growth).

#
### UI screen recording / screenshots:

Not applicable (test-only changes; no user-facing UI change).

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added/updated tests covering the exact scenarios being fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)