### PR TITLE
fix(ui-core): clean up Tooltip (#32211) [2.0 backport]

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/form-field/form-item-label.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/form-field/form-item-label.tsx
@@ -13,7 +13,7 @@
 
 import type { ReactNode } from 'react';
 import { HelpCircle } from '@untitledui/icons';
-import { Tooltip, TooltipTrigger } from '@/components/base/tooltip/tooltip';
+import { Tooltip } from '@/components/base/tooltip/tooltip';
 
 export interface FormItemLabelProps {
   label: ReactNode;
@@ -30,12 +30,11 @@ export const FormItemLabel = ({
     <span data-testid="form-item-label">{label}</span>
     {required && <span className="tw:text-error-primary">*</span>}
     {tooltip && (
-      <Tooltip title={tooltip}>
-        <TooltipTrigger
-          className="tw:flex tw:items-center tw:cursor-pointer tw:text-fg-quaternary tw:transition tw:duration-200 tw:hover:text-fg-quaternary_hover tw:focus:text-fg-quaternary_hover"
-          isDisabled={false}>
-          <HelpCircle className="tw:size-4" />
-        </TooltipTrigger>
+      <Tooltip
+        title={tooltip}
+        triggerClassName="tw:flex tw:items-center tw:cursor-pointer tw:text-fg-quaternary tw:transition tw:duration-200 tw:hover:text-fg-quaternary_hover tw:focus:text-fg-quaternary_hover"
+        triggerIsDisabled={false}>
+        <HelpCircle className="tw:size-4" />
       </Tooltip>
     )}
   </span>

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/table/table.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/table/table.tsx
@@ -36,7 +36,7 @@ import {
 import { Badge } from '@/components/base/badges/badges';
 import { Checkbox } from '@/components/base/checkbox/checkbox';
 import { Dropdown } from '@/components/base/dropdown/dropdown';
-import { Tooltip, TooltipTrigger } from '@/components/base/tooltip/tooltip';
+import { Tooltip } from '@/components/base/tooltip/tooltip';
 import { cx } from '@/utils/cx';
 
 export const TableRowActionsDropdown = () => (
@@ -285,10 +285,11 @@ const TableHead = ({
           </div>
 
           {tooltip && (
-            <Tooltip placement="top" title={tooltip}>
-              <TooltipTrigger className="tw:cursor-pointer tw:text-fg-quaternary tw:transition tw:duration-100 tw:ease-linear tw:hover:text-fg-quaternary_hover tw:focus:text-fg-quaternary_hover">
-                <HelpCircle className="tw:size-4" />
-              </TooltipTrigger>
+            <Tooltip
+              placement="top"
+              title={tooltip}
+              triggerClassName="tw:cursor-pointer tw:text-fg-quaternary tw:transition tw:duration-100 tw:ease-linear tw:hover:text-fg-quaternary_hover tw:focus:text-fg-quaternary_hover">
+              <HelpCircle className="tw:size-4" />
             </Tooltip>
           )}
 

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/avatar/base-components/avatar-add-button.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/avatar/base-components/avatar-add-button.tsx
@@ -1,9 +1,7 @@
 import { Plus } from '@untitledui/icons';
 import type { ButtonProps as AriaButtonProps } from 'react-aria-components';
-import {
-  Tooltip as AriaTooltip,
-  TooltipTrigger as AriaTooltipTrigger,
-} from '@/components/base/tooltip/tooltip';
+import { Button as AriaButton } from 'react-aria-components';
+import { Tooltip } from '@/components/base/tooltip/tooltip';
 import { cx } from '@/utils/cx';
 
 const sizes = {
@@ -24,8 +22,8 @@ export const AvatarAddButton = ({
   title = 'Add user',
   ...props
 }: AvatarAddButtonProps) => (
-  <AriaTooltip title={title}>
-    <AriaTooltipTrigger
+  <Tooltip title={title}>
+    <AriaButton
       {...props}
       aria-label={title}
       className={cx(
@@ -39,6 +37,6 @@ export const AvatarAddButton = ({
           sizes[size].icon
         )}
       />
-    </AriaTooltipTrigger>
-  </AriaTooltip>
+    </AriaButton>
+  </Tooltip>
 );

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/buttons/button.test.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/buttons/button.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { Button } from './button';
 
@@ -31,5 +32,45 @@ describe('Button', () => {
     expect(button).not.toHaveClass('tw:outline-brand');
     expect(button).not.toHaveClass('tw:focus-visible:outline-2');
     expect(button).not.toHaveClass('tw:focus-visible:outline-offset-2');
+  });
+});
+
+describe('Button — tooltip prop', () => {
+  it('shows a tooltip on hover when the tooltip prop is set', async () => {
+    const user = userEvent.setup();
+
+    // Establish pointer modality so react-aria treats hover as a valid trigger.
+    fireEvent.mouseMove(document);
+
+    render(<Button tooltip="Helpful hint">Click me</Button>);
+
+    expect(screen.queryByText('Helpful hint')).not.toBeInTheDocument();
+
+    await user.hover(screen.getByRole('button', { name: 'Click me' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Helpful hint')).toBeInTheDocument();
+    });
+  });
+
+  it('does not render a tooltip when the tooltip prop is omitted', () => {
+    render(<Button>Click me</Button>);
+
+    // The button should not be wrapped in a TooltipTrigger at all.
+    const btn = screen.getByRole('button', { name: 'Click me' });
+
+    expect(btn.closest('[data-rac]')).toBe(btn);
+  });
+
+  it('disables the tooltip when the button is disabled', () => {
+    render(
+      <Button isDisabled tooltip="Hint">
+        Click me
+      </Button>
+    );
+
+    // With isDisabled, Tooltip receives isDisabled={true} and should not render
+    // the tooltip overlay even when isOpen would normally show it.
+    expect(screen.queryByText('Hint')).not.toBeInTheDocument();
   });
 });

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/buttons/button.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/buttons/button.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@/components/base/tooltip/tooltip';
 import { cx, sortCx } from '@/utils/cx';
 import { isReactComponent } from '@/utils/is-react-component';
 import { borderAfter } from '@/utils/tailwindClasses';
@@ -8,11 +9,12 @@ import type {
   FC,
   ReactNode,
 } from 'react';
-import { isValidElement } from 'react';
+import { forwardRef, isValidElement } from 'react';
 import type {
   ButtonProps as AriaButtonProps,
   LinkProps as AriaLinkProps,
 } from 'react-aria-components';
+import type { Placement } from 'react-aria';
 import { Button as AriaButton, Link as AriaLink } from 'react-aria-components';
 
 export const styles = sortCx({
@@ -212,6 +214,10 @@ export interface CommonProps {
   ellipsis?: boolean;
   /** Omits the default focus outline when the surrounding UI intentionally does not use one */
   hideFocusOutline?: boolean;
+  /** Tooltip text shown on hover/focus */
+  tooltip?: string;
+  /** Placement of the tooltip relative to the button */
+  tooltipPlacement?: Placement;
 }
 
 /**
@@ -255,127 +261,155 @@ interface LinkProps
 /** Union type of button and link props */
 export type Props = ButtonProps | LinkProps;
 
-export const Button = ({
-  size = 'sm',
-  color = 'primary',
-  children,
-  className,
-  hideFocusOutline,
-  noTextPadding,
-  ellipsis,
-  iconLeading: IconLeading,
-  iconTrailing: IconTrailing,
-  isDisabled: disabled,
-  isLoading: loading,
-  showTextWhileLoading,
-  ...otherProps
-}: Props) => {
-  const href = 'href' in otherProps ? otherProps.href : undefined;
-  const Component = href ? AriaLink : AriaButton;
+export const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, Props>(
+  function Button(
+    {
+      size = 'sm',
+      color = 'primary',
+      children,
+      className,
+      hideFocusOutline,
+      noTextPadding,
+      ellipsis,
+      iconLeading: IconLeading,
+      iconTrailing: IconTrailing,
+      isDisabled: disabled,
+      isLoading: loading,
+      showTextWhileLoading,
+      tooltip,
+      tooltipPlacement = 'top',
+      ...otherProps
+    }: Props,
+    ref
+  ) {
+    const href = 'href' in otherProps ? otherProps.href : undefined;
+    const Component = href ? AriaLink : AriaButton;
 
-  const isIcon = (IconLeading || IconTrailing) && !children;
-  const isLinkType = ['link-gray', 'link-color', 'link-destructive'].includes(
-    color
-  );
-  noTextPadding = isLinkType || noTextPadding;
+    const isIcon = (IconLeading || IconTrailing) && !children;
+    const isLinkType = ['link-gray', 'link-color', 'link-destructive'].includes(
+      color
+    );
+    noTextPadding = isLinkType || noTextPadding;
 
-  let props = {};
+    let props = {};
 
-  if (href) {
-    props = {
-      ...otherProps,
+    if (href) {
+      props = {
+        ...otherProps,
 
-      href: disabled ? undefined : href,
-    };
-  } else {
-    props = {
-      ...otherProps,
+        href: disabled ? undefined : href,
+      };
+    } else {
+      props = {
+        ...otherProps,
 
-      type: otherProps.type || 'button',
-      isPending: loading,
-    };
+        type: otherProps.type || 'button',
+        isPending: loading,
+      };
+    }
+
+    const button = (
+      <Component
+        data-icon-only={isIcon ? true : undefined}
+        data-loading={loading ? true : undefined}
+        // `Component` is `typeof AriaButton | typeof AriaLink`, chosen at runtime by
+        // `href`. TS can't narrow which branch applies here, so it wants a ref that
+        // satisfies both `RefObject<HTMLButtonElement>` and `RefObject<HTMLAnchorElement>`
+        // simultaneously (an intersection), which `ref`'s real type — a union — can never
+        // satisfy. The cast is safe: at runtime the ref always lands on whichever concrete
+        // DOM node `Component` actually renders.
+        ref={ref as never}
+        {...props}
+        className={cx(
+          styles.common.root,
+          // A base reset also suppresses the native outline when React Aria's
+          // data-focus-visible state is absent, such as a forced browser pseudo-state.
+          hideFocusOutline ? 'tw:outline-none' : styles.common.focusOutline,
+          styles.sizes[size].root,
+          styles.colors[color].root,
+          isLinkType && styles.sizes[size].linkRoot,
+          ellipsis && 'tw:min-w-0',
+          (loading || (href && (disabled || loading))) &&
+            'tw:pointer-events-none',
+          // If in `loading` state, hide everything except the loading icon
+          // (and text if `showTextWhileLoading` is true).
+          loading &&
+            (showTextWhileLoading
+              ? 'tw:[&>*:not([data-icon=loading]):not([data-text])]:hidden'
+              : 'tw:[&>*:not([data-icon=loading])]:invisible'),
+          className
+        )}
+        isDisabled={disabled}>
+        {/* Leading icon */}
+        {isValidElement(IconLeading) && IconLeading}
+        {isReactComponent(IconLeading) && (
+          <IconLeading className={styles.common.icon} data-icon="leading" />
+        )}
+
+        {loading && (
+          <svg
+            className={cx(
+              styles.common.icon,
+              !showTextWhileLoading &&
+                'tw:absolute tw:top-1/2 tw:left-1/2 tw:-translate-x-1/2 tw:-translate-y-1/2'
+            )}
+            data-icon="loading"
+            fill="none"
+            viewBox="0 0 20 20">
+            {/* Background circle */}
+            <circle
+              className="tw:stroke-current tw:opacity-30"
+              cx="10"
+              cy="10"
+              fill="none"
+              r="8"
+              strokeWidth="2"
+            />
+            {/* Spinning circle */}
+            <circle
+              className="tw:origin-center tw:animate-spin tw:stroke-current"
+              cx="10"
+              cy="10"
+              fill="none"
+              r="8"
+              strokeDasharray="12.5 50"
+              strokeLinecap="round"
+              strokeWidth="2"
+            />
+          </svg>
+        )}
+
+        {children && (
+          <span
+            data-text
+            className={cx(
+              'tw:transition-inherit-all',
+              !noTextPadding && 'tw:px-0.5',
+              ellipsis && 'tw:truncate tw:min-w-0'
+            )}>
+            {children}
+          </span>
+        )}
+
+        {/* Trailing icon */}
+        {isValidElement(IconTrailing) && IconTrailing}
+        {isReactComponent(IconTrailing) && (
+          <IconTrailing className={styles.common.icon} data-icon="trailing" />
+        )}
+      </Component>
+    );
+
+    if (tooltip) {
+      return (
+        <Tooltip
+          isDisabled={disabled}
+          placement={tooltipPlacement}
+          title={tooltip}>
+          {button}
+        </Tooltip>
+      );
+    }
+
+    return button;
   }
-
-  return (
-    <Component
-      data-icon-only={isIcon ? true : undefined}
-      data-loading={loading ? true : undefined}
-      {...props}
-      className={cx(
-        styles.common.root,
-        // A base reset also suppresses the native outline when React Aria's
-        // data-focus-visible state is absent, such as a forced browser pseudo-state.
-        hideFocusOutline ? 'tw:outline-none' : styles.common.focusOutline,
-        styles.sizes[size].root,
-        styles.colors[color].root,
-        isLinkType && styles.sizes[size].linkRoot,
-        ellipsis && 'tw:min-w-0',
-        (loading || (href && (disabled || loading))) &&
-          'tw:pointer-events-none',
-        // If in `loading` state, hide everything except the loading icon (and text if `showTextWhileLoading` is true).
-        loading &&
-          (showTextWhileLoading
-            ? 'tw:[&>*:not([data-icon=loading]):not([data-text])]:hidden'
-            : 'tw:[&>*:not([data-icon=loading])]:invisible'),
-        className
-      )}
-      isDisabled={disabled}>
-      {/* Leading icon */}
-      {isValidElement(IconLeading) && IconLeading}
-      {isReactComponent(IconLeading) && (
-        <IconLeading className={styles.common.icon} data-icon="leading" />
-      )}
-
-      {loading && (
-        <svg
-          className={cx(
-            styles.common.icon,
-            !showTextWhileLoading &&
-              'tw:absolute tw:top-1/2 tw:left-1/2 tw:-translate-x-1/2 tw:-translate-y-1/2'
-          )}
-          data-icon="loading"
-          fill="none"
-          viewBox="0 0 20 20">
-          {/* Background circle */}
-          <circle
-            className="tw:stroke-current tw:opacity-30"
-            cx="10"
-            cy="10"
-            fill="none"
-            r="8"
-            strokeWidth="2"
-          />
-          {/* Spinning circle */}
-          <circle
-            className="tw:origin-center tw:animate-spin tw:stroke-current"
-            cx="10"
-            cy="10"
-            fill="none"
-            r="8"
-            strokeDasharray="12.5 50"
-            strokeLinecap="round"
-            strokeWidth="2"
-          />
-        </svg>
-      )}
-
-      {children && (
-        <span
-          data-text
-          className={cx(
-            'tw:transition-inherit-all',
-            !noTextPadding && 'tw:px-0.5',
-            ellipsis && 'tw:truncate tw:min-w-0'
-          )}>
-          {children}
-        </span>
-      )}
-
-      {/* Trailing icon */}
-      {isValidElement(IconTrailing) && IconTrailing}
-      {isReactComponent(IconTrailing) && (
-        <IconTrailing className={styles.common.icon} data-icon="trailing" />
-      )}
-    </Component>
-  );
-};
+);

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/input/input.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/input/input.tsx
@@ -1,6 +1,6 @@
 import { HintText } from '@/components/base/input/hint-text';
 import { Label } from '@/components/base/input/label';
-import { Tooltip, TooltipTrigger } from '@/components/base/tooltip/tooltip';
+import { Tooltip } from '@/components/base/tooltip/tooltip';
 import { cx, sortCx } from '@/utils/cx';
 import { fontSizeClass } from '@/utils/tailwindClasses';
 import { HelpCircle, InfoCircle } from '@untitledui/icons';
@@ -188,16 +188,16 @@ export const InputBase = ({
 
       {/* Tooltip and help icon */}
       {tooltip && !isInvalid && (
-        <Tooltip placement="top" title={tooltip}>
-          <TooltipTrigger
-            className={cx(
-              'tw:absolute tw:cursor-pointer tw:text-fg-quaternary tw:transition tw:duration-200 tw:hover:text-fg-quaternary_hover tw:focus:text-fg-quaternary_hover',
-              sizes[inputSize].iconTrailing,
-              context?.tooltipClassName,
-              tooltipClassName
-            )}>
-            <HelpCircle className="tw:size-4" />
-          </TooltipTrigger>
+        <Tooltip
+          placement="top"
+          title={tooltip}
+          triggerClassName={cx(
+            'tw:absolute tw:cursor-pointer tw:text-fg-quaternary tw:transition tw:duration-200 tw:hover:text-fg-quaternary_hover tw:focus:text-fg-quaternary_hover',
+            sizes[inputSize].iconTrailing,
+            context?.tooltipClassName,
+            tooltipClassName
+          )}>
+          <HelpCircle className="tw:size-4" />
         </Tooltip>
       )}
 

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/input/label.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/input/label.tsx
@@ -2,7 +2,7 @@ import type { ReactNode, Ref } from 'react';
 import { HelpCircle } from '@untitledui/icons';
 import type { LabelProps as AriaLabelProps } from 'react-aria-components';
 import { Label as AriaLabel } from 'react-aria-components';
-import { Tooltip, TooltipTrigger } from '@/components/base/tooltip/tooltip';
+import { Tooltip } from '@/components/base/tooltip/tooltip';
 import { cx } from '@/utils/cx';
 
 interface LabelProps extends AriaLabelProps {
@@ -47,15 +47,12 @@ export const Label = ({
         <Tooltip
           description={tooltipDescription}
           placement="top"
-          title={tooltip}>
-          <TooltipTrigger
-            // `TooltipTrigger` inherits the disabled state from the parent form field
-            // but we don't that. We want the tooltip be enabled even if the parent
-            // field is disabled.
-            className="tw:flex tw:items-center tw:cursor-pointer tw:text-fg-quaternary tw:transition tw:duration-200 tw:hover:text-fg-quaternary_hover tw:focus:text-fg-quaternary_hover"
-            isDisabled={false}>
-            <HelpCircle className="tw:size-4" />
-          </TooltipTrigger>
+          title={tooltip}
+          // triggerIsDisabled={false} keeps the help-icon wrapper interactive
+          // even when the parent form field is disabled.
+          triggerClassName="tw:flex tw:items-center tw:cursor-pointer tw:text-fg-quaternary tw:transition tw:duration-200 tw:hover:text-fg-quaternary_hover tw:focus:text-fg-quaternary_hover"
+          triggerIsDisabled={false}>
+          <HelpCircle className="tw:size-4" />
         </Tooltip>
       )}
     </AriaLabel>

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/tooltip/tooltip.test.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/tooltip/tooltip.test.tsx
@@ -1,0 +1,212 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { Tooltip } from './tooltip';
+
+// Establish pointer modality so react-aria treats hover as a valid trigger.
+// Without a prior mousemove the modality is null and hover events are ignored.
+const setupPointerModality = () => fireEvent.mouseMove(document);
+
+// A minimal focusable React component used to test the triggerClassName
+// "force wrap" behaviour on component children (not just HTML elements).
+const IconStub = ({ className }: { className?: string }) => (
+  <svg className={className} data-testid="icon" viewBox="0 0 24 24" />
+);
+
+describe('Tooltip — child wrapping', () => {
+  it('auto-wraps a non-focusable span in a button so the tooltip can anchor', () => {
+    render(
+      <Tooltip isOpen title="tip">
+        <span>trigger</span>
+      </Tooltip>
+    );
+
+    expect(screen.getByText('trigger').closest('button')).not.toBeNull();
+  });
+
+  it('auto-wraps a div', () => {
+    render(
+      <Tooltip isOpen title="tip">
+        <div>trigger</div>
+      </Tooltip>
+    );
+
+    expect(screen.getByText('trigger').closest('button')).not.toBeNull();
+  });
+
+  it('wraps a native button in an AriaButton so react-aria hover fires reliably', () => {
+    render(
+      <Tooltip isOpen title="tip">
+        <button>trigger</button>
+      </Tooltip>
+    );
+
+    // 'button' is intentionally excluded from NATIVELY_FOCUSABLE_HTML because
+    // react-aria's hover system does not reliably fire on native buttons passed
+    // via cloneElement. Wrapping in an AriaButton ensures useHover/usePress attach.
+    const buttons = screen.getAllByRole('button', { name: 'trigger' });
+    expect(buttons).toHaveLength(2);
+    const outer = buttons[0];
+    const inner = buttons[1];
+
+    expect(outer.contains(inner)).toBe(true);
+  });
+
+  it('does NOT wrap a native anchor', () => {
+    render(
+      <Tooltip isOpen title="tip">
+        <a href="#">trigger</a>
+      </Tooltip>
+    );
+
+    expect(
+      screen.getByRole('link', { name: 'trigger' }).closest('button')
+    ).toBeNull();
+  });
+
+  it('wraps a React component child when triggerClassName is provided', () => {
+    render(
+      <Tooltip isOpen title="tip" triggerClassName="custom-cls">
+        <IconStub />
+      </Tooltip>
+    );
+
+    // IconStub is a React component (not a non-focusable string element), so
+    // it would normally pass through. triggerClassName forces wrapping.
+    const wrapper = screen.getByTestId('icon').closest('button');
+
+    expect(wrapper).not.toBeNull();
+    expect(wrapper).toHaveClass('custom-cls');
+  });
+
+  it('fires onTriggerPress on the generated wrapper', async () => {
+    const user = userEvent.setup();
+    const onPress = vi.fn();
+
+    render(
+      <Tooltip title="tip" onTriggerPress={onPress}>
+        <span>trigger</span>
+      </Tooltip>
+    );
+
+    await user.click(screen.getByText('trigger'));
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes triggerIsDisabled to the wrapper button', () => {
+    render(
+      <Tooltip isOpen triggerIsDisabled title="tip" triggerClassName="">
+        <span>trigger</span>
+      </Tooltip>
+    );
+
+    expect(screen.getByText('trigger').closest('button')).toBeDisabled();
+  });
+});
+
+describe('Tooltip — show/hide behaviour', () => {
+  it('shows the tooltip on hover over an auto-wrapped span child', async () => {
+    const user = userEvent.setup();
+    setupPointerModality();
+
+    render(
+      <Tooltip title="Tooltip text">
+        <span>trigger</span>
+      </Tooltip>
+    );
+
+    expect(screen.queryByText('Tooltip text')).not.toBeInTheDocument();
+
+    await user.hover(screen.getByText('trigger'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Tooltip text')).toBeInTheDocument();
+    });
+  });
+
+  it('shows the tooltip on keyboard focus of an auto-wrapped span child', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Tooltip title="Tooltip text">
+        <span>trigger</span>
+      </Tooltip>
+    );
+
+    await user.tab();
+
+    await waitFor(() => {
+      expect(screen.getByText('Tooltip text')).toBeInTheDocument();
+    });
+  });
+
+  it('shows the tooltip on hover over a native button child', async () => {
+    const user = userEvent.setup();
+    setupPointerModality();
+
+    render(
+      <Tooltip title="Tooltip text">
+        <button>trigger</button>
+      </Tooltip>
+    );
+
+    expect(screen.queryByText('Tooltip text')).not.toBeInTheDocument();
+
+    // Native button is wrapped in AriaButton so useHover fires correctly.
+    // Hover over the outer AriaButton (first match).
+    const buttons = screen.getAllByRole('button', { name: 'trigger' });
+    await user.hover(buttons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Tooltip text')).toBeInTheDocument();
+    });
+  });
+
+  it('renders immediately when isOpen is true', () => {
+    render(
+      <Tooltip isOpen title="Always visible">
+        <button>trigger</button>
+      </Tooltip>
+    );
+
+    expect(screen.getByText('Always visible')).toBeInTheDocument();
+  });
+
+  it('does not show tooltip on interaction when trigger is disabled', async () => {
+    const user = userEvent.setup();
+    setupPointerModality();
+
+    render(
+      <Tooltip triggerIsDisabled title="Hidden">
+        <span>trigger</span>
+      </Tooltip>
+    );
+
+    const wrapper = screen.getByText('trigger').closest('button');
+    expect(wrapper).toBeDisabled();
+
+    expect(screen.queryByText('Hidden')).not.toBeInTheDocument();
+
+    // Try to hover over the disabled trigger — tooltip should not appear
+    await user.hover(wrapper!);
+
+    // Give the tooltip time to appear (if it were going to)
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    expect(screen.queryByText('Hidden')).not.toBeInTheDocument();
+  });
+});

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/tooltip/tooltip.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/tooltip/tooltip.tsx
@@ -1,20 +1,45 @@
-import { cx } from '@/utils/cx';
 import type { ReactNode } from 'react';
+import type { Placement } from 'react-aria';
 import type {
   ButtonProps as AriaButtonProps,
+  PressEvent,
   TooltipProps as AriaTooltipProps,
   TooltipTriggerComponentProps as AriaTooltipTriggerComponentProps,
 } from 'react-aria-components';
+import { forwardRef, isValidElement } from 'react';
 import {
   Button as AriaButton,
   OverlayArrow as AriaOverlayArrow,
   Tooltip as AriaTooltip,
   TooltipTrigger as AriaTooltipTrigger,
 } from 'react-aria-components';
+import { cx } from '@/utils/cx';
+
+// HTML elements that are natively focusable and don't need an AriaButton wrapper.
+// IMPORTANT: do NOT pass a container element whose children are interactive (e.g.
+// a <div> containing a <button>). Tooltip only inspects the top-level element type;
+// wrapping such a container would produce a button-in-button (invalid HTML / a11y).
+// The caller is responsible for ensuring the direct child has no interactive descendants.
+// 'button' is intentionally excluded: react-aria's hover system attaches via
+// cloneElement and does not reliably fire on native buttons. Wrapping in an
+// AriaButton ensures the tooltip trigger uses react-aria's own useHover/usePress.
+const NATIVELY_FOCUSABLE_HTML = new Set([
+  'a',
+  'details',
+  'input',
+  'select',
+  'summary',
+  'textarea',
+]);
 
 interface TooltipProps
   extends AriaTooltipTriggerComponentProps,
-    Omit<AriaTooltipProps, 'children'> {
+    Omit<AriaTooltipProps, 'children' | 'placement'> {
+  /**
+   * Placement of the tooltip relative to the trigger. Accepts react-aria
+   * values ("top", "bottom left", …).
+   */
+  placement?: Placement;
   /**
    * The title of the tooltip.
    */
@@ -40,6 +65,36 @@ interface TooltipProps
    * Use this to override the default dark background, e.g. for a white tooltip.
    */
   containerClassName?: string;
+  /**
+   * className forwarded to the auto-generated focusable wrapper that Tooltip
+   * creates when its child is a non-focusable element (e.g. a plain span, an
+   * SVG icon, or a bare div). Providing this prop also forces wrapping even
+   * for React component children that would otherwise be passed through
+   * directly.
+   */
+  triggerClassName?: string;
+  /**
+   * Press handler forwarded to the auto-generated focusable wrapper. Providing
+   * this prop forces wrapping (same as triggerClassName).
+   */
+  onTriggerPress?: (e: PressEvent) => void;
+  /**
+   * Passed as `isDisabled` to the auto-generated focusable wrapper. Use
+   * `triggerIsDisabled={false}` to keep the help-icon wrapper interactive
+   * even when a surrounding form field is disabled.
+   *
+   * @default false
+   */
+  triggerIsDisabled?: boolean;
+  /**
+   * When true, renders a plain non-focusable span instead of the AriaButton
+   * wrapper for non-focusable children. Use this when the tooltip trigger must
+   * NOT be reachable by keyboard OR by programmatic focus (e.g. chips inside a
+   * data-grid cell where keyboard focus belongs to the cell, not its children).
+   * Mouse hover tooltips still work. Keyboard/focus tooltip triggering is
+   * intentionally skipped.
+   */
+  excludeTriggerFromTabOrder?: boolean;
 }
 
 export const Tooltip = ({
@@ -47,7 +102,7 @@ export const Tooltip = ({
   description,
   children,
   arrow = false,
-  delay = 300,
+  delay,
   closeDelay = 0,
   trigger,
   isDisabled,
@@ -58,8 +113,52 @@ export const Tooltip = ({
   placement = 'top',
   onOpenChange,
   containerClassName,
+  triggerClassName,
+  onTriggerPress,
+  triggerIsDisabled = false,
+  excludeTriggerFromTabOrder,
   ...tooltipProps
 }: TooltipProps) => {
+  const resolvedDelay = delay ?? 300;
+
+  // Determine whether the child needs to be wrapped in a focusable AriaButton.
+  // Non-focusable HTML string elements (span, div, svg, …) can't serve as
+  // react-aria tooltip anchors on their own; wrap them automatically.
+  // Providing triggerClassName or onTriggerPress is an explicit signal to wrap
+  // even React component children (e.g. icon components).
+  const shouldWrap = (() => {
+    if (triggerClassName !== undefined || onTriggerPress !== undefined) {
+      return true;
+    }
+    if (!isValidElement(children)) {
+      return false;
+    }
+    const type = children.type;
+
+    return typeof type === 'string' && !NATIVELY_FOCUSABLE_HTML.has(type);
+  })();
+
+  const trigger_ = shouldWrap ? (
+    excludeTriggerFromTabOrder ? (
+      // Use a plain span instead of AriaButton when the trigger is explicitly
+      // excluded from the tab order. AriaButton with tabindex="-1" is still
+      // programmatically focusable, so Ant Design FocusTrap.restoreFocus() can
+      // accidentally land on it inside rdg cells. A span has no focusability at
+      // all — FocusTrap cannot reach it — while RAC's TooltipTrigger still
+      // passes hover handlers via cloneElement, so mouse tooltips work normally.
+      <span className={triggerClassName}>{children}</span>
+    ) : (
+      <AriaButton
+        className={cx('tw:h-max tw:w-max tw:outline-hidden', triggerClassName)}
+        isDisabled={triggerIsDisabled}
+        onPress={onTriggerPress}>
+        {children}
+      </AriaButton>
+    )
+  ) : (
+    children
+  );
+
   const isTopOrBottomLeft = [
     'top left',
     'top end',
@@ -83,14 +182,14 @@ export const Tooltip = ({
     <AriaTooltipTrigger
       {...{
         trigger,
-        delay,
+        delay: resolvedDelay,
         closeDelay,
         isDisabled,
         isOpen,
         defaultOpen,
         onOpenChange,
       }}>
-      {children}
+      {trigger_}
 
       <AriaTooltip
         {...tooltipProps}
@@ -103,7 +202,7 @@ export const Tooltip = ({
         }
         crossOffset={crossOffset ?? calculatedCrossOffset}
         offset={offset}
-        placement={placement}>
+        placement={placement as Placement}>
         {({ isEntering, isExiting }) => (
           <>
             {arrow && (
@@ -145,13 +244,25 @@ export const Tooltip = ({
 
 type TooltipTriggerProps = AriaButtonProps;
 
-export const TooltipTrigger = ({
-  children,
-  className,
-  ...buttonProps
-}: TooltipTriggerProps) => {
+/**
+ * @deprecated Pass your child element directly to `<Tooltip>` instead.
+ * `Tooltip` now auto-wraps non-focusable children and accepts
+ * `triggerClassName` / `onTriggerPress` for the generated wrapper.
+ * `TooltipTrigger` will be removed in a future release.
+ *
+ * AriaTooltipTrigger passes its hover/focus-open handlers down through
+ * FocusableContext, not through cloned props or a plain ref — AriaButton never
+ * reads that context (it only reads ButtonContext), so wrapping it directly
+ * silently drops the tooltip's open/close wiring. forwardRef is required here
+ * so the ref reaches the underlying DOM button.
+ */
+export const TooltipTrigger = forwardRef<
+  HTMLButtonElement,
+  TooltipTriggerProps
+>(function TooltipTrigger({ children, className, ...buttonProps }, ref) {
   return (
     <AriaButton
+      ref={ref}
       {...buttonProps}
       className={(values) =>
         cx(
@@ -162,4 +273,4 @@ export const TooltipTrigger = ({
       {children}
     </AriaButton>
   );
-};
+});

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/foundations/typography.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/foundations/typography.tsx
@@ -11,9 +11,19 @@
  *  limitations under the License.
  */
 
-import { Tooltip, TooltipTrigger } from '@/components/base/tooltip/tooltip';
+import { Tooltip } from '@/components/base/tooltip/tooltip';
 import { cx } from '@/utils/cx';
 import type { ElementType, HTMLAttributes, ReactNode, Ref } from 'react';
+import type { PressEvent } from 'react-aria-components';
+
+// Tooltip's auto-generated focusable wrapper uses react-aria's AriaButton,
+// whose usePress hook stops press events from propagating to ancestor DOM
+// listeners by default. For the ellipsis tooltip we wrap non-interactive text,
+// so a click should still reach any ancestor onClick (e.g. a selectable card).
+// Calling continuePropagation() restores that, scoped to this call site only.
+const allowEllipsisTooltipPressToPropagate = (e: PressEvent) => {
+  e.continuePropagation();
+};
 
 const lineClampClasses: Record<number, string> = {
   1: 'tw:line-clamp-1',
@@ -63,6 +73,7 @@ interface TypographyProps extends HTMLAttributes<HTMLElement> {
   size?: TypographySize;
   weight?: TypographyWeight;
   ellipsis?: TypographyEllipsis;
+  tooltip?: ReactNode;
 }
 
 const quoteStyles: Record<TypographyQuoteVariant, string> = {
@@ -101,6 +112,7 @@ export const Typography = (props: TypographyProps) => {
     size,
     weight,
     ellipsis,
+    tooltip,
     style,
     ...otherProps
   } = props;
@@ -131,32 +143,36 @@ export const Typography = (props: TypographyProps) => {
     ellipsisClassName
   );
 
-  if (ellipsisTooltip) {
-    return (
-      <Tooltip title={ellipsisTooltip}>
-        <TooltipTrigger className="tw:block tw:w-full tw:min-w-0">
-          <div
-            className={cx(
-              'prose',
-              quoteStyles[quoteVariant],
-              ellipsisClassName
-            )}>
-            <Component {...otherProps} className={innerClassName} style={style}>
-              {children}
-            </Component>
-          </div>
-        </TooltipTrigger>
-      </Tooltip>
-    );
-  }
-
-  return (
+  const content = (
     <div className={cx('prose', quoteStyles[quoteVariant], ellipsisClassName)}>
       <Component {...otherProps} className={innerClassName} style={style}>
         {children}
       </Component>
     </div>
   );
+
+  if (ellipsisTooltip) {
+    return (
+      <Tooltip
+        title={ellipsisTooltip}
+        triggerClassName="tw:block tw:w-full tw:min-w-0"
+        onTriggerPress={allowEllipsisTooltipPressToPropagate}>
+        {content}
+      </Tooltip>
+    );
+  }
+
+  if (tooltip) {
+    return (
+      <Tooltip
+        title={tooltip}
+        onTriggerPress={allowEllipsisTooltipPressToPropagate}>
+        {content}
+      </Tooltip>
+    );
+  }
+
+  return content;
 };
 
 export type {

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/stories/Tooltip.stories.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/stories/Tooltip.stories.tsx
@@ -11,7 +11,8 @@
  *  limitations under the License.
  */
 import type { Meta, StoryObj } from '@storybook/react';
-import { Tooltip, TooltipTrigger } from '../components/base/tooltip/tooltip';
+import { HelpCircle } from '@untitledui/icons';
+import { Tooltip } from '../components/base/tooltip/tooltip';
 import { Button } from '../components/base/buttons/button';
 
 const meta = {
@@ -29,9 +30,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   render: () => (
     <Tooltip title="This is a tooltip">
-      <TooltipTrigger>
-        <Button color="secondary">Hover me</Button>
-      </TooltipTrigger>
+      <Button color="secondary">Hover me</Button>
     </Tooltip>
   ),
 };
@@ -41,9 +40,7 @@ export const WithDescription: StoryObj = {
     <Tooltip
       description="This is a longer description that provides more context."
       title="Tooltip title">
-      <TooltipTrigger>
-        <Button color="secondary">With description</Button>
-      </TooltipTrigger>
+      <Button color="secondary">With description</Button>
     </Tooltip>
   ),
 };
@@ -51,10 +48,34 @@ export const WithDescription: StoryObj = {
 export const WithArrow: StoryObj = {
   render: () => (
     <Tooltip arrow title="Tooltip with arrow">
-      <TooltipTrigger>
-        <Button color="secondary">With arrow</Button>
-      </TooltipTrigger>
+      <Button color="secondary">With arrow</Button>
     </Tooltip>
+  ),
+};
+
+export const OnSpan: StoryObj = {
+  render: () => (
+    <Tooltip title="Tooltip on a plain span">
+      <span>Hover over this text</span>
+    </Tooltip>
+  ),
+};
+
+export const OnIcon: StoryObj = {
+  render: () => (
+    <Tooltip
+      title="Help tooltip on an icon"
+      triggerClassName="tw:flex tw:cursor-pointer tw:text-fg-quaternary tw:hover:text-fg-quaternary_hover">
+      <HelpCircle className="tw:size-5" />
+    </Tooltip>
+  ),
+};
+
+export const ButtonWithTooltip: StoryObj = {
+  render: () => (
+    <Button color="secondary" tooltip="Built-in tooltip via the tooltip prop">
+      Button with tooltip
+    </Button>
   ),
 };
 
@@ -68,32 +89,24 @@ export const Placements: StoryObj = {
         padding: 80,
       }}>
       <Tooltip placement="top" title="Top tooltip">
-        <TooltipTrigger>
-          <Button color="secondary" size="sm">
-            Top
-          </Button>
-        </TooltipTrigger>
+        <Button color="secondary" size="sm">
+          Top
+        </Button>
       </Tooltip>
       <Tooltip placement="bottom" title="Bottom tooltip">
-        <TooltipTrigger>
-          <Button color="secondary" size="sm">
-            Bottom
-          </Button>
-        </TooltipTrigger>
+        <Button color="secondary" size="sm">
+          Bottom
+        </Button>
       </Tooltip>
       <Tooltip placement="left" title="Left tooltip">
-        <TooltipTrigger>
-          <Button color="secondary" size="sm">
-            Left
-          </Button>
-        </TooltipTrigger>
+        <Button color="secondary" size="sm">
+          Left
+        </Button>
       </Tooltip>
       <Tooltip placement="right" title="Right tooltip">
-        <TooltipTrigger>
-          <Button color="secondary" size="sm">
-            Right
-          </Button>
-        </TooltipTrigger>
+        <Button color="secondary" size="sm">
+          Right
+        </Button>
       </Tooltip>
     </div>
   ),
@@ -102,9 +115,7 @@ export const Placements: StoryObj = {
 export const AlwaysVisible: StoryObj = {
   render: () => (
     <Tooltip isOpen title="Always visible tooltip">
-      <TooltipTrigger>
-        <Button color="secondary">Always visible</Button>
-      </TooltipTrigger>
+      <Button color="secondary">Always visible</Button>
     </Tooltip>
   ),
 };

--- a/openmetadata-ui/src/main/resources/ui/eslint-rules/openmetadata-ui-patterns.mjs
+++ b/openmetadata-ui/src/main/resources/ui/eslint-rules/openmetadata-ui-patterns.mjs
@@ -1,0 +1,65 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * Rule: no-raw-title-attribute
+ * Disallow raw HTML title="" attributes on JSX elements.
+ * Use <Tooltip> from @openmetadata/ui-core-components instead.
+ */
+const noRawTitleAttribute = {
+  meta: {
+    messages: {
+      noRawTitle:
+        'Use <Tooltip> from @openmetadata/ui-core-components instead of raw title="" attributes for consistent tooltip behavior.',
+    },
+    schema: [],
+    type: 'suggestion',
+  },
+  create(context) {
+    return {
+      JSXAttribute(node) {
+        // Only flag title attributes on native HTML elements (not components)
+        const parent = node.parent;
+        if (
+          parent &&
+          parent.type === 'JSXOpeningElement' &&
+          node.name.name === 'title'
+        ) {
+          const elementName = parent.name.name;
+
+          // Only flag lowercase (native HTML) elements
+          // Skip uppercase (React components) and special cases like <title> HTML head element
+          if (/^[a-z]/.test(elementName) && elementName !== 'title') {
+            // Skip if it's a component class name like ant-select-selection-item
+            // (these are legacy Ant Design patterns that will be migrated separately)
+            const isLegacyAntd = parent.attributes?.some(
+              (attr) =>
+                attr.name?.name === 'className' &&
+                attr.value?.value?.includes('ant-select-selection-item')
+            );
+
+            if (!isLegacyAntd) {
+              context.report({ messageId: 'noRawTitle', node });
+            }
+          }
+        }
+      },
+    };
+  },
+};
+
+export default {
+  rules: {
+    'no-raw-title-attribute': noRawTitleAttribute,
+  },
+};

--- a/openmetadata-ui/src/main/resources/ui/eslint.config.mjs
+++ b/openmetadata-ui/src/main/resources/ui/eslint.config.mjs
@@ -23,6 +23,7 @@ import globals from 'globals';
 import jsoncParser from 'jsonc-eslint-parser';
 import tseslint from 'typescript-eslint';
 import openMetadataPlaywright from './eslint-rules/openmetadata-playwright.mjs';
+import openMetadataUiPatterns from './eslint-rules/openmetadata-ui-patterns.mjs';
 import omPlaywright from './playwright/eslint-rules/index.mjs';
 
 export default [
@@ -100,6 +101,7 @@ export default [
       jest,
       'jest-formatting': jestFormatting,
       i18next,
+      'openmetadata-ui-patterns': openMetadataUiPatterns,
     },
 
     rules: {
@@ -214,6 +216,7 @@ export default [
             'Do not use Tailwind `ring-*` to draw an edge — it compiles to box-shadow, which WebKit does not pixel-snap, so it thins/vanishes in Safari when zoomed. Use `border-*`, or `outline-1 -outline-offset-1 outline-<token>`. Where the outline is already the focus ring, use `borderAfter` + `after:outline-<token>`. See docs/colors.md §2.3.1.',
         },
       ],
+      'openmetadata-ui-patterns/no-raw-title-attribute': 'error',
     },
   },
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/StatItem.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/StatItem.component.tsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2025 Collate.
+ *  Copyright 2026 Collate.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { Tooltip, TooltipTrigger } from '@openmetadata/ui-core-components';
+import { Button } from '@openmetadata/ui-core-components';
 import classNames from 'classnames';
 import { StatItemProps } from './StatItem.interface';
 
@@ -55,26 +55,18 @@ export const StatItem = ({
     </>
   );
 
-  const interactive = onClick ? (
-    <button
+  return (
+    <Button
       aria-busy={loading || undefined}
       aria-label={srLabel ?? tooltip}
-      className="tw:rounded tw:focus-visible:outline-2 tw:focus-visible:outline-offset-2 tw:focus-visible:outline-brand"
+      className="tw:rounded tw:p-0 tw:hover:bg-transparent"
+      color="tertiary"
       data-testid={testId}
-      disabled={isDisabled}
-      type="button"
+      isDisabled={!onClick || isDisabled}
+      tooltip={tooltip}
+      tooltipPlacement="top"
       onClick={onClick}>
       <span className={labelClassName}>{label}</span>
-    </button>
-  ) : (
-    <span className={labelClassName} data-testid={testId}>
-      {label}
-    </span>
-  );
-
-  return (
-    <Tooltip placement="top" title={tooltip}>
-      <TooltipTrigger>{interactive}</TooltipTrigger>
-    </Tooltip>
+    </Button>
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/ColumnDetailPanel/KeyProfileMetrics/KeyProfileMetrics.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/ColumnDetailPanel/KeyProfileMetrics/KeyProfileMetrics.component.tsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2025 Collate.
+ *  Copyright 2026 Collate.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Tooltip, TooltipTrigger } from '@openmetadata/ui-core-components';
+import { Tooltip } from '@openmetadata/ui-core-components';
 import { HelpCircle } from '@untitledui/icons';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -47,10 +47,11 @@ export const KeyProfileMetrics = ({ profile }: KeyProfileMetricsProps) => {
                   {metric.label}
                 </span>
                 {metric.tooltip && (
-                  <Tooltip placement="top" title={metric.tooltip}>
-                    <TooltipTrigger>
-                      <HelpCircle className="tw:size-2.5 tw:text-tertiary" />
-                    </TooltipTrigger>
+                  <Tooltip
+                    placement="top"
+                    title={metric.tooltip}
+                    triggerClassName="tw:inline-flex">
+                    <HelpCircle className="tw:size-2.5 tw:text-tertiary" />
                   </Tooltip>
                 )}
               </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/LineageTab/LineageTabContent.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/LineageTab/LineageTabContent.tsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2025 Collate.
+ *  Copyright 2026 Collate.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { Tooltip, TooltipTrigger } from '@openmetadata/ui-core-components';
+import { Tooltip } from '@openmetadata/ui-core-components';
 import { Button, Typography } from 'antd';
 import { capitalize } from 'lodash';
 import React, { useMemo, useState } from 'react';
@@ -235,16 +235,18 @@ const LineageTabContent: React.FC<LineageTabContentProps> = ({
                   </div>
                   <div className="lineage-item-direction">
                     {item.direction === 'upstream' ? (
-                      <Tooltip placement="top" title={t('label.upstream')}>
-                        <TooltipTrigger>
-                          <UpstreamIcon height={18} width={18} />
-                        </TooltipTrigger>
+                      <Tooltip
+                        placement="top"
+                        title={t('label.upstream')}
+                        triggerClassName="tw:inline-flex">
+                        <UpstreamIcon height={18} width={18} />
                       </Tooltip>
                     ) : (
-                      <Tooltip placement="top" title={t('label.downstream')}>
-                        <TooltipTrigger>
-                          <DownstreamIcon height={18} width={18} />
-                        </TooltipTrigger>
+                      <Tooltip
+                        placement="top"
+                        title={t('label.downstream')}
+                        triggerClassName="tw:inline-flex">
+                        <DownstreamIcon height={18} width={18} />
                       </Tooltip>
                     )}
                   </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/SettingsSso/SSOConfigurationForm/SsoConfigurationFormArrayFieldTemplate.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SettingsSso/SSOConfigurationForm/SsoConfigurationFormArrayFieldTemplate.tsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2025 Collate.
+ *  Copyright 2026 Collate.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 
+import { Tooltip } from '@openmetadata/ui-core-components';
 import { FieldProps } from '@rjsf/utils';
 import { Col, Row, Select, Typography } from 'antd';
 import classNames from 'classnames';
@@ -23,12 +24,22 @@ import { useClipboard } from '../../../hooks/useClipBoard';
 import { splitCSV } from '../../../utils/CSV/CSVPureUtils';
 import { isValidUrl } from '../../../utils/SSOUtils';
 import './sso-configuration-form-array-field-template.less';
+
 const SsoCustomTagRenderer = (props: CustomTagProps) => {
   const { label, closable, onClose } = props;
+  const labelStr = (label as string) ?? '';
+
+  const labelNode = labelStr ? (
+    <Tooltip title={labelStr}>
+      <span className="ant-select-selection-item-content">{label}</span>
+    </Tooltip>
+  ) : (
+    <span className="ant-select-selection-item-content">{label}</span>
+  );
 
   return (
-    <span className="ant-select-selection-item" title={(label as string) ?? ''}>
-      <span className="ant-select-selection-item-content">{label}</span>
+    <span className="ant-select-selection-item">
+      {labelNode}
       {closable && (
         <button className="ant-select-selection-item-remove" onClick={onClose}>
           <CloseIcon width={8} />

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvCellPreview/CsvCellPreview.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvCellPreview/CsvCellPreview.component.tsx
@@ -10,6 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+import { Tooltip } from '@openmetadata/ui-core-components';
 import { startCase } from 'lodash';
 import type { CSSProperties } from 'react';
 import { SEMICOLON_SPLITTER } from '../../../../constants/regex.constants';
@@ -152,12 +153,15 @@ const CsvCellPreview = ({ column, itemStyles, value }: CsvCellPreviewProps) => {
       content = (
         <div className="csv-cell-chips csv-cell-chips-custom-properties">
           {customPropertyItems.map((item) => (
-            <span
-              className="csv-chip csv-chip-prop"
+            <Tooltip
+              excludeTriggerFromTabOrder
               key={item.key}
               title={`${item.label}: ${item.value}`}>
-              {item.label}: <span className="csv-chip-value">{item.value}</span>
-            </span>
+              <span className="csv-chip csv-chip-prop">
+                {item.label}:{' '}
+                <span className="csv-chip-value">{item.value}</span>
+              </span>
+            </Tooltip>
           ))}
         </div>
       );
@@ -169,12 +173,14 @@ const CsvCellPreview = ({ column, itemStyles, value }: CsvCellPreviewProps) => {
           const { label } = parseEntity(item);
 
           return (
-            <span className="csv-owner-chip" key={item} title={label}>
-              <span className={`csv-owner-avatar ${getAvatarClass(label)}`}>
-                {getInitials(label)}
+            <Tooltip excludeTriggerFromTabOrder key={item} title={label}>
+              <span className="csv-owner-chip">
+                <span className={`csv-owner-avatar ${getAvatarClass(label)}`}>
+                  {getInitials(label)}
+                </span>
+                <span className="csv-owner-name">{label}</span>
               </span>
-              <span className="csv-owner-name">{label}</span>
-            </span>
+            </Tooltip>
           );
         })}
       </div>
@@ -188,13 +194,13 @@ const CsvCellPreview = ({ column, itemStyles, value }: CsvCellPreviewProps) => {
             column === 'glossaryTerms' ? getGlossaryTermLabel(item) : item;
 
           return (
-            <span
-              className={`csv-chip csv-chip-${variant}`}
-              key={item}
-              style={getChipStyle(column, item, itemStyles)}
-              title={item}>
-              {label}
-            </span>
+            <Tooltip excludeTriggerFromTabOrder key={item} title={item}>
+              <span
+                className={`csv-chip csv-chip-${variant}`}
+                style={getChipStyle(column, item, itemStyles)}>
+                {label}
+              </span>
+            </Tooltip>
           );
         })}
       </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvCellPreview/CsvCellPreview.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvCellPreview/CsvCellPreview.test.tsx
@@ -13,6 +13,16 @@
 import { render, screen } from '@testing-library/react';
 import CsvCellPreview from './CsvCellPreview.component';
 
+jest.mock('@openmetadata/ui-core-components', () => ({
+  Tooltip: ({
+    title,
+    children,
+  }: {
+    title?: React.ReactNode;
+    children: React.ReactNode;
+  }) => <span aria-label={String(title ?? '')}>{children}</span>,
+}));
+
 describe('CsvCellPreview', () => {
   it('should render an avatar chip for an owner', () => {
     render(<CsvCellPreview column="owners" value="user:admin" />);
@@ -47,7 +57,7 @@ describe('CsvCellPreview', () => {
       screen.getByText('BusinessGlossary / Revenue / NetSales')
     ).toBeInTheDocument();
     expect(
-      screen.getByTitle('BusinessGlossary.Revenue.NetSales')
+      screen.getByLabelText('BusinessGlossary.Revenue.NetSales')
     ).toBeInTheDocument();
   });
 
@@ -86,8 +96,10 @@ describe('CsvCellPreview', () => {
       />
     );
 
-    expect(screen.getByTitle('Cost Center: FIN-204')).toBeInTheDocument();
-    expect(screen.getByTitle('Review Cadence: Quarterly')).toBeInTheDocument();
+    expect(screen.getByLabelText('Cost Center: FIN-204')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Review Cadence: Quarterly')
+    ).toBeInTheDocument();
   });
 
   it('should render an em-dash when empty', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilderV1/fields/CoreArrayField.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilderV1/fields/CoreArrayField.test.tsx
@@ -21,6 +21,24 @@ jest.mock('@untitledui/icons', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  Button: jest.fn(
+    ({
+      children,
+      tooltip,
+      onPress,
+      iconLeading: Icon,
+    }: {
+      children?: React.ReactNode;
+      tooltip?: string;
+      onPress?: () => void;
+      iconLeading?: React.ElementType;
+    }) => (
+      <button aria-label={tooltip} onClick={() => onPress?.()}>
+        {Icon && <Icon />}
+        {children}
+      </button>
+    )
+  ),
   HintText: jest.fn(
     ({
       children,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilderV1/fields/CoreArrayField.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilderV1/fields/CoreArrayField.tsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2025 Collate.
+ *  Copyright 2026 Collate.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { HintText, Label, Tooltip } from '@openmetadata/ui-core-components';
+import { Button, HintText, Label } from '@openmetadata/ui-core-components';
 import { FieldProps } from '@rjsf/utils';
 import { Copy01, XClose } from '@untitledui/icons';
 import { isEmpty } from 'lodash';
@@ -161,21 +161,18 @@ const CoreArrayField = (props: FieldProps) => {
             onKeyDown={handleKeyDown}
           />
         )}
-        <Tooltip
-          title={
+        <Button
+          className="tw:ml-auto tw:rounded tw:p-0 tw:hover:bg-transparent"
+          color="tertiary"
+          iconLeading={Copy01}
+          tooltip={
             hasCopied ? t('message.copied-to-clipboard') : t('label.copy')
-          }>
-          <button
-            className="tw:ml-auto tw:flex tw:cursor-pointer tw:items-center tw:p-1 tw:text-fg-quaternary tw:transition-colors tw:duration-200 hover:tw:text-fg-quaternary_hover"
-            tabIndex={-1}
-            type="button"
-            onClick={async (e) => {
-              e.stopPropagation();
-              await onCopyToClipBoard();
-            }}>
-            <Copy01 size={14} />
-          </button>
-        </Tooltip>
+          }
+          onPress={async (e) => {
+            e.stopPropagation();
+            await onCopyToClipBoard();
+          }}
+        />
       </div>
       {isInvalid && rawErrors && <HintText isInvalid>{rawErrors[0]}</HintText>}
     </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/LogViewerModal/LogViewerModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/LogViewerModal/LogViewerModal.test.tsx
@@ -76,6 +76,32 @@ jest.mock('@melloware/react-logviewer', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  Button: ({
+    children,
+    onPress,
+    className,
+    'data-testid': testId,
+    'aria-label': ariaLabel,
+    'aria-pressed': ariaPressed,
+    onClick,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    className?: string;
+    'data-testid'?: string;
+    'aria-label'?: string;
+    'aria-pressed'?: boolean;
+    onClick?: () => void;
+  }) => (
+    <button
+      aria-label={ariaLabel}
+      aria-pressed={ariaPressed}
+      className={className}
+      data-testid={testId}
+      onClick={onClick ?? onPress}>
+      {children}
+    </button>
+  ),
   ModalOverlay: ({
     children,
     isOpen,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/LogViewerModal/LogViewerToolbarToggle.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/LogViewerModal/LogViewerToolbarToggle.component.tsx
@@ -10,31 +10,27 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Tooltip, TooltipTrigger } from '@openmetadata/ui-core-components';
+import { Button } from '@openmetadata/ui-core-components';
 import classNames from 'classnames';
 import { FunctionComponent } from 'react';
 import { LogViewerToolbarToggleProps } from './LogViewerToolbarToggle.interface';
 
-const TOOLTIP_DELAY_MS = 500;
-
-// The log viewer is a bespoke terminal surface with its own `lvm-*` palette, so
-// its toolbar toggles cannot use the library's utility buttons (which have no
-// pressed state) — this keeps the shared shape in one place instead.
 const LogViewerToolbarToggle: FunctionComponent<
   LogViewerToolbarToggleProps
 > = ({ icon, isActive, label, testId, onToggle }) => (
-  <Tooltip delay={TOOLTIP_DELAY_MS} placement="top" title={label}>
-    <TooltipTrigger
-      aria-label={label}
-      aria-pressed={isActive}
-      className={classNames('lvm-icon-button', {
-        'lvm-icon-button--active': isActive,
-      })}
-      data-testid={testId}
-      onPress={onToggle}>
-      {icon}
-    </TooltipTrigger>
-  </Tooltip>
+  <Button
+    aria-label={label}
+    aria-pressed={isActive}
+    className={classNames('lvm-icon-button', {
+      'lvm-icon-button--active': isActive,
+    })}
+    color="link-gray"
+    data-testid={testId}
+    tooltip={label}
+    tooltipPlacement="top"
+    onClick={onToggle}>
+    {icon}
+  </Button>
 );
 
 export default LogViewerToolbarToggle;

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TagRenderer/TagRenderer.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TagRenderer/TagRenderer.test.tsx
@@ -13,6 +13,16 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { TagRenderer } from './TagRenderer';
 
+jest.mock('@openmetadata/ui-core-components', () => ({
+  Tooltip: ({
+    title,
+    children,
+  }: {
+    title?: React.ReactNode;
+    children: React.ReactNode;
+  }) => <span aria-label={String(title ?? '')}>{children}</span>,
+}));
+
 describe('TagRenderer', () => {
   const mockOnClose = jest.fn();
   const defaultProps = {
@@ -40,7 +50,7 @@ describe('TagRenderer', () => {
     render(<TagRenderer {...defaultProps} label={longLabel} />);
 
     expect(screen.getByText('test persona...')).toBeInTheDocument();
-    expect(screen.getByTitle(longLabel)).toBeInTheDocument();
+    expect(screen.getByLabelText(longLabel)).toBeInTheDocument();
   });
 
   it('should render close button when closable is true', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TagRenderer/TagRenderer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TagRenderer/TagRenderer.tsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2025 Collate.
+ *  Copyright 2026 Collate.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 import { CloseOutlined } from '@ant-design/icons';
+import { Tooltip } from '@openmetadata/ui-core-components';
 import type { CustomTagProps } from 'rc-select/lib/BaseSelect';
 
 export const TagRenderer = (props: CustomTagProps) => {
@@ -20,9 +21,18 @@ export const TagRenderer = (props: CustomTagProps) => {
       ? `${label.substring(0, 12)}...`
       : label;
 
+  const labelNode =
+    typeof label === 'string' && label.length > 12 ? (
+      <Tooltip title={label}>
+        <span>{displayLabel}</span>
+      </Tooltip>
+    ) : (
+      <span>{displayLabel}</span>
+    );
+
   return (
-    <span className="ant-select-selection-item" title={(label as string) ?? ''}>
-      {displayLabel}
+    <span className="ant-select-selection-item">
+      {labelNode}
       {closable && (
         <button className="selected-chip-tag-remove" onClick={onClose}>
           <CloseOutlined />

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CSV/CSV.utils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CSV/CSV.utils.tsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024 Collate.
+ *  Copyright 2026 Collate.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Tooltip, TooltipTrigger } from '@openmetadata/ui-core-components';
+import { Tooltip } from '@openmetadata/ui-core-components';
 import { ChevronDown } from '@untitledui/icons';
 import { Typography } from 'antd';
 import { startCase } from 'lodash';
@@ -457,9 +457,7 @@ export const renderColumnDataEditor = (
           containerClassName="tw:max-w-sm tw:break-all"
           placement="top"
           title={value}>
-          <TooltipTrigger>
-            <span className="tw:block tw:truncate">{value}</span>
-          </TooltipTrigger>
+          <span className="tw:block tw:truncate">{value}</span>
         </Tooltip>
       ) : (
         value


### PR DESCRIPTION
Backport of #32211 to the `2.0` branch. Fixes #32239 (on 2.0).

## Summary

### `Tooltip` component (`ui-core-components`)
- **Auto-wrapping**: non-focusable children (`span`, `div`, SVG elements, etc.) are automatically wrapped in a focusable `AriaButton` so tooltip hover/focus works without a manual `<TooltipTrigger>`.
- Added `triggerClassName` (force-wrap React component children like SVG icons and style the generated wrapper), `onTriggerPress` (press handler on the wrapper), and `triggerIsDisabled` (keep the help-icon wrapper interactive when a surrounding field is disabled).
- Native `<button>` is now wrapped (react-aria hover does not reliably fire on native buttons via `cloneElement`).
- `TooltipTrigger` deprecated and updated with `forwardRef` so the ref reaches the underlying DOM button.

### `Button` component (`ui-core-components`)
- Added `tooltip?: string` and `tooltipPlacement?: Placement` — the button self-wraps in `<Tooltip>` when `tooltip` is set. `Button` is now `forwardRef`.

### `Typography` component (`ui-core-components`)
- Added standalone `tooltip?: ReactNode` prop — works independently of `ellipsis`.
- Ellipsis tooltip refactored onto the new `triggerClassName` / `onTriggerPress` props.

### ESLint rule — prevent new raw title attributes
- Added `openmetadata-ui-patterns/no-raw-title-attribute` (**error**) blocking new raw `title=""` on native HTML elements, guiding developers to `<Tooltip>`. Exempts legacy Ant Design `ant-select-selection-item`.

### App files
- Removed `TooltipTrigger` usage and raw `title` attributes across the affected components (StatItem, KeyProfileMetrics, LineageTabContent, SSO array field, CsvCellPreview, CoreArrayField, LogViewerToolbarToggle, TagRenderer, CSV utils, form-item-label, input/label, avatar, table).

## Backport notes
- Ports the net diff of the squash-merged #32211 onto `2.0`.
- **Excludes** `typography.test.tsx` (the file does not exist on `2.0`; the PR only added cases to it).
- Preserves pre-existing `2.0`-only divergences that are unrelated to this change (table sizing/`TABLE_SIZES`, `Typography` `color` prop, `CoreArrayField` key strategy, SSO `convertedValue` shape).

## Verification
- `tsc --noEmit` clean on `ui-core-components`.
- `eslint` clean on all changed `ui-core-components` files.
- `prettier --write` applied to every changed file.
- New `no-raw-title-attribute` rule loads and exports correctly; no raw `title=` remain on native elements in the changed components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)