### PR TITLE
Backport #32788 to 1.13: Generate Doris-compatible datetime filters

### DIFF
--- a/ingestion/src/metadata/profiler/orm/functions/datetime.py
+++ b/ingestion/src/metadata/profiler/orm/functions/datetime.py
@@ -113,6 +113,12 @@ def _(elements, compiler, **kwargs):
     return generic_function(elements, compiler, **kwargs)
 
 
+@compiles(DatetimeAddFn, Dialects.Doris)
+def _(elements, compiler, **kwargs):
+    """Doris date and datetime function"""
+    return doris_function(elements, compiler, **kwargs)
+
+
 @compiles(DatetimeAddFn, Dialects.MySQL)
 def _(elements, compiler, **kwargs):
     """MySQL date and datetime function"""
@@ -196,6 +202,12 @@ def _(elements, compiler, **kwargs):  # pylint: disable=unused-argument
     )
 
 
+@compiles(TimestampAddFn, Dialects.Doris)
+def _(elements, compiler, **kwargs):
+    """Doris timestamp function"""
+    return doris_function(elements, compiler, **kwargs)
+
+
 @compiles(TimestampAddFn, Dialects.MySQL)
 def _(elements, compiler, **kwargs):
     """MySQL timestamp function"""
@@ -245,6 +257,13 @@ def generic_function(elements, compiler, **kwargs):
     return (
         f"CAST(CURRENT_TIMESTAMP - interval '{interval}' {interval_unit} AS TIMESTAMP)"
     )
+
+
+def doris_function(elements, compiler, **kwargs):
+    """Doris timestamp and datetime function"""
+    interval = elements.clauses.clauses[0].value
+    interval_unit = compiler.process(elements.clauses.clauses[1], **kwargs)
+    return f"CAST(CURRENT_TIMESTAMP - interval '{interval}' {interval_unit} AS DATETIME)"
 
 
 def mysql_function(elements, compiler, **kwargs):

--- a/ingestion/tests/unit/source/database/doris/test_connection.py
+++ b/ingestion/tests/unit/source/database/doris/test_connection.py
@@ -11,13 +11,15 @@
 """Unit tests for Doris connection handling."""
 
 import pytest
-from sqlalchemy import Column, Integer, MetaData, Table, select
+from pydoris.sqlalchemy.dialect import DorisDialect
+from sqlalchemy import DATETIME, TIMESTAMP, Column, Integer, MetaData, Table, select, text
 
 from metadata.generated.schema.entity.services.connections.database.dorisConnection import (
     DorisConnection,
     DorisScheme,
 )
 from metadata.ingestion.source.database.doris.connection import get_connection
+from metadata.utils.sqa_utils import dispatch_to_date_or_datetime
 
 
 @pytest.fixture
@@ -56,3 +58,16 @@ def test_doris_identifiers_are_always_quoted(
     assert "`events`.`id`" in query
     assert f"`events`.`{column_name}`" in query
     assert "FROM `events`" in query
+
+
+@pytest.mark.parametrize(
+    "column_type",
+    [DATETIME(), TIMESTAMP()],
+    ids=["datetime", "timestamp"],
+)
+def test_doris_time_partition_filter_uses_datetime_cast(column_type):
+    partition_boundary = dispatch_to_date_or_datetime(1, text("DAY"), column_type)
+
+    query = str(partition_boundary.compile(dialect=DorisDialect()))
+
+    assert query == "CAST(CURRENT_TIMESTAMP - interval '1' DAY AS DATETIME)"


### PR DESCRIPTION
Backport of #32788 to 1.13. Fixes #32787.

----
## Summary by Gitar

- **Profiler and ORM:**
    - Added `doris_function` helper and dialect compilation rules for `DatetimeAddFn` and `TimestampAddFn` in `datetime.py`
- **Tests:**
    - Added unit test verifying Doris time partition filter uses `DATETIME` cast

<sub>This will update automatically on new commits.</sub>