### PR TITLE
fix(ui): gate Custom Properties settings on type resource permissions

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/SettingsRouter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/SettingsRouter.tsx
@@ -899,7 +899,11 @@ const SettingsRouter = () => {
 
       <Route
         element={
-          <AdminProtectedRoute hasPermission={false}>
+          <AdminProtectedRoute
+            hasPermission={userPermissions.hasViewPermissions(
+              ResourceEntity.TYPE,
+              permissions
+            )}>
             <CustomPropertiesPageV1 />
           </AdminProtectedRoute>
         }

--- a/openmetadata-ui/src/main/resources/ui/src/utils/GlobalSettingsClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/GlobalSettingsClassBase.ts
@@ -701,7 +701,7 @@ class GlobalSettingsClassBase {
             description: t('message.define-custom-property-for-entity', {
               entity: t('label.api-collection'),
             }),
-            isProtected: Boolean(isAdminUser),
+            isProtected: userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions),
             key: `${GlobalSettingsMenuCategory.CUSTOM_PROPERTIES}.${GlobalSettingOptions.API_COLLECTIONS}`,
             icon: APICollectionIcon,
           },
@@ -710,7 +710,7 @@ class GlobalSettingsClassBase {
             description: t('message.define-custom-property-for-entity', {
               entity: t('label.api-endpoint'),
             }),
-            isProtected: Boolean(isAdminUser),
+            isProtected: userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions),
             key: `${GlobalSettingsMenuCategory.CUSTOM_PROPERTIES}.${GlobalSettingOptions.API_ENDPOINTS}`,
             icon: APIEndpointIcon,
           },
@@ -719,7 +719,7 @@ class GlobalSettingsClassBase {
             description: t('message.define-custom-property-for-entity', {
               entity: t('label.data-product'),
             }),
-            isProtected: Boolean(isAdminUser),
+            isProtected: userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions),
             key: `${GlobalSettingsMenuCategory.CUSTOM_PROPERTIES}.${GlobalSettingOptions.DATA_PRODUCT}`,
             icon: DataProductIcon,
           },
@@ -728,7 +728,7 @@ class GlobalSettingsClassBase {
             description: t('message.define-custom-property-for-entity', {
               entity: t('label.dashboard-data-model-plural'),
             }),
-            isProtected: Boolean(isAdminUser),
+            isProtected: userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions),
             key: `${GlobalSettingsMenuCategory.CUSTOM_PROPERTIES}.${GlobalSettingOptions.DASHBOARD_DATA_MODEL}`,
             icon: DashboardDataModelIcon,
           },
@@ -737,7 +737,7 @@ class GlobalSettingsClassBase {
             description: t('message.define-custom-property-for-entity', {
               entity: t('label.database'),
             }),
-            isProtected: Boolean(isAdminUser),
+            isProtected: userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions),
             key: `${GlobalSettingsMenuCategory.CUSTOM_PROPERTIES}.${GlobalSettingOptions.DATABASES}`,
             icon: DatabaseIcon,
           },
@@ -746,7 +746,7 @@ class GlobalSettingsClassBase {
             description: t('message.define-custom-property-for-entity', {
               entity: t('label.database-schema'),
             }),
-            isProtected: Boolean(isAdminUser),
+            isProtected: userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions),
             key: `${GlobalSettingsMenuCategory.CUSTOM_PROPERTIES}.${GlobalSettingOptions.DATABASE_SCHEMA}`,
             icon: SchemaIcon,
           },
@@ -755,7 +755,7 @@ class GlobalSettingsClassBase {
             description: t('message.define-custom-property-for-entity', {
               entity: t('label.metric'),
             }),
-            isProtected: Boolean(isAdminUser),
+            isProtected: userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions),
             key: `${GlobalSettingsMenuCategory.CUSTOM_PROPERTIES}.${GlobalSettingOptions.METRICS}`,
             icon: MetricIcon,
           },
@@ -764,7 +764,7 @@ class GlobalSettingsClassBase {
             description: t('message.define-custom-property-for-entity', {
               entity: t('label.table-plural'),
             }),
-            isProtected: Boolean(isAdminUser),
+            isProtected: userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions),
             key: `${GlobalSettingsMenuCategory.CUSTOM_PROPERTIES}.${GlobalSettingOptions.TABLES}`,
             icon: TableIcon,
           },
@@ -773,7 +773,7 @@ class GlobalSettingsClassBase {
             description: t('message.define-custom-property-for-entity', {
               entity: t('label.stored-procedure-plural'),
             }),
-            isProtected: Boolean(isAdminUser),
+            isProtected: userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions),
             key: `${GlobalSettingsMenuCategory.CUSTOM_PROPERTIES}.${GlobalSettingOptions.STORED_PROCEDURES}`,
             icon: StoredProcedureIcon,
           },
