### PR TITLE
ci: stop merge_group runs from saving the ingestion venv cache under queue refs

### DIFF
--- a/.github/actions/setup-openmetadata-test-environment/action.yml
+++ b/.github/actions/setup-openmetadata-test-environment/action.yml
@@ -183,10 +183,23 @@ runs:
     # Saved here rather than at job end so a later failure (server startup,
     # tests) still leaves the venv cached. Fork PRs under pull_request_target
     # skip the save — actions/cache-poisoning; their restore above still runs.
+    # merge_group is excluded for the same reason setup-uv's enable-cache is
+    # gated above: the queue's gh-readonly-queue/* ref dies when its entry
+    # merges or is dequeued, but the ~1 GB venv saved under it (x2 — one per
+    # Python version the py-tests matrix runs) stays charged against the
+    # repo's 10 GB LRU budget until evicted. Measured 2026-09-10 03:44-03:49:
+    # four om-venv entries, 3.98 GB, on two dead queue refs — the largest
+    # ephemeral writer left after #33085 — and in the same window the
+    # main-scoped playwright-distribution and playwright-ingestion-image
+    # entries the warmer had saved 25 minutes earlier were LRU-evicted.
+    # The restore above stays unconditional so queue runs still hit main's
+    # copy; only the write is gated, exactly as playwright-e2e-reusable.yml
+    # does for every one of its own saves.
     - name: Save ingestion Python venv
       if: >-
         ${{ inputs.fast-mode != 'true' && inputs.lightweight-ingestion != 'true' &&
         steps.cache-python-venv.outputs.cache-hit != 'true' &&
+        github.event_name != 'merge_group' &&
         !(github.event_name == 'pull_request_target' &&
           github.event.pull_request.head.repo.full_name != github.repository) }}
       continue-on-error: true


### PR DESCRIPTION
## Summary

Follow-up to #33085 — it gated the setup-node yarn cache and the buildkit layer cache off `merge_group`, but **missed the largest ephemeral writer**: the Python venv save in `.github/actions/setup-openmetadata-test-environment/action.yml`. My sweep only covered workflow files with a direct `merge_group:` trigger; this is a **composite action** reached via `py-tests-shared.yml` → `py-tests.yml` / `py-tests-postgres.yml`. That's on me.

One-line fix: add `github.event_name != 'merge_group'` to the save step's `if:`. The restore step is untouched, so queue runs still hit main's copy — same rule `playwright-e2e-reusable.yml` applies to every one of its own saves, and the same rule this very action already applies to `setup-uv`'s `enable-cache` ~50 lines up.

## The writer

```yaml
- name: Save ingestion Python venv
  if: >-
    ${{ inputs.fast-mode != 'true' && inputs.lightweight-ingestion != 'true' &&
    steps.cache-python-venv.outputs.cache-hit != 'true' &&
    !(github.event_name == 'pull_request_target' &&          # ← guards fork poisoning
      github.event.pull_request.head.repo.full_name != github.repository) }}
```

Guards the fork-PRT cache-poisoning case. No `merge_group` guard. ~1 GB per Python version (the py-tests matrix runs two) per merge_group run, saved under `gh-readonly-queue/*` — a ref that dies when the entry merges or is dequeued — and charged against the 10 GB LRU budget until evicted.

## Measured, 2026-09-10 (post-#33085)

| | |
|---|---|
| 03:44–03:49 | **4 × `Linux-py3.1x-om-venv` = 3.98 GB** on two dead queue refs |
| Total cache | **11.46 GB** against 10 GB |
| 03:24 | Warmer (02:54 push run) saved fixture + distribution + ingestion-image under main ✓ |
| ~03:50 | `playwright-distribution` (0.37 GB) and `playwright-ingestion-image` (1.26 GB) **gone from main — LRU-evicted within ~25 min** |
| ~03:50 | 54 MB fixture survived — only because a merge_group run had just restored it (`last_accessed` 03:49, 03:52) |

Net effect on merge_group today: the fixture cache **does** hit now (#33085 + #33061 working), but `build` still runs `mvn` cold (~6.5 min) and ingestion lanes still rebuild the image, because the main-scoped copies can't survive 2 GB/run of ephemeral writes landing next to them.

## What this does and doesn't fix

- **Fixes:** the last ~2 GB/run ephemeral writer. Queue-ref footprint should go to ~0 (the 32 MB `spacy-model` entry aside).
- **Should follow:** distribution + ingestion-image staying on main between warmer runs → `build` job drops from ~6.5 min to ~1 min on merge_group, ingestion lanes skip the image rebuild.
- **Not changed:** `spacy-model` `actions/cache@` in `py-tests-shared.yml` — same class, 32 MB, 0.6% of budget. Not worth the surface.
- **Not ours:** CodeQL overlay-base-database — **8 × ~470 MB = 3.74 GB on main in 45 min**. No `codeql-action` workflow file exists; it's GitHub default-setup CodeQL. It's now the largest single consumer of the budget. Worth a look in repo settings, separately.

## Sweep coverage, corrected

For the record, since #33085's sweep had blind spots: this time I checked **workflows with direct `merge_group:`**, **reusables (`on: workflow_call`) invoked by them**, and **composite actions (`.github/actions/*/action.yml`) they use**. Writers found and their state:

| Location | Writer | State |
|---|---|---|
| `playwright-e2e-reusable.yml` | 5 × `cache/save` | guarded ✓ |
| `java-playwright-nightly.yml` | buildkit `cache-to` | guarded (#33085) ✓ |
| `playwright-postgresql-e2e.yml` | setup-node `cache: yarn` | guarded (#33085) ✓ |
| `setup-openmetadata-test-environment/action.yml` | setup-uv `enable-cache` | guarded (pre-existing) ✓ |
| **`setup-openmetadata-test-environment/action.yml`** | **venv `cache/save`** | **this PR** |
| `py-tests-shared.yml` | spacy `actions/cache@` (32 MB) | unguarded, left |
| ~15 × `actions/cache@v6` maven/yarn | `hashFiles`-keyed | skip save on hit; benign |

## Test plan
- [x] YAML parses; the `if:` expression is a valid folded scalar containing the new guard (verified by loading and inspecting the step)
- [ ] After merge: `gh api repos/open-metadata/OpenMetadata/actions/caches` filtered to `gh-readonly-queue` refs shows no `om-venv` entries after the next merge_group cycle
- [ ] After merge: `playwright-distribution-v2-*` and `playwright-ingestion-image-v2-*` persist under `refs/heads/main` across ≥3 consecutive merge_group runs
- [ ] After merge: merge_group `build` job p50 drops toward ~1 min (distribution cache hit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)