### PR TITLE
backport(ui): Add Description field to Data Product grid card, restyle labels, fix empty-value placeholders (#32948) to 2.0

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TagBadgeList/TagBadgeList.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TagBadgeList/TagBadgeList.component.tsx
@@ -22,11 +22,16 @@ import { TagLabel } from '../../../generated/type/tagLabel';
 interface TagBadgeListProps {
   tags: TagLabel[];
   size?: 'sm' | 'lg';
+  emptyPlaceholder?: string;
 }
 
-const TagBadgeList = ({ tags, size = 'sm' }: TagBadgeListProps) => {
+const TagBadgeList = ({
+  tags,
+  size = 'sm',
+  emptyPlaceholder = NO_DATA,
+}: TagBadgeListProps) => {
   if (!tags.length) {
-    return <Typography size="text-sm">{NO_DATA}</Typography>;
+    return <Typography size="text-sm">{emptyPlaceholder}</Typography>;
   }
 
   const firstTag = tags[0];

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TagBadgeList/TagBadgeList.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TagBadgeList/TagBadgeList.test.tsx
@@ -1,0 +1,69 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import {
+  LabelType,
+  State,
+  TagLabel,
+  TagSource,
+} from '../../../generated/type/tagLabel';
+import TagBadgeList from './TagBadgeList.component';
+
+const baseMockTag: TagLabel = {
+  tagFQN: 'PII.Sensitive',
+  source: TagSource.Classification,
+  labelType: LabelType.Manual,
+  state: State.Confirmed,
+  name: 'Sensitive',
+  displayName: 'Sensitive',
+};
+
+describe('TagBadgeList', () => {
+  it('should render no data placeholder when tags array is empty', () => {
+    render(
+      <MemoryRouter>
+        <TagBadgeList tags={[]} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('-')).toBeInTheDocument();
+  });
+
+  it('renders a custom emptyPlaceholder when provided and tags are empty', () => {
+    render(
+      <MemoryRouter>
+        <TagBadgeList emptyPlaceholder="--" tags={[]} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('--')).toBeInTheDocument();
+  });
+
+  it('should show +N count when multiple tags exist', () => {
+    const tags = [
+      baseMockTag,
+      { ...baseMockTag, tagFQN: 'PII.NonSensitive', name: 'NonSensitive' },
+      { ...baseMockTag, tagFQN: 'PII.Other', name: 'Other' },
+    ];
+
+    render(
+      <MemoryRouter>
+        <TagBadgeList tags={tags} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('+2')).toBeInTheDocument();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/DataProductDescriptionField.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/DataProductDescriptionField.tsx
@@ -1,0 +1,85 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Box, Typography } from '@openmetadata/ui-core-components';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { NO_DATA_PLACEHOLDER } from '../../../../../constants/constants';
+import { isDescriptionContentEmpty } from '../../../../../utils/BlockEditorPureUtils';
+import RichTextEditorPreviewerV1 from '../../../RichTextEditor/RichTextEditorPreviewerV1';
+
+export const DataProductDescriptionField = ({
+  description,
+}: {
+  description?: string;
+}) => {
+  const { t } = useTranslation();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  const checkTruncation = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    // The clamp CSS below targets the nested `.markdown-parser` node that
+    // RichTextEditorPreviewerV1/BlockEditor renders into, not this wrapper -
+    // measure that node (falling back to the wrapper), matching the same
+    // technique FieldCard.tsx already uses for this exact problem.
+    const measureNode =
+      container.querySelector<HTMLElement>('.markdown-parser') ?? container;
+    setIsTruncated(measureNode.scrollHeight > measureNode.clientHeight + 1);
+  }, []);
+
+  useEffect(() => {
+    checkTruncation();
+  }, [description, checkTruncation]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || typeof ResizeObserver === 'undefined') {
+      return;
+    }
+    // RichTextEditorPreviewerV1 renders its BlockEditor lazily (React.lazy +
+    // Suspense), so the real content - and its real height - can land a tick
+    // after this component mounts. The effect above can catch a stale
+    // (pre-load) measurement; this observer re-checks whenever the rendered
+    // height actually changes, which is what BlockEditor's async mount does.
+    const observer = new ResizeObserver(checkTruncation);
+    observer.observe(container);
+
+    return () => observer.disconnect();
+  }, [checkTruncation]);
+
+  if (isDescriptionContentEmpty(description ?? '')) {
+    return <Typography size="text-sm">{NO_DATA_PLACEHOLDER}</Typography>;
+  }
+
+  return (
+    <Box direction="col" gap={1}>
+      <div
+        className="tw:text-sm tw:break-words tw:[&_.markdown-parser]:line-clamp-2"
+        ref={containerRef}>
+        <RichTextEditorPreviewerV1
+          enableSeeMoreVariant={false}
+          markdown={description ?? ''}
+        />
+      </div>
+      {isTruncated && (
+        <Typography className="tw:text-brand-secondary" size="text-xs">
+          {t('label.view-more')}
+        </Typography>
+      )}
+    </Box>
+  );
+};

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.test.tsx
@@ -10,10 +10,17 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { fireEvent, render, screen } from '@testing-library/react';
-import { ReactNode } from 'react';
+import { fireEvent, render, renderHook, screen } from '@testing-library/react';
+import { forwardRef, ReactNode } from 'react';
+import { DataProduct } from '../../../../../generated/entity/domains/dataProduct';
 import { Domain } from '../../../../../generated/entity/domains/domain';
-import { renderDomainNameCell } from './domainFieldRenderers';
+import {
+  renderDomainClassificationTagsCell,
+  renderDomainGlossaryTagsCell,
+  renderDomainNameCell,
+  renderDomainOwnersCell,
+} from './domainFieldRenderers';
+import { useDomainCardTemplates } from './useDomainCardTemplates';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
   Avatar: () => <span data-testid="avatar" />,
@@ -28,14 +35,56 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {children}
     </div>
   ),
-  Typography: ({ children }: { children: ReactNode }) => (
-    <span>{children}</span>
+  Grid: Object.assign(
+    ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    {
+      Item: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    }
   ),
+  Typography: forwardRef<
+    HTMLSpanElement,
+    { children: ReactNode; className?: string; weight?: string }
+  >(({ children, className, weight }, ref) => (
+    <span className={className} data-weight={weight} ref={ref}>
+      {children}
+    </span>
+  )),
 }));
 
 jest.mock('../../../../../utils/TooltipUtils', () => ({
   renderBreakableTooltip: (value: string) => value,
 }));
