### PR TITLE
Fixes #32606: Backport column-name classification fix to 1.13

### DIFF
--- a/ingestion/src/metadata/pii/base_processor.py
+++ b/ingestion/src/metadata/pii/base_processor.py
@@ -11,12 +11,14 @@
 """
 Base class for the Auto Classification Processor.
 """
+
 import traceback
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
 from typing import Any, List, Optional, Sequence, Type, TypeVar, cast, final
 
 from metadata.generated.schema.entity.data.container import Container
-from metadata.generated.schema.entity.data.table import Column, Table
+from metadata.generated.schema.entity.data.table import Column, ColumnName, Table
 from metadata.generated.schema.entity.services.ingestionPipelines.status import (
     StackTraceError,
 )
@@ -32,9 +34,14 @@ from metadata.ingestion.api.parser import parse_workflow_config_gracefully
 from metadata.ingestion.api.steps import Processor
 from metadata.ingestion.models.table_metadata import ColumnTag
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.ingestion.ometa.utils import model_str
 from metadata.sampler.models import SamplerResponse
+from metadata.utils.logger import profiler_logger
 
 C = TypeVar("C", bound="AutoClassificationProcessor")
+MAX_COLUMN_NESTING_DEPTH = 10
+
+logger = profiler_logger()
 
 
 class AutoClassificationProcessor(Processor, ABC):
@@ -98,6 +105,57 @@ class AutoClassificationProcessor(Processor, ABC):
             return entity.dataModel.columns if entity.dataModel else None
         return None
 
+    @classmethod
+    def _get_classifier_columns(
+        cls, columns: list[Column], sampled_columns: Sequence[ColumnName] | None
+    ) -> Iterator[tuple[Column, int | None]]:
+        """Keep sampled fields authoritative unless sampling exposes no fields."""
+        if not sampled_columns:
+            for column in columns:
+                for leaf_column in cls._iter_leaf_columns(column):
+                    yield leaf_column, None
+            return
+
+        for idx, column_name in enumerate(sampled_columns):
+            column = next((c for c in columns if c.name == column_name), None)
+            if column:
+                yield column, idx
+
+    @staticmethod
+    def _iter_leaf_columns(
+        column: Column, max_depth: int = MAX_COLUMN_NESTING_DEPTH
+    ) -> Iterator[Column]:
+        """Iterate leaves without following cyclic or pathologically deep schemas."""
+        stack: list[tuple[Column, int, tuple[int, ...]]] = [(column, 0, ())]
+
+        while stack:
+            current, depth, ancestors = stack.pop()
+            current_id = id(current)
+            if current_id in ancestors:
+                logger.warning(
+                    "Skipping cyclic column hierarchy at %s", model_str(current.name)
+                )
+                continue
+
+            children = [child for child in current.children or [] if child]
+            if not children:
+                yield current
+                continue
+
+            if depth >= max_depth:
+                logger.warning(
+                    "Column hierarchy reached maximum depth %d at %s; treating it as a leaf",
+                    max_depth,
+                    model_str(current.name),
+                )
+                yield current
+                continue
+
+            child_ancestors = (*ancestors, current_id)
+            stack.extend(
+                (child, depth + 1, child_ancestors) for child in reversed(children)
+            )
+
     @final
     def _run(self, record: SamplerResponse) -> Either[SamplerResponse]:
         """
@@ -115,16 +173,21 @@ class AutoClassificationProcessor(Processor, ABC):
             return Either(right=record, left=None)
 
         column_tags = []
+        table_data = record.sample_data.data if record.sample_data else None
+        table_data_columns = table_data.columns if table_data is not None else None
 
-        for idx, column_name in enumerate(record.sample_data.data.columns):
-            column = next((c for c in columns if c.name == column_name), None)
-            if not column:
-                continue
-
+        for column, sample_index in self._get_classifier_columns(
+            columns, table_data_columns
+        ):
             try:
+                column_sample_data = (
+                    [row[sample_index] for row in table_data.rows or []]
+                    if sample_index is not None and table_data is not None
+                    else []
+                )
                 tags = self.create_column_tag_labels(
                     column=column,
-                    sample_data=[row[idx] for row in record.sample_data.data.rows],
+                    sample_data=column_sample_data,
                 )
                 for tag in tags:
                     column_tag = ColumnTag(

--- a/ingestion/tests/integration/auto_classification/databases/test_global_sample_data_config.py
+++ b/ingestion/tests/integration/auto_classification/databases/test_global_sample_data_config.py
@@ -6,10 +6,12 @@ workflow.
 """
 
 import uuid
