### PR TITLE
fix(test): refactor Data Consumer tag permission test to cover system vs user-created classifications (2.0 backport)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Users.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Users.spec.ts
@@ -30,6 +30,7 @@ import { ChartClass } from '../../support/entity/ChartClass';
 import { EntityDataClass } from '../../support/entity/EntityDataClass';
 import { TableClass } from '../../support/entity/TableClass';
 import { PersonaClass } from '../../support/persona/PersonaClass';
+import { ClassificationClass } from '../../support/tag/ClassificationClass';
 import { TeamClass } from '../../support/team/TeamClass';
 import { UserClass } from '../../support/user/UserClass';
 import { createAdminApiContext, performAdminLogin } from '../../utils/admin';
@@ -41,6 +42,7 @@ import {
 } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import { settingClick, sidebarClick } from '../../utils/sidebar';
+import { visitClassificationPage } from '../../utils/tag';
 import {
   addUser,
   checkDataConsumerPermissions,
@@ -322,58 +324,108 @@ test.describe('User with Data Consumer Roles', () => {
   test('User should have only view permission for glossary and tags for Data Consumer', async ({
     dataConsumerPage,
   }) => {
-    await redirectToHomePage(dataConsumerPage);
+    const { apiContext, afterAction } = await createAdminApiContext();
+    const userClassification = new ClassificationClass();
 
-    // Check CRUD for Glossary
-    await sidebarClick(dataConsumerPage, SidebarItem.GLOSSARY);
+    try {
+      await userClassification.create(apiContext);
+      await redirectToHomePage(dataConsumerPage);
 
-    await waitForAllLoadersToDisappear(dataConsumerPage);
+      // Check CRUD for Glossary
+      await sidebarClick(dataConsumerPage, SidebarItem.GLOSSARY);
 
-    await expect(
-      dataConsumerPage.locator('[data-testid="add-glossary"]')
-    ).not.toBeVisible();
+      await waitForAllLoadersToDisappear(dataConsumerPage);
 
-    await expect(
-      dataConsumerPage.locator('[data-testid="add-new-tag-button-header"]')
-    ).not.toBeVisible();
+      // Confirm the glossary page has rendered before asserting button absence
+      await expect(
+        dataConsumerPage.getByTestId('glossary-details')
+      ).toBeVisible();
 
-    await expect(
-      dataConsumerPage.locator('[data-testid="manage-button"]')
-    ).not.toBeVisible();
+      await expect(
+        dataConsumerPage.locator('[data-testid="add-glossary"]')
+      ).not.toBeVisible();
 
-    // Glossary Term Table Action column
-    await expect(dataConsumerPage.getByText('Actions')).not.toBeVisible();
+      await expect(
+        dataConsumerPage.locator('[data-testid="add-new-tag-button-header"]')
+      ).not.toBeVisible();
 
-    // right panel
-    await expect(
-      dataConsumerPage.locator('[data-testid="add-domain"]')
-    ).not.toBeVisible();
-    await expect(
-      dataConsumerPage.locator('[data-testid="edit-review-button"]')
-    ).not.toBeVisible();
+      await expect(
+        dataConsumerPage.locator('[data-testid="manage-button"]')
+      ).not.toBeVisible();
 
-    const hasAddOwnerButton = dataConsumerPage.locator(
-      '[data-testid="add-owner"]'
-    );
+      // Glossary Term Table Action column
+      await expect(dataConsumerPage.getByText('Actions')).not.toBeVisible();
 
-    if (!hasAddOwnerButton) {
-      await checkEditOwnerButtonPermission(dataConsumerPage);
+      // right panel
+      await expect(
+        dataConsumerPage.locator('[data-testid="add-domain"]')
+      ).not.toBeVisible();
+      await expect(
+        dataConsumerPage.locator('[data-testid="edit-review-button"]')
+      ).not.toBeVisible();
+
+      const hasAddOwnerButton = dataConsumerPage.locator(
+        '[data-testid="add-owner"]'
+      );
+
+      if (!hasAddOwnerButton) {
+        await checkEditOwnerButtonPermission(dataConsumerPage);
+      }
+
+      // Check CRUD for Tags — navigate to Tags sidebar to verify create permission is absent
+      await sidebarClick(dataConsumerPage, SidebarItem.TAGS);
+
+      // Confirm the left panel has rendered before asserting button absence
+      await expect(
+        dataConsumerPage.getByTestId('tags-left-panel')
+      ).toBeVisible();
+
+      await expect(
+        dataConsumerPage.locator('[data-testid="add-classification"]')
+      ).not.toBeVisible();
+
+      // System classification (e.g. Certification): manage button must NOT be visible
+      await visitClassificationPage(
+        dataConsumerPage,
+        'Certification',
+        'Certification'
+      );
+
+      // Confirm the header has rendered before asserting button absence
+      await expect(dataConsumerPage.getByTestId('header')).toBeVisible();
+
+      await expect(
+        dataConsumerPage.locator('[data-testid="add-new-tag-button"]')
+      ).not.toBeVisible();
+      await expect(
+        dataConsumerPage.locator('[data-testid="manage-button"]')
+      ).not.toBeVisible();
+
+      // User-created classification: manage button MUST be visible but show only Export
+      await userClassification.visitPage(dataConsumerPage);
+
+      // Confirm the header has rendered before asserting button presence/absence
+      await expect(
+        dataConsumerPage.getByTestId('entity-header-display-name')
+      ).toContainText(userClassification.data.displayName);
+
+      await expect(
+        dataConsumerPage.locator('[data-testid="add-new-tag-button"]')
+      ).not.toBeVisible();
+
+      const manageButton = dataConsumerPage.getByTestId('manage-button');
+
+      await expect(manageButton).toBeVisible();
+      await manageButton.click();
+
+      await expect(dataConsumerPage.getByTestId('export-button')).toBeVisible();
+      await expect(
+        dataConsumerPage.getByTestId('import-button')
+      ).not.toBeVisible();
+    } finally {
+      await userClassification.delete(apiContext);
+      await afterAction();
     }
-
-    // Check CRUD for Tags
-    await sidebarClick(dataConsumerPage, SidebarItem.TAGS);
-
-    await expect(
-      dataConsumerPage.locator('[data-testid="add-classification"]')
-    ).not.toBeVisible();
-
-    await expect(
-      dataConsumerPage.locator('[data-testid="add-new-tag-button"]')
-    ).not.toBeVisible();
-
-    await expect(
-      dataConsumerPage.locator('[data-testid="manage-button"]')
-    ).not.toBeVisible();
   });
 
   test('Operations for settings page for Data Consumer', async ({


### PR DESCRIPTION
Backport of #33047 to `2.0`.

## Summary

- Refactors `User should have only view permission for glossary and tags for Data Consumer` in `Users.spec.ts` to assert the manage-button visibility rules on classification pages.
- **System classifications** (e.g. Certification): manage button must **not** be visible for Data Consumer — import/export are blocked for system classifications and the user has no edit/delete permission.
- **User-created (non-system) classifications**: manage button **must** be visible, but the dropdown must contain **only Export** (no Import — needs `EditAll`; no Edit/Delete — not permitted).
- Each `not.toBeVisible` assertion is now preceded by a positive assertion that the page has rendered (`glossary-details`, `tags-left-panel`, `header`, `entity-header-display-name`), so a slow render cannot produce a false-positive pass.
- The test creates and deletes its own `ClassificationClass` fixture in a `try/finally`.

## Applicability to 2.0

The behaviour under test already exists on `2.0` — `ClassificationDetails.tsx` gates `showManageButton` on `showEditOption || deletePermission || showDisableOption || showExportOption || showImportOption`, with `showExportOption`/`showImportOption` both requiring `!isSystemClassification` and `deletePermission` requiring `!isSystemClassification`. Only the test changes.

## Verification

- Applied cleanly (`git apply --3way`); the pre-change test body on `2.0` is byte-identical to `main`'s.
- **Diff-of-diffs**: `git diff -U0` of the change on `main` vs. on this branch is identical line-for-line (130 lines).
- Every API the test newly reaches for exists on `2.0` with a matching signature: `ClassificationClass` (`create`/`delete`/`visitPage`/`data.displayName`), `visitClassificationPage(page, name, displayName)`, and the `header` / `entity-header-display-name` / `export-button` / `import-button` / `tags-left-panel` / `glossary-details` testids. The `support/fixtures/base` wrapper that `main`'s copy imports is main-only and is **not** part of this diff — `2.0` keeps `import { expect, Page, test as base } from '@playwright/test'`.
- `npx tsc --project playwright/tsconfig.json --noEmit`: 169 errors on `HEAD^` and 169 on `HEAD` — zero delta (the two `Users.spec.ts` entries are pre-existing, shifted only by line offset).
- `npx prettier --check` passes. ESLint and the Playwright run are left to CI.

The `impact-map.generated.json` refresh from the source PR is intentionally omitted — the bot regenerates it on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)