### PR TITLE
Fixes 32021: read native Unity Catalog lineage and its SQL in one streamed query

### DIFF
--- a/ingestion/.ruff-g004-baseline.json
+++ b/ingestion/.ruff-g004-baseline.json
@@ -1850,18 +1850,13 @@
     },
     "ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py": {
       "035ae8b660b2db5fe61999b1ecc22f8027bace92a248ff5a765ee7aa1f2bedf8": 1,
-      "07c4de45a31ce4e6f676f53a5e6937eb5bd5ae03080410f12c6d36557c6dba14": 1,
       "3163fedfa3130a47645d115424e2ac6c36eaf4fbc1f0e692b903dd617c7631d2": 1,
       "4397917e52f08db67f4cda346bf8253627b856a7e45e00bbeab5fab89bbd9f7d": 1,
-      "608cce13eb549a1630c5944537e3baf30fd0c4e9c653e5ec431814157c9f20f1": 1,
       "683f89aa1e6703dc52e817531c2818a137c9376dab8a52645b3f065645ae68dd": 1,
-      "85d4e2fc98a29d964bf7f00da689ff05b3dc7f2d9276fb103008ee19cda1d47d": 1,
-      "a61912d79da128b842bfd8c38d457261daacb8a1d66ea4e2cd1e1cfdc6af8be9": 1,
       "b0ebc506498da2d0797af0e90ad728f33d4083d32e7f26e7fb0540c1cdd9f788": 1,
       "bed630225bcb4cf113aa14695fb2524c732319263cea1dab8c74f0a4d5598793": 1,
       "c3b6a24529cd1100e0d919536ebb9d6462dac03b8bedf80a1d8c496fffd92aa1": 1,
-      "ca36dc1829d1d78ed1df20b7f4c1f706c5f4f7b579afce4db05b519dde52b4f5": 1,
-      "e2c118a65f450497860c6b34c8dfe9fb1fc2f00f161bf3cb198191f202e8333c": 1
+      "ca36dc1829d1d78ed1df20b7f4c1f706c5f4f7b579afce4db05b519dde52b4f5": 1
     },
     "ingestion/src/metadata/ingestion/source/database/unitycatalog/metadata.py": {
       "37586b2eebe730d39b6942bf176c883ee4f68caa88a1fdcf6491883e5f637581": 1,

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py
@@ -74,6 +74,7 @@ if TYPE_CHECKING:
 logger = ingestion_logger()
 
 TABLE_CACHE_MAX_SIZE = 500
+LINEAGE_ROW_BUFFER_SIZE = 1000
 
 
 class UnitycatalogLineageSource(Source):
@@ -96,13 +97,12 @@ class UnitycatalogLineageSource(Source):
         connection = cast("UnityCatalogConnectionHandler", self._connection)
         self.connection_obj = connection.client
         self.engine = connection.sql.client
-        self.table_lineage_map: dict[str, set[str]] = defaultdict(set)
-        self.column_lineage_map: dict[tuple[str, str], dict[tuple[str, str], None]] = defaultdict(dict)
         self.external_location_map: dict[str, str] = {}
         self.path_to_table_map: dict[str, set[str]] = defaultdict(set)
-        self.path_lineage_map: dict[str, set[str]] = defaultdict(set)
-        self.edge_sql: dict[tuple[str, str], str] = {}
         self._table_cache: LRUCache = LRUCache(maxsize=TABLE_CACHE_MAX_SIZE)
+        # A table can be both a lineage target and an external table; the run summary
+        # should still name it once.
+        self._filter_reported: set[str] = set()
         with close_on_failure(self._connection):
             self.test_connection()
 
@@ -194,73 +194,101 @@ class UnitycatalogLineageSource(Source):
             if isinstance(pair, dict) and pair.get("source") and pair.get("target")
         )
 
-    def _cache_lineage(self):
+    def _stream_native_lineage(self) -> Iterable[Either[AddLineageRequest]]:
         """
-        Read every native lineage edge, its column mappings and its SQL in one pass.
+        Emit native lineage one target at a time, as its rows arrive.
 
-        The pairs are kept keyed by table name rather than emitted row by row: the same
-        edge is reported twice when Databricks names one side by path and the other by
-        table, and lineage is stored per edge, so a second request for a pair already
-        sent would overwrite the mappings of the first.
+        The rows are ordered by target, so a target's edges are complete as soon as the
+        next target appears and nothing needs to be held past the target in hand.
+
+        They are grouped at all because Databricks reports one edge twice when it names
+        a side by table on one row and by path on another, and `addLineage` replaces an
+        edge's details instead of merging them: a second request for a pair already sent
+        would drop the column mappings of the first.
         """
         query_log_duration = self.source_config.queryLogDuration or 1
         include_query_history = self._probe_query_history()
         logger.info(
-            "Caching native lineage from system tables (lookback: %s days, SQL text: %s)",
+            "Reading native lineage from system tables (lookback: %s days, SQL text: %s)",
             query_log_duration,
             "yes" if include_query_history else "no",
         )
 
-        # Every edge a statement wrote holds the same text; one string per statement
-        # keeps a run over a large catalog from holding a copy per edge.
-        interned_statements: dict[str, str] = {}
+        target: tuple[str | None, str | None] | None = None
+        upstream_columns: dict[str, dict[tuple[str, str], None]] = {}
+        upstream_sql: dict[str, str] = {}
+        upstream_paths: set[str] = set()
+        targets = 0
+        emitted = 0
 
         try:
             with self.engine.connect() as conn:
-                rows = conn.execute(text(unity_catalog_native_lineage_query(query_log_duration, include_query_history)))
+                rows = conn.execution_options(stream_results=True, max_row_buffer=LINEAGE_ROW_BUFFER_SIZE).execute(
+                    text(unity_catalog_native_lineage_query(query_log_duration, include_query_history))
+                )
+
                 for row in rows:
+                    row_target = (row.target_table_full_name, row.target_path)
+                    if target is not None and row_target != target:
+                        targets += 1
+                        for either in self._process_target_lineage(
+                            target, upstream_columns, upstream_sql, upstream_paths
+                        ):
+                            emitted += 1
+                            yield either
+                        upstream_columns, upstream_sql, upstream_paths = {}, {}, set()
+                    target = row_target
+
                     source_tables, source_path = self._resolve_lineage_side(row.source_table_full_name, row.source_path)
-                    target_tables, _ = self._resolve_lineage_side(row.target_table_full_name, row.target_path)
                     column_pairs = self._parse_column_pairs(row.column_pairs)
-                    statement_text = row.statement_text
+                    for source_table in source_tables:
+                        pairs = upstream_columns.setdefault(source_table, {})
+                        for column_pair in column_pairs:
+                            pairs.setdefault(column_pair, None)
+                        if row.statement_text:
+                            upstream_sql[source_table] = row.statement_text
 
-                    for target_table in target_tables:
-                        for source_table in source_tables:
-                            # A table never derives from itself. The system tables record
-                            # access rather than derivation, so a streaming or CDC write
-                            # legitimately names its target as its own source. Kept as
-                            # lineage it renders as a loop on the node and says nothing.
-                            if source_table == target_table:
-                                continue
-                            self.table_lineage_map[target_table].add(source_table)
-                            table_key = (source_table, target_table)
-                            if column_pairs:
-                                # One edge reaches us twice when Databricks reports it both
-                                # by name and by path, and a duplicated pair would be sent
-                                # as a duplicated column edge.
-                                pairs = self.column_lineage_map[table_key]
-                                for column_pair in column_pairs:
-                                    if column_pair not in pairs:
-                                        pairs[column_pair] = None
-                            if statement_text:
-                                self.edge_sql[table_key] = interned_statements.setdefault(
-                                    statement_text, statement_text
-                                )
+                    if source_path:
+                        upstream_paths.add(source_path)
 
-                        if source_path:
-                            self.path_lineage_map[target_table].add(source_path)
-            logger.info(
-                "Cached native lineage: %s edges for %s target tables, %s column mappings, "
-                "%s edges with SQL, plus %s unresolved path upstreams",
-                sum(len(v) for v in self.table_lineage_map.values()),
-                len(self.table_lineage_map),
-                sum(len(v) for v in self.column_lineage_map.values()),
-                len(self.edge_sql),
-                sum(len(v) for v in self.path_lineage_map.values()),
-            )
+                if target is not None:
+                    targets += 1
+                    for either in self._process_target_lineage(target, upstream_columns, upstream_sql, upstream_paths):
+                        emitted += 1
+                        yield either
+
+            logger.info("Native lineage: emitted %s edges over %s targets", emitted, targets)
         except Exception as exc:
             logger.debug(traceback.format_exc())
-            logger.warning("Failed to cache native lineage: %s", exc)
+            logger.warning("Failed to read native lineage: %s", exc)
+
+    def _process_target_lineage(
+        self,
+        target: tuple[str | None, str | None],
+        upstream_columns: dict[str, dict[tuple[str, str], None]],
+        upstream_sql: dict[str, str],
+        upstream_paths: set[str],
+    ) -> Iterable[Either[AddLineageRequest]]:
+        """
+        Emit the edges collected for one target.
+
+        A target addressed by location stands for every table declared over it, so the
+        rows of one target can belong to more than one table.
+        """
+        target_tables, _ = self._resolve_lineage_side(*target)
+
+        for target_table in sorted(target_tables):
+            if self._is_filtered(target_table):
+                continue
+
+            table = self._get_table_entity(target_table)
+            if not table:
+                logger.debug("Unable to find downstream entity: %s", target_table)
+                continue
+
+            yield from self._process_table_lineage(table, target_table, upstream_columns, upstream_sql)
+
+            yield from self._process_path_lineage(table, target_table, upstream_paths)
 
     def _cache_external_locations(self):
         """
@@ -366,12 +394,9 @@ class UnitycatalogLineageSource(Source):
         self,
         from_table: Table,
         to_table: Table,
-        source_table_fqn: str,
-        target_table_fqn: str,
+        column_pairs: dict[tuple[str, str], None],
     ) -> LineageDetails | None:
         try:
-            table_key = (source_table_fqn, target_table_fqn)
-            column_pairs = self.column_lineage_map.get(table_key, {})
             if not column_pairs:
                 return None
 
@@ -435,14 +460,16 @@ class UnitycatalogLineageSource(Source):
             logger.debug(f"Error processing external location lineage for {databricks_table_fqn}: {exc}")
             logger.debug(traceback.format_exc())
 
-    def _process_path_lineage(self, table: Table, databricks_table_fqn: str) -> Iterable[Either[AddLineageRequest]]:
+    def _process_path_lineage(
+        self, table: Table, databricks_table_fqn: str, upstream_paths: set[str]
+    ) -> Iterable[Either[AddLineageRequest]]:
         """
         Emit lineage for upstream locations that no registered table is declared over.
 
         These reach the table only as a path, so the container ingested from the object
         store is the one entity that can stand in for them.
         """
-        for storage_path in sorted(self.path_lineage_map.get(databricks_table_fqn, set())):
+        for storage_path in sorted(upstream_paths):
             try:
                 location_entity = None
                 for candidate in container_path_candidates(storage_path):
@@ -484,10 +511,20 @@ class UnitycatalogLineageSource(Source):
                 )
                 logger.debug(traceback.format_exc())
 
-    def _process_table_lineage(self, table: Table, databricks_table_fqn: str) -> Iterable[Either[AddLineageRequest]]:
-        upstream_tables = self.table_lineage_map.get(databricks_table_fqn, set())
-
-        for source_table_full_name in sorted(upstream_tables):
+    def _process_table_lineage(
+        self,
+        table: Table,
+        databricks_table_fqn: str,
+        upstream_columns: dict[str, dict[tuple[str, str], None]],
+        upstream_sql: dict[str, str],
+    ) -> Iterable[Either[AddLineageRequest]]:
+        for source_table_full_name in sorted(upstream_columns):
+            # A table never derives from itself. The system tables record access rather
+            # than derivation, so a streaming or CDC write legitimately names its target
+            # as its own source. Kept as lineage it renders as a loop on the node and
+            # says nothing.
+            if source_table_full_name == databricks_table_fqn:
+                continue
             try:
                 from_entity = self._get_table_entity(source_table_full_name)
                 if not from_entity:
@@ -497,11 +534,10 @@ class UnitycatalogLineageSource(Source):
                 lineage_details = self._get_column_lineage_details(
                     from_table=from_entity,
                     to_table=table,
-                    source_table_fqn=source_table_full_name,
-                    target_table_fqn=databricks_table_fqn,
+                    column_pairs=upstream_columns[source_table_full_name],
                 ) or LineageDetails(source=LineageSource.QueryLineage)
 
-                if sql_query := self.edge_sql.get((source_table_full_name, databricks_table_fqn)):
+                if sql_query := upstream_sql.get(source_table_full_name):
                     lineage_details.sqlQuery = SqlQuery(root=sql_query)
 
                 yield Either(
@@ -517,13 +553,6 @@ class UnitycatalogLineageSource(Source):
                 logger.debug(f"Error processing lineage {source_table_full_name} -> {databricks_table_fqn}: {exc}")
                 logger.debug(traceback.format_exc())
 
-    def _lineage_targets(self) -> list[str]:
-        """
-        The tables an edge can end at: a lineage target, a table written by location,
-        or an external table whose storage may have been ingested as a container.
-        """
-        return sorted(set(self.table_lineage_map) | set(self.path_lineage_map) | set(self.external_location_map))
-
     def _is_filtered(self, databricks_table_fqn: str) -> bool:
         """Apply the pipeline's filter patterns to a `catalog.schema.table` name."""
         parts = databricks_table_fqn.split(".")
@@ -534,15 +563,20 @@ class UnitycatalogLineageSource(Source):
         entity_fqn = f"{self.config.serviceName}.{databricks_table_fqn}"
 
         if filter_by_database(self.source_config.databaseFilterPattern, catalog_name):
-            self.status.filter(entity_fqn, "Catalog Filtered Out")
+            self._report_filtered(entity_fqn, "Catalog Filtered Out")
             return True
         if filter_by_schema(self.source_config.schemaFilterPattern, schema_name):
-            self.status.filter(entity_fqn, "Schema Filtered Out")
+            self._report_filtered(entity_fqn, "Schema Filtered Out")
             return True
         if filter_by_table(self.source_config.tableFilterPattern, table_name):
-            self.status.filter(entity_fqn, "Table Filtered Out")
+            self._report_filtered(entity_fqn, "Table Filtered Out")
             return True
         return False
+
+    def _report_filtered(self, entity_fqn: str, reason: str) -> None:
+        if entity_fqn not in self._filter_reported:
+            self._filter_reported.add(entity_fqn)
+            self.status.filter(entity_fqn, reason)
 
     def _iter(self, *_, **__) -> Iterable[Either[AddLineageRequest]]:
         """
@@ -557,27 +591,14 @@ class UnitycatalogLineageSource(Source):
         # External locations first: resolving a path-based lineage row to the table
         # declared over that path needs the location map already populated.
         self._cache_external_locations()
-        self._cache_lineage()
 
-        for databricks_table_fqn in self._lineage_targets():
+        yield from self._stream_native_lineage()
+
+        for databricks_table_fqn in sorted(self.external_location_map):
             if self._is_filtered(databricks_table_fqn):
                 continue
 
             yield from self._process_external_location_lineage(databricks_table_fqn)
-
-            if not (
-                self.table_lineage_map.get(databricks_table_fqn) or self.path_lineage_map.get(databricks_table_fqn)
-            ):
-                continue
-
-            table = self._get_table_entity(databricks_table_fqn)
-            if not table:
-                logger.debug("Unable to find downstream entity: %s", databricks_table_fqn)
-                continue
-
-            yield from self._process_table_lineage(table, databricks_table_fqn)
-
-            yield from self._process_path_lineage(table, databricks_table_fqn)
 
     def test_connection(self) -> None:
         if self._connection is not None:

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py
@@ -12,17 +12,17 @@
 Databricks Unity Catalog Lineage Source Module
 """
 
+import json
 import traceback
 from collections import defaultdict
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, cast
 
+from cachetools import LRUCache
 from sqlalchemy import text
 
 from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.entity.data.container import ContainerDataModel
