### PR TITLE
Fixes #33252: correct Quartz scheduler name and spelling errors in docs

### DIFF
--- a/APPLICATION.md
+++ b/APPLICATION.md
@@ -3,15 +3,15 @@ How to Add a New Application
 ## Create App Config
 
 in `openmetadata-spec/src/main/resources/json/schema/entity/applications/configuration` define the json schema representing your application configuration.
-- external: these are applications that will run externaly (e.g. Airflow). If your application has its execution logic defined in Python, this is where the code logic should live
-- internal: these will application will be executed through the Qwartz scheduler form the application itself. The code logic for this application will be written in Java.
+- external: these are applications that will run externally (e.g. Airflow). If your application has its execution logic defined in Python, this is where the code logic should live
+- internal: these applications will be executed through the Quartz scheduler from the application itself. The code logic for this application will be written in Java.
 
 you can follow this naming convention <yourAppName>AppConfig.json
 
 
 ## Define default app config
 
-in `openmetadata-service/src/main/resources/json/data/app` define the default setting of your application. Create a new json following this naming convention `<youAppName>Application.json`
+in `openmetadata-service/src/main/resources/json/data/app` define the default setting of your application. Create a new json following this naming convention `<yourAppName>Application.json`
 
 ## Define your app in the Application Marketplace
 
@@ -26,7 +26,7 @@ In `openmetadata-ui/src/main/resources/ui/src/utils/ApplicationSchemas` add the 
 ## Implement Java class
 In `openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles` implement the java class corresponding to your application.
 
-Not that the value of the `className` from step 3 should match the class name / path defined at this stage
+Note that the value of the `className` from step 3 should match the class name / path defined at this stage
 
 ## [Optional] Implement Python logic
 If you have defined an external application, you need to create the relevant Python class that implements the logic. The path of the class needs to match the value of `sourcePythonClass`. You will need to inherit from the `AppRunner` class and at minimum implement the `def run` method.

--- a/ingestion/src/metadata/data_quality/README.md
+++ b/ingestion/src/metadata/data_quality/README.md
@@ -1,6 +1,6 @@
 # OpenMetadata Data Quality
 ## Structure
-OpenMetadata data quality is structured around 3 componants:
+OpenMetadata data quality is structured around 3 components:
 1. Test Definition: a test definition is a generic definition describing a test (supported data types, platform is was created from (OM, dbt, etc.), parameter definition, etc.)
 2. Test Case: a test case is the implementation of a specific test definition. It specifies the values parameters should respect for the test to pass or fail
 3. Test Suite: a test suite is a logical or an executable container. Executable test suites are automatically created when you add a new test case to an entity. Logical test suite allow users to logically group together tests from different entity to create data contracts.

--- a/ingestion/tests/load/README.md
+++ b/ingestion/tests/load/README.md
@@ -5,9 +5,9 @@ In your newly created file, you'll need to import at minimum 1 package
 ```python
 from locust import task, TaskSet
 ```
-`task` will be used as a decorator to define our task that will run as part of our load test. `TaskSet` wil be inherited by our task set class.
+`task` will be used as a decorator to define our task that will run as part of our load test. `TaskSet` will be inherited by our task set class.
 
-Here is an example of a locust task definition. The integer argument in `@task` will give a specific weigth to the task (i.e. increasing its probability to be ran)
+Here is an example of a locust task definition. The integer argument in `@task` will give a specific weight to the task (i.e. increasing its probability to be ran)
 ```
 class TestCaseResultTasks(TaskSet):
     """Test case result resource load test"""
@@ -59,7 +59,7 @@ class TestCaseResultTasks(TaskSet):
 ```
 
 **IMPORTANT**
-You MUST define a `def stop(self)` methodd in your `TaskSet` class as shown below so that control is given back to the parent user class.
+You MUST define a `def stop(self)` method in your `TaskSet` class as shown below so that control is given back to the parent user class.
 
 ```python
 class TestCaseResultTasks(TaskSet):

--- a/openmetadata-airflow-apis/README.md
+++ b/openmetadata-airflow-apis/README.md
@@ -110,7 +110,7 @@ curl -X GET -H 'Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpY
 ```
 
 ## Using the API
-Once you deploy the plugin and restart the webserver, you can start to use the REST API. Below you will see the endpoints that are supported. 
+Once you deploy the plugin and restart the webserver, you can start to use the REST API. Below you will see the endpoints that are supported.
 
 **Note:** If enable RBAC, `http://{AIRFLOW_HOST}:{AIRFLOW_PORT}/rest_api/`<br>
 This web page will show the Endpoints supported and provide a form for you to test submitting to them.

