### PR TITLE
Backport #33081: Context Center article Data Products panel and domain save fixes

### DIFF
--- a/.github/playwright/impact-map.generated.json
+++ b/.github/playwright/impact-map.generated.json
@@ -973,6 +973,7 @@
         "openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsContainer/DataProductsContainer.component.tsx"
       ],
       "specs": [
+        "playwright/e2e/Features/ContextCenterArticles.spec.ts",
         "playwright/e2e/Features/ContextCenterPermission.spec.ts",
         "playwright/e2e/Features/DataAssetRulesDisabled.spec.ts",
         "playwright/e2e/Features/DataAssetRulesEnabled.spec.ts",
@@ -996,6 +997,7 @@
         "openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsSelectList/DataProductsSelectList.tsx"
       ],
       "specs": [
+        "playwright/e2e/Features/ContextCenterArticles.spec.ts",
         "playwright/e2e/Features/DataAssetRulesEnabled.spec.ts",
         "playwright/e2e/Features/RestoreEntityInheritedFields.spec.ts"
       ]
@@ -1770,6 +1772,7 @@
         "openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityRightPanel/EntityRightPanel.tsx"
       ],
       "specs": [
+        "playwright/e2e/Features/ContextCenterArticles.spec.ts",
         "playwright/e2e/Features/ContextCenterPermission.spec.ts",
         "playwright/e2e/Features/DataAssetRulesDisabled.spec.ts",
         "playwright/e2e/Features/DataAssetRulesEnabled.spec.ts",

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
@@ -667,6 +667,197 @@ test.describe('Context Center Articles', () => {
     await afterAction();
   });
 
+  test(
+    'Data Products panel shows domain message when no domain and opens selector when domain present',
+    async ({ page }) => {
+      test.slow();
+
+      const dpArticleEntity = new KnowledgeCenterClass({
+        displayName: `CC DP Test ${uuid()}`,
+      });
+      const { apiContext: createCtx, afterAction: createAfter } =
+        await getApiContext(page);
+      await dpArticleEntity.create(createCtx);
+      await createAfter();
+
+      try {
+        await test.step(
+          'No domain: + button is disabled and card shows informational message',
+          async () => {
+            await navigateToArticle(
+              page,
+              dpArticleEntity.responseData.fullyQualifiedName
+            );
+
+            const dpContainer = page
+              .getByTestId('KnowledgePanel.DataProducts')
+              .getByTestId('data-products-container');
+
+            await expect(dpContainer).toContainText(
+              'Select a domain to add data product.'
+            );
+          }
+        );
+
+        await test.step(
+          'With domain: + opens selector and data product can be selected and saved',
+          async () => {
+            const { apiContext: patchCtx, afterAction: patchAfter } =
+              await getApiContext(page);
+            await dpArticleEntity.patch(patchCtx, [
+              {
+                op: 'add',
+                path: '/domains',
+                value: [
+                  {
+                    id: domain.responseData.id,
+                    type: 'domain',
+                    name: domain.responseData.name,
+                    fullyQualifiedName: domain.responseData.fullyQualifiedName,
+                  },
+                ],
+              },
+            ]);
+            await patchAfter();
+
+            await navigateToArticle(
+              page,
+              dpArticleEntity.responseData.fullyQualifiedName
+            );
+
+            const dpContainer = page
+              .getByTestId('KnowledgePanel.DataProducts')
+              .getByTestId('data-products-container');
+
+            const addBtn = dpContainer.getByTestId('add-data-product');
+            await expect(addBtn).toBeEnabled();
+
+            const searchResponse = page.waitForResponse(
+              (response) =>
+                response.url().includes('/api/v1/search/query') &&
+                response.url().includes('dataProduct')
+            );
+            await addBtn.click();
+            await searchResponse;
+
+            await expect(
+              dpContainer.getByTestId('data-product-selector')
+            ).toBeVisible();
+
+            await page
+              .getByTestId(
+                `tag-${dataProduct.responseData.fullyQualifiedName}`
+              )
+              .click();
+
+            const savePatch = page.waitForResponse(
+              (response) =>
+                response.url().includes('/api/v1/contextCenter/pages/') &&
+                response.request().method() === 'PATCH'
+            );
+            await page.getByTestId('saveAssociatedTag').click();
+            await savePatch;
+            await waitForAllLoadersToDisappear(page);
+
+            await expect(
+              dpContainer.getByTestId(
+                `data-product-${dataProduct.responseData.fullyQualifiedName}`
+              )
+            ).toBeVisible();
+          }
+        );
+      } finally {
+        const { apiContext: cleanupCtx, afterAction: cleanupAfter } =
+          await getApiContext(page);
+        await dpArticleEntity.delete(cleanupCtx);
+        await cleanupAfter();
+      }
+    }
+  );
+
+  test(
+    'Removing a domain from an article sends a valid PATCH and clears the domain',
+    async ({ page }) => {
+      test.slow();
+
+      const domainArticleEntity = new KnowledgeCenterClass({
+        displayName: `CC Domain Remove Test ${uuid()}`,
+      });
+      const { apiContext: createCtx, afterAction: createAfter } =
+        await getApiContext(page);
+      await domainArticleEntity.create(createCtx);
+      await domainArticleEntity.patch(createCtx, [
+        {
+          op: 'add',
+          path: '/domains',
+          value: [
+            {
+              id: domain.responseData.id,
+              type: 'domain',
+              name: domain.responseData.name,
+              fullyQualifiedName: domain.responseData.fullyQualifiedName,
+            },
+          ],
+        },
+      ]);
+      await createAfter();
+
+      try {
+        await test.step('Domain appears in article header', async () => {
+          await navigateToArticle(
+            page,
+            domainArticleEntity.responseData.fullyQualifiedName
+          );
+          await expect(page.getByTestId('domain-link')).toBeVisible();
+        });
+
+        await test.step(
+          'Removing the domain sends a valid PATCH (200) and clears the header',
+          async () => {
+            await page.getByTestId('edit-domain-btn').click();
+
+            const searchResponse = page.waitForResponse(
+              (response) =>
+                response.url().includes('/api/v1/search/query') &&
+                response
+                  .url()
+                  .includes(
+                    encodeURIComponent(domain.responseData.name as string)
+                  )
+            );
+            await page
+              .getByTestId('domain-selectable-tree')
+              .getByTestId('searchbar')
+              .fill(domain.responseData.name as string);
+            await searchResponse;
+
+            const domainTagSelector = page.getByTestId(
+              `tag-${domain.responseData.fullyQualifiedName}`
+            );
+            await domainTagSelector.waitFor({ state: 'visible' });
+
+            const removePatch = page.waitForResponse(
+              (response) =>
+                response.url().includes('/api/v1/contextCenter/pages/') &&
+                response.request().method() === 'PATCH'
+            );
+            await domainTagSelector.click();
+            const removeResponse = await removePatch;
+
+            expect(removeResponse.status()).toBe(200);
+            await waitForAllLoadersToDisappear(page);
+            await expect(page.getByTestId('domain-link')).toHaveText('No Domain');
+          }
+        );
+      } finally {
+        const { apiContext: cleanupCtx, afterAction: cleanupAfter } =
+          await getApiContext(page);
+        await domainArticleEntity.delete(cleanupCtx);
+        await cleanupAfter();
+      }
+    }
+  );
+
   test('Article list cards, recently viewed widget, and pagination work', async ({
     page,
   }) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
@@ -667,196 +667,181 @@ test.describe('Context Center Articles', () => {
     await afterAction();
   });
 
-  test(
-    'Data Products panel shows domain message when no domain and opens selector when domain present',
-    async ({ page }) => {
-      test.slow();
+  test('Data Products panel shows domain message when no domain and opens selector when domain present', async ({
+    page,
+  }) => {
+    test.slow();
 
-      const dpArticleEntity = new KnowledgeCenterClass({
-        displayName: `CC DP Test ${uuid()}`,
-      });
-      const { apiContext: createCtx, afterAction: createAfter } =
-        await getApiContext(page);
-      await dpArticleEntity.create(createCtx);
-      await createAfter();
+    const dpArticleEntity = new KnowledgeCenterClass({
+      displayName: `CC DP Test ${uuid()}`,
+    });
+    const { apiContext: createCtx, afterAction: createAfter } =
+      await getApiContext(page);
+    await dpArticleEntity.create(createCtx);
+    await createAfter();
 
-      try {
-        await test.step(
-          'No domain: + button is disabled and card shows informational message',
-          async () => {
-            await navigateToArticle(
-              page,
-              dpArticleEntity.responseData.fullyQualifiedName
-            );
-
-            const dpContainer = page
-              .getByTestId('KnowledgePanel.DataProducts')
-              .getByTestId('data-products-container');
-
-            await expect(dpContainer).toContainText(
-              'Select a domain to add data product.'
-            );
-          }
+    try {
+      await test.step('No domain: + button is disabled and card shows informational message', async () => {
+        await navigateToArticle(
+          page,
+          dpArticleEntity.responseData.fullyQualifiedName
         );
 
-        await test.step(
-          'With domain: + opens selector and data product can be selected and saved',
-          async () => {
-            const { apiContext: patchCtx, afterAction: patchAfter } =
-              await getApiContext(page);
-            await dpArticleEntity.patch(patchCtx, [
+        const dpContainer = page
+          .getByTestId('KnowledgePanel.DataProducts')
+          .getByTestId('data-products-container');
+
+        await expect(dpContainer).toContainText(
+          'Select a domain to add data product.'
+        );
+      });
+
+      await test.step('With domain: + opens selector and data product can be selected and saved', async () => {
+        const { apiContext: patchCtx, afterAction: patchAfter } =
+          await getApiContext(page);
+        await dpArticleEntity.patch(patchCtx, [
+          {
+            op: 'add',
+            path: '/domains',
+            value: [
               {
-                op: 'add',
-                path: '/domains',
-                value: [
-                  {
-                    id: domain.responseData.id,
-                    type: 'domain',
-                    name: domain.responseData.name,
-                    fullyQualifiedName: domain.responseData.fullyQualifiedName,
-                  },
-                ],
+                id: domain.responseData.id,
+                type: 'domain',
+                name: domain.responseData.name,
+                fullyQualifiedName: domain.responseData.fullyQualifiedName,
               },
-            ]);
-            await patchAfter();
+            ],
+          },
+        ]);
+        await patchAfter();
 
-            await navigateToArticle(
-              page,
-              dpArticleEntity.responseData.fullyQualifiedName
-            );
-
-            const dpContainer = page
-              .getByTestId('KnowledgePanel.DataProducts')
-              .getByTestId('data-products-container');
-
-            const addBtn = dpContainer.getByTestId('add-data-product');
-            await expect(addBtn).toBeEnabled();
-
-            const searchResponse = page.waitForResponse(
-              (response) =>
-                response.url().includes('/api/v1/search/query') &&
-                response.url().includes('dataProduct')
-            );
-            await addBtn.click();
-            await searchResponse;
-
-            await expect(
-              dpContainer.getByTestId('data-product-selector')
-            ).toBeVisible();
-
-            await page
-              .getByTestId(
-                `tag-${dataProduct.responseData.fullyQualifiedName}`
-              )
-              .click();
-
-            const savePatch = page.waitForResponse(
-              (response) =>
-                response.url().includes('/api/v1/contextCenter/pages/') &&
-                response.request().method() === 'PATCH'
-            );
-            await page.getByTestId('saveAssociatedTag').click();
-            await savePatch;
-            await waitForAllLoadersToDisappear(page);
-
-            await expect(
-              dpContainer.getByTestId(
-                `data-product-${dataProduct.responseData.fullyQualifiedName}`
-              )
-            ).toBeVisible();
-          }
+        await navigateToArticle(
+          page,
+          dpArticleEntity.responseData.fullyQualifiedName
         );
-      } finally {
-        const { apiContext: cleanupCtx, afterAction: cleanupAfter } =
-          await getApiContext(page);
-        await dpArticleEntity.delete(cleanupCtx);
-        await cleanupAfter();
-      }
-    }
-  );
 
-  test(
-    'Removing a domain from an article sends a valid PATCH and clears the domain',
-    async ({ page }) => {
-      test.slow();
+        const dpContainer = page
+          .getByTestId('KnowledgePanel.DataProducts')
+          .getByTestId('data-products-container');
 
-      const domainArticleEntity = new KnowledgeCenterClass({
-        displayName: `CC Domain Remove Test ${uuid()}`,
+        const addBtn = dpContainer.getByTestId('add-data-product');
+        await expect(addBtn).toBeEnabled();
+
+        const searchResponse = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/search/query') &&
+            response.url().includes('dataProduct')
+        );
+        await addBtn.click();
+        await searchResponse;
+
+        await expect(
+          dpContainer.getByTestId('data-product-selector')
+        ).toBeVisible();
+
+        await page
+          .getByTestId(`tag-${dataProduct.responseData.fullyQualifiedName}`)
+          .click();
+
+        const savePatch = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/contextCenter/pages/') &&
+            response.request().method() === 'PATCH'
+        );
+        await page.getByTestId('saveAssociatedTag').click();
+        await savePatch;
+        await waitForAllLoadersToDisappear(page);
+
+        await expect(
+          dpContainer.getByTestId(
+            `data-product-${dataProduct.responseData.fullyQualifiedName}`
+          )
+        ).toBeVisible();
       });
-      const { apiContext: createCtx, afterAction: createAfter } =
+    } finally {
+      const { apiContext: cleanupCtx, afterAction: cleanupAfter } =
         await getApiContext(page);
-      await domainArticleEntity.create(createCtx);
-      await domainArticleEntity.patch(createCtx, [
-        {
-          op: 'add',
-          path: '/domains',
-          value: [
-            {
-              id: domain.responseData.id,
-              type: 'domain',
-              name: domain.responseData.name,
-              fullyQualifiedName: domain.responseData.fullyQualifiedName,
-            },
-          ],
-        },
-      ]);
-      await createAfter();
-
-      try {
-        await test.step('Domain appears in article header', async () => {
-          await navigateToArticle(
-            page,
-            domainArticleEntity.responseData.fullyQualifiedName
-          );
-          await expect(page.getByTestId('domain-link')).toBeVisible();
-        });
-
-        await test.step(
-          'Removing the domain sends a valid PATCH (200) and clears the header',
-          async () => {
-            await page.getByTestId('edit-domain-btn').click();
-
-            const searchResponse = page.waitForResponse(
-              (response) =>
-                response.url().includes('/api/v1/search/query') &&
-                response
-                  .url()
-                  .includes(
-                    encodeURIComponent(domain.responseData.name as string)
-                  )
-            );
-            await page
-              .getByTestId('domain-selectable-tree')
-              .getByTestId('searchbar')
-              .fill(domain.responseData.name as string);
-            await searchResponse;
-
-            const domainTagSelector = page.getByTestId(
-              `tag-${domain.responseData.fullyQualifiedName}`
-            );
-            await domainTagSelector.waitFor({ state: 'visible' });
-
-            const removePatch = page.waitForResponse(
-              (response) =>
-                response.url().includes('/api/v1/contextCenter/pages/') &&
-                response.request().method() === 'PATCH'
-            );
-            await domainTagSelector.click();
-            const removeResponse = await removePatch;
-
-            expect(removeResponse.status()).toBe(200);
-            await waitForAllLoadersToDisappear(page);
-            await expect(page.getByTestId('domain-link')).toHaveText('No Domain');
-          }
-        );
-      } finally {
-        const { apiContext: cleanupCtx, afterAction: cleanupAfter } =
-          await getApiContext(page);
-        await domainArticleEntity.delete(cleanupCtx);
-        await cleanupAfter();
-      }
+      await dpArticleEntity.delete(cleanupCtx);
+      await cleanupAfter();
     }
-  );
+  });
+
+  test('Removing a domain from an article sends a valid PATCH and clears the domain', async ({
+    page,
+  }) => {
+    test.slow();
+
+    const domainArticleEntity = new KnowledgeCenterClass({
+      displayName: `CC Domain Remove Test ${uuid()}`,
+    });
+    const { apiContext: createCtx, afterAction: createAfter } =
+      await getApiContext(page);
+    await domainArticleEntity.create(createCtx);
+    await domainArticleEntity.patch(createCtx, [
+      {
+        op: 'add',
+        path: '/domains',
+        value: [
+          {
+            id: domain.responseData.id,
+            type: 'domain',
+            name: domain.responseData.name,
+            fullyQualifiedName: domain.responseData.fullyQualifiedName,
+          },
+        ],
+      },
+    ]);
+    await createAfter();
+
+    try {
+      await test.step('Domain appears in article header', async () => {
+        await navigateToArticle(
+          page,
+          domainArticleEntity.responseData.fullyQualifiedName
+        );
+        await expect(page.getByTestId('domain-link')).toBeVisible();
+      });
+
+      await test.step('Removing the domain sends a valid PATCH (200) and clears the header', async () => {
+        await page.getByTestId('edit-domain-btn').click();
+
+        const searchResponse = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/search/query') &&
+            response
+              .url()
+              .includes(encodeURIComponent(domain.responseData.name as string))
+        );
+        await page
+          .getByTestId('domain-selectable-tree')
+          .getByTestId('searchbar')
+          .fill(domain.responseData.name as string);
+        await searchResponse;
+
+        const domainTagSelector = page.getByTestId(
+          `tag-${domain.responseData.fullyQualifiedName}`
+        );
+        await domainTagSelector.waitFor({ state: 'visible' });
+
+        const removePatch = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/contextCenter/pages/') &&
+            response.request().method() === 'PATCH'
+        );
+        await domainTagSelector.click();
+        const removeResponse = await removePatch;
+
+        expect(removeResponse.status()).toBe(200);
+        await waitForAllLoadersToDisappear(page);
+        await expect(page.getByTestId('domain-link')).toHaveText('No Domain');
+      });
+    } finally {
+      const { apiContext: cleanupCtx, afterAction: cleanupAfter } =
+        await getApiContext(page);
+      await domainArticleEntity.delete(cleanupCtx);
+      await cleanupAfter();
+    }
+  });
 
   test('Article list cards, recently viewed widget, and pagination work', async ({
     page,

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ArticleDetailHeader/ArticleDetailHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ArticleDetailHeader/ArticleDetailHeader.component.tsx
@@ -224,13 +224,11 @@ const ArticleDetailHeader: FC<ArticleDetailHeaderProps> = ({
         return;
       }
       const updated = cloneDeep(knowledgePage);
-      updated.domains = Array.isArray(selectedDomain)
-        ? selectedDomain.length
-          ? selectedDomain
-          : undefined
-        : selectedDomain
-          ? [selectedDomain]
-          : undefined;
+      if (Array.isArray(selectedDomain)) {
+        updated.domains = selectedDomain.length ? selectedDomain : undefined;
+      } else {
+        updated.domains = selectedDomain ? [selectedDomain] : undefined;
+      }
       await onUpdate(updated);
     },
     [knowledgePage, onUpdate]

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ArticleDetailHeader/ArticleDetailHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ArticleDetailHeader/ArticleDetailHeader.component.tsx
@@ -225,8 +225,12 @@ const ArticleDetailHeader: FC<ArticleDetailHeaderProps> = ({
       }
       const updated = cloneDeep(knowledgePage);
       updated.domains = Array.isArray(selectedDomain)
-        ? selectedDomain
-        : [selectedDomain];
+        ? selectedDomain.length
+          ? selectedDomain
+          : undefined
+        : selectedDomain
+          ? [selectedDomain]
+          : undefined;
       await onUpdate(updated);
     },
     [knowledgePage, onUpdate]

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsContainer/DataProductsContainer.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsContainer/DataProductsContainer.component.tsx
@@ -122,7 +122,7 @@ const DataProductsContainer = ({
         onSubmit={handleSave}
       />
     );
-  }, [handleCancel, handleSave, dataProducts, fetchAPI]);
+  }, [handleCancel, handleSave, dataProducts, fetchAPI, multiple, t]);
 
   const showAddTagButton = useMemo(
     () => hasPermission && !domainMissing && isEmpty(dataProducts),
@@ -168,7 +168,14 @@ const DataProductsContainer = ({
         </Tag>
       );
     });
-  }, [dataProducts, activeDomains, domainMissing]);
+  }, [
+    dataProducts,
+    activeDomains,
+    domainMissing,
+    hasPermission,
+    redirectLink,
+    t,
+  ]);
 
   const headerExtra = useMemo(() => {
     if (!showHeader) {
@@ -202,7 +209,7 @@ const DataProductsContainer = ({
         )}
       </Space>
     );
-  }, [showHeader, dataProducts, hasPermission, domainMissing]);
+  }, [showHeader, dataProducts, hasPermission, domainMissing, t]);
 
   const addTagButton = useMemo(
     () =>
@@ -248,7 +255,9 @@ const DataProductsContainer = ({
         dataTestId="data-products-container"
         forceExpand={isEditMode}
         headerExtra={headerExtra}
-        isExpandDisabled={isEmpty(dataProducts) && !isEditMode && !domainMissing}
+        isExpandDisabled={
+          isEmpty(dataProducts) && !isEditMode && !domainMissing
+        }
         title={t('label.data-product-plural')}>
         {renderer}
       </WidgetCard>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsContainer/DataProductsContainer.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsContainer/DataProductsContainer.component.tsx
@@ -248,7 +248,7 @@ const DataProductsContainer = ({
         dataTestId="data-products-container"
         forceExpand={isEditMode}
         headerExtra={headerExtra}
-        isExpandDisabled={isEmpty(dataProducts) && !isEditMode}
+        isExpandDisabled={isEmpty(dataProducts) && !isEditMode && !domainMissing}
         title={t('label.data-product-plural')}>
         {renderer}
       </WidgetCard>


### PR DESCRIPTION
Backport of #33081 to the `2.0` branch.

### Describe your changes:

Fixes #33030

Fixes three bugs in the Context Center Articles right panel:

1. **Data Products widget card collapsed when no domain** — `isExpandDisabled` now includes `!domainMissing` so the card expands automatically, showing the "Select a domain to add data product." message instead of silently hiding it.

2. **Domain save sends wrong PATCH operation** — `handleDomainSave` in `ArticleDetailHeader` was doing `[selectedDomain]` even when `selectedDomain` is `null` (remove → `[null]`) or a single object (add → unwrapped object). Fixed to: wrap single domain in array for add/replace, set `undefined` for remove so `compare()` generates the correct `remove` op.

3. **Playwright E2E tests** covering the full lifecycle: disabled button + informational message (no domain), data-product selector opens after domain assigned, and domain removal round-trip.

### Type of change:
- [x] Bug fix

### Tests:

#### Playwright (UI) tests
- [x] Added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/`
- Files: `playwright/e2e/Features/ContextCenterArticles.spec.ts`

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR is linked to the original fix via #33081.