### PR TITLE
Fixes 33053: stabilize DQ select-option flakes and burn the Playwright quarantine from 8 to 4

### DIFF
--- a/.github/playwright/impact-map.generated.json
+++ b/.github/playwright/impact-map.generated.json
@@ -154,6 +154,7 @@
         "playwright/e2e/Pages/SearchIndexApplication.spec.ts",
         "playwright/e2e/Pages/SearchSettings.spec.ts",
         "playwright/e2e/Pages/SubDomainPagination.spec.ts",
+        "playwright/e2e/Pages/TableAliases.spec.ts",
         "playwright/e2e/Pages/TestSuite.spec.ts",
         "playwright/e2e/Pages/TestSuiteDetailsPage.spec.ts",
         "playwright/e2e/Pages/UserCreationWithPersona.spec.ts",
@@ -453,7 +454,6 @@
         "playwright/e2e/Features/SampleDataDomainDataProduct.spec.ts",
         "playwright/e2e/Features/Table.spec.ts",
         "playwright/e2e/Features/UserProfileOnlineStatus.spec.ts",
-        "playwright/e2e/Features/Workflows/RecognizerFeedbackSchemaNodeLock.spec.ts",
         "playwright/e2e/Features/Workflows/WorkflowOssRestrictions.spec.ts",
         "playwright/e2e/Flow/Collect.spec.ts",
         "playwright/e2e/Flow/CustomizeWidgets.spec.ts",
@@ -730,6 +730,7 @@
         "playwright/e2e/Pages/LogsViewer.spec.ts",
         "playwright/e2e/Pages/ODCSImportExport.spec.ts",
         "playwright/e2e/Pages/ODCSImportExportPermissions.spec.ts",
+        "playwright/e2e/Pages/TableAliases.spec.ts",
         "playwright/e2e/Pages/TestSuite.spec.ts",
         "playwright/e2e/Pages/TestSuiteDetailsPage.spec.ts",
         "playwright/e2e/Pages/UserCreationWithPersona.spec.ts"
@@ -1641,6 +1642,7 @@
         "playwright/e2e/Pages/ODCSImportExport.spec.ts",
         "playwright/e2e/Pages/ODCSImportExportPermissions.spec.ts",
         "playwright/e2e/Pages/SearchSettings.spec.ts",
+        "playwright/e2e/Pages/TableAliases.spec.ts",
         "playwright/e2e/Pages/TagPageRightPanel.spec.ts",
         "playwright/e2e/Pages/Tags.spec.ts",
         "playwright/e2e/Pages/TaskComments.spec.ts",
@@ -2373,6 +2375,7 @@
         "playwright/e2e/Pages/TagPageRightPanel.spec.ts",
         "playwright/e2e/Pages/Tags.spec.ts",
         "playwright/e2e/Pages/TeamAssetsRightPanel.spec.ts",
+        "playwright/e2e/Pages/Users.spec.ts",
         "playwright/e2e/VersionPages/ClassificationVersionPage.spec.ts"
       ]
     },
@@ -2428,6 +2431,7 @@
         "playwright/e2e/Features/Tasks/TaskResolution.spec.ts",
         "playwright/e2e/Features/Tasks/TeamActivity.spec.ts",
         "playwright/e2e/Features/TeamSubscriptions.spec.ts",
+        "playwright/e2e/Features/TeamsHierarchy.spec.ts",
         "playwright/e2e/Flow/PersonaFlow.spec.ts",
         "playwright/e2e/Pages/DataContractsSemanticRules.spec.ts",
         "playwright/e2e/Pages/DomainAdvanced.spec.ts",
@@ -2717,6 +2721,7 @@
         "playwright/e2e/Features/ExploreSortOrderFilter.spec.ts",
         "playwright/e2e/Features/FailedTestCaseSampleData.spec.ts",
         "playwright/e2e/Features/Glossary/GlossaryApprovalAfterMove.spec.ts",
+        "playwright/e2e/Features/Glossary/GlossaryDisplayNameEdit.spec.ts",
         "playwright/e2e/Features/Glossary/GlossaryInheritedReviewerApproval.spec.ts",
         "playwright/e2e/Features/Glossary/GlossaryPersonaCustomization.spec.ts",
         "playwright/e2e/Features/Glossary/GlossaryWorkflow.spec.ts",
@@ -2815,6 +2820,7 @@
         "playwright/e2e/Pages/ProfilerConfigurationPage.spec.ts",
         "playwright/e2e/Pages/SearchSettings.spec.ts",
         "playwright/e2e/Pages/ServiceEntity.spec.ts",
+        "playwright/e2e/Pages/TableAliases.spec.ts",
         "playwright/e2e/Pages/Tag.spec.ts",
         "playwright/e2e/Pages/TagPageRightPanel.spec.ts",
         "playwright/e2e/Pages/TaskFormSettings.spec.ts",
@@ -3231,6 +3237,7 @@
         "playwright/e2e/Pages/ServiceEntity.spec.ts",
         "playwright/e2e/Pages/ServiceListing.spec.ts",
         "playwright/e2e/Pages/SubDomainPagination.spec.ts",
+        "playwright/e2e/Pages/TableAliases.spec.ts",
         "playwright/e2e/Pages/Tag.spec.ts",
         "playwright/e2e/Pages/TagPageRightPanel.spec.ts",
         "playwright/e2e/Pages/Tags.spec.ts",
@@ -3646,6 +3653,7 @@
         "playwright/e2e/Pages/Roles.spec.ts",
         "playwright/e2e/Pages/SearchSettings.spec.ts",
         "playwright/e2e/Pages/SubDomainPagination.spec.ts",
+        "playwright/e2e/Pages/TableAliases.spec.ts",
         "playwright/e2e/Pages/Tag.spec.ts",
         "playwright/e2e/Pages/Tags.spec.ts",
         "playwright/e2e/Pages/Teams.spec.ts",
@@ -4054,6 +4062,7 @@
       ],
       "specs": [
         "playwright/e2e/Features/BulkEditEntity.spec.ts",
+        "playwright/e2e/Features/OnlineUsers.spec.ts",
         "playwright/e2e/Pages/Teams.spec.ts"
       ]
     },
@@ -4286,7 +4295,8 @@
         "playwright/e2e/Pages/DataProducts.spec.ts",
         "playwright/e2e/Pages/Domains.spec.ts",
         "playwright/e2e/Pages/Tag.spec.ts",
-        "playwright/e2e/Pages/Tags.spec.ts"
+        "playwright/e2e/Pages/Tags.spec.ts",
+        "playwright/e2e/Pages/Users.spec.ts"
       ]
     },
     {
@@ -7761,6 +7771,7 @@
         "openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UsersProfile/UserProfileTeams/UserProfileTeams.component.tsx"
       ],
       "specs": [
+        "playwright/e2e/Features/TeamsHierarchy.spec.ts",
         "playwright/e2e/Pages/Teams.spec.ts",
         "playwright/e2e/Pages/UserDetails.spec.ts"
       ]
@@ -8729,7 +8740,8 @@
         "openmetadata-ui/src/main/resources/ui/src/components/common/OwnersSection/OwnersSection.tsx"
       ],
       "specs": [
-        "playwright/e2e/Pages/ExplorePageRightPanel.spec.ts"
+        "playwright/e2e/Pages/ExplorePageRightPanel.spec.ts",
+        "playwright/e2e/Pages/ExplorePageRightPanel_KnowledgeCenter.spec.ts"
       ]
     },
     {
@@ -9841,6 +9853,7 @@
         "playwright/e2e/Pages/ServiceEntity.spec.ts",
         "playwright/e2e/Pages/ServiceListing.spec.ts",
         "playwright/e2e/Pages/SubDomainPagination.spec.ts",
+        "playwright/e2e/Pages/TableAliases.spec.ts",
         "playwright/e2e/Pages/Tag.spec.ts",
         "playwright/e2e/Pages/TagPageRightPanel.spec.ts",
         "playwright/e2e/Pages/Tags.spec.ts",
@@ -10725,6 +10738,14 @@
       ],
       "specs": [
         "playwright/e2e/Flow/ApiDocs.spec.ts"
+      ]
+    },
+    {
+      "sources": [
+        "openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableAliases/TableAliases.component.tsx"
+      ],
+      "specs": [
+        "playwright/e2e/Pages/TableAliases.spec.ts"
       ]
     },
     {

--- a/.github/playwright/impact-map.generated.json
+++ b/.github/playwright/impact-map.generated.json
@@ -154,6 +154,7 @@
         "playwright/e2e/Pages/SearchIndexApplication.spec.ts",
         "playwright/e2e/Pages/SearchSettings.spec.ts",
         "playwright/e2e/Pages/SubDomainPagination.spec.ts",
+        "playwright/e2e/Pages/TableAliases.spec.ts",
         "playwright/e2e/Pages/TestSuite.spec.ts",
         "playwright/e2e/Pages/TestSuiteDetailsPage.spec.ts",
         "playwright/e2e/Pages/UserCreationWithPersona.spec.ts",
@@ -453,7 +454,6 @@
         "playwright/e2e/Features/SampleDataDomainDataProduct.spec.ts",
         "playwright/e2e/Features/Table.spec.ts",
         "playwright/e2e/Features/UserProfileOnlineStatus.spec.ts",
-        "playwright/e2e/Features/Workflows/RecognizerFeedbackSchemaNodeLock.spec.ts",
         "playwright/e2e/Features/Workflows/WorkflowOssRestrictions.spec.ts",
         "playwright/e2e/Flow/Collect.spec.ts",
         "playwright/e2e/Flow/CustomizeWidgets.spec.ts",
@@ -730,6 +730,7 @@
         "playwright/e2e/Pages/LogsViewer.spec.ts",
         "playwright/e2e/Pages/ODCSImportExport.spec.ts",
         "playwright/e2e/Pages/ODCSImportExportPermissions.spec.ts",
+        "playwright/e2e/Pages/TableAliases.spec.ts",
         "playwright/e2e/Pages/TestSuite.spec.ts",
         "playwright/e2e/Pages/TestSuiteDetailsPage.spec.ts",
         "playwright/e2e/Pages/UserCreationWithPersona.spec.ts"
@@ -1641,6 +1642,7 @@
         "playwright/e2e/Pages/ODCSImportExport.spec.ts",
         "playwright/e2e/Pages/ODCSImportExportPermissions.spec.ts",
         "playwright/e2e/Pages/SearchSettings.spec.ts",
+        "playwright/e2e/Pages/TableAliases.spec.ts",
         "playwright/e2e/Pages/TagPageRightPanel.spec.ts",
         "playwright/e2e/Pages/Tags.spec.ts",
         "playwright/e2e/Pages/TaskComments.spec.ts",
@@ -2373,6 +2375,7 @@
         "playwright/e2e/Pages/TagPageRightPanel.spec.ts",
         "playwright/e2e/Pages/Tags.spec.ts",
         "playwright/e2e/Pages/TeamAssetsRightPanel.spec.ts",
+        "playwright/e2e/Pages/Users.spec.ts",
         "playwright/e2e/VersionPages/ClassificationVersionPage.spec.ts"
       ]
     },
@@ -2428,6 +2431,7 @@
         "playwright/e2e/Features/Tasks/TaskResolution.spec.ts",
         "playwright/e2e/Features/Tasks/TeamActivity.spec.ts",
         "playwright/e2e/Features/TeamSubscriptions.spec.ts",
+        "playwright/e2e/Features/TeamsHierarchy.spec.ts",
         "playwright/e2e/Flow/PersonaFlow.spec.ts",
         "playwright/e2e/Pages/DataContractsSemanticRules.spec.ts",
         "playwright/e2e/Pages/DomainAdvanced.spec.ts",
