### PR TITLE
Fixes #32911: allow only Group teams to be selected in team dropdowns (#32915)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsHierarchy.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsHierarchy.spec.ts
@@ -13,7 +13,13 @@
 import { expect, test } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { GlobalSettingOptions } from '../../constant/settings';
-import { redirectToHomePage, uuid } from '../../utils/common';
+import { TeamClass } from '../../support/team/TeamClass';
+import {
+  getApiContext,
+  redirectToHomePage,
+  uuid,
+  visitOwnProfilePage,
+} from '../../utils/common';
 import { settingClick } from '../../utils/sidebar';
 import {
   addTeamHierarchy,
@@ -106,6 +112,170 @@ test.describe(
         await expect(page.locator('.ant-tree-select-dropdown')).toContainText(
           teamName
         );
+      }
+    });
+
+    test('Only Group teams are selectable in Add User team dropdown', async ({
+      page,
+    }) => {
+      const childlessDepartmentName = `pw-childless-department-${uuid()}`;
+      const childlessDepartment = new TeamClass({
+        name: childlessDepartmentName,
+        displayName: childlessDepartmentName,
+        description: 'playwright childless department team',
+        teamType: 'Department',
+      });
+      const { apiContext, afterAction } = await getApiContext(page);
+      await childlessDepartment.create(apiContext);
+
+      try {
+        await settingClick(page, GlobalSettingOptions.USERS);
+
+        const teamHierarchyResponse = page.waitForResponse(
+          '/api/v1/teams/hierarchy?isJoinable=false'
+        );
+        await page.locator('[data-testid="add-user"]').click();
+        await teamHierarchyResponse;
+
+        const teamSelect = page.getByTestId('team-select');
+        const teamSelectInput = teamSelect.getByRole('combobox');
+        const dropdown = page.getByRole('tree');
+        // Selection chips only — the select also mirrors the typed search
+        // text as a text node (ant-select-selection-search-mirror), so a
+        // bare getByText inside the control matches even with no selection.
+        const selectedTeamChips = teamSelect.locator(
+          '.ant-select-selection-item'
+        );
+
+        await test.step('Non-Group team with children is visible but not selectable', async () => {
+          await teamSelect.click();
+          await teamSelectInput.fill(departmentTeamName);
+
+          const departmentOption = dropdown.getByText(departmentTeamName);
+
+          await expect(departmentOption).toBeVisible();
+
+          await departmentOption.click();
+
+          await expect(
+            selectedTeamChips.filter({ hasText: departmentTeamName })
+          ).toHaveCount(0);
+        });
+
+        await test.step('Non-Group team without children is hidden', async () => {
+          await teamSelectInput.fill(childlessDepartmentName);
+
+          // With every option pruned antd unmounts the tree ("No data"), so a
+          // count assertion is used — not.toContainText fails on a missing
+          // element instead of passing.
+          await expect(dropdown.getByText(childlessDepartmentName)).toHaveCount(
+            0
+          );
+        });
+
+        await test.step('Group team is selectable', async () => {
+          await teamSelectInput.fill(groupTeamName);
+
+          const groupOption = dropdown.getByText(groupTeamName);
+
+          await expect(groupOption).toBeVisible();
+
+          await groupOption.click();
+
+          await expect(
+            selectedTeamChips.filter({ hasText: groupTeamName })
+          ).toHaveCount(1);
+        });
+      } finally {
+        await childlessDepartment.delete(apiContext);
+        await afterAction();
+      }
+    });
+
+    test('Only Group teams are selectable in user profile teams edit', async ({
+      page,
+    }) => {
+      const childlessDivisionName = `pw-childless-division-${uuid()}`;
+      const childlessDivision = new TeamClass({
+        name: childlessDivisionName,
+        displayName: childlessDivisionName,
+        description: 'playwright childless division team',
+        teamType: 'Division',
+      });
+      const { apiContext, afterAction } = await getApiContext(page);
+      await childlessDivision.create(apiContext);
+
+      try {
+        await visitOwnProfilePage(page);
+
+        const teamHierarchyResponse = page.waitForResponse(
+          '/api/v1/teams/hierarchy?isJoinable=false'
+        );
+        await page.getByTestId('edit-teams-button').click();
+        await teamHierarchyResponse;
+
+        const popover = page.getByTestId('profile-teams-edit-popover');
+
+        await expect(popover).toBeVisible();
+
+        const teamSelect = popover.getByTestId('team-select');
+        const teamSelectInput = teamSelect.getByRole('combobox');
+        // `teams-custom-dropdown-class` is set by TeamsSelectableNew via
+        // popupClassName (component-owned, not an antd internal).
+        const dropdown = page.locator('.teams-custom-dropdown-class');
+        // Chips truncate long labels, so selection is asserted on the tree
+        // node's selected state where the full team name is rendered. The antd
+        // class is the only selected-state signal: rc-tree renders no treeitem
+        // role and (mis)maps aria-selected to `selectable`, not `selected`.
+        const selectedTreeNodes = dropdown.locator(
+          '.ant-select-tree-treenode-selected'
+        );
+
+        await test.step('Non-Group team with children is visible but not selectable', async () => {
+          await teamSelectInput.fill(departmentTeamName);
+
+          const departmentOption = dropdown.getByText(departmentTeamName);
+
+          await expect(departmentOption).toBeVisible();
+
+          await departmentOption.click();
+
+          await expect(
+            selectedTreeNodes.filter({ hasText: departmentTeamName })
+          ).toHaveCount(0);
+        });
+
+        await test.step('Non-Group team without children is hidden', async () => {
+          await teamSelectInput.fill(childlessDivisionName);
+
+          // Count assertion: not.toContainText fails when antd unmounts the
+          // emptied dropdown content instead of passing.
+          await expect(dropdown.getByText(childlessDivisionName)).toHaveCount(
+            0
+          );
+        });
+
+        await test.step('Group team is selectable', async () => {
+          await teamSelectInput.fill(groupTeamName);
+
+          const groupOption = dropdown.getByText(groupTeamName);
+
+          await expect(groupOption).toBeVisible();
+
+          await groupOption.click();
+
+          await expect(
+            selectedTreeNodes.filter({ hasText: groupTeamName })
+          ).toHaveCount(1);
+        });
+
+        // Close without saving so the admin's team memberships stay untouched
+        await page.getByTestId('teams-edit-close-btn').click();
+
+        await expect(popover).not.toBeVisible();
+      } finally {
+        await childlessDivision.delete(apiContext);
+        await afterAction();
       }
     });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectable.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Alert, TreeSelect } from 'antd';