+from collections.abc import Generator
 
 import pytest
 
 from _openmetadata_testutils.ometa import int_admin_ometa
+from metadata.generated.schema.api.classification.createTag import CreateTagRequest
 from metadata.generated.schema.api.services.createDatabaseService import (
     CreateDatabaseServiceRequest,
 )
@@ -38,8 +40,21 @@ from metadata.generated.schema.metadataIngestion.databaseServiceMetadataPipeline
     DatabaseMetadataConfigType,
 )
 from metadata.generated.schema.settings.settings import Settings, SettingType
+from metadata.generated.schema.type.classificationLanguages import (
+    ClassificationLanguage,
+)
 from metadata.generated.schema.type.filterPattern import FilterPattern
+from metadata.generated.schema.type.patternRecognizer import PatternRecognizer
+from metadata.generated.schema.type.recognizer import (
+    Recognizer,
+    RecognizerConfig,
+    Target,
+)
+from metadata.generated.schema.type.recognizers.patterns import Pattern
+from metadata.generated.schema.type.recognizers.regexFlags import RegexFlags
+from metadata.generated.schema.type.tagLabel import LabelType, State
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.pii.constants import PII
 from metadata.workflow.classification import AutoClassificationWorkflow
 from metadata.workflow.metadata import MetadataWorkflow
 
@@ -83,9 +98,17 @@ def ingestion_config(db_service, metadata, workflow_config, sink_config):
     }
 
 
-@pytest.fixture(scope="module")
-def load_metadata(run_workflow, ingestion_config) -> MetadataWorkflow:
-    return run_workflow(MetadataWorkflow, ingestion_config)
+@pytest.fixture
+def load_metadata(
+    run_workflow, ingestion_config, metadata, table_fqn
+) -> Generator[MetadataWorkflow, None, None]:
+    yield run_workflow(MetadataWorkflow, ingestion_config)
+    # Each test needs a fresh table: generated PII tags affect subsequent recognition.
+    table = metadata.get_by_name(entity=Table, fqn=table_fqn)
+    if table:
+        metadata.delete(
+            entity=Table, entity_id=table.id, recursive=True, hard_delete=True
+        )
 
 
 @pytest.fixture(scope="module")
@@ -120,6 +143,7 @@ def autoclassification_config(db_service, bot_workflow_config, sink_config):
                     "type": "AutoClassification",
                     "tableFilterPattern": FilterPattern(includes=["^example_table$"]),
                     "storeSampleData": True,
+                    "enableAutoClassification": True,
                 }
             },
         },
@@ -130,18 +154,6 @@ def autoclassification_config(db_service, bot_workflow_config, sink_config):
         "sink": sink_config,
         "workflowConfig": bot_workflow_config,
     }
-
-
-@pytest.fixture(autouse=True)
-def clean_sample_data(metadata, table_fqn):
-    """Delete sample data before and after each test so results are isolated."""
-    table = metadata.get_by_name(entity=Table, fqn=table_fqn)
-    if table:
-        metadata.delete_sample_data(table)
-    yield
-    table = metadata.get_by_name(entity=Table, fqn=table_fqn)
-    if table:
-        metadata.delete_sample_data(table)
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -158,7 +170,7 @@ def _cleanup_profiler_config(metadata):
     )
 
 