@@ -2717,6 +2721,7 @@
         "playwright/e2e/Features/ExploreSortOrderFilter.spec.ts",
         "playwright/e2e/Features/FailedTestCaseSampleData.spec.ts",
         "playwright/e2e/Features/Glossary/GlossaryApprovalAfterMove.spec.ts",
+        "playwright/e2e/Features/Glossary/GlossaryDisplayNameEdit.spec.ts",
         "playwright/e2e/Features/Glossary/GlossaryInheritedReviewerApproval.spec.ts",
         "playwright/e2e/Features/Glossary/GlossaryPersonaCustomization.spec.ts",
         "playwright/e2e/Features/Glossary/GlossaryWorkflow.spec.ts",
@@ -2815,6 +2820,7 @@
         "playwright/e2e/Pages/ProfilerConfigurationPage.spec.ts",
         "playwright/e2e/Pages/SearchSettings.spec.ts",
         "playwright/e2e/Pages/ServiceEntity.spec.ts",
+        "playwright/e2e/Pages/TableAliases.spec.ts",
         "playwright/e2e/Pages/Tag.spec.ts",
         "playwright/e2e/Pages/TagPageRightPanel.spec.ts",
         "playwright/e2e/Pages/TaskFormSettings.spec.ts",
@@ -3231,6 +3237,7 @@
         "playwright/e2e/Pages/ServiceEntity.spec.ts",
         "playwright/e2e/Pages/ServiceListing.spec.ts",
         "playwright/e2e/Pages/SubDomainPagination.spec.ts",
+        "playwright/e2e/Pages/TableAliases.spec.ts",
         "playwright/e2e/Pages/Tag.spec.ts",
         "playwright/e2e/Pages/TagPageRightPanel.spec.ts",
         "playwright/e2e/Pages/Tags.spec.ts",
@@ -3646,6 +3653,7 @@
         "playwright/e2e/Pages/Roles.spec.ts",
         "playwright/e2e/Pages/SearchSettings.spec.ts",
         "playwright/e2e/Pages/SubDomainPagination.spec.ts",
+        "playwright/e2e/Pages/TableAliases.spec.ts",
         "playwright/e2e/Pages/Tag.spec.ts",
         "playwright/e2e/Pages/Tags.spec.ts",
         "playwright/e2e/Pages/Teams.spec.ts",
@@ -4054,6 +4062,7 @@
       ],
       "specs": [
         "playwright/e2e/Features/BulkEditEntity.spec.ts",
+        "playwright/e2e/Features/OnlineUsers.spec.ts",
         "playwright/e2e/Pages/Teams.spec.ts"
       ]
     },
@@ -4286,7 +4295,8 @@
         "playwright/e2e/Pages/DataProducts.spec.ts",
         "playwright/e2e/Pages/Domains.spec.ts",
         "playwright/e2e/Pages/Tag.spec.ts",
-        "playwright/e2e/Pages/Tags.spec.ts"
+        "playwright/e2e/Pages/Tags.spec.ts",
+        "playwright/e2e/Pages/Users.spec.ts"
       ]
     },
     {
@@ -7761,6 +7771,7 @@
         "openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UsersProfile/UserProfileTeams/UserProfileTeams.component.tsx"
       ],
       "specs": [
+        "playwright/e2e/Features/TeamsHierarchy.spec.ts",
         "playwright/e2e/Pages/Teams.spec.ts",
         "playwright/e2e/Pages/UserDetails.spec.ts"
       ]
@@ -9840,6 +9851,7 @@
         "playwright/e2e/Pages/ServiceEntity.spec.ts",
         "playwright/e2e/Pages/ServiceListing.spec.ts",
         "playwright/e2e/Pages/SubDomainPagination.spec.ts",
+        "playwright/e2e/Pages/TableAliases.spec.ts",
         "playwright/e2e/Pages/Tag.spec.ts",
         "playwright/e2e/Pages/TagPageRightPanel.spec.ts",
         "playwright/e2e/Pages/Tags.spec.ts",