--- a/openmetadata-airflow-apis/README.md
+++ b/openmetadata-airflow-apis/README.md
@@ -110,7 +110,7 @@ curl -X GET -H 'Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpY
 ```
 
 ## Using the API
-Once you deploy the plugin and restart the webserver, you can start to use the REST API. Bellow you will see the endpoints that are supported. 
+Once you deploy the plugin and restart the webserver, you can start to use the REST API. Below you will see the endpoints that are supported. 
 
 **Note:** If enable RBAC, `http://{AIRFLOW_HOST}:{AIRFLOW_PORT}/rest_api/`<br>
 This web page will show the Endpoints supported and provide a form for you to test submitting to them.

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/BigQuery.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/BigQuery.md
@@ -4,7 +4,7 @@ In this section, we provide guides and references to use the BigQuery connector.
 
 ## Requirements
 
-We need to enable the Data Catalog API and use an account with a specific set of minnimum permissions:
+We need to enable the Data Catalog API and use an account with a specific set of minimum permissions:
 
 ### Data Catalog API Permissions
 

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Couchbase.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Couchbase.md
@@ -30,6 +30,6 @@ In OpenMetadata, the Database Service hierarchy works as follows:
 ```
 Database Service > Bucket > Schema > Table
 ```
-In the case of Couchbase, if you don't provide bucket name then by default it will ingest all availabe buckets.
+In the case of Couchbase, if you don't provide bucket name then by default it will ingest all available buckets.
 $$
 

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Datalake.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Datalake.md
@@ -134,7 +134,7 @@ $$section
 This is the ID of the project associated with the service account. To fetch this key, look for the value associated with the `project_id` key in the service account file.
 
 - **Single Project ID**: Fetch Resources from Single Bigquery/GCP Project ID
-- **Mutiple Project IDs**: Fetch Resources from Multiple Bigquery/GCP Project ID
+- **Multiple Project IDs**: Fetch Resources from Multiple Bigquery/GCP Project ID
 
 #### Find your Project ID
 

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Hive.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Hive.md
@@ -82,7 +82,7 @@ There are 2 types of auth configs:
 - IAM based Auth.
 - Azure Based Auth.
 
