### PR TITLE
Clean up pre-existing direct user memberships on non-Group teams

### DIFF
--- a/bootstrap/sql/migrations/native/2.1.0/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/2.1.0/mysql/postDataMigrationSQLScript.sql
@@ -121,3 +121,14 @@ UPDATE entity_extension
 SET json = JSON_INSERT(json, '$.appConfiguration.activityCommentsRetentionPeriod', 0)
 WHERE extension LIKE 'app.version.%'
   AND json->>'$.name' = 'DataRetentionApplication';
+
+-- Users may only be direct members of Group teams (enforced by #32208). Remove pre-existing direct
+-- memberships on non-Group hierarchy teams (BusinessUnit/Division/Department) created before the
+-- rule so those users fall back to Organization (the default). Organization is the special root
+-- fallback and is left untouched. relation 10 = HAS. Idempotent (re-runs match nothing).
+DELETE er FROM entity_relationship er
+JOIN team_entity te ON er.fromId = te.id
+WHERE er.fromEntity = 'team'
+  AND er.toEntity = 'user'
+  AND er.relation = 10
+  AND te.teamType IN ('BusinessUnit', 'Division', 'Department');

--- a/bootstrap/sql/migrations/native/2.1.0/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/2.1.0/postgres/postDataMigrationSQLScript.sql
@@ -108,3 +108,15 @@ SET json = jsonb_set(
 WHERE extension LIKE 'app.version.%'
   AND json::jsonb ->> 'name' = 'DataRetentionApplication'
   AND NOT jsonb_exists(json::jsonb #> '{appConfiguration}', 'activityCommentsRetentionPeriod');
+
+-- Users may only be direct members of Group teams (enforced by #32208). Remove pre-existing direct
+-- memberships on non-Group hierarchy teams (BusinessUnit/Division/Department) created before the
+-- rule so those users fall back to Organization (the default). Organization is the special root
+-- fallback and is left untouched. relation 10 = HAS. Idempotent (re-runs match nothing).
+DELETE FROM entity_relationship er
+USING team_entity te
+WHERE er.fromId = te.id
+  AND er.fromEntity = 'team'
+  AND er.toEntity = 'user'
+  AND er.relation = 10
+  AND te.teamType IN ('BusinessUnit', 'Division', 'Department');


### PR DESCRIPTION
Data-cleanup follow-up to #32208 (API enforcement) and #32911 (team dropdowns).

Users may only be direct members of `Group` teams. That rule is now enforced on the API (#32208) and the UI team selector (#32911), but instances upgraded from before the rule can still have users attached directly to `Department` / `Division` / `BusinessUnit` teams. Those stale memberships are now invalid: the team's Add User action is hidden and editing such a user's teams fails validation, so there is no in-product way to remove them.

This adds a one-time data migration that removes those pre-existing direct memberships so the affected users fall back to `Organization` (the default team). `Group` teams and the special `Organization` root are left untouched.

---

## Change

A 2.0.2 post-data migration (targeting the 2.0.2 release) (MySQL + Postgres) deletes the `HAS` relationships (`relation = 10`) between a user and any `BusinessUnit` / `Division` / `Department` team:

```sql
DELETE FROM entity_relationship er
USING team_entity te
WHERE er.fromId = te.id
  AND er.fromEntity = 'team'
  AND er.toEntity = 'user'
  AND er.relation = 10
  AND te.teamType IN ('BusinessUnit', 'Division', 'Department');
```

It is idempotent — a second run matches nothing.

---

## Search index

Deleting the relationship updates the user's `teams` on read immediately, but the user's search document still lists the old team until it is reindexed. A standard post-upgrade users reindex refreshes Explore; no inline reindex is included here.

---

## Testing

Validated on throwaway MySQL 8 and Postgres 15 against the real `team_entity` (generated `teamType`/`id` columns) and `entity_relationship` schema, with a seeded mix of memberships:

- deletes exactly the user memberships on `Department` / `Division` / `BusinessUnit`
- keeps `Group` and `Organization` user memberships
- keeps non-user rows on the same teams (e.g. team→role)
- re-running deletes 0 rows (idempotent)

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) documentation.
- [x] The migration is idempotent and covers both MySQL and PostgreSQL.