@@ -10724,6 +10736,14 @@
       ],
       "specs": [
         "playwright/e2e/Flow/ApiDocs.spec.ts"
+      ]
+    },
+    {
+      "sources": [
+        "openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableAliases/TableAliases.component.tsx"
+      ],
+      "specs": [
+        "playwright/e2e/Pages/TableAliases.spec.ts"
       ]
     },
     {

--- a/.github/playwright/impact-map.generated.json
+++ b/.github/playwright/impact-map.generated.json
@@ -9204,6 +9204,7 @@
         "playwright/e2e/Pages/DomainUIInteractions.spec.ts",
         "playwright/e2e/Pages/Domains.spec.ts",
         "playwright/e2e/Pages/Glossary.spec.ts",
+        "playwright/e2e/Pages/Lineage/LineageInteraction.spec.ts",
         "playwright/e2e/Pages/Lineage/LineageRightPanel.spec.ts",
         "playwright/e2e/Pages/Policies.spec.ts",
         "playwright/e2e/Pages/Roles.spec.ts",

--- a/openmetadata-ui/src/main/resources/ui/eslint-suppressions.json
+++ b/openmetadata-ui/src/main/resources/ui/eslint-suppressions.json
@@ -387,7 +387,7 @@
   },
   "playwright/e2e/Features/PersonaAIContextRules.spec.ts": {
     "om-playwright/no-positional-locator": {
-      "count": 10
+      "count": 8
     }
   },
   "playwright/e2e/Features/QueryEntity.spec.ts": {
@@ -752,7 +752,7 @@
   },
   "playwright/e2e/Pages/Lineage/LineageInteraction.spec.ts": {
     "om-playwright/no-positional-locator": {
-      "count": 2
+      "count": 1
     }
   },
   "playwright/e2e/Pages/LiveIndexingTab.spec.ts": {

--- a/openmetadata-ui/src/main/resources/ui/eslint-suppressions.json
+++ b/openmetadata-ui/src/main/resources/ui/eslint-suppressions.json
@@ -184,7 +184,7 @@
   },
   "playwright/e2e/Features/DataQuality/TableLevelTests.spec.ts": {
     "om-playwright/no-positional-locator": {
-      "count": 10
+      "count": 9
     }
   },
   "playwright/e2e/Features/DataQuality/TestCaseImportExportBasic.spec.ts": {

--- a/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
+++ b/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
@@ -27,7 +27,7 @@ coverage, a retried one looks green.
 
 ## Entries
 
-8 tests. Evidence is failures observed across 11 merge_group runs sampled on
+6 tests. Evidence is failures observed across 11 merge_group runs sampled on
 2026-09-04; the threshold for quarantining is **2 or more**, counted per
 generated variant rather than per source line.
 
@@ -35,11 +35,9 @@ generated variant rather than per source line.
 |---|---|---|---|
 | `e2e/Pages/ExplorePageRightPanel_KnowledgeCenter.spec.ts` | Should remove user owner for knowledgeCenter | 11/11 | `entity-summary-panel-container` → owner chip not found (10s). Regressed around #31853, which removed the welcome-banner dismiss helpers. |
 | `e2e/Features/PersonaAIContextRules.spec.ts` | knowledge entity type forces Fully rendered on and disables it | 7/11 | Test timeout. |
-| `e2e/Features/Table.spec.ts` | should persist page size | 6/11 | Test timeout after `waitForAllLoadersToDisappear`. |
 | `e2e/Pages/TestSuiteDetailsPage.spec.ts` | Add test case modal — filters and select | 3/11 | `waitForResponse` on the test-case search never resolves. |
 | `e2e/Features/Glossary/GlossaryHierarchy.spec.ts` | should move term to root of different glossary | 2/11 | Drag-and-drop. |
 | `e2e/Features/DataQuality/TableLevelTests.spec.ts` | Table Difference | 2/11 | |
-| `e2e/Features/ActivityStream.spec.ts` | activity stream API is called when visiting entity page | 2/11 | |
 
 `PLAYWRIGHT_RUN_QUARANTINED=true` selects these 9 plus the 7 setup/teardown
 fixture projects, which the soak lane deliberately leaves unfiltered so login and
@@ -56,6 +54,8 @@ These were failing their first attempt in ~every run and are root-caused, so
 they were repaired rather than parked:
 
 | Spec | Root cause |
+| `e2e/Features/ActivityStream.spec.ts` — activity stream API is called when visiting entity page | Released without a code change: 3/3 green locally, and no load-dependent symptom was ever recorded for it. |
+| `e2e/Features/Table.spec.ts` — should persist page size | Released without a code change: 3/3 green locally. Its recorded symptom (timeout after `waitForAllLoadersToDisappear`) is load-dependent, so local runs are weak evidence — re-tag it if it ejects a PR. No mechanism was identified for why it now passes. |
 | `e2e/Pages/Lineage/LineageInteraction.spec.ts` — Verify node panel opens on click | Two causes, and the symptom recorded here was only the second. (1) `fitToScreen` returned before its menu popover finished its exit animation, leaving a second `[role="dialog"]` in the DOM, so the test's unscoped `[role="dialog"]` assertion tripped strict mode. (2) `Verify edge delete button in drawer` deletes the shared `table1 → topic` edge and never restores it, so every later test in the file saw a graph without the topic — that is the "node is not in the graph" symptom. Fixed by having `fitToScreen` wait for the menu to detach, scoping the assertion to `lineage-entity-panel`, and restoring the edge in a `finally`. |
 |---|---|
 | `e2e/Pages/Glossary.spec.ts` 128 / 198 / 421 | `utils/glossary.ts` used `page.textContent()` — waits for the element, not its text — so a cold first attempt read `""`. #32333 (a revert of #30896) had reintroduced this after it was already fixed. Restored to `toContainText`. |

--- a/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
+++ b/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
@@ -27,26 +27,25 @@ coverage, a retried one looks green.
 
 ## Entries
 
-5 tests. Evidence is failures observed across 11 merge_group runs sampled on
+4 tests. Evidence is failures observed across 11 merge_group runs sampled on
 2026-09-04; the threshold for quarantining is **2 or more**, counted per
 generated variant rather than per source line.
 
 | Spec | Test | Seen | Symptom |
 |---|---|---|---|
-| `e2e/Features/PersonaAIContextRules.spec.ts` | knowledge entity type forces Fully rendered on and disables it | 7/11 | Test timeout. |
 | `e2e/Pages/TestSuiteDetailsPage.spec.ts` | Add test case modal — filters and select | 3/11 | `waitForResponse` on the test-case search never resolves. |
 | `e2e/Features/Glossary/GlossaryHierarchy.spec.ts` | should move term to root of different glossary | 2/11 | Drag-and-drop. |
 | `e2e/Features/DataQuality/TableLevelTests.spec.ts` | Table Difference | 2/11 | |
 
-`PLAYWRIGHT_RUN_QUARANTINED=true` selects these 5 plus the 7 setup/teardown
+`PLAYWRIGHT_RUN_QUARANTINED=true` selects these 4 plus the 7 setup/teardown
 fixture projects, which the soak lane deliberately leaves unfiltered so login and
 entity seeding still happen — a project-level `grep` *is* applied to dependency
 projects, so filtering them would make every quarantined test fail for want of
 `admin.json` instead of for its flake.
 
 Re-run `npx playwright test --list` after changing this file and update the
-default-lane count here. It is **4566 of 4571** with these 5 entries; the
-quarantined lane lists 12, which is the 5 plus the 7 fixture projects above.
+default-lane count here. It is **4567 of 4571** with these 4 entries; the
+quarantined lane lists 11, which is the 4 plus the 7 fixture projects above.
 (It was 4543 of 4555 when the list held 13.)
 
 ## Not quarantined — fixed instead
@@ -74,6 +73,7 @@ entry.
 | `e2e/Pages/EntityDataConsumer.spec.ts` | Update description (Table) | `updateDescription` resolved the editor with a page-global `descriptionBox` and `.first()`, so with the edit modal open it targeted the inline editor *behind* the overlay — visible, so the assertion passed, then the click failed on `ant-modal-wrap ... intercepts pointer events` until the test timed out. Now scoped to the dialog, asserting a single match. |
 | `e2e/Features/DataQuality/TestLibrary.spec.ts` | should create, edit, and delete a test definition | `TestDefinitionFormBody` rebuilt `options: toOptions(Object.values(…))` on every render. Focusing a field re-renders it via `onActiveFieldChange`, and the new `items` identity made react-aria rebuild the listbox collection, detaching the option mid-click. The option lists are enum-derived and now built once at module scope. |
 | `e2e/Features/DataQuality/TestLibrary.spec.ts` | should maintain page on edit and reset to first page on delete | Same select-option path as above. |
+| `e2e/Features/PersonaAIContextRules.spec.ts` | knowledge entity type forces Fully rendered on and disables it | The evidence was already stale when it was written down. Every test in the file reached its subject through `navigateToAIContextTab`, which called `navigateToPersonaWithPagination` — a walk of up to 15 pages, each costing a `waitForAllLoadersToDisappear`, a `next` click and a `/api/v1/personas*` round trip, before the test touched anything it was asserting on. That is the timeout, and it is why the rate tracked shard load (7/11) rather than being deterministic: the walk grows with the personas the shard has accumulated. #32458 then moved the editor into Context Center on 2026-09-07, replacing the whole walk with `goto('/context-center/ai-context')` plus one card click, and made the list page follow its cursor to exhaustion server-side. Green 9/9 locally at ~5s against a 60s budget. |
 | `e2e/Pages/ExplorePageRightPanel_KnowledgeCenter.spec.ts` | Should remove user owner for knowledgeCenter | `openEntitySummaryPanel` always waited for `searchBox`, the NavBar `GlobalSearchBar`. `/explore` renders its own `ExploreSearchInput` and never mounts the NavBar one, so on that page the wait could only time out — `runSearch` returned false every attempt and the retry poll spun until its budget expired. The helper had never worked for callers landing on `/explore`, which is why this failed 11/11 rather than flaking. It now picks the field the page actually renders. |
 | `e2e/Features/Glossary/GlossaryHierarchy.spec.ts` | should cancel drag and drop operation | `dragAndDropTerm` pressed at coordinates computed before the glossary page finished hydrating — the description block lands last and pushes every row down about a row height — and `force: true` skipped the actionability check that would have waited. It now holds both rows still before pressing. |
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
+++ b/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
@@ -39,7 +39,7 @@ generated variant rather than per source line.
 | `e2e/Features/Glossary/GlossaryHierarchy.spec.ts` | should move term to root of different glossary | 2/11 | Drag-and-drop. |
 | `e2e/Features/DataQuality/TableLevelTests.spec.ts` | Table Difference | 2/11 | |
 
-`PLAYWRIGHT_RUN_QUARANTINED=true` selects these 9 plus the 7 setup/teardown
+`PLAYWRIGHT_RUN_QUARANTINED=true` selects these 6 plus the 7 setup/teardown
 fixture projects, which the soak lane deliberately leaves unfiltered so login and
 entity seeding still happen — a project-level `grep` *is* applied to dependency
 projects, so filtering them would make every quarantined test fail for want of
@@ -54,10 +54,10 @@ These were failing their first attempt in ~every run and are root-caused, so
 they were repaired rather than parked:
 
 | Spec | Root cause |
+|---|---|
 | `e2e/Features/ActivityStream.spec.ts` — activity stream API is called when visiting entity page | Released without a code change: 3/3 green locally, and no load-dependent symptom was ever recorded for it. |
 | `e2e/Features/Table.spec.ts` — should persist page size | Released without a code change: 3/3 green locally. Its recorded symptom (timeout after `waitForAllLoadersToDisappear`) is load-dependent, so local runs are weak evidence — re-tag it if it ejects a PR. No mechanism was identified for why it now passes. |
 | `e2e/Pages/Lineage/LineageInteraction.spec.ts` — Verify node panel opens on click | Two causes, and the symptom recorded here was only the second. (1) `fitToScreen` returned before its menu popover finished its exit animation, leaving a second `[role="dialog"]` in the DOM, so the test's unscoped `[role="dialog"]` assertion tripped strict mode. (2) `Verify edge delete button in drawer` deletes the shared `table1 → topic` edge and never restores it, so every later test in the file saw a graph without the topic — that is the "node is not in the graph" symptom. Fixed by having `fitToScreen` wait for the menu to detach, scoping the assertion to `lineage-entity-panel`, and restoring the edge in a `finally`. |
-|---|---|
 | `e2e/Pages/Glossary.spec.ts` 128 / 198 / 421 | `utils/glossary.ts` used `page.textContent()` — waits for the element, not its text — so a cold first attempt read `""`. #32333 (a revert of #30896) had reintroduced this after it was already fixed. Restored to `toContainText`. |
 | `e2e/Features/ContextCenterArticles.spec.ts:670` | #32283 removed a `waitForTimeout(500)` that was covering the zustand → localStorage flush of `recentlyViewed`. Navigating away before the flush meant the Recently Viewed panel had no entry to render, so the trailing assertion had nothing to auto-wait for. Replaced with `waitForRecentlyViewed`, which polls the persisted store. |
 | `e2e/Features/ClassificationImportExport.spec.ts:64` | `beforeAll` POSTed fixtures whose names were generated at module scope, so a second pass in the same worker 409'd on every create. Fixtures are now rebuilt inside `beforeAll`, and an `afterAll` was added — the spec previously leaked two classifications, a tag and a user into the shard on every run. |

--- a/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
+++ b/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
@@ -27,7 +27,7 @@ coverage, a retried one looks green.
 
 ## Entries
 
-4 tests. Evidence is failures observed across 11 merge_group runs sampled on
+3 tests. Evidence is failures observed across 11 merge_group runs sampled on
 2026-09-04; the threshold for quarantining is **2 or more**, counted per
 generated variant rather than per source line.
 
@@ -70,8 +70,8 @@ projects, so filtering them would make every quarantined test fail for want of
 `admin.json` instead of for its flake.
 
 Re-run `npx playwright test --list` after changing this file and update the
-default-lane count here. It is **4567 of 4571** with these 4 entries; the
-quarantined lane lists 11, which is the 4 plus the 7 fixture projects above.
+default-lane count here. It is **4577 of 4580** with these 3 entries; the
+quarantined lane lists 10, which is the 3 plus the 7 fixture projects above.
 (It was 4543 of 4555 when the list held 13.)
 
 ## Not quarantined — fixed instead

--- a/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
+++ b/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
@@ -37,7 +37,33 @@ generated variant rather than per source line.
 | `e2e/Features/Glossary/GlossaryHierarchy.spec.ts` | should move term to root of different glossary | 2/11 | Drag-and-drop. |
 | `e2e/Features/DataQuality/TableLevelTests.spec.ts` | Table Difference | 2/11 | |
 
-`PLAYWRIGHT_RUN_QUARANTINED=true` selects these 4 plus the 7 setup/teardown
+### Triage, 2026-09-09
+
+All three were run against a local stack (current UI via the Vite dev server,
+`--repeat-each=3`) and all three passed 3/3, well inside their budgets: the test
+suite modal at 12-21s under a `test.slow()` timeout, Table Difference at
+10-19s, the glossary drag at 6-7s. Their recorded rates are 3/11 and 2/11, so
+this is the expected result rather than a contradiction — these are
+load-dependent and an idle laptop does not reproduce them. **More local runs
+will not settle them** — but neither will waiting for CI: nothing under
+`.github/` sets `PLAYWRIGHT_RUN_QUARANTINED`, so a quarantined test runs in no
+lane at all and has produced no evidence since it was tagged. The soak lane this
+file describes does not exist. Getting these three moving needs that lane (or a
+one-off dispatch) first.
+
+One unverified lead, for whoever picks up the test suite entry: its recorded
+symptom is a `waitForResponse` that never resolves, and every listener in
+`utils/addTestCaseList.ts` is correctly hoisted above the action that triggers
+it — so a missed-because-registered-late response is not the cause.
+`addTestCaseListFilterByFirstColumn` is the one that can genuinely never see its
+request: it picks the Column dropdown's first `menuitem` and then waits for a
+`testCases/search/list` carrying `columnName`. If the dropdown is still
+populating, the first menuitem is not yet a real column, and the update it
+submits produces a request without `columnName`. `addTestCaseListResetFilters`
+repeats the same `.first()` menuitem pick. Confirm against a CI trace before
+changing anything.
+
+`PLAYWRIGHT_RUN_QUARANTINED=true` selects these 3 plus the 7 setup/teardown
 fixture projects, which the soak lane deliberately leaves unfiltered so login and
 entity seeding still happen — a project-level `grep` *is* applied to dependency
 projects, so filtering them would make every quarantined test fail for want of

--- a/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
+++ b/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
@@ -27,26 +27,27 @@ coverage, a retried one looks green.
 
 ## Entries
 
-6 tests. Evidence is failures observed across 11 merge_group runs sampled on
+5 tests. Evidence is failures observed across 11 merge_group runs sampled on
 2026-09-04; the threshold for quarantining is **2 or more**, counted per
 generated variant rather than per source line.
 
 | Spec | Test | Seen | Symptom |
 |---|---|---|---|
-| `e2e/Pages/ExplorePageRightPanel_KnowledgeCenter.spec.ts` | Should remove user owner for knowledgeCenter | 11/11 | `entity-summary-panel-container` → owner chip not found (10s). Regressed around #31853, which removed the welcome-banner dismiss helpers. |
 | `e2e/Features/PersonaAIContextRules.spec.ts` | knowledge entity type forces Fully rendered on and disables it | 7/11 | Test timeout. |
 | `e2e/Pages/TestSuiteDetailsPage.spec.ts` | Add test case modal — filters and select | 3/11 | `waitForResponse` on the test-case search never resolves. |
 | `e2e/Features/Glossary/GlossaryHierarchy.spec.ts` | should move term to root of different glossary | 2/11 | Drag-and-drop. |
 | `e2e/Features/DataQuality/TableLevelTests.spec.ts` | Table Difference | 2/11 | |
 
-`PLAYWRIGHT_RUN_QUARANTINED=true` selects these 6 plus the 7 setup/teardown
+`PLAYWRIGHT_RUN_QUARANTINED=true` selects these 5 plus the 7 setup/teardown
 fixture projects, which the soak lane deliberately leaves unfiltered so login and
 entity seeding still happen — a project-level `grep` *is* applied to dependency
 projects, so filtering them would make every quarantined test fail for want of
 `admin.json` instead of for its flake.
 
 Re-run `npx playwright test --list` after changing this file and update the
-default-lane count here; it was 4543 of 4555 when the list held 13 entries.
+default-lane count here. It is **4566 of 4571** with these 5 entries; the
+quarantined lane lists 12, which is the 5 plus the 7 fixture projects above.
+(It was 4543 of 4555 when the list held 13.)
 
 ## Not quarantined — fixed instead
 
@@ -73,6 +74,7 @@ entry.
 | `e2e/Pages/EntityDataConsumer.spec.ts` | Update description (Table) | `updateDescription` resolved the editor with a page-global `descriptionBox` and `.first()`, so with the edit modal open it targeted the inline editor *behind* the overlay — visible, so the assertion passed, then the click failed on `ant-modal-wrap ... intercepts pointer events` until the test timed out. Now scoped to the dialog, asserting a single match. |
 | `e2e/Features/DataQuality/TestLibrary.spec.ts` | should create, edit, and delete a test definition | `TestDefinitionFormBody` rebuilt `options: toOptions(Object.values(…))` on every render. Focusing a field re-renders it via `onActiveFieldChange`, and the new `items` identity made react-aria rebuild the listbox collection, detaching the option mid-click. The option lists are enum-derived and now built once at module scope. |
 | `e2e/Features/DataQuality/TestLibrary.spec.ts` | should maintain page on edit and reset to first page on delete | Same select-option path as above. |
+| `e2e/Pages/ExplorePageRightPanel_KnowledgeCenter.spec.ts` | Should remove user owner for knowledgeCenter | `openEntitySummaryPanel` always waited for `searchBox`, the NavBar `GlobalSearchBar`. `/explore` renders its own `ExploreSearchInput` and never mounts the NavBar one, so on that page the wait could only time out — `runSearch` returned false every attempt and the retry poll spun until its budget expired. The helper had never worked for callers landing on `/explore`, which is why this failed 11/11 rather than flaking. It now picks the field the page actually renders. |
 | `e2e/Features/Glossary/GlossaryHierarchy.spec.ts` | should cancel drag and drop operation | `dragAndDropTerm` pressed at coordinates computed before the glossary page finished hydrating — the description block lands last and pushes every row down about a row height — and `force: true` skipped the actionability check that would have waited. It now holds both rows still before pressing. |
 
 ## Left running deliberately

--- a/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
+++ b/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
@@ -27,13 +27,12 @@ coverage, a retried one looks green.
 
 ## Entries
 
-9 tests. Evidence is failures observed across 11 merge_group runs sampled on
+8 tests. Evidence is failures observed across 11 merge_group runs sampled on
 2026-09-04; the threshold for quarantining is **2 or more**, counted per
 generated variant rather than per source line.
 
 | Spec | Test | Seen | Symptom |
 |---|---|---|---|
-| `e2e/Pages/Lineage/LineageInteraction.spec.ts` | Verify node panel opens on click | 11/11 | `clickLineageNode` → `entity-header-display-name` never visible (15s). The topic node is not in the graph the `beforeEach` renders. |
 | `e2e/Pages/ExplorePageRightPanel_KnowledgeCenter.spec.ts` | Should remove user owner for knowledgeCenter | 11/11 | `entity-summary-panel-container` → owner chip not found (10s). Regressed around #31853, which removed the welcome-banner dismiss helpers. |
 | `e2e/Features/PersonaAIContextRules.spec.ts` | knowledge entity type forces Fully rendered on and disables it | 7/11 | Test timeout. |
 | `e2e/Features/Table.spec.ts` | should persist page size | 6/11 | Test timeout after `waitForAllLoadersToDisappear`. |
@@ -57,6 +56,7 @@ These were failing their first attempt in ~every run and are root-caused, so
 they were repaired rather than parked:
 
 | Spec | Root cause |
+| `e2e/Pages/Lineage/LineageInteraction.spec.ts` — Verify node panel opens on click | Two causes, and the symptom recorded here was only the second. (1) `fitToScreen` returned before its menu popover finished its exit animation, leaving a second `[role="dialog"]` in the DOM, so the test's unscoped `[role="dialog"]` assertion tripped strict mode. (2) `Verify edge delete button in drawer` deletes the shared `table1 → topic` edge and never restores it, so every later test in the file saw a graph without the topic — that is the "node is not in the graph" symptom. Fixed by having `fitToScreen` wait for the menu to detach, scoping the assertion to `lineage-entity-panel`, and restoring the edge in a `finally`. |
 |---|---|
 | `e2e/Pages/Glossary.spec.ts` 128 / 198 / 421 | `utils/glossary.ts` used `page.textContent()` — waits for the element, not its text — so a cold first attempt read `""`. #32333 (a revert of #30896) had reintroduced this after it was already fixed. Restored to `toContainText`. |
 | `e2e/Features/ContextCenterArticles.spec.ts:670` | #32283 removed a `waitForTimeout(500)` that was covering the zustand → localStorage flush of `recentlyViewed`. Navigating away before the flush meant the Recently Viewed panel had no entry to render, so the trailing assertion had nothing to auto-wait for. Replaced with `waitForRecentlyViewed`, which polls the persisted store. |

--- a/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
+++ b/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
@@ -27,12 +27,13 @@ coverage, a retried one looks green.
 
 ## Entries
 
-3 tests. Evidence is failures observed across 11 merge_group runs sampled on
+4 tests. Most evidence is failures observed across 11 merge_group runs sampled on
 2026-09-04; the threshold for quarantining is **2 or more**, counted per
 generated variant rather than per source line.
 
 | Spec | Test | Seen | Symptom |
 |---|---|---|---|
+| `e2e/Pages/ExplorePageRightPanel_KnowledgeCenter.spec.ts` | Should remove user owner for knowledgeCenter | 1/1 | Re-quarantined 2026-09-10 on fresh evidence, not the 2026-09-04 sample. The 11/11 failure it was first tagged for was real and is fixed (`openEntitySummaryPanel` waited for the NavBar `searchBox` on a page that renders `ExploreSearchInput`), but releasing it surfaced a second cause underneath. In PR #33054 it failed its first attempt and passed on retry: `expectOwnerInPanel` polled for the owner chip for the full 60s, re-navigating between attempts, and never saw it — even though `addOwnerInKCPanel` had already awaited the PATCH, so the owner was persisted. That is the *original* recorded symptom (owner chip not found), so the panel's read path lags the write rather than the navigation being wrong. A longer poll is not the fix; find what the panel reads and wait on that. |
 | `e2e/Pages/TestSuiteDetailsPage.spec.ts` | Add test case modal — filters and select | 3/11 | `waitForResponse` on the test-case search never resolves. |
 | `e2e/Features/Glossary/GlossaryHierarchy.spec.ts` | should move term to root of different glossary | 2/11 | Drag-and-drop. |
 | `e2e/Features/DataQuality/TableLevelTests.spec.ts` | Table Difference | 2/11 | |
@@ -63,15 +64,15 @@ submits produces a request without `columnName`. `addTestCaseListResetFilters`
 repeats the same `.first()` menuitem pick. Confirm against a CI trace before
 changing anything.
 
-`PLAYWRIGHT_RUN_QUARANTINED=true` selects these 3 plus the 7 setup/teardown
+`PLAYWRIGHT_RUN_QUARANTINED=true` selects these 4 plus the 7 setup/teardown
 fixture projects, which the soak lane deliberately leaves unfiltered so login and
 entity seeding still happen — a project-level `grep` *is* applied to dependency
 projects, so filtering them would make every quarantined test fail for want of
 `admin.json` instead of for its flake.
 
 Re-run `npx playwright test --list` after changing this file and update the
-default-lane count here. It is **4577 of 4580** with these 3 entries; the
-quarantined lane lists 10, which is the 3 plus the 7 fixture projects above.
+default-lane count here. It is **4576 of 4580** with these 4 entries; the
+quarantined lane lists 11, which is the 4 plus the 7 fixture projects above.
 (It was 4543 of 4555 when the list held 13.)
 
 ## Not quarantined — fixed instead
@@ -100,7 +101,6 @@ entry.
 | `e2e/Features/DataQuality/TestLibrary.spec.ts` | should create, edit, and delete a test definition | `TestDefinitionFormBody` rebuilt `options: toOptions(Object.values(…))` on every render. Focusing a field re-renders it via `onActiveFieldChange`, and the new `items` identity made react-aria rebuild the listbox collection, detaching the option mid-click. The option lists are enum-derived and now built once at module scope. |
 | `e2e/Features/DataQuality/TestLibrary.spec.ts` | should maintain page on edit and reset to first page on delete | Same select-option path as above. |
 | `e2e/Features/PersonaAIContextRules.spec.ts` | knowledge entity type forces Fully rendered on and disables it | The evidence was already stale when it was written down. Every test in the file reached its subject through `navigateToAIContextTab`, which called `navigateToPersonaWithPagination` — a walk of up to 15 pages, each costing a `waitForAllLoadersToDisappear`, a `next` click and a `/api/v1/personas*` round trip, before the test touched anything it was asserting on. That is the timeout, and it is why the rate tracked shard load (7/11) rather than being deterministic: the walk grows with the personas the shard has accumulated. #32458 then moved the editor into Context Center on 2026-09-07, replacing the whole walk with `goto('/context-center/ai-context')` plus one card click, and made the list page follow its cursor to exhaustion server-side. Green 9/9 locally at ~5s against a 60s budget. |
-| `e2e/Pages/ExplorePageRightPanel_KnowledgeCenter.spec.ts` | Should remove user owner for knowledgeCenter | `openEntitySummaryPanel` always waited for `searchBox`, the NavBar `GlobalSearchBar`. `/explore` renders its own `ExploreSearchInput` and never mounts the NavBar one, so on that page the wait could only time out — `runSearch` returned false every attempt and the retry poll spun until its budget expired. The helper had never worked for callers landing on `/explore`, which is why this failed 11/11 rather than flaking. It now picks the field the page actually renders. |
 | `e2e/Features/Glossary/GlossaryHierarchy.spec.ts` | should cancel drag and drop operation | `dragAndDropTerm` pressed at coordinates computed before the glossary page finished hydrating — the description block lands last and pushes every row down about a row height — and `force: true` skipped the actionability check that would have waited. It now holds both rows still before pressing. |
 
 ## Left running deliberately

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityStream.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityStream.spec.ts
@@ -14,7 +14,10 @@
 import { TableClass } from '../../support/entity/TableClass';
 import { expect, test as base } from '../../support/fixtures/base';
 import { UserClass } from '../../support/user/UserClass';
-import { insertActivityEventForTest } from '../../utils/activityAPI';
+import {
+  insertActivityEventForTest,
+  visitTableActivityFeed,
+} from '../../utils/activityAPI';
 import { performAdminLogin } from '../../utils/admin';
 import { uuid } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
@@ -230,31 +233,10 @@ test.describe('Activity Stream on Entity Pages', () => {
   test('activity stream API is called when visiting entity page', async ({
     page,
   }) => {
-    const activityApiPromise = page
-      .waitForResponse(
-        (response) =>
-          response.url().includes('/api/v1/activity') &&
-          response.status() === 200,
-        { timeout: 10000 }
-      )
-      .catch(() => null);
+    const responseBody = await visitTableActivityFeed(page, testTable);
 
-    await testTable.visitEntityPage(page);
-    await waitForAllLoadersToDisappear(page);
-
-    const activityFeedTab = page.getByRole('tab', {
-      name: 'Activity Feeds & Tasks',
-    });
-    await activityFeedTab.click();
-
-    const response = await activityApiPromise;
-
-    if (response) {
-      const responseBody = await response.json();
-
-      expect(responseBody).toHaveProperty('data');
-      expect(Array.isArray(responseBody.data)).toBe(true);
-    }
+    expect(responseBody).toHaveProperty('data');
+    expect(Array.isArray(responseBody.data)).toBe(true);
   });
 
   test('activity feed left panel shows All and Tasks options', async ({

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityStream.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityStream.spec.ts
@@ -227,37 +227,35 @@ test.describe('Activity Stream on Entity Pages', () => {
     await expect(countBadge).toHaveText(/^[1-9]\d*$/, { timeout: 30_000 });
   });
 
-  test(
-    'activity stream API is called when visiting entity page',
-    { tag: '@quarantine' },
-    async ({ page }) => {
-      const activityApiPromise = page
-        .waitForResponse(
-          (response) =>
-            response.url().includes('/api/v1/activity') &&
-            response.status() === 200,
-          { timeout: 10000 }
-        )
-        .catch(() => null);
+  test('activity stream API is called when visiting entity page', async ({
+    page,
+  }) => {
+    const activityApiPromise = page
+      .waitForResponse(
+        (response) =>
+          response.url().includes('/api/v1/activity') &&
+          response.status() === 200,
+        { timeout: 10000 }
+      )
+      .catch(() => null);
 
-      await testTable.visitEntityPage(page);
-      await waitForAllLoadersToDisappear(page);
+    await testTable.visitEntityPage(page);
+    await waitForAllLoadersToDisappear(page);
 
-      const activityFeedTab = page.getByRole('tab', {
-        name: 'Activity Feeds & Tasks',
-      });
-      await activityFeedTab.click();
+    const activityFeedTab = page.getByRole('tab', {
+      name: 'Activity Feeds & Tasks',
+    });
+    await activityFeedTab.click();
 
-      const response = await activityApiPromise;
+    const response = await activityApiPromise;
 
-      if (response) {
-        const responseBody = await response.json();
+    if (response) {
+      const responseBody = await response.json();
 
-        expect(responseBody).toHaveProperty('data');
-        expect(Array.isArray(responseBody.data)).toBe(true);
-      }
+      expect(responseBody).toHaveProperty('data');
+      expect(Array.isArray(responseBody.data)).toBe(true);
     }
-  );
+  });
 
   test('activity feed left panel shows All and Tasks options', async ({
     page,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TableLevelTests.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TableLevelTests.spec.ts
@@ -873,12 +873,10 @@ test.describe(
           .getByTestId('code-mirror-container')
           .getByRole('textbox')
           .fill(testCase.sqlQuery);
-        await page.click('#testCaseFormV1_params_strategy');
-        await page
-          .getByRole('option')
-          .filter({ hasText: 'ROWS' })
-          .first()
-          .click();
+        await selectOptionWithRetry(
+          page.locator('#testCaseFormV1_params_strategy'),
+          page.getByRole('option').filter({ hasText: 'ROWS' }).first()
+        );
         await page.fill('#testCaseFormV1_params_threshold', '23');
         await submitTestCaseForm(page);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TableLevelTests.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TableLevelTests.spec.ts
@@ -875,7 +875,7 @@ test.describe(
           .fill(testCase.sqlQuery);
         await selectOptionWithRetry(
           page.locator('#testCaseFormV1_params_strategy'),
-          page.getByRole('option').filter({ hasText: 'ROWS' }).first()
+          page.getByRole('option', { name: 'ROWS' })
         );
         await page.fill('#testCaseFormV1_params_threshold', '23');
         await submitTestCaseForm(page);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestLibrary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestLibrary.spec.ts
@@ -28,6 +28,8 @@ const UPDATE_TEST_DEFINITION_DISPLAY_NAME = `Aaro Updated Custom Test Definition
 const TEST_DEFINITION_DESCRIPTION =
   'Aaro This is a custom test definition for E2E testing';
 
+// Only for the multi-select combobox — its popup is typing-driven, so
+// selectOptionWithRetry's aria-expanded guard does not apply.
 const selectOptionWithMouse = async (page: Page, option: Locator) => {
   await expect(option).toBeVisible();
 
@@ -44,26 +46,18 @@ const selectOptionWithMouse = async (page: Page, option: Locator) => {
   );
 };
 
-// React Aria's listbox is a non-modal popover, and a press on a trigger that
-// does not already hold focus both opens it and — via the focus transition that
-// same press produces — dismisses it a frame later. That leaves roughly 160ms to
-// pick an option, and nothing reopens the listbox afterwards, so a loaded runner
-// that misses the window retries the option click until the test times out.
-// Focusing the trigger first removes the transition, and with it the window.
+// Assert on the trigger, never on the Select root: the root also holds React
+// Aria's hidden <select>, whose <option> text makes toContainText on the root
+// pass for any value the field offers, selected or not.
 const selectEntityType = async (page: Page, entityType: string) => {
-  const entityTypeSelect = page.getByTestId('entity-type');
-  const entityTypeTrigger = entityTypeSelect.getByRole('button');
+  const entityTypeTrigger = page.getByTestId('entity-type').getByRole('button');
 
-  await entityTypeTrigger.focus();
-  await expect(entityTypeTrigger).toBeFocused();
-  await entityTypeTrigger.click();
-
-  await selectOptionWithMouse(
-    page,
+  await selectOptionWithRetry(
+    entityTypeTrigger,
     page.getByRole('option', { name: entityType, exact: true })
   );
 
-  await expect(entityTypeSelect).toContainText(entityType);
+  await expect(entityTypeTrigger).toContainText(entityType);
 };
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
@@ -763,26 +757,17 @@ test.describe(
 
         // Add a DQ Dimension — verifies that editing a test definition with existing
         // parameters does not prevent the dimension from being saved correctly.
-        const dimensionField = page.getByTestId('data-quality-dimension');
+        const dimensionTrigger = page
+          .getByTestId('data-quality-dimension')
+          .getByRole('button');
         const accuracyOption = page.getByRole('option', {
           name: 'Accuracy',
           exact: true,
         });
 
-        // The listbox is a non-modal React Aria popover, so it is dismissed by any
-        // scroll of the pane holding the trigger — including the one Playwright
-        // emits to bring this field into view, delivered a frame after the popup
-        // opened. Reopen on each attempt; nothing else reopens it.
-        await expect(async () => {
-          if (!(await accuracyOption.isVisible())) {
-            await dimensionField.getByRole('button').click();
-            await expect(accuracyOption).toBeVisible({ timeout: 2_000 });
-          }
-          await selectOptionWithMouse(page, accuracyOption);
-          await expect(dimensionField).toContainText('Accuracy', {
-            timeout: 2_000,
-          });
-        }).toPass({ timeout: 20_000, intervals: [500, 1_000, 2_000] });
+        await selectOptionWithRetry(dimensionTrigger, accuracyOption);
+
+        await expect(dimensionTrigger).toContainText('Accuracy');
 
         // Save without providing parameter dataType or description — both are optional.
         const patchResponse = page.waitForResponse(

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaAIContextRules.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaAIContextRules.spec.ts
@@ -445,35 +445,33 @@ test.describe.serial('Persona AI Context — Rule Builder', () => {
       await page.keyboard.press('Escape');
     });
 
-    test(
-      'knowledge entity type forces Fully rendered on and disables it',
-      { tag: '@quarantine' },
-      async ({ adminPage: page }) => {
-        await openPersonaContext(page);
-        await openAddRuleDrawer(page);
+    test('knowledge entity type forces Fully rendered on and disables it', async ({
+      adminPage: page,
+    }) => {
+      await openPersonaContext(page);
+      await openAddRuleDrawer(page);
 
-        await test.step('switch to a knowledge entity type', async () => {
-          await page.getByTestId('context-rule-entity-type').click();
-          await page
-            .getByRole('listbox')
-            .getByText(/knowledge/i)
-            .first()
-            .click();
-        });
+      await test.step('switch to a knowledge entity type', async () => {
+        await page.getByTestId('context-rule-entity-type').click();
+        await page
+          .getByRole('listbox')
+          .getByText(/knowledge/i)
+          .first()
+          .click();
+      });
 
-        await test.step('Fully rendered switch must be checked and disabled', async () => {
-          const fullyRenderedSwitch = page
-            .getByTestId('context-rule-fully-rendered')
-            .getByRole('switch')
-            .first();
-          // toBeChecked() reads the checkbox `checked` property — react-aria Switch
-          // does not always set the aria-checked attribute, so attribute checks fail
-          await expect(fullyRenderedSwitch).toBeChecked();
-          await expect(fullyRenderedSwitch).toBeDisabled();
-        });
+      await test.step('Fully rendered switch must be checked and disabled', async () => {
+        const fullyRenderedSwitch = page
+          .getByTestId('context-rule-fully-rendered')
+          .getByRole('switch')
+          .first();
+        // toBeChecked() reads the checkbox `checked` property — react-aria Switch
+        // does not always set the aria-checked attribute, so attribute checks fail
+        await expect(fullyRenderedSwitch).toBeChecked();
+        await expect(fullyRenderedSwitch).toBeDisabled();
+      });
 
-        await page.keyboard.press('Escape');
-      }
-    );
+      await page.keyboard.press('Escape');
+    });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaAIContextRules.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaAIContextRules.spec.ts
@@ -453,18 +453,19 @@ test.describe.serial('Persona AI Context — Rule Builder', () => {
 
       await test.step('switch to a knowledge entity type', async () => {
         await page.getByTestId('context-rule-entity-type').click();
+        // Each option carries its EntityType as data-key. Matching the
+        // "Knowledge" supporting text instead would match all three knowledge
+        // types and leave DOM order to decide which one the test exercises.
         await page
           .getByRole('listbox')
-          .getByText(/knowledge/i)
-          .first()
+          .locator('[data-key="glossaryTerm"]')
           .click();
       });
 
       await test.step('Fully rendered switch must be checked and disabled', async () => {
         const fullyRenderedSwitch = page
           .getByTestId('context-rule-fully-rendered')
-          .getByRole('switch')
-          .first();
+          .getByRole('switch');
         // toBeChecked() reads the checkbox `checked` property — react-aria Switch
         // does not always set the aria-checked attribute, so attribute checks fail
         await expect(fullyRenderedSwitch).toBeChecked();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Table.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Table.spec.ts
@@ -257,7 +257,6 @@ test.describe('Table pagination sorting search scenarios ', () => {
     await expect(page.getByTestId('databaseSchema-tables')).toBeVisible();
 
     const pageSizeDropdown = page.getByTestId('page-size-selection-dropdown');
-    await pageSizeDropdown.scrollIntoViewIfNeeded();
     await expect(pageSizeDropdown).toBeVisible();
     await expect(pageSizeDropdown).toBeEnabled();
 
@@ -265,16 +264,13 @@ test.describe('Table pagination sorting search scenarios ', () => {
     // trigger, so a bare click only fires preventDefault. Hover + click-fallback
     // + retry — a re-render that nudges the footer out from under the pointer
     // otherwise leaves the menu closed for good.
-    const pageSizeMenu = page.getByRole('menu').filter({ hasText: '/ Page' });
-    const pageSizeOption = pageSizeMenu.getByRole('menuitem', {
-      name: '15 / Page',
-    });
+    const pageSizeOption = page.getByRole('menuitem', { name: '15 / Page' });
     await expect(async () => {
       await pageSizeDropdown.hover();
-      if (!(await pageSizeMenu.isVisible())) {
+      if (!(await pageSizeOption.isVisible())) {
         await pageSizeDropdown.click();
       }
-      await expect(pageSizeMenu).toBeVisible({ timeout: 2_000 });
+      await expect(pageSizeOption).toBeVisible({ timeout: 2_000 });
     }).toPass({ timeout: 15_000, intervals: [500, 1_000, 2_000] });
 
     await pageSizeOption.click();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Table.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Table.spec.ts
@@ -249,60 +249,56 @@ test.describe('Table pagination sorting search scenarios ', () => {
     );
   });
 
-  test(
-    'should persist page size',
-    { tag: '@quarantine' },
-    async ({ dataConsumerPage: page }) => {
-      await page.goto('/databaseSchema/sample_data.ecommerce_db.shopify');
+  test('should persist page size', async ({ dataConsumerPage: page }) => {
+    await page.goto('/databaseSchema/sample_data.ecommerce_db.shopify');
 
-      await waitForAllLoadersToDisappear(page);
+    await waitForAllLoadersToDisappear(page);
 
-      await expect(page.getByTestId('databaseSchema-tables')).toBeVisible();
+    await expect(page.getByTestId('databaseSchema-tables')).toBeVisible();
 
-      const pageSizeDropdown = page.getByTestId('page-size-selection-dropdown');
-      await pageSizeDropdown.scrollIntoViewIfNeeded();
-      await expect(pageSizeDropdown).toBeVisible();
-      await expect(pageSizeDropdown).toBeEnabled();
+    const pageSizeDropdown = page.getByTestId('page-size-selection-dropdown');
+    await pageSizeDropdown.scrollIntoViewIfNeeded();
+    await expect(pageSizeDropdown).toBeVisible();
+    await expect(pageSizeDropdown).toBeEnabled();
 
-      // NextPrevious wraps the button in an Ant Dropdown with the default hover
-      // trigger, so a bare click only fires preventDefault. Hover + click-fallback
-      // + retry — a re-render that nudges the footer out from under the pointer
-      // otherwise leaves the menu closed for good.
-      const pageSizeMenu = page.getByRole('menu').filter({ hasText: '/ Page' });
-      const pageSizeOption = pageSizeMenu.getByRole('menuitem', {
-        name: '15 / Page',
-      });
-      await expect(async () => {
-        await pageSizeDropdown.hover();
-        if (!(await pageSizeMenu.isVisible())) {
-          await pageSizeDropdown.click();
-        }
-        await expect(pageSizeMenu).toBeVisible({ timeout: 2_000 });
-      }).toPass({ timeout: 15_000, intervals: [500, 1_000, 2_000] });
+    // NextPrevious wraps the button in an Ant Dropdown with the default hover
+    // trigger, so a bare click only fires preventDefault. Hover + click-fallback
+    // + retry — a re-render that nudges the footer out from under the pointer
+    // otherwise leaves the menu closed for good.
+    const pageSizeMenu = page.getByRole('menu').filter({ hasText: '/ Page' });
+    const pageSizeOption = pageSizeMenu.getByRole('menuitem', {
+      name: '15 / Page',
+    });
+    await expect(async () => {
+      await pageSizeDropdown.hover();
+      if (!(await pageSizeMenu.isVisible())) {
+        await pageSizeDropdown.click();
+      }
+      await expect(pageSizeMenu).toBeVisible({ timeout: 2_000 });
+    }).toPass({ timeout: 15_000, intervals: [500, 1_000, 2_000] });
 
-      await pageSizeOption.click();
-      await waitForAllLoadersToDisappear(page);
+    await pageSizeOption.click();
+    await waitForAllLoadersToDisappear(page);
 
-      const linkInColumn = getFirstRowColumnLink(page);
-      const entityApiResponse = page.waitForResponse(
-        '/api/v1/permissions/table/name/*'
-      );
-      await linkInColumn.click();
+    const linkInColumn = getFirstRowColumnLink(page);
+    const entityApiResponse = page.waitForResponse(
+      '/api/v1/permissions/table/name/*'
+    );
+    await linkInColumn.click();
 
-      await entityApiResponse;
-      await waitForAllLoadersToDisappear(page);
+    await entityApiResponse;
+    await waitForAllLoadersToDisappear(page);
 
-      await page.goBack();
-      await waitForAllLoadersToDisappear(page);
-      await page
-        .getByTestId('page-size-selection-dropdown')
-        .scrollIntoViewIfNeeded();
+    await page.goBack();
+    await waitForAllLoadersToDisappear(page);
+    await page
+      .getByTestId('page-size-selection-dropdown')
+      .scrollIntoViewIfNeeded();
 
-      await expect(page.getByTestId('page-size-selection-dropdown')).toHaveText(
-        '15 / Page'
-      );
-    }
-  );
+    await expect(page.getByTestId('page-size-selection-dropdown')).toHaveText(
+      '15 / Page'
+    );
+  });
 });
 
 test.describe('Table & Data Model columns table pagination', () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Table.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Table.spec.ts
@@ -261,9 +261,11 @@ test.describe('Table pagination sorting search scenarios ', () => {
     await expect(pageSizeDropdown).toBeEnabled();
 
     // NextPrevious wraps the button in an Ant Dropdown with the default hover
-    // trigger, so a bare click only fires preventDefault. Hover + click-fallback
-    // + retry — a re-render that nudges the footer out from under the pointer
-    // otherwise leaves the menu closed for good.
+    // trigger, so a bare click only fires preventDefault. Open and pick inside
+    // one retry: the menu can close between a visibility check and the click,
+    // and a click left outside the loop then waits on a hidden option for the
+    // rest of the test. Asserting the trigger's new label retries the whole
+    // open-and-pick when it did not take.
     const pageSizeOption = page.getByRole('menuitem', { name: '15 / Page' });
     await expect(async () => {
       await pageSizeDropdown.hover();
@@ -271,9 +273,10 @@ test.describe('Table pagination sorting search scenarios ', () => {
         await pageSizeDropdown.click();
       }
       await expect(pageSizeOption).toBeVisible({ timeout: 2_000 });
-    }).toPass({ timeout: 15_000, intervals: [500, 1_000, 2_000] });
+      await pageSizeOption.click({ timeout: 5_000 });
 
-    await pageSizeOption.click();
+      await expect(pageSizeDropdown).toContainText('15 / Page');
+    }).toPass({ timeout: 30_000, intervals: [500, 1_000, 2_000] });
     await waitForAllLoadersToDisappear(page);
 
     const linkInColumn = getFirstRowColumnLink(page);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
@@ -1177,7 +1177,6 @@ test.describe('Domains', () => {
     const domain = new Domain();
     try {
       await domain.create(apiContext);
-      await page.reload();
       await sidebarClick(page, SidebarItem.DOMAIN);
       await waitForAllLoadersToDisappear(page);
       await selectDomain(page, domain.data);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
@@ -1177,6 +1177,7 @@ test.describe('Domains', () => {
     const domain = new Domain();
     try {
       await domain.create(apiContext);
+      await page.reload();
       await sidebarClick(page, SidebarItem.DOMAIN);
       await waitForAllLoadersToDisappear(page);
       await selectDomain(page, domain.data);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExplorePageRightPanel_KnowledgeCenter.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExplorePageRightPanel_KnowledgeCenter.spec.ts
@@ -320,7 +320,7 @@ test.describe('Knowledge Center Right Panel Test Suite', () => {
           getEntityDisplayName(knowledgeCenter.responseData)
         );
         const ownerElement = adminPage
-          .locator('.owners-section')
+          .getByTestId('owners-section')
           .getByText(user1.getUserDisplayName());
         await expect(ownerElement).not.toBeVisible();
       });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExplorePageRightPanel_KnowledgeCenter.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExplorePageRightPanel_KnowledgeCenter.spec.ts
@@ -293,37 +293,37 @@ test.describe('Knowledge Center Right Panel Test Suite', () => {
         ).not.toBeVisible();
       });
 
-      test(
-        'Should remove user owner for knowledgeCenter',
-        { tag: '@quarantine' },
-        async ({ adminPage, rightPanel, overview }) => {
-          await navigateToKCEntity(
-            adminPage,
-            getEntityDisplayName(knowledgeCenter.responseData)
-          );
-          await rightPanel.waitForPanelLoaded();
-          rightPanel.setEntityConfigByType('knowledgeCenter');
+      test('Should remove user owner for knowledgeCenter', async ({
+        adminPage,
+        rightPanel,
+        overview,
+      }) => {
+        await navigateToKCEntity(
+          adminPage,
+          getEntityDisplayName(knowledgeCenter.responseData)
+        );
+        await rightPanel.waitForPanelLoaded();
+        rightPanel.setEntityConfigByType('knowledgeCenter');
 
-          await addOwnerInKCPanel(adminPage, user1.getUserDisplayName());
-          await expectOwnerInPanel(
-            adminPage,
-            getEntityDisplayName(knowledgeCenter.responseData),
-            user1.getUserDisplayName()
-          );
+        await addOwnerInKCPanel(adminPage, user1.getUserDisplayName());
+        await expectOwnerInPanel(
+          adminPage,
+          getEntityDisplayName(knowledgeCenter.responseData),
+          user1.getUserDisplayName()
+        );
 
-          await overview.removeOwner([user1.getUserDisplayName()], 'Users');
-          await waitForAllLoadersToDisappear(adminPage);
+        await overview.removeOwner([user1.getUserDisplayName()], 'Users');
+        await waitForAllLoadersToDisappear(adminPage);
 
-          await navigateToKCEntity(
-            adminPage,
-            getEntityDisplayName(knowledgeCenter.responseData)
-          );
-          const ownerElement = adminPage
-            .locator('.owners-section')
-            .getByText(user1.getUserDisplayName());
-          await expect(ownerElement).not.toBeVisible();
-        }
-      );
+        await navigateToKCEntity(
+          adminPage,
+          getEntityDisplayName(knowledgeCenter.responseData)
+        );
+        const ownerElement = adminPage
+          .locator('.owners-section')
+          .getByText(user1.getUserDisplayName());
+        await expect(ownerElement).not.toBeVisible();
+      });
     });
 
     test.describe('Overview panel - Deleted entity verification', () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExplorePageRightPanel_KnowledgeCenter.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExplorePageRightPanel_KnowledgeCenter.spec.ts
@@ -293,37 +293,37 @@ test.describe('Knowledge Center Right Panel Test Suite', () => {
         ).not.toBeVisible();
       });
 
-      test('Should remove user owner for knowledgeCenter', async ({
-        adminPage,
-        rightPanel,
-        overview,
-      }) => {
-        await navigateToKCEntity(
-          adminPage,
-          getEntityDisplayName(knowledgeCenter.responseData)
-        );
-        await rightPanel.waitForPanelLoaded();
-        rightPanel.setEntityConfigByType('knowledgeCenter');
+      test(
+        'Should remove user owner for knowledgeCenter',
+        { tag: '@quarantine' },
+        async ({ adminPage, rightPanel, overview }) => {
+          await navigateToKCEntity(
+            adminPage,
+            getEntityDisplayName(knowledgeCenter.responseData)
+          );
+          await rightPanel.waitForPanelLoaded();
+          rightPanel.setEntityConfigByType('knowledgeCenter');
 
-        await addOwnerInKCPanel(adminPage, user1.getUserDisplayName());
-        await expectOwnerInPanel(
-          adminPage,
-          getEntityDisplayName(knowledgeCenter.responseData),
-          user1.getUserDisplayName()
-        );
+          await addOwnerInKCPanel(adminPage, user1.getUserDisplayName());
+          await expectOwnerInPanel(
+            adminPage,
+            getEntityDisplayName(knowledgeCenter.responseData),
+            user1.getUserDisplayName()
+          );
 
-        await overview.removeOwner([user1.getUserDisplayName()], 'Users');
-        await waitForAllLoadersToDisappear(adminPage);
+          await overview.removeOwner([user1.getUserDisplayName()], 'Users');
+          await waitForAllLoadersToDisappear(adminPage);
 
-        await navigateToKCEntity(
-          adminPage,
-          getEntityDisplayName(knowledgeCenter.responseData)
-        );
-        const ownerElement = adminPage
-          .getByTestId('owners-section')
-          .getByText(user1.getUserDisplayName());
-        await expect(ownerElement).not.toBeVisible();
-      });
+          await navigateToKCEntity(
+            adminPage,
+            getEntityDisplayName(knowledgeCenter.responseData)
+          );
+          const ownerElement = adminPage
+            .getByTestId('owners-section')
+            .getByText(user1.getUserDisplayName());
+          await expect(ownerElement).not.toBeVisible();
+        }
+      );
     });
 
     test.describe('Overview panel - Deleted entity verification', () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageInteraction.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageInteraction.spec.ts
@@ -166,29 +166,44 @@ test.describe('Lineage Interactions', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
     });
 
     test('Verify edge delete button in drawer', async ({ page }) => {
+      const { apiContext, afterAction } = await getApiContext(page);
       const table1Fqn = get(table1, 'entityResponseData.fullyQualifiedName');
       const topicFqn = get(topic, 'entityResponseData.fullyQualifiedName');
 
-      await editLineage(page);
+      try {
+        await editLineage(page);
 
-      await clickEdgeBetweenNodes(page, table1, topic, false);
+        await clickEdgeBetweenNodes(page, table1, topic, false);
 
-      const deleteBtn = page.getByTestId('add-pipeline');
-      await expect(deleteBtn).toBeVisible();
+        const deleteBtn = page.getByTestId('add-pipeline');
+        await expect(deleteBtn).toBeVisible();
 
-      await deleteBtn.click();
+        await deleteBtn.click();
 
-      await page.getByTestId('remove-edge-button').click();
+        await page.getByTestId('remove-edge-button').click();
 
-      await page.getByRole('button', { name: /confirm/i }).waitFor();
-      await page.getByRole('button', { name: /confirm/i }).click();
+        await page.getByRole('button', { name: /confirm/i }).waitFor();
+        await page.getByRole('button', { name: /confirm/i }).click();
 
-      await waitForAllLoadersToDisappear(page);
+        await waitForAllLoadersToDisappear(page);
 
-      await editLineageClick(page);
+        await editLineageClick(page);
 
-      const edgeDiv = page.getByTestId(`edge-${table1Fqn}-${topicFqn}`);
-      await expect(edgeDiv).not.toBeVisible();
+        const edgeDiv = page.getByTestId(`edge-${table1Fqn}-${topicFqn}`);
+        await expect(edgeDiv).not.toBeVisible();
+      } finally {
+        // This edge is shared fixture state seeded in beforeAll, and deleting
+        // it is the point of the test -- but leaving it deleted takes the topic
+        // out of table1's graph for every later test in this file. That is why
+        // "Verify node panel opens on click" was quarantined at 11/11: it looked
+        // for a node this test had removed. Put the edge back.
+        await connectEdgeBetweenNodesViaAPI(
+          apiContext,
+          { id: table1.entityResponseData.id, type: 'table' },
+          { id: topic.entityResponseData.id, type: 'topic' }
+        );
+        await afterAction();
+      }
     });
 
     test('Verify function data in edge drawer', async ({ page }) => {
@@ -362,31 +377,30 @@ test.describe('Lineage Interactions', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       await fitToScreen(page);
     });
 
-    test(
-      'Verify node panel opens on click',
-      { tag: '@quarantine' },
-      async ({ page }) => {
-        const topicFqn = get(
-          topic,
-          'entityResponseData.fullyQualifiedName',
-          ''
-        );
+    test('Verify node panel opens on click', async ({ page }) => {
+      const topicFqn = get(topic, 'entityResponseData.fullyQualifiedName', '');
 
-        await clickLineageNode(page, topicFqn);
+      await clickLineageNode(page, topicFqn);
 
-        await expect(page.locator('[role="dialog"]')).toBeVisible();
+      // Scope to the panel under test: the page carries other dialogs (the
+      // lineage view-options popover among them), so a bare [role="dialog"]
+      // is ambiguous under strict mode.
+      const nodePanel = page
+        .getByTestId('lineage-entity-panel')
+        .getByRole('dialog');
 
-        await expect(
-          page
-            .getByTestId('entity-summary-panel-container')
-            .getByTestId('entity-header-title')
-        ).toHaveText(topic.entityResponseData.displayName ?? '');
+      await expect(nodePanel).toBeVisible();
 
-        await page.getByLabel('Close').first().click();
+      await expect(
+        page
+          .getByTestId('entity-summary-panel-container')
+          .getByTestId('entity-header-title')
+      ).toHaveText(topic.entityResponseData.displayName ?? '');
 
-        await expect(page.locator('[role="dialog"]')).not.toBeVisible();
-      }
-    );
+      await page.getByLabel('Close').first().click();
+
+      await expect(nodePanel).not.toBeVisible();
+    });
 
     test('Verify node full path is present as breadcrumb in lineage node', async ({
       page,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageInteraction.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageInteraction.spec.ts
@@ -397,7 +397,7 @@ test.describe('Lineage Interactions', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
           .getByTestId('entity-header-title')
       ).toHaveText(topic.entityResponseData.displayName ?? '');
 
-      await page.getByLabel('Close').first().click();
+      await nodePanel.getByTestId('drawer-close-icon').click();
 
       await expect(nodePanel).not.toBeVisible();
     });

--- a/openmetadata-ui/src/main/resources/ui/playwright/eslint-rules/tests/corpus.test.mjs
+++ b/openmetadata-ui/src/main/resources/ui/playwright/eslint-rules/tests/corpus.test.mjs
@@ -41,7 +41,7 @@ test('the suppressions baseline matches its recorded state exactly', () => {
   // of the same rule in the same file stays invisible here.
   const EXPECTED = {
     'om-playwright/justified-rule-disable': 12,
-    'om-playwright/no-positional-locator': 1304,
+    'om-playwright/no-positional-locator': 1303,
     'om-playwright/require-assertion-per-test': 1,
     'playwright/no-skipped-test': 4,
     'playwright/no-wait-for-selector': 35,

--- a/openmetadata-ui/src/main/resources/ui/playwright/eslint-rules/tests/corpus.test.mjs
+++ b/openmetadata-ui/src/main/resources/ui/playwright/eslint-rules/tests/corpus.test.mjs
@@ -41,7 +41,7 @@ test('the suppressions baseline matches its recorded state exactly', () => {
   // of the same rule in the same file stays invisible here.
   const EXPECTED = {
     'om-playwright/justified-rule-disable': 12,
-    'om-playwright/no-positional-locator': 1304,
+    'om-playwright/no-positional-locator': 1301,
     'om-playwright/require-assertion-per-test': 1,
     'playwright/no-skipped-test': 4,
     'playwright/no-wait-for-selector': 35,

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/TableClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/TableClass.ts
@@ -511,8 +511,14 @@ export class TableClass extends EntityClass {
       await this.create(apiContext);
     }
 
-    const testCase = await apiContext
-      .post('/api/v1/dataQuality/testCases', {
+    // Checked, not bare .json(): a failed create used to be pushed onto
+    // testCasesResponseData as an error body, so callers read `undefined` for
+    // the name and failed much later somewhere unrelated -- a search that waits
+    // for `q === undefined` simply never resolves.
+    const testCase = await okJson<
+      ResponseDataType & { testSuite?: ResponseDataType }
+    >(
+      await apiContext.post('/api/v1/dataQuality/testCases', {
         data: {
           name: `pw_test_case_${uuid()}`,
           entityLink: `<#E::table::${this.entityResponseData?.fullyQualifiedName}>`,
@@ -523,11 +529,14 @@ export class TableClass extends EntityClass {
           ],
           ...testCaseData,
         },
-      })
-      .then((res) => res.json());
+      }),
+      'TableClass.createTestCase'
+    );
 
-    if (isEmpty(this.testSuiteResponseData)) {
-      this.testSuiteResponseData = testCase?.testSuite;
+    // okJson guarantees testCase now, so only the optional testSuite needs a
+    // guard -- assigning undefined here used to be masked by the untyped read.
+    if (isEmpty(this.testSuiteResponseData) && testCase.testSuite) {
+      this.testSuiteResponseData = testCase.testSuite;
     }
 
     this.testCasesResponseData.push(testCase);

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts
@@ -107,12 +107,26 @@ export const openEntitySummaryPanel = async ({
         return false;
       }
     }
+    // The global search box lives in the NavBar, which is not mounted the
+    // instant /explore resolves. fill() auto-waits with no timeout of its own,
+    // so calling it on an absent box hangs this callback forever -- and a poll
+    // cannot interrupt a pending callback, so the retry-and-reload this helper
+    // is built around never happened and the test died on its own timeout with
+    // nothing to show for it. Bound the wait and let the poll do its job.
+    const searchBox = page.getByTestId('searchBox');
+
+    try {
+      await searchBox.waitFor({ state: 'visible', timeout: 15_000 });
+    } catch {
+      return false;
+    }
+
     const searchResponsePromise = page.waitForResponse((response) =>
       response.url().includes('/api/v1/search/query')
     );
-    await page.getByTestId('searchBox').fill(entityName);
+    await searchBox.fill(entityName);
     await searchResponsePromise;
-    await page.getByTestId('searchBox').press('Enter');
+    await searchBox.press('Enter');
     await waitForAllLoadersToDisappear(page);
 
     // Select the entity-type tab as part of each search attempt: for callers that

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts
@@ -107,13 +107,17 @@ export const openEntitySummaryPanel = async ({
         return false;
       }
     }
-    // The global search box lives in the NavBar, which is not mounted the
-    // instant /explore resolves. fill() auto-waits with no timeout of its own,
-    // so calling it on an absent box hangs this callback forever -- and a poll
-    // cannot interrupt a pending callback, so the retry-and-reload this helper
-    // is built around never happened and the test died on its own timeout with
-    // nothing to show for it. Bound the wait and let the poll do its job.
-    const searchBox = page.getByTestId('searchBox');
+    // Two different components own the query depending on where the caller
+    // landed: /explore renders its own ExploreSearchInput and never mounts the
+    // NavBar's GlobalSearchBar, so waiting for the NavBar box there can only
+    // ever time out. Pick whichever this page actually renders.
+    // `explore-search-input` marks the field wrapper, not the field, so the
+    // textbox inside it is what accepts fill().
+    const exploreSearchWrapper = page.getByTestId('explore-search-input');
+    const searchBox =
+      (await exploreSearchWrapper.count()) > 0
+        ? exploreSearchWrapper.getByRole('textbox')
+        : page.getByTestId('searchBox');
 
     try {
       await searchBox.waitFor({ state: 'visible', timeout: 15_000 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts
@@ -120,6 +120,13 @@ export const openEntitySummaryPanel = async ({
     // only renders under its tab, so the poll's visibility check must run after the
     // tab is selected — not once, after the poll.
     if (exploreTab) {
+      // The left panel only becomes an entity-type Menu once the URL carries a
+      // search query -- ExploreV1 renders <ExploreTree> otherwise, whose items
+      // are plain divs with no menuitem role. Waiting for the query first turns
+      // "no menuitem ever appears" into a fast, legible failure instead of a
+      // callback that hangs until the whole test times out.
+      await page.waitForURL(/[?&]search=[^&]+/, { timeout: 30_000 });
+
       const tab = page
         .getByTestId('explore-left-panel')
         .getByRole('menuitem', { name: exploreTab });
@@ -171,7 +178,10 @@ export const openEntitySummaryPanel = async ({
 
           return entityResultCard.isVisible();
         },
-        { timeout: 90_000, intervals: [2_000, 3_000, 5_000, 5_000] }
+        // Deliberately under the 60s default test budget: a poll sized at or
+        // above it can never finish, so the test dies on its own timeout and
+        // reports nothing instead of this poll's message.
+        { timeout: 45_000, intervals: [2_000, 3_000, 5_000, 5_000] }
       )
       .toBe(true);
   }

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/lineage.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/lineage.ts
@@ -262,8 +262,15 @@ export const rearrangeNodes = async (page: Page) => {
 };
 
 export const fitToScreen = async (page: Page) => {
+  const fitToScreenItem = page.getByRole('menuitem', { name: 'Fit to screen' });
+
   await page.getByTestId('fit-screen').click();
-  await page.getByRole('menuitem', { name: 'Fit to screen' }).click();
+  await fitToScreenItem.click();
+
+  // The menu closes with an exit animation, so without this it lingers in the
+  // DOM as a second [role="dialog"] -- and any caller that later asserts on a
+  // dialog trips strict mode against a popover already on its way out.
+  await fitToScreenItem.waitFor({ state: 'detached' });
 };
 
 export const connectEdgeBetweenNodes = async (

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/OwnersSection/OwnersSection.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/OwnersSection/OwnersSection.tsx
@@ -205,7 +205,7 @@ const OwnersSection: React.FC<OwnersSectionProps> = ({
 
   if (!displayOwners.length) {
     return (
-      <div className="owners-section">
+      <div className="owners-section" data-testid="owners-section">
         <div className="owners-header">
           <Typography.Text className="owners-title">
             {t('label.owner-plural')}
@@ -230,7 +230,7 @@ const OwnersSection: React.FC<OwnersSectionProps> = ({
   }
 
   return (
-    <div className="owners-section">
+    <div className="owners-section" data-testid="owners-section">
       <div className="owners-header">
         <Typography.Text className="owners-title">
           {t('label.owner-plural')}


### PR DESCRIPTION
### Describe your changes:

Fixes #33053

Two pieces of Playwright CI hygiene, combined here because they touch the same guardrail
baseline and would otherwise conflict on merge: the DQ select-option flakes below, and the
quarantine burn-down from #33054 (closed in favour of this PR).

## Part 1 — DQ select-option flakes

Two merge-queue flakes found while triaging
dequeue alerts in #ci-cleanup. Evidence:
[run 34415936354](https://github.com/open-metadata/OpenMetadata/actions/runs/34415936354)
([chromium-12](https://github.com/open-metadata/OpenMetadata/actions/runs/34415936354/job/102686213232),
[chromium-11](https://github.com/open-metadata/OpenMetadata/actions/runs/34415936354/job/102686213262)),
which dequeued #32919 despite being unrelated to it. Cross-PR rate at the time:
`TableLevelTests › Custom SQL Query` **5/26 PRs**, `TestLibrary › external test definitions with
read-only fields` **1/26**.

**Root cause 1 — the listbox is gone before the click lands.**
The core `Select` renders its listbox in a non-modal React Aria popover. Pressing a trigger that
does not already hold focus opens it and — via the focus transition that same press produces —
dismisses it a frame later. `TestLibrary.spec.ts` already documented this window as ~160ms.
Neither call site bounded its option click, so a missed window left Playwright retrying a detached
node until the 60s test cap. From the trace:

```
[  25.0s] click #testCaseFormV1_params_strategy   dur=  0.2s
[  25.2s] click option ROWS                       dur= 38.3s   <- never completes
[  63.6s] Test timeout of 60000ms exceeded
```

Playwright's log shows `element is not stable` → `element was detached from the DOM, retrying`, and
the a11y snapshot at timeout has no `listbox` and no `option` at all — just
`button "Please Select a Strategy Strategy" [active]`.

Both sites now use `selectOptionWithRetry`, which reopens the listbox whenever the trigger reports
itself collapsed and bounds each click. `TableLevelTests.spec.ts` already used it for this same
field's *edit* step (L928); the *create* step was the straggler.

**Root cause 2 — the assertion could not fail.**
`TestLibrary` asserted the selection with `expect(dimensionField).toContainText('Accuracy')` where
`dimensionField` is the **Select root**. That root also contains React Aria's visually hidden
`<select>` (rendered because the field renderer passes `name`), whose `<option>` text satisfies
`toContainText` for any offered value. Measured against a live instance with nothing selected:

```
root    = "Select Data Quality Dimension AccuracyCompletenessConsistencyIntegrityNoDimensionSQLUniquenessValidity"
trigger = "Select Data Quality Dimension"
```

So a missed selection passed here and surfaced 20 lines later as a PATCH response with no
`dataQualityDimension` — which is exactly how attempt #0 failed. Both assertions now read the
trigger.

`selectOptionWithMouse` stays for the test-platforms **multi-select**, whose popup is typing-driven
and has no collapsed/expanded trigger to guard on.

## Part 2 — burn the Playwright quarantine from 8 to 4 (was #33054)

Quarantine is a holding pen, not a resting place. Four tests are released, each naming a cause
rather than resting on a green local run.

| Entry | Cause |
|---|---|
| `LineageInteraction` — node panel opens on click (11/11) | Two causes, and the recorded symptom was only the second. `fitToScreen` returned before its menu popover finished its exit animation, leaving a second `[role="dialog"]` in the DOM, so an unscoped assertion tripped strict mode. Separately, `Verify edge delete button in drawer` deletes the shared `table1 → topic` edge and never restores it, so every later test in the file saw a graph without the topic. |
| `PersonaAIContextRules` — knowledge entity type (7/11) | The evidence was stale before it was written down. Every test in the file reached its subject through `navigateToAIContextTab` → `navigateToPersonaWithPagination`, a walk of up to **15 pages**, each costing a loader wait, a `next` click and a `/api/v1/personas*` round trip. #32458 replaced that walk with a direct route on 2026-09-07, three days after the sample. |
| `Table` — should persist page size (6/11) | Released earlier on "3/3 green locally", then caught **flaky** in this branch's own run — first attempt failed, retry passed. The trace named it: the option click sat *outside* the retry that opens the menu, so once the menu closed Playwright logged **324 polls of "element is not visible"** until the 180s cap. Opening and picking now happen in one retry, with the trigger's new label asserted so the loop redoes the whole thing when the pick did not take. |
| `ActivityStream` — activity stream API is called (2/11) | It could not fail. `waitForResponse` required `status() === 200` inside the predicate, so any other status left it waiting; `.catch(() => null)` swallowed the timeout and `if (response)` skipped every assertion. It now uses the existing `visitTableActivityFeed` helper, which waits on the specific entity-activity endpoint and asserts the status. |

**`ExplorePageRightPanel_KnowledgeCenter` was released and is now re-quarantined.** The 11/11 failure
it was tagged for was real and is fixed — `openEntitySummaryPanel` waited for `searchBox`, the NavBar
`GlobalSearchBar`, but `/explore` renders its own `ExploreSearchInput` and never mounts it, so on that
page the wait could only time out. Releasing it surfaced a second cause: `expectOwnerInPanel` polled
the owner chip for a full 60s, re-navigating between attempts, and never saw it — even though
`addOwnerInKCPanel` had already awaited the PATCH. The write landed and the panel's read path lagged
it. That is the *original* recorded symptom, so the fix was incomplete rather than wrong; it goes back
in with that evidence.

`QUARANTINE.md` also gains a correction: nothing under `.github/` sets `PLAYWRIGHT_RUN_QUARANTINED`,
so a quarantined test runs in **no lane at all** and has produced no evidence since being tagged. The
soak lane that file described does not exist.

**Not in this PR:** `Domains — Verify domain tags and glossary terms`. I diagnosed the same root cause
independently (the row-centre click landing on a tag link) but `main` fixed it first, with
`domainRow.getByTestId('entity-name').click()`. That commit was dropped as redundant.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Creating a table-level Custom SQL Query test case: selecting `ROWS` in the Strategy dropdown
- Editing an external (dbt) test definition: setting Data Quality Dimension to `Accuracy` and
  confirming it reaches the PATCH payload
- Four flows are covered by the merge queue again instead of skipped: lineage node panel, persona
  AI-context rule editor, table page-size persistence, and the entity activity stream.

#### Unit tests
`yarn test:eslint-rules` — **114 pass, 0 fail**. The merge required recomputing the pinned
`no-positional-locator` total: `main` 1304, this branch's DQ half −1, the quarantine half −3, so
**1300**. Either PR's number alone would have failed `ui-checkstyle` on the combined branch.

#### Backend integration tests
Not applicable — no backend API changes.

#### Ingestion integration tests
Not applicable — no ingestion changes.

#### Playwright (UI) tests
No new tests; this repairs existing ones.
- `playwright/e2e/Features/DataQuality/TestLibrary.spec.ts`
- `playwright/e2e/Features/DataQuality/TableLevelTests.spec.ts`
- `playwright/e2e/Features/ActivityStream.spec.ts`, `Features/PersonaAIContextRules.spec.ts`,
  `Features/Table.spec.ts`, `Pages/Lineage/LineageInteraction.spec.ts`
- `playwright/QUARANTINE.md` carries the causes and refreshed counts (**4576 of 4580**; quarantined
  lane lists 11 = 4 entries + 7 fixture projects)

#### Manual testing performed
Against a local stack (server + MySQL + Elasticsearch):

1. `yarn lint:playwright` — **0 errors** (214 pre-existing warnings, none in these files).
2. `organize-imports` + `eslint --fix` + `prettier` (the CI checkstyle sequence) — no diff produced.
3. `TestLibrary › should handle external test definitions with read-only fields` — **3/3 passed**,
   `--retries=0`. This test asserts `updatedBody.dataQualityDimension === 'Accuracy'` on the PATCH
   response, so passing proves the new path commits a real selection rather than passing vacuously.
4. A throwaway probe opened the drawer, selected nothing, and captured the root vs trigger
   `textContent` shown above — confirming the old assertion was unfalsifiable.

**Not verified locally: the `TableLevelTests` half.** My local server image is 143 commits behind
this branch, and that test dies at L853 waiting for a `ServiceDocPanel` anchor, well before the
changed line. I confirmed by control run that the **unmodified** test fails identically at L853, so
this change neither causes nor is exercised by that failure. Serving the branch's UI from Vite to
get past it pushed the failure earlier still (dev-server cold compiles exceed the 60s timeout).
That half rests on CI.

**Quarantine half.** Each changed test was run 2-4x locally, red-before / green-after where a fix was
involved. Then verified against CI rather than trusting local runs: on the pre-merge commit
`ff2a4f0b21` — **4492 passed, 0 failed, 6 flaky** — every test this PR touches passed on a **single
attempt**, checked against each shard's `results.json` rather than inferred from the flaky list:

| Test | Attempts |
|---|---|
| `ActivityStream › activity stream API is called…` | 1 — passed |
| `Table › should persist page size` | 1 — passed |
| `PersonaAIContextRules › knowledge entity type forces…` | 1 — passed |
| `LineageInteraction › Verify node panel opens on click` | 1 — passed |
| `ExplorePageRightPanel_KnowledgeCenter › Should remove user owner` | not run — quarantined |

The 6 flaky tests in that run are unrelated to this PR and share no test with the previous run's 8 —
a churning population of ambient load-dependent flakes, which is the hole a per-test flake ledger
would close.

#
### UI screen recording / screenshots:

Not applicable — no product code changed.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For UI changes: not applicable beyond one added `data-testid` on `OwnersSection`.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
