### PR TITLE
fix(ui): reset TierCard selectedTier on close to prevent stale radio state

### DIFF
--- a/.github/playwright/impact-map.generated.json
+++ b/.github/playwright/impact-map.generated.json
@@ -652,6 +652,7 @@
         "playwright/e2e/Features/ServiceAgentsStatusDegradation.spec.ts",
         "playwright/e2e/Features/StorageMetadataAgentForm.spec.ts",
         "playwright/e2e/Features/Table.spec.ts",
+        "playwright/e2e/Features/TierWidget.spec.ts",
         "playwright/e2e/Pages/DataContracts.spec.ts",
         "playwright/e2e/Pages/DataContractsSemanticRules.spec.ts",
         "playwright/e2e/Pages/ExplorePageRightPanel.spec.ts",
@@ -1232,7 +1233,8 @@
       ],
       "specs": [
         "playwright/e2e/Features/DataQuality/AddTestCaseNewFlow.spec.ts",
-        "playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts"
+        "playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts",
+        "playwright/e2e/Features/TestSuitePipelineRedeploy.spec.ts"
       ]
     },
     {
@@ -2038,6 +2040,7 @@
         "playwright/e2e/Features/Glossary/GlossaryStatusFilterLargeDataset.spec.ts",
         "playwright/e2e/Features/Glossary/GlossaryStatusFilterNestedTerms.spec.ts",
         "playwright/e2e/Features/Glossary/LargeGlossaryPerformance.spec.ts",
+        "playwright/e2e/Features/TeamsDragAndDrop.spec.ts",
         "playwright/e2e/Pages/Glossary.spec.ts",
         "playwright/e2e/Pages/Tags.spec.ts",
         "playwright/e2e/Pages/Users.spec.ts"
@@ -3081,7 +3084,8 @@
       ],
       "specs": [
         "playwright/e2e/Features/DataQuality/AddTestCaseNewFlow.spec.ts",
-        "playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts"
+        "playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts",
+        "playwright/e2e/Features/TestSuitePipelineRedeploy.spec.ts"
       ]
     },
     {
@@ -4466,6 +4470,14 @@
     },
     {
       "sources": [
+        "openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx"
+      ],
+      "specs": [
+        "playwright/e2e/Features/TeamsDragAndDrop.spec.ts"
+      ]
+    },
+    {
+      "sources": [
         "openmetadata-ui/src/main/resources/ui/src/components/common/Table/__tests__/tableParity.shared.tsx"
       ],
       "specs": [
@@ -4542,11 +4554,20 @@
     },
     {
       "sources": [
+        "openmetadata-ui/src/main/resources/ui/src/components/common/TierCard/TierCard.tsx"
+      ],
+      "specs": [
+        "playwright/e2e/Features/TierWidget.spec.ts"
+      ]
+    },
+    {
+      "sources": [
         "openmetadata-ui/src/main/resources/ui/src/components/common/TierWidget/TierWidget.tsx"
       ],
       "specs": [
         "playwright/e2e/Features/DomainTierCertificationVoting.spec.ts",
         "playwright/e2e/Features/Permissions/EntityPermissions.spec.ts",
+        "playwright/e2e/Features/TierWidget.spec.ts",
         "playwright/e2e/Pages/ExplorePageRightPanel_KnowledgeCenter.spec.ts"
       ]
     },
@@ -5254,6 +5275,7 @@
         "playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts",
         "playwright/e2e/Features/TestSuitePipelineRedeploy.spec.ts",
         "playwright/e2e/Features/TierDropdown.spec.ts",
+        "playwright/e2e/Features/TierWidget.spec.ts",
         "playwright/e2e/Features/Topic.spec.ts",
         "playwright/e2e/Features/UserProfileOnlineStatus.spec.ts",
         "playwright/e2e/Features/Workflows/NoOpWorkflowNodeConfig.spec.ts",
@@ -5462,6 +5484,7 @@
         "playwright/e2e/Features/Tasks/TaskPipelineEntity.spec.ts",
         "playwright/e2e/Features/Tasks/TaskTopicEntity.spec.ts",
         "playwright/e2e/Features/TierDropdown.spec.ts",
+        "playwright/e2e/Features/TierWidget.spec.ts",
         "playwright/e2e/Features/Topic.spec.ts",
         "playwright/e2e/Flow/ConditionalPermissions.spec.ts",
         "playwright/e2e/Flow/ExploreDiscovery.spec.ts",

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TierWidget.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TierWidget.spec.ts
@@ -12,13 +12,10 @@
  */
 import { TableClass } from '../../support/entity/TableClass';
 import { expect, test } from '../../support/fixtures/base';
+import { createNewPage, redirectToHomePage } from '../../utils/common';
 import { addTierWidget } from '../../utils/domain';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
-import {
-  closeTierDropdown,
-  openTierDropdown,
-} from '../../utils/tier';
-import { createNewPage, redirectToHomePage } from '../../utils/common';
+import { closeTierDropdown } from '../../utils/tier';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 
@@ -38,55 +35,51 @@ test.describe('TierWidget stale state regression', () => {
   });
 
   test('TierWidget stale-state regression', async ({ page }) => {
-  await redirectToHomePage(page);
-  await table.visitEntityPage(page);
+    await redirectToHomePage(page);
+    await table.visitEntityPage(page);
 
-  await test.step('Radio resets to persisted tier after cancelling a change', async () => {
-    // Set Tier1 as the starting state.
-    await addTierWidget(page, 'Tier1', 'tables', true);
+    await test.step('Radio resets to persisted tier after cancelling a change', async () => {
+      // Set Tier1 as the starting state.
+      await addTierWidget(page, 'Tier1', 'tables', true);
 
-    // Open the editor and change the radio to Tier2 without saving.
-    // Tier tags are cached from addTierWidget above, so no API call fires here.
-    await page.getByTestId('edit-tier').click();
-    await page.getByTestId('cards').waitFor({ state: 'visible' });
-    await waitForAllLoadersToDisappear(page);
-    await page.getByTestId('radio-btn-Tier2').click();
+      // Open the editor and change the radio to Tier2 without saving.
+      // Tier tags are cached from addTierWidget above, so no API call fires here.
+      await page.getByTestId('edit-tier').click();
+      await page.getByTestId('cards').waitFor({ state: 'visible' });
+      await waitForAllLoadersToDisappear(page);
+      await page.getByTestId('radio-btn-Tier2').click();
 
-    // Cancel — the radio selection must NOT be persisted.
-    await closeTierDropdown(page);
+      // Cancel — the radio selection must NOT be persisted.
+      await closeTierDropdown(page);
 
-    // Reopen — tier tags are already cached so no API call fires; skip the
-    // response wait that openTierDropdown uses and go straight to the UI signal.
-    await page.getByTestId('edit-tier').click();
-    await page.getByTestId('cards').waitFor({ state: 'visible' });
-    await waitForAllLoadersToDisappear(page);
+      // Reopen — tier tags are already cached so no API call fires; skip the
+      // response wait that openTierDropdown uses and go straight to the UI signal.
+      await page.getByTestId('edit-tier').click();
+      await page.getByTestId('cards').waitFor({ state: 'visible' });
+      await waitForAllLoadersToDisappear(page);
 
-    await expect(
-      page.getByTestId('radio-btn-Tier1')    ).toBeChecked();
-    await expect(
-      page.getByTestId('radio-btn-Tier2')    ).not.toBeChecked();
+      await expect(page.getByTestId('radio-btn-Tier1')).toBeChecked();
+      await expect(page.getByTestId('radio-btn-Tier2')).not.toBeChecked();
 
-    await closeTierDropdown(page);
-  });
+      await closeTierDropdown(page);
+    });
 
-  await test.step('Radio shows newly saved tier on reopen after a successful save', async () => {
-    // Ensure Tier1 is set (carried over from step A).
-    await addTierWidget(page, 'Tier1', 'tables', true);
+    await test.step('Radio shows newly saved tier on reopen after a successful save', async () => {
+      // Ensure Tier1 is set (carried over from step A).
+      await addTierWidget(page, 'Tier1', 'tables', true);
 
-    // Save Tier2.
-    await addTierWidget(page, 'Tier2', 'tables', true);
+      // Save Tier2.
+      await addTierWidget(page, 'Tier2', 'tables', true);
 
-    // Reopen the editor — should show Tier2, not the stale Tier1.
-    await page.getByTestId('edit-tier').click();
-    await page.getByTestId('cards').waitFor({ state: 'visible' });
-    await waitForAllLoadersToDisappear(page);
+      // Reopen the editor — should show Tier2, not the stale Tier1.
+      await page.getByTestId('edit-tier').click();
+      await page.getByTestId('cards').waitFor({ state: 'visible' });
+      await waitForAllLoadersToDisappear(page);
 
-    await expect(
-      page.getByTestId('radio-btn-Tier2')    ).toBeChecked();
-    await expect(
-      page.getByTestId('radio-btn-Tier1')    ).not.toBeChecked();
+      await expect(page.getByTestId('radio-btn-Tier2')).toBeChecked();
+      await expect(page.getByTestId('radio-btn-Tier1')).not.toBeChecked();
 
-    await closeTierDropdown(page);
-  });
+      await closeTierDropdown(page);
+    });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TierWidget.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TierWidget.spec.ts
@@ -41,7 +41,7 @@ test.describe('TierWidget stale state regression', () => {
   await redirectToHomePage(page);
   await table.visitEntityPage(page);
 
-  await test.step('Bug A — radio resets to persisted tier after cancelling a change', async () => {
+  await test.step('Radio resets to persisted tier after cancelling a change', async () => {
     // Set Tier1 as the starting state.
     await addTierWidget(page, 'Tier1', 'tables', true);
 
@@ -69,7 +69,7 @@ test.describe('TierWidget stale state regression', () => {
     await closeTierDropdown(page);
   });
 
-  await test.step('Bug B — radio shows newly saved tier on reopen after a successful save', async () => {
+  await test.step('Radio shows newly saved tier on reopen after a successful save', async () => {
     // Ensure Tier1 is set (carried over from step A).
     await addTierWidget(page, 'Tier1', 'tables', true);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TierWidget.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TierWidget.spec.ts
@@ -19,10 +19,11 @@ import { closeTierDropdown } from '../../utils/tier';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 
-const table = new TableClass();
+let table: TableClass;
 
 test.describe('TierWidget stale state regression', () => {
   test.beforeAll(async ({ browser }) => {
+    table = new TableClass();
     const { apiContext, afterAction } = await createNewPage(browser);
     await table.create(apiContext);
     await afterAction();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TierWidget.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TierWidget.spec.ts
@@ -1,0 +1,92 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { TableClass } from '../../support/entity/TableClass';
+import { expect, test } from '../../support/fixtures/base';
+import { addTierWidget } from '../../utils/domain';
+import { waitForAllLoadersToDisappear } from '../../utils/entity';
+import {
+  closeTierDropdown,
+  openTierDropdown,
+} from '../../utils/tier';
+import { createNewPage, redirectToHomePage } from '../../utils/common';
+
+test.use({ storageState: 'playwright/.auth/admin.json' });
+
+const table = new TableClass();
+
+test.describe('TierWidget stale state regression', () => {
+  test.beforeAll(async ({ browser }) => {
+    const { apiContext, afterAction } = await createNewPage(browser);
+    await table.create(apiContext);
+    await afterAction();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const { apiContext, afterAction } = await createNewPage(browser);
+    await table.delete(apiContext);
+    await afterAction();
+  });
+
+  test('TierWidget stale-state regression', async ({ page }) => {
+  await redirectToHomePage(page);
+  await table.visitEntityPage(page);
+
+  await test.step('Bug A — radio resets to persisted tier after cancelling a change', async () => {
+    // Set Tier1 as the starting state.
+    await addTierWidget(page, 'Tier1', 'tables', true);
+
+    // Open the editor and change the radio to Tier2 without saving.
+    // Tier tags are cached from addTierWidget above, so no API call fires here.
+    await page.getByTestId('edit-tier').click();
+    await page.getByTestId('cards').waitFor({ state: 'visible' });
+    await waitForAllLoadersToDisappear(page);
+    await page.getByTestId('radio-btn-Tier2').click();
+
+    // Cancel — the radio selection must NOT be persisted.
+    await closeTierDropdown(page);
+
+    // Reopen — tier tags are already cached so no API call fires; skip the
+    // response wait that openTierDropdown uses and go straight to the UI signal.
+    await page.getByTestId('edit-tier').click();
+    await page.getByTestId('cards').waitFor({ state: 'visible' });
+    await waitForAllLoadersToDisappear(page);
+
+    await expect(
+      page.getByTestId('radio-btn-Tier1')    ).toBeChecked();
+    await expect(
+      page.getByTestId('radio-btn-Tier2')    ).not.toBeChecked();
+
+    await closeTierDropdown(page);
+  });
+
+  await test.step('Bug B — radio shows newly saved tier on reopen after a successful save', async () => {
+    // Ensure Tier1 is set (carried over from step A).
+    await addTierWidget(page, 'Tier1', 'tables', true);
+
+    // Save Tier2.
+    await addTierWidget(page, 'Tier2', 'tables', true);
+
+    // Reopen the editor — should show Tier2, not the stale Tier1.
+    await page.getByTestId('edit-tier').click();
+    await page.getByTestId('cards').waitFor({ state: 'visible' });
+    await waitForAllLoadersToDisappear(page);
+
+    await expect(
+      page.getByTestId('radio-btn-Tier2')    ).toBeChecked();
+    await expect(
+      page.getByTestId('radio-btn-Tier1')    ).not.toBeChecked();
+
+    await closeTierDropdown(page);
+  });
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TierCard/TierCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TierCard/TierCard.tsx
@@ -246,6 +246,8 @@ const TierCard = ({
       showArrow={false}
       trigger="click"
       {...popoverProps}
+      // Intentionally overrides popoverProps.onOpenChange — handleOpenChange
+      // wraps it and delegates to popoverProps?.onOpenChange internally (line 146).
       onOpenChange={handleOpenChange}>
       {children}
     </Popover>

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TierCard/TierCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TierCard/TierCard.tsx
@@ -55,6 +55,7 @@ const TierCard = ({
   );
   const [selectedTier, setSelectedTier] = useState<string>(currentTier ?? '');
   const [isLoadingTierData, setIsLoadingTierData] = useState<boolean>(false);
+  const [isOpen, setIsOpen] = useState<boolean>(popoverProps?.open ?? false);
   const { t } = useTranslation();
 
   const getTierData = async () => {
@@ -123,15 +124,17 @@ const TierCard = ({
   }, [popoverProps?.open]);
 
   // Re-syncs selectedTier when the persisted tier changes after a successful save.
-  // handleOpenChange resets on close but captures a stale closure when popoverRef.current.close()
-  // fires before React propagates the updated currentTier prop from the entity context.
+  // Guards with isOpen (internal state) rather than popoverProps?.open so that
+  // uncontrolled usages (no popoverProps) are covered correctly.
   useEffect(() => {
-    if (!popoverProps?.open) {
+    if (!isOpen) {
       setSelectedTier(currentTier ?? '');
     }
-  }, [currentTier]);
+  }, [currentTier, isOpen]);
 
   const handleOpenChange = (visible: boolean) => {
+    setIsOpen(visible);
+
     if (visible && !tierCardData.length) {
       getTierData();
     }

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TierCard/TierCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TierCard/TierCard.tsx
@@ -122,6 +122,27 @@ const TierCard = ({
     }
   }, [popoverProps?.open]);
 
+  // Re-syncs selectedTier when the persisted tier changes after a successful save.
+  // handleOpenChange resets on close but captures a stale closure when popoverRef.current.close()
+  // fires before React propagates the updated currentTier prop from the entity context.
+  useEffect(() => {
+    if (!popoverProps?.open) {
+      setSelectedTier(currentTier ?? '');
+    }
+  }, [currentTier]);
+
+  const handleOpenChange = (visible: boolean) => {
+    if (visible && !tierCardData.length) {
+      getTierData();
+    }
+
+    if (!visible) {
+      setSelectedTier(currentTier ?? '');
+    }
+
+    popoverProps?.onOpenChange?.(visible);
+  };
+
   return (
     <Popover
       className="p-0"
@@ -221,10 +242,8 @@ const TierCard = ({
       ref={popoverRef}
       showArrow={false}
       trigger="click"
-      onOpenChange={(visible) =>
-        visible && !tierCardData.length && getTierData()
-      }
-      {...popoverProps}>
+      {...popoverProps}
+      onOpenChange={handleOpenChange}>
       {children}
     </Popover>
   );

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TierWidget/TierWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TierWidget/TierWidget.test.tsx
@@ -1,0 +1,186 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import TierCard from '../TierCard/TierCard';
+
+const mockTierData = [
+  {
+    id: 'tier1-id',
+    name: 'Tier1',
+    fullyQualifiedName: 'Tier.Tier1',
+    description: '**Tier1 desc**\n\nTier1 details',
+    version: 0.1,
+    updatedAt: 1665646906357,
+    updatedBy: 'admin',
+    href: 'http://localhost:8585/api/v1/tags/Tier/Tier1',
+    deprecated: false,
+    deleted: false,
+  },
+  {
+    id: 'tier3-id',
+    name: 'Tier3',
+    fullyQualifiedName: 'Tier.Tier3',
+    description: '**Tier3 desc**\n\nTier3 details',
+    version: 0.1,
+    updatedAt: 1665646906357,
+    updatedBy: 'admin',
+    href: 'http://localhost:8585/api/v1/tags/Tier/Tier3',
+    deprecated: false,
+    deleted: false,
+  },
+];
+
+const mockGetTags = jest.fn().mockResolvedValue({ data: mockTierData });
+const mockUpdateTier = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../../../rest/tagAPI', () => ({
+  getTags: jest.fn().mockImplementation((...args) => mockGetTags(...args)),
+}));
+
+jest.mock('../Loader/Loader', () => {
+  return jest.fn().mockReturnValue(<div>Loader</div>);
+});
+
+jest.mock('../../../utils/ToastUtils', () => ({
+  showErrorToast: jest.fn(),
+}));
+
+jest.mock('../RichTextEditor/RichTextEditorPreviewerV1', () => {
+  return jest.fn().mockReturnValue(<div>RichTextEditorPreviewer</div>);
+});
+
+// Capture onOpenChange so tests can simulate AntD open/close events directly.
+// AntD does not call onOpenChange when `open` changes programmatically, so
+// prop-based open/close cycles cannot be used to drive this test.
+let capturedOnOpenChange: ((visible: boolean) => void) | null = null;
+
+jest.mock('antd', () => ({
+  ...jest.requireActual('antd'),
+  Popover: jest.fn().mockImplementation(({ content, onOpenChange, children }) => {
+    capturedOnOpenChange = onOpenChange;
+
+    return (
+      <>
+        {content}
+        {children}
+      </>
+    );
+  }),
+}));
+
+describe('TierCard stale selectedTier', () => {
+  beforeEach(() => {
+    mockUpdateTier.mockClear();
+    capturedOnOpenChange = null;
+  });
+
+  it('resets radio to persisted tier after a cancelled change (Bug A — cancel-stale)', async () => {
+    render(
+      <TierCard
+        currentTier="Tier.Tier1"
+        popoverProps={{ open: true }}
+        updateTier={mockUpdateTier}>
+        <button>Edit Tier</button>
+      </TierCard>
+    );
+
+    // Simulate AntD firing onOpenChange(true) — loads tier data via handleOpenChange.
+    await act(async () => {
+      capturedOnOpenChange?.(true);
+    });
+
+    const tier3Radio = await screen.findByTestId('radio-btn-Tier3');
+    expect(tier3Radio).toBeInTheDocument();
+
+    // User selects Tier3 without saving.
+    await act(async () => {
+      fireEvent.click(tier3Radio);
+    });
+
+    // Cancel: AntD fires onOpenChange(false). handleOpenChange resets selectedTier to Tier1.
+    await act(async () => {
+      capturedOnOpenChange?.(false);
+    });
+
+    // Immediately click Update — selectedTier must be the persisted Tier1, not cancelled Tier3.
+    const updateButton = await screen.findByTestId('update-tier-card');
+
+    await act(async () => {
+      fireEvent.click(updateButton);
+    });
+
+    expect(mockUpdateTier).toHaveBeenCalledWith(
+      expect.objectContaining({ fullyQualifiedName: 'Tier.Tier1' })
+    );
+    expect(mockUpdateTier).not.toHaveBeenCalledWith(
+      expect.objectContaining({ fullyQualifiedName: 'Tier.Tier3' })
+    );
+  });
+
+  it('shows the newly saved tier on reopen after a successful save (Bug B — save-stale)', async () => {
+    const { rerender } = render(
+      <TierCard
+        currentTier="Tier.Tier1"
+        popoverProps={{ open: true }}
+        updateTier={mockUpdateTier}>
+        <button>Edit Tier</button>
+      </TierCard>
+    );
+
+    // Open and load tier data.
+    await act(async () => {
+      capturedOnOpenChange?.(true);
+    });
+
+    const tier3Radio = await screen.findByTestId('radio-btn-Tier3');
+
+    // User selects Tier3 and saves.
+    await act(async () => {
+      fireEvent.click(tier3Radio);
+    });
+
+    // Close fires after save. handleOpenChange captures stale currentTier="Tier.Tier1" from
+    // its closure (entity context hasn't propagated yet) → resets selectedTier to Tier1 (wrong).
+    await act(async () => {
+      capturedOnOpenChange?.(false);
+    });
+
+    // Entity context now propagates: TierCard receives currentTier="Tier.Tier3", popover closed.
+    // The useEffect([currentTier]) guard fires and corrects selectedTier to Tier3.
+    await act(async () => {
+      rerender(
+        <TierCard
+          currentTier="Tier.Tier3"
+          popoverProps={{ open: false }}
+          updateTier={mockUpdateTier}>
+          <button>Edit Tier</button>
+        </TierCard>
+      );
+    });
+
+    // User reopens and clicks Update without re-selecting — must commit Tier3, not Tier1.
+    const updateButton = await screen.findByTestId('update-tier-card');
+
+    await act(async () => {
+      fireEvent.click(updateButton);
+    });
+
+    expect(mockUpdateTier).toHaveBeenCalledWith(
+      expect.objectContaining({ fullyQualifiedName: 'Tier.Tier3' })
+    );
+    expect(mockUpdateTier).not.toHaveBeenCalledWith(
+      expect.objectContaining({ fullyQualifiedName: 'Tier.Tier1' })
+    );
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TierWidget/TierWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TierWidget/TierWidget.test.tsx
@@ -67,16 +67,18 @@ let capturedOnOpenChange: ((visible: boolean) => void) | null = null;
 
 jest.mock('antd', () => ({
   ...jest.requireActual('antd'),
-  Popover: jest.fn().mockImplementation(({ content, onOpenChange, children }) => {
-    capturedOnOpenChange = onOpenChange;
+  Popover: jest
+    .fn()
+    .mockImplementation(({ content, onOpenChange, children }) => {
+      capturedOnOpenChange = onOpenChange;
 
-    return (
-      <>
-        {content}
-        {children}
-      </>
-    );
-  }),
+      return (
+        <>
+          {content}
+          {children}
+        </>
+      );
+    }),
 }));
 
 describe('TierCard stale selectedTier', () => {
@@ -101,6 +103,7 @@ describe('TierCard stale selectedTier', () => {
     });
 
     const tier3Radio = await screen.findByTestId('radio-btn-Tier3');
+
     expect(tier3Radio).toBeInTheDocument();
 
     // User selects Tier3 without saving.


### PR DESCRIPTION
### Describe your changes:

Fixes #<!-- add issue number -->

Two bugs in `TierCard` caused the tier radio button to show stale state:
- **Bug A (cancel-stale):** cancelling a tier change left the unsaved selection active on reopen — `handleOpenChange` reset `selectedTier` on close, but the old inline `onOpenChange` didn't.
- **Bug B (save-stale):** after a successful save, the old tier was shown on reopen because the close handler closed over a stale `currentTier` before React propagated the updated prop from the entity context.

**Fix:** extracted `handleOpenChange` that resets `selectedTier → currentTier` on every close, and added a `useEffect([currentTier])` guard that re-syncs when the prop updates while the popover is closed (covers the save-stale race).

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Cancelling a tier change: on reopen the radio shows the persisted tier, not the cancelled one.
- Saving a new tier: on reopen the radio shows the newly saved tier, not the stale previous one.

#### Unit tests
- [x] Added `openmetadata-ui/src/main/resources/ui/src/components/common/TierWidget/TierWidget.test.tsx` — covers both bugs via direct `onOpenChange` simulation and prop rerender.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Added `openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TierWidget.spec.ts` — E2E regression spec covering both stale-state scenarios on a real table entity.

#### Manual testing performed
1. Set Tier1 on a table entity via the tier widget.
2. Reopened the widget, selected Tier2, cancelled — verified Tier1 still shown on next reopen.
3. Saved Tier2 — verified Tier2 shown on next reopen (not stale Tier1).

#
### UI screen recording / screenshots:

Not applicable — logic-only change; no visual layout changes.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: N/A.
- [x] For UI changes: no layout changes, no recording needed.
- [x] I have added tests (unit + Playwright) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing.