### PR TITLE
CHORE: Update docker compose format [skip ci]

### DIFF
--- a/docker/docker-compose-quickstart/docker-compose.yml
+++ b/docker/docker-compose-quickstart/docker-compose.yml
@@ -18,7 +18,7 @@ volumes:
 services:
   mysql:
     container_name: openmetadata_mysql
-    image: ${OPENMETADATA_DB_IMAGE:-docker.getcollate.io/openmetadata/db:2.0.0}
+    image: docker.getcollate.io/openmetadata/db:2.0.0
     command: "--sort_buffer_size=10M"
     restart: always
     environment:
@@ -59,7 +59,7 @@ services:
 
   execute-migrate-all:
     container_name: execute_migrate_all
-    image: ${OPENMETADATA_SERVER_IMAGE:-docker.getcollate.io/openmetadata/server:2.0.0}
+    image: docker.getcollate.io/openmetadata/server:2.0.0
     command: "./bootstrap/openmetadata-ops.sh migrate"
     environment:
       OPENMETADATA_CLUSTER_NAME: ${OPENMETADATA_CLUSTER_NAME:-openmetadata}
@@ -286,7 +286,7 @@ services:
   openmetadata-server:
     container_name: openmetadata_server
     restart: always
-    image: ${OPENMETADATA_SERVER_IMAGE:-docker.getcollate.io/openmetadata/server:2.0.0}
+    image: docker.getcollate.io/openmetadata/server:2.0.0
     environment:
       OPENMETADATA_CLUSTER_NAME: ${OPENMETADATA_CLUSTER_NAME:-openmetadata}
       SERVER_PORT: ${SERVER_PORT:-8585}
@@ -508,7 +508,7 @@ services:
 
   ingestion:
     container_name: openmetadata_ingestion
-    image: ${OPENMETADATA_INGESTION_IMAGE:-docker.getcollate.io/openmetadata/ingestion:2.0.0}
+    image: docker.getcollate.io/openmetadata/ingestion:2.0.0
     depends_on:
       elasticsearch:
         condition: service_started


### PR DESCRIPTION
This PR reverts the environment variable expansion on the quickstart docker-compose.yml which is meant to be updated during the release process.
It adopted this format in PR #30548 