### PR TITLE
Fixes #33159: add ingestion review report and on-duty alerts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@
 /openmetadata-service/ @open-metadata/backend
 
 # Review from Ingestion owners for changes around Ingestion code
-/ingestion @open-metadata/ingestion @akashverma0786
+/ingestion @open-metadata/ingestion
 
 # Review from Devops owners for changes around workflows
 /.github @akash-jain-10 @harshach @tutte @open-metadata/mergers

--- a/.github/scripts/ingestion_review_report.py
+++ b/.github/scripts/ingestion_review_report.py
@@ -1,0 +1,305 @@
+"""Build and publish open PRs grouped by ingestion reviewer."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+COLUMNS = ("PR creator", "PR number", "Title", "Days since opened")
+
+
+def github_list(endpoint: str, token: str | None = None) -> list[dict]:
+    env = os.environ.copy()
+    if token:
+        env["GH_TOKEN"] = token
+    result = subprocess.run(
+        ["gh", "api", "--paginate", "--slurp", endpoint],
+        env=env,
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=180,
+    )
+    if result.returncode:
+        raise RuntimeError(
+            f"GitHub read failed for {endpoint}: {result.stderr.strip()}"
+        )
+    return [item for page in json.loads(result.stdout) for item in page]
+
+
+def group_reviews(
+    pulls: list[dict], members: list[dict], team: str
+) -> dict[str, list[dict]]:
+    names = {member["login"].casefold(): member["login"] for member in members}
+    groups = {name: [] for name in sorted(names.values(), key=str.casefold)}
+    unassigned = []
+    for pr in sorted(pulls, key=lambda pr: (pr["created_at"], pr["number"])):
+        if pr["state"] != "open" or pr["draft"] or pr["user"]["type"] == "Bot":
+            continue
+        reviewers = {
+            names[user["login"].casefold()]
+            for user in pr["requested_reviewers"]
+            + [review["user"] for review in pr["reviews"] if review.get("user")]
+            if user["login"].casefold() in names
+        }
+        for reviewer in reviewers:
+            groups[reviewer].append(pr)
+        if not reviewers and any(t["slug"] == team for t in pr["requested_teams"]):
+            unassigned.append(pr)
+    if unassigned:
+        groups["Team request — no individual reviewer"] = unassigned
+    return groups
+
+
+def group_sections(
+    pulls: list[dict], members: list[dict], team: str, internal: set[str]
+) -> dict[str, dict[str, list[dict]]]:
+    sections = {}
+    for scope, is_internal in (
+        ("External contributor PRs", False),
+        ("Organization-member PRs", True),
+    ):
+        sections[scope] = group_reviews(
+            [
+                pr
+                for pr in pulls
+                if (pr["user"]["login"].casefold() in internal) == is_internal
+            ],
+            members,
+            team,
+        )
+    return sections
+
+
+def markdown_cell(value: str) -> str:
+    return html.escape(" ".join(value.split()), quote=False).replace("|", "&#124;")
+
+
+def render_section(
+    groups: dict[str, list[dict]], now: datetime, scope: str
+) -> tuple[str, list[dict]]:
+    count = len({pr["number"] for pulls in groups.values() for pr in pulls})
+    intro = f"{scope} — {count} open PRs"
+    markdown = [f"## {intro}", ""]
+    messages = [{"text": intro}]
+    without_prs = []
+    for reviewer, pulls in groups.items():
+        if not pulls:
+            without_prs.append(reviewer)
+            continue
+        heading = f"{reviewer} ({len(pulls)})"
+        if reviewer == "Team request — no individual reviewer":
+            heading = f"⚠️ Needs assignment — {heading}"
+        markdown.extend([f"### {heading}", ""])
+        markdown.extend(["| " + " | ".join(COLUMNS) + " |", "|---|---|---|---:|"])
+        rows = [[{"type": "raw_text", "text": column} for column in COLUMNS]]
+        size = sum(map(len, COLUMNS))
+
+        def flush(heading: str, rows: list) -> None:
+            messages.append(
+                {
+                    "text": heading,
+                    "blocks": [
+                        {
+                            "type": "section",
+                            "text": {"type": "plain_text", "text": heading},
+                        },
+                        {
+                            "type": "table",
+                            "column_settings": [
+                                {},
+                                {},
+                                {"is_wrapped": True},
+                                {"align": "right"},
+                            ],
+                            "rows": list(rows),
+                        },
+                    ],
+                }
+            )
+
+        for pr in pulls:
+            created = datetime.fromisoformat(pr["created_at"].replace("Z", "+00:00"))
+            days = str(max(0, (now - created).days))
+            author, number, pr_title, url = (
+                pr["user"]["login"],
+                f"#{pr['number']}",
+                pr["title"],
+                pr["html_url"],
+            )
+            markdown.append(
+                f"| {markdown_cell(author)} | [{number}]({url}) | {markdown_cell(pr_title)} | {days} |"
+            )
+            # Slack limits tables to 100 rows and 10,000 characters per message.
+            row_size = sum(map(len, (author, number, pr_title, url, days)))
+            if len(rows) == 100 or size + row_size > 9000:
+                flush(heading, rows)
+                rows = rows[:1]
+                size = sum(map(len, COLUMNS))
+            rows.append(
+                [
+                    {"type": "raw_text", "text": author},
+                    {
+                        "type": "rich_text",
+                        "elements": [
+                            {
+                                "type": "rich_text_section",
+                                "elements": [
+                                    {"type": "link", "url": url, "text": number}
+                                ],
+                            }
+                        ],
+                    },
+                    {"type": "raw_text", "text": pr_title},
+                    {"type": "raw_text", "text": days},
+                ]
+            )
+            size += row_size
+        flush(heading, rows)
+        markdown.append("")
+    if without_prs:
+        markdown.extend(
+            ["### No open PRs", "", *[f"- {name}" for name in without_prs], ""]
+        )
+        messages.append(
+            {"text": "No open PRs\n" + "\n".join(f"• {name}" for name in without_prs)}
+        )
+    return "\n".join(markdown), messages
+
+
+def render_report(
+    sections: dict[str, dict[str, list[dict]]], now: datetime, repository: str
+) -> tuple[str, list[dict]]:
+    title = f"Open PRs by ingestion reviewer — {now:%Y-%m-%d}"
+    description = (
+        f"{repository} · All review states; drafts and bots excluded.\n"
+        "Grouped by current review requests and previous review authors."
+    )
+    markdown = [f"# {title}", "", description, ""]
+    messages = [{"text": f"{title}\n{description}"}]
+    for scope, groups in sections.items():
+        section_markdown, section_messages = render_section(groups, now, scope)
+        markdown.append(section_markdown)
+        messages.extend(section_messages)
+    return "\n".join(markdown), messages
+
+
+def slack_post(payload: dict, token: str) -> dict:
+    request = urllib.request.Request(
+        "https://slack.com/api/chat.postMessage",
+        data=json.dumps(payload).encode(),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json; charset=utf-8",
+        },
+        method="POST",
+    )
+    for attempt in range(3):
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                result = json.load(response)
+            if not result.get("ok"):
+                raise RuntimeError(
+                    f"Slack post failed: {result.get('error', 'unknown_error')}"
+                )
+            return result
+        except urllib.error.HTTPError as exc:
+            if exc.code != 429 or attempt == 2:
+                raise
+            delay = max(1, int(exc.headers.get("Retry-After", "1")))
+            if delay > 60:
+                raise RuntimeError(
+                    f"Slack rate limited; retry after {delay} seconds"
+                ) from exc
+            time.sleep(delay)
+    raise RuntimeError("Slack retry limit reached")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    build = commands.add_parser("build")
+    build.add_argument("--repository", required=True)
+    build.add_argument("--team", default="ingestion")
+    build.add_argument("--channel", required=True)
+    build.add_argument("--output", type=Path, required=True)
+    post = commands.add_parser("post")
+    post.add_argument("--input", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "post":
+            token = os.environ.get("SLACK_TOKEN")
+            if not token:
+                raise RuntimeError("SLACK_TOKEN is required to publish the report")
+            messages = json.loads(args.input.read_text(encoding="utf-8"))
+            parent = slack_post(messages[0], token)
+            for message in messages[1:]:
+                slack_post({**message, "thread_ts": parent["ts"]}, token)
+            return 0
+
+        org = args.repository.split("/", 1)[0]
+        org_token = os.environ.get("GH_ORG_TOKEN")
+        if not org_token:
+            raise RuntimeError(
+                "GH_ORG_TOKEN requires organization Members:read (or read:org)"
+            )
+        members = github_list(
+            f"orgs/{org}/teams/{args.team}/members?per_page=100", org_token
+        )
+        if not members:
+            raise RuntimeError(
+                "Team membership is empty; refusing to publish an empty report"
+            )
+        internal = {
+            user["login"].casefold()
+            for user in github_list(f"orgs/{org}/members?per_page=100", org_token)
+        }
+        if not {member["login"].casefold() for member in members} <= internal:
+            raise RuntimeError(
+                "Organization membership is incomplete; cannot classify external authors"
+            )
+        pulls = github_list(f"repos/{args.repository}/pulls?state=open&per_page=100")
+        pulls = [pr for pr in pulls if not pr["draft"] and pr["user"]["type"] != "Bot"]
+        for pr in pulls:
+            pr["reviews"] = github_list(
+                f"repos/{args.repository}/pulls/{pr['number']}/reviews?per_page=100"
+            )
+        sections = group_sections(pulls, members, args.team, internal)
+        markdown, messages = render_report(
+            sections, datetime.now(timezone.utc), args.repository
+        )
+        args.output.write_text(
+            json.dumps(
+                [
+                    {
+                        "channel": args.channel,
+                        "unfurl_links": False,
+                        "unfurl_media": False,
+                        **message,
+                    }
+                    for message in messages
+                ]
+            ),
+            encoding="utf-8",
+        )
+        if summary := os.environ.get("GITHUB_STEP_SUMMARY"):
+            with open(summary, "a", encoding="utf-8") as output:
+                output.write(markdown + "\n")
+        print(markdown)
+        return 0
+    except (RuntimeError, OSError, ValueError, subprocess.TimeoutExpired) as exc:
+        print(f"Report failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_ingestion_review_report.py
+++ b/.github/scripts/tests/test_ingestion_review_report.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+import urllib.error
+from contextlib import redirect_stderr, redirect_stdout
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import ingestion_review_report as report
+
+NOW = datetime(2026, 9, 14, tzinfo=timezone.utc)
+MEMBERS = [{"login": "reviewer-a"}, {"login": "reviewer-b"}, {"login": "reviewer-c"}]
+
+
+def pull(number=1, created="2026-09-10T00:00:00Z", **fields):
+    return {
+        "number": number,
+        "created_at": created,
+        "html_url": f"https://github.com/example/project/pull/{number}",
+        "title": "Fix connector",
+        "state": "open",
+        "draft": False,
+        "user": {"login": "contributor", "type": "User"},
+        "requested_reviewers": [{"login": "reviewer-a"}],
+        "requested_teams": [],
+        "reviews": [],
+        **fields,
+    }
+
+
+class ReviewReportTest(unittest.TestCase):
+    def test_slack_rate_limit_recovers_and_permanent_rate_limit_fails(self):
+        def limited():
+            return urllib.error.HTTPError(
+                "https://slack.com/api/chat.postMessage",
+                429,
+                "Too many requests",
+                {"Retry-After": "1"},
+                None,
+            )
+
+        with (
+            patch.object(report.time, "sleep"),
+            patch.object(
+                report.urllib.request,
+                "urlopen",
+                side_effect=[limited(), io.BytesIO(b'{"ok":true,"ts":"123.456"}')],
+            ),
+        ):
+            self.assertEqual(
+                report.slack_post({"text": "Report"}, "test-token")["ts"], "123.456"
+            )
+        with (
+            patch.object(report.time, "sleep"),
+            patch.object(report.urllib.request, "urlopen", side_effect=limited()),
+            self.assertRaises(urllib.error.HTTPError),
+        ):
+            report.slack_post({"text": "Report"}, "test-token")
+
+    def test_open_prs_remain_after_reviews_but_drafts_and_closed_prs_are_excluded(self):
+        pulls = [
+            pull(1),
+            pull(
+                2,
+                requested_reviewers=[],
+                reviews=[
+                    {"user": {"login": "Reviewer-B"}, "state": "APPROVED"},
+                    {"user": {"login": "reviewer-b"}, "state": "COMMENTED"},
+                ],
+            ),
+            pull(
+                3,
+                requested_reviewers=[],
+                reviews=[
+                    {"user": {"login": "reviewer-a"}, "state": "CHANGES_REQUESTED"},
+                ],
+            ),
+            pull(4, state="closed"),
+            pull(5, requested_reviewers=[{"login": "another-team"}]),
+            pull(6, draft=True),
+        ]
+        groups = report.group_reviews(pulls, MEMBERS, "ingestion")
+        self.assertEqual([pr["number"] for pr in groups["reviewer-a"]], [1, 3])
+        self.assertEqual([pr["number"] for pr in groups["reviewer-b"]], [2])
+        self.assertEqual(groups["reviewer-c"], [])
+
+    def test_external_scope_uses_membership_not_author_association(self):
+        pulls = [
+            pull(1, author_association="COLLABORATOR"),
+            pull(
+                2,
+                user={"login": "Internal", "type": "User"},
+                author_association="CONTRIBUTOR",
+            ),
+            pull(3, user={"login": "automation", "type": "Bot"}),
+        ]
+        sections = report.group_sections(pulls, MEMBERS, "ingestion", {"internal"})
+        external = sections["External contributor PRs"]
+        self.assertEqual([pr["number"] for pr in external["reviewer-a"]], [1])
+        internal = sections["Organization-member PRs"]
+        self.assertEqual([pr["number"] for pr in internal["reviewer-a"]], [2])
+
+    def test_team_request_does_not_duplicate_pr_already_associated_with_member(self):
+        pulls = [
+            pull(1, requested_reviewers=[], requested_teams=[{"slug": "ingestion"}]),
+            pull(2, requested_teams=[{"slug": "ingestion"}]),
+            pull(3, requested_reviewers=[], requested_teams=[{"slug": "other"}]),
+        ]
+        groups = report.group_reviews(pulls, MEMBERS, "ingestion")
+        self.assertEqual(
+            [pr["number"] for pr in groups["Team request — no individual reviewer"]],
+            [1],
+        )
+        self.assertEqual([pr["number"] for pr in groups["reviewer-a"]], [2])
+
+    def test_oldest_first_exact_columns_links_and_elapsed_days(self):
+        pulls = [
+            pull(1),
+            pull(2, "2026-09-01T00:00:00Z"),
+            pull(3, "2026-09-13T23:00:00Z"),
+        ]
+        groups = report.group_reviews(pulls, MEMBERS, "ingestion")
+        markdown, messages = report.render_section(
+            groups, NOW, "External contributor PRs"
+        )
+        self.assertIn(
+            "| PR creator | PR number | Title | Days since opened |", markdown
+        )
+        self.assertIn(
+            "| contributor | [#2](https://github.com/example/project/pull/2) | Fix connector | 13 |",
+            markdown,
+        )
+        self.assertLess(markdown.index("[#2]"), markdown.index("[#1]"))
+        self.assertLess(markdown.index("[#1]"), markdown.index("[#3]"))
+        rows = messages[1]["blocks"][1]["rows"]
+        self.assertEqual([row[3]["text"] for row in rows[1:]], ["13", "4", "0"])
+        link = rows[1][1]["elements"][0]["elements"][0]
+        self.assertEqual(
+            link,
+            {
+                "type": "link",
+                "text": "#2",
+                "url": "https://github.com/example/project/pull/2",
+            },
+        )
+
+    def test_multiple_reviewers_count_as_one_pr_and_untrusted_titles_are_literal(self):
+        title = "Fix | <script> & <!subteam^S123>\nmore"
+        pr = pull(
+            title=title,
+            requested_reviewers=[{"login": "reviewer-a"}, {"login": "reviewer-b"}],
+        )
+        markdown, messages = report.render_section(
+            report.group_reviews([pr], MEMBERS, "ingestion"),
+            NOW,
+            "External contributor PRs",
+        )
+        self.assertIn("1 open PRs", messages[0]["text"])
+        self.assertIn(
+            "Fix &#124; &lt;script&gt; &amp; &lt;!subteam^S123&gt; more", markdown
+        )
+        self.assertEqual(
+            messages[1]["blocks"][1]["rows"][1][2], {"type": "raw_text", "text": title}
+        )
+
+    def test_large_reports_split_without_dropping_or_reordering_prs(self):
+        for title in ("Fix", "x" * 250):
+            with self.subTest(title_length=len(title)):
+                pulls = [pull(i, title=title) for i in range(1, 221)]
+                _, messages = report.render_section(
+                    {"reviewer-a": pulls}, NOW, "External contributor PRs"
+                )
+                numbers = []
+                for message in messages[1:]:
+                    rows = message["blocks"][1]["rows"]
+                    self.assertLessEqual(len(rows), 100)
+                    character_count = 0
+                    for row in rows:
+                        for cell in row:
+                            if cell["type"] == "raw_text":
+                                character_count += len(cell["text"])
+                            else:
+                                link = cell["elements"][0]["elements"][0]
+                                character_count += len(link["text"]) + len(link["url"])
+                    self.assertLessEqual(character_count, 10000)
+                    numbers.extend(
+                        row[1]["elements"][0]["elements"][0]["text"] for row in rows[1:]
+                    )
+                self.assertEqual(numbers, [f"#{i}" for i in range(1, 221)])
+
+    def test_cli_paginates_members_pulls_reviews_and_writes_summary_without_posting(
+        self,
+    ):
+        responses = {
+            "orgs/example/teams/ingestion/members?per_page=100": [
+                MEMBERS[:1],
+                MEMBERS[1:],
+            ],
+            "orgs/example/members?per_page=100": [MEMBERS, [{"login": "internal"}]],
+            "repos/example/project/pulls?state=open&per_page=100": [
+                [pull(1, user={"login": "internal", "type": "User"})],
+                [
+                    pull(2, requested_reviewers=[]),
+                    pull(3, draft=True),
+                    pull(4, draft=True, user={"login": "internal", "type": "User"}),
+                ],
+            ],
+            "repos/example/project/pulls/1/reviews?per_page=100": [[]],
+            "repos/example/project/pulls/2/reviews?per_page=100": [
+                [],
+                [{"user": {"login": "reviewer-b"}, "state": "APPROVED"}],
+            ],
+        }
+
+        def github(command, **kwargs):
+            pages = responses[command[-1]]
+            return subprocess.CompletedProcess(command, 0, json.dumps(pages), "")
+
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "slack.json"
+            summary = Path(directory) / "summary.md"
+            with (
+                patch.dict(
+                    os.environ,
+                    {"GH_ORG_TOKEN": "test-token", "GITHUB_STEP_SUMMARY": str(summary)},
+                ),
+                patch.object(report.subprocess, "run", side_effect=github),
+                patch.object(
+                    report.urllib.request,
+                    "urlopen",
+                    side_effect=AssertionError("Build must not send Slack messages"),
+                ),
+                redirect_stdout(io.StringIO()),
+            ):
+                status = report.main(
+                    [
+                        "build",
+                        "--repository",
+                        "example/project",
+                        "--channel",
+                        "C123",
+                        "--output",
+                        str(output),
+                    ]
+                )
+            self.assertEqual(status, 0)
+            external_text, internal_text = summary.read_text().split(
+                "## Organization-member PRs", 1
+            )
+            self.assertIn("[#2]", external_text)
+            self.assertNotIn("[#1]", external_text)
+            self.assertIn("[#1]", internal_text)
+            self.assertNotIn("[#2]", internal_text)
+            self.assertNotIn("[#3]", summary.read_text())
+            self.assertNotIn("[#4]", summary.read_text())
+            messages = json.loads(output.read_text())
+            self.assertEqual(messages[0]["channel"], "C123")
+            self.assertIn("External contributor PRs", messages[1]["text"])
+            internal_index = next(
+                i
+                for i, message in enumerate(messages)
+                if message["text"].startswith("Organization-member PRs")
+            )
+            external_numbers = [
+                row[1]["elements"][0]["elements"][0]["text"]
+                for message in messages[2:internal_index]
+                if "blocks" in message
+                for row in message["blocks"][1]["rows"][1:]
+            ]
+            internal_numbers = [
+                row[1]["elements"][0]["elements"][0]["text"]
+                for message in messages[internal_index + 1 :]
+                if "blocks" in message
+                for row in message["blocks"][1]["rows"][1:]
+            ]
+            self.assertEqual(external_numbers, ["#2"])
+            self.assertEqual(internal_numbers, ["#1"])
+
+    def test_membership_failure_does_not_publish_a_misleading_empty_report(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "slack.json"
+            failure = subprocess.CompletedProcess([], 1, "", "HTTP 403")
+            with (
+                patch.dict(os.environ, {"GH_ORG_TOKEN": "test-token"}),
+                patch.object(report.subprocess, "run", return_value=failure),
+                redirect_stderr(io.StringIO()),
+            ):
+                status = report.main(
+                    [
+                        "build",
+                        "--repository",
+                        "example/project",
+                        "--channel",
+                        "C123",
+                        "--output",
+                        str(output),
+                    ]
+                )
+            self.assertEqual(status, 1)
+            self.assertFalse(output.exists())
+
+    def test_post_uses_one_thread_and_surfaces_slack_api_errors(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "slack.json"
+            path.write_text(
+                json.dumps(
+                    [
+                        {"channel": "C123", "text": "Report"},
+                        {"channel": "C123", "text": "Reviewer"},
+                    ]
+                )
+            )
+            sent = []
+
+            def slack(request, **kwargs):
+                sent.append(json.loads(request.data))
+                return io.BytesIO(json.dumps({"ok": True, "ts": "123.456"}).encode())
+
+            with (
+                patch.dict(os.environ, {"SLACK_TOKEN": "test-token"}),
+                patch.object(report.urllib.request, "urlopen", side_effect=slack),
+            ):
+                status = report.main(["post", "--input", str(path)])
+            self.assertEqual(status, 0)
+            self.assertNotIn("thread_ts", sent[0])
+            self.assertEqual(sent[1]["thread_ts"], "123.456")
+            with (
+                patch.dict(os.environ, {"SLACK_TOKEN": "test-token"}),
+                patch.object(
+                    report.urllib.request,
+                    "urlopen",
+                    return_value=io.BytesIO(b'{"ok":false,"error":"not_in_channel"}'),
+                ),
+                redirect_stderr(io.StringIO()),
+            ):
+                self.assertEqual(report.main(["post", "--input", str(path)]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ingestion-review-weekly-report.yml
+++ b/.github/workflows/ingestion-review-weekly-report.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/ingestion-review-weekly-report.yml
+++ b/.github/workflows/ingestion-review-weekly-report.yml
@@ -1,0 +1,58 @@
+#  Copyright 2026 Collate
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+name: Ingestion Weekly Review Report
+
+on:
+  schedule:
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Build the report without posting to Slack.
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ingestion-review-weekly-report
+  cancel-in-progress: false
+
+jobs:
+  report:
+    if: github.repository == 'open-metadata/OpenMetadata'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Build open PR report
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # Team and private organization membership require read:org / Members:read.
+          GH_ORG_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
+          SLACK_CHANNEL: C03EYBDDX17
+        run: |
+          python3 .github/scripts/ingestion_review_report.py build \
+            --repository "$GITHUB_REPOSITORY" \
+            --channel "$SLACK_CHANNEL" \
+            --output ingestion-review-report.json
+
+      - name: Post report to Slack
+        if: ${{ inputs.dry_run != true }}
+        env:
+          SLACK_TOKEN: ${{ secrets.COLLATE_BOT_SLACK_TOKEN }}
+        run: python3 .github/scripts/ingestion_review_report.py post --input ingestion-review-report.json

--- a/.github/workflows/py-cli-e2e-tests.yml
+++ b/.github/workflows/py-cli-e2e-tests.yml
@@ -346,7 +346,7 @@ jobs:
         payload: |
           {
             "channel": "C03EYBDDX17",
-            "text": "🔥 Failed E2E Test for: ${{ matrix.e2e-test }} 🔥\nLogs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            "text": "<!subteam^S0AH093PEQL> 🔥 Failed E2E Test for: ${{ matrix.e2e-test }} 🔥\nLogs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           }
 
   py-cli-e2e-tests-status:

--- a/.github/workflows/py-sonarcloud-nightly.yml
+++ b/.github/workflows/py-sonarcloud-nightly.yml
@@ -249,5 +249,5 @@ jobs:
           payload: |
             {
               "channel": "C03EYBDDX17",
-              "text": "🔥 *SonarCloud Ingestion Nightly* failed on `${{ env.BRANCH_NAME }}` 🔥\nunit: ${{ needs.py-unit-tests.result }} · integration: ${{ needs.py-integration-tests.result }} · combine+sonar: ${{ needs.py-combine-coverage.result }}\nLogs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": "<!subteam^S0AH093PEQL> 🔥 *SonarCloud Ingestion Nightly* failed on `${{ env.BRANCH_NAME }}` 🔥\nunit: ${{ needs.py-unit-tests.result }} · integration: ${{ needs.py-integration-tests.result }} · combine+sonar: ${{ needs.py-combine-coverage.result }}\nLogs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }


### PR DESCRIPTION
### Describe your changes

Fixes #33159

Add a Monday 00:00 UTC Slack report of open PRs associated with ingestion reviewers. External-contributor and organization-member PRs appear in separate sections, oldest first per reviewer, with creator, linked PR number, title, and days open. Drafts and bots are excluded; open PRs remain visible after a review. Team-only requests are flagged for assignment, and members without PRs appear at the bottom of each section.

Remove the redundant individual ingestion CODEOWNERS entry and mention the integration on-duty group in ingestion CLI E2E and nightly SonarCloud failure alerts.

### Type of change

- [x] Improvement

### High-level design

A scheduled workflow invokes a Python standard-library script that paginates GitHub team membership, organization membership, open PRs, and submitted reviews. Reviewer association includes active review requests and previous review authors; a PR can appear under multiple reviewers. The report posts to the existing ingestion alerts channel, with tables split across replies in one Slack thread. Manual runs default to a preview in the Actions job summary.

The workflow uses `PROJECTS_TOKEN` for membership reads; it requires `read:org` or organization `Members: read`. `COLLATE_BOT_SLACK_TOKEN` publishes the report. Scheduling takes effect after merging to the default branch. No schema or database migration is needed.

### Validation

- Ten tests in `.github/scripts/tests/test_ingestion_review_report.py` pass, covering reviewer association, external/internal partitioning, draft exclusion, ordering and age, pagination, 220-PR message splitting, Slack threading, and API failures. Report script line coverage: 95%.
- Ruff lint and format checks pass.
- The new workflow passes actionlint. Existing alert workflows pass actionlint with ShellCheck disabled; the full check reproduces a pre-existing SC2086 warning at `py-sonarcloud-nightly.yml:141` in the unchanged base version.
- A read-only live preview found 17 external-contributor and 34 organization-member PRs associated with ingestion reviewers or the team. No Slack messages were sent. Verified the final layout places assignment warnings before the list of members without PRs.
- Backend, ingestion connector, and Playwright integration tests: not applicable; this changes CI reporting only.

### UI screen recording / screenshots

Not applicable; no application UI changes.

### Checklist

- [x] PR title and description link the companion issue.
- [x] Tests cover the reporting behavior and failure paths.
- [x] High-level design and deployment requirements are described above.
- Schema migrations, connector documentation, and application UI recordings: not applicable.
