### PR TITLE
fix(ci): push auto-generated refreshes with a PAT so PR checks re-run

### DIFF
--- a/.github/workflows/playwright-impact-map-drift.yml
+++ b/.github/workflows/playwright-impact-map-drift.yml
@@ -233,14 +233,12 @@ jobs:
       - name: Auto-commit + push (same-repo PRs only)
         if: steps.git-check.outcome != 'success' && steps.check-fork.outputs.is_fork == 'false' && (steps.pr-details.outputs.head_ref || github.event.pull_request.head.ref) != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Not GITHUB_TOKEN: pushes made with it never trigger workflow runs,
+          # so every required check stays pending and the PR can't merge.
+          GH_TOKEN: ${{ secrets.COLLATE_PAT }}
           HEAD_REF: ${{ steps.pr-details.outputs.head_ref || github.event.pull_request.head.ref }}
         run: |
-          # `[skip ci]` prevents the push from re-triggering this same workflow
-          # (which would find a clean tree and pass anyway, wasting a run).
-          # PR CI's other checks still re-fire because they gate on push events,
-          # not on this workflow.
-          git commit -m "chore(playwright): auto-refresh impact-map.generated.json [skip ci]"
+          git commit -m "chore(playwright): auto-refresh impact-map.generated.json"
           # persist-credentials: false above, so re-attach the token to origin.
           # Bare URL would break --force-with-lease (no remote-tracking ref to
           # lease against).

--- a/.github/workflows/typescript-type-generation.yml
+++ b/.github/workflows/typescript-type-generation.yml
@@ -182,7 +182,9 @@ jobs:
 
       - name: Commit and push changes
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Not GITHUB_TOKEN: pushes made with it never trigger workflow runs,
+          # so every required check stays pending and the PR can't merge.
+          GH_TOKEN: ${{ secrets.COLLATE_PAT }}
           HEAD_REF: ${{ steps.pr-details.outputs.head_ref || github.event.pull_request.head.ref || github.event.inputs.branch }}
         if: steps.git-check.outcome != 'success' && steps.check-fork.outputs.is_fork == 'false' && github.event_name != 'merge_group'
         run: |


### PR DESCRIPTION
### Describe your changes:

No linked issue — raised from a CI incident on #32701 and fixed directly.

`playwright-impact-map-drift.yml` and `typescript-type-generation.yml` both auto-commit a regenerated file to the PR branch, and both pushed authenticated as `secrets.GITHUB_TOKEN`. GitHub suppresses workflow runs for events generated by that token (its recursion guard), and that suppression covers `pull_request` **and** `pull_request_target`. So the bot's commit lands as a head SHA that no PR workflow ever reports on: every required check sits at *"Expected — Waiting for status to be reported"* and the PR cannot merge until a human pushes over it.

Measured on the head SHAs either side of a bot commit:

| Workflow | bot commit | checks | human parent | checks |
|---|---|---|---|---|
| impact-map | `3c4394efa4` | **6** | `992a220146` | **97** |
| ts-type-gen | `c266ed185c` | **6** | `2465e03482` | **110** |

The 6 survivors in both cases are the same non-PR-triggered ones (`claude` on `issue_comment`, and GitHub's app-level default CodeQL setup, which isn't an Actions workflow). Zero `pull_request` / `pull_request_target` workflows ran.

This inverts each workflow's stated purpose: a check whose job is *"I regenerated the drift for you so you don't have to"* instead blocks the PR and makes you push manually.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

Two files, one line of behaviour each.

**Push with `COLLATE_PAT` instead of `GITHUB_TOKEN`.** A PAT-authenticated push is not subject to the recursion guard, so the `synchronize` event fires normally and the PR's checks run against the fresh head. `COLLATE_PAT` is not scoped to the Collate repo despite the name — `merge-queue-health-alert.yml` already uses it for a write on *this* repo that `GITHUB_TOKEN` cannot perform at any permission level.

**Drop `[skip ci]` from the impact-map commit message.** It was added to stop the push re-triggering that same workflow — which it never did, because the workflow is `pull_request_target` and `[skip ci]` only suppresses `push` and `pull_request`. All it actually suppressed was the PR's own `pull_request`-triggered checks (Playwright, unit tests). Leaving it in would trade a full stall for a half one once the token is fixed.

`typescript-type-generation.yml` carries **no** `[skip ci]` and stranded identically — that is what isolates the token as the cause rather than the commit message.

Alternatives considered:

