### PR TITLE
Fixes #27825: build table custom properties as a `some` group for JsonLogic

### DIFF
--- a/.github/playwright/impact-map.generated.json
+++ b/.github/playwright/impact-map.generated.json
@@ -122,6 +122,7 @@
         "playwright/e2e/Flow/LineageSettings.spec.ts",
         "playwright/e2e/Flow/Metric.spec.ts",
         "playwright/e2e/Flow/Navbar.spec.ts",
+        "playwright/e2e/Flow/PasswordFieldClear.spec.ts",
         "playwright/e2e/Flow/ServiceCreationPermissions.spec.ts",
         "playwright/e2e/Flow/ServiceDocPanel.spec.ts",
         "playwright/e2e/Flow/ServiceForm.spec.ts",
@@ -334,6 +335,7 @@
         "playwright/e2e/Features/BulkImportWithDotInName.spec.ts",
         "playwright/e2e/Features/DataAssetRulesDisabled.spec.ts",
         "playwright/e2e/Features/Permissions/ServiceEntityPermissions.spec.ts",
+        "playwright/e2e/Flow/PasswordFieldClear.spec.ts",
         "playwright/e2e/Flow/ServiceForm.spec.ts",
         "playwright/e2e/Pages/ServiceEntity.spec.ts",
         "playwright/e2e/Pages/ServiceListing.spec.ts"
@@ -1805,6 +1807,7 @@
         "playwright/e2e/Features/DataAssetRulesDisabled.spec.ts",
         "playwright/e2e/Features/DataAssetRulesEnabled.spec.ts",
         "playwright/e2e/Features/Pagination.spec.ts",
+        "playwright/e2e/Flow/PasswordFieldClear.spec.ts",
         "playwright/e2e/Pages/Lineage/LineageRightPanel.spec.ts",
         "playwright/e2e/Pages/ServiceEntity.spec.ts",
         "playwright/e2e/Pages/ServiceListing.spec.ts",
@@ -1823,6 +1826,7 @@
         "playwright/e2e/Features/IngestionListNameSorting.spec.ts",
         "playwright/e2e/Features/PersonaAIContext.spec.ts",
         "playwright/e2e/Features/ServiceAgentsLiveProgress.spec.ts",
+        "playwright/e2e/Flow/PasswordFieldClear.spec.ts",
         "playwright/e2e/Flow/ServiceCreationPermissions.spec.ts",
         "playwright/e2e/Flow/ServiceForm.spec.ts",
         "playwright/e2e/Pages/Lineage/LineageRightPanel.spec.ts",
