### PR TITLE
fix(ui): show original casing for tag-like options in Advanced Search [2.0 backport]

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AdvancedSearch.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AdvancedSearch.spec.ts
@@ -1212,9 +1212,9 @@ test.describe(
       await test.step('Filter chip reflects the applied column tag', async () => {
         await expect(
           page.getByTestId('advance-search-filter-container')
-        ).toContainText(
-          columnTag1.responseData.fullyQualifiedName.toLowerCase()
-        );
+        ).toContainText(columnTag1.responseData.fullyQualifiedName, {
+          ignoreCase: true,
+        });
       });
 
       await test.step('table1 (tagged with tag1) is visible', async () => {
@@ -1262,9 +1262,9 @@ test.describe(
       await test.step('Filter chip reflects the applied column tag', async () => {
         await expect(
           page.getByTestId('advance-search-filter-container')
-        ).toContainText(
-          columnTag2.responseData.fullyQualifiedName.toLowerCase()
-        );
+        ).toContainText(columnTag2.responseData.fullyQualifiedName, {
+          ignoreCase: true,
+        });
       });
 
       await test.step('table2 (tagged with tag2) is visible', async () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CuratedAssets.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CuratedAssets.spec.ts
@@ -609,7 +609,7 @@ test.describe('Curated Assets Widget', () => {
     await selectOption(
       page,
       ruleLocator3.locator('.rule--value .ant-select'),
-      'tier.tier5',
+      'Tier.Tier5',
       true
     );
 
@@ -620,7 +620,7 @@ test.describe('Curated Assets Widget', () => {
       (response) =>
         response.url().includes('/api/v1/search/query') &&
         response.url().includes('index=all') &&
-        response.url().includes('tier.tier5')
+        response.url().toLowerCase().includes('tier.tier5')
     );
 
     await page.locator('[data-testid="saveButton"]').click();

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/advancedSearch.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/advancedSearch.ts
@@ -332,6 +332,22 @@ export const fillRule = async (
   }
 };
 
+// Tag-like fields (tags, tier, certification, glossary) now apply the
+// original-cased value while other fields still apply the lowercased
+// aggregation key, so URL and chip expectations must be case-insensitive.
+const waitForSearchQueryWithValues = (page: Page, values: string[]) =>
+  page.waitForResponse((response) => {
+    const url = response.url().toLowerCase();
+
+    return (
+      url.includes('/api/v1/search/query') &&
+      url.includes('index=dataasset&from=0&size=15') &&
+      values.every((value) =>
+        url.includes(getEncodedFqn(value, true).toLowerCase())
+      )
+    );
+  });
+
 export const checkMustPaths = async (
   page: Page,
   {
@@ -355,17 +371,14 @@ export const checkMustPaths = async (
     index,
   });
 
-  const searchRes = page.waitForResponse(
-    `/api/v1/search/query?*index=dataAsset&from=0&size=15*${getEncodedFqn(
-      searchData,
-      true
-    )}*`
-  );
+  const searchRes = waitForSearchQueryWithValues(page, [searchData]);
   await page.getByTestId('apply-btn').click();
 
   const res = await searchRes;
 
-  expect(res.request().url()).toContain(getEncodedFqn(searchData, true));
+  expect(res.request().url().toLowerCase()).toContain(
+    getEncodedFqn(searchData, true).toLowerCase()
+  );
 
   const json = await res.json();
 
@@ -373,7 +386,7 @@ export const checkMustPaths = async (
 
   await expect(
     page.getByTestId('advance-search-filter-container')
-  ).toContainText(searchData);
+  ).toContainText(searchData, { ignoreCase: true });
 };
 
 export const checkMustNotPaths = async (
@@ -399,16 +412,13 @@ export const checkMustNotPaths = async (
     index,
   });
 
-  const searchRes = page.waitForResponse(
-    `/api/v1/search/query?*index=dataAsset&from=0&size=15*${getEncodedFqn(
-      searchData,
-      true
-    )}*`
-  );
+  const searchRes = waitForSearchQueryWithValues(page, [searchData]);
   await page.getByTestId('apply-btn').click();
   const res = await searchRes;
 
-  expect(res.request().url()).toContain(getEncodedFqn(searchData, true));
+  expect(res.request().url().toLowerCase()).toContain(
+    getEncodedFqn(searchData, true).toLowerCase()
+  );
 
   if (!['columns.name.keyword'].includes(field.name)) {
     const json = await res.json();
@@ -418,7 +428,7 @@ export const checkMustNotPaths = async (
 
   await expect(
     page.getByTestId('advance-search-filter-container')
-  ).toContainText(searchData);
+  ).toContainText(searchData, { ignoreCase: true });
 };
 
 export const checkNullPaths = async (
@@ -591,12 +601,10 @@ export const checkAddRuleOrGroupWithOperator = async (
   if (field.id === 'Column') {
     await page.getByTestId('apply-btn').click();
   } else {
-    const searchRes = page.waitForResponse(
-      `/api/v1/search/query?*index=dataAsset&from=0&size=15*${getEncodedFqn(
-        searchCriteria1.toLowerCase(),
-        true
-      )}*${getEncodedFqn(searchCriteria2.toLowerCase(), true)}*`
-    );
+    const searchRes = waitForSearchQueryWithValues(page, [
+      searchCriteria1,
+      searchCriteria2,
+    ]);
     await page.getByTestId('apply-btn').click();
     const res = await searchRes;
     const json = await res.json();

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.test.ts
@@ -20,6 +20,7 @@ import {
 import { EntityFields } from '../enums/AdvancedSearch.enum';
 import { SearchIndex } from '../enums/search.enum';
 import { CustomPropertySummary } from '../rest/metadataTypeAPI.interface';
+import { getAggregateFieldOptions } from '../rest/miscAPI';
 import { AdvancedSearchClassBase } from './AdvancedSearchClassBase';
 import { getCustomPropertyAdvanceSearchEnumOptions } from './AdvancedSearchPureUtils';
 import { getEntityName } from './EntityNameUtils';
@@ -1244,5 +1245,65 @@ describe('buildEnumAsyncFetch', () => {
 
     expect(result.values).toHaveLength(2);
     expect(result.values.map((v) => v.value)).toEqual(['Active', 'ACTIVE']);
+  });
+});
+
+describe('tag-like field autocomplete casing (#31999)', () => {
+  // Terms aggregations on lowercase_normalizer fields return lowercased bucket
+  // keys; without a sourceFields top-hits sub-aggregation the option label falls
+  // back to that lowercased key. These configs must request fullyQualifiedName.
+  let advancedSearchClassBase: AdvancedSearchClassBase;
+
+  beforeEach(() => {
+    advancedSearchClassBase = new AdvancedSearchClassBase();
+    jest.useFakeTimers();
+    (getAggregateFieldOptions as jest.Mock).mockClear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const expectSourceFieldsRequested = (field: {
+    fieldSettings?: { asyncFetch?: unknown };
+  }) => {
+    const asyncFetch = field.fieldSettings?.asyncFetch as (
+      search: string
+    ) => Promise<unknown>;
+    asyncFetch('pii');
+    jest.advanceTimersByTime(300);
+
+    expect(getAggregateFieldOptions).toHaveBeenCalledWith(
+      expect.anything(),
+      EntityFields.FULLY_QUALIFIED_NAME,
+      'pii',
+      expect.anything(),
+      'fullyQualifiedName'
+    );
+  };
+
+  it.each([
+    EntityFields.TAG,
+    EntityFields.GLOSSARY_TERMS,
+    EntityFields.CERTIFICATION,
+    EntityFields.TIER,
+  ])('%s config should request fullyQualifiedName source field', (key) => {
+    const config = advancedSearchClassBase.getCommonConfig({});
+
+    expectSourceFieldsRequested(
+      config[key] as { fieldSettings?: { asyncFetch?: unknown } }
+    );
+  });
+
+  it('column tag config should request fullyQualifiedName source field', () => {
+    const config = advancedSearchClassBase.getColumnTagConfig([
+      SearchIndex.TABLE,
+    ]);
+
+    expectSourceFieldsRequested(
+      config[EntityFields.COLUMN_TAG] as {
+        fieldSettings?: { asyncFetch?: unknown };
+      }
+    );
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
@@ -940,6 +940,7 @@ class AdvancedSearchClassBase {
           asyncFetch: this.autocomplete({
             searchIndex: [SearchIndex.TAG, SearchIndex.GLOSSARY_TERM],
             entityField: EntityFields.FULLY_QUALIFIED_NAME,
+            sourceFields: 'fullyQualifiedName',
             q: buildTermQuery(
               [
                 {
@@ -968,6 +969,7 @@ class AdvancedSearchClassBase {
           asyncFetch: this.autocomplete({
             searchIndex: SearchIndex.GLOSSARY_TERM,
             entityField: EntityFields.FULLY_QUALIFIED_NAME,
+            sourceFields: 'fullyQualifiedName',
           }),
           useAsyncSearch: true,
         },
@@ -981,6 +983,7 @@ class AdvancedSearchClassBase {
           asyncFetch: this.autocomplete({
             searchIndex: [SearchIndex.TAG],
             entityField: EntityFields.FULLY_QUALIFIED_NAME,
+            sourceFields: 'fullyQualifiedName',
             q: buildTermQuery(
               {
                 field: 'classification.name.keyword',
@@ -1001,6 +1004,7 @@ class AdvancedSearchClassBase {
           asyncFetch: this.autocomplete({
             searchIndex: [SearchIndex.TAG],
             entityField: EntityFields.FULLY_QUALIFIED_NAME,
+            sourceFields: 'fullyQualifiedName',
             q: buildTermQuery(
               {
                 field: 'classification.name.keyword',
@@ -1156,6 +1160,7 @@ class AdvancedSearchClassBase {
               asyncFetch: this.autocomplete({
                 searchIndex: [SearchIndex.TAG, SearchIndex.GLOSSARY_TERM],
                 entityField: EntityFields.FULLY_QUALIFIED_NAME,
+                sourceFields: 'fullyQualifiedName',
               }),
               useAsyncSearch: true,
             },


### PR DESCRIPTION
Backport of #33007 to `2.0`.

Fixes #31999.

## What

Terms aggregations on `lowercase_normalizer` keyword fields return lowercased bucket keys, so the Advanced Search query builder displayed tags, glossary terms, tier and certification options in lowercase. This requests the `fullyQualifiedName` source field via the `top_hits` sub-aggregation (the same mechanism `NAME_KEYWORD` already uses) so options carry their original casing.

Query behavior is unchanged: the target fields (`tags.tagFQN`, `columns.tags.tagFQN`, `tier.tagFQN`, `certification.tagLabel.tagFQN`) all use `lowercase_normalizer`, which normalizes term-level query input, so original-cased values match identically.

E2E utils were updated to be casing-agnostic (URL waits lowercase both sides, chip assertions use `ignoreCase`).

## Backport notes

Cherry-picked from 59dc5bfc420a589002036ed1e3f1b9eef78e3cda. Two deltas vs. the `main` PR:

- `CuratedAssets.spec.ts` conflicted — `2.0` has an extra `Is Not` operator step and selects the value through `.rule--value .ant-select`. Kept the `2.0` structure and applied only the value change (`tier.tier5` → `Tier.Tier5`).
- `AdvancedSearchClassBase.test.ts` on `2.0` did not import `getAggregateFieldOptions` (only `jest.mock`s the module), so the import was added for the new assertions.
- The `chore(ci): regenerate playwright impact map` commit from the original PR is not part of the squashed diff and was not backported.

## Verification

`yarn jest src/utils/AdvancedSearchClassBase.test.ts` → 61 passed (including the 5 new casing tests). ESLint could not run locally in the backport worktree (dependency resolution issue unrelated to this change); CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