-import { BaseOptionType } from 'antd/lib/select';
 import { AxiosError } from 'axios';
 
 import { isEmpty } from 'lodash';
@@ -25,6 +24,7 @@ import { getEntityName } from '../../../../utils/EntityNameUtils';
 import i18n from '../../../../utils/i18next/LocalUtil';
 import { showErrorToast } from '../../../../utils/ToastUtils';
 import { TeamsSelectableProps } from './TeamsSelectable.interface';
+import { buildTeamsSelectableTree } from './TeamsSelectable.utils';
 
 const TeamsSelectable = ({
   showTeamsAlert,
@@ -79,27 +79,10 @@ const TeamsSelectable = ({
 
   const showLeafIcon = false;
 
-  const getTreeNodeData = (team: TeamHierarchy): BaseOptionType => {
-    const teamName = getEntityName(team);
-    const value = team.id;
-    const disabled = filterJoinable ? !team.isJoinable : false;
-
-    return {
-      title: teamName,
-      value,
-      selectable: !team.children?.length,
-      disabled,
-      children:
-        team.children &&
-        team.children.map((n: TeamHierarchy) => getTreeNodeData(n)),
-    };
-  };
-
-  const teamsTree = useMemo(() => {
-    return teams.map((team) => {
-      return getTreeNodeData(team);
-    });
-  }, [teams]);
+  const teamsTree = useMemo(
+    () => buildTeamsSelectableTree(teams, filterJoinable),
+    [teams, filterJoinable]
+  );
 
   const selectedTeamsInternal = useMemo(() => {
     return selectedTeams?.map((selectedTeam) => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectable.utils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectable.utils.test.ts
@@ -1,0 +1,107 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import {
+  TeamHierarchy,
+  TeamType,
+} from '../../../../generated/entity/teams/teamHierarchy';
+import { buildTeamsSelectableTree } from './TeamsSelectable.utils';
+
+const groupTeam = (id: string, isJoinable = true): TeamHierarchy => ({
+  id,
+  name: id,
+  displayName: id,
+  teamType: TeamType.Group,
+  isJoinable,
+});
+
+describe('buildTeamsSelectableTree', () => {
+  it('should mark Group teams as selectable', () => {
+    const tree = buildTeamsSelectableTree([groupTeam('group-1')]);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0]).toMatchObject({
+      value: 'group-1',
+      selectable: true,
+      disabled: false,
+    });
+  });
+
+  it('should prune non-Group teams without nested Group teams', () => {
+    const tree = buildTeamsSelectableTree([
+      {
+        id: 'department-1',
+        name: 'department-1',
+        teamType: TeamType.Department,
+      },
+      {
+        id: 'division-1',
+        name: 'division-1',
+        teamType: TeamType.Division,
+        children: [
+          {
+            id: 'department-2',
+            name: 'department-2',
+            teamType: TeamType.Department,
+          },
+        ],
+      },
+    ]);
+
+    expect(tree).toHaveLength(0);
+  });
+
+  it('should keep non-Group branches leading to Group teams as non-selectable', () => {
+    const tree = buildTeamsSelectableTree([
+      {
+        id: 'division-1',
+        name: 'division-1',
+        teamType: TeamType.Division,
+        children: [
+          {
+            id: 'department-1',
+            name: 'department-1',
+            teamType: TeamType.Department,
+            children: [groupTeam('group-1')],
+          },
+          {
+            id: 'department-2',
+            name: 'department-2',
+            teamType: TeamType.Department,
+          },
+        ],
+      },
+    ]);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0].selectable).toBe(false);
+    expect(tree[0].children).toHaveLength(1);
+    expect(tree[0].children?.[0]).toMatchObject({
+      value: 'department-1',
+      selectable: false,
+    });
+    expect(tree[0].children?.[0].children?.[0]).toMatchObject({
+      value: 'group-1',
+      selectable: true,
+    });
+  });
+
+  it('should disable non-joinable teams when filterJoinable is set', () => {
+    const tree = buildTeamsSelectableTree(
+      [groupTeam('group-1', false), groupTeam('group-2')],
+      true
+    );
+
+    expect(tree[0]).toMatchObject({ value: 'group-1', disabled: true });
+    expect(tree[1]).toMatchObject({ value: 'group-2', disabled: false });
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectable.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectable.utils.ts
@@ -1,0 +1,60 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { isEmpty } from 'lodash';
+import {
+  ChildElement,
+  TeamHierarchy,
+  TeamType,
+} from '../../../../generated/entity/teams/teamHierarchy';
+import { getEntityName } from '../../../../utils/EntityNameUtils';
+
+export interface TeamsSelectableTreeNode {
+  title: string;
+  value: string;
+  selectable: boolean;
+  disabled: boolean;
+  children?: TeamsSelectableTreeNode[];
+}
+
+const getTreeNodeData = (
+  team: TeamHierarchy | ChildElement,
+  filterJoinable?: boolean
+): TeamsSelectableTreeNode | null => {
+  const children = (team.children ?? [])
+    .map((child) => getTreeNodeData(child, filterJoinable))
+    .filter((child): child is TeamsSelectableTreeNode => child !== null);
+
+  const isGroupTeam = team.teamType === TeamType.Group;
+
+  // Only Group teams can have direct users; non-Group teams stay visible
+  // solely as branches leading to nested Group teams.
+  if (!isGroupTeam && isEmpty(children)) {
+    return null;
+  }
+
+  return {
+    title: getEntityName(team),
+    value: team.id,
+    selectable: isGroupTeam,
+    disabled: filterJoinable ? !team.isJoinable : false,
+    children: isEmpty(children) ? undefined : children,
+  };
+};
+
+export const buildTeamsSelectableTree = (
+  teams: TeamHierarchy[],
+  filterJoinable?: boolean
+): TeamsSelectableTreeNode[] =>
+  teams
+    .map((team) => getTreeNodeData(team, filterJoinable))
+    .filter((team): team is TeamsSelectableTreeNode => team !== null);

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectableNew.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectableNew.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Alert, TreeSelect } from 'antd';
-import { BaseOptionType } from 'antd/lib/select';
 import { AxiosError } from 'axios';
 
 import { isEmpty } from 'lodash';
@@ -25,6 +24,7 @@ import i18n from '../../../../utils/i18next/LocalUtil';
 import { showErrorToast } from '../../../../utils/ToastUtils';
 import { TagRenderer } from '../../../common/TagRenderer/TagRenderer';
 import { TeamsSelectableProps } from './TeamsSelectable.interface';
+import { buildTeamsSelectableTree } from './TeamsSelectable.utils';
 
 const TeamsSelectableNew = forwardRef<any, TeamsSelectableProps>(
   (
@@ -77,25 +77,10 @@ const TeamsSelectableNew = forwardRef<any, TeamsSelectableProps>(
 
     const showLeafIcon = false;
 
-    const getTreeNodeData = (team: TeamHierarchy): BaseOptionType => {
-      const teamName = getEntityName(team);
-      const value = team.id;
-      const disabled = filterJoinable ? !team.isJoinable : false;
-
-      return {
-        title: teamName,
-        value,
-        selectable: !team.children?.length,
-        disabled,
-        children:
-          team.children &&
-          team.children.map((n: TeamHierarchy) => getTreeNodeData(n)),
-      };
-    };
-
-    const teamsTree = useMemo(() => {
-      return teams.map((team) => getTreeNodeData(team));
-    }, [teams]);
+    const teamsTree = useMemo(
+      () => buildTeamsSelectableTree(teams, filterJoinable),
+      [teams, filterJoinable]
+    );
 
     const selectedTeamsInternal = useMemo(() => {
       return selectedTeams?.map((selectedTeam) => ({


### PR DESCRIPTION
### Describe your changes:

Backport of #32915 to `2.0`. Fixes #32911.

Cherry-pick of 642fdf3e90cd9df3fb3f083f1874b5244bed8141. The only conflict was the import block of `playwright/e2e/Features/TeamsHierarchy.spec.ts`: `main` imports `test`/`expect` from `support/fixtures/base`, which does not exist on `2.0`, so the spec keeps the `@playwright/test` import. Everything else applied cleanly.

The team selector (user profile Edit Teams, Create User form, Sign Up page) marked any *leaf* team as selectable. Leaf is not Group: a childless `Department`/`Division`/`BusinessUnit` was offered as a valid choice, while only `Group` teams can have direct users. Users added this way got stuck since the Team page blocks removal for non-Group teams.

- Only `Group` teams are selectable.
- Non-Group teams remain visible as non-selectable branches when they lead to nested Group teams.
- Non-Group subtrees containing no Group team are pruned from the dropdown.
- Existing invalid memberships still render as removable tags.
- `filterJoinable` (Sign Up flow) behavior is preserved.

#
### Type of change:
- [x] Bug fix

#
### Tests:

- `TeamsSelectable.utils.test.ts` (4 cases) and existing `TeamsSelectable.test.tsx` run green on this branch.
- Playwright `TeamsHierarchy.spec.ts` extended with two tests (Add User dropdown, profile teams edit).
- Prettier clean; no `tsc` errors in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)