- **`RELEASE_BOT_TOKEN`** — does not exist as a repo secret. `auto-revert-release.yml` only survives referencing it via its `|| secrets.GITHUB_TOKEN` fallback, which would have silently reintroduced this exact bug.
- **A dedicated GitHub App token** (`actions/create-github-app-token`) — the correct long-term answer, scoping to `contents: write` on this repo alone instead of reusing a broad PAT. Not taken here because it blocks the fix on an org admin installing an App and adding `APP_ID` / `APP_PRIVATE_KEY`.
- **Stop auto-pushing; fail the check with regenerate instructions** — needs no secret at all and can never strand a PR, which is what both workflows already do for fork PRs. Rejected as a larger behavioural change that pushes work onto every UI PR author.

Reviewer note: this puts a broader-scoped credential in `pull_request_target` workflows. Both refuse to run against fork code before reaching the push step (`is_fork` gate + `safe to test` label), so it is not reachable by an outside contributor — but that is the part worth a careful look.

#
### Tests:

#### Use cases covered
- A same-repo PR whose UI source changes the generated impact map: bot pushes the refresh, and the PR's required checks run against the new head instead of hanging. **Validated end-to-end — see below.**
- A same-repo PR changing JSON schemas: same, for the regenerated TypeScript types. Same one-line change to the same push pattern; not separately exercised.
- Fork PRs: unchanged — both workflows short-circuit before the push step.

#### Unit tests
Not applicable — the change is GitHub Actions workflow YAML, and this failure mode only reproduces against GitHub's real event dispatcher. Validated with a live end-to-end run instead.

> **This PR cannot test its own fix.** `pull_request_target` executes workflow YAML from the *base* branch, never the PR branch — that is the whole point of its security model. The green checks on this PR therefore say nothing about the change. Validation used `workflow_dispatch`, the one trigger that runs PR-branch YAML.

**Method.** Throwaway draft PR #33132 with one mapping entry deleted from `impact-map.generated.json` (generator confirmed `+15 lines` out of date). Kept as a draft so the current broken `pull_request_target` version would not fire and auto-fix the drift first — the job's `if: !github.event.pull_request.draft` gate skips drafts but evaluates truthy on `workflow_dispatch`. Then dispatched the **fixed** workflow from this branch at it:

```
gh workflow run playwright-impact-map-drift.yml --ref fix/ci-bot-push-strands-required-checks -f pr_number=33132
```

**Result** — [run 34466286666](https://github.com/open-metadata/OpenMetadata/actions/runs/34466286666), `success`:

| | |
|---|---|
| head before | `6891711c8a` |
| head after | `939384ec55` — `chore(playwright): auto-refresh impact-map.generated.json`, `github-actions[bot]` |
| **check-runs on the bot commit** | **90** |
| same push under `GITHUB_TOKEN` (measured on #32701) | **6** |

Both trigger types came back, which is the specific thing that was broken:

```
pull_request_target   UI Checkstyle, Java Checkstyle, Python Checkstyle, PR Metadata
                      Validation, Integration Tests (MySQL+ES / PG+OS / PG+ES+Redis),
                      Postgresql PR Playwright E2E, py-tests, Team Label, …
pull_request          OpenMetadata Service Unit Tests, Postgresql PR Playwright E2E,
                      JavaUIIT Integration Tests, PostgreSQL PR RDF E2E, …
```

**This also settles the credential question above:** `COLLATE_PAT` does have `contents: write` on this repo. That was inferred from `merge-queue-health-alert.yml`; it is now directly demonstrated by a successful push.

**No push loop.** The drift workflow re-triggered on the bot commit and the head did not move again. Caveat: that re-run reported `skipped` because #33132 was a draft, so the *clean-tree pass* path was not exercised. It terminates by construction regardless — on a clean tree `git-check` succeeds, and the summarise / commit / push steps all gate on `steps.git-check.outcome != 'success'`.

Throwaway PR closed and its branch deleted.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. Pulled #32701 and walked its commits: bot commit `3c4394efa4` was head from 08:06Z to 09:07Z — exactly the window it was reported stuck.
2. Compared `check-runs` counts across bot vs human head SHAs on both workflows (table above).
3. Enumerated the 6 surviving checks and confirmed each comes from a non-PR trigger.
4. Confirmed `RELEASE_BOT_TOKEN` is absent from repo secrets and `COLLATE_PAT` is present.
5. Ran the full dispatch experiment on throwaway PR #33132 described above; recorded 90 check-runs on the PAT-pushed bot commit and confirmed the head did not move a second time.
6. `yaml.safe_load` parses both changed files.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` — no issue linked, see above.
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above — intentionally omitted.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: N/A.
- [x] For UI changes: N/A.
- [x] I have added tests — no unit-test harness exists for workflow YAML; validated with a live end-to-end dispatch run, evidence above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing — reproduced the failure on #32701 and demonstrated the fix on #33132, both with measured check-run counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)