### PR TITLE
fix(backend): skip HTML sanitizer for pure-markdown descriptions

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/DescriptionSanitizer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/DescriptionSanitizer.java
@@ -193,7 +193,8 @@ public final class DescriptionSanitizer {
     }
     matcher.appendTail(replaced);
 
-    String sanitized = policy.sanitize(replaced.toString());
+    String toSanitize = replaced.toString();
+    String sanitized = toSanitize.contains("<") ? policy.sanitize(toSanitize) : toSanitize;
 
     for (int i = 0; i < entityLinks.size(); i++) {
       sanitized =

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/DescriptionSanitizerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/DescriptionSanitizerTest.java
@@ -279,6 +279,24 @@ class DescriptionSanitizerTest {
   }
 
   @Test
+  void pureMarkdownBackticksAreNotEncoded() {
+    String input = "**Source:** `deal_option_attrs`";
+    assertEquals(input, DescriptionSanitizer.sanitize(input));
+  }
+
+  @Test
+  void pureMarkdownApostrophesAreNotEncoded() {
+    String input = "It's a test with 'single quotes'";
+    assertEquals(input, DescriptionSanitizer.sanitize(input));
+  }
+
+  @Test
+  void entityLinkWithSurroundingMarkdownIsPreserved() {
+    String input = "See `table` via <#E::table::db.schema.t1>";
+    assertEquals(input, DescriptionSanitizer.sanitize(input));
+  }
+
+  @Test
   void entityMentionAttributesOnAnchorArePreservedForMention() {
     String input =
         "<a data-type=\"mention\" data-id=\"u1\" data-label=\"admin\""


### PR DESCRIPTION
### Describe your changes:

Fixes #32410

`DescriptionSanitizer.sanitizeWith()` unconditionally ran every description through the OWASP HTML sanitizer. When a description contains no HTML, the sanitizer still HTML-encodes text-node characters, converting `` ` `` → `&#96;` and `'` → `&#39;`. This breaks Markdown code spans in storage and is visible to API and MCP consumers that never decode HTML entities.

Guard: skip `policy.sanitize()` when the substituted string contains no `<`. Without a `<` there is no markup to sanitize; content with `<` continues through the existing path unchanged.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — single conditional added to `sanitizeWith()`. The `<` check is correct by construction: the OWASP sanitizer only changes content the HTML parser touches, and the parser only activates on `<`. Entity-link tokens (`<#E::...>`) are already swapped for opaque placeholders before the check, so a description with only entity links and Markdown (no other `<`) also bypasses the sanitizer correctly.

#
### Tests:

#### Unit tests
- [x] Added 3 new cases in `DescriptionSanitizerTest`:
  - pure Markdown backticks preserved
  - pure Markdown apostrophes preserved
  - entity link mixed with Markdown backtick preserved

#### Backend integration tests
- [x] Not applicable

#### Ingestion integration tests
- [x] Not applicable

#### Playwright (UI) tests
- [x] Not applicable (backend-only change)

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR is linked to a GitHub issue via `Fixes #32410` above.
