### PR TITLE
Fixes #28694: UTF-8-safe base64 encoding for the login password

### DIFF
--- a/.github/playwright/impact-map.generated.json
+++ b/.github/playwright/impact-map.generated.json
@@ -1604,6 +1604,7 @@
         "playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts",
         "playwright/e2e/Features/TestSuitePipelineRedeploy.spec.ts",
         "playwright/e2e/Features/TierDropdown.spec.ts",
+        "playwright/e2e/Features/TierWidget.spec.ts",
         "playwright/e2e/Flow/CustomizeWidgets.spec.ts",
         "playwright/e2e/Flow/ExploreDiscovery.spec.ts",
         "playwright/e2e/Flow/LineageSettings.spec.ts",
@@ -2060,6 +2061,7 @@
         "playwright/e2e/Features/TeamsHierarchy.spec.ts",
         "playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts",
         "playwright/e2e/Features/TierDropdown.spec.ts",
+        "playwright/e2e/Features/TierWidget.spec.ts",
         "playwright/e2e/Features/UserProfileOnlineStatus.spec.ts",
         "playwright/e2e/Features/Workflows/NoOpWorkflowNodeConfig.spec.ts",
         "playwright/e2e/Features/Workflows/RecognizerFeedbackSchemaNodeLock.spec.ts",
@@ -3138,6 +3140,7 @@
         "playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts",
         "playwright/e2e/Features/TestSuitePipelineRedeploy.spec.ts",
         "playwright/e2e/Features/TierDropdown.spec.ts",
+        "playwright/e2e/Features/TierWidget.spec.ts",
         "playwright/e2e/Features/Topic.spec.ts",
         "playwright/e2e/Features/UserProfileOnlineStatus.spec.ts",
         "playwright/e2e/Features/Workflows/NoOpWorkflowNodeConfig.spec.ts",
@@ -3435,6 +3438,7 @@
         "playwright/e2e/Features/LandingPageWidgets/DomainWidgetFilter.spec.ts",
         "playwright/e2e/Features/Permissions/DataProductPermissions.spec.ts",
         "playwright/e2e/Features/SampleDataDomainDataProduct.spec.ts",
+        "playwright/e2e/Features/TierWidget.spec.ts",
         "playwright/e2e/Flow/IngestionBot.spec.ts",
         "playwright/e2e/Pages/DataContractInheritance.spec.ts",
         "playwright/e2e/Pages/DataMarketplace.spec.ts",
@@ -3597,6 +3601,7 @@
         "playwright/e2e/Features/Tasks/TaskNavigation.spec.ts",
         "playwright/e2e/Features/TeamSubscriptions.spec.ts",
         "playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts",
+        "playwright/e2e/Features/TierWidget.spec.ts",
         "playwright/e2e/Features/Topic.spec.ts",
         "playwright/e2e/Features/Workflows/NoOpWorkflowNodeConfig.spec.ts",
         "playwright/e2e/Features/Workflows/RecognizerFeedbackSchemaNodeLock.spec.ts",
