### PR TITLE
backport(ui): drive the contract status badge off the actual status (#32964) to 2.0

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ContractDetailTab/ContractDetail.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ContractDetailTab/ContractDetail.tsx
@@ -26,7 +26,6 @@ import {
 import {
   ChevronDown,
   Download02,
-  Flag04,
   PlayCircle,
   Plus,
   Trash01,
@@ -67,6 +66,7 @@ import {
 } from '../../../utils/DataContract/DataContractUtils';
 import { formatDateTime } from '../../../utils/date-time/DateTimeUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
+import { getEntityStatusBadgeConfig } from '../../../utils/EntityStatusUtils';
 import { pruneEmptyChildren } from '../../../utils/TablePureUtils';
 import { showErrorToast, showSuccessToast } from '../../../utils/ToastUtils';
 import AlertBar from '../../AlertBar/AlertBar';
@@ -292,6 +292,20 @@ const ContractDetail: React.FC<{
     setMode(e.target.value);
   }, []);
 
+  const statusBadge = useMemo(() => {
+    const { color, icon } = getEntityStatusBadgeConfig(contract?.entityStatus);
+
+    return (
+      <BadgeWithIcon
+        color={color}
+        iconLeading={icon}
+        size="sm"
+        type="pill-color">
+        {contract?.entityStatus ?? t('label.approved')}
+      </BadgeWithIcon>
+    );
+  }, [contract?.entityStatus, t]);
+
   const renderDataContractHeader = useMemo(() => {
     if (!contract) {
       return null;
@@ -505,13 +519,7 @@ const ContractDetail: React.FC<{
                 {`${t('label.status')} : `}
               </Typography>
 
-              <BadgeWithIcon
-                color="success"
-                iconLeading={Flag04}
-                size="sm"
-                type="pill-color">
-                {contract.entityStatus ?? t('label.approved')}
-              </BadgeWithIcon>
+              {statusBadge}
             </Box>
 
             <Divider
@@ -545,6 +553,7 @@ const ContractDetail: React.FC<{
     hasEditPermission,
     isInheritedContract,
     handleContractAction,
+    statusBadge,
     t,
   ]);
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityStatusUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityStatusUtils.ts
@@ -11,6 +11,17 @@
  *  limitations under the License.
  */
 
+import type {
+  BadgeColors,
+  IconComponentType,
+} from '@openmetadata/ui-core-components';
+import {
+  ArrowCircleDown,
+  CheckCircle,
+  Clipboard,
+  Eye,
+  XCircle,
+} from '@untitledui/icons';
 import { isNil } from 'lodash';
 import { StatusType } from '../components/common/StatusBadge/StatusBadge.interface';
 import { EntityStatus } from '../generated/entity/data/glossaryTerm';
@@ -28,6 +39,33 @@ export const EntityStatusClass: Record<EntityStatus, StatusType> = {
 export const getEntityStatusClass = (status: EntityStatus): StatusType => {
   return EntityStatusClass[status] ?? StatusType.Pending;
 };
+
+export interface StatusBadgeConfig {
+  color: BadgeColors;
+  icon: IconComponentType;
+}
+
+const DEFAULT_STATUS_BADGE_CONFIG: StatusBadgeConfig = {
+  color: 'success',
+  icon: CheckCircle,
+};
+
+export const StatusBadgeConfigs: Partial<
+  Record<StatusType, StatusBadgeConfig>
+> = {
+  [StatusType.Success]: DEFAULT_STATUS_BADGE_CONFIG,
+  [StatusType.Failure]: { color: 'error', icon: XCircle },
+  [StatusType.InReview]: { color: 'purple', icon: Eye },
+  [StatusType.Pending]: { color: 'warning', icon: Clipboard },
+  [StatusType.Deprecated]: { color: 'gray', icon: ArrowCircleDown },
+  [StatusType.Archived]: { color: 'gray', icon: ArrowCircleDown },
+};
+
+export const getEntityStatusBadgeConfig = (
+  status?: string
+): StatusBadgeConfig =>
+  StatusBadgeConfigs[EntityStatusClass[status as EntityStatus]] ??
+  DEFAULT_STATUS_BADGE_CONFIG;
 
 export const isDeleted = (deleted: unknown): boolean => {
   return (deleted as string) === 'false' || deleted === false || isNil(deleted)


### PR DESCRIPTION
Backport of #32964 to `2.0` (cherry-pick of `a5034d4`).

Applied cleanly — no conflicts, no adaptation needed.

## Verification

- **Diff-of-diffs** — `git diff -U0 <sha>^ <sha>` on `main` vs. on this branch, whitespace-normalized — is identical line-for-line:

  | file | lines |
  |---|---|
  | `ContractDetail.tsx` | 25 |
  | `EntityStatusUtils.ts` | 38 |

- **Jest**: `ContractDetail.test.tsx` passes (49 tests), 0 failures.
- **`tsc --noEmit`**: 719 errors on the `2.0` tip and 719 with this applied — zero delta, and none in either touched file.
- **`prettier --check`** passes on both files. ESLint is left to CI (`2.0`'s flat config cannot run against the borrowed `node_modules` used here).

Split out from the combined backport so it can be reviewed and reverted independently of #32948's backport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)