-from metadata.generated.schema.entity.data.database import Database
-from metadata.generated.schema.entity.data.databaseSchema import DatabaseSchema
 from metadata.generated.schema.entity.data.table import Table
 from metadata.generated.schema.entity.services.connections.database.unityCatalogConnection import (
     UnityCatalogConnection,
@@ -30,6 +30,7 @@ from metadata.generated.schema.entity.services.connections.database.unityCatalog
 from metadata.generated.schema.metadataIngestion.workflow import (
     Source as WorkflowSource,
 )
+from metadata.generated.schema.type.basic import SqlQuery
 from metadata.generated.schema.type.entityLineage import (
     ColumnLineage,
     EntitiesEdge,
@@ -52,9 +53,9 @@ from metadata.ingestion.source.database.unitycatalog.path_utils import (
     normalize_storage_path,
 )
 from metadata.ingestion.source.database.unitycatalog.queries import (
-    UNITY_CATALOG_COLUMN_LINEAGE,
     UNITY_CATALOG_EXTERNAL_TABLES,
-    UNITY_CATALOG_TABLE_LINEAGE,
+    UNITY_CATALOG_QUERY_HISTORY_PROBE,
+    unity_catalog_native_lineage_query,
 )
 from metadata.utils import fqn
 from metadata.utils.filters import filter_by_database, filter_by_schema, filter_by_table
@@ -62,12 +63,17 @@ from metadata.utils.helpers import retry_with_docker_host
 from metadata.utils.logger import ingestion_logger
 
 if TYPE_CHECKING:
+    from metadata.generated.schema.metadataIngestion.databaseServiceQueryLineagePipeline import (
+        DatabaseServiceQueryLineagePipeline,
+    )
     from metadata.ingestion.source.database.unitycatalog.connection import (
         UnityCatalogConnection as UnityCatalogConnectionHandler,
     )
 
 
 logger = ingestion_logger()
+
+TABLE_CACHE_MAX_SIZE = 500
 
 
 class UnitycatalogLineageSource(Source):
@@ -85,7 +91,7 @@ class UnitycatalogLineageSource(Source):
         self.config = config
         self.metadata = metadata
         self.service_connection = self.config.serviceConnection.root.config
-        self.source_config = self.config.sourceConfig.config
+        self.source_config = cast("DatabaseServiceQueryLineagePipeline", self.config.sourceConfig.config)
         self._connection = create_connection(self.service_connection)
         connection = cast("UnityCatalogConnectionHandler", self._connection)
         self.connection_obj = connection.client
@@ -95,6 +101,8 @@ class UnitycatalogLineageSource(Source):
         self.external_location_map: dict[str, str] = {}
         self.path_to_table_map: dict[str, set[str]] = defaultdict(set)
         self.path_lineage_map: dict[str, set[str]] = defaultdict(set)
+        self.edge_sql: dict[tuple[str, str], str] = {}
+        self._table_cache: LRUCache = LRUCache(maxsize=TABLE_CACHE_MAX_SIZE)
         with close_on_failure(self._connection):
             self.test_connection()
 
@@ -142,19 +150,79 @@ class UnitycatalogLineageSource(Source):
 
         return set(), normalized_path
 
+    def _probe_query_history(self) -> bool:
+        """
+        Whether `system.query.history` can be joined for the statement that wrote an edge.
+
+        The join needs `statement_id` on the lineage rows and SELECT on the history
+        table, and neither is guaranteed: the column is only populated for statements
+        run on a SQL warehouse, and reading statement text is separately granted. A
+        query that names them both would fail as a whole, taking the lineage with it,
+        so it is analysed once here with nothing to scan.
+        """
+        try:
+            with self.engine.connect() as conn:
+                conn.execute(text(UNITY_CATALOG_QUERY_HISTORY_PROBE))
+        except Exception as exc:
+            logger.info(
+                "system.query.history is not readable, native lineage will be ingested "
+                "without its SQL. Grant SELECT on system.query.history to attach it: %s",
+                exc,
+            )
+            return False
+        return True
+
+    @staticmethod
+    def _parse_column_pairs(raw_column_pairs: str | None) -> list[tuple[str, str]]:
+        """
+        Read the column mappings an edge carries on its own row.
+
+        Aggregating them into JSON inside the warehouse is what lets one query answer
+        for both system tables. Sorted because `collect_set` has no order of its own
+        and an edge that is re-ingested unchanged should serialize identically.
+        """
+        if not raw_column_pairs:
+            return []
+        try:
+            pairs = json.loads(raw_column_pairs)
+        except (TypeError, ValueError) as exc:
+            logger.debug("Skipping unreadable column pairs %r: %s", raw_column_pairs, exc)
+            return []
+        return sorted(
+            (pair["source"], pair["target"])
+            for pair in pairs
+            if isinstance(pair, dict) and pair.get("source") and pair.get("target")
+        )
+
     def _cache_lineage(self):
         """
-        Bulk-fetch all table and column lineage from system tables into memory.
+        Read every native lineage edge, its column mappings and its SQL in one pass.
+
+        The pairs are kept keyed by table name rather than emitted row by row: the same
+        edge is reported twice when Databricks names one side by path and the other by
+        table, and lineage is stored per edge, so a second request for a pair already
+        sent would overwrite the mappings of the first.
         """
-        query_log_duration = self.source_config.queryLogDuration or 1  # pyright: ignore[reportAttributeAccessIssue]
-        logger.info(f"Caching lineage from system tables (lookback: {query_log_duration} days)")
+        query_log_duration = self.source_config.queryLogDuration or 1
+        include_query_history = self._probe_query_history()
+        logger.info(
+            "Caching native lineage from system tables (lookback: %s days, SQL text: %s)",
+            query_log_duration,
+            "yes" if include_query_history else "no",
+        )
+
+        # Every edge a statement wrote holds the same text; one string per statement
+        # keeps a run over a large catalog from holding a copy per edge.
+        interned_statements: dict[str, str] = {}
 
         try:
             with self.engine.connect() as conn:
-                rows = conn.execute(text(UNITY_CATALOG_TABLE_LINEAGE.format(query_log_duration=query_log_duration)))
+                rows = conn.execute(text(unity_catalog_native_lineage_query(query_log_duration, include_query_history)))
                 for row in rows:
                     source_tables, source_path = self._resolve_lineage_side(row.source_table_full_name, row.source_path)
                     target_tables, _ = self._resolve_lineage_side(row.target_table_full_name, row.target_path)
+                    column_pairs = self._parse_column_pairs(row.column_pairs)
+                    statement_text = row.statement_text
 
                     for target_table in target_tables:
                         for source_table in source_tables:
@@ -165,47 +233,34 @@ class UnitycatalogLineageSource(Source):
                             if source_table == target_table:
                                 continue
                             self.table_lineage_map[target_table].add(source_table)
+                            table_key = (source_table, target_table)
+                            if column_pairs:
+                                # One edge reaches us twice when Databricks reports it both
+                                # by name and by path, and a duplicated pair would be sent
+                                # as a duplicated column edge.
+                                pairs = self.column_lineage_map[table_key]
+                                for column_pair in column_pairs:
+                                    if column_pair not in pairs:
+                                        pairs[column_pair] = None
+                            if statement_text:
+                                self.edge_sql[table_key] = interned_statements.setdefault(
+                                    statement_text, statement_text
+                                )
 
                         if source_path:
                             self.path_lineage_map[target_table].add(source_path)
             logger.info(
-                "Cached table lineage: %s edges for %s target tables, plus %s unresolved path upstreams",
+                "Cached native lineage: %s edges for %s target tables, %s column mappings, "
+                "%s edges with SQL, plus %s unresolved path upstreams",
                 sum(len(v) for v in self.table_lineage_map.values()),
                 len(self.table_lineage_map),
+                sum(len(v) for v in self.column_lineage_map.values()),
+                len(self.edge_sql),
                 sum(len(v) for v in self.path_lineage_map.values()),
             )
         except Exception as exc:
             logger.debug(traceback.format_exc())
-            logger.warning(f"Failed to cache table lineage: {exc}")
-
-        try:
-            with self.engine.connect() as conn:
-                rows = conn.execute(text(UNITY_CATALOG_COLUMN_LINEAGE.format(query_log_duration=query_log_duration)))
-                for row in rows:
-                    source_tables, _ = self._resolve_lineage_side(row.source_table_full_name, row.source_path)
-                    target_tables, _ = self._resolve_lineage_side(row.target_table_full_name, row.target_path)
-
-                    for target_table in target_tables:
-                        for source_table in source_tables:
-                            # The table pair this belongs to is dropped above, so caching the
-                            # columns only grows the map with entries nothing can read.
-                            if source_table == target_table:
-                                continue
-                            table_key = (source_table, target_table)
-                            column_pair = (row.source_column_name, row.target_column_name)
-                            # One edge reaches us twice when Databricks reports it both by
-                            # name and by path, and a duplicated pair would be sent as a
-                            # duplicated column edge.
-                            pairs = self.column_lineage_map[table_key]
-                            if column_pair not in pairs:
-                                pairs[column_pair] = None
-            logger.info(
-                f"Cached column lineage: {sum(len(v) for v in self.column_lineage_map.values())} "
-                f"column mappings for {len(self.column_lineage_map)} table pairs"
-            )
-        except Exception as exc:
-            logger.debug(traceback.format_exc())
-            logger.warning(f"Failed to cache column lineage: {exc}")
+            logger.warning("Failed to cache native lineage: %s", exc)
 
     def _cache_external_locations(self):
         """
@@ -232,6 +287,47 @@ class UnitycatalogLineageSource(Source):
         except Exception as exc:
             logger.debug(traceback.format_exc())
             logger.warning(f"Failed to cache external table locations: {exc}")
+
+    def _get_table_entity(self, databricks_table_fqn: str) -> Table | None:
+        """
+        Resolve a `catalog.schema.table` name to the table ingested for it.
+
+        A hot upstream is named by many edges and an upstream that was never ingested
+        is named just as often, so both answers are cached; a lookup that failed is
+        not, since one unreachable call would otherwise blind the rest of the run.
+        """
+        if databricks_table_fqn in self._table_cache:
+            return self._table_cache[databricks_table_fqn]
+
+        parts = databricks_table_fqn.split(".")
+        if len(parts) != 3:
+            logger.debug("Skipping malformed table name: %s", databricks_table_fqn)
+            return None
+        catalog_name, schema_name, table_name = parts
+
+        entity_fqn = cast(
+            "str | None",
+            fqn.build(
+                metadata=self.metadata,
+                entity_type=Table,
+                database_name=catalog_name,
+                schema_name=schema_name,
+                table_name=table_name,
+                service_name=self.config.serviceName,
+            ),
+        )
+        if not entity_fqn:
+            return None
+
+        try:
+            entity = self.metadata.get_by_name(entity=Table, fqn=entity_fqn)
+        except Exception as exc:
+            logger.debug("Failed to resolve table %s: %s", databricks_table_fqn, exc)
+            logger.debug(traceback.format_exc())
+            return None
+
+        self._table_cache[databricks_table_fqn] = entity
+        return entity
 
     def _get_data_model_column_fqn(self, data_model_entity: ContainerDataModel, column: str) -> str | None:
         if not data_model_entity:
@@ -294,9 +390,7 @@ class UnitycatalogLineageSource(Source):
             logger.debug(traceback.format_exc())
             return None
 
-    def _process_external_location_lineage(
-        self, table: Table, databricks_table_fqn: str
-    ) -> Iterable[Either[AddLineageRequest]]:
+    def _process_external_location_lineage(self, databricks_table_fqn: str) -> Iterable[Either[AddLineageRequest]]:
         """
         Look up external table storage location from cache and create
         container lineage if a matching container is found.
@@ -310,6 +404,14 @@ class UnitycatalogLineageSource(Source):
             location_entity = self.metadata.es_search_container_by_path(full_path=storage_location, fields="dataModel")
 
             if location_entity and location_entity[0]:
+                # The container is resolved before the table: an external table whose
+                # storage was never ingested cannot carry this edge, and every external
+                # table in the metastore reaches here.
+                table = self._get_table_entity(databricks_table_fqn)
+                if not table:
+                    logger.debug("Unable to find external table: %s", databricks_table_fqn)
+                    return
+
                 lineage_details = None
                 if location_entity[0].dataModel:
                     lineage_details = self._get_container_column_lineage(location_entity[0].dataModel, table)
@@ -385,24 +487,9 @@ class UnitycatalogLineageSource(Source):
     def _process_table_lineage(self, table: Table, databricks_table_fqn: str) -> Iterable[Either[AddLineageRequest]]:
         upstream_tables = self.table_lineage_map.get(databricks_table_fqn, set())
 
-        for source_table_full_name in upstream_tables:
+        for source_table_full_name in sorted(upstream_tables):
             try:
-                parts = source_table_full_name.split(".")
-                if len(parts) != 3:
-                    logger.debug(f"Skipping malformed source table name: {source_table_full_name}")
-                    continue
-                catalog_name, schema_name, table_name = parts
-
-                from_entity_fqn = fqn.build(
-                    metadata=self.metadata,
-                    entity_type=Table,
-                    database_name=catalog_name,
-                    schema_name=schema_name,
-                    table_name=table_name,
-                    service_name=self.config.serviceName,
-                )
-
-                from_entity = self.metadata.get_by_name(entity=Table, fqn=from_entity_fqn)
+                from_entity = self._get_table_entity(source_table_full_name)
                 if not from_entity:
                     logger.debug(f"Unable to find upstream entity: {source_table_full_name} -> {databricks_table_fqn}")
                     continue
@@ -412,7 +499,10 @@ class UnitycatalogLineageSource(Source):
                     to_table=table,
                     source_table_fqn=source_table_full_name,
                     target_table_fqn=databricks_table_fqn,
-                )
+                ) or LineageDetails(source=LineageSource.QueryLineage)
+
+                if sql_query := self.edge_sql.get((source_table_full_name, databricks_table_fqn)):
+                    lineage_details.sqlQuery = SqlQuery(root=sql_query)
 
                 yield Either(
                     right=AddLineageRequest(
@@ -427,51 +517,67 @@ class UnitycatalogLineageSource(Source):
                 logger.debug(f"Error processing lineage {source_table_full_name} -> {databricks_table_fqn}: {exc}")
                 logger.debug(traceback.format_exc())
 
+    def _lineage_targets(self) -> list[str]:
+        """
+        The tables an edge can end at: a lineage target, a table written by location,
+        or an external table whose storage may have been ingested as a container.
+        """
+        return sorted(set(self.table_lineage_map) | set(self.path_lineage_map) | set(self.external_location_map))
+
+    def _is_filtered(self, databricks_table_fqn: str) -> bool:
+        """Apply the pipeline's filter patterns to a `catalog.schema.table` name."""
+        parts = databricks_table_fqn.split(".")
+        if len(parts) != 3:
+            logger.debug("Skipping malformed table name: %s", databricks_table_fqn)
+            return True
+        catalog_name, schema_name, table_name = parts
+        entity_fqn = f"{self.config.serviceName}.{databricks_table_fqn}"
+
+        if filter_by_database(self.source_config.databaseFilterPattern, catalog_name):
+            self.status.filter(entity_fqn, "Catalog Filtered Out")
+            return True
+        if filter_by_schema(self.source_config.schemaFilterPattern, schema_name):
+            self.status.filter(entity_fqn, "Schema Filtered Out")
+            return True
+        if filter_by_table(self.source_config.tableFilterPattern, table_name):
+            self.status.filter(entity_fqn, "Table Filtered Out")
+            return True
+        return False
+
     def _iter(self, *_, **__) -> Iterable[Either[AddLineageRequest]]:
         """
         Fetch lineage from system tables for both table-to-table
         and external location lineage.
+
+        The system tables name every table an edge can end at, so those are the only
+        ones looked up. Listing every table of every schema of every catalog instead
+        costs a paginated request per hundred tables in the service, nearly all of
+        them for tables no edge mentions.
         """
         # External locations first: resolving a path-based lineage row to the table
         # declared over that path needs the location map already populated.
         self._cache_external_locations()
         self._cache_lineage()
 
-        for database in self.metadata.list_all_entities(entity=Database, params={"service": self.config.serviceName}):
-            if filter_by_database(self.source_config.databaseFilterPattern, database.name.root):  # pyright: ignore[reportAttributeAccessIssue]
-                self.status.filter(
-                    database.fullyQualifiedName.root,
-                    "Catalog Filtered Out",
-                )
+        for databricks_table_fqn in self._lineage_targets():
+            if self._is_filtered(databricks_table_fqn):
                 continue
-            for schema in self.metadata.list_all_entities(
-                entity=DatabaseSchema,
-                params={"database": database.fullyQualifiedName.root},
+
+            yield from self._process_external_location_lineage(databricks_table_fqn)
+
+            if not (
+                self.table_lineage_map.get(databricks_table_fqn) or self.path_lineage_map.get(databricks_table_fqn)
             ):
-                if filter_by_schema(self.source_config.schemaFilterPattern, schema.name.root):  # pyright: ignore[reportAttributeAccessIssue]
-                    self.status.filter(
-                        schema.fullyQualifiedName.root,
-                        "Schema Filtered Out",
-                    )
-                    continue
-                for table in self.metadata.list_all_entities(
-                    entity=Table,
-                    params={"databaseSchema": schema.fullyQualifiedName.root},
-                ):
-                    if filter_by_table(self.source_config.tableFilterPattern, table.name.root):  # pyright: ignore[reportAttributeAccessIssue]
-                        self.status.filter(
-                            table.fullyQualifiedName.root,
-                            "Table Filtered Out",
-                        )
-                        continue
+                continue
 
-                    databricks_table_fqn = f"{table.database.name}.{table.databaseSchema.name}.{table.name.root}"
+            table = self._get_table_entity(databricks_table_fqn)
+            if not table:
+                logger.debug("Unable to find downstream entity: %s", databricks_table_fqn)
+                continue
 
-                    yield from self._process_table_lineage(table, databricks_table_fqn)
+            yield from self._process_table_lineage(table, databricks_table_fqn)
 
-                    yield from self._process_path_lineage(table, databricks_table_fqn)
-
-                    yield from self._process_external_location_lineage(table, databricks_table_fqn)
+            yield from self._process_path_lineage(table, databricks_table_fqn)
 
     def test_connection(self) -> None:
         if self._connection is not None:

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py
@@ -323,6 +323,11 @@ class UnitycatalogLineageSource(Source):
         A hot upstream is named by many edges and an upstream that was never ingested
         is named just as often, so both answers are cached; a lookup that failed is
         not, since one unreachable call would otherwise blind the rest of the run.
+
+        The name is built rather than searched for: Unity Catalog normalises its
+        identifiers, so the three parts the system tables report are the three parts
+        the table was ingested under, and `fqn.build` would spend an Elasticsearch
+        search per table to arrive at the same string.
         """
         if databricks_table_fqn in self._table_cache:
             return self._table_cache[databricks_table_fqn]
@@ -333,19 +338,7 @@ class UnitycatalogLineageSource(Source):
             return None
         catalog_name, schema_name, table_name = parts
 
-        entity_fqn = cast(
-            "str | None",
-            fqn.build(
-                metadata=self.metadata,
-                entity_type=Table,
-                database_name=catalog_name,
-                schema_name=schema_name,
-                table_name=table_name,
-                service_name=self.config.serviceName,
-            ),
-        )
-        if not entity_fqn:
-            return None
+        entity_fqn = fqn._build(self.config.serviceName, catalog_name, schema_name, table_name)
 
         try:
             entity = self.metadata.get_by_name(entity=Table, fqn=entity_fqn)

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/queries.py
@@ -52,45 +52,114 @@ UNITY_CATALOG_SQL_STATEMENT = textwrap.dedent(
 
 UNITY_CATALOG_GET_TABLE_DDL = "SHOW CREATE TABLE `{database}`.`{schema}`.`{table}`"
 
-UNITY_CATALOG_TABLE_LINEAGE = textwrap.dedent(
+UNITY_CATALOG_QUERY_HISTORY_PROBE = textwrap.dedent(
     """
-    SELECT
-        source_table_full_name,
-        source_path,
-        target_table_full_name,
-        target_path
-    FROM system.access.table_lineage
-    WHERE event_time >= current_date() - INTERVAL {query_log_duration} DAYS
-        AND (source_table_full_name IS NOT NULL OR source_path IS NOT NULL)
-        AND (target_table_full_name IS NOT NULL OR target_path IS NOT NULL)
-    GROUP BY source_table_full_name, source_path, target_table_full_name, target_path
+    SELECT lineage.statement_id, history.statement_text
+    FROM system.access.table_lineage lineage
+    JOIN system.query.history history
+        ON lineage.statement_id = history.statement_id
+        AND lineage.workspace_id = history.workspace_id
+    WHERE 1=0
     """
 )
 
-UNITY_CATALOG_COLUMN_LINEAGE = textwrap.dedent(
+UNITY_CATALOG_NATIVE_LINEAGE = textwrap.dedent(
     """
+    WITH table_edges AS (
+        SELECT
+            source_table_full_name,
+            source_path,
+            target_table_full_name,
+            target_path{statement_columns}
+        FROM system.access.table_lineage
+        WHERE event_date >= current_date() - INTERVAL {query_log_duration} DAYS
+            AND event_time >= current_date() - INTERVAL {query_log_duration} DAYS
+            AND (source_table_full_name IS NOT NULL OR source_path IS NOT NULL)
+            AND (target_table_full_name IS NOT NULL OR target_path IS NOT NULL)
+        GROUP BY source_table_full_name, source_path, target_table_full_name, target_path
+    ),
+    column_edges AS (
+        SELECT
+            source_table_full_name,
+            source_path,
+            target_table_full_name,
+            target_path,
+            to_json(collect_set(struct(source_column_name AS source, target_column_name AS target)))
+                AS column_pairs
+        FROM system.access.column_lineage
+        WHERE event_date >= current_date() - INTERVAL {query_log_duration} DAYS
+            AND event_time >= current_date() - INTERVAL {query_log_duration} DAYS
+            AND (source_table_full_name IS NOT NULL OR source_path IS NOT NULL)
+            AND (target_table_full_name IS NOT NULL OR target_path IS NOT NULL)
+            AND source_column_name IS NOT NULL
+            AND target_column_name IS NOT NULL
+        GROUP BY source_table_full_name, source_path, target_table_full_name, target_path
+    )
     SELECT
-        source_table_full_name,
-        source_path,
-        source_column_name,
-        target_table_full_name,
-        target_path,
-        target_column_name
-    FROM system.access.column_lineage
-    WHERE event_time >= current_date() - INTERVAL {query_log_duration} DAYS
-        AND (source_table_full_name IS NOT NULL OR source_path IS NOT NULL)
-        AND (target_table_full_name IS NOT NULL OR target_path IS NOT NULL)
-        AND source_column_name IS NOT NULL
-        AND target_column_name IS NOT NULL
-    GROUP BY
-        source_table_full_name,
-        source_path,
-        source_column_name,
-        target_table_full_name,
-        target_path,
-        target_column_name
+        table_edges.source_table_full_name,
+        table_edges.source_path,
+        table_edges.target_table_full_name,
+        table_edges.target_path,
+        column_edges.column_pairs,
+        {statement_text} AS statement_text
+    FROM table_edges
+    LEFT JOIN column_edges
+        ON table_edges.source_table_full_name <=> column_edges.source_table_full_name
+        AND table_edges.source_path <=> column_edges.source_path
+        AND table_edges.target_table_full_name <=> column_edges.target_table_full_name
+        AND table_edges.target_path <=> column_edges.target_path{history_join}
     """
 )
+
+# The pair a lineage row belongs to is `event_time`'s latest statement, kept as one
+# struct so both halves of the query.history key come from the same row.
+UNITY_CATALOG_LATEST_STATEMENT_COLUMNS = (
+    ",\n        max_by("
+    "struct(statement_id AS statement_id, workspace_id AS workspace_id), event_time"
+    ") AS latest_statement"
+)
+
+UNITY_CATALOG_QUERY_HISTORY_JOIN = textwrap.dedent(
+    """
+    LEFT JOIN system.query.history history
+        ON history.statement_id = table_edges.latest_statement.statement_id
+        AND history.workspace_id = table_edges.latest_statement.workspace_id
+        AND history.start_time >= current_date() - INTERVAL {history_lookback} DAYS
+        AND history.statement_text IS NOT NULL
+        AND TRIM(history.statement_text) <> ''
+        AND UPPER(TRIM(history.statement_text)) <> '<REDACTED>'
+    """
+).rstrip()
+
+
+def unity_catalog_native_lineage_query(query_log_duration: int, include_query_history: bool) -> str:
+    """
+    Table edges, their column mappings and the statement that wrote them, in one query.
+
+    Column mappings are aggregated into a JSON array per edge so the second result set
+    they used to arrive in is no longer needed, and the statement is joined here rather
+    than looked up per batch of edges, which re-scanned the lineage window each time.
+
+    `include_query_history` is False when `system.query.history` cannot be read: the
+    statement columns and the join are then left out entirely so a missing grant costs
+    the SQL text rather than all of the lineage.
+    """
+    if not include_query_history:
+        return UNITY_CATALOG_NATIVE_LINEAGE.format(
+            query_log_duration=query_log_duration,
+            statement_columns="",
+            statement_text="CAST(NULL AS STRING)",
+            history_join="",
+        )
+    return UNITY_CATALOG_NATIVE_LINEAGE.format(
+        query_log_duration=query_log_duration,
+        statement_columns=UNITY_CATALOG_LATEST_STATEMENT_COLUMNS,
+        statement_text="history.statement_text",
+        # A statement that ran just before midnight of the oldest lineage day is still
+        # the one that wrote the edge, so history reaches back one day further.
+        history_join=UNITY_CATALOG_QUERY_HISTORY_JOIN.format(history_lookback=query_log_duration + 1),
+    )
+
 
 UNITY_CATALOG_EXTERNAL_TABLES = textwrap.dedent(
     """

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/queries.py
@@ -108,6 +108,7 @@ UNITY_CATALOG_NATIVE_LINEAGE = textwrap.dedent(
         AND table_edges.source_path <=> column_edges.source_path
         AND table_edges.target_table_full_name <=> column_edges.target_table_full_name
         AND table_edges.target_path <=> column_edges.target_path{history_join}
+    ORDER BY table_edges.target_table_full_name, table_edges.target_path
     """
 )
 
@@ -139,6 +140,9 @@ def unity_catalog_native_lineage_query(query_log_duration: int, include_query_hi
     Column mappings are aggregated into a JSON array per edge so the second result set
     they used to arrive in is no longer needed, and the statement is joined here rather
     than looked up per batch of edges, which re-scanned the lineage window each time.
+
+    Ordered by target so the rows of one target arrive together and the reader can emit
+    them and move on, instead of holding every edge of the catalog to group them.
 
     `include_query_history` is False when `system.query.history` cannot be read: the
     statement columns and the join are then left out entirely so a missing grant costs

--- a/ingestion/tests/unit/topology/database/test_unity_catalog_lineage.py
+++ b/ingestion/tests/unit/topology/database/test_unity_catalog_lineage.py
@@ -610,6 +610,16 @@ class TestExternalLocationLineage:
         assert len(results) == 0
         lineage_source.metadata.get_by_name.assert_not_called()
 
+    def test_process_external_location_table_not_ingested(self, lineage_source):
+        """The container exists but nothing was ingested for the external table"""
+        lineage_source.external_location_map = {"cat.schema.test_table": "s3://bucket/path"}
+        lineage_source.metadata.es_search_container_by_path.return_value = [a_container()]
+        resolve_tables(lineage_source, {})
+
+        results = list(lineage_source._process_external_location_lineage("cat.schema.test_table"))
+
+        assert len(results) == 0
+
     def test_external_tables_are_emitted_without_any_lineage_row(self, lineage_source):
         """An external table's container edge does not depend on the system lineage tables"""
         tables = {"cat.schema.ext": a_table("ext")}
@@ -991,6 +1001,11 @@ class TestLineageDrivenIteration:
         assert len(results) == 2
         resolved = [call.kwargs["fqn"] for call in lineage_source.metadata.get_by_name.call_args_list]
         assert resolved.count("local_unitycatalog.cat.schema.src") == 1
+
+    def test_a_name_that_is_not_three_parts_is_skipped(self, lineage_source):
+        """A target has to be catalog.schema.table to be filtered or resolved at all"""
+        assert lineage_source._is_filtered("system.access") is True
+        assert lineage_source.status.filtered == []
 
     def test_a_failing_lookup_is_not_cached(self, lineage_source):
         """A transient failure must not blind every later edge naming that table"""

--- a/ingestion/tests/unit/topology/database/test_unity_catalog_lineage.py
+++ b/ingestion/tests/unit/topology/database/test_unity_catalog_lineage.py
@@ -13,8 +13,8 @@
 Test Unity Catalog lineage functionality
 """
 
+import json
 from collections import namedtuple
-from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 from uuid import uuid4
 
@@ -37,9 +37,13 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 from metadata.generated.schema.type.basic import EntityName, FullyQualifiedEntityName
 from metadata.generated.schema.type.entityLineage import Source as LineageSource
 from metadata.generated.schema.type.entityReference import EntityReference
+from metadata.generated.schema.type.filterPattern import FilterPattern
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.source.database.unitycatalog.lineage import (
     UnitycatalogLineageSource,
+)
+from metadata.ingestion.source.database.unitycatalog.queries import (
+    unity_catalog_native_lineage_query,
 )
 
 MOCK_CONFIG = {
@@ -71,30 +75,72 @@ MOCK_CONFIG = {
 
 TableRow = namedtuple(
     "TableRow",
-    ["source_table_full_name", "source_path", "target_table_full_name", "target_path"],
-)
-ColumnRow = namedtuple(
-    "ColumnRow",
     [
         "source_table_full_name",
         "source_path",
-        "source_column_name",
         "target_table_full_name",
         "target_path",
-        "target_column_name",
+        "column_pairs",
+        "statement_text",
     ],
 )
 ExternalRow = namedtuple("ExternalRow", ["table_catalog", "table_schema", "table_name", "storage_path"])
 
 
-def table_row(source=None, target=None, source_path=None, target_path=None):
-    """A system.access.table_lineage row, named or path based on either side"""
-    return TableRow(source, source_path, target, target_path)
+def pairs_json(column_pairs):
+    """The JSON array `to_json(collect_set(struct(...)))` aggregates an edge's mappings into"""
+    if column_pairs is None:
+        return None
+    return json.dumps([{"source": source, "target": target} for source, target in column_pairs])
 
 
-def column_row(source, source_column, target, target_column, source_path=None, target_path=None):
-    """A system.access.column_lineage row"""
-    return ColumnRow(source, source_path, source_column, target, target_path, target_column)
+def table_row(
+    source=None,
+    target=None,
+    source_path=None,
+    target_path=None,
+    column_pairs=None,
+    statement_text=None,
+):
+    """A native lineage row: one table edge with its column mappings and its SQL"""
+    return TableRow(source, source_path, target, target_path, pairs_json(column_pairs), statement_text)
+
+
+def stub_rows(lineage_source, rows=(), external_rows=(), probe_error=None):
+    """
+    Answer every query the connector runs: the query history probe, the external
+    location query and the native lineage query.
+
+    Returns the list executed statements are recorded into, so a test can assert what
+    was actually asked of the warehouse.
+    """
+    executed = []
+
+    def execute(statement, *_args, **_kwargs):
+        sql = str(statement)
+        executed.append(sql)
+        if "WHERE 1=0" in sql:
+            if probe_error:
+                raise probe_error
+            return []
+        if "information_schema.tables" in sql:
+            return external_rows
+        return rows
+
+    mock_conn = MagicMock()
+    mock_conn.execute.side_effect = execute
+    lineage_source.engine.connect.return_value.__enter__ = Mock(return_value=mock_conn)
+    lineage_source.engine.connect.return_value.__exit__ = Mock(return_value=False)
+    return executed
+
+
+def resolve_tables(lineage_source, tables):
+    """Resolve `catalog.schema.table` names, keyed the way the connector asks for them"""
+
+    def get_by_name(entity=None, fqn=None, **_kwargs):
+        return tables.get(str(fqn).split(".", 1)[1] if fqn else None)
+
+    lineage_source.metadata.get_by_name.side_effect = get_by_name
 
 
 def a_table(name="test_table", columns=None):
@@ -103,6 +149,14 @@ def a_table(name="test_table", columns=None):
         name=EntityName(root=name),
         fullyQualifiedName=FullyQualifiedEntityName(root=f"service.db.schema.{name}"),
         columns=columns or [],
+    )
+
+
+def a_column(name, column_fqn):
+    return Column(
+        name=ColumnName(root=name),
+        dataType=DataType.STRING,
+        fullyQualifiedName=FullyQualifiedEntityName(root=column_fqn),
     )
 
 
@@ -130,16 +184,14 @@ def lineage_source():
 
 class TestCacheLineage:
     def test_cache_table_lineage(self, lineage_source):
-        mock_rows = [
-            table_row("cat.schema.source1", "cat.schema.target1"),
-            table_row("cat.schema.source2", "cat.schema.target1"),
-            table_row("cat.schema.source1", "cat.schema.target2"),
-        ]
-
-        mock_conn = MagicMock()
-        mock_conn.execute.return_value = mock_rows
-        lineage_source.engine.connect.return_value.__enter__ = Mock(return_value=mock_conn)
-        lineage_source.engine.connect.return_value.__exit__ = Mock(return_value=False)
+        stub_rows(
+            lineage_source,
+            [
+                table_row("cat.schema.source1", "cat.schema.target1"),
+                table_row("cat.schema.source2", "cat.schema.target1"),
+                table_row("cat.schema.source1", "cat.schema.target2"),
+            ],
+        )
 
         lineage_source._cache_lineage()
 
@@ -153,22 +205,17 @@ class TestCacheLineage:
         }
 
     def test_cache_column_lineage(self, lineage_source):
-        call_count = 0
-
-        def mock_execute(query):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                return [table_row("cat.schema.src", "cat.schema.tgt")]
-            return [
-                column_row("cat.schema.src", "col_a", "cat.schema.tgt", "col_x"),
-                column_row("cat.schema.src", "col_b", "cat.schema.tgt", "col_y"),
-            ]
-
-        mock_conn = MagicMock()
-        mock_conn.execute.side_effect = mock_execute
-        lineage_source.engine.connect.return_value.__enter__ = Mock(return_value=mock_conn)
-        lineage_source.engine.connect.return_value.__exit__ = Mock(return_value=False)
+        """The mappings of an edge travel on the edge's own row"""
+        stub_rows(
+            lineage_source,
+            [
+                table_row(
+                    "cat.schema.src",
+                    "cat.schema.tgt",
+                    column_pairs=[("col_b", "col_y"), ("col_a", "col_x")],
+                )
+            ],
+        )
 
         lineage_source._cache_lineage()
 
@@ -179,6 +226,19 @@ class TestCacheLineage:
             ("col_b", "col_y"),
         ]
 
+    def test_lineage_is_read_in_a_single_query(self, lineage_source):
+        """
+        One query returns table edges, column mappings and SQL. A second query per
+        result set, or per batch of edges, re-scans the whole lineage window.
+        """
+        executed = stub_rows(lineage_source, [table_row("cat.schema.src", "cat.schema.tgt")])
+
+        lineage_source._cache_lineage()
+
+        lineage_queries = [sql for sql in executed if "system.access.table_lineage" in sql and "WHERE 1=0" not in sql]
+        assert len(lineage_queries) == 1
+        assert "system.access.column_lineage" in lineage_queries[0]
+
     def test_cache_lineage_handles_query_failure(self, lineage_source):
         mock_conn = MagicMock()
         mock_conn.execute.side_effect = Exception("Access denied")
@@ -188,6 +248,131 @@ class TestCacheLineage:
         lineage_source._cache_lineage()
 
         assert len(lineage_source.table_lineage_map) == 0
+        assert len(lineage_source.column_lineage_map) == 0
+        assert len(lineage_source.edge_sql) == 0
+
+    def test_a_row_without_column_pairs_leaves_no_entry_behind(self, lineage_source):
+        stub_rows(lineage_source, [table_row("cat.schema.src", "cat.schema.tgt")])
+
+        lineage_source._cache_lineage()
+
+        assert len(lineage_source.column_lineage_map) == 0
+
+
+class TestNativeLineageSql:
+    """The statement that wrote an edge, joined in the same query as the edge itself."""
+
+    def test_sql_is_attached_to_the_edge(self, lineage_source):
+        stub_rows(
+            lineage_source,
+            [
+                table_row(
+                    "cat.schema.src",
+                    "cat.schema.tgt",
+                    statement_text="INSERT INTO tgt SELECT * FROM src",
+                )
+            ],
+        )
+        lineage_source._cache_lineage()
+
+        target = a_table("tgt")
+        resolve_tables(lineage_source, {"cat.schema.src": a_table("src")})
+
+        results = list(lineage_source._process_table_lineage(target, "cat.schema.tgt"))
+
+        assert len(results) == 1
+        assert results[0].right.edge.lineageDetails.sqlQuery.root == "INSERT INTO tgt SELECT * FROM src"
+
+    def test_an_edge_without_sql_is_still_emitted(self, lineage_source):
+        stub_rows(lineage_source, [table_row("cat.schema.src", "cat.schema.tgt")])
+        lineage_source._cache_lineage()
+
+        resolve_tables(lineage_source, {"cat.schema.src": a_table("src")})
+
+        results = list(lineage_source._process_table_lineage(a_table("tgt"), "cat.schema.tgt"))
+
+        assert len(results) == 1
+        assert results[0].right.edge.lineageDetails.sqlQuery is None
+
+    def test_one_statement_is_stored_once_for_all_of_its_edges(self, lineage_source):
+        """A statement writing many edges must not be held once per edge"""
+        statement = "INSERT INTO tgt SELECT * FROM a JOIN b"
+        stub_rows(
+            lineage_source,
+            [
+                table_row("cat.schema.a", "cat.schema.tgt", statement_text=statement),
+                # the driver hands out an equal but distinct string per row
+                table_row("cat.schema.b", "cat.schema.tgt", statement_text=str(statement)),
+            ],
+        )
+
+        lineage_source._cache_lineage()
+
+        stored = list(lineage_source.edge_sql.values())
+        assert len(stored) == 2
+        assert stored[0] is stored[1]
+
+    def test_column_mappings_and_sql_ride_the_same_edge(self, lineage_source):
+        stub_rows(
+            lineage_source,
+            [
+                table_row(
+                    "cat.schema.src",
+                    "cat.schema.tgt",
+                    column_pairs=[("col_a", "col_x")],
+                    statement_text="INSERT INTO tgt SELECT col_a FROM src",
+                )
+            ],
+        )
+        lineage_source._cache_lineage()
+
+        target = a_table("tgt", columns=[a_column("col_x", "svc.cat.schema.tgt.col_x")])
+        resolve_tables(
+            lineage_source,
+            {"cat.schema.src": a_table("src", columns=[a_column("col_a", "svc.cat.schema.src.col_a")])},
+        )
+
+        results = list(lineage_source._process_table_lineage(target, "cat.schema.tgt"))
+
+        details = results[0].right.edge.lineageDetails
+        assert details.sqlQuery.root == "INSERT INTO tgt SELECT col_a FROM src"
+        assert details.columnsLineage[0].fromColumns[0].root == "svc.cat.schema.src.col_a"
+        assert details.columnsLineage[0].toColumn.root == "svc.cat.schema.tgt.col_x"
+
+    def test_unreadable_query_history_keeps_the_lineage(self, lineage_source):
+        """
+        A missing grant on system.query.history must cost the SQL text, not the edges,
+        so the statement columns and the join are left out of the query entirely.
+        """
+        executed = stub_rows(
+            lineage_source,
+            [table_row("cat.schema.src", "cat.schema.tgt")],
+            probe_error=Exception("permission denied on system.query.history"),
+        )
+
+        lineage_source._cache_lineage()
+
+        lineage_query = next(sql for sql in executed if "table_edges" in sql)
+        assert "system.query.history" not in lineage_query
+        assert "latest_statement" not in lineage_query
+        assert lineage_source.table_lineage_map["cat.schema.tgt"] == {"cat.schema.src"}
+        assert len(lineage_source.edge_sql) == 0
+
+    def test_readable_query_history_is_joined(self, lineage_source):
+        executed = stub_rows(lineage_source, [table_row("cat.schema.src", "cat.schema.tgt")])
+
+        lineage_source._cache_lineage()
+
+        lineage_query = next(sql for sql in executed if "table_edges" in sql)
+        assert "system.query.history" in lineage_query
+        assert "latest_statement" in lineage_query
+
+    def test_unreadable_column_pairs_are_skipped(self, lineage_source):
+        stub_rows(lineage_source, [TableRow("cat.schema.src", None, "cat.schema.tgt", None, "not json", None)])
+
+        lineage_source._cache_lineage()
+
+        assert lineage_source.table_lineage_map["cat.schema.tgt"] == {"cat.schema.src"}
         assert len(lineage_source.column_lineage_map) == 0
 
 
@@ -383,12 +568,8 @@ class TestExternalLocationLineage:
     def test_process_external_location_lineage_from_cache(self, lineage_source):
         lineage_source.external_location_map = {"cat.schema.test_table": "s3://bucket/path"}
 
-        table_entity = Table(
-            id=uuid4(),
-            name=EntityName(root="test_table"),
-            fullyQualifiedName=FullyQualifiedEntityName(root="service.db.schema.test_table"),
-            columns=[],
-        )
+        table_entity = a_table("test_table")
+        resolve_tables(lineage_source, {"cat.schema.test_table": table_entity})
 
         container_entity = Container(
             id=uuid4(),
@@ -398,7 +579,7 @@ class TestExternalLocationLineage:
 
         lineage_source.metadata.es_search_container_by_path.return_value = [container_entity]
 
-        results = list(lineage_source._process_external_location_lineage(table_entity, "cat.schema.test_table"))
+        results = list(lineage_source._process_external_location_lineage("cat.schema.test_table"))
 
         assert len(results) == 1
         assert isinstance(results[0], Either)
@@ -415,12 +596,7 @@ class TestExternalLocationLineage:
     def test_process_external_location_strips_trailing_slash(self, lineage_source):
         lineage_source.external_location_map = {"cat.schema.test_table": "s3://test-bucket/data/"}
 
-        table_entity = Table(
-            id=uuid4(),
-            name=EntityName(root="test_table"),
-            fullyQualifiedName=FullyQualifiedEntityName(root="service.db.schema.test_table"),
-            columns=[],
-        )
+        resolve_tables(lineage_source, {"cat.schema.test_table": a_table("test_table")})
 
         container_entity = Container(
             id=uuid4(),
@@ -430,7 +606,7 @@ class TestExternalLocationLineage:
 
         lineage_source.metadata.es_search_container_by_path.return_value = [container_entity]
 
-        results = list(lineage_source._process_external_location_lineage(table_entity, "cat.schema.test_table"))
+        results = list(lineage_source._process_external_location_lineage("cat.schema.test_table"))
 
         assert len(results) == 1
         lineage_source.metadata.es_search_container_by_path.assert_called_once_with(
@@ -440,32 +616,24 @@ class TestExternalLocationLineage:
     def test_process_external_location_no_cache_entry(self, lineage_source):
         lineage_source.external_location_map = {}
 
-        table_entity = Table(
-            id=uuid4(),
-            name=EntityName(root="test_table"),
-            fullyQualifiedName=FullyQualifiedEntityName(root="service.db.schema.test_table"),
-            columns=[],
-        )
-
-        results = list(lineage_source._process_external_location_lineage(table_entity, "cat.schema.test_table"))
+        results = list(lineage_source._process_external_location_lineage("cat.schema.test_table"))
 
         assert len(results) == 0
+        lineage_source.metadata.es_search_container_by_path.assert_not_called()
 
     def test_process_external_location_no_container_found(self, lineage_source):
+        """
+        Every external table in the metastore reaches here, so one whose storage was
+        never ingested must not cost a request to resolve the table itself.
+        """
         lineage_source.external_location_map = {"cat.schema.test_table": "s3://bucket/path"}
-
-        table_entity = Table(
-            id=uuid4(),
-            name=EntityName(root="test_table"),
-            fullyQualifiedName=FullyQualifiedEntityName(root="service.db.schema.test_table"),
-            columns=[],
-        )
 
         lineage_source.metadata.es_search_container_by_path.return_value = []
 
-        results = list(lineage_source._process_external_location_lineage(table_entity, "cat.schema.test_table"))
+        results = list(lineage_source._process_external_location_lineage("cat.schema.test_table"))
 
         assert len(results) == 0
+        lineage_source.metadata.get_by_name.assert_not_called()
 
 
 class TestContainerColumnLineage:
@@ -544,18 +712,8 @@ class TestPathBasedLineage:
     """
 
     @staticmethod
-    def _cache_rows(lineage_source, table_rows, column_rows=None):
-        call_count = 0
-
-        def mock_execute(query):
-            nonlocal call_count
-            call_count += 1
-            return table_rows if call_count == 1 else (column_rows or [])
-
-        mock_conn = MagicMock()
-        mock_conn.execute.side_effect = mock_execute
-        lineage_source.engine.connect.return_value.__enter__ = Mock(return_value=mock_conn)
-        lineage_source.engine.connect.return_value.__exit__ = Mock(return_value=False)
+    def _cache_rows(lineage_source, table_rows):
+        stub_rows(lineage_source, table_rows)
         lineage_source._cache_lineage()
 
     def test_path_source_resolves_to_external_table(self, lineage_source):
@@ -645,10 +803,12 @@ class TestPathBasedLineage:
 
         self._cache_rows(
             lineage_source,
-            [table_row(target="cat.schema.tgt", source_path="s3://bucket/data")],
             [
-                column_row(None, "col_a", "cat.schema.tgt", "col_x", source_path="s3://bucket/data"),
-                column_row(None, "col_b", "cat.schema.tgt", "col_y", source_path="s3://bucket/data/"),
+                table_row(
+                    target="cat.schema.tgt",
+                    source_path="s3://bucket/data",
+                    column_pairs=[("col_a", "col_x"), ("col_b", "col_y")],
+                )
             ],
         )
 
@@ -658,18 +818,25 @@ class TestPathBasedLineage:
         ]
 
     def test_column_pair_reported_by_both_name_and_path_is_not_duplicated(self, lineage_source):
-        """Widening the GROUP BY lets one edge arrive twice"""
+        """
+        One edge arrives twice when Databricks names its source by table on one row
+        and by path on another, and both rows resolve to the same pair.
+        """
         lineage_source.path_to_table_map["s3://bucket/data"] = {"cat.schema.ext"}
 
         self._cache_rows(
             lineage_source,
-            [table_row("cat.schema.ext", "cat.schema.tgt")],
             [
-                column_row("cat.schema.ext", "col_a", "cat.schema.tgt", "col_x"),
-                column_row(None, "col_a", "cat.schema.tgt", "col_x", source_path="s3://bucket/data"),
+                table_row("cat.schema.ext", "cat.schema.tgt", column_pairs=[("col_a", "col_x")]),
+                table_row(
+                    target="cat.schema.tgt",
+                    source_path="s3://bucket/data",
+                    column_pairs=[("col_a", "col_x")],
+                ),
             ],
         )
 
+        assert lineage_source.table_lineage_map["cat.schema.tgt"] == {"cat.schema.ext"}
         assert lineage_source.column_lineage_map[("cat.schema.ext", "cat.schema.tgt")] == {("col_a", "col_x"): None}
 
     def test_cache_external_locations_builds_the_inverse_map(self, lineage_source):
@@ -749,7 +916,6 @@ class TestPathBasedLineage:
         calls = []
         lineage_source._cache_external_locations = lambda: calls.append("locations")
         lineage_source._cache_lineage = lambda: calls.append("lineage")
-        lineage_source.metadata.list_all_entities.return_value = []
 
         list(lineage_source._iter())
 
@@ -807,18 +973,18 @@ class TestPathBasedLineage:
         external_table = "bronze_ns.deltalake_ns.external_table"
         managed_table = "bronze_ns.deltalake_ns.managed_table_ns"
 
-        def mock_execute(statement):
-            sql = str(statement)
-            if "information_schema.tables" in sql:
-                return [ExternalRow("bronze_ns", "deltalake_ns", "external_table", raw_path)]
-            if "table_lineage" in sql:
-                return [table_row(target=managed_table, source_path=raw_path)]
-            return [column_row(None, "id", managed_table, "id", source_path=raw_path)]
-
-        mock_conn = MagicMock()
-        mock_conn.execute.side_effect = mock_execute
-        lineage_source.engine.connect.return_value.__enter__ = Mock(return_value=mock_conn)
-        lineage_source.engine.connect.return_value.__exit__ = Mock(return_value=False)
+        stub_rows(
+            lineage_source,
+            rows=[
+                table_row(
+                    target=managed_table,
+                    source_path=raw_path,
+                    column_pairs=[("id", "id")],
+                    statement_text="CREATE TABLE managed_table_ns AS SELECT id FROM delta.`" + raw_path + "`",
+                )
+            ],
+            external_rows=[ExternalRow("bronze_ns", "deltalake_ns", "external_table", raw_path)],
+        )
 
         target_entity = Table(
             id=uuid4(),
@@ -847,20 +1013,11 @@ class TestPathBasedLineage:
             ],
         )
 
-        database = SimpleNamespace(
-            name=SimpleNamespace(root="bronze_ns"),
-            fullyQualifiedName=SimpleNamespace(root="svc.bronze_ns"),
+        resolve_tables(
+            lineage_source,
+            {managed_table: target_entity, external_table: upstream_entity},
         )
-        schema = SimpleNamespace(
-            name=SimpleNamespace(root="deltalake_ns"),
-            fullyQualifiedName=SimpleNamespace(root="svc.bronze_ns.deltalake_ns"),
-        )
-        lineage_source.metadata.list_all_entities.side_effect = [[database], [schema], [target_entity]]
-        lineage_source.metadata.get_by_name.return_value = upstream_entity
         lineage_source.metadata.es_search_container_by_path.return_value = []
-        lineage_source.source_config.databaseFilterPattern = None
-        lineage_source.source_config.schemaFilterPattern = None
-        lineage_source.source_config.tableFilterPattern = None
 
         results = list(lineage_source._iter())
 
@@ -870,3 +1027,186 @@ class TestPathBasedLineage:
         assert edge.toEntity.id == target_entity.id
         assert edge.lineageDetails.columnsLineage[0].fromColumns[0].root == f"svc.{external_table}.id"
         assert edge.lineageDetails.columnsLineage[0].toColumn.root == f"svc.{managed_table}.id"
+        assert edge.lineageDetails.sqlQuery.root.startswith("CREATE TABLE managed_table_ns")
+        lineage_source.metadata.list_all_entities.assert_not_called()
+
+
+class TestLineageDrivenIteration:
+    """
+    The system tables name every table an edge can end at, so those are the tables
+    looked up. Walking the whole service instead pages through every table of every
+    schema of every catalog to find the few an edge mentions.
+    """
+
+    def test_the_service_is_not_walked(self, lineage_source):
+        stub_rows(lineage_source, [table_row("cat.schema.src", "cat.schema.tgt")])
+        resolve_tables(lineage_source, {"cat.schema.src": a_table("src"), "cat.schema.tgt": a_table("tgt")})
+
+        results = list(lineage_source._iter())
+
+        assert len(results) == 1
+        lineage_source.metadata.list_all_entities.assert_not_called()
+
+    def test_targets_cover_lineage_paths_and_external_locations(self, lineage_source):
+        lineage_source.table_lineage_map["cat.schema.from_lineage"] = {"cat.schema.src"}
+        lineage_source.path_lineage_map["cat.schema.from_path"] = {"s3://bucket/data"}
+        lineage_source.external_location_map["cat.schema.external"] = "s3://bucket/ext"
+
+        assert lineage_source._lineage_targets() == [
+            "cat.schema.external",
+            "cat.schema.from_lineage",
+            "cat.schema.from_path",
+        ]
+
+    def test_an_upstream_named_by_two_targets_is_resolved_once(self, lineage_source):
+        stub_rows(
+            lineage_source,
+            [
+                table_row("cat.schema.src", "cat.schema.tgt1"),
+                table_row("cat.schema.src", "cat.schema.tgt2"),
+            ],
+        )
+        resolve_tables(
+            lineage_source,
+            {
+                "cat.schema.src": a_table("src"),
+                "cat.schema.tgt1": a_table("tgt1"),
+                "cat.schema.tgt2": a_table("tgt2"),
+            },
+        )
+
+        results = list(lineage_source._iter())
+
+        assert len(results) == 2
+        resolved = [call.kwargs["fqn"] for call in lineage_source.metadata.get_by_name.call_args_list]
+        assert resolved.count("local_unitycatalog.cat.schema.src") == 1
+
+    def test_a_target_that_was_never_ingested_is_skipped(self, lineage_source):
+        stub_rows(lineage_source, [table_row("cat.schema.src", "cat.schema.tgt")])
+        resolve_tables(lineage_source, {"cat.schema.src": a_table("src")})
+
+        assert list(lineage_source._iter()) == []
+
+    def test_a_failing_lookup_is_not_cached(self, lineage_source):
+        """A transient failure must not blind every later edge naming that table"""
+        lineage_source.metadata.get_by_name.side_effect = RuntimeError("connection reset")
+
+        assert lineage_source._get_table_entity("cat.schema.tgt") is None
+        assert "cat.schema.tgt" not in lineage_source._table_cache
+
+    def test_filters_apply_to_the_names_the_system_tables_report(self, lineage_source):
+        stub_rows(
+            lineage_source,
+            [
+                table_row("cat.schema.src", "excluded_cat.schema.tgt"),
+                table_row("cat.schema.src", "cat.excluded_schema.tgt"),
+                table_row("cat.schema.src", "cat.schema.excluded_table"),
+                table_row("cat.schema.src", "cat.schema.tgt"),
+            ],
+        )
+        resolve_tables(
+            lineage_source,
+            {
+                "cat.schema.src": a_table("src"),
+                "excluded_cat.schema.tgt": a_table("tgt"),
+                "cat.excluded_schema.tgt": a_table("tgt"),
+                "cat.schema.excluded_table": a_table("excluded_table"),
+                "cat.schema.tgt": a_table("tgt"),
+            },
+        )
+        lineage_source.source_config.databaseFilterPattern = FilterPattern(excludes=["excluded_cat"])
+        lineage_source.source_config.schemaFilterPattern = FilterPattern(excludes=["excluded_schema"])
+        lineage_source.source_config.tableFilterPattern = FilterPattern(excludes=["excluded_table"])
+
+        results = list(lineage_source._iter())
+
+        assert len(results) == 1
+        assert results[0].right.edge.toEntity.id is not None
+        assert lineage_source.status.filtered == [
+            {"local_unitycatalog.cat.excluded_schema.tgt": "Schema Filtered Out"},
+            {"local_unitycatalog.cat.schema.excluded_table": "Table Filtered Out"},
+            {"local_unitycatalog.excluded_cat.schema.tgt": "Catalog Filtered Out"},
+        ]
+
+
+class TestNativeLineageQuery:
+    """The single query both system tables and the statement text are read with."""
+
+    def test_both_system_tables_are_read_in_one_query(self):
+        query = unity_catalog_native_lineage_query(7, include_query_history=True)
+
+        assert query.count("FROM system.access.table_lineage") == 1
+        assert query.count("FROM system.access.column_lineage") == 1
+        assert query.count("INTERVAL 7 DAYS") == 4
+
+    def test_column_mappings_join_on_null_safe_equality(self):
+        """
+        `source_path` is NULL on every edge reported by table name and `=` on NULL
+        never matches, so a plain join would drop those edges' column mappings.
+        """
+        query = unity_catalog_native_lineage_query(1, include_query_history=True)
+
+        join = query.split("LEFT JOIN column_edges")[1].split("LEFT JOIN system.query.history")[0]
+        assert join.count("<=>") == 4
+        assert " = " not in join
+
+    def test_history_reaches_one_day_further_back_than_lineage(self):
+        """A statement that ran just before the oldest lineage day still wrote that edge"""
+        query = unity_catalog_native_lineage_query(2, include_query_history=True)
+
+        assert "history.start_time >= current_date() - INTERVAL 3 DAYS" in query
+
+    def test_unusable_statement_text_is_left_out(self):
+        query = unity_catalog_native_lineage_query(1, include_query_history=True)
+
+        assert "UPPER(TRIM(history.statement_text)) <> '<REDACTED>'" in query
+
+    def test_without_query_history_the_query_does_not_name_it(self):
+        query = unity_catalog_native_lineage_query(1, include_query_history=False)
+
+        assert "system.query.history" not in query
+        assert "statement_id" not in query
+        assert "CAST(NULL AS STRING) AS statement_text" in query
+
+
+class TestExternalTablesWithoutLineage:
+    def test_an_external_table_with_no_lineage_still_gets_its_container_edge(self, lineage_source):
+        stub_rows(
+            lineage_source,
+            external_rows=[ExternalRow("cat", "schema", "ext", "s3://bucket/data")],
+        )
+        table_entity = a_table("ext")
+        resolve_tables(lineage_source, {"cat.schema.ext": table_entity})
+        container_entity = a_container()
+        lineage_source.metadata.es_search_container_by_path.return_value = [container_entity]
+
+        results = list(lineage_source._iter())
+
+        assert len(results) == 1
+        assert results[0].right.edge.fromEntity.id == container_entity.id
+        assert results[0].right.edge.toEntity.id == table_entity.id
+
+    def test_a_table_with_no_upstream_is_never_resolved(self, lineage_source):
+        """Resolving it would spend a request per external table in the metastore"""
+        stub_rows(
+            lineage_source,
+            external_rows=[ExternalRow("cat", "schema", "ext", "s3://bucket/data")],
+        )
+        lineage_source.metadata.es_search_container_by_path.return_value = []
+
+        assert list(lineage_source._iter()) == []
+        lineage_source.metadata.get_by_name.assert_not_called()
+
+    def test_an_external_table_that_was_never_ingested_yields_nothing(self, lineage_source):
+        lineage_source.external_location_map = {"cat.schema.ext": "s3://bucket/data"}
+        lineage_source.metadata.es_search_container_by_path.return_value = [a_container()]
+        resolve_tables(lineage_source, {})
+
+        assert list(lineage_source._process_external_location_lineage("cat.schema.ext")) == []
+
+    def test_a_malformed_target_name_is_dropped(self, lineage_source):
+        """A name that is not `catalog.schema.table` cannot be resolved or filtered"""
+        stub_rows(lineage_source, [table_row("cat.schema.src", "two.parts")])
+
+        assert list(lineage_source._iter()) == []
+        lineage_source.metadata.get_by_name.assert_not_called()

--- a/ingestion/tests/unit/topology/database/test_unity_catalog_lineage.py
+++ b/ingestion/tests/unit/topology/database/test_unity_catalog_lineage.py
@@ -106,41 +106,12 @@ def table_row(
     return TableRow(source, source_path, target, target_path, pairs_json(column_pairs), statement_text)
 
 
-def stub_rows(lineage_source, rows=(), external_rows=(), probe_error=None):
-    """
-    Answer every query the connector runs: the query history probe, the external
-    location query and the native lineage query.
-
-    Returns the list executed statements are recorded into, so a test can assert what
-    was actually asked of the warehouse.
-    """
-    executed = []
-
-    def execute(statement, *_args, **_kwargs):
-        sql = str(statement)
-        executed.append(sql)
-        if "WHERE 1=0" in sql:
-            if probe_error:
-                raise probe_error
-            return []
-        if "information_schema.tables" in sql:
-            return external_rows
-        return rows
-
-    mock_conn = MagicMock()
-    mock_conn.execute.side_effect = execute
-    lineage_source.engine.connect.return_value.__enter__ = Mock(return_value=mock_conn)
-    lineage_source.engine.connect.return_value.__exit__ = Mock(return_value=False)
-    return executed
-
-
-def resolve_tables(lineage_source, tables):
-    """Resolve `catalog.schema.table` names, keyed the way the connector asks for them"""
-
-    def get_by_name(entity=None, fqn=None, **_kwargs):
-        return tables.get(str(fqn).split(".", 1)[1] if fqn else None)
-
-    lineage_source.metadata.get_by_name.side_effect = get_by_name
+def a_column(name, column_fqn):
+    return Column(
+        name=ColumnName(root=name),
+        dataType=DataType.STRING,
+        fullyQualifiedName=FullyQualifiedEntityName(root=column_fqn),
+    )
 
 
 def a_table(name="test_table", columns=None):
@@ -149,14 +120,6 @@ def a_table(name="test_table", columns=None):
         name=EntityName(root=name),
         fullyQualifiedName=FullyQualifiedEntityName(root=f"service.db.schema.{name}"),
         columns=columns or [],
-    )
-
-
-def a_column(name, column_fqn):
-    return Column(
-        name=ColumnName(root=name),
-        dataType=DataType.STRING,
-        fullyQualifiedName=FullyQualifiedEntityName(root=column_fqn),
     )
 
 
@@ -182,49 +145,123 @@ def lineage_source():
         yield source
 
 
-class TestCacheLineage:
-    def test_cache_table_lineage(self, lineage_source):
-        stub_rows(
-            lineage_source,
-            [
-                table_row("cat.schema.source1", "cat.schema.target1"),
-                table_row("cat.schema.source2", "cat.schema.target1"),
-                table_row("cat.schema.source1", "cat.schema.target2"),
-            ],
-        )
+def stub_rows(lineage_source, rows=(), external_rows=(), probe_error=None):
+    """
+    Answer every query the connector runs: the query history probe, the external
+    location query and the native lineage query.
 
-        lineage_source._cache_lineage()
+    Returns the list executed statements are recorded into, so a test can assert what
+    was actually asked of the warehouse.
+    """
+    executed = []
 
-        assert "cat.schema.target1" in lineage_source.table_lineage_map
-        assert lineage_source.table_lineage_map["cat.schema.target1"] == {
-            "cat.schema.source1",
-            "cat.schema.source2",
-        }
-        assert lineage_source.table_lineage_map["cat.schema.target2"] == {
-            "cat.schema.source1",
-        }
+    def execute(statement, *_args, **_kwargs):
+        sql = str(statement)
+        executed.append(sql)
+        if "WHERE 1=0" in sql:
+            if probe_error:
+                raise probe_error
+            return []
+        if "information_schema.tables" in sql:
+            return external_rows
+        return rows
 
-    def test_cache_column_lineage(self, lineage_source):
-        """The mappings of an edge travel on the edge's own row"""
-        stub_rows(
-            lineage_source,
-            [
-                table_row(
-                    "cat.schema.src",
-                    "cat.schema.tgt",
-                    column_pairs=[("col_b", "col_y"), ("col_a", "col_x")],
-                )
-            ],
-        )
+    mock_conn = MagicMock()
+    mock_conn.execute.side_effect = execute
+    mock_conn.execution_options.return_value = mock_conn
+    lineage_source.engine.connect.return_value.__enter__ = Mock(return_value=mock_conn)
+    lineage_source.engine.connect.return_value.__exit__ = Mock(return_value=False)
+    return executed
 
-        lineage_source._cache_lineage()
 
-        key = ("cat.schema.src", "cat.schema.tgt")
-        assert key in lineage_source.column_lineage_map
-        assert list(lineage_source.column_lineage_map[key]) == [
-            ("col_a", "col_x"),
-            ("col_b", "col_y"),
-        ]
+def resolve_tables(lineage_source, tables):
+    """Resolve `catalog.schema.table` names to entities, keyed as the connector asks"""
+
+    def get_by_name(entity=None, fqn=None, **_kwargs):
+        return tables.get(str(fqn).split(".", 1)[1]) if fqn else None
+
+    lineage_source.metadata.get_by_name.side_effect = get_by_name
+
+
+def run(lineage_source, rows=(), tables=None, external_rows=(), probe_error=None):
+    """Everything the connector emits for `rows`"""
+    stub_rows(lineage_source, rows, external_rows=external_rows, probe_error=probe_error)
+    resolve_tables(lineage_source, tables or {})
+    return list(lineage_source._iter())
+
+
+def _entity_names(tables):
+    return {str(table.id.root): name for name, table in tables.items()}
+
+
+def table_edges(results, tables):
+    """The emitted table-to-table edges, back in Databricks names"""
+    names = _entity_names(tables)
+    return sorted(
+        (names[str(result.right.edge.fromEntity.id.root)], names[str(result.right.edge.toEntity.id.root)])
+        for result in results
+        if result.right.edge.fromEntity.type == "table"
+    )
+
+
+def container_edges(results, tables):
+    """The emitted container-to-table edges, with the target back in its Databricks name"""
+    names = _entity_names(tables)
+    return sorted(
+        (str(result.right.edge.fromEntity.id.root), names[str(result.right.edge.toEntity.id.root)])
+        for result in results
+        if result.right.edge.fromEntity.type == "container"
+    )
+
+
+class TestNativeLineageQuery:
+    """The single query both system tables and the statement text are read with."""
+
+    def test_both_system_tables_are_read_in_one_query(self):
+        query = unity_catalog_native_lineage_query(7, include_query_history=True)
+
+        assert query.count("FROM system.access.table_lineage") == 1
+        assert query.count("FROM system.access.column_lineage") == 1
+        assert query.count("INTERVAL 7 DAYS") == 4
+
+    def test_rows_are_ordered_by_target(self):
+        """The reader emits a target and forgets it, which needs its rows together"""
+        query = unity_catalog_native_lineage_query(1, include_query_history=True)
+
+        assert query.rstrip().endswith("ORDER BY table_edges.target_table_full_name, table_edges.target_path")
+
+    def test_column_mappings_join_on_null_safe_equality(self):
+        """
+        `source_path` is NULL on every edge reported by table name and `=` on NULL
+        never matches, so a plain join would drop those edges' column mappings.
+        """
+        query = unity_catalog_native_lineage_query(1, include_query_history=True)
+
+        join = query.split("LEFT JOIN column_edges")[1].split("LEFT JOIN system.query.history")[0]
+        assert join.count("<=>") == 4
+        assert " = " not in join
+
+    def test_history_reaches_one_day_further_back_than_lineage(self):
+        """A statement that ran just before the oldest lineage day still wrote that edge"""
+        query = unity_catalog_native_lineage_query(2, include_query_history=True)
+
+        assert "history.start_time >= current_date() - INTERVAL 3 DAYS" in query
+
+    def test_unusable_statement_text_is_left_out(self):
+        query = unity_catalog_native_lineage_query(1, include_query_history=True)
+
+        assert "UPPER(TRIM(history.statement_text)) <> '<REDACTED>'" in query
+
+    def test_without_query_history_the_query_does_not_name_it(self):
+        query = unity_catalog_native_lineage_query(1, include_query_history=False)
+
+        assert "system.query.history" not in query
+        assert "statement_id" not in query
+        assert "CAST(NULL AS STRING) AS statement_text" in query
+
+
+class TestNativeLineageStream:
+    """Rows in, lineage out, without holding the catalog in memory."""
 
     def test_lineage_is_read_in_a_single_query(self, lineage_source):
         """
@@ -232,38 +269,154 @@ class TestCacheLineage:
         result set, or per batch of edges, re-scans the whole lineage window.
         """
         executed = stub_rows(lineage_source, [table_row("cat.schema.src", "cat.schema.tgt")])
+        resolve_tables(lineage_source, {})
 
-        lineage_source._cache_lineage()
+        list(lineage_source._iter())
 
         lineage_queries = [sql for sql in executed if "system.access.table_lineage" in sql and "WHERE 1=0" not in sql]
         assert len(lineage_queries) == 1
         assert "system.access.column_lineage" in lineage_queries[0]
 
-    def test_cache_lineage_handles_query_failure(self, lineage_source):
+    def test_every_source_of_every_target_is_emitted(self, lineage_source):
+        tables = {
+            "cat.schema.source1": a_table("source1"),
+            "cat.schema.source2": a_table("source2"),
+            "cat.schema.target1": a_table("target1"),
+            "cat.schema.target2": a_table("target2"),
+        }
+        rows = [
+            table_row("cat.schema.source1", "cat.schema.target1"),
+            table_row("cat.schema.source2", "cat.schema.target1"),
+            table_row("cat.schema.source1", "cat.schema.target2"),
+        ]
+
+        results = run(lineage_source, rows, tables)
+
+        assert table_edges(results, tables) == [
+            ("cat.schema.source1", "cat.schema.target1"),
+            ("cat.schema.source1", "cat.schema.target2"),
+            ("cat.schema.source2", "cat.schema.target1"),
+        ]
+
+    def test_only_the_target_in_hand_is_held(self, lineage_source):
+        """
+        A target is emitted when the next one appears, so what is buffered is one
+        target's edges rather than every edge in the catalog.
+        """
+        held = []
+        tables = {
+            "cat.schema.src": a_table("src"),
+            "cat.schema.tgt1": a_table("tgt1"),
+            "cat.schema.tgt2": a_table("tgt2"),
+        }
+        stub_rows(
+            lineage_source,
+            [
+                table_row("cat.schema.src", "cat.schema.tgt1"),
+                table_row("cat.schema.src", "cat.schema.tgt2"),
+            ],
+        )
+        resolve_tables(lineage_source, tables)
+
+        original = lineage_source._process_target_lineage
+
+        def record(target, upstream_columns, upstream_sql, upstream_paths):
+            held.append(len(upstream_columns))
+            yield from original(target, upstream_columns, upstream_sql, upstream_paths)
+
+        lineage_source._process_target_lineage = record
+
+        results = list(lineage_source._iter())
+
+        assert len(results) == 2
+        assert held == [1, 1]
+
+    def test_column_mappings_of_an_edge_are_emitted_sorted(self, lineage_source):
+        """`collect_set` has no order; an unchanged edge should serialize identically"""
+        tables = {
+            "cat.schema.src": a_table(
+                "src", columns=[a_column("col_a", "svc.src.col_a"), a_column("col_b", "svc.src.col_b")]
+            ),
+            "cat.schema.tgt": a_table(
+                "tgt", columns=[a_column("col_x", "svc.tgt.col_x"), a_column("col_y", "svc.tgt.col_y")]
+            ),
+        }
+
+        results = run(
+            lineage_source,
+            [table_row("cat.schema.src", "cat.schema.tgt", column_pairs=[("col_b", "col_y"), ("col_a", "col_x")])],
+            tables,
+        )
+
+        columns_lineage = results[0].right.edge.lineageDetails.columnsLineage
+        assert [(pair.fromColumns[0].root, pair.toColumn.root) for pair in columns_lineage] == [
+            ("svc.src.col_a", "svc.tgt.col_x"),
+            ("svc.src.col_b", "svc.tgt.col_y"),
+        ]
+
+    def test_a_query_failure_emits_nothing(self, lineage_source):
         mock_conn = MagicMock()
+        mock_conn.execution_options.return_value = mock_conn
         mock_conn.execute.side_effect = Exception("Access denied")
         lineage_source.engine.connect.return_value.__enter__ = Mock(return_value=mock_conn)
         lineage_source.engine.connect.return_value.__exit__ = Mock(return_value=False)
 
-        lineage_source._cache_lineage()
+        assert list(lineage_source._iter()) == []
 
-        assert len(lineage_source.table_lineage_map) == 0
-        assert len(lineage_source.column_lineage_map) == 0
-        assert len(lineage_source.edge_sql) == 0
+    def test_unreadable_column_pairs_keep_the_edge(self, lineage_source):
+        tables = {"cat.schema.src": a_table("src"), "cat.schema.tgt": a_table("tgt")}
+        stub_rows(lineage_source, [TableRow("cat.schema.src", None, "cat.schema.tgt", None, "not json", None)])
+        resolve_tables(lineage_source, tables)
 
-    def test_a_row_without_column_pairs_leaves_no_entry_behind(self, lineage_source):
-        stub_rows(lineage_source, [table_row("cat.schema.src", "cat.schema.tgt")])
+        results = list(lineage_source._iter())
 
-        lineage_source._cache_lineage()
+        assert table_edges(results, tables) == [("cat.schema.src", "cat.schema.tgt")]
+        assert results[0].right.edge.lineageDetails.columnsLineage is None
 
-        assert len(lineage_source.column_lineage_map) == 0
+    def test_a_self_referencing_row_is_not_an_edge(self, lineage_source):
+        """
+        The system tables record access rather than derivation, so a streaming or CDC
+        write legitimately names its target as its own source.
+        """
+        tables = {"cat.schema.stream": a_table("stream")}
+
+        results = run(lineage_source, [table_row("cat.schema.stream", "cat.schema.stream")], tables)
+
+        assert results == []
+
+    def test_only_the_self_reference_is_dropped(self, lineage_source):
+        tables = {"cat.schema.events": a_table("events"), "cat.schema.snapshot": a_table("snapshot")}
+        rows = [
+            table_row("cat.schema.events", "cat.schema.snapshot"),
+            table_row("cat.schema.snapshot", "cat.schema.snapshot"),
+        ]
+
+        results = run(lineage_source, rows, tables)
+
+        assert table_edges(results, tables) == [("cat.schema.events", "cat.schema.snapshot")]
+
+    def test_a_malformed_source_name_is_skipped(self, lineage_source):
+        tables = {"cat.schema.tgt": a_table("tgt")}
+
+        results = run(lineage_source, [table_row("malformed_name", "cat.schema.tgt")], tables)
+
+        assert results == []
+
+    def test_an_upstream_that_was_never_ingested_is_skipped(self, lineage_source):
+        tables = {"cat.schema.tgt": a_table("tgt")}
+
+        results = run(lineage_source, [table_row("cat.schema.src", "cat.schema.tgt")], tables)
+
+        assert results == []
 
 
-class TestNativeLineageSql:
+class TestSqlEnrichment:
     """The statement that wrote an edge, joined in the same query as the edge itself."""
 
     def test_sql_is_attached_to_the_edge(self, lineage_source):
-        stub_rows(
+        tables = {"cat.schema.src": a_table("src"), "cat.schema.tgt": a_table("tgt")}
+
+        results = run(
             lineage_source,
             [
                 table_row(
@@ -272,48 +425,27 @@ class TestNativeLineageSql:
                     statement_text="INSERT INTO tgt SELECT * FROM src",
                 )
             ],
+            tables,
         )
-        lineage_source._cache_lineage()
 
-        target = a_table("tgt")
-        resolve_tables(lineage_source, {"cat.schema.src": a_table("src")})
-
-        results = list(lineage_source._process_table_lineage(target, "cat.schema.tgt"))
-
-        assert len(results) == 1
         assert results[0].right.edge.lineageDetails.sqlQuery.root == "INSERT INTO tgt SELECT * FROM src"
 
     def test_an_edge_without_sql_is_still_emitted(self, lineage_source):
-        stub_rows(lineage_source, [table_row("cat.schema.src", "cat.schema.tgt")])
-        lineage_source._cache_lineage()
+        tables = {"cat.schema.src": a_table("src"), "cat.schema.tgt": a_table("tgt")}
 
-        resolve_tables(lineage_source, {"cat.schema.src": a_table("src")})
-
-        results = list(lineage_source._process_table_lineage(a_table("tgt"), "cat.schema.tgt"))
+        results = run(lineage_source, [table_row("cat.schema.src", "cat.schema.tgt")], tables)
 
         assert len(results) == 1
         assert results[0].right.edge.lineageDetails.sqlQuery is None
-
-    def test_one_statement_is_stored_once_for_all_of_its_edges(self, lineage_source):
-        """A statement writing many edges must not be held once per edge"""
-        statement = "INSERT INTO tgt SELECT * FROM a JOIN b"
-        stub_rows(
-            lineage_source,
-            [
-                table_row("cat.schema.a", "cat.schema.tgt", statement_text=statement),
-                # the driver hands out an equal but distinct string per row
-                table_row("cat.schema.b", "cat.schema.tgt", statement_text=str(statement)),
-            ],
-        )
-
-        lineage_source._cache_lineage()
-
-        stored = list(lineage_source.edge_sql.values())
-        assert len(stored) == 2
-        assert stored[0] is stored[1]
+        assert results[0].right.edge.lineageDetails.source == LineageSource.QueryLineage
 
     def test_column_mappings_and_sql_ride_the_same_edge(self, lineage_source):
-        stub_rows(
+        tables = {
+            "cat.schema.src": a_table("src", columns=[a_column("col_a", "svc.src.col_a")]),
+            "cat.schema.tgt": a_table("tgt", columns=[a_column("col_x", "svc.tgt.col_x")]),
+        }
+
+        results = run(
             lineage_source,
             [
                 table_row(
@@ -323,231 +455,73 @@ class TestNativeLineageSql:
                     statement_text="INSERT INTO tgt SELECT col_a FROM src",
                 )
             ],
+            tables,
         )
-        lineage_source._cache_lineage()
-
-        target = a_table("tgt", columns=[a_column("col_x", "svc.cat.schema.tgt.col_x")])
-        resolve_tables(
-            lineage_source,
-            {"cat.schema.src": a_table("src", columns=[a_column("col_a", "svc.cat.schema.src.col_a")])},
-        )
-
-        results = list(lineage_source._process_table_lineage(target, "cat.schema.tgt"))
 
         details = results[0].right.edge.lineageDetails
         assert details.sqlQuery.root == "INSERT INTO tgt SELECT col_a FROM src"
-        assert details.columnsLineage[0].fromColumns[0].root == "svc.cat.schema.src.col_a"
-        assert details.columnsLineage[0].toColumn.root == "svc.cat.schema.tgt.col_x"
+        assert details.columnsLineage[0].fromColumns[0].root == "svc.src.col_a"
+        assert details.columnsLineage[0].toColumn.root == "svc.tgt.col_x"
 
     def test_unreadable_query_history_keeps_the_lineage(self, lineage_source):
         """
         A missing grant on system.query.history must cost the SQL text, not the edges,
         so the statement columns and the join are left out of the query entirely.
         """
+        tables = {"cat.schema.src": a_table("src"), "cat.schema.tgt": a_table("tgt")}
         executed = stub_rows(
             lineage_source,
             [table_row("cat.schema.src", "cat.schema.tgt")],
             probe_error=Exception("permission denied on system.query.history"),
         )
+        resolve_tables(lineage_source, tables)
 
-        lineage_source._cache_lineage()
+        results = list(lineage_source._iter())
 
         lineage_query = next(sql for sql in executed if "table_edges" in sql)
         assert "system.query.history" not in lineage_query
         assert "latest_statement" not in lineage_query
-        assert lineage_source.table_lineage_map["cat.schema.tgt"] == {"cat.schema.src"}
-        assert len(lineage_source.edge_sql) == 0
+        assert table_edges(results, tables) == [("cat.schema.src", "cat.schema.tgt")]
+        assert results[0].right.edge.lineageDetails.sqlQuery is None
 
     def test_readable_query_history_is_joined(self, lineage_source):
         executed = stub_rows(lineage_source, [table_row("cat.schema.src", "cat.schema.tgt")])
+        resolve_tables(lineage_source, {})
 
-        lineage_source._cache_lineage()
+        list(lineage_source._iter())
 
         lineage_query = next(sql for sql in executed if "table_edges" in sql)
         assert "system.query.history" in lineage_query
         assert "latest_statement" in lineage_query
 
-    def test_unreadable_column_pairs_are_skipped(self, lineage_source):
-        stub_rows(lineage_source, [TableRow("cat.schema.src", None, "cat.schema.tgt", None, "not json", None)])
-
-        lineage_source._cache_lineage()
-
-        assert lineage_source.table_lineage_map["cat.schema.tgt"] == {"cat.schema.src"}
-        assert len(lineage_source.column_lineage_map) == 0
-
-
-class TestProcessTableLineage:
-    def test_process_table_lineage_from_cache(self, lineage_source):
-        lineage_source.table_lineage_map = {"cat.schema.target": {"cat.schema.source"}}
-        lineage_source.column_lineage_map = {}
-
-        target_table = Table(
-            id=uuid4(),
-            name=EntityName(root="target"),
-            fullyQualifiedName=FullyQualifiedEntityName(root="local_unitycatalog.cat.schema.target"),
-            columns=[],
-        )
-
-        source_table = Table(
-            id=uuid4(),
-            name=EntityName(root="source"),
-            fullyQualifiedName=FullyQualifiedEntityName(root="local_unitycatalog.cat.schema.source"),
-            columns=[],
-        )
-
-        lineage_source.metadata.get_by_name.return_value = source_table
-
-        results = list(lineage_source._process_table_lineage(target_table, "cat.schema.target"))
-
-        assert len(results) == 1
-        assert isinstance(results[0], Either)
-        assert isinstance(results[0].right, AddLineageRequest)
-        assert results[0].right.edge.fromEntity.id == source_table.id
-        assert results[0].right.edge.toEntity.id == target_table.id
-
-    def test_process_table_lineage_with_column_lineage(self, lineage_source):
-        lineage_source.table_lineage_map = {"cat.schema.target": {"cat.schema.source"}}
-        lineage_source.column_lineage_map = {("cat.schema.source", "cat.schema.target"): {("col_a", "col_x"): None}}
-
-        target_table = Table(
-            id=uuid4(),
-            name=EntityName(root="target"),
-            fullyQualifiedName=FullyQualifiedEntityName(root="local_unitycatalog.cat.schema.target"),
-            columns=[
-                Column(
-                    name=ColumnName(root="col_x"),
-                    dataType=DataType.STRING,
-                    fullyQualifiedName=FullyQualifiedEntityName(root="local_unitycatalog.cat.schema.target.col_x"),
-                )
-            ],
-        )
-
-        source_table = Table(
-            id=uuid4(),
-            name=EntityName(root="source"),
-            fullyQualifiedName=FullyQualifiedEntityName(root="local_unitycatalog.cat.schema.source"),
-            columns=[
-                Column(
-                    name=ColumnName(root="col_a"),
-                    dataType=DataType.STRING,
-                    fullyQualifiedName=FullyQualifiedEntityName(root="local_unitycatalog.cat.schema.source.col_a"),
-                )
-            ],
-        )
-
-        lineage_source.metadata.get_by_name.return_value = source_table
-
-        results = list(lineage_source._process_table_lineage(target_table, "cat.schema.target"))
-
-        assert len(results) == 1
-        lineage_details = results[0].right.edge.lineageDetails
-        assert lineage_details is not None
-        assert len(lineage_details.columnsLineage) == 1
-        assert lineage_details.columnsLineage[0].fromColumns[0].root == "local_unitycatalog.cat.schema.source.col_a"
-        assert lineage_details.columnsLineage[0].toColumn.root == "local_unitycatalog.cat.schema.target.col_x"
-
-    def test_process_table_lineage_skips_malformed_names(self, lineage_source):
-        lineage_source.table_lineage_map = {"cat.schema.target": {"malformed_name"}}
-        lineage_source.column_lineage_map = {}
-
-        target_table = Table(
-            id=uuid4(),
-            name=EntityName(root="target"),
-            fullyQualifiedName=FullyQualifiedEntityName(root="local_unitycatalog.cat.schema.target"),
-            columns=[],
-        )
-
-        results = list(lineage_source._process_table_lineage(target_table, "cat.schema.target"))
-
-        assert len(results) == 0
-
-    def test_process_table_lineage_skips_missing_entity(self, lineage_source):
-        lineage_source.table_lineage_map = {"cat.schema.target": {"cat.schema.source"}}
-        lineage_source.column_lineage_map = {}
-
-        target_table = Table(
-            id=uuid4(),
-            name=EntityName(root="target"),
-            fullyQualifiedName=FullyQualifiedEntityName(root="local_unitycatalog.cat.schema.target"),
-            columns=[],
-        )
-
-        lineage_source.metadata.get_by_name.return_value = None
-
-        results = list(lineage_source._process_table_lineage(target_table, "cat.schema.target"))
-
-        assert len(results) == 0
-
 
 class TestColumnLineageDetails:
     def test_self_loop_prevention(self, lineage_source):
-        lineage_source.column_lineage_map = {("cat.schema.src", "cat.schema.tgt"): {("col_a", "col_a"): None}}
-
-        table = Table(
-            id=uuid4(),
-            name=EntityName(root="tgt"),
-            fullyQualifiedName=FullyQualifiedEntityName(root="local_unitycatalog.cat.schema.tgt"),
-            columns=[
-                Column(
-                    name=ColumnName(root="col_a"),
-                    dataType=DataType.STRING,
-                    fullyQualifiedName=FullyQualifiedEntityName(root="local_unitycatalog.cat.schema.tgt.col_a"),
-                )
-            ],
-        )
-
-        same_table_as_source = Table(
-            id=uuid4(),
-            name=EntityName(root="src"),
-            fullyQualifiedName=FullyQualifiedEntityName(root="local_unitycatalog.cat.schema.src"),
-            columns=[
-                Column(
-                    name=ColumnName(root="col_a"),
-                    dataType=DataType.STRING,
-                    fullyQualifiedName=FullyQualifiedEntityName(root="local_unitycatalog.cat.schema.src.col_a"),
-                )
-            ],
-        )
+        table = a_table("tgt", columns=[a_column("col_a", "local_unitycatalog.cat.schema.tgt.col_a")])
+        same_table_as_source = a_table("src", columns=[a_column("col_a", "local_unitycatalog.cat.schema.src.col_a")])
 
         result = lineage_source._get_column_lineage_details(
-            same_table_as_source, table, "cat.schema.src", "cat.schema.tgt"
+            same_table_as_source, table, column_pairs={("col_a", "col_a"): None}
         )
 
         assert result is not None
         assert len(result.columnsLineage) == 1
 
     def test_no_column_lineage_returns_none(self, lineage_source):
-        lineage_source.column_lineage_map = {}
-
-        table = Table(
-            id=uuid4(),
-            name=EntityName(root="tgt"),
-            fullyQualifiedName=FullyQualifiedEntityName(root="local_unitycatalog.cat.schema.tgt"),
-            columns=[],
-        )
-        from_table = Table(
-            id=uuid4(),
-            name=EntityName(root="src"),
-            fullyQualifiedName=FullyQualifiedEntityName(root="local_unitycatalog.cat.schema.src"),
-            columns=[],
-        )
-
-        result = lineage_source._get_column_lineage_details(from_table, table, "cat.schema.src", "cat.schema.tgt")
+        result = lineage_source._get_column_lineage_details(a_table("src"), a_table("tgt"), column_pairs={})
 
         assert result is None
 
 
 class TestExternalLocationLineage:
     def test_cache_external_locations(self, lineage_source):
-        mock_rows = [
-            ExternalRow("cat", "schema", "ext_table1", "s3://bucket/path1"),
-            ExternalRow("cat", "schema", "ext_table2", "s3://bucket/path2/"),
-        ]
-
-        mock_conn = MagicMock()
-        mock_conn.execute.return_value = mock_rows
-        lineage_source.engine.connect.return_value.__enter__ = Mock(return_value=mock_conn)
-        lineage_source.engine.connect.return_value.__exit__ = Mock(return_value=False)
+        stub_rows(
+            lineage_source,
+            external_rows=[
+                ExternalRow("cat", "schema", "ext_table1", "s3://bucket/path1"),
+                ExternalRow("cat", "schema", "ext_table2", "s3://bucket/path2/"),
+            ],
+        )
 
         lineage_source._cache_external_locations()
 
@@ -558,6 +532,7 @@ class TestExternalLocationLineage:
     def test_cache_external_locations_handles_failure(self, lineage_source):
         mock_conn = MagicMock()
         mock_conn.execute.side_effect = Exception("Access denied")
+        mock_conn.execution_options.return_value = mock_conn
         lineage_source.engine.connect.return_value.__enter__ = Mock(return_value=mock_conn)
         lineage_source.engine.connect.return_value.__exit__ = Mock(return_value=False)
 
@@ -565,18 +540,33 @@ class TestExternalLocationLineage:
 
         assert len(lineage_source.external_location_map) == 0
 
-    def test_process_external_location_lineage_from_cache(self, lineage_source):
-        lineage_source.external_location_map = {"cat.schema.test_table": "s3://bucket/path"}
-
-        table_entity = a_table("test_table")
-        resolve_tables(lineage_source, {"cat.schema.test_table": table_entity})
-
-        container_entity = Container(
-            id=uuid4(),
-            name=EntityName(root="test_container"),
-            service=EntityReference(id=uuid4(), type="storageService"),
+    def test_cache_external_locations_builds_the_inverse_map(self, lineage_source):
+        stub_rows(
+            lineage_source,
+            external_rows=[
+                ExternalRow("cat", "schema", "ext1", "s3://bucket/path1"),
+                ExternalRow("cat", "schema", "ext2", "s3a://bucket/path2/"),
+                ExternalRow("cat", "schema", "ext3", "s3://bucket/path1"),
+                ExternalRow("cat", "schema", "no_path", None),
+            ],
         )
 
+        lineage_source._cache_external_locations()
+
+        assert lineage_source.path_to_table_map["s3://bucket/path1"] == {
+            "cat.schema.ext1",
+            "cat.schema.ext3",
+        }
+        assert lineage_source.path_to_table_map["s3://bucket/path2"] == {"cat.schema.ext2"}
+        assert "cat.schema.no_path" not in {
+            table for tables in lineage_source.path_to_table_map.values() for table in tables
+        }
+
+    def test_process_external_location_lineage_from_cache(self, lineage_source):
+        lineage_source.external_location_map = {"cat.schema.test_table": "s3://bucket/path"}
+        table_entity = a_table("test_table")
+        container_entity = a_container()
+        resolve_tables(lineage_source, {"cat.schema.test_table": table_entity})
         lineage_source.metadata.es_search_container_by_path.return_value = [container_entity]
 
         results = list(lineage_source._process_external_location_lineage("cat.schema.test_table"))
@@ -588,23 +578,14 @@ class TestExternalLocationLineage:
         assert results[0].right.edge.fromEntity.type == "container"
         assert results[0].right.edge.toEntity.id == table_entity.id
         assert results[0].right.edge.toEntity.type == "table"
-
         lineage_source.metadata.es_search_container_by_path.assert_called_once_with(
             full_path="s3://bucket/path", fields="dataModel"
         )
 
     def test_process_external_location_strips_trailing_slash(self, lineage_source):
         lineage_source.external_location_map = {"cat.schema.test_table": "s3://test-bucket/data/"}
-
         resolve_tables(lineage_source, {"cat.schema.test_table": a_table("test_table")})
-
-        container_entity = Container(
-            id=uuid4(),
-            name=EntityName(root="test_container"),
-            service=EntityReference(id=uuid4(), type="storageService"),
-        )
-
-        lineage_source.metadata.es_search_container_by_path.return_value = [container_entity]
+        lineage_source.metadata.es_search_container_by_path.return_value = [a_container()]
 
         results = list(lineage_source._process_external_location_lineage("cat.schema.test_table"))
 
@@ -619,21 +600,30 @@ class TestExternalLocationLineage:
         results = list(lineage_source._process_external_location_lineage("cat.schema.test_table"))
 
         assert len(results) == 0
-        lineage_source.metadata.es_search_container_by_path.assert_not_called()
 
     def test_process_external_location_no_container_found(self, lineage_source):
-        """
-        Every external table in the metastore reaches here, so one whose storage was
-        never ingested must not cost a request to resolve the table itself.
-        """
         lineage_source.external_location_map = {"cat.schema.test_table": "s3://bucket/path"}
-
         lineage_source.metadata.es_search_container_by_path.return_value = []
 
         results = list(lineage_source._process_external_location_lineage("cat.schema.test_table"))
 
         assert len(results) == 0
         lineage_source.metadata.get_by_name.assert_not_called()
+
+    def test_external_tables_are_emitted_without_any_lineage_row(self, lineage_source):
+        """An external table's container edge does not depend on the system lineage tables"""
+        tables = {"cat.schema.ext": a_table("ext")}
+        container_entity = a_container()
+        lineage_source.metadata.es_search_container_by_path.return_value = [container_entity]
+
+        results = run(
+            lineage_source,
+            rows=[],
+            tables=tables,
+            external_rows=[ExternalRow("cat", "schema", "ext", "s3://bucket/ext")],
+        )
+
+        assert container_edges(results, tables) == [(str(container_entity.id.root), "cat.schema.ext")]
 
 
 class TestContainerColumnLineage:
@@ -669,37 +659,14 @@ class TestContainerColumnLineage:
                     dataType=DataType.INT,
                     fullyQualifiedName=FullyQualifiedEntityName(root="service.container.id"),
                 ),
-                Column(
-                    name=ColumnName(root="name"),
-                    displayName="name",
-                    dataType=DataType.STRING,
-                    fullyQualifiedName=FullyQualifiedEntityName(root="service.container.name"),
-                ),
             ]
         )
-
-        table_entity = Table(
-            id=uuid4(),
-            name=EntityName(root="test_table"),
-            fullyQualifiedName=FullyQualifiedEntityName(root="service.db.schema.test_table"),
-            columns=[
-                Column(
-                    name=ColumnName(root="id"),
-                    dataType=DataType.INT,
-                    fullyQualifiedName=FullyQualifiedEntityName(root="service.db.schema.test_table.id"),
-                ),
-                Column(
-                    name=ColumnName(root="name"),
-                    dataType=DataType.STRING,
-                    fullyQualifiedName=FullyQualifiedEntityName(root="service.db.schema.test_table.name"),
-                ),
-            ],
-        )
+        table_entity = a_table("test_table", columns=[a_column("id", "service.db.schema.test_table.id")])
 
         result = lineage_source._get_container_column_lineage(data_model, table_entity)
 
         assert result is not None
-        assert len(result.columnsLineage) == 2
+        assert len(result.columnsLineage) == 1
         assert result.source == LineageSource.ExternalTableLineage
         assert result.columnsLineage[0].fromColumns[0].root == "service.container.id"
         assert result.columnsLineage[0].toColumn.root == "service.db.schema.test_table.id"
@@ -711,165 +678,160 @@ class TestPathBasedLineage:
     at all, only source_path. Issue #27561.
     """
 
-    @staticmethod
-    def _cache_rows(lineage_source, table_rows):
-        stub_rows(lineage_source, table_rows)
-        lineage_source._cache_lineage()
-
     def test_path_source_resolves_to_external_table(self, lineage_source):
         """The scenario reported in the issue"""
         raw_path = "abfss://raw@storage.dfs.core.windows.net/external_table"
+        tables = {
+            "bronze_ns.deltalake_ns.external_table": a_table("external_table"),
+            "bronze_ns.deltalake_ns.managed_table_ns": a_table("managed_table_ns"),
+        }
         lineage_source.path_to_table_map[raw_path] = {"bronze_ns.deltalake_ns.external_table"}
 
-        self._cache_rows(
+        results = run(
             lineage_source,
             [table_row(target="bronze_ns.deltalake_ns.managed_table_ns", source_path=raw_path)],
+            tables,
         )
 
-        assert lineage_source.table_lineage_map["bronze_ns.deltalake_ns.managed_table_ns"] == {
-            "bronze_ns.deltalake_ns.external_table"
-        }
-        assert len(lineage_source.path_lineage_map) == 0
+        assert table_edges(results, tables) == [
+            ("bronze_ns.deltalake_ns.external_table", "bronze_ns.deltalake_ns.managed_table_ns")
+        ]
 
     def test_path_source_matches_despite_trailing_slash_and_scheme_alias(self, lineage_source):
+        tables = {
+            "cat.schema.ext": a_table("ext"),
+            "cat.schema.tgt1": a_table("tgt1"),
+            "cat.schema.tgt2": a_table("tgt2"),
+        }
         lineage_source.path_to_table_map["s3://bucket/data"] = {"cat.schema.ext"}
 
-        self._cache_rows(
+        results = run(
             lineage_source,
             [
                 table_row(target="cat.schema.tgt1", source_path="s3://bucket/data/"),
                 table_row(target="cat.schema.tgt2", source_path="s3a://bucket/data"),
             ],
+            tables,
         )
 
-        assert lineage_source.table_lineage_map["cat.schema.tgt1"] == {"cat.schema.ext"}
-        assert lineage_source.table_lineage_map["cat.schema.tgt2"] == {"cat.schema.ext"}
+        assert table_edges(results, tables) == [
+            ("cat.schema.ext", "cat.schema.tgt1"),
+            ("cat.schema.ext", "cat.schema.tgt2"),
+        ]
 
     def test_path_shared_by_two_external_tables_yields_both_upstreams(self, lineage_source):
-        lineage_source.path_to_table_map["s3://bucket/shared"] = {
-            "cat.schema.ext_a",
-            "cat.schema.ext_b",
+        tables = {
+            "cat.schema.ext_a": a_table("ext_a"),
+            "cat.schema.ext_b": a_table("ext_b"),
+            "cat.schema.tgt": a_table("tgt"),
         }
+        lineage_source.path_to_table_map["s3://bucket/shared"] = {"cat.schema.ext_a", "cat.schema.ext_b"}
 
-        self._cache_rows(
+        results = run(
             lineage_source,
             [table_row(target="cat.schema.tgt", source_path="s3://bucket/shared")],
+            tables,
         )
 
-        assert lineage_source.table_lineage_map["cat.schema.tgt"] == {
-            "cat.schema.ext_a",
-            "cat.schema.ext_b",
-        }
-
-    def test_unresolved_path_is_kept_for_container_lookup(self, lineage_source):
-        self._cache_rows(
-            lineage_source,
-            [table_row(target="cat.schema.tgt", source_path="s3a://bucket/unregistered/")],
-        )
-
-        assert len(lineage_source.table_lineage_map) == 0
-        assert lineage_source.path_lineage_map["cat.schema.tgt"] == {"s3://bucket/unregistered"}
+        assert table_edges(results, tables) == [
+            ("cat.schema.ext_a", "cat.schema.tgt"),
+            ("cat.schema.ext_b", "cat.schema.tgt"),
+        ]
 
     def test_target_path_resolves_to_external_table(self, lineage_source):
         """A write addressed by location, e.g. CREATE TABLE ... LOCATION"""
+        tables = {"cat.schema.src": a_table("src"), "cat.schema.gold_ext": a_table("gold_ext")}
         lineage_source.path_to_table_map["s3://bucket/gold"] = {"cat.schema.gold_ext"}
 
-        self._cache_rows(
+        results = run(
             lineage_source,
             [table_row(source="cat.schema.src", target_path="s3://bucket/gold")],
+            tables,
         )
 
-        assert lineage_source.table_lineage_map["cat.schema.gold_ext"] == {"cat.schema.src"}
+        assert table_edges(results, tables) == [("cat.schema.src", "cat.schema.gold_ext")]
 
     def test_path_resolving_back_to_the_target_is_not_a_self_loop(self, lineage_source):
+        tables = {"cat.schema.ext": a_table("ext")}
         lineage_source.path_to_table_map["s3://bucket/data"] = {"cat.schema.ext"}
 
-        self._cache_rows(
+        results = run(
             lineage_source,
             [table_row(target="cat.schema.ext", source_path="s3://bucket/data")],
+            tables,
         )
 
-        assert len(lineage_source.table_lineage_map) == 0
-        assert len(lineage_source.path_lineage_map) == 0
+        assert results == []
 
     def test_row_with_neither_name_nor_path_is_ignored(self, lineage_source):
-        self._cache_rows(lineage_source, [table_row(target="cat.schema.tgt")])
+        tables = {"cat.schema.tgt": a_table("tgt")}
 
-        assert len(lineage_source.table_lineage_map) == 0
-        assert len(lineage_source.path_lineage_map) == 0
+        results = run(lineage_source, [table_row(target="cat.schema.tgt")], tables)
+
+        assert results == []
 
     def test_column_lineage_keyed_by_path_resolved_table(self, lineage_source):
+        tables = {
+            "cat.schema.ext": a_table("ext", columns=[a_column("col_a", "svc.ext.col_a")]),
+            "cat.schema.tgt": a_table("tgt", columns=[a_column("col_x", "svc.tgt.col_x")]),
+        }
         lineage_source.path_to_table_map["s3://bucket/data"] = {"cat.schema.ext"}
 
-        self._cache_rows(
+        results = run(
             lineage_source,
             [
-                table_row(
-                    target="cat.schema.tgt",
-                    source_path="s3://bucket/data",
-                    column_pairs=[("col_a", "col_x"), ("col_b", "col_y")],
-                )
-            ],
-        )
-
-        assert list(lineage_source.column_lineage_map[("cat.schema.ext", "cat.schema.tgt")]) == [
-            ("col_a", "col_x"),
-            ("col_b", "col_y"),
-        ]
-
-    def test_column_pair_reported_by_both_name_and_path_is_not_duplicated(self, lineage_source):
-        """
-        One edge arrives twice when Databricks names its source by table on one row
-        and by path on another, and both rows resolve to the same pair.
-        """
-        lineage_source.path_to_table_map["s3://bucket/data"] = {"cat.schema.ext"}
-
-        self._cache_rows(
-            lineage_source,
-            [
-                table_row("cat.schema.ext", "cat.schema.tgt", column_pairs=[("col_a", "col_x")]),
                 table_row(
                     target="cat.schema.tgt",
                     source_path="s3://bucket/data",
                     column_pairs=[("col_a", "col_x")],
-                ),
+                )
             ],
+            tables,
         )
 
-        assert lineage_source.table_lineage_map["cat.schema.tgt"] == {"cat.schema.ext"}
-        assert lineage_source.column_lineage_map[("cat.schema.ext", "cat.schema.tgt")] == {("col_a", "col_x"): None}
-
-    def test_cache_external_locations_builds_the_inverse_map(self, lineage_source):
-        mock_rows = [
-            ExternalRow("cat", "schema", "ext1", "s3://bucket/path1"),
-            ExternalRow("cat", "schema", "ext2", "s3a://bucket/path2/"),
-            ExternalRow("cat", "schema", "ext3", "s3://bucket/path1"),
-            ExternalRow("cat", "schema", "no_path", None),
+        columns_lineage = results[0].right.edge.lineageDetails.columnsLineage
+        assert [(pair.fromColumns[0].root, pair.toColumn.root) for pair in columns_lineage] == [
+            ("svc.ext.col_a", "svc.tgt.col_x")
         ]
 
-        mock_conn = MagicMock()
-        mock_conn.execute.return_value = mock_rows
-        lineage_source.engine.connect.return_value.__enter__ = Mock(return_value=mock_conn)
-        lineage_source.engine.connect.return_value.__exit__ = Mock(return_value=False)
-
-        lineage_source._cache_external_locations()
-
-        assert lineage_source.path_to_table_map["s3://bucket/path1"] == {
-            "cat.schema.ext1",
-            "cat.schema.ext3",
+    def test_an_edge_reported_by_both_name_and_path_is_emitted_once(self, lineage_source):
+        """
+        One edge arrives twice when Databricks names its source by table on one row and
+        by path on another. `addLineage` replaces an edge's details, so emitting it
+        twice would leave whichever request landed last.
+        """
+        tables = {
+            "cat.schema.ext": a_table("ext", columns=[a_column("col_a", "svc.ext.col_a")]),
+            "cat.schema.tgt": a_table(
+                "tgt", columns=[a_column("col_x", "svc.tgt.col_x"), a_column("col_y", "svc.tgt.col_y")]
+            ),
         }
-        assert lineage_source.path_to_table_map["s3://bucket/path2"] == {"cat.schema.ext2"}
-        assert "cat.schema.no_path" not in {
-            table for tables in lineage_source.path_to_table_map.values() for table in tables
-        }
+        lineage_source.path_to_table_map["s3://bucket/data"] = {"cat.schema.ext"}
+
+        results = run(
+            lineage_source,
+            [
+                table_row("cat.schema.ext", "cat.schema.tgt", column_pairs=[("col_a", "col_x")]),
+                table_row(target="cat.schema.tgt", source_path="s3://bucket/data", column_pairs=[("col_a", "col_y")]),
+            ],
+            tables,
+        )
+
+        assert table_edges(results, tables) == [("cat.schema.ext", "cat.schema.tgt")]
+        columns_lineage = results[0].right.edge.lineageDetails.columnsLineage
+        assert [(pair.fromColumns[0].root, pair.toColumn.root) for pair in columns_lineage] == [
+            ("svc.ext.col_a", "svc.tgt.col_x"),
+            ("svc.ext.col_a", "svc.tgt.col_y"),
+        ]
 
     def test_process_path_lineage_emits_container_edge(self, lineage_source):
         table_entity = a_table()
         container_entity = a_container()
-        lineage_source.path_lineage_map["cat.schema.test_table"] = {"s3://bucket/unregistered"}
         lineage_source.metadata.es_search_container_by_path.return_value = [container_entity]
 
-        results = list(lineage_source._process_path_lineage(table_entity, "cat.schema.test_table"))
+        results = list(
+            lineage_source._process_path_lineage(table_entity, "cat.schema.test_table", {"s3://bucket/unregistered"})
+        )
 
         assert len(results) == 1
         assert results[0].right.edge.fromEntity.id == container_entity.id
@@ -882,12 +844,10 @@ class TestPathBasedLineage:
 
     def test_process_path_lineage_falls_back_to_the_de_aliased_scheme(self, lineage_source):
         """A container ingested by the S3 connector is stored as s3://, never s3a://"""
-        table_entity = a_table()
         container_entity = a_container()
-        lineage_source.path_lineage_map["cat.schema.test_table"] = {"s3a://bucket/data"}
         lineage_source.metadata.es_search_container_by_path.side_effect = [[], [container_entity]]
 
-        results = list(lineage_source._process_path_lineage(table_entity, "cat.schema.test_table"))
+        results = list(lineage_source._process_path_lineage(a_table(), "cat.schema.test_table", {"s3a://bucket/data"}))
 
         assert len(results) == 1
         assert [
@@ -895,42 +855,24 @@ class TestPathBasedLineage:
         ] == ["s3a://bucket/data", "s3://bucket/data"]
 
     def test_process_path_lineage_without_a_container_yields_nothing(self, lineage_source):
-        lineage_source.path_lineage_map["cat.schema.test_table"] = {"abfss://raw@storage.dfs.core.windows.net/t"}
         lineage_source.metadata.es_search_container_by_path.return_value = []
 
-        results = list(lineage_source._process_path_lineage(a_table(), "cat.schema.test_table"))
+        results = list(
+            lineage_source._process_path_lineage(
+                a_table(), "cat.schema.test_table", {"abfss://raw@storage.dfs.core.windows.net/t"}
+            )
+        )
 
         assert len(results) == 0
 
     def test_process_path_lineage_no_paths_for_table(self, lineage_source):
-        results = list(lineage_source._process_path_lineage(a_table(), "cat.schema.test_table"))
+        results = list(lineage_source._process_path_lineage(a_table(), "cat.schema.test_table", set()))
 
         assert len(results) == 0
         lineage_source.metadata.es_search_container_by_path.assert_not_called()
 
-    def test_external_locations_are_cached_before_lineage(self, lineage_source):
-        """
-        Resolving a path to the table declared over it reads the location map, so
-        filling it after the lineage rows would silently resolve nothing.
-        """
-        calls = []
-        lineage_source._cache_external_locations = lambda: calls.append("locations")
-        lineage_source._cache_lineage = lambda: calls.append("lineage")
-
-        list(lineage_source._iter())
-
-        assert calls == ["locations", "lineage"]
-
     def test_process_path_lineage_carries_container_column_lineage(self, lineage_source):
-        table_entity = a_table(
-            columns=[
-                Column(
-                    name=ColumnName(root="id"),
-                    dataType=DataType.INT,
-                    fullyQualifiedName=FullyQualifiedEntityName(root="service.db.schema.test_table.id"),
-                )
-            ]
-        )
+        table_entity = a_table(columns=[a_column("id", "service.db.schema.test_table.id")])
         container_entity = a_container(
             data_model=ContainerDataModel(
                 columns=[
@@ -943,10 +885,11 @@ class TestPathBasedLineage:
                 ]
             )
         )
-        lineage_source.path_lineage_map["cat.schema.test_table"] = {"s3://bucket/data"}
         lineage_source.metadata.es_search_container_by_path.return_value = [container_entity]
 
-        results = list(lineage_source._process_path_lineage(table_entity, "cat.schema.test_table"))
+        results = list(
+            lineage_source._process_path_lineage(table_entity, "cat.schema.test_table", {"s3://bucket/data"})
+        )
 
         assert len(results) == 1
         details = results[0].right.edge.lineageDetails
@@ -957,74 +900,57 @@ class TestPathBasedLineage:
 
     def test_process_path_lineage_survives_a_failing_container_lookup(self, lineage_source):
         """One unreachable path must not take the rest of the table's lineage down."""
-        lineage_source.path_lineage_map["cat.schema.test_table"] = {"s3://bucket/boom"}
         lineage_source.metadata.es_search_container_by_path.side_effect = RuntimeError("elasticsearch down")
 
-        results = list(lineage_source._process_path_lineage(a_table(), "cat.schema.test_table"))
+        results = list(lineage_source._process_path_lineage(a_table(), "cat.schema.test_table", {"s3://bucket/boom"}))
 
         assert len(results) == 0
 
+    def test_an_unresolved_path_reaches_the_container_of_its_target(self, lineage_source):
+        tables = {"cat.schema.tgt": a_table("tgt")}
+        container_entity = a_container()
+        lineage_source.metadata.es_search_container_by_path.return_value = [container_entity]
+
+        results = run(
+            lineage_source,
+            [table_row(target="cat.schema.tgt", source_path="s3a://bucket/unregistered/")],
+            tables,
+        )
+
+        assert container_edges(results, tables) == [(str(container_entity.id.root), "cat.schema.tgt")]
+
     def test_iter_emits_a_path_resolved_edge_end_to_end(self, lineage_source):
         """
-        From system-table rows to an AddLineageRequest, the way the workflow runs
-        it: the path source resolves to the external table declared over it.
+        From system-table rows to an AddLineageRequest, the way the workflow runs it:
+        the path source resolves to the external table declared over it.
         """
         raw_path = "abfss://raw@storage.dfs.core.windows.net/external_table"
         external_table = "bronze_ns.deltalake_ns.external_table"
         managed_table = "bronze_ns.deltalake_ns.managed_table_ns"
+        tables = {
+            external_table: a_table("external_table", columns=[a_column("id", f"svc.{external_table}.id")]),
+            managed_table: a_table("managed_table_ns", columns=[a_column("id", f"svc.{managed_table}.id")]),
+        }
+        lineage_source.metadata.es_search_container_by_path.return_value = []
 
-        stub_rows(
+        results = run(
             lineage_source,
             rows=[
                 table_row(
                     target=managed_table,
                     source_path=raw_path,
                     column_pairs=[("id", "id")],
-                    statement_text="CREATE TABLE managed_table_ns AS SELECT id FROM delta.`" + raw_path + "`",
+                    statement_text=f"CREATE TABLE managed_table_ns AS SELECT id FROM delta.`{raw_path}`",
                 )
             ],
+            tables=tables,
             external_rows=[ExternalRow("bronze_ns", "deltalake_ns", "external_table", raw_path)],
         )
 
-        target_entity = Table(
-            id=uuid4(),
-            name=EntityName(root="managed_table_ns"),
-            fullyQualifiedName=FullyQualifiedEntityName(root=f"svc.{managed_table}"),
-            database=EntityReference(id=uuid4(), type="database", name="bronze_ns"),
-            databaseSchema=EntityReference(id=uuid4(), type="databaseSchema", name="deltalake_ns"),
-            columns=[
-                Column(
-                    name=ColumnName(root="id"),
-                    dataType=DataType.INT,
-                    fullyQualifiedName=FullyQualifiedEntityName(root=f"svc.{managed_table}.id"),
-                )
-            ],
-        )
-        upstream_entity = Table(
-            id=uuid4(),
-            name=EntityName(root="external_table"),
-            fullyQualifiedName=FullyQualifiedEntityName(root=f"svc.{external_table}"),
-            columns=[
-                Column(
-                    name=ColumnName(root="id"),
-                    dataType=DataType.INT,
-                    fullyQualifiedName=FullyQualifiedEntityName(root=f"svc.{external_table}.id"),
-                )
-            ],
-        )
-
-        resolve_tables(
-            lineage_source,
-            {managed_table: target_entity, external_table: upstream_entity},
-        )
-        lineage_source.metadata.es_search_container_by_path.return_value = []
-
-        results = list(lineage_source._iter())
-
         assert len(results) == 1
         edge = results[0].right.edge
-        assert edge.fromEntity.id == upstream_entity.id
-        assert edge.toEntity.id == target_entity.id
+        assert edge.fromEntity.id == tables[external_table].id
+        assert edge.toEntity.id == tables[managed_table].id
         assert edge.lineageDetails.columnsLineage[0].fromColumns[0].root == f"svc.{external_table}.id"
         assert edge.lineageDetails.columnsLineage[0].toColumn.root == f"svc.{managed_table}.id"
         assert edge.lineageDetails.sqlQuery.root.startswith("CREATE TABLE managed_table_ns")
@@ -1039,53 +965,32 @@ class TestLineageDrivenIteration:
     """
 
     def test_the_service_is_not_walked(self, lineage_source):
-        stub_rows(lineage_source, [table_row("cat.schema.src", "cat.schema.tgt")])
-        resolve_tables(lineage_source, {"cat.schema.src": a_table("src"), "cat.schema.tgt": a_table("tgt")})
+        tables = {"cat.schema.src": a_table("src"), "cat.schema.tgt": a_table("tgt")}
 
-        results = list(lineage_source._iter())
+        results = run(lineage_source, [table_row("cat.schema.src", "cat.schema.tgt")], tables)
 
         assert len(results) == 1
         lineage_source.metadata.list_all_entities.assert_not_called()
 
-    def test_targets_cover_lineage_paths_and_external_locations(self, lineage_source):
-        lineage_source.table_lineage_map["cat.schema.from_lineage"] = {"cat.schema.src"}
-        lineage_source.path_lineage_map["cat.schema.from_path"] = {"s3://bucket/data"}
-        lineage_source.external_location_map["cat.schema.external"] = "s3://bucket/ext"
-
-        assert lineage_source._lineage_targets() == [
-            "cat.schema.external",
-            "cat.schema.from_lineage",
-            "cat.schema.from_path",
-        ]
-
     def test_an_upstream_named_by_two_targets_is_resolved_once(self, lineage_source):
-        stub_rows(
+        tables = {
+            "cat.schema.src": a_table("src"),
+            "cat.schema.tgt1": a_table("tgt1"),
+            "cat.schema.tgt2": a_table("tgt2"),
+        }
+
+        results = run(
             lineage_source,
             [
                 table_row("cat.schema.src", "cat.schema.tgt1"),
                 table_row("cat.schema.src", "cat.schema.tgt2"),
             ],
+            tables,
         )
-        resolve_tables(
-            lineage_source,
-            {
-                "cat.schema.src": a_table("src"),
-                "cat.schema.tgt1": a_table("tgt1"),
-                "cat.schema.tgt2": a_table("tgt2"),
-            },
-        )
-
-        results = list(lineage_source._iter())
 
         assert len(results) == 2
         resolved = [call.kwargs["fqn"] for call in lineage_source.metadata.get_by_name.call_args_list]
         assert resolved.count("local_unitycatalog.cat.schema.src") == 1
-
-    def test_a_target_that_was_never_ingested_is_skipped(self, lineage_source):
-        stub_rows(lineage_source, [table_row("cat.schema.src", "cat.schema.tgt")])
-        resolve_tables(lineage_source, {"cat.schema.src": a_table("src")})
-
-        assert list(lineage_source._iter()) == []
 
     def test_a_failing_lookup_is_not_cached(self, lineage_source):
         """A transient failure must not blind every later edge naming that table"""
@@ -1095,118 +1000,64 @@ class TestLineageDrivenIteration:
         assert "cat.schema.tgt" not in lineage_source._table_cache
 
     def test_filters_apply_to_the_names_the_system_tables_report(self, lineage_source):
-        stub_rows(
-            lineage_source,
-            [
-                table_row("cat.schema.src", "excluded_cat.schema.tgt"),
-                table_row("cat.schema.src", "cat.excluded_schema.tgt"),
-                table_row("cat.schema.src", "cat.schema.excluded_table"),
-                table_row("cat.schema.src", "cat.schema.tgt"),
-            ],
-        )
-        resolve_tables(
-            lineage_source,
-            {
-                "cat.schema.src": a_table("src"),
-                "excluded_cat.schema.tgt": a_table("tgt"),
-                "cat.excluded_schema.tgt": a_table("tgt"),
-                "cat.schema.excluded_table": a_table("excluded_table"),
-                "cat.schema.tgt": a_table("tgt"),
-            },
-        )
+        tables = {
+            "cat.schema.src": a_table("src"),
+            "excluded_cat.schema.tgt": a_table("tgt"),
+            "cat.excluded_schema.tgt": a_table("tgt"),
+            "cat.schema.excluded_table": a_table("excluded_table"),
+            "cat.schema.tgt": a_table("tgt"),
+        }
         lineage_source.source_config.databaseFilterPattern = FilterPattern(excludes=["excluded_cat"])
         lineage_source.source_config.schemaFilterPattern = FilterPattern(excludes=["excluded_schema"])
         lineage_source.source_config.tableFilterPattern = FilterPattern(excludes=["excluded_table"])
 
-        results = list(lineage_source._iter())
+        results = run(
+            lineage_source,
+            [
+                table_row("cat.schema.src", "cat.excluded_schema.tgt"),
+                table_row("cat.schema.src", "cat.schema.excluded_table"),
+                table_row("cat.schema.src", "cat.schema.tgt"),
+                table_row("cat.schema.src", "excluded_cat.schema.tgt"),
+            ],
+            tables,
+        )
 
-        assert len(results) == 1
-        assert results[0].right.edge.toEntity.id is not None
+        assert table_edges(results, tables) == [("cat.schema.src", "cat.schema.tgt")]
         assert lineage_source.status.filtered == [
             {"local_unitycatalog.cat.excluded_schema.tgt": "Schema Filtered Out"},
             {"local_unitycatalog.cat.schema.excluded_table": "Table Filtered Out"},
             {"local_unitycatalog.excluded_cat.schema.tgt": "Catalog Filtered Out"},
         ]
 
+    def test_a_filtered_table_is_reported_once(self, lineage_source):
+        """An external table that is also a lineage target is one entry in the summary"""
+        lineage_source.source_config.tableFilterPattern = FilterPattern(excludes=["ext"])
 
-class TestNativeLineageQuery:
-    """The single query both system tables and the statement text are read with."""
-
-    def test_both_system_tables_are_read_in_one_query(self):
-        query = unity_catalog_native_lineage_query(7, include_query_history=True)
-
-        assert query.count("FROM system.access.table_lineage") == 1
-        assert query.count("FROM system.access.column_lineage") == 1
-        assert query.count("INTERVAL 7 DAYS") == 4
-
-    def test_column_mappings_join_on_null_safe_equality(self):
-        """
-        `source_path` is NULL on every edge reported by table name and `=` on NULL
-        never matches, so a plain join would drop those edges' column mappings.
-        """
-        query = unity_catalog_native_lineage_query(1, include_query_history=True)
-
-        join = query.split("LEFT JOIN column_edges")[1].split("LEFT JOIN system.query.history")[0]
-        assert join.count("<=>") == 4
-        assert " = " not in join
-
-    def test_history_reaches_one_day_further_back_than_lineage(self):
-        """A statement that ran just before the oldest lineage day still wrote that edge"""
-        query = unity_catalog_native_lineage_query(2, include_query_history=True)
-
-        assert "history.start_time >= current_date() - INTERVAL 3 DAYS" in query
-
-    def test_unusable_statement_text_is_left_out(self):
-        query = unity_catalog_native_lineage_query(1, include_query_history=True)
-
-        assert "UPPER(TRIM(history.statement_text)) <> '<REDACTED>'" in query
-
-    def test_without_query_history_the_query_does_not_name_it(self):
-        query = unity_catalog_native_lineage_query(1, include_query_history=False)
-
-        assert "system.query.history" not in query
-        assert "statement_id" not in query
-        assert "CAST(NULL AS STRING) AS statement_text" in query
-
-
-class TestExternalTablesWithoutLineage:
-    def test_an_external_table_with_no_lineage_still_gets_its_container_edge(self, lineage_source):
-        stub_rows(
+        run(
             lineage_source,
-            external_rows=[ExternalRow("cat", "schema", "ext", "s3://bucket/data")],
+            rows=[table_row("cat.schema.src", "cat.schema.ext")],
+            external_rows=[ExternalRow("cat", "schema", "ext", "s3://bucket/ext")],
         )
-        table_entity = a_table("ext")
-        resolve_tables(lineage_source, {"cat.schema.ext": table_entity})
-        container_entity = a_container()
-        lineage_source.metadata.es_search_container_by_path.return_value = [container_entity]
 
-        results = list(lineage_source._iter())
+        assert lineage_source.status.filtered == [{"local_unitycatalog.cat.schema.ext": "Table Filtered Out"}]
 
-        assert len(results) == 1
-        assert results[0].right.edge.fromEntity.id == container_entity.id
-        assert results[0].right.edge.toEntity.id == table_entity.id
+    def test_external_locations_are_cached_before_lineage(self, lineage_source):
+        """
+        Resolving a path to the table declared over it reads the location map, so
+        filling it after the lineage rows would silently resolve nothing.
+        """
+        calls = []
 
-    def test_a_table_with_no_upstream_is_never_resolved(self, lineage_source):
-        """Resolving it would spend a request per external table in the metastore"""
-        stub_rows(
-            lineage_source,
-            external_rows=[ExternalRow("cat", "schema", "ext", "s3://bucket/data")],
-        )
-        lineage_source.metadata.es_search_container_by_path.return_value = []
+        def cache_locations():
+            calls.append("locations")
 
-        assert list(lineage_source._iter()) == []
-        lineage_source.metadata.get_by_name.assert_not_called()
+        def stream_lineage():
+            calls.append("lineage")
+            return iter(())
 
-    def test_an_external_table_that_was_never_ingested_yields_nothing(self, lineage_source):
-        lineage_source.external_location_map = {"cat.schema.ext": "s3://bucket/data"}
-        lineage_source.metadata.es_search_container_by_path.return_value = [a_container()]
-        resolve_tables(lineage_source, {})
+        lineage_source._cache_external_locations = cache_locations
+        lineage_source._stream_native_lineage = stream_lineage
 
-        assert list(lineage_source._process_external_location_lineage("cat.schema.ext")) == []
+        list(lineage_source._iter())
 
-    def test_a_malformed_target_name_is_dropped(self, lineage_source):
-        """A name that is not `catalog.schema.table` cannot be resolved or filtered"""
-        stub_rows(lineage_source, [table_row("cat.schema.src", "two.parts")])
-
-        assert list(lineage_source._iter()) == []
-        lineage_source.metadata.get_by_name.assert_not_called()
+        assert calls == ["locations", "lineage"]

--- a/ingestion/tests/unit/topology/database/test_unitycatalog_self_referencing_lineage.py
+++ b/ingestion/tests/unit/topology/database/test_unitycatalog_self_referencing_lineage.py
@@ -17,6 +17,7 @@ Those rows must not reach the lineage map, or the table ends up in its own
 upstream set and is later emitted as an edge pointing at itself.
 """
 
+import json
 from collections import defaultdict
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -30,27 +31,22 @@ EVENT_LOG = f"{CATALOG}.{SCHEMA}.orders_event_log"
 SNAPSHOT = f"{CATALOG}.{SCHEMA}.orders_snapshot"
 
 
-def _row(source_table: str, target_table: str) -> SimpleNamespace:
+def _row(source_table: str, target_table: str, column_pairs=None) -> SimpleNamespace:
     return SimpleNamespace(
         source_table_full_name=source_table,
         target_table_full_name=target_table,
         source_path=None,
         target_path=None,
+        column_pairs=(
+            None
+            if column_pairs is None
+            else json.dumps([{"source": source, "target": target} for source, target in column_pairs])
+        ),
+        statement_text=None,
     )
 
 
-def _column_row(source_table: str, target_table: str, column: str) -> SimpleNamespace:
-    return SimpleNamespace(
-        source_table_full_name=source_table,
-        target_table_full_name=target_table,
-        source_path=None,
-        target_path=None,
-        source_column_name=column,
-        target_column_name=column,
-    )
-
-
-def _source(rows, column_rows=None):
+def _source(rows):
     """The real caching method, with only the SQL connection stubbed."""
     with patch.object(UnitycatalogLineageSource, "__init__", lambda s: None):
         source = UnitycatalogLineageSource()
@@ -62,10 +58,15 @@ def _source(rows, column_rows=None):
     source.column_lineage_map = defaultdict(dict)
     source.path_to_table_map = defaultdict(set)
     source.path_lineage_map = defaultdict(set)
+    source.edge_sql = {}
 
     connection = MagicMock()
-    # _cache_lineage runs the table query first, then the column query
-    connection.execute.side_effect = [rows, column_rows if column_rows is not None else []]
+
+    def execute(statement, *_args, **_kwargs):
+        # the query history probe runs first and scans nothing
+        return [] if "WHERE 1=0" in str(statement) else rows
+
+    connection.execute.side_effect = execute
     engine = MagicMock()
     engine.connect.return_value.__enter__ = MagicMock(return_value=connection)
     engine.connect.return_value.__exit__ = MagicMock(return_value=False)
@@ -103,18 +104,12 @@ class TestSelfReferencingColumnLineageCache:
     """A self-pair's columns are unreadable once its table pair is dropped."""
 
     def test_self_referencing_columns_are_not_cached(self):
-        source = _source(
-            [_row(EVENT_LOG, EVENT_LOG)],
-            column_rows=[_column_row(EVENT_LOG, EVENT_LOG, "id")],
-        )
+        source = _source([_row(EVENT_LOG, EVENT_LOG, column_pairs=[("id", "id")])])
         source._cache_lineage()
         assert (EVENT_LOG, EVENT_LOG) not in source.column_lineage_map
         assert sum(len(v) for v in source.column_lineage_map.values()) == 0
 
     def test_normal_columns_are_still_cached(self):
-        source = _source(
-            [_row(EVENT_LOG, SNAPSHOT)],
-            column_rows=[_column_row(EVENT_LOG, SNAPSHOT, "id")],
-        )
+        source = _source([_row(EVENT_LOG, SNAPSHOT, column_pairs=[("id", "id")])])
         source._cache_lineage()
         assert source.column_lineage_map[(EVENT_LOG, SNAPSHOT)] == {("id", "id"): None}

--- a/ingestion/tests/unit/topology/database/test_unitycatalog_self_referencing_lineage.py
+++ b/ingestion/tests/unit/topology/database/test_unitycatalog_self_referencing_lineage.py
@@ -1,27 +1,20 @@
-#  Copyright 2025 Collate
-#  Licensed under the Collate Community License, Version 1.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
 """
-A table is never cached as its own upstream.
+A table is never emitted as its own upstream.
 
 `system.access.table_lineage` records table access rather than derivation, so a
 streaming or CDC write legitimately names its target table as its own source.
-Those rows must not reach the lineage map, or the table ends up in its own
-upstream set and is later emitted as an edge pointing at itself.
+Those rows must not become an edge, or the table is sent to OpenMetadata as its
+own upstream and renders as a loop on the node.
 """
 
-import json
-from collections import defaultdict
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
+from cachetools import LRUCache
+
+from metadata.generated.schema.entity.data.table import Table
+from metadata.generated.schema.type.basic import EntityName, FullyQualifiedEntityName
 from metadata.ingestion.source.database.unitycatalog.lineage import (
     UnitycatalogLineageSource,
 )
@@ -31,85 +24,64 @@ EVENT_LOG = f"{CATALOG}.{SCHEMA}.orders_event_log"
 SNAPSHOT = f"{CATALOG}.{SCHEMA}.orders_snapshot"
 
 
-def _row(source_table: str, target_table: str, column_pairs=None) -> SimpleNamespace:
-    return SimpleNamespace(
-        source_table_full_name=source_table,
-        target_table_full_name=target_table,
-        source_path=None,
-        target_path=None,
-        column_pairs=(
-            None
-            if column_pairs is None
-            else json.dumps([{"source": source, "target": target} for source, target in column_pairs])
-        ),
-        statement_text=None,
+def _table(databricks_table_fqn: str) -> Table:
+    return Table(
+        id=uuid4(),
+        name=EntityName(root=databricks_table_fqn.rsplit(".", maxsplit=1)[-1]),
+        fullyQualifiedName=FullyQualifiedEntityName(root=f"svc.{databricks_table_fqn}"),
+        columns=[],
     )
 
 
-def _source(rows):
-    """The real caching method, with only the SQL connection stubbed."""
+def _source(upstreams: dict[str, Table]):
+    """The real emitting method, with only the entity lookups stubbed."""
     with patch.object(UnitycatalogLineageSource, "__init__", lambda s: None):
         source = UnitycatalogLineageSource()
 
-    source.table_lineage_map = defaultdict(set)
-    source.source_config = MagicMock()
-    source.source_config.queryLogDuration = 1
-
-    source.column_lineage_map = defaultdict(dict)
-    source.path_to_table_map = defaultdict(set)
-    source.path_lineage_map = defaultdict(set)
-    source.edge_sql = {}
-
-    connection = MagicMock()
-
-    def execute(statement, *_args, **_kwargs):
-        # the query history probe runs first and scans nothing
-        return [] if "WHERE 1=0" in str(statement) else rows
-
-    connection.execute.side_effect = execute
-    engine = MagicMock()
-    engine.connect.return_value.__enter__ = MagicMock(return_value=connection)
-    engine.connect.return_value.__exit__ = MagicMock(return_value=False)
-    source.engine = engine
+    source.config = SimpleNamespace(serviceName="svc")
+    source.metadata = MagicMock()
+    source._table_cache = LRUCache(maxsize=10)
+    source.metadata.get_by_name.side_effect = lambda entity=None, fqn=None, **_: upstreams.get(
+        str(fqn).split(".", 1)[1]
+    )
     return source
 
 
-class TestSelfReferencingLineageCache:
-    def test_a_self_referencing_row_is_not_cached(self):
-        source = _source([_row(EVENT_LOG, EVENT_LOG)])
-        source._cache_lineage()
-        assert EVENT_LOG not in source.table_lineage_map.get(EVENT_LOG, set())
-        assert sum(len(v) for v in source.table_lineage_map.values()) == 0
+def _edges(source, target: str, upstream_columns: dict[str, dict]):
+    return [
+        (
+            str(result.right.edge.fromEntity.id.root),
+            str(result.right.edge.toEntity.id.root),
+        )
+        for result in source._process_table_lineage(_table(target), target, upstream_columns, {})
+    ]
 
-    def test_a_normal_row_is_still_cached(self):
-        source = _source([_row(EVENT_LOG, SNAPSHOT)])
-        source._cache_lineage()
-        assert source.table_lineage_map[SNAPSHOT] == {EVENT_LOG}
+
+class TestSelfReferencingLineage:
+    def test_a_self_referencing_row_is_not_an_edge(self):
+        source = _source({EVENT_LOG: _table(EVENT_LOG)})
+
+        assert _edges(source, EVENT_LOG, {EVENT_LOG: {}}) == []
+
+    def test_a_normal_row_is_still_an_edge(self):
+        upstream = _table(EVENT_LOG)
+        source = _source({EVENT_LOG: upstream})
+
+        edges = _edges(source, SNAPSHOT, {EVENT_LOG: {}})
+
+        assert [source for source, _ in edges] == [str(upstream.id.root)]
 
     def test_only_the_self_reference_is_dropped(self):
         """The guard must not suppress real upstreams of the same table."""
-        source = _source(
-            [
-                _row(EVENT_LOG, SNAPSHOT),
-                _row(SNAPSHOT, SNAPSHOT),
-                _row(EVENT_LOG, EVENT_LOG),
-            ]
-        )
-        source._cache_lineage()
-        assert source.table_lineage_map[SNAPSHOT] == {EVENT_LOG}
-        assert source.table_lineage_map.get(EVENT_LOG, set()) == set()
+        upstream = _table(EVENT_LOG)
+        source = _source({EVENT_LOG: upstream, SNAPSHOT: _table(SNAPSHOT)})
 
+        edges = _edges(source, SNAPSHOT, {EVENT_LOG: {}, SNAPSHOT: {}})
 
-class TestSelfReferencingColumnLineageCache:
-    """A self-pair's columns are unreadable once its table pair is dropped."""
+        assert [source for source, _ in edges] == [str(upstream.id.root)]
 
-    def test_self_referencing_columns_are_not_cached(self):
-        source = _source([_row(EVENT_LOG, EVENT_LOG, column_pairs=[("id", "id")])])
-        source._cache_lineage()
-        assert (EVENT_LOG, EVENT_LOG) not in source.column_lineage_map
-        assert sum(len(v) for v in source.column_lineage_map.values()) == 0
+    def test_the_columns_of_a_self_reference_are_dropped_with_it(self):
+        """A self-pair's mappings are unreachable once its edge is dropped."""
+        source = _source({EVENT_LOG: _table(EVENT_LOG)})
 
-    def test_normal_columns_are_still_cached(self):
-        source = _source([_row(EVENT_LOG, SNAPSHOT, column_pairs=[("id", "id")])])
-        source._cache_lineage()
-        assert source.column_lineage_map[(EVENT_LOG, SNAPSHOT)] == {("id", "id"): None}
+        assert _edges(source, EVENT_LOG, {EVENT_LOG: {("id", "id"): None}}) == []

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/UnityCatalog.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/UnityCatalog.md
@@ -72,10 +72,27 @@ $$note
 Access to `system.access` tables is restricted by default. These grants must be executed by an **account administrator** in the Databricks account console. Regular workspace admins cannot grant access to system tables.
 $$
 
+To also show the SQL that produced each lineage edge, grant access to the query history:
+
+```sql
+GRANT USE CATALOG ON CATALOG system TO '<user_or_service_principal>';
+GRANT USE SCHEMA ON SCHEMA system.query TO '<user_or_service_principal>';
+GRANT SELECT ON TABLE system.query.history TO '<user_or_service_principal>';
+```
+
+$$note
+The SQL Query of an edge is the latest statement recorded for that source-target pair
+within the lineage lookback window, so a single statement may not explain every column
+mapping of the edge. Databricks only records the statement for queries run on a SQL
+warehouse, and its text can be empty or `<REDACTED>` depending on the principal's access
+and the workspace's encryption settings. Lineage is always ingested; when the query
+history cannot be read, it is ingested without SQL and a message is logged.
+$$
+
 ### Usage & Lineage
 
 $$note
-To get Query Usage and Lineage details, you need a Databricks Premium account, since we will be extracting this information from your SQL Warehouse's history API.
+To get Query Usage details, you need a Databricks Premium account, since we will be extracting this information from your SQL Warehouse's history API.
 $$
 
 ### Profiler & Data Quality


### PR DESCRIPTION
### Describe your changes:

Fixes #32021

Native Unity Catalog lineage edges carry no SQL even when the statement that wrote
them is available. I attached it by joining `system.access.table_lineage` to
`system.query.history` inside the query that already reads the lineage, and while
there I removed the two things that made that lookup expensive: the walk over every
table in the service, and the in-memory copy of every edge in the catalog.

Before: two system-table queries cached into unbounded maps, then one paginated
`list_all_entities` request per hundred tables in the service (nearly all of them for
tables no edge mentions) plus one uncached `get_by_name` per edge. Now: one query for
table edges, column mappings and SQL together, streamed in target order, with the
tables an edge actually names resolved once each behind an LRU cache.

This supersedes #33002, which fixes the same issue by batching a second
`table_lineage ⋈ query.history` query per 100 edges. Measured on the same live
workspace and window, that costs **53.2s of warehouse time against 7.1s here**
(numbers below). This branch is cut from current `main`, which #33002's branch
predates by ~150 lines in this file (path lineage, self-reference dedupe).

#
### Type of change:

- [x] Improvement

#
### High-level design:

**One query instead of two plus one per batch.**
`unity_catalog_native_lineage_query(query_log_duration, include_query_history)`
aggregates each edge's column mappings server-side
(`to_json(collect_set(struct(...)))`) and left-joins `system.query.history` on the
edge's latest `statement_id`/`workspace_id` (`max_by(struct(...), event_time)`).
Column mappings join on `<=>`, not `=`: `source_path` is NULL on every edge reported
by table name, and `=` on NULL never matches, so a plain join would silently drop
those edges' mappings.

**Graceful degradation.** `statement_id` is only populated for statements run on a
SQL warehouse and `system.query.history` is separately granted, so a query naming
them would fail as a whole and take the lineage with it. A single `WHERE 1=0` probe
decides once per run; on failure the statement columns and the join are left out
entirely and lineage is ingested without SQL.

**Streaming, one target at a time.** The query is `ORDER BY target`, so a target's
edges are complete as soon as the next target appears. `_stream_native_lineage`
buffers only the target in hand and hands it to `_process_target_lineage`.

**Why the rows are grouped at all** (rather than emitted one by one, Snowflake
`ACCESS_HISTORY` style): Databricks reports one edge twice when it names a side by
table on one row and by path on another, and `LineageRepository.addLineage` *replaces*
an edge's `lineageDetails` instead of merging them — a second request for a pair
already sent would drop the column mappings of the first. That replace-not-merge
behaviour was confirmed live: running `main`'s connector over the same service
stripped `sqlQuery` from all 444 edges, and re-running this one put it back.
Grouping per target covers every duplication observed so far, since both rows share
the target. A *target* reported both by name and by path would still emit twice; on
the live dataset **0 of 239 targets** had more than one raw key. Closing that case
too would mean pushing path→table resolution (scheme aliases, trailing slashes) into
SQL, moving the `path_utils` behaviours out of unit tests and into something only
verifiable on a live workspace. Rejected on that basis.

**Iteration is driven by the lineage rows**, not the catalog: targets come from the
system tables and external-location edges from `system.information_schema.tables`. No
`list_all_entities` call remains. The FQN of a table is built rather than searched
for — Unity Catalog normalises identifiers, so `fqn.build`'s Elasticsearch round trip
per table returns the same string `fqn._build` produces (same approach as
`snowflake/lineage.py`); all 444 live edges still resolve. Filter patterns apply to
the `catalog.schema.table` names the system tables report, and a table that is both a
lineage target and an external table is reported once in the run summary.

Backward compatibility: no schema, API or config change. Same edges and column
mappings as before, plus SQL. `queryLogDuration` keeps its meaning; history reaches
one day further back so a statement that ran just before the oldest lineage day is
still found.

#
### Tests:

#### Use cases covered

- A native lineage edge whose statement is in query history shows that SQL in the Edge
  Information panel (the issue).
- Lineage is still ingested, without SQL, when `system.query.history` is not readable.
- Column mappings survive on edges whose source or target is reported by path.
- An edge reported twice (once by table name, once by path) is sent once, with both
  rows' column mappings merged.
- Ingestion filter patterns exclude catalogs/schemas/tables named by the system tables.
- External tables still get their container edge with no lineage rows at all.

#### Unit tests

- [x] I added unit tests for the new/changed logic.
- Files added/updated:
  - `ingestion/tests/unit/topology/database/test_unity_catalog_lineage.py` (rewritten
    to assert on emitted `AddLineageRequest`s rather than internal maps; 57 tests)
  - `ingestion/tests/unit/topology/database/test_unitycatalog_self_referencing_lineage.py`
    (retargeted to the method that now owns the rule; 4 tests)
- Coverage: **99% of changed executable lines** (128/129). Whole-module: `lineage.py`
  **90%**, `queries.py` **100%**.
- `61 passed` in those two files; `140 passed` across all collectible `test_unity*` files.

#### Backend integration tests

- [x] Not applicable (no backend API changes).

#### Ingestion integration tests

- No automated ingestion integration test added — the behaviour that needs a live
  metastore is the SQL of the query itself, which no fixture reproduces. Validated
  manually against a live workspace instead; see below.

#### Playwright (UI) tests

- [x] Not applicable (no UI changes — only connector help text in
  `locales/en-US/Database/UnityCatalog.md`).

#### Manual testing performed

Live Databricks workspace, catalog `demo`, schema `om_lineage_acceptance`
(205 batch targets + `my_source`/`my_target`), 7-day lookback.

1. Ingested metadata into a fresh service (`uc_lineage_live_test`): 245 tables, 0 errors.
2. Ran the lineage workflow on this branch: `Reading native lineage from system tables
   (lookback: 7 days, SQL text: yes)` → `emitted 444 edges over 239 targets`,
   444 processed, **0 errors, 0 warnings, 100% success**.
3. Verified **all 444 edges** through `/v1/lineage/getLineageEdge/...`: every edge has a
   non-empty `sqlQuery` **byte-identical** to the statement in `system.query.history`,
   and its column-mapping count matches the warehouse's mappings for that pair exactly.
   Example (`my_source → my_target`): `INSERT INTO demo.om_lineage_acceptance.my_target
   SELECT id, amount * 2 AS total FROM demo.om_lineage_acceptance.my_source` with
   2 column mappings and `source: QueryLineage`.
4. Equivalence with `main`'s two queries over the same window: **444 edges and 683
   column mappings on both sides, 0 missing, 0 extra** — the single query loses nothing.
5. Row ordering holds on real data: 239 distinct targets, 239 adjacent runs, so the
   one-target buffer never sees a target twice.
6. Fallback path: the `include_query_history=False` variant runs on the warehouse and
   returns the same 444 rows with `statement_text` NULL and column mappings intact.
7. Re-ran the workflow: same 444 edges, `sqlQuery` preserved.

Warehouse cost, same window, warm warehouse:

| | queries | time |
|---|---|---|
| `main` (no SQL text) | `table_lineage` + `column_lineage` | 7.5s |
| **this PR** (with SQL text) | 1 joined query | **7.1s** |
| this PR, no query-history access | 1 query | 4.5s |
| #33002 (with SQL text) | the 2 above + 5 batched enrichment joins (11.0 / 8.9 / 8.5 / 9.0 / 8.3s) | **53.2s** |

Source-side wall clock is a wash at this size — 10.2s here (245 `get_by_name`, 1.5s
probe, 7.1s query) against `main`'s 10.6s (450 `get_by_name` + catalog pagination,
7.5s+ of queries) — because this service has 245 tables and 239 of them are lineage
targets, the best possible case for the catalog walk. The saving scales with
tables-in-service ÷ tables-in-lineage. End to end the run is 39s against `main`'s 23s;
that difference is the sink writing the statement text onto 444 edges, i.e. the
feature, not the restructure.

Static checks: `ruff check`, `ruff format --check`, `check_ruff_suppressions.py --check`
(the 5 obsolete G004 baseline entries this change retires are pruned), and
`basedpyright --baselinemode=discard` — its two `reportOptionalIterable` hits on
`for row in rows` also occur on `main`'s copy of this file in the same environment
(3 there, 2 here), so they are the local partial venv, not a regression.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable, no schema change.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

- [x] I have added tests around the new logic.
- [x] For connector/ingestion changes: I updated the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
