### PR TITLE
Fixes 32661: build profiler partitioning from the form, not stale state

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/Profiler.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/Profiler.spec.ts
@@ -409,6 +409,46 @@ test.describe(
           page.getByTestId('profile-sample').locator('div')
         ).toBeVisible();
       });
+
+      await test.step('Preserve partitioning when saving without any edit', async () => {
+        // Close the drawer the previous step left open, then reopen it clean.
+        await page.getByRole('button', { name: 'Cancel' }).click();
+        await page
+          .getByTestId('profiler-settings-modal')
+          .waitFor({ state: 'detached' });
+
+        await page.click('[data-testid="profiler-setting-btn"]');
+        await page.getByTestId('profiler-settings-modal').waitFor();
+        await expect(page.getByTestId('interval-type')).toBeVisible();
+
+        const updateTableProfilerConfigResponse = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/tables/') &&
+            response.url().includes('/tableProfilerConfig') &&
+            response.request().method() === 'PUT'
+        );
+        await page.getByRole('button', { name: 'Save' }).click();
+        const updateResponse = await updateTableProfilerConfigResponse;
+        const requestBody = await updateResponse.request().postData();
+
+        // Saving without touching anything must round-trip the stored
+        // partitioning block. The backend replaces this extension wholesale,
+        // so any field missing from the payload is erased on the server.
+        expect(requestBody).toEqual(
+          JSON.stringify({
+            excludeColumns: [table.entity?.columns[0].name],
+            profileQuery: 'select * from table',
+            includeColumns: [{ columnName: table.entity?.columns[1].name }],
+            partitioning: {
+              partitionColumnName: table.entity?.columns[2].name,
+              partitionIntervalType: 'COLUMN-VALUE',
+              partitionValues: ['test'],
+              enablePartitioning: true,
+            },
+            sampleDataCount: 100,
+          })
+        );
+      });
     });
   }
 );

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ProfilerSettingsModal/ProfilerSettingsModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ProfilerSettingsModal/ProfilerSettingsModal.test.tsx
@@ -20,8 +20,17 @@ import {
   waitFor,
 } from '@testing-library/react';
 import { Column } from '../../../../../generated/entity/data/dashboardDataModel';
+import {
+  DataType,
+  PartitionIntervalTypes,
+  PartitionIntervalUnit,
+  TableProfilerConfig,
+} from '../../../../../generated/entity/data/table';
 import { MOCK_TABLE } from '../../../../../mocks/TableData.mock';
-import { getTableProfilerConfig } from '../../../../../rest/tableAPI';
+import {
+  getTableProfilerConfig,
+  putTableProfileConfig,
+} from '../../../../../rest/tableAPI';
 import { ProfilerSettingsModalProps } from '../TableProfiler.interface';
 import ProfilerSettingsModal from './ProfilerSettingsModal';
 
