### PR TITLE
fix(ui): stop Profiler Settings drawer crashing on unmapped partition…

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ProfilerSettingsModal/ProfilerSettingsModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ProfilerSettingsModal/ProfilerSettingsModal.test.tsx
@@ -181,6 +181,27 @@ describe('Test ProfilerSettingsModal component', () => {
     });
   });
 
+  it('should not crash when the stored partitionIntervalType has no entry in SUPPORTED_COLUMN_DATA_TYPE_FOR_INTERVAL', async () => {
+    (getTableProfilerConfig as jest.Mock).mockResolvedValueOnce({
+      ...MOCK_TABLE,
+      tableProfilerConfig: {
+        ...mockTableProfilerConfig,
+        partitioning: {
+          ...mockTableProfilerConfig.partitioning,
+          partitionIntervalType: 'ENUM',
+        },
+      },
+    });
+
+    await act(async () => {
+      render(<ProfilerSettingsModal {...mockProps} />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('profiler-settings-modal')).toBeInTheDocument();
+    });
+  });
+
   it('should handle sample data count change', async () => {
     await act(async () => {
       render(<ProfilerSettingsModal {...mockProps} />);

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ProfilerSettingsModal/ProfilerSettingsModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ProfilerSettingsModal/ProfilerSettingsModal.tsx
@@ -158,7 +158,7 @@ const ProfilerSettingsModal: React.FC<ProfilerSettingsModalProps> = ({
   const partitionColumnOptions = useMemo(() => {
     const partitionColumnOptions = columns.reduce((result, column) => {
       const filter = partitionIntervalType
-        ? SUPPORTED_COLUMN_DATA_TYPE_FOR_INTERVAL[partitionIntervalType]
+        ? SUPPORTED_COLUMN_DATA_TYPE_FOR_INTERVAL[partitionIntervalType] ?? []
         : [];
       if (filter.includes(column.dataType)) {
         return [
@@ -617,7 +617,7 @@ const ProfilerSettingsModal: React.FC<ProfilerSettingsModalProps> = ({
             id="profiler-setting-form"
             initialValues={{
               includeColumns: state?.includeCol,
-              partitionData: [''],
+              partitionValues: [''],
               ...state?.data?.partitioning,
             }}
             layout="vertical"

--- a/openmetadata-ui/src/main/resources/ui/src/constants/profiler.constant.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/profiler.constant.ts
@@ -317,7 +317,7 @@ export const SUPPORTED_COLUMN_DATA_TYPE_FOR_INTERVAL = {
   [PartitionIntervalTypes.TimeUnit]: SUPPORTED_PARTITION_TYPE_FOR_DATE_TIME,
   [PartitionIntervalTypes.IntegerRange]: [DataType.Int, DataType.Bigint],
   [PartitionIntervalTypes.ColumnValue]: [DataType.Varchar, DataType.String],
-} as Record<PartitionIntervalTypes, DataType[]>;
+} as Partial<Record<PartitionIntervalTypes, DataType[]>>;
 
 export const INTERVAL_TYPE_OPTIONS = Object.keys(
   SUPPORTED_COLUMN_DATA_TYPE_FOR_INTERVAL


### PR DESCRIPTION
### Describe your changes:

Fixes #33123

`SUPPORTED_COLUMN_DATA_TYPE_FOR_INTERVAL` in profiler.constant.ts only maps 4 of the 7
`partitionIntervalType` enum values but was cast as `Record<PartitionIntervalTypes, DataType[]>`,
asserting coverage it doesn't have. Looking up an unmapped value (ENUM/INJECTED/OTHER) returns
undefined, and ProfilerSettingsModal immediately calls .includes() on it inside a useMemo, which
throws during render and blanks the whole drawer. This only affects tables whose stored
partitionIntervalType is one of those 3 values (ingestion/the API accept all 7 even though the
UI's own dropdown only offers 4).

Fix: cast the map as Partial<...> instead, so the lookup is typed DataType[] | undefined, and
fall back to an empty array at the one call site that reads it. No dropdown/behavior change for
the 4 already-supported types.

Also fixed a one-line typo in the same file's Form initialValues (`partitionData` -> the actual
field name `partitionValues`), which was silently a no-op — a fresh COLUMN-VALUE config was
showing zero input rows instead of one empty row.

### Type of change:
- [x] Bug fix

### High-level design:
N/A — small change.

### Tests:

#### Use cases covered
- Opening Profiler Settings on a table whose stored partitionIntervalType is ENUM/INJECTED/OTHER
  no longer crashes the drawer.
- Opening Profiler Settings on a fresh COLUMN-VALUE partition config (no stored values) now shows
  one empty input row instead of zero.

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Files added/updated: ProfilerSettingsModal.test.tsx

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable — this is a crash fix with no new UI surface to exercise end-to-end; covered
  by the unit test above.

#### Manual testing performed
1. Set a table's tableProfilerConfig.partitioning.partitionIntervalType to ENUM via the API.
2. Opened that table's Profiler Settings in the UI - confirmed it no longer blanks.
3. Opened Profiler Settings on a COLUMN-VALUE config with no stored partition values - confirmed
   one empty input row renders.

### UI screen recording / screenshots:
Not applicable — this fixes a crash (blank drawer), no visual layout change to the working state.

### Checklist:
- [x] I have read the CONTRIBUTING document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable, no schema changes.
- [x] For UI changes: not applicable per above (no visual change).
- [x] I have added tests and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
