### PR TITLE
Backport #33022 to 2.0: avoid overlay click intercepts in domain and service flows

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterMemories.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterMemories.spec.ts
@@ -17,6 +17,7 @@ import {
   createNewPage,
   getApiContext,
   redirectToHomePage,
+  selectOptionWithRetry,
   uuid,
 } from '../../utils/common';
 import {
@@ -447,8 +448,10 @@ test.describe(
           .fill('This memory has all optional fields populated.');
 
         // Select type: Note
-        await dialog.getByTestId('memory-type-select').click();
-        await page.getByRole('option', { name: /note/i }).click();
+        await selectOptionWithRetry(
+          dialog.getByTestId('memory-type-select'),
+          page.getByRole('option', { name: /note/i })
+        );
 
         const createResPromise = page.waitForResponse(
           (res) =>
@@ -1518,8 +1521,10 @@ test.describe(
         );
         await editVisibilityBtn.click();
 
-        await dialog.getByTestId('memory-visibility-select').click();
-        await page.getByRole('option', { name: /private/i }).click();
+        await selectOptionWithRetry(
+          dialog.getByTestId('memory-visibility-select'),
+          page.getByRole('option', { name: /private/i })
+        );
 
         const updateResPromise = page.waitForResponse(
           new RegExp(`${MEMORIES_API}/${visBadgeMemoryId}`)

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TableLevelTests.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TableLevelTests.spec.ts
@@ -17,6 +17,7 @@ import {
   createNewPage,
   getApiContext,
   redirectToHomePage,
+  selectOptionWithRetry,
 } from '../../../utils/common';
 import {
   clickUpdateButton,
@@ -924,8 +925,10 @@ test.describe(
           .getByTestId('code-mirror-container')
           .getByRole('textbox')
           .fill(' update');
-        await page.getByRole('button', { name: 'ROWS Strategy' }).click();
-        await page.getByRole('option', { name: 'COUNT' }).click();
+        await selectOptionWithRetry(
+          page.getByRole('button', { name: 'ROWS Strategy' }),
+          page.getByRole('option', { name: 'COUNT' })
+        );
         await page.locator('[data-id="tableCustomSQLQuery"]').waitFor({
           state: 'visible',
         });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestLibrary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestLibrary.spec.ts
@@ -15,6 +15,7 @@ import { DOMAIN_TAGS } from '../../../constant/config';
 import {
   getApiContext,
   redirectToHomePage,
+  selectOptionWithRetry,
   toastNotification,
   uuid,
 } from '../../../utils/common';
@@ -403,8 +404,10 @@ test.describe(
           ).toHaveCount(0);
 
           // Add dbt
-          await page.getByTestId('test-platforms').click();
-          await page.getByRole('option', { name: 'dbt', exact: true }).click();
+          await selectOptionWithRetry(
+            page.getByTestId('test-platforms'),
+            page.getByRole('option', { name: 'dbt', exact: true })
+          );
 
           // Close dropdown
           await page.keyboard.press('Escape');

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LineageExportPNGSnapshot.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LineageExportPNGSnapshot.spec.ts
@@ -13,6 +13,7 @@
 
 import { expect, test } from '@playwright/test';
 import * as fs from 'fs';
+import { selectOptionWithRetry } from '../../utils/common';
 import { performZoomOut } from '../../utils/lineage';
 
 /**
@@ -79,8 +80,10 @@ test.describe('Lineage PNG export — snapshot regression', () => {
       .waitFor({ state: 'visible' });
 
     // Select PNG (the modal defaults to CSV for entity lineage)
-    await page.getByTestId('export-type-select').click();
-    await page.getByRole('option', { name: 'PNG' }).click();
+    await selectOptionWithRetry(
+      page.getByTestId('export-type-select'),
+      page.getByRole('option', { name: 'PNG' })
+    );
     await expect(page.getByTestId('export-type-select')).toContainText('PNG');
 
     // Trigger download

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryTermRelationSettings.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryTermRelationSettings.spec.ts
@@ -17,6 +17,7 @@ import {
   getApiContext,
   getAuthContext,
   getSavedAdminToken,
+  selectOptionWithRetry,
   toastNotification,
   uuid,
 } from '../../utils/common';
@@ -102,8 +103,10 @@ const fillInput = async (page: Page, testId: string, value: string) => {
 };
 
 const selectOption = async (page: Page, testId: string, option: string) => {
-  await page.getByTestId(testId).click();
-  await page.getByRole('option', { name: option, exact: true }).click();
+  await selectOptionWithRetry(
+    page.getByTestId(testId),
+    page.getByRole('option', { name: option, exact: true })
+  );
 };
 
 // The drawer's save fires a single non-retrying write against the shared

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -374,6 +374,26 @@ export const waitForToastToDisappear = async (
 };
 
 /**
+ * Waits until the toast stack holds no toast, so a click on something beneath it
+ * cannot be swallowed.
+ *
+ * The toast region renders fixed at bottom-center — the same spot as many
+ * dialogs' action buttons (Test Connection's Done/OK, for one). The backend fans
+ * async-delete notifications from parallel workers' cleanup out to every socket
+ * of the logged-in user, so unrelated "…deleted successfully!" toasts can pile up
+ * over a button and intercept the click. A count assertion is used instead of a
+ * message-filtered `waitFor` because the intercepting toast can be any of them —
+ * `toHaveCount(0)` retries until the whole stack has drained and never trips
+ * strict mode.
+ */
+export const waitForToastStackToClear = async (
+  page: Page,
+  timeout?: number
+) => {
+  await expect(page.getByTestId('alert-bar')).toHaveCount(0, { timeout });
+};
+
+/**
  * Asserts that the page is showing no error toast, optionally narrowed to the
  * ones carrying `message`.
  *
@@ -1707,4 +1727,17 @@ export const testTableSearch = async (
       timeout: 5_000,
     });
   }).toPass({ timeout: 30_000, intervals: [2_000, 5_000] });
+};
+
+export const selectOptionWithRetry = async (
+  trigger: Locator,
+  option: Locator
+) => {
+  await expect(async () => {
+    if ((await trigger.getAttribute('aria-expanded')) !== 'true') {
+      await trigger.click();
+    }
+
+    await option.click({ timeout: 2000 });
+  }).toPass({ timeout: 15000 });
 };

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
@@ -28,6 +28,7 @@ import {
   clickOutside,
   descriptionBox,
   descriptionBoxReadOnly,
+  selectOptionWithRetry,
   uuid,
 } from './common';
 import { waitForAllLoadersToDisappear } from './entity';
@@ -698,8 +699,10 @@ export const addCustomPropertiesForEntity = async ({
   await page.fill('[data-testid="display-name"]', propertyName);
 
   // Select custom type
-  await page.locator('[data-testid="propertyType"]').click();
-  await page.getByRole('option', { name: customType, exact: true }).click();
+  await selectOptionWithRetry(
+    page.locator('[data-testid="propertyType"]'),
+    page.getByRole('option', { name: customType, exact: true })
+  );
 
   // Enum configuration
   if (customType === 'Enum' && enumConfig) {
@@ -759,8 +762,10 @@ export const addCustomPropertiesForEntity = async ({
 
   // Format configuration
   if (['Date', 'Date Time', 'Time'].includes(customType) && formatConfig) {
-    await page.getByTestId('formatConfig').click();
-    await page.getByRole('option', { name: formatConfig, exact: true }).click();
+    await selectOptionWithRetry(
+      page.getByTestId('formatConfig'),
+      page.getByRole('option', { name: formatConfig, exact: true })
+    );
   }
 
   // Description

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
@@ -43,6 +43,7 @@ import {
   NAME_VALIDATION_ERROR,
   readElementInListWithScroll,
   redirectToHomePage,
+  selectOptionWithRetry,
   uuid,
 } from './common';
 import { addOwner, waitForAllLoadersToDisappear } from './entity';
@@ -442,8 +443,11 @@ export const selectDomain = async (page: Page, domain: Domain['data']) => {
     )
     .toBe(true);
 
+  // Click the domain name cell, not the row center — the row's center column is
+  // the glossary-terms cell whose tags are their own links, so a row-center
+  // click lands on a tag instead of triggering the domain navigation.
   await Promise.all([
-    domainRow.click(),
+    domainRow.getByTestId('entity-name').click(),
     page.waitForResponse('/api/v1/domains/name/*'),
   ]);
 
@@ -534,9 +538,12 @@ export const selectDataProduct = async (
 
   await waitForSearchDebounce(page);
 
+  // Click the data product name cell, not the row center — the row's center
+  // column can be the glossary-terms cell whose tags are their own links, so a
+  // row-center click lands on a tag instead of triggering navigation.
   await Promise.all([
     page.waitForResponse('/api/v1/dataProducts/name/*'),
-    page.getByTestId(dataProduct.name).click(),
+    page.getByTestId(dataProduct.name).getByTestId('entity-name').click(),
   ]);
 
   await waitForAllLoadersToDisappear(page);
@@ -611,11 +618,15 @@ export const fillDomainForm = async (
     .getByTestId('add-domain-form')
     .getByTestId('domainType')
     .getByRole('button');
-  await domainTypeTrigger.click();
+  const domainTypeOption = page.getByRole('option', {
+    name: entity.domainType,
+    exact: true,
+  });
 
-  await page
-    .getByRole('option', { name: entity.domainType, exact: true })
-    .click();
+  // React Aria can close the listbox mid-click and detach the option
+  // ("element was detached from the DOM"); selectOptionWithRetry re-resolves the
+  // trigger's expanded state and reopens the popover before retrying the click.
+  await selectOptionWithRetry(domainTypeTrigger, domainTypeOption);
 };
 
 export const checkDomainDisplayName = async (

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/lineage.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/lineage.ts
@@ -35,6 +35,7 @@ import {
   clickOutside,
   getApiContext,
   getEntityTypeSearchIndexMapping,
+  selectOptionWithRetry,
   toastNotification,
 } from './common';
 import { waitForAllLoadersToDisappear } from './entity';
@@ -872,8 +873,10 @@ export const verifyExportLineagePNG = async (
     });
 
   if (!isPNGSelected) {
-    await page.getByTestId('export-type-select').click();
-    await page.getByRole('option', { name: 'PNG' }).click();
+    await selectOptionWithRetry(
+      page.getByTestId('export-type-select'),
+      page.getByRole('option', { name: 'PNG' })
+    );
   }
 
   await expect(page.getByTestId('export-type-select')).toContainText('PNG');

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/scheduleInterval.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/scheduleInterval.ts
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 import { expect, Page } from '@playwright/test';
+import { selectOptionWithRetry } from './common';
 
 /**
  * Helpers for the ScheduleIntervalV1 scheduler used by the Add / Edit Ingestion
@@ -41,8 +42,10 @@ export const selectScheduleFrequency = async (
 };
 
 const selectOption = async (page: Page, testId: string, option: string) => {
-  await page.getByTestId(testId).getByRole('button').click();
-  await page.getByRole('option', { name: option, exact: true }).click();
+  await selectOptionWithRetry(
+    page.getByTestId(testId).getByRole('button'),
+    page.getByRole('option', { name: option, exact: true })
+  );
 };
 
 export const selectScheduleMinute = async (page: Page, minute: string) =>

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/serviceIngestion.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/serviceIngestion.ts
@@ -21,7 +21,11 @@ import {
 import { BIG_ENTITY_DELETE_TIMEOUT } from '../constant/delete';
 import { GlobalSettingOptions } from '../constant/settings';
 import { EntityTypeEndpoint } from '../support/entity/Entity.interface';
-import { getApiContext, toastNotification } from './common';
+import {
+  getApiContext,
+  toastNotification,
+  waitForToastStackToClear,
+} from './common';
 import { getEncodedFqn, waitForAllLoadersToDisappear } from './entity';
 
 export enum Services {
@@ -201,6 +205,11 @@ export const testConnection = async (page: Page) => {
     .filter({ hasText: /Connection status|Test Connection/ });
 
   await expect(testConnectionDialog).toBeVisible();
+
+  // The toast stack renders bottom-center, over the dialog's Done/OK button; a
+  // background "…deleted successfully!" toast from a parallel worker's cleanup
+  // can otherwise swallow this click. Wait for the stack to drain first.
+  await waitForToastStackToClear(page, 30_000);
 
   await testConnectionDialog.getByRole('button', { name: /Done|OK/ }).click();
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx
@@ -184,6 +184,7 @@ const DataProductListPage = ({
             <Box
               align="center"
               className={NAME_CELL_CLIP_CLASS}
+              data-testid="entity-name"
               direction="row"
               gap={3}
               onClick={handleNameClick}>

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.test.tsx
@@ -20,11 +20,13 @@ jest.mock('@openmetadata/ui-core-components', () => ({
   Box: ({
     children,
     onClick,
+    'data-testid': dataTestId,
   }: {
     children: ReactNode;
     onClick?: () => void;
+    'data-testid'?: string;
   }) => (
-    <div data-testid="name-cell" onClick={onClick}>
+    <div data-testid={dataTestId} onClick={onClick}>
       {children}
     </div>
   ),

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.tsx
@@ -83,6 +83,7 @@ export const renderDomainNameCell = (
     <Box
       align="center"
       className={NAME_CELL_CLIP_CLASS}
+      data-testid="entity-name"
       direction="row"
       gap={3}
       onClick={onClick ? handleNameClick : undefined}>


### PR DESCRIPTION
Backport of #33022 to `2.0`.

## Summary
Three Playwright click-intercept flakes, all cases where an element on top swallowed a click:

1. **Domain listing** — `selectDomain` clicked the table-row center, which lands in the Glossary Terms column where each tag is its own link, so the click hit a tag instead of triggering navigation. Added `data-testid="entity-name"` to the domain name cell and switched the helper to click that cell.
2. **Data product listing** — `selectDataProduct` had the identical row-center bug. Same `data-testid="entity-name"` treatment.
3. **Test Connection dialog** — the toast stack renders fixed at bottom-center, over the dialog's Done/OK button; background "…deleted successfully!" toasts from parallel workers' cleanup pile up and intercept the click. Added `waitForToastStackToClear` (count-based, no strict-mode risk) and drain the stack before clicking.

## Backport notes

The cherry-pick did **not** apply cleanly. Eight of the fourteen files applied byte-identically (verified by whitespace-normalized diff-of-diffs against `main`); the rest needed adaptation:

**Dropped — these files do not exist on `2.0`:**

| File | Why |
|---|---|
| `playwright/QUARANTINE.md` | 2.0 has no quarantine ledger |
| `e2e/Features/AppMode/AppModeRouteIsolation.spec.ts` | main-only spec |
| `e2e/Features/OntologyQueryRdf.spec.ts` | main-only spec |
| `.github/playwright/impact-map.generated.json` | 2.0 has `impact-map.json`, not the generated variant |

The upstream PR also un-quarantined `Domains.spec.ts › "Verify domain tags and glossary terms"`. That is a no-op here — the test was never quarantined on 2.0 (`@quarantine` count is 0 in that file), which is why the hunk merged away to nothing.

**Ported a missing dependency.** The upstream PR converted ~9 call sites to `selectOptionWithRetry`, but that helper landed on `main` in an *earlier*, un-backported PR — it is not on 2.0. The cherry-pick happily merged the imports and call sites, which would have failed to compile. Added the helper to `playwright/utils/common.ts` verbatim from `main` (11 lines, self-contained).

**Adapted for main-only refactors that 2.0 does not have:**

| File | Divergence | Resolution |
|---|---|---|
| `DataProductListPage.tsx` | main extracted `renderDataProductNameCell`/`renderDataProductDomainCell` to module scope; 2.0 renders the name cell inline in `renderDataProductCell`'s `case 'name'` | kept 2.0's inline form, added just `data-testid="entity-name"` to that `Box` — net diff is **1 line** |
| `utils/domain.ts` | main's `selectDataProduct` has a `dataProductRow` local; 2.0 inlines `page.getByTestId(dataProduct.name)` | `page.getByTestId(dataProduct.name).getByTestId('entity-name').click()`. `EntityListingTable` sets the row's `data-testid={entity.name}`, so this matches how `selectDomain` already resolves its row on 2.0 |
| `LineageExportPNGSnapshot.spec.ts` | main imports `{ expect, test }` from the main-only `support/fixtures/base`; 2.0 takes them from `@playwright/test`, and the whole `test.describe` body is indented differently | restored 2.0's file, applied only the import + the `selectOptionWithRetry` call |
| `utils/customProperty.ts` | import block conflict — main's list has `fillDescriptionBox`/`getDescriptionBox`, 2.0's does not | kept 2.0's list, added only `selectOptionWithRetry` |
| `domainFieldRenderers.test.tsx` | main's `Box` mock carries a pre-existing `role="presentation"` | kept 2.0's mock shape, applied only the `data-testid={dataTestId}` binding |

## Verification on this branch (2.0)
- [x] `tsc --project playwright/tsconfig.json --noEmit` — **169 errors, identical to the count on clean `origin/2.0`**, and **zero** in any of the 14 touched files
- [x] `jest domainFieldRenderers.test.tsx` — **3/3 pass**
- [x] `prettier --check` on all 14 changed files — clean
- [x] diff-of-diffs vs `main` — identical for all 8 cleanly-applied files
- [ ] `eslint` — cannot run locally on a 2.0 worktree borrowing main's `node_modules` (`jsonc-eslint-parser` has no default export under main's ESLint 9 config); left to CI

Playwright itself is not run locally — CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