@@ -39,8 +48,9 @@ jest.mock('../../../../../rest/tableAPI', () => ({
 const mockProps: ProfilerSettingsModalProps = {
   tableId: MOCK_TABLE.id,
   columns: [
-    { name: 'column1', dataType: 'string' },
-    { name: 'column2', dataType: 'timestamp' },
+    { name: 'column1', dataType: DataType.String },
+    { name: 'column2', dataType: DataType.Timestamp },
+    { name: 'column3', dataType: DataType.Int },
   ] as unknown as Column[],
   visible: true,
   onVisibilityChange: mockOnVisibilityChange,
@@ -55,37 +65,11 @@ const mockTableProfilerConfig = {
   includeColumns: [{ columnName: 'column2', metrics: ['column_count'] }],
   partitioning: {
     enablePartitioning: true,
-    partitionColumnName: 'column2',
-    partitionIntervalType: 'COLUMN-VALUE',
+    partitionColumnName: 'column1',
+    partitionIntervalType: PartitionIntervalTypes.ColumnValue,
     partitionValues: ['test'],
   },
 };
-
-jest.mock('../../../../../constants/profiler.constant', () => ({
-  DEFAULT_INCLUDE_PROFILE: [],
-  INTERVAL_TYPE_OPTIONS: [
-    { label: 'Column Value', value: 'COLUMN-VALUE' },
-    { label: 'Time Unit', value: 'TIME-UNIT' },
-  ],
-  INTERVAL_UNIT_OPTIONS: [
-    { label: 'Day', value: 'DAY' },
-    { label: 'Hour', value: 'HOUR' },
-  ],
-  PROFILER_MODAL_LABEL_STYLE: {},
-  PROFILE_SAMPLE_OPTIONS: [
-    { label: 'Percentage', value: 'PERCENTAGE' },
-    { label: 'Row Count', value: 'ROW_COUNT' },
-  ],
-  SUPPORTED_COLUMN_DATA_TYPE_FOR_INTERVAL: {
-    'COLUMN-VALUE': ['string'],
-    'TIME-UNIT': ['timestamp'],
-  },
-  TIME_BASED_PARTITION: ['TIME-UNIT'],
-}));
-
-jest.mock('../../../../../utils/ObjectUtils', () => ({
-  reducerWithoutAction: jest.fn(),
-}));
 
 jest.mock('../../../../../utils/ProfilerMetricsClassBase', () => ({
   __esModule: true,
@@ -106,12 +90,58 @@ jest.mock('../../../../../utils/ToastUtils', () => ({
 }));
 
 jest.mock('../../../SchemaEditor/SchemaEditor', () => {
-  return jest.fn().mockReturnValue(<div data-testid="schema-editor" />);
+  return jest
+    .fn()
+    .mockImplementation(({ onChange }: { onChange: (v: string) => void }) => (
+      <button
+        data-testid="schema-editor"
+        onClick={() => onChange('select 1 from table')}>
+        sql editor
+      </button>
+    ));
 });
 
 jest.mock('../../../../common/SliderWithInput/SliderWithInput', () => {
   return jest.fn().mockReturnValue(<div data-testid="slider-input" />);
 });
+
+/**
+ * Renders the modal with `config` already persisted, waits for it to load, and
+ * returns the payload `putTableProfileConfig` was called with after a Save.
+ */
+const renderAndSave = async (
+  config: TableProfilerConfig,
+  beforeSave?: () => Promise<void> | void
+): Promise<TableProfilerConfig> => {
+  (getTableProfilerConfig as jest.Mock).mockResolvedValueOnce({
+    ...MOCK_TABLE,
+    tableProfilerConfig: config,
+  });
+
+  await act(async () => {
+    render(<ProfilerSettingsModal {...mockProps} />);
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId('interval-type')).toBeInTheDocument();
+  });
+
+  if (beforeSave) {
+    await act(async () => {
+      await beforeSave();
+    });
+  }
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+  });
+
+  await waitFor(() => {
+    expect(putTableProfileConfig).toHaveBeenCalled();
+  });
+
+  return (putTableProfileConfig as jest.Mock).mock.calls[0][1];
+};
 
 describe('Test ProfilerSettingsModal component', () => {
   beforeEach(() => {
@@ -195,5 +225,136 @@ describe('Test ProfilerSettingsModal component', () => {
     await waitFor(() => {
       expect(sampleDataCount).toHaveAttribute('value', '100');
     });
+  });
+});
+
+describe('ProfilerSettingsModal partitioning round-trip', () => {
+  beforeEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+  });
+
+  it('should preserve a COLUMN-VALUE partitioning config when saved untouched', async () => {
+    const payload = await renderAndSave(mockTableProfilerConfig);
+
+    expect(payload.partitioning).toEqual({
+      enablePartitioning: true,
+      partitionColumnName: 'column1',
+      partitionIntervalType: PartitionIntervalTypes.ColumnValue,
+      partitionValues: ['test'],
+    });
+  });
+
+  it('should preserve a TIME-UNIT partitioning config when saved untouched', async () => {
+    const payload = await renderAndSave({
+      ...mockTableProfilerConfig,
+      partitioning: {
+        enablePartitioning: true,
+        partitionColumnName: 'column2',
+        partitionIntervalType: PartitionIntervalTypes.TimeUnit,
+        partitionInterval: 7,
+        partitionIntervalUnit: PartitionIntervalUnit.Day,
+      },
+    });
+
+    expect(payload.partitioning).toEqual({
+      enablePartitioning: true,
+      partitionColumnName: 'column2',
+      partitionIntervalType: PartitionIntervalTypes.TimeUnit,
+      partitionInterval: 7,
+      partitionIntervalUnit: PartitionIntervalUnit.Day,
+      partitionValues: undefined,
+    });
+  });
+
+  it('should preserve an INTEGER-RANGE partitioning config when saved untouched', async () => {
+    const payload = await renderAndSave({
+      ...mockTableProfilerConfig,
+      partitioning: {
+        enablePartitioning: true,
+        partitionColumnName: 'column3',
+        partitionIntervalType: PartitionIntervalTypes.IntegerRange,
+        partitionIntegerRangeStart: 1,
+        partitionIntegerRangeEnd: 100,
+      },
+    });
+
+    expect(payload.partitioning).toEqual({
+      enablePartitioning: true,
+      partitionColumnName: 'column3',
+      partitionIntervalType: PartitionIntervalTypes.IntegerRange,
+      partitionIntegerRangeStart: 1,
+      partitionIntegerRangeEnd: 100,
+      partitionValues: undefined,
+    });
+  });
+
+  it('should preserve partitioning when only the SQL query is edited', async () => {
+    // The SQL editor sits outside any `<Form>`, so editing it never reaches the
+    // form's `onValuesChange` -- the path that masked the bug for fields that do.
+    const payload = await renderAndSave(mockTableProfilerConfig, () => {
+      fireEvent.click(screen.getByTestId('schema-editor'));
+    });
+
+    expect(payload.profileQuery).toBe('select 1 from table');
+    expect(payload.partitioning).toEqual({
+      enablePartitioning: true,
+      partitionColumnName: 'column1',
+      partitionIntervalType: PartitionIntervalTypes.ColumnValue,
+      partitionValues: ['test'],
+    });
+  });
+
+  it('should send the edited value when a partition field is changed', async () => {
+    const payload = await renderAndSave(mockTableProfilerConfig, () => {
+      fireEvent.change(screen.getByTestId('partition-value'), {
+        target: { value: 'edited' },
+      });
+    });
+
+    expect(payload.partitioning?.partitionValues).toEqual(['edited']);
+  });
+
+  it('should block the save instead of writing a partial config when a partition value is blank', async () => {
+    (getTableProfilerConfig as jest.Mock).mockResolvedValueOnce({
+      ...MOCK_TABLE,
+      tableProfilerConfig: {
+        ...mockTableProfilerConfig,
+        partitioning: {
+          enablePartitioning: true,
+          partitionColumnName: 'column1',
+          partitionIntervalType: PartitionIntervalTypes.ColumnValue,
+          partitionValues: ['first', '', 'second'],
+        },
+      },
+    });
+
+    await act(async () => {
+      render(<ProfilerSettingsModal {...mockProps} />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('interval-type')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    });
+
+    // The blank value fails the `required` rule, so nothing is written at all
+    // rather than a config with the blank entry silently dropped.
+    expect(putTableProfileConfig).not.toHaveBeenCalled();
+  });
+
+  it('should send no partitioning when partitioning is disabled', async () => {
+    const payload = await renderAndSave({
+      ...mockTableProfilerConfig,
+      partitioning: {
+        ...mockTableProfilerConfig.partitioning,
+        enablePartitioning: false,
+      },
+    });
+
+    expect(payload.partitioning).toBeUndefined();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ProfilerSettingsModal/ProfilerSettingsModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ProfilerSettingsModal/ProfilerSettingsModal.test.tsx
@@ -315,7 +315,9 @@ describe('ProfilerSettingsModal partitioning round-trip', () => {
     expect(payload.partitioning?.partitionValues).toEqual(['edited']);
   });
 
-  it('should block the save instead of writing a partial config when a partition value is blank', async () => {
+  // Documents current behaviour, not desired behaviour: a stored config with a
+  // blank partition value cannot be saved at all until the field is cleared.
+  it('currently blocks the save outright when a stored partition value is blank', async () => {
     (getTableProfilerConfig as jest.Mock).mockResolvedValueOnce({
       ...MOCK_TABLE,
       tableProfilerConfig: {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ProfilerSettingsModal/ProfilerSettingsModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ProfilerSettingsModal/ProfilerSettingsModal.tsx
@@ -104,7 +104,6 @@ const ProfilerSettingsModal: React.FC<ProfilerSettingsModalProps> = ({
       excludeCol: [],
       includeCol: DEFAULT_INCLUDE_PROFILE,
       enablePartition: false,
-      partitionData: undefined,
       selectedProfileSampleType: ProfileSampleType.Percentage,
     }),
     []
@@ -303,21 +302,33 @@ const ProfilerSettingsModal: React.FC<ProfilerSettingsModalProps> = ({
   const handleSave: FormProps['onFinish'] = useCallback(
     async (data: ProfilerForm) => {
       const buildPartitioning = (): TableProfilerConfig['partitioning'] => {
-        const { enablePartition, partitionData } = state;
-
-        if (!enablePartition) {
+        if (!state.enablePartition) {
           return undefined;
         }
+
+        // Read straight from the form: the loaded config is pushed into the
+        // form with `setFieldsValue`, which never fires `onValuesChange`, so
+        // any state copy is stale until the user edits a partition field.
+        const partitionData = pick(
+          data,
+          'partitionColumnName',
+          'partitionIntegerRangeEnd',
+          'partitionIntegerRangeStart',
+          'partitionInterval',
+          'partitionIntervalType',
+          'partitionIntervalUnit',
+          'partitionValues'
+        );
 
         return {
           ...partitionData,
           partitionValues:
-            partitionIntervalType === PartitionIntervalTypes.ColumnValue
-              ? partitionData?.partitionValues?.filter(
+            data.partitionIntervalType === PartitionIntervalTypes.ColumnValue
+              ? partitionData.partitionValues?.filter(
                   (value) => !isEmpty(value)
                 )
               : undefined,
-          enablePartitioning: enablePartition,
+          enablePartitioning: state.enablePartition,
         };
       };
 
@@ -438,16 +449,6 @@ const ProfilerSettingsModal: React.FC<ProfilerSettingsModalProps> = ({
 
       handleStateChange({
         includeCol: data.includeColumns,
-        partitionData: pick(
-          data,
-          'partitionColumnName',
-          'partitionIntegerRangeEnd',
-          'partitionIntegerRangeStart',
-          'partitionInterval',
-          'partitionIntervalType',
-          'partitionIntervalUnit',
-          'partitionValues'
-        ),
       });
     },
     []

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/TableProfiler.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/TableProfiler.interface.ts
@@ -110,7 +110,6 @@ export interface ProfilerSettingModalState {
   excludeCol: string[];
   includeCol: ColumnProfilerConfig[];
   enablePartition: boolean;
-  partitionData: PartitionProfilerConfig | undefined;
   selectedProfileSampleType: ProfileSampleType | undefined;
 }
 


### PR DESCRIPTION
### Describe your changes:

Fixes #32661

Opening the profiler settings drawer on a table that already has a partitioning config and pressing **Save** wrote back a payload reduced to `{ enablePartitioning: true }` — erasing `partitionColumnName`, `partitionIntervalType`, `partitionValues`, `partitionInterval`, `partitionIntervalUnit` and `partitionIntegerRangeStart/End`. `TableRepository.addTableProfilerConfig` stores this extension via `entityExtensionDAO().insert(...)` as a **full replacement**, not a merge, so the omitted fields were permanently lost on the server.

**Cause.** `updateInitialConfig` pushes the loaded config into the form with `form.setFieldsValue(...)`, which in `rc-field-form` does *not* fire `onValuesChange` — the only thing that populated `state.partitionData`. `handleSave` then built the outgoing `partitioning` from that still-`undefined` state copy. Controls that live outside a `<Form>` (the SQL editor, the exclude-column select) don't reach `onValuesChange` either, so editing only one of those and saving lost the config the same way.

**Fix.** `buildPartitioning` now reads the partition fields from the form's `onFinish` payload. Both `<Form>`s share one `form` instance, so `data` already carries every partition field. That removes the split source of truth — `partitionIntervalType` was read from the form via `Form.useWatch` while everything else came from React state — and lets `partitionData` drop out of the reducer state entirely, along with the `pick` that maintained it.

Net **+18/−18** in the component; one source of truth instead of two.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- A user opens profiler settings on a table with a **COLUMN-VALUE** partitioning config and saves without editing anything — the config round-trips instead of being erased
- Same for a **TIME-UNIT** config (`partitionInterval` + `partitionIntervalUnit`)
- Same for an **INTEGER-RANGE** config (`partitionIntegerRangeStart/End`)
- A user edits only the SQL query and saves — partitioning survives (a control outside any `<Form>`, one of the reported triggers)
- A user edits a partition value and saves — the edit is what gets written
- A user disables partitioning and saves — `partitioning` is cleared
- A stored config containing a blank partition value — the save is blocked by the `required` rule rather than writing a partial config

#### Unit tests
- [x] I added unit tests for the changed logic.
- Files updated: `openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ProfilerSettingsModal/ProfilerSettingsModal.test.tsx` (+7 tests, 11 total)
- **Four of the new tests were verified to fail against the unfixed component** (the three round-trips and the SQL-query edit); the other three are regression guards that must pass both before and after, pinning behaviour the fix must not break.
- Round-trips cover COLUMN-VALUE, TIME-UNIT and INTEGER-RANGE. INGESTION-TIME is not separately covered because it takes the identical render branch as TIME-UNIT (`TIME_BASED_PARTITION`). The remaining schema values (ENUM, INJECTED, OTHER) belong to `tablePartition` (discovered physical partitioning), not to the profiler sampling config this drawer edits, so they are correctly absent here.
- Also removed the `profiler.constant` and `ObjectUtils` mocks so the suite runs against the real constants and enums. The second mattered: `reducerWithoutAction` was mocked as a bare `jest.fn()` returning `undefined`, so every pre-existing test in this file ran with `state === undefined` and exercised no state at all.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] I added a Playwright step for this change.
- Files updated: `openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/Profiler.spec.ts` (+1 `test.step`)

`Profiler.spec.ts` already builds a table with a COLUMN-VALUE partitioning config and asserts the full PUT body — but that step clears the sample-slider input first. That is a `Form.Item`-bound control, so its change fires `onValuesChange` and repopulates `state.partitionData`, masking the bug; it is why the suite stayed green on `main`. The new step reopens the drawer and saves with **no edit at all**, so nothing masks the loss, and it covers the one thing Jest cannot: that the backend stores this extension as a full replacement.

I have not executed this step locally — it needs the full Docker stack — so CI is its first real run.

#### Manual testing performed
1. `yarn jest .../ProfilerSettingsModal` — 11/11 pass
2. Reverted the component fix, re-ran — 4 fail with `partitioning` collapsed to `{ enablePartitioning: true, partitionValues: undefined }`, matching the issue exactly; restored the fix, 11/11 pass again
3. `tsc --noEmit` — clean on the changed files, and on the Playwright project
4. ESLint + Prettier + organize-imports (the CI checkstyle sequence) — 0 errors, format idempotent

#
### UI screen recording / screenshots:

Not applicable — no visual change. The drawer renders identically before and after; only the payload sent to `PUT /v1/tables/{id}/tableProfilerConfig` differs. The before/after is captured in the test evidence above.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: no visual change — explained above.
- [x] I have added tests and listed them above.

- [x] I have added a test that covers the exact scenario we are fixing.

#
### Notes for reviewers

1. **The `filter(!isEmpty)` on `partitionValues` is unreachable.** A blank value fails the per-item `required` rule first, so `validateFields()` rejects and nothing is written. Side effect: a table whose stored config contains a blank partition value **cannot have its profiler settings saved at all** until the field is cleared. Pre-existing and out of scope here — happy to open a separate issue.
2. **Not every edit exposes the bug.** Both `<Form>`s share a `form` instance, so editing *any* form-bound field fires `onValuesChange` and repopulates `partitionData`, masking the loss. Only controls outside a `<Form>` hit it — which is why the Jest test drives the SQL editor rather than a form input, and why the existing Playwright step stayed green on `main`.
3. **`ProfilerSettingsModal.tsx:621`** has a dead `partitionData: ['']` key in `initialValues` where `partitionValues: ['']` was intended. Harmless and pre-existing — flagging it only so it isn't mistaken for a leftover of the reducer field this PR removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
