### PR TITLE
Fixes #33154: correct Airflow Sonar coverage report paths

### DIFF
--- a/.github/workflows/airflow-apis-tests.yml
+++ b/.github/workflows/airflow-apis-tests.yml
@@ -121,8 +121,8 @@ jobs:
         make install_apis
         make coverage_apis
         rm pom.xml
-        # fix coverage xml report for github
-        sed -i 's/openmetadata_managed_apis/\/github\/workspace\/openmetadata-airflow-apis\/openmetadata_managed_apis/g' openmetadata-airflow-apis/ci-coverage.xml
+        # The scanner runs in the module directory; coverage runs from the repository root.
+        sed -i 's|filename="openmetadata-airflow-apis/|filename="|g' openmetadata-airflow-apis/ci-coverage.xml
 
     - name: Push Results in PR to Sonar
       id: push-to-sonar


### PR DESCRIPTION
### Describe your changes:

Fixes #33154

SonarCloud discarded coverage for 47 Airflow API files despite all 41 tests passing because the workflow rewrote filenames to an obsolete `/github/workspace` container path.
Keep filenames relative to the scanner's `openmetadata-airflow-apis/` base directory.
This extracts the existing correction from #33088 so it can merge first: `pull_request_target` uses the workflow from `main`, preventing #33088 from using its own workflow fix during PR validation.

### Type of change:

- [x] Bug fix

### High-level design:

Not applicable — one workflow command and its explanatory comment

### Tests:

#### Use cases covered

- All 47 source paths listed in the failed CI coverage report: 47 unresolved before the rewrite correction, zero afterward

#### Unit tests

Not applicable — no application logic or changed-class coverage

#### Backend integration tests

Not applicable — no backend changes

#### Ingestion integration tests

- Existing [CI evidence](https://github.com/open-metadata/OpenMetadata/actions/runs/34487109427/job/102904371899): 41 passing Airflow API tests on Python 3.10 / Airflow 3.3.1
- No test execution changes

#### Playwright (UI) tests

Not applicable — no UI changes

#### Manual testing performed

- Replayed the exact old and corrected `sed` expressions against a path fixture built from all 47 filenames in the CI log; verified every corrected filename exists under the scanner base directory
- `actionlint .github/workflows/airflow-apis-tests.yml`: passed
- `git diff --check` and commit hooks: passed

### UI screen recording / screenshots:

Not applicable — no UI changes

### Checklist:

- [x] CONTRIBUTING reviewed
- [x] Linked issue and required PR title format
- [x] Root cause documented in the workflow comment and linked issue
- [x] Before/after path validation completed
- Schema regeneration, migrations, endpoint tests, and UI recording: not applicable