@@ -782,7 +782,7 @@ class GlobalSettingsClassBase {
             description: t('message.define-custom-property-for-entity', {
               entity: t('label.dashboard-plural'),
             }),
-            isProtected: Boolean(isAdminUser),
+            isProtected: userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions),
             key: `${GlobalSettingsMenuCategory.CUSTOM_PROPERTIES}.${GlobalSettingOptions.DASHBOARDS}`,
             icon: DashboardIcon,
           },
@@ -791,7 +791,7 @@ class GlobalSettingsClassBase {
             description: t('message.define-custom-property-for-entity', {
               entity: t('label.pipeline-plural'),
             }),
-            isProtected: Boolean(isAdminUser),
+            isProtected: userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions),
             key: `${GlobalSettingsMenuCategory.CUSTOM_PROPERTIES}.${GlobalSettingOptions.PIPELINES}`,
             icon: PipelineIcon,
           },
@@ -800,7 +800,7 @@ class GlobalSettingsClassBase {
             description: t('message.define-custom-property-for-entity', {
               entity: t('label.topic-plural'),
             }),
-            isProtected: Boolean(isAdminUser),
+            isProtected: userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions),
             key: `${GlobalSettingsMenuCategory.CUSTOM_PROPERTIES}.${GlobalSettingOptions.TOPICS}`,
             icon: MessagingIcon,
           },
@@ -809,7 +809,7 @@ class GlobalSettingsClassBase {
             description: t('message.define-custom-property-for-entity', {
               entity: t('label.container-plural'),
             }),
-            isProtected: Boolean(isAdminUser),
+            isProtected: userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions),
             key: `${GlobalSettingsMenuCategory.CUSTOM_PROPERTIES}.${GlobalSettingOptions.CONTAINERS}`,
             icon: StorageIcon,
           },
@@ -818,7 +818,7 @@ class GlobalSettingsClassBase {
             description: t('message.define-custom-property-for-entity', {
               entity: t('label.ml-model-plural'),
             }),
-            isProtected: Boolean(isAdminUser),
+            isProtected: userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions),
             key: `${GlobalSettingsMenuCategory.CUSTOM_PROPERTIES}.${GlobalSettingOptions.MLMODELS}`,
             icon: MlModelIcon,
           },
@@ -827,14 +827,14 @@ class GlobalSettingsClassBase {
             description: t('message.define-custom-property-for-entity', {
               entity: t('label.search-index-plural'),
             }),
-            isProtected: Boolean(isAdminUser),
+            isProtected: userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions),
             key: `${GlobalSettingsMenuCategory.CUSTOM_PROPERTIES}.${GlobalSettingOptions.SEARCH_INDEXES}`,
             icon: SearchIndexIcon,
           },
           {
             label: t('label.column-plural'),
             description: t('message.define-custom-property-for-column'),
-            isProtected: Boolean(isAdminUser),
+            isProtected: userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions),
             key: `${GlobalSettingsMenuCategory.CUSTOM_PROPERTIES}.${GlobalSettingOptions.COLUMN}`,
             icon: ColumnIcon,
           },
@@ -843,7 +843,7 @@ class GlobalSettingsClassBase {
             description: t('message.define-custom-property-for-entity', {
               entity: t('label.glossary-term'),
             }),
-            isProtected: Boolean(isAdminUser),
+            isProtected: userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions),
             key: `${GlobalSettingsMenuCategory.CUSTOM_PROPERTIES}.${GlobalSettingOptions.GLOSSARY_TERM}`,
             icon: GlossaryIcon,
           },
@@ -852,7 +852,7 @@ class GlobalSettingsClassBase {
             description: t('message.define-custom-property-for-entity', {
               entity: t('label.domain'),
             }),
-            isProtected: Boolean(isAdminUser),
+            isProtected: userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions),
             key: `${GlobalSettingsMenuCategory.CUSTOM_PROPERTIES}.${GlobalSettingOptions.DOMAINS}`,
             icon: DomainIcon,
           },
@@ -861,7 +861,7 @@ class GlobalSettingsClassBase {
             description: t('message.define-custom-property-for-entity', {
               entity: t('label.chart-plural'),
             }),
-            isProtected: Boolean(isAdminUser),
+            isProtected: userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions),
             key: `${GlobalSettingsMenuCategory.CUSTOM_PROPERTIES}.${GlobalSettingOptions.CHARTS}`,
             icon: ChartIcon,
           },
@@ -870,7 +870,7 @@ class GlobalSettingsClassBase {
             description: t('message.define-custom-property-for-entity', {
               entity: t('label.directory-plural'),
             }),
-            isProtected: Boolean(isAdminUser),
+            isProtected: userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions),
             key: `${GlobalSettingsMenuCategory.CUSTOM_PROPERTIES}.${GlobalSettingOptions.DIRECTORIES}`,
             icon: DirectoryIcon,
           },
