### PR TITLE
Fixes #32664: Backport guard Data Products picker multi-select while entity rules load to 2.0

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/CommonWidgets/CommonWidgets.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/CommonWidgets/CommonWidgets.test.tsx
@@ -30,9 +30,11 @@ jest.mock(
   '../../DataProducts/DataProductsContainer/DataProductsContainer.component',
   () => ({
     __esModule: true,
-    default: () => (
-      <div data-testid="data-products-widget">Data Products Widget</div>
-    ),
+    default: jest
+      .fn()
+      .mockImplementation(() => (
+        <div data-testid="data-products-widget">Data Products Widget</div>
+      )),
   })
 );
 jest.mock('../../Tag/TagsContainerV2/TagsContainerV2', () => ({
@@ -392,6 +394,94 @@ describe('CommonWidgets', () => {
       expect(
         await screen.findByTestId('custom-properties-widget')
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('Data Products multi-select rule gating', () => {
+    const getDataProductsContainerMock = () =>
+      jest.requireMock(
+        '../../DataProducts/DataProductsContainer/DataProductsContainer.component'
+      ).default as jest.Mock;
+
+    const dataProductsWidgetConfig = {
+      i: DetailPageWidgetKeys.DATA_PRODUCTS,
+      x: 0,
+      y: 0,
+      w: 1,
+      h: 1,
+    };
+
+    beforeEach(() => {
+      getDataProductsContainerMock().mockClear();
+    });
+
+    it('holds single-select (multiple=false) while entity rules are loading', () => {
+      (useGenericContext as jest.Mock).mockReturnValue({
+        ...mockGenericContext,
+        entityRules: {
+          ...mockGenericContext.entityRules,
+          canAddMultipleDataProducts: true,
+          requireDomainForDataProduct: false,
+        },
+        isRulesLoaded: false,
+      });
+
+      render(
+        <CommonWidgets
+          entityType={EntityType.TABLE}
+          widgetConfig={dataProductsWidgetConfig}
+        />
+      );
+
+      expect(
+        getDataProductsContainerMock().mock.calls.at(-1)?.[0]
+      ).toMatchObject({ multiple: false });
+    });
+
+    it('enables multiple select when rules are loaded and multi-product rule is not enabled', () => {
+      (useGenericContext as jest.Mock).mockReturnValue({
+        ...mockGenericContext,
+        entityRules: {
+          ...mockGenericContext.entityRules,
+          canAddMultipleDataProducts: true,
+          requireDomainForDataProduct: false,
+        },
+        isRulesLoaded: true,
+      });
+
+      render(
+        <CommonWidgets
+          entityType={EntityType.TABLE}
+          widgetConfig={dataProductsWidgetConfig}
+        />
+      );
+
+      expect(
+        getDataProductsContainerMock().mock.calls.at(-1)?.[0]
+      ).toMatchObject({ multiple: true });
+    });
+
+    it('keeps single select when rules are loaded and multi-product rule is enabled', () => {
+      (useGenericContext as jest.Mock).mockReturnValue({
+        ...mockGenericContext,
+        entityRules: {
+          ...mockGenericContext.entityRules,
+          canAddMultipleDataProducts: false,
+          requireDomainForDataProduct: false,
+        },
+        isRulesLoaded: true,
+      });
+
+      render(
+        <CommonWidgets
+          entityType={EntityType.TABLE}
+          widgetConfig={dataProductsWidgetConfig}
+        />
+      );
+
+      expect(
+        getDataProductsContainerMock().mock.calls.at(-1)?.[0]
+      ).toMatchObject({ multiple: false });
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/CommonWidgets/CommonWidgets.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/CommonWidgets/CommonWidgets.tsx
@@ -389,7 +389,7 @@ export const CommonWidgets = ({
         activeDomains={domains}
         dataProducts={dataProducts ?? []}
         hasPermission={editDataProductPermission}
-        multiple={entityRules.canAddMultipleDataProducts}
+        multiple={isRulesLoaded && entityRules.canAddMultipleDataProducts}
         requireDomainForDataProduct={
           !isRulesLoaded || entityRules.requireDomainForDataProduct
         }

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityRightPanel/EntityRightPanel.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityRightPanel/EntityRightPanel.test.tsx
@@ -14,6 +14,7 @@ import { render, screen } from '@testing-library/react';
 import { EntityTags } from 'Models';
 import { EntityType } from '../../../enums/entity.enum';
 import { Table } from '../../../generated/entity/data/table';
+import { useEntityRules } from '../../../hooks/useEntityRules';
 import entityRightPanelClassBase from '../../../utils/EntityRightPanelClassBase';
 import EntityRightPanel from './EntityRightPanel';
 
@@ -224,5 +225,78 @@ describe('EntityRightPanel component test', () => {
     );
 
     expect(screen.queryByText('CustomPropertyTable')).not.toBeInTheDocument();
+  });
+
+  describe('Data Products multi-select rule gating', () => {
+    const getDataProductsContainerMock = () =>
+      jest.requireMock(
+        '../../DataProducts/DataProductsContainer/DataProductsContainer.component'
+      ) as jest.Mock;
+
+    beforeEach(() => {
+      getDataProductsContainerMock().mockClear();
+    });
+
+    const renderPanel = () =>
+      render(
+        <EntityRightPanel
+          editGlossaryTermsPermission
+          editTagPermission
+          entityType={EntityType.TABLE}
+          selectedTags={mockSelectedTags}
+          onTagSelectionChange={mockOnTagSelectionChange}
+        />
+      );
+
+    it('holds single-select (multiple=false) while entity rules are loading', () => {
+      (useEntityRules as jest.Mock).mockReturnValue({
+        entityRules: {
+          canAddMultipleDataProducts: true,
+          requireDomainForDataProduct: false,
+        },
+        isRulesLoaded: false,
+        isLoading: true,
+      });
+
+      renderPanel();
+
+      expect(
+        getDataProductsContainerMock().mock.calls.at(-1)?.[0]
+      ).toMatchObject({ multiple: false });
+    });
+
+    it('enables multiple select when rules are loaded and multi-product rule is not enabled', () => {
+      (useEntityRules as jest.Mock).mockReturnValue({
+        entityRules: {
+          canAddMultipleDataProducts: true,
+          requireDomainForDataProduct: false,
+        },
+        isRulesLoaded: true,
+        isLoading: false,
+      });
+
+      renderPanel();
+
+      expect(
+        getDataProductsContainerMock().mock.calls.at(-1)?.[0]
+      ).toMatchObject({ multiple: true });
+    });
+
+    it('keeps single select when rules are loaded and multi-product rule is enabled', () => {
+      (useEntityRules as jest.Mock).mockReturnValue({
+        entityRules: {
+          canAddMultipleDataProducts: false,
+          requireDomainForDataProduct: false,
+        },
+        isRulesLoaded: true,
+        isLoading: false,
+      });
+
+      renderPanel();
+
+      expect(
+        getDataProductsContainerMock().mock.calls.at(-1)?.[0]
+      ).toMatchObject({ multiple: false });
+    });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityRightPanel/EntityRightPanel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityRightPanel/EntityRightPanel.tsx
@@ -87,7 +87,7 @@ const EntityRightPanel = <T extends ExtentionEntitiesKeys>({
               activeDomains={domains}
               dataProducts={dataProducts}
               hasPermission={editDataProductPermission ?? false}
-              multiple={entityRules.canAddMultipleDataProducts}
+              multiple={isRulesLoaded && entityRules.canAddMultipleDataProducts}
               requireDomainForDataProduct={
                 !isRulesLoaded || entityRules.requireDomainForDataProduct
               }

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePageDetailRightPanel/KnowledgePageDetailRightPanel.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePageDetailRightPanel/KnowledgePageDetailRightPanel.test.tsx
@@ -1,0 +1,164 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { render } from '@testing-library/react';
+import { EntityTags } from 'Models';
+import { OperationPermission } from '../../../context/PermissionProvider/PermissionProvider.interface';
+import { useGenericContext } from '../../Customization/GenericProvider/GenericContext';
+import KnowledgePageDetailRightPanel from './KnowledgePageDetailRightPanel';
+
+jest.mock('@openmetadata/ui-core-components', () => {
+  const Card: React.FC<{ children: React.ReactNode }> & {
+    Content: React.FC<{ children: React.ReactNode }>;
+  } = Object.assign(
+    ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="card">{children}</div>
+    ),
+    {
+      Content: ({ children }: { children: React.ReactNode }) => (
+        <div data-testid="card-content">{children}</div>
+      ),
+    }
+  );
+
+  return { Card };
+});
+
+jest.mock('../../Customization/GenericProvider/GenericContext', () => ({
+  useGenericContext: jest.fn(),
+}));
+
+jest.mock('../../DataAssets/ReviewerLabelV2/ReviewerLabelV2', () => ({
+  ReviewerLabelV2: () => <div data-testid="reviewer-label" />,
+}));
+
+jest.mock(
+  '../../DataProducts/DataProductsContainer/DataProductsContainer.component',
+  () => ({
+    __esModule: true,
+    default: jest
+      .fn()
+      .mockImplementation(() => <div data-testid="data-products-container" />),
+  })
+);
+
+jest.mock('../../Tag/TagsContainerV2/TagsContainerV2', () => ({
+  __esModule: true,
+  default: () => <div data-testid="tags-container" />,
+}));
+
+jest.mock('../AttachmentWidget/AttachmentWidget', () => ({
+  __esModule: true,
+  default: () => <div data-testid="attachment-widget" />,
+}));
+
+jest.mock('../RelatedDataAssets/RelatedDataAssets', () => ({
+  __esModule: true,
+  default: () => <div data-testid="related-data-assets" />,
+}));
+
+jest.mock('../../../utils/ToastUtils', () => ({
+  showErrorToast: jest.fn(),
+}));
+
+const baseGenericContext = {
+  data: {
+    id: 'kp-1',
+    fullyQualifiedName: 'kp.fqn',
+    domains: [],
+    dataProducts: [],
+    deleted: false,
+  },
+  onUpdate: jest.fn(),
+  permissions: { EditAll: true },
+  entityRules: {
+    canAddMultipleDataProducts: true,
+    requireDomainForDataProduct: false,
+  },
+  isRulesLoaded: true,
+};
+
+const defaultProps = {
+  permissions: { EditAll: true, EditTags: true } as OperationPermission,
+  tags: [] as EntityTags[],
+  updatePageTag: jest.fn(),
+  handleRelatedEntitiesUpdate: jest.fn(),
+};
+
+describe('KnowledgePageDetailRightPanel', () => {
+  const getDataProductsContainerMock = () =>
+    jest.requireMock(
+      '../../DataProducts/DataProductsContainer/DataProductsContainer.component'
+    ).default as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useGenericContext as jest.Mock).mockReturnValue(baseGenericContext);
+  });
+
+  it('renders the data products container', () => {
+    render(<KnowledgePageDetailRightPanel {...defaultProps} />);
+
+    expect(getDataProductsContainerMock()).toHaveBeenCalled();
+  });
+
+  it('holds single-select (multiple=false) while entity rules are loading', () => {
+    (useGenericContext as jest.Mock).mockReturnValue({
+      ...baseGenericContext,
+      entityRules: {
+        canAddMultipleDataProducts: true,
+        requireDomainForDataProduct: false,
+      },
+      isRulesLoaded: false,
+    });
+
+    render(<KnowledgePageDetailRightPanel {...defaultProps} />);
+
+    expect(getDataProductsContainerMock().mock.calls.at(-1)?.[0]).toMatchObject(
+      { multiple: false }
+    );
+  });
+
+  it('enables multiple select when rules are loaded and multi-product rule is not enabled', () => {
+    (useGenericContext as jest.Mock).mockReturnValue({
+      ...baseGenericContext,
+      entityRules: {
+        canAddMultipleDataProducts: true,
+        requireDomainForDataProduct: false,
+      },
+      isRulesLoaded: true,
+    });
+
+    render(<KnowledgePageDetailRightPanel {...defaultProps} />);
+
+    expect(getDataProductsContainerMock().mock.calls.at(-1)?.[0]).toMatchObject(
+      { multiple: true }
+    );
+  });
+
+  it('keeps single select when rules are loaded and multi-product rule is enabled', () => {
+    (useGenericContext as jest.Mock).mockReturnValue({
+      ...baseGenericContext,
+      entityRules: {
+        canAddMultipleDataProducts: false,
+        requireDomainForDataProduct: false,
+      },
+      isRulesLoaded: true,
+    });
+
+    render(<KnowledgePageDetailRightPanel {...defaultProps} />);
+
+    expect(getDataProductsContainerMock().mock.calls.at(-1)?.[0]).toMatchObject(
+      { multiple: false }
+    );
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePageDetailRightPanel/KnowledgePageDetailRightPanel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePageDetailRightPanel/KnowledgePageDetailRightPanel.tsx
@@ -89,7 +89,7 @@ const KnowledgePageDetailRightPanel: FC<KnowledgePageDetailRightPanelProps> = ({
             activeDomains={data?.domains ?? []}
             dataProducts={data?.dataProducts ?? []}
             hasPermission={hasDataProductsPermission}
-            multiple={entityRules?.canAddMultipleDataProducts}
+            multiple={isRulesLoaded && entityRules?.canAddMultipleDataProducts}
             requireDomainForDataProduct={
               !isRulesLoaded || entityRules?.requireDomainForDataProduct
             }

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DataProductsSection/DataProductsSection.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DataProductsSection/DataProductsSection.test.tsx
@@ -664,4 +664,106 @@ describe('DataProductsSection', () => {
       expect(screen.getByTestId('edit-data-products')).toBeInTheDocument();
     });
   });
+
+  describe('Multi-Select Rule Gating', () => {
+    const getLastMultiSelect = () => {
+      const { DataProductsSelectListV1 } = jest.requireMock(
+        '../../DataProducts/DataProductsSelectList/DataProductsSelectListV1'
+      );
+
+      return (DataProductsSelectListV1 as jest.Mock).mock.calls.at(-1)?.[0]
+        ?.multiSelect;
+    };
+
+    const enterEditMode = () => {
+      fireEvent.click(screen.getByTestId('edit-data-products'));
+    };
+
+    it('holds the single-select default while entity rules are still loading', () => {
+      (useEntityRules as jest.Mock).mockReturnValue({
+        entityRules: {
+          canAddMultipleDataProducts: true,
+          maxDataProducts: Infinity,
+          requireDomainForDataProduct: false,
+        },
+        rules: [],
+        isRulesLoaded: false,
+        isLoading: true,
+      });
+
+      render(<DataProductsSection {...defaultProps} />);
+      enterEditMode();
+
+      expect(getLastMultiSelect()).toBe(false);
+    });
+
+    it('re-enables multi-select once rules load and the multi-product rule is not enabled', () => {
+      (useEntityRules as jest.Mock).mockReturnValue({
+        entityRules: {
+          canAddMultipleDataProducts: true,
+          maxDataProducts: Infinity,
+          requireDomainForDataProduct: false,
+        },
+        rules: [],
+        isRulesLoaded: true,
+        isLoading: false,
+      });
+
+      render(<DataProductsSection {...defaultProps} />);
+      enterEditMode();
+
+      expect(getLastMultiSelect()).toBe(true);
+    });
+
+    it('keeps single-select once rules load and the multi-product rule is enabled', () => {
+      (useEntityRules as jest.Mock).mockReturnValue({
+        entityRules: {
+          canAddMultipleDataProducts: false,
+          maxDataProducts: 1,
+          requireDomainForDataProduct: false,
+        },
+        rules: [],
+        isRulesLoaded: true,
+        isLoading: false,
+      });
+
+      render(<DataProductsSection {...defaultProps} />);
+      enterEditMode();
+
+      expect(getLastMultiSelect()).toBe(false);
+    });
+
+    it('updates multiSelect from strict to permissive once rules finish loading', () => {
+      (useEntityRules as jest.Mock).mockReturnValue({
+        entityRules: {
+          canAddMultipleDataProducts: true,
+          maxDataProducts: Infinity,
+          requireDomainForDataProduct: false,
+        },
+        rules: [],
+        isRulesLoaded: false,
+        isLoading: true,
+      });
+
+      const { rerender } = render(<DataProductsSection {...defaultProps} />);
+      enterEditMode();
+
+      expect(getLastMultiSelect()).toBe(false);
+
+      (useEntityRules as jest.Mock).mockReturnValue({
+        entityRules: {
+          canAddMultipleDataProducts: true,
+          maxDataProducts: Infinity,
+          requireDomainForDataProduct: false,
+        },
+        rules: [],
+        isRulesLoaded: true,
+        isLoading: false,
+      });
+
+      rerender(<DataProductsSection {...defaultProps} />);
+
+      expect(getLastMultiSelect()).toBe(true);
+    });
+  });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DataProductsSection/DataProductsSection.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DataProductsSection/DataProductsSection.tsx
@@ -181,7 +181,7 @@ const DataProductsSectionV1: React.FC<DataProductsSectionProps> = ({
     () => (
       <DataProductsSelectListV1
         fetchOptions={fetchAPI}
-        multiSelect={entityRules.canAddMultipleDataProducts}
+        multiSelect={isRulesLoaded && entityRules.canAddMultipleDataProducts}
         popoverProps={{
           open: popoverOpen,
           onOpenChange: handlePopoverOpenChange,
@@ -201,6 +201,7 @@ const DataProductsSectionV1: React.FC<DataProductsSectionProps> = ({
       handlePopoverOpenChange,
       editingDataProducts,
       handleSaveWithDataProducts,
+      isRulesLoaded,
       entityRules.canAddMultipleDataProducts,
       cancelEditing,
     ]


### PR DESCRIPTION
Backport of #32729 to `2.0`.

### Describe your changes:

Fixes #32664

Clean cherry-pick of b7aab09c006 from #32729. The Data Products picker's `multiSelect`/`multiple` flag was driven by `entityRules.canAddMultipleDataProducts` without the `isRulesLoaded` guard that the same files already apply to `requireDomainForDataProduct`. Because the rules hook emits a permissive default while loading, a fast user on a deployment with `MULTIPLE_DATA_PRODUCTS_NOT_ALLOWED` could pick 2+ Data Products and hit `server.entity-updating-error` on save.

Guarded `multiSelect`/`multiple` with `isRulesLoaded` in the four callers:
- `DataProductsSection.tsx`
- `CommonWidgets.tsx`
- `EntityRightPanel.tsx`
- `KnowledgePageDetailRightPanel.tsx`

Loaded behaviour is unchanged; only the loading window flips from multi-select to single-select.

The bot-generated `.github/playwright/impact-map.generated.json` change from the original PR is intentionally not included.

#
### Type of change:
- [x] Bug fix

#
### Tests:

#### Unit tests
- [x] Cherry-picked with the original PR's unit tests; ran the four touched suites locally on this branch:
  - `CommonWidgets.test.tsx`, `EntityRightPanel.test.tsx`, `KnowledgePageDetailRightPanel.test.tsx`, `DataProductsSection.test.tsx` — 5 suites, 93 tests passing.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable — covered by unit tests asserting the exact prop value per caller (see #32729).

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: no visible change once rules load; no screenshots needed.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)