### PR TITLE
Fixes #32600: render table sample rows in the AI context markdown

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/AIContextRestIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/AIContextRestIT.java
@@ -202,6 +202,22 @@ class AIContextRestIT extends McpTestBase {
     assertThat(markdown).startsWith("---");
     assertThat(markdown).contains("type: \"table\"");
     assertThat(markdown).contains("# Schema");
+    assertThat(markdown).contains("# Sample Data");
+    assertThat(markdown).contains("| id | name | created_at |");
+    assertThat(markdown).contains("| 9 | name-9 | 2026-09-04T00:00:00Z |");
+    assertThat(markdown).doesNotContain("name-10");
+  }
+
+  @Test
+  void tableContext_omitsSamplesFromMarkdownWithoutViewSampleDataPermission() throws Exception {
+    HttpResponse<String> response =
+        getResponse(
+            "tables/name/" + table.getFullyQualifiedName() + "/context", sampleRestrictedToken);
+
+    assertThat(response.statusCode()).isEqualTo(200);
+    assertThat(response.body()).contains("# Schema");
+    assertThat(response.body()).doesNotContain("# Sample Data");
+    assertThat(response.body()).doesNotContain("name-0");
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AIContextMarkdown.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AIContextMarkdown.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 import org.openmetadata.schema.type.AIContext;
 import org.openmetadata.schema.type.ColumnLineage;
+import org.openmetadata.schema.type.TableData;
 import org.openmetadata.schema.type.aicontext.AssetContext;
 import org.openmetadata.schema.type.aicontext.ColumnProfileSummary;
 import org.openmetadata.schema.type.aicontext.DataQuality;
@@ -59,7 +60,11 @@ public final class AIContextMarkdown {
 
   private static final int MAX_CONTENT_CHARS = 2000;
   private static final int MAX_SUMMARY_CHARS = 150;
+  private static final int MAX_SAMPLE_CELL_CHARS = 120;
   private static final String ABSENT_CONSTRAINT_CELL = "--";
+  private static final String SAMPLE_DATA_CAVEAT =
+      "\n_Representative stored sample rows — not the full table; never count or aggregate over "
+          + "them._\n";
   private static final String COLUMN_MAPPING_CAP_NOTE =
       "\n_Column mappings are capped at %d per edge — fetch the full lineage graph with "
           + "get_entity_lineage(entityType=`%s`, fqn=`%s`)._\n";
@@ -382,6 +387,7 @@ public final class AIContextMarkdown {
     if (sections.contains(ContextSection.SCHEMA)) {
       appendSchemaTable(markdown, table.getColumns(), headingPrefix);
       appendDataModel(markdown, table.getDataModel(), headingPrefix);
+      appendSampleData(markdown, table.getSampleData(), headingPrefix);
     }
     if (sections.contains(ContextSection.CONSTRAINTS)) {
       appendPrimaryKey(markdown, table);
@@ -434,6 +440,56 @@ public final class AIContextMarkdown {
           .append(cell(PromptText.forPrompt(column.getDescription())))
           .append(" |\n");
     }
+  }
+
+  /**
+   * Renders the permission-filtered, PII-masked sample rows the builder attached. Markdown — not the
+   * structured JSON — is what the MCP {@code get_entity} tool and {@code /context} return by
+   * default, so without this section the stored samples were only reachable through
+   * {@code ?format=json}.
+   */
+  private static void appendSampleData(
+      StringBuilder markdown, TableData sampleData, String headingPrefix) {
+    List<String> columns = sampleData == null ? null : sampleData.getColumns();
+    List<List<Object>> rows = sampleData == null ? null : sampleData.getRows();
+    if (nullOrEmpty(columns) || nullOrEmpty(rows)) {
+      return;
+    }
+    appendHeading(markdown, headingPrefix, "Sample Data");
+    markdown.append(SAMPLE_DATA_CAVEAT).append('\n');
+    appendSampleRow(markdown, columns, columns.size());
+    markdown.append("|---".repeat(columns.size())).append("|\n");
+    for (List<Object> row : rows) {
+      appendSampleRow(markdown, row, columns.size());
+    }
+  }
+
+  /**
+   * Pads every row out to the declared column count and drops anything beyond it: a stored payload
+   * whose rows disagree with its header would otherwise render a misaligned table, and one ragged
+   * row silently shifts every value under the wrong column name.
+   */
+  private static void appendSampleRow(StringBuilder markdown, List<?> row, int width) {
+    List<?> values = listOrEmpty(row);
+    for (int i = 0; i < width; i++) {
+      markdown
+          .append("| ")
+          .append(sampleCell(i < values.size() ? values.get(i) : null))
+          .append(' ');
+    }
+    markdown.append("|\n");
+  }
+
+  /**
+   * A stored sample value can be a nested object, a long text blob, or carry the pipes and line
+   * breaks that delimit a markdown table. Values are flattened to one line and capped so a single
+   * blob column cannot crowd the rest of the context out of the model's window.
+   */
+  private static String sampleCell(Object value) {
+    String text = value == null ? "" : cell(Objects.toString(value).replaceAll("\\R+", " "));
+    return text.length() > MAX_SAMPLE_CELL_CHARS
+        ? text.substring(0, MAX_SAMPLE_CELL_CHARS) + "…"
+        : text;
   }
 
   private static void appendDataModel(

--- a/openmetadata-service/src/test/java/org/openmetadata/service/aicontext/AIContextMarkdownTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/aicontext/AIContextMarkdownTest.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.type.AIContext;
 import org.openmetadata.schema.type.ColumnLineage;
+import org.openmetadata.schema.type.TableData;
 import org.openmetadata.schema.type.aicontext.AssetContext;
 import org.openmetadata.schema.type.aicontext.ColumnProfileSummary;
 import org.openmetadata.schema.type.aicontext.DataQuality;
@@ -558,6 +559,99 @@ class AIContextMarkdownTest {
     assertTrue(
         markdown.contains("```sql\nSELECT COUNT(DISTINCT user_id) FROM events\n```"),
         "missing metric expression block");
+  }
+
+  @Test
+  void render_emitsSampleDataRowsUnderSchema() {
+    AIContext context = sampleContext();
+    context
+        .getAssetContext()
+        .getTable()
+        .withSampleData(
+            new TableData()
+                .withColumns(List.of("id", "customer_id"))
+                .withRows(List.of(List.of(1, 42), List.of(2, 43))));
+
+    String markdown = AIContextMarkdown.render(context);
+
+    assertTrue(markdown.contains("# Sample Data"), "missing sample-data heading");
+    assertTrue(
+        markdown.contains("not the full table"),
+        "sample rows must be captioned as a sample so the agent does not read them as the table");
+    assertTrue(markdown.contains("| id | customer_id |"), "missing sample-data header row");
+    assertTrue(markdown.contains("| 1 | 42 |"), "missing first sample row");
+    assertTrue(markdown.contains("| 2 | 43 |"), "missing second sample row");
+  }
+
+  @Test
+  void render_omitsSampleDataWhenAbsentOrEmpty() {
+    assertFalse(render().contains("Sample Data"), "no sample data attached");
+
+    AIContext context = sampleContext();
+    context
+        .getAssetContext()
+        .getTable()
+        .withSampleData(new TableData().withColumns(List.of("id")).withRows(List.of()));
+
+    assertFalse(
+        AIContextMarkdown.render(context).contains("Sample Data"),
+        "a column-only payload carries no values to show");
+  }
+
+  @Test
+  void render_sanitizesAndPadsDelimiterSensitiveSampleValues() {
+    AIContext context = sampleContext();
+    context
+        .getAssetContext()
+        .getTable()
+        .withSampleData(
+            new TableData()
+                .withColumns(List.of("a", "b", "c"))
+                .withRows(List.of(Arrays.asList("x|y", "line1\nline2", null))));
+
+    String markdown = AIContextMarkdown.render(context);
+
+    assertTrue(
+        markdown.contains("| x\\|y | line1 line2 |  |"),
+        "pipes must be escaped, newlines flattened, and a null value rendered as an empty cell");
+  }
+
+  @Test
+  void render_padsRaggedSampleRowsToTheColumnWidth() {
+    AIContext context = sampleContext();
+    context
+        .getAssetContext()
+        .getTable()
+        .withSampleData(
+            new TableData()
+                .withColumns(List.of("a", "b", "c"))
+                .withRows(List.of(List.of("only"), List.of("x", "y", "z", "overflow"))));
+
+    String markdown = AIContextMarkdown.render(context);
+
+    assertTrue(
+        markdown.contains("| only |  |  |"), "a short row must be padded, not left misaligned");
+    assertTrue(
+        markdown.contains("| x | y | z |"),
+        "values beyond the declared columns must be dropped, not appended as phantom cells");
+    assertFalse(markdown.contains("overflow"), "overflowing cell must not widen the table");
+  }
+
+  @Test
+  void render_capsLongSampleValues() {
+    AIContext context = sampleContext();
+    context
+        .getAssetContext()
+        .getTable()
+        .withSampleData(
+            new TableData()
+                .withColumns(List.of("blob"))
+                .withRows(List.of(List.of("z".repeat(500)))));
+
+    String markdown = AIContextMarkdown.render(context);
+
+    assertFalse(markdown.contains("z".repeat(200)), "a blob column must not crowd out the context");
+    assertTrue(markdown.contains("\u2026 |"), "a capped value must be marked as elided");
   }
 
   private String render() {


### PR DESCRIPTION
### Describe your changes:

Fixes #32600

I reopened #32600 because the change that closed it (#32608) only surfaced the samples in the
structured representation. Markdown is what both consumers return **by default** —
`GET /v1/tables/{id}/context` with no `format` param, and the MCP `get_entity` tool with
`include: ["context"]` — so `assetContext.table.sampleData` was populated but never rendered, and
the stored rows stayed unreachable for exactly the SQL-agent path the issue was filed for. That PR's
own description states it: *"The default Markdown rendering is unchanged."*

This renders a `# Sample Data` section into the markdown document from the payload the builder
already authorized against `ViewSampleData` and PII-masked, so no new data reaches a caller who
could not already read it via `?format=json`.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

- `AIContextMarkdown.appendTableContext` gains `appendSampleData`, placed under the existing
  `SCHEMA` section gate after the schema table and data model — definitions first, then values.
- Rendering is defensive because the payload is user/ingestion-supplied JSON, not a typed row set:
  values are flattened to one line (`\R+` → space), pipes escaped, `null` rendered as an empty
  cell, rows padded or truncated to the declared column width, and each cell capped at 120 chars.
  The width normalization matters for correctness, not just looks — one ragged row otherwise shifts
  every value under the wrong column name, which is worse than no samples at all for an agent.
- A caveat line (`_Representative stored sample rows — not the full table; never count or aggregate
  over them._`) precedes the table, so an agent does not read 10 rows as the table's cardinality.
- **No new `ContextSection` enum value was added, deliberately.**
  `AIContextBuilder.applySearchFields` indexes `buildTableContext(table)` *without* sample data, and
  `PersonaContextBuilder.assetContext(document)` deserializes `TableContext` from that search
  document. So the persona path has no samples to render, and a `sampleData` persona toggle would
  advertise a section that path can never fill. Materializing samples there would also be a real
  leak: the persona context document is cached and shared across users, so it cannot carry a
  per-caller `ViewSampleData`/PII decision. Gating on `SCHEMA` keeps the section on the one path
  that does the per-request authorization.
- No migration and no schema change: `sampleData` already exists on `assetContext.table` from
  #32608. This PR is presentation-only.

#
### Tests:

#### Use cases covered

- An authorized caller requesting the markdown default (no `?format=json`) receives a
  `# Sample Data` table with the header row and the first 10 of 12 stored rows.
- A caller with explicit `deny ViewSampleData` receives the markdown context with `# Schema` and
  **no** `# Sample Data` section and no sample values anywhere in the body.
- A payload whose rows are shorter or longer than its declared columns renders an aligned table:
  short rows padded, overflowing values dropped rather than appended as phantom cells.
- A value containing a pipe, an embedded newline, or `null` does not break the table delimiters.
- A 500-char blob value is capped so it cannot crowd the rest of the context out of the window.
- Sample data absent, or present with columns but zero rows, emits no section at all.

#### Unit tests

- [x] I added unit tests for the new/changed logic.
- File updated: `openmetadata-service/src/test/java/org/openmetadata/service/aicontext/AIContextMarkdownTest.java`
  (5 new tests: `render_emitsSampleDataRowsUnderSchema`, `render_omitsSampleDataWhenAbsentOrEmpty`,
  `render_sanitizesAndPadsDelimiterSensitiveSampleValues`,
  `render_padsRaggedSampleRowsToTheColumnWidth`, `render_capsLongSampleValues`)
- Coverage on the changed class (`mvn -Pstatic-code-analysis ... jacoco:report`):
  `AIContextMarkdown.java` — **90.8% lines** (376/414), 79.7% branches. Meets the 90% target.

```
AIContextMarkdownTest      29/29 pass
AIContextBuilderTest       47/47 pass
PersonaContextMarkdownTest 12/12 pass
PersonaContextBuilderTest  21/21 pass
```

#### Backend integration tests

- [x] I added integration tests for the changed response representation.
- File updated: `openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/AIContextRestIT.java`
  - `tableContext_returnsOkfMarkdownByFqn` now asserts the `# Sample Data` heading, the header row,
    row 9, and the absence of `name-10` (the 10-row cap holds in markdown too).
  - `tableContext_omitsSamplesFromMarkdownWithoutViewSampleDataPermission` (new) — the denied
    caller's markdown has `# Schema` but no `# Sample Data` and no sample values.

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Not applicable (no UI changes; this is a server-rendered markdown response).

#### Manual testing performed

1. Rendered the document from a fixture with a pipe-bearing value, an embedded newline, a `null`,
   a 200-char blob, and a 3-column header against 1- and 4-value rows; confirmed the table stays
   aligned, `a|b` renders as `a\|b`, the newline flattens, the blob elides with `…`, and the caveat
   line precedes the table:

```
# Sample Data

_Representative stored sample rows — not the full table; never count or aggregate over them._

| id | note | amount |
|---|---|---|
| 1 | a\|b c |  |
| 2 | zzzz…(capped at 120) | 9.5 |
```

2. `mvn -o -pl openmetadata-service test -Dtest=AIContextMarkdownTest,AIContextBuilderTest` — pass.
3. `mvn -o -pl openmetadata-service test -Dtest=PersonaContextMarkdownTest,PersonaContextBuilderTest`
   — pass, confirming the persona rendering path is unchanged.
4. `mvn -o -pl openmetadata-integration-tests test-compile` — clean.
5. `mvn -pl openmetadata-service,openmetadata-integration-tests spotless:apply` — no diff.

> `AIContextRestIT` compiles but was not executed locally (needs the live stack); the two new HTTP
> cases run in CI.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable — no schema change; `sampleData` already exists on `assetContext.table` from #32608.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

#### Bug fix

- [x] I have added a test that covers the exact scenario we are fixing. Verified RED: checking out
      `origin/main`'s `AIContextMarkdown.java` against the new test file gives
      `Tests run: 29, Failures: 4` — the 4 assertion tests fail without the fix. The 5th
      (`render_omitsSampleDataWhenAbsentOrEmpty`) asserts *absence* and so passes on `main` by
      construction; it guards against a future regression that renders an empty section, not
      against today's bug.