@@ -4407,7 +4412,8 @@
         "openmetadata-ui/src/main/resources/ui/playwright/utils/tier.ts"
       ],
       "specs": [
-        "playwright/e2e/Features/TierDropdown.spec.ts"
+        "playwright/e2e/Features/TierDropdown.spec.ts",
+        "playwright/e2e/Features/TierWidget.spec.ts"
       ]
     },
     {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Login.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Login.spec.ts
@@ -18,6 +18,7 @@ import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import {
   clickOutside,
+  generateRandomUsername,
   getDefaultAdminAPIContext,
   redirectToHomePage,
   toastNotification,
@@ -132,6 +133,42 @@ test.describe(
       await expect(page.getByTestId('nav-user-name')).toContainText(
         `${CREDENTIALS.firstName}${CREDENTIALS.lastName}`
       );
+    });
+
+    // The UI base64-encodes the password before POSTing it to
+    // /api/v1/auth/login and the server decodes those bytes as UTF-8. `btoa`
+    // maps every character to a single Latin-1 byte, so a non-ASCII password
+    // was reconstructed as a different string and the login was rejected —
+    // issue #28694.
+    test('Signin with a password containing non-ASCII characters', async ({
+      page,
+      browser,
+    }) => {
+      const { apiContext, afterAction } = await getDefaultAdminAPIContext(
+        browser
+      );
+      const nonAsciiUser = new UserClass({
+        ...generateRandomUsername(),
+        password: 'T\u00ebst\u00a7123\u00a3aA!',
+      });
+
+      try {
+        await nonAsciiUser.create(apiContext);
+        await nonAsciiUser.login(page);
+
+        await expect(page).toHaveURL(
+          (url) => !url.pathname.includes('/signin')
+        );
+
+        await page.getByTestId('dropdown-profile').click();
+
+        await expect(page.getByTestId('nav-user-name')).toContainText(
+          `${nonAsciiUser.data.firstName}${nonAsciiUser.data.lastName}`
+        );
+      } finally {
+        await nonAsciiUser.delete(apiContext);
+        await afterAction();
+      }
     });
 
     test('Signin using invalid credentials', async ({ page }) => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/BasicAuthProvider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/BasicAuthProvider.test.tsx
@@ -1,0 +1,109 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BasicAuthProvider, { useBasicAuth } from './BasicAuthProvider';
+
+const mockBasicAuthSignIn = jest.fn().mockResolvedValue({});
+
+jest.mock('../../../rest/auth-API', () => ({
+  basicAuthRegister: jest.fn(),
+  basicAuthSignIn: (...args: unknown[]) => mockBasicAuthSignIn(...args),
+  generatePasswordResetLink: jest.fn(),
+  logoutUser: jest.fn(),
+  resetPassword: jest.fn(),
+}));
+
+jest.mock('./AuthProvider', () => ({
+  useAuthProvider: () => ({
+    handleSuccessfulLogin: jest.fn(),
+    handleFailedLogin: jest.fn(),
+    handleSuccessfulLogout: jest.fn(),
+  }),
+}));
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn().mockReturnValue(jest.fn()),
+}));
+
+jest.mock('../../../utils/SwTokenStorageUtils', () => ({
+  getOidcToken: jest.fn().mockResolvedValue(''),
+  getRefreshToken: jest.fn().mockResolvedValue(''),
+  setOidcToken: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../../utils/WebAnalyticsUtils', () => ({
+  resetWebAnalyticSession: jest.fn(),
+}));
+
+jest.mock('../../../utils/ToastUtils', () => ({
+  showErrorToast: jest.fn(),
+  showInfoToast: jest.fn(),
+  showSuccessToast: jest.fn(),
+}));
+
+const LoginTrigger = ({ password }: { password: string }) => {
+  const { handleLogin } = useBasicAuth();
+
+  return (
+    <button onClick={() => handleLogin('user@example.com', password)}>
+      login
+    </button>
+  );
+};
+
+const login = async (password: string) => {
+  render(
+    <BasicAuthProvider>
+      <LoginTrigger password={password} />
+    </BasicAuthProvider>
+  );
+
+  await userEvent.click(screen.getByRole('button', { name: 'login' }), {
+    advanceTimers: jest.advanceTimersByTime,
+  });
+
+  await waitFor(() => expect(mockBasicAuthSignIn).toHaveBeenCalled());
+
+  return mockBasicAuthSignIn.mock.calls[0][0].password as string;
+};
+
+const decodeUtf8Base64 = (encoded: string) =>
+  new TextDecoder().decode(
+    Uint8Array.from(atob(encoded), (char) => char.charCodeAt(0))
+  );
+
+describe('BasicAuthProvider handleLogin', () => {
+  it('should base64 encode an ASCII password', async () => {
+    expect(await login('plainAscii123')).toBe('cGxhaW5Bc2NpaTEyMw==');
+  });
+
+  // Regression for issue #28694: the password was encoded with `btoa`, which
+  // maps each character to a single Latin-1 byte, so the server's UTF-8 decode
+  // reconstructed a different password and basic/LDAP login failed.
+  it.each(['Test§123£', 'Pässwörd1!', '密码2024', 'pw🔒key'])(
+    'should send %j as base64 of its UTF-8 bytes',
+    async (password) => {
+      const sent = await login(password);
+
+      expect(decodeUtf8Base64(sent)).toBe(password);
+    }
+  );
+
+  it('should not send the Latin-1 encoding for a non-ASCII password', async () => {
+    const password = 'Test§123£';
+
+    expect(await login(password)).not.toBe(btoa(password));
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/BasicAuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/BasicAuthProvider.tsx
@@ -44,6 +44,7 @@ import { resetWebAnalyticSession } from '../../../utils/WebAnalyticsUtils';
 
 import { toLower } from 'lodash';
 import { extractDetailsFromToken } from '../../../utils/AuthProvider.util';
+import { getBase64EncodedString } from '../../../utils/StringUtils';
 import {
   getOidcToken,
   getRefreshToken,
@@ -95,7 +96,7 @@ const BasicAuthProvider = ({ children }: BasicAuthProps) => {
         try {
           const response = await basicAuthSignIn({
             email,
-            password: btoa(password),
+            password: getBase64EncodedString(password),
           });
 
           if (response.accessToken) {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.test.ts
@@ -33,6 +33,7 @@ import {
   decodeHtmlEntities,
   escapeESReservedCharacters,
   formatJsonString,
+  getBase64EncodedString,
   getDecodedFqn,
   getEncodedFqn,
   getPermissionErrorText,
@@ -590,6 +591,39 @@ describe('StringUtils', () => {
     it('should escape a Lucene field query so it is searched as literal text', () => {
       expect(escapeESReservedCharacters('name:value')).toBe(
         String.raw`name\:value`
+      );
+    });
+  });
+
+  describe('getBase64EncodedString', () => {
+    // Regression: `btoa` treats each character as a Latin-1 byte, so non-ASCII
+    // passwords reached the server corrupted and login failed — issue #28694.
+    it.each([
+      ['plainAscii123', 'cGxhaW5Bc2NpaTEyMw=='],
+      ['Test\u00a7123\u00a3', 'VGVzdMKnMTIzwqM='],
+      ['P\u00e4ssw\u00f6rd1!', 'UMOkc3N3w7ZyZDEh'],
+      ['\u5bc6\u78012024', '5a+G56CBMjAyNA=='],
+      ['pw\ud83d\udd12key', 'cHfwn5SSa2V5'],
+      ['', ''],
+    ])('should base64 encode the UTF-8 bytes of %j', (input, expected) => {
+      expect(getBase64EncodedString(input)).toBe(expected);
+    });
+
+    it('should round-trip through a UTF-8 base64 decode', () => {
+      const password = 'Test\u00a7123\u00a3 \u5bc6\u7801 \ud83d\udd12';
+
+      expect(
+        new TextDecoder().decode(
+          Uint8Array.from(atob(getBase64EncodedString(password)), (char) =>
+            char.charCodeAt(0)
+          )
+        )
+      ).toBe(password);
+    });
+
+    it('should not emit the Latin-1 encoding btoa would produce', () => {
+      expect(getBase64EncodedString('Test\u00a7123\u00a3')).not.toBe(
+        btoa('Test\u00a7123\u00a3')
       );
     });
   });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.ts
@@ -72,10 +72,20 @@ export const removeOuterEscapes = (input: string) => {
 };
 
 /**
+ * `btoa` alone treats every JS character as a Latin-1 byte, so non-ASCII input
+ * is silently corrupted (`\u00a3` -> `a3` instead of `c2 a3`) and input above
+ * U+00FF throws. Encode to UTF-8 bytes first, since consumers (the login API)
+ * decode the base64 as UTF-8. See issue #28694.
+ *
  * @param text plain text
- * @returns base64 encoded text
+ * @returns base64 encoding of the UTF-8 bytes of `text`
  */
-export const getBase64EncodedString = (text: string): string => btoa(text);
+export const getBase64EncodedString = (text: string): string =>
+  btoa(
+    Array.from(new TextEncoder().encode(text), (byte) =>
+      String.fromCharCode(byte)
+    ).join('')
+  );
 
 export const stringToSlug = (dataString: string, slugString = '') => {
   return dataString.toLowerCase().replaceAll(' ', slugString);


### PR DESCRIPTION
### Describe your changes:

Fixes #28694

The UI base64-encodes the password before POSTing it to `/api/v1/auth/login`, using
`btoa(password)`. `btoa` maps every JS character to a single Latin-1 byte, while the server
base64-decodes and interprets the bytes as UTF-8 — so any non-ASCII character arrived as a
different byte sequence (`£` → `a3` instead of `c2 a3`), the reconstructed password did not
match, and login was rejected. For LDAP the bind failed with error 49 / `data 52e`. Characters
above U+00FF (emoji, CJK) made `btoa` throw outright, breaking login entirely.

I encoded the UTF-8 bytes before base64. The fix lands in the shared
`getBase64EncodedString` helper in `StringUtils.ts` — previously an unused `btoa` wrapper
carrying the same defect — and the login call site now routes through it, so any future
client-side base64 path gets the correct implementation rather than raw `btoa`.

Scope notes from the investigation:

- `btoa(password)` in `BasicAuthProvider.tsx` was the **only** password path that base64-encodes.
  Registration, password reset, and change-password send the password as plaintext JSON (already
  UTF-8 via axios), so they were never affected and need no change.
- One frontend fix covers both providers: `AuthProvider.tsx` routes `case LDAP: case Basic:` to
  the same `BasicAuthProvider`.
- The server side is correct and unchanged — `new String(decodedBytes)` on Java 21 is UTF-8 per
  JEP 400 (`BasicAuthServletHandler`, `LdapAuthServletHandler`, `UserResource#loginUserWithPassword`).
- Non-ASCII passwords are settable: they satisfy both the server rules in `PasswordUtil` (passay)
  and the UI `passwordRegex`.

I used `Array.from(...).join('')` rather than the `String.fromCharCode(...spread)` form suggested
in the issue, because the spread blows the argument limit on long input and this is a shared util.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered

- A user whose password contains Latin-1-range non-ASCII characters (`Test§123£`, `Pässwörd1!`)
  can log in with the `basic` provider.
- A user whose password contains characters above U+00FF (`密码2024`, `pw🔒key`) can log in —
  previously `btoa` threw and the login never left the browser.
- The same fix covers the `ldap` provider, which shares the authenticator.
- Plain-ASCII passwords keep encoding byte-for-byte identically (no regression for existing users).

#### Unit tests

- [x] I added unit tests for the new/changed logic.
- Files added/updated:
  - `openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.test.ts` — byte-exact expected
    base64 for ASCII, Latin-1-range, CJK, emoji and empty input; a UTF-8 round-trip through
    `atob` + `TextDecoder`; and an explicit assertion that the output is *not* what `btoa` would
    produce.
  - `openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/BasicAuthProvider.test.tsx`
    (new) — asserts the exact `password` value handed to `basicAuthSignIn` decodes back to what the
    user typed. This is the guard against someone reintroducing `btoa` at the call site, which a
    util-level test alone would not catch.
- Verified as a real RED→GREEN: 106 tests pass with the fix; reverting the helper to `btoa(text)`
  fails 11 of them.

#### Backend integration tests

- [x] Not applicable (no backend API changes).

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] I added Playwright E2E tests for UI changes.
- Files added/updated:
  - `openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Login.spec.ts` — creates a user
    with the password `Tëst§123£aA!` via the API, then signs in through the UI and asserts the
    session lands off `/signin` with the correct profile name. This is the only test that proves
    the round trip end to end against a real server.

#### Manual testing performed

Checks run locally, on the changed files only:

```
yarn test src/utils/StringUtils.test.ts src/components/Auth/AuthProviders/BasicAuthProvider.test.tsx
  → 2 suites, 106 tests passed
yarn test src/components/Auth
  → 9 suites, 79 tests passed
yarn license-header-check     → All files have licenses
yarn lint:playwright          → 0 errors (no new warnings in Login.spec.ts)
prettier --check + organize-imports + eslint --fix on all 5 changed files → clean
tsc --noEmit -p playwright/tsconfig.json → clean
```

The new Playwright spec has **not** been executed locally — I did not have a local stack up. It is
left for CI to run.

#
### UI screen recording / screenshots:

Not applicable — no visual change; the fix is to the encoding of the login request payload. The
observable behaviour is verified by the Playwright spec and the payload assertion in the unit test.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: no screen recording — no visual change (explained above).
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

- [x] I have added a test that covers the exact scenario we are fixing. The issue number (#28694) is
  commented in each of the three test files for future reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