@@ -1851,6 +1855,7 @@
       "specs": [
         "playwright/e2e/Features/DataAssetRulesDisabled.spec.ts",
         "playwright/e2e/Features/DataAssetRulesEnabled.spec.ts",
+        "playwright/e2e/Flow/PasswordFieldClear.spec.ts",
         "playwright/e2e/Flow/ServiceForm.spec.ts",
         "playwright/e2e/Pages/Lineage/LineageRightPanel.spec.ts",
         "playwright/e2e/Pages/ServiceEntity.spec.ts",
@@ -2073,6 +2078,7 @@
         "playwright/e2e/Flow/Navbar.spec.ts",
         "playwright/e2e/Flow/NestedChildrenUpdates.spec.ts",
         "playwright/e2e/Flow/NotificationAlerts.spec.ts",
+        "playwright/e2e/Flow/PasswordFieldClear.spec.ts",
         "playwright/e2e/Flow/ServiceCreationPermissions.spec.ts",
         "playwright/e2e/Flow/ServiceDocPanel.spec.ts",
         "playwright/e2e/Flow/ServiceForm.spec.ts",
@@ -3158,6 +3164,7 @@
         "playwright/e2e/Flow/NestedChildrenUpdates.spec.ts",
         "playwright/e2e/Flow/NotificationAlerts.spec.ts",
         "playwright/e2e/Flow/ObservabilityAlerts.spec.ts",
+        "playwright/e2e/Flow/PasswordFieldClear.spec.ts",
         "playwright/e2e/Flow/PersonaDeletionUserProfile.spec.ts",
         "playwright/e2e/Flow/PersonaFlow.spec.ts",
         "playwright/e2e/Flow/PlatformLineage.spec.ts",
@@ -3606,6 +3613,7 @@
         "playwright/e2e/Flow/NestedChildrenUpdates.spec.ts",
         "playwright/e2e/Flow/NotificationAlerts.spec.ts",
         "playwright/e2e/Flow/ObservabilityAlerts.spec.ts",
+        "playwright/e2e/Flow/PasswordFieldClear.spec.ts",
         "playwright/e2e/Flow/PersonaDeletionUserProfile.spec.ts",
         "playwright/e2e/Flow/PersonaFlow.spec.ts",
         "playwright/e2e/Flow/SchemaTable.spec.ts",
@@ -4115,6 +4123,7 @@
         "playwright/e2e/Features/BulkImportWithDotInName.spec.ts",
         "playwright/e2e/Features/DataAssetRulesDisabled.spec.ts",
         "playwright/e2e/Flow/IngestionBot.spec.ts",
+        "playwright/e2e/Flow/PasswordFieldClear.spec.ts",
         "playwright/e2e/Flow/ServiceCreationPermissions.spec.ts",
         "playwright/e2e/Flow/ServiceForm.spec.ts",
         "playwright/e2e/Pages/Entity.spec.ts"
@@ -4143,6 +4152,7 @@
         "playwright/e2e/Features/ServiceAgentsPauseResume.spec.ts",
         "playwright/e2e/Features/ServiceAgentsStatusDegradation.spec.ts",
         "playwright/e2e/Flow/ApiServiceRest.spec.ts",
+        "playwright/e2e/Flow/PasswordFieldClear.spec.ts",
         "playwright/e2e/Flow/ServiceCreationPermissions.spec.ts",
         "playwright/e2e/Flow/ServiceDocPanel.spec.ts",
         "playwright/e2e/Flow/ServiceForm.spec.ts",
@@ -9768,6 +9778,7 @@
         "playwright/e2e/Flow/NestedChildrenUpdates.spec.ts",
         "playwright/e2e/Flow/NotificationAlerts.spec.ts",
         "playwright/e2e/Flow/ObservabilityAlerts.spec.ts",
+        "playwright/e2e/Flow/PasswordFieldClear.spec.ts",
         "playwright/e2e/Flow/PersonaDeletionUserProfile.spec.ts",
         "playwright/e2e/Flow/PersonaFlow.spec.ts",
         "playwright/e2e/Flow/PlatformLineage.spec.ts",
@@ -10673,6 +10684,7 @@
         "openmetadata-ui/src/main/resources/ui/src/pages/ServiceDetailsPage/ServiceDetailsPage.tsx"
       ],
       "specs": [
+        "playwright/e2e/Flow/PasswordFieldClear.spec.ts",
         "playwright/e2e/Flow/ServiceCreationPermissions.spec.ts",
         "playwright/e2e/Flow/ServiceForm.spec.ts",
         "playwright/e2e/Flow/TestConnectionModal.spec.ts"
@@ -11114,6 +11126,7 @@
         "openmetadata-ui/src/main/resources/ui/src/utils/TestConnectionModalUtils.tsx"
       ],
       "specs": [
+        "playwright/e2e/Flow/PasswordFieldClear.spec.ts",
         "playwright/e2e/Flow/ServiceCreationPermissions.spec.ts",
         "playwright/e2e/Flow/ServiceForm.spec.ts",
         "playwright/e2e/Flow/TestConnectionModal.spec.ts"

--- a/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
@@ -500,6 +500,13 @@ export const LIST_VALUE_OPERATORS = ['select_equals', 'select_not_equals'];
 
 export const NULL_CHECK_OPERATORS = ['is_null', 'is_not_null'];
 
+export const SELECT_TEXT_FIELD_OPERATORS = [
+  ...LIST_VALUE_OPERATORS,
+  'like',
+  'not_like',
+  ...NULL_CHECK_OPERATORS,
+];
+
 export const OWNER_QUICK_FILTER_DEFAULT_OPTIONS_KEY = 'displayName.keyword';
 
 export const NULL_OPTION_KEY = 'OM_NULL_FIELD';

--- a/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
@@ -500,6 +500,18 @@ export const LIST_VALUE_OPERATORS = ['select_equals', 'select_not_equals'];
 
 export const NULL_CHECK_OPERATORS = ['is_null', 'is_not_null'];
 
+// The `select` counterpart of TEXT_FIELD_OPERATORS. A select field takes
+// `select_equals` / `select_not_equals` rather than `equal` / `not_equal`, and
+// gets `like` / `not_like` from the text widget both query-builder configs add
+// to the select type. Using TEXT_FIELD_OPERATORS on a select leaves the field
+// with no valid operator, so it silently cannot build a rule at all.
+export const SELECT_TEXT_FIELD_OPERATORS = [
+  ...LIST_VALUE_OPERATORS,
+  'like',
+  'not_like',
+  ...NULL_CHECK_OPERATORS,
+];
+
 export const OWNER_QUICK_FILTER_DEFAULT_OPTIONS_KEY = 'displayName.keyword';
 
 export const NULL_OPTION_KEY = 'OM_NULL_FIELD';

--- a/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
@@ -500,11 +500,6 @@ export const LIST_VALUE_OPERATORS = ['select_equals', 'select_not_equals'];
 
 export const NULL_CHECK_OPERATORS = ['is_null', 'is_not_null'];
 
-// The `select` counterpart of TEXT_FIELD_OPERATORS. A select field takes
-// `select_equals` / `select_not_equals` rather than `equal` / `not_equal`, and
-// gets `like` / `not_like` from the text widget both query-builder configs add
-// to the select type. Using TEXT_FIELD_OPERATORS on a select leaves the field
-// with no valid operator, so it silently cannot build a rule at all.
 export const SELECT_TEXT_FIELD_OPERATORS = [
   ...LIST_VALUE_OPERATORS,
   'like',

--- a/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
@@ -500,13 +500,6 @@ export const LIST_VALUE_OPERATORS = ['select_equals', 'select_not_equals'];
 
 export const NULL_CHECK_OPERATORS = ['is_null', 'is_not_null'];
 
-export const SELECT_TEXT_FIELD_OPERATORS = [
-  ...LIST_VALUE_OPERATORS,
-  'like',
-  'not_like',
-  ...NULL_CHECK_OPERATORS,
-];
-
 export const OWNER_QUICK_FILTER_DEFAULT_OPTIONS_KEY = 'displayName.keyword';
 
 export const NULL_OPTION_KEY = 'OM_NULL_FIELD';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.test.ts
@@ -22,6 +22,7 @@ import { SearchOutputType } from '../components/Explore/AdvanceSearchProvider/Ad
 import {
   MULTISELECT_FIELD_OPERATORS,
   NUMBER_FIELD_OPERATORS,
+  SELECT_TEXT_FIELD_OPERATORS,
   TEXT_FIELD_OPERATORS,
 } from '../constants/AdvancedSearch.constants';
 import { EntityFields } from '../enums/AdvancedSearch.enum';
@@ -1434,8 +1435,11 @@ describe('table-cp custom property sub-fields', () => {
       ].map(({ subfieldsKey, dataObject }) => [subfieldsKey, dataObject])
     );
 
+    // Derived from the class's own config rather than bare CoreConfig: the real
+    // types/operators/widgets are what decide whether a field's operator set is
+    // valid at all, and CoreConfig alone does not carry them.
     return {
-      ...CoreConfig,
+      ...new AdvancedSearchClassBase().getInitialConfigWithoutFields(false),
       fields: {
         extension: {
           label: 'label.custom-property-plural',
@@ -1488,30 +1492,34 @@ describe('table-cp custom property sub-fields', () => {
   it('should model rows as a some group holding one sub-field per column for JsonLogic output', () => {
     expect(subFieldsFor(mockField, SearchOutputType.JSONLogic)).toEqual([
       {
-        subfieldsKey: 'tableType',
+        subfieldsKey: 'tableType.rows',
         dataObject: {
           __omPropertyType: 'table-cp',
-          label: 'tableType',
-          type: '!struct',
+          label: 'tableType - label.row-plural',
+          type: '!group',
+          mode: 'some',
+          defaultField: 'name',
           subfields: {
-            rows: {
-              label: 'label.row-plural',
-              type: '!group',
-              mode: 'some',
-              defaultField: 'name',
-              subfields: {
-                name: {
-                  type: 'text',
-                  label: 'name',
-                  operators: TEXT_FIELD_OPERATORS,
-                  valueSources: ['value'],
-                },
-                age: {
-                  type: 'text',
-                  label: 'age',
-                  operators: TEXT_FIELD_OPERATORS,
-                  valueSources: ['value'],
-                },
+            name: {
+              type: 'select',
+              label: 'name',
+              operators: SELECT_TEXT_FIELD_OPERATORS,
+              valueSources: ['value'],
+              fieldSettings: {
+                allowCustomValues: true,
+                showSearch: true,
+                useAsyncSearch: false,
+              },
+            },
+            age: {
+              type: 'select',
+              label: 'age',
+              operators: SELECT_TEXT_FIELD_OPERATORS,
+              valueSources: ['value'],
+              fieldSettings: {
+                allowCustomValues: true,
+                showSearch: true,
+                useAsyncSearch: false,
               },
             },
           },
@@ -1520,16 +1528,39 @@ describe('table-cp custom property sub-fields', () => {
     ]);
   });
 
-  it('should rewrite a legacy flat rows rule into a some group', () => {
-    const legacyLogic = {
-      and: [{ '==': [{ var: `${ROWS_VAR}.name` }, 'karan'] }],
+  // migrateJsonLogic has to find the flat var wherever the operator puts it -
+  // `like` exports as `{in: [value, {var}]}`, so it is not always argument 0.
+  it.each([
+    [
+      'equal',
+      { '==': [{ var: `${ROWS_VAR}.name` }, 'karan'] },
+      { '==': [{ var: 'name' }, 'karan'] },
+    ],
+    [
+      'like',
+      { in: ['kar', { var: `${ROWS_VAR}.name` }] },
+      { in: ['kar', { var: 'name' }] },
+    ],
+    [
+      'is_not_null',
+      { '!=': [{ var: `${ROWS_VAR}.name` }, null] },
+      { '!=': [{ var: 'name' }, null] },
+    ],
+  ])(
+    'should rewrite a legacy flat %s rule into a some group',
+    (_name, legacyRule, expectedCondition) => {
+      expect(roundTrip({ and: [legacyRule] }, buildJsonLogicConfig())).toEqual({
+        and: [{ some: [{ var: ROWS_VAR }, expectedCondition] }],
+      });
+    }
+  );
+
+  it('should leave an already-migrated rule alone', () => {
+    const logic = {
+      and: [{ some: [{ var: ROWS_VAR }, { in: ['kar', { var: 'name' }] }] }],
     };
 
-    expect(roundTrip(legacyLogic, buildJsonLogicConfig())).toEqual({
-      and: [
-        { some: [{ var: ROWS_VAR }, { '==': [{ var: 'name' }, 'karan'] }] },
-      ],
-    });
+    expect(roundTrip(logic, buildJsonLogicConfig())).toEqual(logic);
   });
 
   it('should keep a scalar custom property usable alongside the rows group', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.test.ts
@@ -15,7 +15,7 @@ import {
   ConfigContext,
   CoreConfig,
   ImmutableTree,
-  Utils,
+  Utils as QbUtils,
 } from '@react-awesome-query-builder/core';
 import { AxiosHeaders } from 'axios';
 import { SearchOutputType } from '../components/Explore/AdvanceSearchProvider/AdvanceSearchProvider.interface';
@@ -31,6 +31,7 @@ import { getAggregateFieldOptions } from '../rest/miscAPI';
 import { AdvancedSearchClassBase } from './AdvancedSearchClassBase';
 import { getCustomPropertyAdvanceSearchEnumOptions } from './AdvancedSearchPureUtils';
 import { getEntityName } from './EntityNameUtils';
+import { migrateJsonLogic } from './QueryBuilderPureUtils';
 jest.mock('../rest/miscAPI', () => ({
   getAggregateFieldOptions: jest.fn().mockImplementation(() =>
     Promise.resolve({
@@ -1388,8 +1389,9 @@ describe('buildEnumAsyncFetch', () => {
   });
 });
 
-describe('table-cp custom property with JSONLogic output', () => {
+describe('table-cp custom property sub-fields', () => {
   const mockGetEntityName = getEntityName as jest.Mock;
+  const ROWS_VAR = 'extension.tableType.rows';
   const mockField = {
     name: 'tableType',
     type: 'table-cp',
@@ -1400,28 +1402,36 @@ describe('table-cp custom property with JSONLogic output', () => {
     },
   } as unknown as CustomPropertySummary;
 
-  // The rule shape the workflow rule engine evaluates against
-  // `extension.tableType.rows`, which is an array of `{ <column>: <cell> }`.
-  const expectedLogic = {
-    and: [
-      {
-        some: [
-          { var: 'extension.tableType.rows' },
-          { '==': [{ var: 'name' }, 'karan'] },
-        ],
-      },
-    ],
+  // A scalar custom property that has to keep working alongside the group.
+  const mockScalarField = {
+    name: 'stringProp',
+    type: 'string',
+  } as unknown as CustomPropertySummary;
+
+  const subFieldsFor = (
+    field: CustomPropertySummary,
+    searchOutputType: SearchOutputType
+  ) => {
+    const result = new AdvancedSearchClassBase().getCustomPropertiesSubFields(
+      field,
+      searchOutputType
+    );
+
+    return Array.isArray(result) ? result : [result];
   };
 
+  // Mirrors what QueryBuilderWidget builds for JsonLogic output: the custom
+  // property sub-fields hung off the `extension` struct.
   const buildJsonLogicConfig = () => {
-    const result = new AdvancedSearchClassBase().getCustomPropertiesSubFields(
-      mockField,
-      SearchOutputType.JSONLogic
+    mockGetEntityName.mockImplementation(
+      (field: CustomPropertySummary) => field.name
     );
+
     const subfields = Object.fromEntries(
-      (Array.isArray(result) ? result : [result]).map(
-        ({ subfieldsKey, dataObject }) => [subfieldsKey, dataObject]
-      )
+      [
+        ...subFieldsFor(mockField, SearchOutputType.JSONLogic),
+        ...subFieldsFor(mockScalarField, SearchOutputType.JSONLogic),
+      ].map(({ subfieldsKey, dataObject }) => [subfieldsKey, dataObject])
     );
 
     return {
@@ -1436,18 +1446,47 @@ describe('table-cp custom property with JSONLogic output', () => {
     } as unknown as Config;
   };
 
+  // Mirrors QueryBuilderWidget's load -> save cycle: migrateJsonLogic, then
+  // loadFromJsonLogic, then sanitizeTree, then jsonLogicFormat.
+  const roundTrip = (logic: Record<string, unknown>, config: Config) => {
+    const tree = QbUtils.loadFromJsonLogic(migrateJsonLogic(logic), config);
+
+    expect(tree).toBeDefined();
+
+    const { fixedTree } = QbUtils.Validation.sanitizeTree(
+      tree as ImmutableTree,
+      config
+    );
+    const { logic: exported, errors } = QbUtils.jsonLogicFormat(
+      fixedTree,
+      config
+    );
+
+    expect(errors).toEqual([]);
+
+    return exported;
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetEntityName.mockReturnValue('tableType');
   });
 
-  it('should model rows as a some group holding one sub-field per column', () => {
-    const result = new AdvancedSearchClassBase().getCustomPropertiesSubFields(
-      mockField,
-      SearchOutputType.JSONLogic
-    );
+  it('should keep the flat rows sub-fields for ElasticSearch output', () => {
+    const result = subFieldsFor(mockField, SearchOutputType.ElasticSearch);
 
-    expect(result).toEqual([
+    expect(result.map(({ subfieldsKey }) => subfieldsKey)).toEqual([
+      'tableType.rows.name',
+      'tableType.rows.age',
+    ]);
+    expect(result.map(({ dataObject }) => dataObject.type)).toEqual([
+      'text',
+      'text',
+    ]);
+  });
+
+  it('should model rows as a some group holding one sub-field per column for JsonLogic output', () => {
+    expect(subFieldsFor(mockField, SearchOutputType.JSONLogic)).toEqual([
       {
         subfieldsKey: 'tableType',
         dataObject: {
@@ -1481,26 +1520,74 @@ describe('table-cp custom property with JSONLogic output', () => {
     ]);
   });
 
-  it('should export a rule that iterates the rows array with some', () => {
-    const config = buildJsonLogicConfig();
-    const tree = Utils.loadFromJsonLogic(expectedLogic, config);
+  it('should rewrite a legacy flat rows rule into a some group', () => {
+    const legacyLogic = {
+      and: [{ '==': [{ var: `${ROWS_VAR}.name` }, 'karan'] }],
+    };
 
-    expect(tree).toBeDefined();
-    expect(Utils.jsonLogicFormat(tree as ImmutableTree, config).logic).toEqual(
-      expectedLogic
-    );
+    expect(roundTrip(legacyLogic, buildJsonLogicConfig())).toEqual({
+      and: [
+        { some: [{ var: ROWS_VAR }, { '==': [{ var: 'name' }, 'karan'] }] },
+      ],
+    });
   });
 
-  it('should rewrite a legacy flat rows rule into a some group', () => {
-    const config = buildJsonLogicConfig();
-    const legacyLogic = {
-      and: [{ '==': [{ var: 'extension.tableType.rows.name' }, 'karan'] }],
+  it('should keep a scalar custom property usable alongside the rows group', () => {
+    const logic = {
+      and: [
+        { some: [{ var: ROWS_VAR }, { '==': [{ var: 'name' }, 'karan'] }] },
+        { '==': [{ var: 'extension.stringProp' }, 'x'] },
+      ],
     };
-    const tree = Utils.loadFromJsonLogic(legacyLogic, config);
 
-    expect(tree).toBeDefined();
-    expect(Utils.jsonLogicFormat(tree as ImmutableTree, config).logic).toEqual(
-      expectedLogic
-    );
+    expect(roundTrip(logic, buildJsonLogicConfig())).toEqual(logic);
+  });
+
+  // Every operator TEXT_FIELD_OPERATORS exposes on a column, plus the shapes
+  // the builder wraps them in, has to survive the widget's load/save cycle.
+  it.each([
+    ['equal', { '==': [{ var: 'name' }, 'karan'] }],
+    ['not_equal', { '!=': [{ var: 'name' }, 'karan'] }],
+    ['like', { in: ['kar', { var: 'name' }] }],
+    ['is_not_null', { '!=': [{ var: 'name' }, null] }],
+    ['is_null', { '==': [{ var: 'name' }, null] }],
+    [
+      'two columns',
+      {
+        and: [
+          { '==': [{ var: 'name' }, 'karan'] },
+          { '==': [{ var: 'age' }, '30'] },
+        ],
+      },
+    ],
+  ])('should round-trip a %s rule on a rows column', (_name, condition) => {
+    const logic = { and: [{ some: [{ var: ROWS_VAR }, condition] }] };
+
+    expect(roundTrip(logic, buildJsonLogicConfig())).toEqual(logic);
+  });
+
+  it('should round-trip a negated rows group', () => {
+    const logic = {
+      and: [
+        {
+          '!': {
+            some: [{ var: ROWS_VAR }, { '==': [{ var: 'name' }, 'karan'] }],
+          },
+        },
+      ],
+    };
+
+    expect(roundTrip(logic, buildJsonLogicConfig())).toEqual(logic);
+  });
+
+  it('should return no sub-fields when the property defines no columns', () => {
+    const noColumns = {
+      name: 'tableType',
+      type: 'table-cp',
+      customPropertyConfig: { config: { columns: [] } },
+    } as unknown as CustomPropertySummary;
+
+    expect(subFieldsFor(noColumns, SearchOutputType.JSONLogic)).toEqual([]);
+    expect(subFieldsFor(noColumns, SearchOutputType.ElasticSearch)).toEqual([]);
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.test.ts
@@ -21,6 +21,7 @@ import { SearchOutputType } from '../components/Explore/AdvanceSearchProvider/Ad
 import {
   MULTISELECT_FIELD_OPERATORS,
   NUMBER_FIELD_OPERATORS,
+  SELECT_TEXT_FIELD_OPERATORS,
   TEXT_FIELD_OPERATORS,
 } from '../constants/AdvancedSearch.constants';
 import { EntityFields } from '../enums/AdvancedSearch.enum';
@@ -1491,16 +1492,24 @@ describe('table-cp custom property sub-fields', () => {
           defaultField: 'name',
           subfields: {
             name: {
-              type: 'text',
+              type: 'select',
               label: 'tableType - name',
-              operators: TEXT_FIELD_OPERATORS,
+              operators: SELECT_TEXT_FIELD_OPERATORS,
               valueSources: ['value'],
+              fieldSettings: {
+                allowCustomValues: true,
+                useAsyncSearch: false,
+              },
             },
             age: {
-              type: 'text',
+              type: 'select',
               label: 'tableType - age',
-              operators: TEXT_FIELD_OPERATORS,
+              operators: SELECT_TEXT_FIELD_OPERATORS,
               valueSources: ['value'],
+              fieldSettings: {
+                allowCustomValues: true,
+                useAsyncSearch: false,
+              },
             },
           },
         },

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.test.ts
@@ -13,7 +13,6 @@
 import {
   Config,
   ConfigContext,
-  CoreConfig,
   ImmutableTree,
   Utils as QbUtils,
 } from '@react-awesome-query-builder/core';
@@ -1403,7 +1402,6 @@ describe('table-cp custom property sub-fields', () => {
     },
   } as unknown as CustomPropertySummary;
 
-  // A scalar custom property that has to keep working alongside the group.
   const mockScalarField = {
     name: 'stringProp',
     type: 'string',
@@ -1421,8 +1419,6 @@ describe('table-cp custom property sub-fields', () => {
     return Array.isArray(result) ? result : [result];
   };
 
-  // Mirrors what QueryBuilderWidget builds for JsonLogic output: the custom
-  // property sub-fields hung off the `extension` struct.
   const buildJsonLogicConfig = () => {
     mockGetEntityName.mockImplementation(
       (field: CustomPropertySummary) => field.name
@@ -1435,9 +1431,6 @@ describe('table-cp custom property sub-fields', () => {
       ].map(({ subfieldsKey, dataObject }) => [subfieldsKey, dataObject])
     );
 
-    // Derived from the class's own config rather than bare CoreConfig: the real
-    // types/operators/widgets are what decide whether a field's operator set is
-    // valid at all, and CoreConfig alone does not carry them.
     return {
       ...new AdvancedSearchClassBase().getInitialConfigWithoutFields(false),
       fields: {
@@ -1450,8 +1443,6 @@ describe('table-cp custom property sub-fields', () => {
     } as unknown as Config;
   };
 
-  // Mirrors QueryBuilderWidget's load -> save cycle: migrateJsonLogic, then
-  // loadFromJsonLogic, then sanitizeTree, then jsonLogicFormat.
   const roundTrip = (logic: Record<string, unknown>, config: Config) => {
     const tree = QbUtils.loadFromJsonLogic(migrateJsonLogic(logic), config);
 
@@ -1539,8 +1530,6 @@ describe('table-cp custom property sub-fields', () => {
     expect(roundTrip(logic, buildJsonLogicConfig())).toEqual(logic);
   });
 
-  // Every operator TEXT_FIELD_OPERATORS exposes on a column, plus the shapes
-  // the builder wraps them in, has to survive the widget's load/save cycle.
   it.each([
     ['equal', { '==': [{ var: 'name' }, 'karan'] }],
     ['not_equal', { '!=': [{ var: 'name' }, 'karan'] }],

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.test.ts
@@ -10,7 +10,13 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Config, ConfigContext } from '@react-awesome-query-builder/core';
+import {
+  Config,
+  ConfigContext,
+  CoreConfig,
+  ImmutableTree,
+  Utils,
+} from '@react-awesome-query-builder/core';
 import { AxiosHeaders } from 'axios';
 import { SearchOutputType } from '../components/Explore/AdvanceSearchProvider/AdvanceSearchProvider.interface';
 import {
@@ -1379,5 +1385,122 @@ describe('buildEnumAsyncFetch', () => {
 
     expect(result.values).toHaveLength(2);
     expect(result.values.map((v) => v.value)).toEqual(['Active', 'ACTIVE']);
+  });
+});
+
+describe('table-cp custom property with JSONLogic output', () => {
+  const mockGetEntityName = getEntityName as jest.Mock;
+  const mockField = {
+    name: 'tableType',
+    type: 'table-cp',
+    customPropertyConfig: {
+      config: {
+        columns: ['name', 'age'],
+      },
+    },
+  } as unknown as CustomPropertySummary;
+
+  // The rule shape the workflow rule engine evaluates against
+  // `extension.tableType.rows`, which is an array of `{ <column>: <cell> }`.
+  const expectedLogic = {
+    and: [
+      {
+        some: [
+          { var: 'extension.tableType.rows' },
+          { '==': [{ var: 'name' }, 'karan'] },
+        ],
+      },
+    ],
+  };
+
+  const buildJsonLogicConfig = () => {
+    const result = new AdvancedSearchClassBase().getCustomPropertiesSubFields(
+      mockField,
+      SearchOutputType.JSONLogic
+    );
+    const subfields = Object.fromEntries(
+      (Array.isArray(result) ? result : [result]).map(
+        ({ subfieldsKey, dataObject }) => [subfieldsKey, dataObject]
+      )
+    );
+
+    return {
+      ...CoreConfig,
+      fields: {
+        extension: {
+          label: 'label.custom-property-plural',
+          type: '!struct',
+          subfields,
+        },
+      },
+    } as unknown as Config;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetEntityName.mockReturnValue('tableType');
+  });
+
+  it('should model rows as a some group holding one sub-field per column', () => {
+    const result = new AdvancedSearchClassBase().getCustomPropertiesSubFields(
+      mockField,
+      SearchOutputType.JSONLogic
+    );
+
+    expect(result).toEqual([
+      {
+        subfieldsKey: 'tableType',
+        dataObject: {
+          __omPropertyType: 'table-cp',
+          label: 'tableType',
+          type: '!struct',
+          subfields: {
+            rows: {
+              label: 'label.row-plural',
+              type: '!group',
+              mode: 'some',
+              defaultField: 'name',
+              subfields: {
+                name: {
+                  type: 'text',
+                  label: 'name',
+                  operators: TEXT_FIELD_OPERATORS,
+                  valueSources: ['value'],
+                },
+                age: {
+                  type: 'text',
+                  label: 'age',
+                  operators: TEXT_FIELD_OPERATORS,
+                  valueSources: ['value'],
+                },
+              },
+            },
+          },
+        },
+      },
+    ]);
+  });
+
+  it('should export a rule that iterates the rows array with some', () => {
+    const config = buildJsonLogicConfig();
+    const tree = Utils.loadFromJsonLogic(expectedLogic, config);
+
+    expect(tree).toBeDefined();
+    expect(Utils.jsonLogicFormat(tree as ImmutableTree, config).logic).toEqual(
+      expectedLogic
+    );
+  });
+
+  it('should rewrite a legacy flat rows rule into a some group', () => {
+    const config = buildJsonLogicConfig();
+    const legacyLogic = {
+      and: [{ '==': [{ var: 'extension.tableType.rows.name' }, 'karan'] }],
+    };
+    const tree = Utils.loadFromJsonLogic(legacyLogic, config);
+
+    expect(tree).toBeDefined();
+    expect(Utils.jsonLogicFormat(tree as ImmutableTree, config).logic).toEqual(
+      expectedLogic
+    );
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.test.ts
@@ -21,7 +21,6 @@ import { SearchOutputType } from '../components/Explore/AdvanceSearchProvider/Ad
 import {
   MULTISELECT_FIELD_OPERATORS,
   NUMBER_FIELD_OPERATORS,
-  SELECT_TEXT_FIELD_OPERATORS,
   TEXT_FIELD_OPERATORS,
 } from '../constants/AdvancedSearch.constants';
 import { EntityFields } from '../enums/AdvancedSearch.enum';
@@ -1492,26 +1491,16 @@ describe('table-cp custom property sub-fields', () => {
           defaultField: 'name',
           subfields: {
             name: {
-              type: 'select',
-              label: 'name',
-              operators: SELECT_TEXT_FIELD_OPERATORS,
+              type: 'text',
+              label: 'tableType - name',
+              operators: TEXT_FIELD_OPERATORS,
               valueSources: ['value'],
-              fieldSettings: {
-                allowCustomValues: true,
-                showSearch: true,
-                useAsyncSearch: false,
-              },
             },
             age: {
-              type: 'select',
-              label: 'age',
-              operators: SELECT_TEXT_FIELD_OPERATORS,
+              type: 'text',
+              label: 'tableType - age',
+              operators: TEXT_FIELD_OPERATORS,
               valueSources: ['value'],
-              fieldSettings: {
-                allowCustomValues: true,
-                showSearch: true,
-                useAsyncSearch: false,
-              },
             },
           },
         },

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.test.ts
@@ -1528,41 +1528,6 @@ describe('table-cp custom property sub-fields', () => {
     ]);
   });
 
-  // migrateJsonLogic has to find the flat var wherever the operator puts it -
-  // `like` exports as `{in: [value, {var}]}`, so it is not always argument 0.
-  it.each([
-    [
-      'equal',
-      { '==': [{ var: `${ROWS_VAR}.name` }, 'karan'] },
-      { '==': [{ var: 'name' }, 'karan'] },
-    ],
-    [
-      'like',
-      { in: ['kar', { var: `${ROWS_VAR}.name` }] },
-      { in: ['kar', { var: 'name' }] },
-    ],
-    [
-      'is_not_null',
-      { '!=': [{ var: `${ROWS_VAR}.name` }, null] },
-      { '!=': [{ var: 'name' }, null] },
-    ],
-  ])(
-    'should rewrite a legacy flat %s rule into a some group',
-    (_name, legacyRule, expectedCondition) => {
-      expect(roundTrip({ and: [legacyRule] }, buildJsonLogicConfig())).toEqual({
-        and: [{ some: [{ var: ROWS_VAR }, expectedCondition] }],
-      });
-    }
-  );
-
-  it('should leave an already-migrated rule alone', () => {
-    const logic = {
-      and: [{ some: [{ var: ROWS_VAR }, { in: ['kar', { var: 'name' }] }] }],
-    };
-
-    expect(roundTrip(logic, buildJsonLogicConfig())).toEqual(logic);
-  });
-
   it('should keep a scalar custom property usable alongside the rows group', () => {
     const logic = {
       and: [

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
@@ -34,7 +34,6 @@ import {
   NULL_CHECK_OPERATORS,
   NUMBER_FIELD_OPERATORS,
   SEARCH_INDICES_WITH_COLUMNS_FIELD,
-  SELECT_TEXT_FIELD_OPERATORS,
   TAG_LABEL_TYPE_LIST_VALUES,
   TEXT_FIELD_OPERATORS,
 } from '../constants/AdvancedSearch.constants';
@@ -1555,15 +1554,10 @@ class AdvancedSearchClassBase {
             columns.map((columnName) => [
               columnName,
               {
-                type: 'select',
-                label: columnName,
-                operators: SELECT_TEXT_FIELD_OPERATORS,
+                type: 'text',
+                label: `${label} - ${columnName}`,
+                operators: TEXT_FIELD_OPERATORS,
                 valueSources: ['value'],
-                fieldSettings: {
-                  allowCustomValues: true,
-                  showSearch: true,
-                  useAsyncSearch: false,
-                },
               },
             ])
           );

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
@@ -15,9 +15,11 @@ import {
   type AsyncFetchListValuesResult,
   type BasicConfig,
   type Field,
+  type FieldPath,
   type Fields,
   type ListItem,
   type ListValues,
+  type RuleGroupMode,
   type SelectFieldSettings,
 } from '@react-awesome-query-builder/ui';
 import { debounce, isEmpty, sortBy, toLower } from 'lodash';
@@ -71,7 +73,16 @@ const MULTI_VALUE_CUSTOM_PROPERTY_TYPES: string[] = [
   'table-cp',
 ];
 
-type OMField = Field & { __omPropertyType: CustomPropertySummary['type'] };
+// Sub-field config, plus the `!struct` / `!group` keys used by nested types.
+type OMFieldOrGroup = Field & {
+  subfields?: Fields;
+  mode?: RuleGroupMode;
+  defaultField?: FieldPath;
+};
+
+type OMField = OMFieldOrGroup & {
+  __omPropertyType: CustomPropertySummary['type'];
+};
 
 class AdvancedSearchClassBase {
   baseConfig = OMConfig;
@@ -1355,7 +1366,7 @@ class AdvancedSearchClassBase {
     const result = this.buildCustomPropertiesSubFields(field, searchOutputType);
     const attachType = (entry: {
       subfieldsKey: string;
-      dataObject: Field;
+      dataObject: OMFieldOrGroup;
     }): { subfieldsKey: string; dataObject: OMField } => ({
       subfieldsKey: entry.subfieldsKey,
       dataObject: {
@@ -1487,10 +1498,48 @@ class AdvancedSearchClassBase {
     }
   }
 
+  // `rows` is an array of objects, so it needs a `some` group - a flat
+  // `<prop>.rows.<column>` var never resolves against it and is always false.
+  private buildTableCustomPropertyGroup(
+    field: CustomPropertySummary,
+    label: string,
+    columns: string[]
+  ): { subfieldsKey: string; dataObject: OMFieldOrGroup } {
+    const columnSubfields: Fields = Object.fromEntries(
+      columns.map((columnName) => [
+        columnName,
+        {
+          type: 'text',
+          label: columnName,
+          operators: TEXT_FIELD_OPERATORS,
+          valueSources: ['value'],
+        },
+      ])
+    );
+
+    return {
+      subfieldsKey: field.name,
+      dataObject: {
+        label,
+        type: '!struct',
+        subfields: {
+          rows: {
+            label: t('label.row-plural'),
+            type: '!group',
+            mode: 'some',
+            defaultField: columns[0],
+            subfields: columnSubfields,
+          },
+        },
+      },
+    };
+  }
+
   private buildMultiValueCustomPropertySubFields(
     field: CustomPropertySummary,
-    label: string
-  ): Array<{ subfieldsKey: string; dataObject: Field }> {
+    label: string,
+    searchOutputType: SearchOutputType
+  ): Array<{ subfieldsKey: string; dataObject: OMFieldOrGroup }> {
     switch (field.type) {
       case 'timeInterval':
         return [
@@ -1546,6 +1595,10 @@ class AdvancedSearchClassBase {
           return [];
         }
 
+        if (searchOutputType === SearchOutputType.JSONLogic) {
+          return [this.buildTableCustomPropertyGroup(field, label, columns)];
+        }
+
         return columns.map((columnName) => ({
           subfieldsKey: `${field.name}.rows.${columnName}`,
           dataObject: {
@@ -1566,8 +1619,8 @@ class AdvancedSearchClassBase {
     field: CustomPropertySummary,
     searchOutputType: SearchOutputType
   ):
-    | { subfieldsKey: string; dataObject: Field }
-    | Array<{ subfieldsKey: string; dataObject: Field }> {
+    | { subfieldsKey: string; dataObject: OMFieldOrGroup }
+    | Array<{ subfieldsKey: string; dataObject: OMFieldOrGroup }> {
     const label = getEntityName(field);
     const subfieldsKey = this.resolveCustomPropertySubfieldsKey(
       field,
@@ -1579,7 +1632,11 @@ class AdvancedSearchClassBase {
     }
 
     if (MULTI_VALUE_CUSTOM_PROPERTY_TYPES.includes(field.type)) {
-      return this.buildMultiValueCustomPropertySubFields(field, label);
+      return this.buildMultiValueCustomPropertySubFields(
+        field,
+        label,
+        searchOutputType
+      );
     }
 
     return this.buildScalarCustomPropertySubField(field, subfieldsKey, label);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
@@ -1554,6 +1554,23 @@ class AdvancedSearchClassBase {
         // with `some` - a flat `<prop>.rows.<column>` var never resolves against
         // an array. A cell is free text, hence `allowCustomValues` over a list.
         if (searchOutputType === SearchOutputType.JSONLogic) {
+          const columnSubfields: Fields = Object.fromEntries(
+            columns.map((columnName) => [
+              columnName,
+              {
+                type: 'select',
+                label: columnName,
+                operators: SELECT_TEXT_FIELD_OPERATORS,
+                valueSources: ['value'],
+                fieldSettings: {
+                  allowCustomValues: true,
+                  showSearch: true,
+                  useAsyncSearch: false,
+                },
+              },
+            ])
+          );
+
           return [
             {
               subfieldsKey: `${field.name}.rows`,
@@ -1562,22 +1579,7 @@ class AdvancedSearchClassBase {
                 type: '!group',
                 mode: 'some',
                 defaultField: columns[0],
-                subfields: Object.fromEntries(
-                  columns.map((columnName) => [
-                    columnName,
-                    {
-                      type: 'select',
-                      label: columnName,
-                      operators: SELECT_TEXT_FIELD_OPERATORS,
-                      valueSources: ['value'],
-                      fieldSettings: {
-                        allowCustomValues: true,
-                        showSearch: true,
-                        useAsyncSearch: false,
-                      },
-                    },
-                  ])
-                ),
+                subfields: columnSubfields,
               },
             },
           ];

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
@@ -60,20 +60,6 @@ import { parseBucketsData } from './SearchPureUtils';
 const CLASSIFICATION_NAME_KEYWORD = 'classification.name.keyword';
 const ENUM_ASYNC_FETCH_PAGE_SIZE = 100;
 
-// Custom-property types whose sub-field needs an async fetch (select/multiselect).
-const ASYNC_CUSTOM_PROPERTY_TYPES: string[] = [
-  'array<entityReference>',
-  'entityReference',
-  'enum',
-];
-
-// Custom-property types that expand into multiple sub-fields.
-const MULTI_VALUE_CUSTOM_PROPERTY_TYPES: string[] = [
-  'timeInterval',
-  'hyperlink-cp',
-  'table-cp',
-];
-
 // Sub-field config, plus the `!struct` / `!group` keys used by nested types.
 type OMFieldOrGroup = Field & {
   subfields?: Fields;
@@ -1623,6 +1609,8 @@ class AdvancedSearchClassBase {
     }
   }
 
+  // One switch on the custom property type. Types with no special handling fall
+  // through to the scalar builder, which switches again on date / number / text.
   private buildCustomPropertiesSubFields(
     field: CustomPropertySummary,
     searchOutputType: SearchOutputType
@@ -1635,19 +1623,32 @@ class AdvancedSearchClassBase {
       searchOutputType
     );
 
-    if (ASYNC_CUSTOM_PROPERTY_TYPES.includes(field.type)) {
-      return this.buildAsyncCustomPropertySubField(field, subfieldsKey, label);
-    }
+    switch (field.type) {
+      case 'array<entityReference>':
+      case 'entityReference':
+      case 'enum':
+        return this.buildAsyncCustomPropertySubField(
+          field,
+          subfieldsKey,
+          label
+        );
 
-    if (MULTI_VALUE_CUSTOM_PROPERTY_TYPES.includes(field.type)) {
-      return this.buildMultiValueCustomPropertySubFields(
-        field,
-        label,
-        searchOutputType
-      );
-    }
+      case 'timeInterval':
+      case 'hyperlink-cp':
+      case 'table-cp':
+        return this.buildMultiValueCustomPropertySubFields(
+          field,
+          label,
+          searchOutputType
+        );
 
-    return this.buildScalarCustomPropertySubField(field, subfieldsKey, label);
+      default:
+        return this.buildScalarCustomPropertySubField(
+          field,
+          subfieldsKey,
+          label
+        );
+    }
   }
 }
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
@@ -60,7 +60,6 @@ import { parseBucketsData } from './SearchPureUtils';
 const CLASSIFICATION_NAME_KEYWORD = 'classification.name.keyword';
 const ENUM_ASYNC_FETCH_PAGE_SIZE = 100;
 
-// Sub-field config, plus the `!struct` / `!group` keys used by nested types.
 type OMFieldOrGroup = Field & {
   subfields?: Fields;
   mode?: RuleGroupMode;
@@ -1550,9 +1549,7 @@ class AdvancedSearchClassBase {
           return [];
         }
 
-        // `rows` is an array of objects, so a JsonLogic rule has to iterate it
-        // with `some` - a flat `<prop>.rows.<column>` var never resolves against
-        // an array. A cell is free text, hence `allowCustomValues` over a list.
+        // `rows` is an array, so the rule has to iterate it with `some`.
         if (searchOutputType === SearchOutputType.JSONLogic) {
           const columnSubfields: Fields = Object.fromEntries(
             columns.map((columnName) => [
@@ -1601,8 +1598,6 @@ class AdvancedSearchClassBase {
     }
   }
 
-  // One switch on the custom property type. Types with no special handling fall
-  // through to the scalar builder, which switches again on date / number / text.
   private buildCustomPropertiesSubFields(
     field: CustomPropertySummary,
     searchOutputType: SearchOutputType

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
@@ -1490,45 +1490,6 @@ class AdvancedSearchClassBase {
     }
   }
 
-  // `rows` is an array of objects, so it needs a `some` group - a flat
-  // `<prop>.rows.<column>` var never resolves against it. Rules saved in the flat
-  // shape are rewritten by `migrateJsonLogic` when the builder loads them.
-  private buildTableCustomPropertyGroup(
-    field: CustomPropertySummary,
-    label: string,
-    columns: string[]
-  ): { subfieldsKey: string; dataObject: OMFieldOrGroup } {
-    // A cell is free text, so there is no list to offer - `allowCustomValues`
-    // keeps the select widget while letting the value be typed.
-    const columnSubfields: Fields = Object.fromEntries(
-      columns.map((columnName) => [
-        columnName,
-        {
-          type: 'select',
-          label: columnName,
-          operators: SELECT_TEXT_FIELD_OPERATORS,
-          valueSources: ['value'],
-          fieldSettings: {
-            allowCustomValues: true,
-            showSearch: true,
-            useAsyncSearch: false,
-          },
-        },
-      ])
-    );
-
-    return {
-      subfieldsKey: `${field.name}.rows`,
-      dataObject: {
-        label: `${label} - ${t('label.row-plural')}`,
-        type: '!group',
-        mode: 'some',
-        defaultField: columns[0],
-        subfields: columnSubfields,
-      },
-    };
-  }
-
   private buildMultiValueCustomPropertySubFields(
     field: CustomPropertySummary,
     label: string,
@@ -1589,8 +1550,37 @@ class AdvancedSearchClassBase {
           return [];
         }
 
+        // `rows` is an array of objects, so a JsonLogic rule has to iterate it
+        // with `some` - a flat `<prop>.rows.<column>` var never resolves against
+        // an array. A cell is free text, hence `allowCustomValues` over a list.
         if (searchOutputType === SearchOutputType.JSONLogic) {
-          return [this.buildTableCustomPropertyGroup(field, label, columns)];
+          return [
+            {
+              subfieldsKey: `${field.name}.rows`,
+              dataObject: {
+                label: `${label} - ${t('label.row-plural')}`,
+                type: '!group',
+                mode: 'some',
+                defaultField: columns[0],
+                subfields: Object.fromEntries(
+                  columns.map((columnName) => [
+                    columnName,
+                    {
+                      type: 'select',
+                      label: columnName,
+                      operators: SELECT_TEXT_FIELD_OPERATORS,
+                      valueSources: ['value'],
+                      fieldSettings: {
+                        allowCustomValues: true,
+                        showSearch: true,
+                        useAsyncSearch: false,
+                      },
+                    },
+                  ])
+                ),
+              },
+            },
+          ];
         }
 
         return columns.map((columnName) => ({

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
@@ -34,6 +34,7 @@ import {
   NULL_CHECK_OPERATORS,
   NUMBER_FIELD_OPERATORS,
   SEARCH_INDICES_WITH_COLUMNS_FIELD,
+  SELECT_TEXT_FIELD_OPERATORS,
   TAG_LABEL_TYPE_LIST_VALUES,
   TEXT_FIELD_OPERATORS,
 } from '../constants/AdvancedSearch.constants';
@@ -1554,10 +1555,14 @@ class AdvancedSearchClassBase {
             columns.map((columnName) => [
               columnName,
               {
-                type: 'text',
+                type: 'select',
                 label: `${label} - ${columnName}`,
-                operators: TEXT_FIELD_OPERATORS,
+                operators: SELECT_TEXT_FIELD_OPERATORS,
                 valueSources: ['value'],
+                fieldSettings: {
+                  allowCustomValues: true,
+                  useAsyncSearch: false,
+                },
               },
             ])
           );

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
@@ -34,6 +34,7 @@ import {
   NULL_CHECK_OPERATORS,
   NUMBER_FIELD_OPERATORS,
   SEARCH_INDICES_WITH_COLUMNS_FIELD,
+  SELECT_TEXT_FIELD_OPERATORS,
   TAG_LABEL_TYPE_LIST_VALUES,
   TEXT_FIELD_OPERATORS,
 } from '../constants/AdvancedSearch.constants';
@@ -1504,38 +1505,40 @@ class AdvancedSearchClassBase {
   }
 
   // `rows` is an array of objects, so it needs a `some` group - a flat
-  // `<prop>.rows.<column>` var never resolves against it and is always false.
+  // `<prop>.rows.<column>` var never resolves against it. Rules saved in the flat
+  // shape are rewritten by `migrateJsonLogic` when the builder loads them.
   private buildTableCustomPropertyGroup(
     field: CustomPropertySummary,
     label: string,
     columns: string[]
   ): { subfieldsKey: string; dataObject: OMFieldOrGroup } {
+    // A cell is free text, so there is no list to offer - `allowCustomValues`
+    // keeps the select widget while letting the value be typed.
     const columnSubfields: Fields = Object.fromEntries(
       columns.map((columnName) => [
         columnName,
         {
-          type: 'text',
+          type: 'select',
           label: columnName,
-          operators: TEXT_FIELD_OPERATORS,
+          operators: SELECT_TEXT_FIELD_OPERATORS,
           valueSources: ['value'],
+          fieldSettings: {
+            allowCustomValues: true,
+            showSearch: true,
+            useAsyncSearch: false,
+          },
         },
       ])
     );
 
     return {
-      subfieldsKey: field.name,
+      subfieldsKey: `${field.name}.rows`,
       dataObject: {
-        label,
-        type: '!struct',
-        subfields: {
-          rows: {
-            label: t('label.row-plural'),
-            type: '!group',
-            mode: 'some',
-            defaultField: columns[0],
-            subfields: columnSubfields,
-          },
-        },
+        label: `${label} - ${t('label.row-plural')}`,
+        type: '!group',
+        mode: 'some',
+        defaultField: columns[0],
+        subfields: columnSubfields,
       },
     };
   }

--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderPureUtils.ts
@@ -993,61 +993,22 @@ export const migrateJsonLogic = (
     );
   };
 
-  // A `table-cp` value keeps its cells in a `rows` array, so a rule on a column
-  // has to iterate it with `some`. Rules saved before that fix used a flat
-  // `extension.<prop>.rows.<column>` var, which cannot resolve against an array.
-  const TABLE_ROWS_VAR = /^(extension\..+\.rows)\.([^.]+)$/;
-
-  const migrateTableRowsRule = (node: JsonLogic): JsonLogic | undefined => {
-    const operators = Object.keys(node);
-    const args = operators.length === 1 ? node[operators[0]] : undefined;
-    if (!Array.isArray(args)) {
-      return undefined;
-    }
-
-    const argIndex = args.findIndex(
-      (arg) => isVarObject(arg) && TABLE_ROWS_VAR.test(arg.var)
-    );
-    if (argIndex === -1) {
-      return undefined;
-    }
-
-    const [, rowsVar, column] = TABLE_ROWS_VAR.exec(
-      (args[argIndex] as { var: string }).var
-    ) as RegExpExecArray;
-    const relativeArgs = args.map((arg, index) =>
-      index === argIndex ? { var: column } : arg
-    );
-
-    return { some: [{ var: rowsVar }, { [operators[0]]: relativeArgs }] };
-  };
-
-  const migrateNotNullRule = (node: JsonLogic): JsonLogic | undefined => {
-    if (!('!!' in node) || !isVarObject(node['!!'])) {
-      return undefined;
-    }
-
-    const varName = node['!!'].var;
-    const mappedField = FIELD_MAPPING[varName];
-
-    return mappedField
-      ? { some: [{ var: varName }, { '!=': [{ var: mappedField }, null] }] }
-      : undefined;
-  };
-
   const migrateNode = (node: JsonLogic): JsonLogic => {
     if (node === null || typeof node !== 'object') {
       return node;
     }
+    if (!Array.isArray(node) && '!!' in node && isVarObject(node['!!'])) {
+      const varName = node['!!'].var;
+      const mappedField = FIELD_MAPPING[varName];
+      if (mappedField) {
+        return {
+          some: [{ var: varName }, { '!=': [{ var: mappedField }, null] }],
+        };
+      }
+    }
     if (Array.isArray(node)) {
       return node.map(migrateNode) as unknown as JsonLogic;
     }
-
-    const migrated = migrateTableRowsRule(node) ?? migrateNotNullRule(node);
-    if (migrated) {
-      return migrated;
-    }
-
     const result: Record<string, JsonLogic> = {};
     for (const key in node) {
       result[key] = migrateNode(node[key] as JsonLogic);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderPureUtils.ts
@@ -993,22 +993,61 @@ export const migrateJsonLogic = (
     );
   };
 
+  // A `table-cp` value keeps its cells in a `rows` array, so a rule on a column
+  // has to iterate it with `some`. Rules saved before that fix used a flat
+  // `extension.<prop>.rows.<column>` var, which cannot resolve against an array.
+  const TABLE_ROWS_VAR = /^(extension\..+\.rows)\.([^.]+)$/;
+
+  const migrateTableRowsRule = (node: JsonLogic): JsonLogic | undefined => {
+    const operators = Object.keys(node);
+    const args = operators.length === 1 ? node[operators[0]] : undefined;
+    if (!Array.isArray(args)) {
+      return undefined;
+    }
+
+    const argIndex = args.findIndex(
+      (arg) => isVarObject(arg) && TABLE_ROWS_VAR.test(arg.var)
+    );
+    if (argIndex === -1) {
+      return undefined;
+    }
+
+    const [, rowsVar, column] = TABLE_ROWS_VAR.exec(
+      (args[argIndex] as { var: string }).var
+    ) as RegExpExecArray;
+    const relativeArgs = args.map((arg, index) =>
+      index === argIndex ? { var: column } : arg
+    );
+
+    return { some: [{ var: rowsVar }, { [operators[0]]: relativeArgs }] };
+  };
+
+  const migrateNotNullRule = (node: JsonLogic): JsonLogic | undefined => {
+    if (!('!!' in node) || !isVarObject(node['!!'])) {
+      return undefined;
+    }
+
+    const varName = node['!!'].var;
+    const mappedField = FIELD_MAPPING[varName];
+
+    return mappedField
+      ? { some: [{ var: varName }, { '!=': [{ var: mappedField }, null] }] }
+      : undefined;
+  };
+
   const migrateNode = (node: JsonLogic): JsonLogic => {
     if (node === null || typeof node !== 'object') {
       return node;
     }
-    if (!Array.isArray(node) && '!!' in node && isVarObject(node['!!'])) {
-      const varName = node['!!'].var;
-      const mappedField = FIELD_MAPPING[varName];
-      if (mappedField) {
-        return {
-          some: [{ var: varName }, { '!=': [{ var: mappedField }, null] }],
-        };
-      }
-    }
     if (Array.isArray(node)) {
       return node.map(migrateNode) as unknown as JsonLogic;
     }
+
+    const migrated = migrateTableRowsRule(node) ?? migrateNotNullRule(node);
+    if (migrated) {
+      return migrated;
+    }
+
     const result: Record<string, JsonLogic> = {};
     for (const key in node) {
       result[key] = migrateNode(node[key] as JsonLogic);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/queryBuilderWidgets/OMSelectWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/queryBuilderWidgets/OMSelectWidget.test.tsx
@@ -31,13 +31,22 @@ jest.mock('@openmetadata/ui-core-components', () => {
       items?: { id: string; label: string }[];
       onOpenChange?: (isOpen: boolean) => void;
       onInputChange?: (value: string) => void;
+      allowsCustomValue?: boolean;
+      inputValue?: string;
     }) => JSX.Element;
   } = ({ isDisabled }) =>
     ReactModule.createElement('button', { disabled: isDisabled }, 'select');
-  Select.ComboBox = ({ isDisabled, items, onOpenChange, onInputChange }) =>
+  Select.ComboBox = ({
+    isDisabled,
+    items,
+    onOpenChange,
+    onInputChange,
+    allowsCustomValue,
+    inputValue,
+  }) =>
     ReactModule.createElement(
       'div',
-      null,
+      { 'data-allows-custom-value': String(Boolean(allowsCustomValue)) },
       ReactModule.createElement(
         'button',
         {
@@ -49,6 +58,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
       ),
       ReactModule.createElement('input', {
         role: 'combobox',
+        value: inputValue,
         onChange: (event: { target: { value: string } }) =>
           onInputChange?.(event.target.value),
       }),
@@ -146,5 +156,61 @@ describe('OMSelectWidget', () => {
     expect(screen.getByTestId('options').children).toHaveLength(2);
     expect(asyncFetch).toHaveBeenCalledTimes(callsBeforeReopen);
     expect(asyncFetch).toHaveBeenLastCalledWith('Option 1');
+  });
+
+  describe('allowCustomValues', () => {
+    const customValueProps = {
+      ...baseProps,
+      listValues: undefined,
+      allowCustomValues: true,
+    } as unknown as SelectWidgetProps;
+
+    it('should accept a typed value when there is no list to pick from', () => {
+      const setValue = jest.fn();
+      render(<OMSelectWidget {...customValueProps} setValue={setValue} />);
+
+      const input = screen.getByRole('combobox');
+
+      expect(input).toBeInTheDocument();
+      expect(
+        screen.getByRole('combobox').closest('[data-allows-custom-value]')
+      ).toHaveAttribute('data-allows-custom-value', 'true');
+
+      fireEvent.change(input, { target: { value: 'john' } });
+
+      expect(setValue).toHaveBeenCalledWith('john');
+    });
+
+    it('should clear the value when the input is emptied', () => {
+      const setValue = jest.fn();
+      render(
+        <OMSelectWidget
+          {...customValueProps}
+          setValue={setValue}
+          value="john"
+        />
+      );
+
+      expect(screen.getByRole('combobox')).toHaveValue('john');
+
+      fireEvent.change(screen.getByRole('combobox'), { target: { value: '' } });
+
+      expect(setValue).toHaveBeenCalledWith(null);
+    });
+
+    it('should defer to the async branch when an asyncFetch is supplied', async () => {
+      const asyncFetch = jest
+        .fn()
+        .mockResolvedValue({ values: [{ value: 'opt1', title: 'Option 1' }] });
+      render(
+        <OMSelectWidget
+          {...customValueProps}
+          useAsyncSearch
+          asyncFetch={asyncFetch}
+        />
+      );
+
+      await waitFor(() => expect(asyncFetch).toHaveBeenCalledWith(''));
+    });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/queryBuilderWidgets/OMSelectWidget.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/queryBuilderWidgets/OMSelectWidget.tsx
@@ -45,9 +45,12 @@ const OMSelectWidget: FC<SelectWidgetProps> = ({
   listValues,
   asyncFetch,
   useAsyncSearch,
+  allowCustomValues,
   field,
 }) => {
   const staticItems = toSelectItems(listValues);
+  const selectedValue =
+    value === null || value === undefined ? undefined : String(value);
   // Seed with the current value as a placeholder so the widget shows
   // something while the async fetch is in-flight. The real items replace
   // this when loadAsync completes.
@@ -55,8 +58,8 @@ const OMSelectWidget: FC<SelectWidgetProps> = ({
     if (staticItems.length > 0) {
       return staticItems;
     }
-    if (value !== null && value !== undefined) {
-      return [{ id: String(value), label: String(value) }];
+    if (selectedValue !== undefined) {
+      return [{ id: selectedValue, label: selectedValue }];
     }
 
     return [];
@@ -94,6 +97,31 @@ const OMSelectWidget: FC<SelectWidgetProps> = ({
     }
   }, [fieldKey, useAsyncSearch]);
 
+  // Free-text values: there is no list to pick from, so the value has to be
+  // typed. Without this the widget falls through to a plain Select whose
+  // collection is empty, and the value can never be set.
+  if (allowCustomValues && !asyncFetch) {
+    return (
+      <Select.ComboBox
+        allowsCustomValue
+        allowsEmptyCollection
+        inputValue={selectedValue ?? ''}
+        isDisabled={readonly}
+        items={items}
+        placeholder={placeholder}
+        shortcut={false}
+        showSearchIcon={false}
+        size="sm"
+        onInputChange={(input) => setValue(input || null)}>
+        {(item) => (
+          <Select.Item id={item.id} key={item.id}>
+            {item.label}
+          </Select.Item>
+        )}
+      </Select.ComboBox>
+    );
+  }
+
   if (useAsyncSearch && asyncFetch) {
     return (
       <Select.ComboBox
@@ -105,9 +133,7 @@ const OMSelectWidget: FC<SelectWidgetProps> = ({
         isDisabled={readonly}
         items={items}
         placeholder={placeholder}
-        selectedKey={
-          value !== null && value !== undefined ? String(value) : undefined
-        }
+        selectedKey={selectedValue}
         shortcut={false}
         showSearchIcon={false}
         size="sm"
@@ -144,7 +170,7 @@ const OMSelectWidget: FC<SelectWidgetProps> = ({
       isDisabled={readonly}
       items={items}
       placeholder={placeholder}
-      selectedKey={value !== null && value !== undefined ? String(value) : null}
+      selectedKey={selectedValue ?? null}
       size="sm"
       onSelectionChange={(key) => setValue(key !== null ? String(key) : null)}>
       {(item) => (


### PR DESCRIPTION
## Describe your changes

A `table-cp` custom property value is `{ columns: [...], rows: [{ <column>: <cell> }] }` — `rows` is an **array**. The query builder registered one flat sub-field per column, keyed `<prop>.rows.<column>`, and react-awesome-query-builder exports a plain sub-field as a dotted var. So a workflow rule came out as:

```json
{"and":[{"==":[{"var":"extension.Tabel.rows.Name"},"anuj"]}]}
```

That var does not merely fail to match. `json-logic-java` walks into the array and then tries `Integer.parseInt("Name")` as an index, throwing `NumberFormatException`. `RuleEngine#apply` catches everything and returns `false`, so a `checkEntityAttributes` node on a table custom property always took the false branch.

For JsonLogic output the property is now a `!group` in `mode: 'some'` keyed `<prop>.rows`, with one `select` sub-field per column — the same shape every other array-valued field in `JSONLogicSearchClassBase.mapFields` already uses (`owners`, `tags`, `columns.tags`, `tier`, `domains`, `dataProducts`, `reviewers`, `relatedTerms`):

```
extension (!struct)
└── <prop>.rows (!group, mode: 'some', defaultField: columns[0])
    ├── <column1> (select, allowCustomValues)
    └── <column2> (select, allowCustomValues)
```

which exports the rule the engine can evaluate:

```json
{"and":[{"some":[{"var":"extension.tableType.rows"},{"==":[{"var":"name"},"karan"]}]}]}
```

The change is one `case` in one switch, plus one operator constant.

Notes:

- **Custom property sub-fields are dispatched from one `switch (field.type)` again.** #19113 originally had that switch; #32493 replaced it with two `*_CUSTOM_PROPERTY_TYPES.includes(...)` guards to clear `sonarjs/cyclomatic-complexity`, which the same PR promoted to an error. It is restorable as long as types with no special handling fall through to `default` rather than being enumerated: listing all eleven scores a complexity of 12 and fails the rule, listing only the six that need a non-scalar builder scores 7. Scalar types were already dispatched by the inner switch in `buildScalarCustomPropertySubField`, so nothing is lost, and the two magic type arrays are gone — adding a custom property type now means adding a case beside the others. This also mirrors the backend, which dispatches the same way in `SearchIndexUtils.buildTypedPropertyEntries` (`case "table-cp" -> buildTableEntries(...)`).
- **The columns are `select`, and the select widget grew the branch that makes that possible.** A cell is `additionalProperties: {"type": "string"}` — arbitrary text — so there is no list to offer and no source to fetch one from. `allowCustomValues` is meant to cover exactly that, but `OMSelectWidget` never read it (nothing in the repo did; it is leftover antd-era RAQB config), so a select with no `listValues` and no `asyncFetch` fell through to a plain react-aria `Select` over an empty collection and its value could never be set. It now renders `Select.ComboBox` with `allowsCustomValue` in that case, committing the typed text on change the way `OMTextWidget` does; `react-aria-components` supports the flag and `ui-core-components` passes `AriaComboBoxProps` through, so neither package needed a change. The branch is additive and gated on a flag whose only other user is the `multiselect` `synonyms` field (a different widget), so every select already in both query builders is untouched. `type: 'select'` also forces the operator set to change: a select takes `select_equals` / `select_not_equals`, not `equal` / `not_equal`, so `TEXT_FIELD_OPERATORS` would leave the field with **no valid operator** and it would silently build no rule — hence `SELECT_TEXT_FIELD_OPERATORS`, composed from the existing constants, which keeps `like` / `not_like` (both configs add a text widget to the select type) and the null checks. The exported JsonLogic is byte-identical to the text version.
- **Rules already saved in the flat shape are not migrated, deliberately.** They never worked: the flat var throws and `RuleEngine` returns false. The un-migrated shape evaluates to false as well, so such a rule is equally dead before and after this change and has to be re-created by hand. An earlier revision of this PR carried a `migrateJsonLogic` rewrite for them; it was removed because it repaired nothing that mattered and cost a helper plus a complexity refactor in `QueryBuilderPureUtils`.
- **The ElasticSearch branch is left byte-for-byte unchanged**, which is why `searchOutputType` is threaded into `buildMultiValueCustomPropertySubFields`. Its flat `<prop>.rows.<column>` key is deliberate, not accidental: `SearchIndexUtils.buildTableEntries` indexes each cell as a `customPropertiesTyped` entry under exactly that name. The two output types genuinely need different sub-field shapes, because the JsonLogic rule evaluates against the raw entity JSON while ES matches the flattened typed copy.
- `OMField` gained the optional `subfields` / `mode` / `defaultField` keys. Since `Field['type']` is a plain string this stays a single object type, so existing callers and tests keep direct property access instead of having to narrow a union.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) document.
- [x] My PR title is following the [contributing standard](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md).
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added unit tests.

## Tests

11 tests in `AdvancedSearchClassBase.test.ts`. They mirror QueryBuilderWidget's real cycle — `migrateJsonLogic` → `loadFromJsonLogic` → `Validation.sanitizeTree` → `jsonLogicFormat` — and assert `errors: []`, because a shape can survive a bare round trip and still be rewritten or dropped by `sanitizeTree`:

- the emitted field config, and that ElasticSearch output still returns the flat `<prop>.rows.<column>` keys so a later refactor cannot silently flip Explore;
- every operator the column exposes, plus a two-column `AND` inside one group and a negated group;
- a scalar custom property remaining usable alongside the group under `extension`;
- the no-columns case for both output types.

The config under test is derived from `getInitialConfigWithoutFields` rather than bare `CoreConfig`. That matters: `CoreConfig` carries no text widget on the select type, so it accepts operator sets the real builder rejects — which is exactly why the operator mismatch described above slipped past the first version of these tests. The suite was verified to fail on that specific mistake.

214 tests across 12 suites pass, including three new `OMSelectWidget` cases covering the custom-value branch (accepts a typed value, clears on empty, still defers to the async branch when an `asyncFetch` is supplied). `tsc --noEmit` and eslint are clean on the changed files.

Separately, every emitted shape was evaluated against the real `json-logic-java` 1.0.7 that `RuleEngine` uses, on entity maps built to match the schema:

| rule | 1 matching row | 2 rows, 2nd matches | `rows: []` | `rows` absent | `extension` absent |
|---|---|---|---|---|---|
| equal | `true` | `true` | `false` | `false` | `false` |
| not_equal | `false` | `true` | `false` | — | — |
| like | `true` | — | — | — | — |
| two columns AND | `true` | `true` | — | — | — |
| is set | `true` | — | `false` | — | — |
| NOT(group) | `false` | `false` | `true` | — | — |

No exceptions in any case, and `some` / `all` / `none` are all supported by the engine, so the group-operator selector is safe too.

Manual check: define a `Table` custom property on Table, then add a condition on it to a `checkEntityAttributes` node in a governance workflow. The field picker offers **Custom Properties → \<property\> - Rows** as a rule group over the column names, the saved `rules` payload uses `some`, and the workflow takes the true branch on a table whose row matches instead of always failing.

## Follow-up

Out of scope here — happy to file either as its own issue:

1. `array<entityReference>` custom properties have the same defect as this one: `resolveCustomPropertySubfieldsKey` gives them `<prop>.displayName` for JsonLogic, and that value is an array too, so they need the same `some` treatment.
2. Advanced-search **query filters** on custom properties target `extension.*`, which the index mappings set to `enabled: false`. The free-text search path translates `extension.<name>` into the `customPropertiesTyped` nested field (`CustomPropertySearchFields`); the query-filter path does not appear to, so those filters may not match. Worth confirming separately.

Also worth noting, not introduced here: with `entityType: ALL` (the default for the workflow query builder) custom properties from every entity type merge flat under `extension`, so same-named properties across entity types collide, last writer wins. That already happened between two same-named scalar properties. Namespacing the path would fix it but would break every saved rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