@@ -879,7 +879,7 @@ class GlobalSettingsClassBase {
             description: t('message.define-custom-property-for-entity', {
               entity: t('label.file-plural'),
             }),
-            isProtected: Boolean(isAdminUser),
+            isProtected: userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions),
             key: `${GlobalSettingsMenuCategory.CUSTOM_PROPERTIES}.${GlobalSettingOptions.FILES}`,
             icon: FileIcon,
           },
@@ -888,7 +888,7 @@ class GlobalSettingsClassBase {
             description: t('message.define-custom-property-for-entity', {
               entity: t('label.spreadsheet-plural'),
             }),
-            isProtected: Boolean(isAdminUser),
+            isProtected: userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions),
             key: `${GlobalSettingsMenuCategory.CUSTOM_PROPERTIES}.${GlobalSettingOptions.SPREADSHEETS}`,
             icon: SpreadsheetIcon,
           },

--- a/openmetadata-ui/src/main/resources/ui/src/utils/GlobalSettingsClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/GlobalSettingsClassBase.ts
@@ -897,7 +897,7 @@ class GlobalSettingsClassBase {
             description: t('message.define-custom-property-for-entity', {
               entity: t('label.worksheet-plural'),
             }),
-            isProtected: Boolean(isAdminUser),
+            isProtected: userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions),
             key: `${GlobalSettingsMenuCategory.CUSTOM_PROPERTIES}.${GlobalSettingOptions.WORKSHEETS}`,
             icon: WorksheetIcon,
           },


### PR DESCRIPTION
### Describe your changes:

Fixes #32413

The Custom Properties settings category in Global Settings was gating all menu items and the route on `isAdminUser`, while the backend authorizes the `type` resource through the policy engine. A non-admin user with a policy granting `Create`/`EditAll`/`ViewAll` on `type` could use the API but couldn't access the UI at all.

Replaces `Boolean(isAdminUser)` with `userPermissions.hasViewPermissions(ResourceEntity.TYPE, permissions)` on all Custom Properties menu items in `GlobalSettingsClassBase.ts` and on the `CustomPropertiesPageV1` route in `SettingsRouter.tsx`, matching the pattern already used for Services, Notifications, Teams, and other settings categories.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — mechanical replacement. `ResourceEntity.TYPE` and `userPermissions.hasViewPermissions` are already imported in both files. The pattern is identical to how `ResourceEntity.DATABASE_SERVICE` gates the Services category in the same function.

#
### Tests:

#### Unit tests
- [x] Not applicable (permission utility already tested; this is wiring)

#### Backend integration tests
- [x] Not applicable

#### Ingestion integration tests
- [x] Not applicable

#### Playwright (UI) tests
- [x] Not added (permission routing; covered by existing GlobalSettings permission tests)

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR is linked to a GitHub issue via `Fixes #32413` above.


<!-- greptile_comment -->

<!-- greptile_summary -->

<details open><summary>Greptile Summary</summary>

This PR replaces administrator-only Custom Properties navigation and route checks with TYPE view-permission checks. The broader access is not fully aligned with the backend's per-entity read and TYPE Create authorization, leaving realistic non-admin permission combinations with inaccessible pages or failing creation actions.

- Gates all Custom Properties menu entries on TYPE view access.
- Allows TYPE viewers through the Custom Properties route.
- Preserves administrator access through `AdminProtectedRoute`.
</details>


<details open><summary>Confidence Score: 3/5</summary>

The PR is not yet safe to merge because newly admitted non-admin users can encounter authorization failures when loading or creating custom properties.

The navigation gate checks TYPE view access, while backend reads require target-resource ViewCustomFields and creation requires TYPE Create; two independently reachable permission combinations therefore produce broken UI flows.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/src/components/AppRouter/SettingsRouter.tsx, openmetadata-ui/src/main/resources/ui/src/utils/GlobalSettingsClassBase.ts
</details>


<details open><summary>Important Files Changed</summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/AppRouter/SettingsRouter.tsx | Broadens Custom Properties route access to TYPE viewers, but that predicate does not cover the permissions enforced by all page operations. |
| openmetadata-ui/src/main/resources/ui/src/utils/GlobalSettingsClassBase.ts | Shows every Custom Properties target under one TYPE-level view check even though reads are authorized per target entity resource. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/custom-prop..."](https://github.com/open-metadata/openmetadata/commit/cfcf8b9d222ca3ad646f79a80b1a2c968852be44) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62135412)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Metadata web application](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/metadata-web-application.md)
- Knowledge Base — [UI foundations](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/ui-foundations.md)

<!-- /greptile_comment -->