-def _set_global_profiler_config(metadata: OpenMetadata, store: bool):
+def _set_global_profiler_config(metadata: OpenMetadata, store: bool, read: bool = True):
     """Set the global profiler configuration for sample data."""
     metadata.create_or_update_settings(
         Settings(
@@ -166,11 +178,52 @@ def _set_global_profiler_config(metadata: OpenMetadata, store: bool):
             config_value=ProfilerConfiguration(
                 sampleDataConfig=SampleDataIngestionConfig(
                     storeSampleData=store,
-                    readSampleData=True,
+                    readSampleData=read,
                 ),
             ),
         )
     )
+
+
+@pytest.fixture
+def column_name_tag(metadata: OpenMetadata) -> Generator[Tag, None, None]:
+    """A tag whose only recognizer matches on the column name, never on values.
+
+    It has to live under the seeded ``PII`` classification: the workflow builds its
+    processor with ``classification_filter=[PII]``, so tags from any other
+    classification are dropped before they ever become candidates.
+    """
+    recognizer = Recognizer(
+        name="AddressColumnNameRecognizer",
+        recognizerConfig=RecognizerConfig(
+            root=PatternRecognizer(
+                type="pattern",
+                patterns=[
+                    Pattern(name="address-column", regex=r"^address$", score=1.0)
+                ],
+                regexFlags=RegexFlags(),
+                supportedLanguage=ClassificationLanguage.en,
+            )
+        ),
+        confidenceThreshold=0.8,
+        target=Target.column_name,
+    )
+    tag = metadata.create_or_update(
+        CreateTagRequest(
+            name=f"ColumnNameOnly{uuid.uuid4().hex[:8]}",
+            classification=PII,
+            description="Metadata-only classification driven by the column name",
+            recognizers=[recognizer],
+            autoClassificationEnabled=True,
+        )
+    )
+
+    try:
+        yield tag
+    finally:
+        # PII is a seeded, system classification: drop only the tag we added, or
+        # its column-name recognizer leaks into every later test on this server.
+        metadata.delete(entity=Tag, entity_id=tag.id, recursive=True, hard_delete=True)
 
 
 def test_store_sample_data_when_global_config_enabled(
@@ -227,3 +280,44 @@ def test_no_sample_data_when_global_config_disabled(
     assert (
         not has_sample_data
     ), "Expected no sample data when global storeSampleData is disabled"
+
+
+def test_column_name_classification_when_sample_data_access_disabled(
+    metadata: OpenMetadata,
+    load_metadata: MetadataWorkflow,
+    run_workflow,
+    autoclassification_config,
+    table_fqn,
+    column_name_tag: Tag,
+):
+    """A column-name recognizer must still propose its tag when the pipeline is
+    forbidden from both reading and storing sample values."""
+    _set_global_profiler_config(metadata, store=False, read=False)
+
+    run_workflow(AutoClassificationWorkflow, autoclassification_config)
+
+    table = metadata.get_by_name(entity=Table, fqn=table_fqn)
+    sample_data = metadata.get_sample_data(table)
+    has_sample_data = (
+        sample_data is not None
+        and sample_data.sampleData is not None
+        and len(sample_data.sampleData.rows) > 0
+    )
+    assert (
+        not has_sample_data
+    ), "Expected no sample data when reading and storing are both disabled"
+
+    columns = metadata.get_table_columns(table_fqn, fields=["tags"])
+    # Postgres folds unquoted identifiers, so init.sql's ADDRESS arrives as `address`.
+    address_column = next(column for column in columns if column.name.root == "address")
+    matching_tags = [
+        tag
+        for tag in address_column.tags or []
+        if tag.tagFQN.root == column_name_tag.fullyQualifiedName
+    ]
+
+    assert (
+        len(matching_tags) == 1
+    ), f"Expected the column-name tag on `address`, got {address_column.tags}"
+    assert matching_tags[0].labelType is LabelType.Generated
+    assert matching_tags[0].state is State.Suggested

--- a/ingestion/tests/unit/metadata/pii/test_base_processor.py
+++ b/ingestion/tests/unit/metadata/pii/test_base_processor.py
@@ -1,0 +1,406 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Tests for the sampler-to-auto-classification bridge."""
+
+import uuid
+from collections.abc import Sequence
+from itertools import pairwise
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from metadata.generated.schema.entity.data.container import (
+    Container,
+    ContainerDataModel,
+)
+from metadata.generated.schema.entity.data.table import (
+    Column,
+    ColumnName,
+    DataType,
+    Table,
+    TableData,
+)
+from metadata.generated.schema.metadataIngestion.databaseServiceAutoClassificationPipeline import (
+    DatabaseServiceAutoClassificationPipeline,
+)
+from metadata.generated.schema.metadataIngestion.workflow import (
+    OpenMetadataWorkflowConfig,
+    Source,
+    SourceConfig,
+    WorkflowConfig,
+)
+from metadata.generated.schema.type.basic import (
+    EntityName,
+    FullyQualifiedEntityName,
+    Uuid,
+)
+from metadata.generated.schema.type.entityReference import EntityReference
+from metadata.generated.schema.type.tagLabel import (
+    LabelType,
+    State,
+    TagLabel,
+    TagSource,
+)
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.pii.base_processor import AutoClassificationProcessor
+from metadata.sampler.models import SampleData, SamplerResponse
+
+
+class RecordingClassificationProcessor(AutoClassificationProcessor):
+    def __init__(self, config: OpenMetadataWorkflowConfig):
+        super().__init__(config=config, metadata=Mock(spec=OpenMetadata))
+        self.classifier_inputs: list[tuple[Column, list[Any]]] = []
+
+    def create_column_tag_labels(
+        self, column: Column, sample_data: Sequence[Any]
+    ) -> Sequence[TagLabel]:
+        self.classifier_inputs.append((column, list(sample_data)))
+        return [
+            TagLabel(
+                tagFQN="PII.Email",
+                source=TagSource.Classification,
+                state=State.Suggested,
+                labelType=LabelType.Generated,
+            )
+        ]
+
+
+@pytest.fixture
+def workflow_config() -> OpenMetadataWorkflowConfig:
+    return OpenMetadataWorkflowConfig(
+        source=Source(
+            type="postgres",
+            sourceConfig=SourceConfig(
+                config=DatabaseServiceAutoClassificationPipeline(
+                    enableAutoClassification=True
+                )
+            ),
+        ),
+        workflowConfig=WorkflowConfig.model_construct(),
+    )
+
+
+def _column(name: str) -> Column:
+    return Column(
+        name=ColumnName(root=name),
+        dataType=DataType.STRING,
+        fullyQualifiedName=FullyQualifiedEntityName(
+            root=f"service.database.schema.table.{name}"
+        ),
+    )
+
+
+def _table(columns: list[Column]) -> Table:
+    return Table(
+        id=Uuid(root=uuid.uuid4()),
+        name=EntityName(root="table"),
+        fullyQualifiedName=FullyQualifiedEntityName(
+            root="service.database.schema.table"
+        ),
+        columns=columns,
+    )
+
+
+def _container(columns: list[Column]) -> Container:
+    return Container(
+        id=Uuid(root=uuid.uuid4()),
+        name=EntityName(root="container"),
+        fullyQualifiedName=FullyQualifiedEntityName(root="service.container"),
+        service=EntityReference(id=Uuid(root=uuid.uuid4()), type="storageService"),
+        dataModel=ContainerDataModel(columns=columns),
+    )
+
+
+def _table_case():
+    column = _column("email")
+    return _table([column]), column
+
+
+def _container_case():
+    column = Column(
+        name=ColumnName(root="email"),
+        dataType=DataType.STRING,
+        fullyQualifiedName=FullyQualifiedEntityName(root="service.container.email"),
+    )
+    return _container([column]), column
+
+
+def _nested_columns(fqn_prefix: str) -> tuple[list[Column], list[Column]]:
+    id_column = Column(
+        name=ColumnName(root="id"),
+        dataType=DataType.STRING,
+        fullyQualifiedName=FullyQualifiedEntityName(root=f"{fqn_prefix}.id"),
+    )
+    nested_email = Column(
+        name=ColumnName(root="email"),
+        dataType=DataType.STRING,
+        fullyQualifiedName=FullyQualifiedEntityName(root=f"{fqn_prefix}.contact.email"),
+    )
+    city = Column(
+        name=ColumnName(root="city"),
+        dataType=DataType.STRING,
+        fullyQualifiedName=FullyQualifiedEntityName(
+            root=f"{fqn_prefix}.contact.address.city"
+        ),
+    )
+    postal_code = Column(
+        name=ColumnName(root="postal_code"),
+        dataType=DataType.STRING,
+        fullyQualifiedName=FullyQualifiedEntityName(
+            root=f"{fqn_prefix}.contact.address.postal_code"
+        ),
+    )
+    address = Column(
+        name=ColumnName(root="address"),
+        dataType=DataType.RECORD,
+        fullyQualifiedName=FullyQualifiedEntityName(
+            root=f"{fqn_prefix}.contact.address"
+        ),
+        children=[city, postal_code],
+    )
+    parent = Column(
+        name=ColumnName(root="contact"),
+        dataType=DataType.RECORD,
+        fullyQualifiedName=FullyQualifiedEntityName(root=f"{fqn_prefix}.contact"),
+        children=[nested_email, address],
+    )
+    return [id_column, parent], [id_column, nested_email, city, postal_code]
+
+
+def _nested_table_case():
+    columns, leaves = _nested_columns("service.database.schema.table")
+    return _table(columns), leaves
+
+
+def _nested_container_case():
+    columns, leaves = _nested_columns("service.container")
+    return _container(columns), leaves
+
+
+def test_classifies_metadata_columns_when_sample_fields_are_empty(workflow_config):
+    email_column = _column("project_manager_email_md")
+    record = SamplerResponse(
+        entity=_table([email_column]),
+        sample_data=SampleData(data=TableData(columns=[], rows=[])),
+    )
+    processor = RecordingClassificationProcessor(workflow_config)
+
+    result = processor.run(record)
+
+    assert processor.classifier_inputs == [(email_column, [])]
+    assert len(result.column_tags) == 1
+    assert result.column_tags[0].column_fqn == email_column.fullyQualifiedName.root
+    assert result.column_tags[0].tag_label.tagFQN.root == "PII.Email"
+
+
+@pytest.mark.parametrize("entity_case", [_table_case, _container_case])
+def test_metadata_fallback_supports_each_classifiable_entity(
+    workflow_config, entity_case
+):
+    entity, column = entity_case()
+    record = SamplerResponse(
+        entity=entity,
+        sample_data=SampleData(data=TableData(columns=[], rows=[])),
+    )
+    processor = RecordingClassificationProcessor(workflow_config)
+
+    result = processor.run(record)
+
+    assert processor.classifier_inputs == [(column, [])]
+    assert [column_tag.column_fqn for column_tag in result.column_tags] == [
+        column.fullyQualifiedName.root
+    ]
+
+
+def test_missing_sample_data_uses_metadata_fallback(workflow_config):
+    email_column = _column("email")
+    record = SamplerResponse(entity=_table([email_column]), sample_data=None)
+    processor = RecordingClassificationProcessor(workflow_config)
+
+    processor.run(record)
+
+    assert processor.classifier_inputs == [(email_column, [])]
+
+
+@pytest.mark.parametrize(
+    "entity_case",
+    [_nested_table_case, _nested_container_case],
+)
+def test_classifies_all_metadata_leaves_in_canonical_order(
+    workflow_config, entity_case
+):
+    entity, leaves = entity_case()
+    record = SamplerResponse(
+        entity=entity,
+        sample_data=SampleData(data=TableData(columns=[], rows=[])),
+    )
+    processor = RecordingClassificationProcessor(workflow_config)
+
+    result = processor.run(record)
+
+    assert processor.classifier_inputs == [(leaf, []) for leaf in leaves]
+    assert [column_tag.column_fqn for column_tag in result.column_tags] == [
+        leaf.fullyQualifiedName.root for leaf in leaves
+    ]
+
+
+def test_leaf_iteration_treats_depth_limit_as_leaf():
+    columns = [_column(f"level_{depth}") for depth in range(4)]
+    for parent, child in pairwise(columns):
+        parent.dataType = DataType.RECORD
+        parent.children = [child]
+
+    leaves = list(
+        RecordingClassificationProcessor._iter_leaf_columns(columns[0], max_depth=2)
+    )
+
+    assert leaves == [columns[2]]
+
+
+def test_leaf_iteration_stops_at_cycles():
+    parent = _column("parent")
+    child = _column("child")
+    parent.dataType = DataType.RECORD
+    child.dataType = DataType.RECORD
+    parent.children = [child]
+    child.children = [parent]
+
+    leaves = list(RecordingClassificationProcessor._iter_leaf_columns(parent))
+
+    assert leaves == []
+
+
+def test_classifies_only_sampled_fields_with_their_values(workflow_config):
+    id_column = _column("id")
+    email_column = _column("email")
+    other_column = _column("other")
+    record = SamplerResponse(
+        entity=_table([id_column, email_column, other_column]),
+        sample_data=SampleData(
+            data=TableData(
+                columns=[ColumnName(root="id"), ColumnName(root="email")],
+                rows=[[1, "first@example.com"], [2, "second@example.com"]],
+            )
+        ),
+    )
+    processor = RecordingClassificationProcessor(workflow_config)
+
+    processor.run(record)
+
+    assert processor.classifier_inputs == [
+        (id_column, [1, 2]),
+        (email_column, ["first@example.com", "second@example.com"]),
+    ]
+
+
+def test_empty_sample_rows_do_not_expand_sampled_field_selection(workflow_config):
+    email_column = _column("email")
+    other_column = _column("other")
+    record = SamplerResponse(
+        entity=_table([email_column, other_column]),
+        sample_data=SampleData(
+            data=TableData(
+                columns=[ColumnName(root="email")],
+                rows=[],
+            )
+        ),
+    )
+    processor = RecordingClassificationProcessor(workflow_config)
+
+    processor.run(record)
+
+    assert processor.classifier_inputs == [(email_column, [])]
+
+
+def test_unmatched_sampled_fields_do_not_trigger_metadata_fallback(workflow_config):
+    email_column = _column("email")
+    record = SamplerResponse(
+        entity=_table([email_column]),
+        sample_data=SampleData(
+            data=TableData(
+                columns=[ColumnName(root="missing"), ColumnName(root="missing.nested")],
+                rows=[["value", "nested value"]],
+            )
+        ),
+    )
+    processor = RecordingClassificationProcessor(workflow_config)
+
+    result = processor.run(record)
+
+    assert processor.classifier_inputs == []
+    assert result.column_tags == []
+
+
+def test_disabled_classification_does_not_process_metadata_fallback(workflow_config):
+    workflow_config.source.sourceConfig.config.enableAutoClassification = False
+    record = SamplerResponse(
+        entity=_table([_column("email")]),
+        sample_data=SampleData(data=TableData(columns=[], rows=[])),
+    )
+    processor = RecordingClassificationProcessor(workflow_config)
+
+    result = processor.run(record)
+
+    assert processor.classifier_inputs == []
+    assert result.column_tags is None
+
+
+def test_entity_without_columns_is_ignored(workflow_config):
+    record = SamplerResponse(
+        entity=_table([]),
+        sample_data=SampleData(data=TableData(columns=[], rows=[])),
+    )
+    processor = RecordingClassificationProcessor(workflow_config)
+
+    result = processor.run(record)
+
+    assert processor.classifier_inputs == []
+    assert result.column_tags is None
+
+
+@pytest.mark.parametrize("has_literal_dotted_column", [False, True])
+def test_sampled_dotted_name_only_matches_top_level_column(
+    workflow_config, has_literal_dotted_column
+):
+    nested_email = _column("email")
+    parent = Column(
+        name=ColumnName(root="contact"),
+        dataType=DataType.RECORD,
+        fullyQualifiedName=FullyQualifiedEntityName(
+            root="service.database.schema.table.contact"
+        ),
+        children=[nested_email],
+    )
+    literal_column = _column("contact.email")
+    columns = [parent, literal_column] if has_literal_dotted_column else [parent]
+    record = SamplerResponse(
+        entity=_table(columns),
+        sample_data=SampleData(
+            data=TableData(
+                columns=[ColumnName(root="contact.email")],
+                rows=[["first@example.com"], ["second@example.com"]],
+            )
+        ),
+    )
+    processor = RecordingClassificationProcessor(workflow_config)
+
+    result = processor.run(record)
+
+    expected_inputs = (
+        [(literal_column, ["first@example.com", "second@example.com"])]
+        if has_literal_dotted_column
+        else []
+    )
+    assert processor.classifier_inputs == expected_inputs
+    assert [tag.column_fqn for tag in result.column_tags] == (
+        [literal_column.fullyQualifiedName.root] if has_literal_dotted_column else []
+    )


### PR DESCRIPTION
### Describe your changes:

Replaces #33124 with the same verified patch on an upstream-hosted branch so the branch-local 1.13 CI workflow runs.

Fixes #32606

Backports #32607 (commit `807dfa38fd1d97927dbdd1cf5076164db5952fdb`) to `1.13`. When sampling supplies no fields, auto-classification now traverses metadata leaf columns with empty sample values so column-name recognizers still run. When sampled fields exist, those fields and their values remain authoritative. The traversal guards against cycles and excessive nesting.

Retained the existing table/container entity handling because 1.13 has no topic classification adapter. Preserved 1.13’s exact top-level matching for sampled column names; metadata traversal only applies when sampled fields are missing or empty. Limited entity tests to the types supported by 1.13. Preserved existing integration fixtures and applied the branch’s Black/isort formatting.

### Type of change:

- [x] Bug fix

### High-level design:

Not applicable — backport of a focused processor fix. No schema or API changes.

### Tests:

#### Use cases covered

Missing/empty sample data, nested metadata leaves, supported entity types, cycle/depth guards, sampled field selection and values, literal dotted sampled names and unchanged handling of nested sampled paths, unmatched fields, disabled classification, and entities without columns.

#### Unit tests

Backported `ingestion/tests/unit/metadata/pii/test_base_processor.py`.

From `ingestion/`, using Python 3.11 and models generated from this release branch:

```bash
PYTHONPATH=src python -m pytest tests/unit/metadata/pii tests/unit/pii/test_processor.py --cov=metadata.pii.base_processor --cov-report=term-missing -q
```

**127 passed; 95% combined line/branch coverage for `metadata.pii.base_processor`.** Repository formatting hooks and `git diff --check` passed.

#### Backend integration tests

Not applicable — no backend API changes.

#### Ingestion integration tests

Backported the regression in `ingestion/tests/integration/auto_classification/databases/test_global_sample_data_config.py`, including fresh-table isolation. Executed against OpenMetadata server/database images 1.13.5 and a PostgreSQL 15 sample-source container using this branch’s ingestion code. All three sample-data configuration tests plus `test_tag_processor.py` passed (4 total). The unchanged release processor passed the three existing-flow scenarios and failed only the metadata-only regression, with no tag on `address`.

#### Playwright (UI) tests

Not applicable — no UI changes.

#### Manual testing performed

Executed the automated integration scenarios against a live local stack. Reproduction: configure a column-name recognizer matching `address`, disable both global sample-data reading and storage, run auto-classification, and verify its generated/suggested tag appears on `address` while sample data remains absent. This scenario is encoded in the integration regression above.

### UI screen recording / screenshots:

Not applicable — no UI changes.

### Checklist:

- [x] PR title references issue 32606 and the target release.
- [x] Linked to the original issue and PR.
- [x] Backported regression tests and ran the relevant unit suites.
- [x] Retained comments explaining traversal safeguards and test isolation.
- Schema/migrations: not applicable.
- UI recording: not applicable.
- [x] Live database integration execution: 4 tests passed on 1.13.5 server images; baseline reproduced the original bug.