-User can authenticate the Postgres Instance with auth type as `Basic Authentication` i.e. Password **or** by using `IAM based Authentication` to connect to AWS related services **or** by using `Azure Baed Authentication` to connecto to Azure releated services.
+User can authenticate the Postgres Instance with auth type as `Basic Authentication` i.e. Password **or** by using `IAM based Authentication` to connect to AWS related services **or** by using `Azure Based Authentication` to connect to Azure related services.
 $$
 
 ## Basic Auth

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Mysql.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Mysql.md
@@ -6,7 +6,7 @@ In this section, we provide guides and references to use the MySQL connector.
 To extract metadata the user used in the connection needs to have access to the `INFORMATION_SCHEMA`. By default, a user can see only the rows in the `INFORMATION_SCHEMA` that correspond to objects for which the user has the proper access privileges.
 
 ```SQL
--- Create user. If <hostName> is ommited, defaults to '%'
+-- Create user. If <hostName> is omitted, defaults to '%'
 -- More details https://dev.mysql.com/doc/refman/8.0/en/create-user.html
 CREATE USER '<username>'[@'<hostName>'] IDENTIFIED BY '<password>';
 
@@ -60,7 +60,7 @@ There are 2 types of auth configs:
 - IAM based Auth.
 - Azure Based Auth.
 
-User can authenticate the Mysql Instance with auth type as `Basic Authentication` i.e. Password **or** by using `IAM based Authentication` to connect to AWS related services **or** by using `Azure Baed Authentication` to connecto to Azure releated services.
+User can authenticate the Mysql Instance with auth type as `Basic Authentication` i.e. Password **or** by using `IAM based Authentication` to connect to AWS related services **or** by using `Azure Based Authentication` to connect to Azure related services.
 $$
 
 

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Postgres.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Postgres.md
@@ -123,7 +123,7 @@ There are 2 types of auth configs:
 - IAM based Auth.
 - Azure Based Auth.
 
-User can authenticate the Postgres Instance with auth type as `Basic Authentication` i.e. Password **or** by using `IAM based Authentication` to connect to AWS related services **or** by using `Azure Baed Authentication` to connecto to Azure releated services.
+User can authenticate the Postgres Instance with auth type as `Basic Authentication` i.e. Password **or** by using `IAM based Authentication` to connect to AWS related services **or** by using `Azure Based Authentication` to connect to Azure related services.
 $$
 
 ## Basic Auth

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Timescale.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Timescale.md
@@ -25,7 +25,7 @@ There are 3 types of auth configs:
 - IAM based Auth.
 - Azure Based Auth.
 
-User can authenticate the Timescale Instance with auth type as `Basic Authentication` i.e. Password **or** by using `IAM based Authentication` to connect to AWS related services **or** by using `Azure Baed Authentication` to connecto to Azure releated services.
+User can authenticate the Timescale Instance with auth type as `Basic Authentication` i.e. Password **or** by using `IAM based Authentication` to connect to AWS related services **or** by using `Azure Based Authentication` to connect to Azure related services.
 $$
 
 ## Basic Auth

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/workflows/profiler.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/workflows/profiler.md
@@ -117,7 +117,7 @@ $$section
 
 **This parameter is effective when Profile Sample Type is ROWS**
 
-When using the ROWS sampling type choose wheather to randomized the sample or. Non randomized sample will be faster to compute.
+When using the ROWS sampling type choose whether to randomize the sample or not. Non randomized sample will be faster to compute.
 
 Defaults to `True`
 $$

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Pipeline/Airflow.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Pipeline/Airflow.md
@@ -274,7 +274,7 @@ There are 2 types of auth configs:
 - IAM based Auth.
 - Azure Based Auth.
 
-User can authenticate the Mysql Instance with auth type as `Basic Authentication` i.e. Password **or** by using `IAM based Authentication` to connect to AWS related services **or** by using `Azure Baed Authentication` to connecto to Azure releated services.
+User can authenticate the Mysql Instance with auth type as `Basic Authentication` i.e. Password **or** by using `IAM based Authentication` to connect to AWS related services **or** by using `Azure Based Authentication` to connect to Azure related services.
 $$
 
 ## Basic Auth
@@ -496,7 +496,7 @@ There are 2 types of auth configs:
 - IAM based Auth.
 - Azure Based Auth.
 
-User can authenticate the Postgres Instance with auth type as `Basic Authentication` i.e. Password **or** by using `IAM based Authentication` to connect to AWS related services **or** by using `Azure Baed Authentication` to connecto to Azure releated services.
+User can authenticate the Postgres Instance with auth type as `Basic Authentication` i.e. Password **or** by using `IAM based Authentication` to connect to AWS related services **or** by using `Azure Based Authentication` to connect to Azure related services.
 $$
 
 


### PR DESCRIPTION
### Describe your changes:

Fixes #33252

Documentation-only spelling corrections; no code or behavioral change.

`APPLICATION.md` (the how-to for adding a new application):

- calls the internal scheduler the "Qwartz scheduler". The library is Quartz, as used by `AppScheduler` under `openmetadata-service/.../apps/scheduler/`. Also straightened the surrounding sentence (`these will application will be executed ... form the application` → `these applications will be executed ... from the application`).
- gives the default-config naming convention as `<youAppName>Application.json`, while the rest of the file uses `<yourAppName>`. Made them consistent.
- `Not that the value of the className` → `Note that ...`, and `externaly` → `externally`.

Other files:

- `ingestion/tests/load/README.md`: `wil`, `weigth`, `methodd`
- `ingestion/src/metadata/data_quality/README.md`: `componants`
- `openmetadata-airflow-apis/README.md`: `Bellow`
- en-US connector docs rendered in the UI (`openmetadata-ui/.../public/locales/en-US/`): the shared sentence `Azure Baed Authentication to connecto to Azure releated services` in Hive, Mysql, Postgres, Timescale and Airflow (twice); plus `minnimum` (BigQuery), `availabe` (Couchbase), `Mutiple` (Datalake), `ommited` (Mysql SQL comment), and `choose wheather to randomized the sample or.` → `choose whether to randomize the sample or not.` (profiler workflow).

The `fr-FR` and `sv-SE` locale files, the generated Playwright test docs, and `docs/generated/` were left untouched. `git diff --word-diff` shows the changes compactly.

#
### Type of change:
- [x] Documentation

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
N/A — markdown text only.

#### Unit tests
Not applicable (no code changes).

#### Backend integration tests
Not applicable (no backend API changes).

#### Ingestion integration tests
Not applicable (no ingestion changes).

#### Playwright (UI) tests
Not applicable (no UI code changes; only the markdown content served under `public/locales/en-US`).

#### Manual testing performed
Re-read each changed line in context; `git diff --check` is clean apart from a pre-existing trailing space.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas. (N/A)
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. (N/A)
- [x] For UI changes: I attached a screen recording and/or screenshots above. (N/A)
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above. (N/A)




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62215509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 5/5</h2>

The documentation-only changes appear safe to merge, with no actionable correctness or repository-rule violations identified.

<details open><summary>Summary</summary>

Corrects spelling, grammar, and terminology across application-development guidance, ingestion documentation, Airflow API documentation, and English connector help content.
- Corrects the Quartz scheduler name and application configuration naming examples.
- Fixes typographical errors in Markdown documentation.
- Updates Postgres authentication descriptions to count the three documented authentication modes accurately.
</details>

<sub>Reviews (2) · Last reviewed commit: ["docs: correct auth config count in Postg..."](https://github.com/open-metadata/openmetadata/commit/dd7f2887a8fe4f83b8427262aaf390be219d02df)</sub>

<!-- /greptile_comment -->