+
+jest.mock('../../../../../utils/IconUtils', () => ({
+  getEntityAvatarProps: () => ({}),
+}));
+
+jest.mock('../../../OwnerLabel/OwnerLabel.component', () => ({
+  OwnerLabel: ({ showDashPlaceholder }: { showDashPlaceholder?: boolean }) => (
+    <div
+      data-show-dash={String(showDashPlaceholder)}
+      data-testid="owner-label"
+    />
+  ),
+}));
+
+jest.mock('../../../TagBadgeList/TagBadgeList.component', () => ({
+  __esModule: true,
+  default: ({ emptyPlaceholder }: { emptyPlaceholder?: string }) => (
+    <div
+      data-empty-placeholder={emptyPlaceholder}
+      data-testid="tag-badge-list"
+    />
+  ),
+}));
+
+jest.mock('../../../RichTextEditor/RichTextEditorPreviewerV1', () =>
+  jest
+    .fn()
+    .mockImplementation(({ markdown }: { markdown: string }) => (
+      <div data-testid="rte-previewer">{markdown}</div>
+    ))
+);
 
 const DOMAIN = {
   id: 'domain-id',
@@ -75,5 +124,190 @@ describe('renderDomainNameCell', () => {
 
     // With no cell handler the click falls through to the row unchanged.
     expect(rowClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('renderDomainOwnersCell', () => {
+  it('forwards showDashPlaceholder to OwnerLabel', () => {
+    render(
+      <>
+        {renderDomainOwnersCell({ owners: [] }, { showDashPlaceholder: true })}
+      </>
+    );
+
+    expect(screen.getByTestId('owner-label')).toHaveAttribute(
+      'data-show-dash',
+      'true'
+    );
+  });
+
+  it('defaults showDashPlaceholder to undefined when no options are passed', () => {
+    render(<>{renderDomainOwnersCell({ owners: [] })}</>);
+
+    expect(screen.getByTestId('owner-label')).toHaveAttribute(
+      'data-show-dash',
+      'undefined'
+    );
+  });
+});
+
+describe('renderDomainGlossaryTagsCell / renderDomainClassificationTagsCell', () => {
+  it('forwards emptyPlaceholder to TagBadgeList for glossary terms', () => {
+    render(
+      <>
+        {renderDomainGlossaryTagsCell({ tags: [] }, { emptyPlaceholder: '--' })}
+      </>
+    );
+
+    expect(screen.getByTestId('tag-badge-list')).toHaveAttribute(
+      'data-empty-placeholder',
+      '--'
+    );
+  });
+
+  it('forwards emptyPlaceholder to TagBadgeList for classification tags', () => {
+    render(
+      <>
+        {renderDomainClassificationTagsCell(
+          { tags: [] },
+          { emptyPlaceholder: '--' }
+        )}
+      </>
+    );
+
+    expect(screen.getByTestId('tag-badge-list')).toHaveAttribute(
+      'data-empty-placeholder',
+      '--'
+    );
+  });
+});
+
+const DATA_PRODUCT_BASE = {
+  id: 'dp-1',
+  name: 'fifth',
+  displayName: 'Fifth',
+  fullyQualifiedName: 'fifth',
+} as DataProduct;
+
+describe('useDomainCardTemplates > renderDataProductCard', () => {
+  it('styles all 5 field labels as 12px / medium / text-primary', () => {
+    const { result } = renderHook(() => useDomainCardTemplates());
+
+    render(<>{result.current.renderDataProductCard(DATA_PRODUCT_BASE)}</>);
+
+    [
+      'label.description',
+      'label.owner-plural',
+      'label.expert-plural',
+      'label.glossary-term-plural',
+      'label.tag-plural',
+    ].forEach((key) => {
+      const label = screen.getByText(key);
+
+      expect(label).toHaveClass('tw:text-primary');
+      expect(label).toHaveAttribute('data-weight', 'medium');
+    });
+  });
+
+  it('renders -- for description when empty', () => {
+    const { result } = renderHook(() => useDomainCardTemplates());
+
+    render(
+      <>
+        {result.current.renderDataProductCard({
+          ...DATA_PRODUCT_BASE,
+          description: '',
+        })}
+      </>
+    );
+
+    expect(screen.getByText('--')).toBeInTheDocument();
+  });
+
+  it('renders the description text and no "View more" when it fits within 2 lines', () => {
+    const { result } = renderHook(() => useDomainCardTemplates());
+
+    render(
+      <>
+        {result.current.renderDataProductCard({
+          ...DATA_PRODUCT_BASE,
+          description: '**A short description.**',
+        })}
+      </>
+    );
+
+    // The mock renders markdown verbatim (no actual parsing) - this just
+    // confirms the raw description string reaches the previewer unmodified,
+    // i.e. nothing is stripping it before it gets there.
+    expect(screen.getByTestId('rte-previewer')).toHaveTextContent(
+      '**A short description.**'
+    );
+    expect(screen.queryByText('label.view-more')).not.toBeInTheDocument();
+  });
+
+  it('shows "View more" when the description overflows 2 lines', () => {
+    // jsdom never lays out real text, so scrollHeight/clientHeight always
+    // report 0 unless overridden. The truncation check runs synchronously in
+    // a mount-time useEffect, so the getters must already return the
+    // overflowing values *before* render() flushes that effect - mocking
+    // scrollHeight/clientHeight on an already-rendered node (and re-rendering
+    // to retrigger the effect) doesn't work here: a fresh render() mounts a
+    // fresh element, and re-rendering with the same description string
+    // doesn't change the effect's dependency, so it wouldn't re-run anyway.
+    const scrollHeightSpy = jest
+      .spyOn(window.HTMLElement.prototype, 'scrollHeight', 'get')
+      .mockReturnValue(60);
+    const clientHeightSpy = jest
+      .spyOn(window.HTMLElement.prototype, 'clientHeight', 'get')
+      .mockReturnValue(32);
+
+    try {
+      const { result } = renderHook(() => useDomainCardTemplates());
+
+      render(
+        <>
+          {result.current.renderDataProductCard({
+            ...DATA_PRODUCT_BASE,
+            description: 'A description long enough to wrap past two lines.',
+          })}
+        </>
+      );
+
+      const viewMore = screen.getByText('label.view-more');
+
+      expect(viewMore).toBeInTheDocument();
+      expect(viewMore).toHaveClass('tw:text-brand-secondary');
+    } finally {
+      scrollHeightSpy.mockRestore();
+      clientHeightSpy.mockRestore();
+    }
+  });
+
+  it('requests the dash placeholder for both owners and experts', () => {
+    const { result } = renderHook(() => useDomainCardTemplates());
+
+    render(<>{result.current.renderDataProductCard(DATA_PRODUCT_BASE)}</>);
+
+    const ownerLabels = screen.getAllByTestId('owner-label');
+
+    expect(ownerLabels).toHaveLength(2);
+
+    ownerLabels.forEach((el) =>
+      expect(el).toHaveAttribute('data-show-dash', 'true')
+    );
+  });
+
+  it('requests the -- placeholder for both glossary terms and tags', () => {
+    const { result } = renderHook(() => useDomainCardTemplates());
+
+    render(<>{result.current.renderDataProductCard(DATA_PRODUCT_BASE)}</>);
+
+    const tagBadgeLists = screen.getAllByTestId('tag-badge-list');
+
+    expect(tagBadgeLists).toHaveLength(2);
+
+    tagBadgeLists.forEach((el) =>
+      expect(el).toHaveAttribute('data-empty-placeholder', '--')
+    );
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.tsx
@@ -105,27 +105,36 @@ export const renderDomainTypeCell = (entity: Domain): ReactNode =>
     <Typography size="text-sm">{NO_DATA}</Typography>
   );
 
-export const renderDomainOwnersCell = (entity: OwnedEntity): ReactNode => (
+export const renderDomainOwnersCell = (
+  entity: OwnedEntity,
+  options?: { showDashPlaceholder?: boolean }
+): ReactNode => (
   <OwnerLabel
     isCompactView={false}
     maxVisibleOwners={4}
     owners={entity.owners}
+    showDashPlaceholder={options?.showDashPlaceholder}
     showLabel={false}
   />
 );
 
 export const renderDomainGlossaryTagsCell = (
   entity: TaggedEntity,
-  options?: { size?: TagSize }
+  options?: { size?: TagSize; emptyPlaceholder?: string }
 ): ReactNode => (
-  <TagBadgeList size={options?.size} tags={getGlossaryTags(entity.tags)} />
+  <TagBadgeList
+    emptyPlaceholder={options?.emptyPlaceholder}
+    size={options?.size}
+    tags={getGlossaryTags(entity.tags)}
+  />
 );
 
 export const renderDomainClassificationTagsCell = (
   entity: TaggedEntity,
-  options?: { size?: TagSize }
+  options?: { size?: TagSize; emptyPlaceholder?: string }
 ): ReactNode => (
   <TagBadgeList
+    emptyPlaceholder={options?.emptyPlaceholder}
     size={options?.size}
     tags={getClassificationTags(entity.tags)}
   />

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/useDomainCardTemplates.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/useDomainCardTemplates.tsx
@@ -19,12 +19,14 @@ import {
 } from '@openmetadata/ui-core-components';
 import { ReactNode, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { NO_DATA_PLACEHOLDER } from '../../../../../constants/constants';
 import { DataProduct } from '../../../../../generated/entity/domains/dataProduct';
 import { Domain } from '../../../../../generated/entity/domains/domain';
 import { getEntityName } from '../../../../../utils/EntityNameUtils';
 import { getEntityAvatarProps } from '../../../../../utils/IconUtils';
 import { renderBreakableTooltip } from '../../../../../utils/TooltipUtils';
 import { OwnerLabel } from '../../../OwnerLabel/OwnerLabel.component';
+import { DataProductDescriptionField } from './DataProductDescriptionField';
 import {
   CARD_NAME_CLIP_CLASS,
   CLIPPED_NAME_CLASS,
@@ -127,20 +129,41 @@ export const useDomainCardTemplates = () => {
           </Box>
 
           <Grid gap="4">
+            <Grid.Item span={24}>
+              <Box direction="col" gap={1}>
+                <Typography
+                  className="tw:text-primary"
+                  size="text-xs"
+                  weight="medium">
+                  {t('label.description')}
+                </Typography>
+                <DataProductDescriptionField description={entity.description} />
+              </Box>
+            </Grid.Item>
+          </Grid>
+
+          <Grid gap="4">
             <Grid.Item span={12}>
               <Box direction="col" gap={1}>
-                <Typography size="text-xs">
+                <Typography
+                  className="tw:text-primary"
+                  size="text-xs"
+                  weight="medium">
                   {t('label.owner-plural')}
                 </Typography>
-                {renderDomainOwnersCell(entity)}
+                {renderDomainOwnersCell(entity, { showDashPlaceholder: true })}
               </Box>
             </Grid.Item>
             <Grid.Item span={12}>
               <Box direction="col" gap={1}>
-                <Typography size="text-xs">
+                <Typography
+                  className="tw:text-primary"
+                  size="text-xs"
+                  weight="medium">
                   {t('label.expert-plural')}
                 </Typography>
                 <OwnerLabel
+                  showDashPlaceholder
                   isCompactView={false}
                   maxVisibleOwners={4}
                   owners={entity.experts}
@@ -153,16 +176,28 @@ export const useDomainCardTemplates = () => {
           <Grid gap="4">
             <Grid.Item span={12}>
               <Box direction="col" gap={1}>
-                <Typography size="text-xs">
+                <Typography
+                  className="tw:text-primary"
+                  size="text-xs"
+                  weight="medium">
                   {t('label.glossary-term-plural')}
                 </Typography>
-                {renderDomainGlossaryTagsCell(entity)}
+                {renderDomainGlossaryTagsCell(entity, {
+                  emptyPlaceholder: NO_DATA_PLACEHOLDER,
+                })}
               </Box>
             </Grid.Item>
             <Grid.Item span={12}>
               <Box direction="col" gap={1}>
-                <Typography size="text-xs">{t('label.tag-plural')}</Typography>
-                {renderDomainClassificationTagsCell(entity)}
+                <Typography
+                  className="tw:text-primary"
+                  size="text-xs"
+                  weight="medium">
+                  {t('label.tag-plural')}
+                </Typography>
+                {renderDomainClassificationTagsCell(entity, {
+                  emptyPlaceholder: NO_DATA_PLACEHOLDER,
+                })}
               </Box>
             </Grid.Item>
           </Grid>


### PR DESCRIPTION
Backport of #32948 to `2.0` (cherry-pick of `f67e60b`).

## Conflict resolution — `TagBadgeList`

Four of the six files cherry-picked cleanly. `TagBadgeList` conflicted because **`main` and `2.0` have different implementations of this component**: `main` renders each tag with `TagChip` (and carries a `TAG_CHIP_SIZE_MAP`), while `2.0` renders `BadgeWithIcon` and has neither. Git offered `main`'s whole `TagChip` block as the incoming side.

- **`TagBadgeList.component.tsx`** — resolved by keeping `2.0`'s `BadgeWithIcon` body and re-applying only the intent of the change: the new `emptyPlaceholder?: string` prop, defaulted to `NO_DATA`, used in the empty branch. `TAG_CHIP_SIZE_MAP` is **not** brought over, since `2.0` has nothing to use it for.
- **`TagBadgeList.test.tsx`** — does not exist on `2.0` (modify/delete conflict). `main`'s file is written against the `TagChip` implementation (`getByTestId('tags')`, `tag-<fqn>`, `tag-redirect-link`) and would not pass here. Rather than drop the coverage the source PR added, this adds a small `2.0`-appropriate suite covering the default `-` placeholder, the new custom `--` placeholder, and the `+N` overflow count.

These two files are the only intentional divergence from the source diff.

## Verification

- **Diff-of-diffs** on every cleanly-applied file — `git diff -U0 <sha>^ <sha>` on `main` vs. on this branch, whitespace-normalized — is identical line-for-line:

  | file | lines |
  |---|---|
  | `DataProductDescriptionField.tsx` | 86 |
  | `domainFieldRenderers.tsx` | 17 |
  | `useDomainCardTemplates.tsx` | 49 |
  | `domainFieldRenderers.test.tsx` | 244 |

- Every API the picked code reaches for exists on `2.0`: `OwnerLabel`'s `showDashPlaceholder` prop, the `NO_DATA_PLACEHOLDER` constant, `isDescriptionContentEmpty` in `BlockEditorPureUtils`, and `RichTextEditorPreviewerV1`.
- **Jest**: `domainFieldRenderers.test.tsx` (13) and `TagBadgeList.test.tsx` (3) pass, 0 failures.
- **`tsc --noEmit`**: 719 errors on the `2.0` tip and 719 with both this and #32964 applied — zero delta, and none in any touched file.
- **`prettier --check`** passes on all six files. ESLint is left to CI (`2.0`'s flat config cannot run against the borrowed `node_modules` used here).

Split out from the combined backport so it can be reviewed and reverted independently of #32964's backport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)