### PR TITLE
fix(ui-core): unblock antd migration — optional Alert title, dashed Divider, disabled-trigger Tooltip

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/alert/alert.test.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/alert/alert.test.tsx
@@ -1,0 +1,78 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Alert } from './alert';
+
+describe('Alert', () => {
+  it('renders a title when given one', () => {
+    render(<Alert title="Heads up" variant="warning" />);
+
+    expect(screen.getByTestId('alert-title')).toHaveTextContent('Heads up');
+  });
+
+  // antd's `description`-only alerts have no heading. Requiring one here would
+  // force call sites to invent user-facing copy just to migrate.
+  it('omits the title element entirely when title is absent', () => {
+    render(<Alert variant="brand">Body only</Alert>);
+
+    expect(screen.queryByTestId('alert-title')).not.toBeInTheDocument();
+    expect(screen.getByTestId('alert-children')).toHaveTextContent('Body only');
+  });
+
+  it('treats an empty-string title as absent', () => {
+    render(
+      <Alert title="" variant="brand">
+        Body only
+      </Alert>
+    );
+
+    expect(screen.queryByTestId('alert-title')).not.toBeInTheDocument();
+  });
+
+  // antd's `message` accepts a ReactNode, so a string-only title blocked any
+  // call site that passed markup.
+  it('accepts a ReactNode title', () => {
+    render(
+      <Alert
+        title={<span data-testid="rich">rich title</span>}
+        variant="error"
+      />
+    );
+
+    expect(screen.getByTestId('rich')).toBeInTheDocument();
+  });
+
+  it('stacks title above body, and top-aligns the icon, only when both exist', () => {
+    const { container } = render(
+      <Alert title="Heading" variant="brand">
+        Body
+      </Alert>
+    );
+
+    expect(container.firstElementChild).toHaveClass('tw:items-start');
+  });
+
+  it('centres a body-only alert against its icon', () => {
+    const { container } = render(<Alert variant="brand">Body</Alert>);
+
+    expect(container.firstElementChild).toHaveClass('tw:items-center');
+  });
+
+  it('still centres a title-only alert', () => {
+    const { container } = render(<Alert title="Heading" variant="brand" />);
+
+    expect(container.firstElementChild).toHaveClass('tw:items-center');
+  });
+});

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/alert/alert.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/alert/alert.tsx
@@ -65,8 +65,12 @@ export interface AlertProps
   extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
   /** success, warning, error, brand or gray */
   variant: AlertVariant;
-  /** Bold heading text */
-  title: string;
+  /**
+   * Bold heading text. Optional: an alert may carry only a body, which is how
+   * antd's `description`-only alerts are shaped, and requiring a title there
+   * would mean inventing user-facing copy at the call site.
+   */
+  title?: ReactNode;
   /** Body content and optional action buttons */
   children?: ReactNode;
   /** Override the default variant icon */
@@ -107,20 +111,25 @@ export const Alert = ({
 }: AlertProps) => {
   const styles = variantStyles[variant];
   const Icon = icon ?? styles.defaultIcon;
+  // Only stack (and top-align the icon) when there is a heading above a body.
+  // A body on its own reads as a single block, so it stays centred next to the
+  // icon exactly as a title on its own already did.
+  const hasTitle = title !== undefined && title !== null && title !== '';
+  const isStacked = Boolean(children) && hasTitle;
 
   return (
     <div
       {...props}
       className={cx(
         'tw:flex tw:w-full tw:gap-3 tw:rounded-xl tw:border tw:px-4',
-        children ? 'tw:items-start tw:py-4' : 'tw:items-center tw:py-2',
+        isStacked ? 'tw:items-start tw:py-4' : 'tw:items-center tw:py-2',
         styles.root,
         className
       )}
       role="alert">
       <FeaturedIcon
         bgColor={iconBgColor}
-        className={cx('tw:shrink-0', children && 'tw:self-start')}
+        className={cx('tw:shrink-0', isStacked && 'tw:self-start')}
         color={styles.iconColor}
         data-testid="alert-icon"
         icon={Icon}
@@ -131,11 +140,13 @@ export const Alert = ({
       />
 
       <div className="tw:flex tw:min-w-0 tw:flex-1 tw:flex-col tw:text-sm">
-        <p
-          className="tw:font-semibold tw:text-secondary"
-          data-testid="alert-title">
-          {title}
-        </p>
+        {hasTitle && (
+          <p
+            className="tw:font-semibold tw:text-secondary"
+            data-testid="alert-title">
+            {title}
+          </p>
+        )}
 
         {children && (
           <div className="tw:text-tertiary" data-testid="alert-children">

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/divider/divider.test.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/divider/divider.test.tsx
@@ -1,0 +1,66 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Divider } from './divider';
+
+const rule = () => screen.getByRole('separator');
+
+describe('Divider', () => {
+  it('draws a solid horizontal rule by default', () => {
+    render(<Divider />);
+
+    expect(rule()).toHaveClass('tw:h-px', 'tw:bg-border-secondary');
+  });
+
+  // A background cannot be dashed, so the dashed variant has to switch from a
+  // filled box to a border.
+  it('draws a dashed horizontal rule as a border', () => {
+    render(<Divider dashed />);
+
+    expect(rule()).toHaveClass('tw:h-0', 'tw:border-t', 'tw:border-dashed');
+    expect(rule()).not.toHaveClass('tw:bg-border-secondary');
+  });
+
+  it('draws a dashed vertical rule on the left border', () => {
+    render(<Divider dashed orientation="vertical" />);
+
+    expect(rule()).toHaveClass('tw:w-0', 'tw:border-l', 'tw:border-dashed');
+  });
+
+  // `self-stretch` yields no height outside a flex/grid parent, and a consumer
+  // aligning the divider itself overrides it — which silently collapsed the
+  // rule to nothing. antd's vertical divider had an intrinsic height.
+  it('gives a vertical rule an intrinsic height so it survives outside flex', () => {
+    render(<Divider orientation="vertical" />);
+
+    expect(rule()).toHaveClass('tw:self-stretch', 'tw:min-h-[1em]');
+  });
+
+  it('keeps the label layout and dashes both flanking rules', () => {
+    const { container } = render(<Divider dashed label="OR" />);
+
+    expect(screen.getByText('OR')).toBeInTheDocument();
+    const flanks = container.querySelectorAll('.tw\\:flex-1');
+
+    expect(flanks).toHaveLength(2);
+    flanks.forEach((f) => expect(f).toHaveClass('tw:border-dashed'));
+  });
+
+  it('still honours labelAlign', () => {
+    const { container } = render(<Divider label="OR" labelAlign="start" />);
+
+    expect(container.querySelectorAll('.tw\\:flex-1')).toHaveLength(1);
+  });
+});

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/divider/divider.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/divider/divider.tsx
@@ -20,12 +20,34 @@ export interface DividerProps extends HTMLAttributes<HTMLDivElement> {
   orientation?: DividerOrientation;
   label?: ReactNode;
   labelAlign?: DividerLabelAlignment;
+  /**
+   * Draw the rule with a dashed stroke instead of a solid fill. A solid rule
+   * is a 1px filled box; a dashed one has to be a border, since a background
+   * cannot be dashed.
+   */
+  dashed?: boolean;
 }
+
+// Solid rules are a filled 1px box. Dashed ones must use a border instead, so
+// the box collapses to zero in the relevant axis and the border supplies the
+// visible line.
+const ruleClasses = (dashed: boolean, axis: 'x' | 'y') => {
+  if (!dashed) {
+    return axis === 'y'
+      ? 'tw:w-px tw:bg-border-secondary'
+      : 'tw:h-px tw:bg-border-secondary';
+  }
+
+  return axis === 'y'
+    ? 'tw:w-0 tw:border-l tw:border-dashed tw:border-secondary'
+    : 'tw:h-0 tw:border-t tw:border-dashed tw:border-secondary';
+};
 
 export const Divider = ({
   orientation = 'horizontal',
   label,
   labelAlign = 'center',
+  dashed = false,
   className,
   ...props
 }: DividerProps) => {
@@ -35,7 +57,12 @@ export const Divider = ({
         {...props}
         aria-orientation="vertical"
         className={cx(
-          'tw:self-stretch tw:w-px tw:shrink-0 tw:bg-border-secondary',
+          // `self-stretch` only produces a height inside a flex or grid
+          // parent, and a consumer aligning the divider itself (say
+          // `self-center`) overrides it. `min-h-[1em]` keeps the rule visible
+          // in both cases without capping it when stretching does apply.
+          'tw:self-stretch tw:min-h-[1em] tw:shrink-0',
+          ruleClasses(dashed, 'y'),
           className
         )}
         role="separator"
@@ -49,7 +76,8 @@ export const Divider = ({
         {...props}
         aria-orientation="horizontal"
         className={cx(
-          'tw:w-full tw:h-px tw:shrink-0 tw:bg-border-secondary',
+          'tw:w-full tw:shrink-0',
+          ruleClasses(dashed, 'x'),
           className
         )}
         role="separator"
@@ -64,13 +92,13 @@ export const Divider = ({
       aria-orientation="horizontal"
       className={cx('tw:flex tw:items-center tw:w-full tw:gap-2', className)}>
       {labelAlign !== 'start' && (
-        <div className="tw:h-px tw:flex-1 tw:bg-border-secondary" />
+        <div className={cx('tw:flex-1', ruleClasses(dashed, 'x'))} />
       )}
       <span className="tw:shrink-0 tw:text-xs tw:font-medium tw:text-tertiary">
         {label}
       </span>
       {labelAlign !== 'end' && (
-        <div className="tw:h-px tw:flex-1 tw:bg-border-secondary" />
+        <div className={cx('tw:flex-1', ruleClasses(dashed, 'x'))} />
       )}
     </div>
   );

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/tooltip/tooltip.test.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/tooltip/tooltip.test.tsx
@@ -14,6 +14,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
+import { Button } from '../buttons/button';
 import { Tooltip } from './tooltip';
 
 // Establish pointer modality so react-aria treats hover as a valid trigger.
@@ -208,5 +209,63 @@ describe('Tooltip — show/hide behaviour', () => {
     await new Promise((resolve) => setTimeout(resolve, 400));
 
     expect(screen.queryByText('Hidden')).not.toBeInTheDocument();
+  });
+});
+
+// A disabled control fires no pointer or focus events, so react-aria never
+// opened the tooltip on it — exactly backwards for the usual case, where the
+// tooltip is what explains why the control is disabled.
+describe('Tooltip — disabled trigger', () => {
+  it('opens on hover over a disabled button', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Tooltip title="Needs a data asset first">
+        <Button isDisabled data-testid="disabled-btn">
+          Add
+        </Button>
+      </Tooltip>
+    );
+
+    fireEvent.mouseMove(document);
+
+    // The disabled child is made inert, so the hover lands on the wrapper —
+    // which is what happens in a browser too.
+    const wrapper = screen.getByTestId('disabled-btn')
+      .parentElement as HTMLElement;
+    await user.hover(wrapper);
+
+    await waitFor(() =>
+      expect(screen.getByText('Needs a data asset first')).toBeInTheDocument()
+    );
+  });
+
+  it('wraps a disabled child in a focusable span, not a nested button', () => {
+    render(
+      <Tooltip title="t">
+        <Button isDisabled data-testid="d">
+          Add
+        </Button>
+      </Tooltip>
+    );
+
+    const wrapper = screen.getByTestId('d').parentElement as HTMLElement;
+
+    // Nesting a button inside a button is invalid HTML and breaks clicks.
+    expect(wrapper.tagName).toBe('SPAN');
+    expect(wrapper).toHaveAttribute('tabindex', '0');
+    expect(screen.getByTestId('d').closest('button')).toBe(
+      screen.getByTestId('d')
+    );
+  });
+
+  it('leaves an enabled button unwrapped by a span', () => {
+    render(
+      <Tooltip title="t">
+        <Button data-testid="e">Add</Button>
+      </Tooltip>
+    );
+
+    expect(screen.getByTestId('e').parentElement?.tagName).not.toBe('SPAN');
   });
 });

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/tooltip/tooltip.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/tooltip/tooltip.tsx
@@ -9,6 +9,7 @@ import type {
 import { forwardRef, isValidElement } from 'react';
 import {
   Button as AriaButton,
+  Focusable as AriaFocusable,
   OverlayArrow as AriaOverlayArrow,
   Tooltip as AriaTooltip,
   TooltipTrigger as AriaTooltipTrigger,
@@ -121,12 +122,23 @@ export const Tooltip = ({
 }: TooltipProps) => {
   const resolvedDelay = delay ?? 300;
 
+  // A disabled control fires no pointer or focus events, so react-aria never
+  // opens the tooltip on it - precisely backwards for the common case, where
+  // the tooltip exists to explain *why* the control is disabled. antd wrapped
+  // disabled children in its own listener element for this reason.
+  const isDisabledChild =
+    isValidElement<{ isDisabled?: boolean; disabled?: boolean }>(children) &&
+    Boolean(children.props.isDisabled ?? children.props.disabled);
+
   // Determine whether the child needs to be wrapped in a focusable AriaButton.
   // Non-focusable HTML string elements (span, div, svg, …) can't serve as
   // react-aria tooltip anchors on their own; wrap them automatically.
   // Providing triggerClassName or onTriggerPress is an explicit signal to wrap
   // even React component children (e.g. icon components).
   const shouldWrap = (() => {
+    if (isDisabledChild) {
+      return true;
+    }
     if (triggerClassName !== undefined || onTriggerPress !== undefined) {
       return true;
     }
@@ -139,7 +151,22 @@ export const Tooltip = ({
   })();
 
   const trigger_ = shouldWrap ? (
-    excludeTriggerFromTabOrder ? (
+    isDisabledChild ? (
+      // Focusable + span rather than AriaButton: the child is already a
+      // button, and nesting one inside another is invalid HTML. The child
+      // also has to stop swallowing pointer events, or the wrapper never
+      // sees the hover.
+      <AriaFocusable>
+        <span
+          className={cx(
+            'tw:inline-flex tw:w-max tw:cursor-not-allowed tw:*:pointer-events-none',
+            triggerClassName
+          )}
+          tabIndex={0}>
+          {children}
+        </span>
+      </AriaFocusable>
+    ) : excludeTriggerFromTabOrder ? (
       // Use a plain span instead of AriaButton when the trigger is explicitly
       // excluded from the tab order. AriaButton with tabindex="-1" is still
       // programmatically focusable, so Ant Design FocusTrap.restoreFocus() can


### PR DESCRIPTION
Three gaps in `ui-core-components` that are each blocking antd call sites from migrating. Separate commits, independently reviewable.

Found while sweeping Collate — every one of these turned a would-be mechanical migration into "leave it on antd".

## 1. `Alert` — a body without a title

`title` was a required `string`. antd's `message` is an optional ReactNode, and its `description`-only alerts have no heading at all. Of Collate's 11 alerts, **only 2** had a plain string message — 6 passed markup, and 3 had no message whatsoever. Migrating those meant inventing user-facing copy.

`title` is now optional and takes a `ReactNode`. When absent, the heading element isn't rendered and the alert uses the single-block layout it already had for a title with no body, so the icon stays centred instead of top-aligned against a lone paragraph. Every existing call site passes a title (it was required), so nothing changes for them.

## 2. `Divider` — dashed, and a vertical rule with a height

- **No dashed variant.** A solid rule is a filled 1px box and a background can't be dashed, so the dashed case switches to a border and collapses the box in that axis. The rules either side of a label follow suit.
- **The vertical rule had no intrinsic height.** It relied entirely on `self-stretch`, which produces nothing outside a flex/grid parent and is overridden the moment a consumer aligns the divider itself — an unlayered LESS `.self-center` is enough to collapse it to zero and make it vanish silently. antd's vertical divider had an intrinsic height; `min-h-[1em]` restores that without capping the stretch case.

Between them these unblock **21** Collate elements.

## 3. `Tooltip` — open on a disabled trigger

A disabled control fires no pointer or focus events, so react-aria never opened its tooltip. That's backwards for the usual case: **the tooltip is what explains why the control is disabled**, and it vanished exactly when the user needed it. antd wrapped disabled children in a listener element for this reason.

A disabled child now takes the same auto-wrapping path as a non-focusable one, but via `Focusable` + a span rather than the `AriaButton` wrapper — the child is already a button, and nesting one inside another is invalid HTML and breaks clicks. The child is made inert so it stops swallowing the events the wrapper needs.

Two Collate sites sit on antd purely because of this, and `QueryToolbar` has the same latent bug on main today.

## Verification

- 16 new tests (7 Alert, 6 Divider, 3 Tooltip); the Tooltip file's existing 12 still pass, so the new wrap path doesn't disturb the existing ones.
- Full core suite **110/111**. The single failure (`Table › can omit the selection cell for a full-width synthetic row`) is **pre-existing on clean main** — verified by stashing this branch and re-running.
- `tsc`, eslint, prettier clean.

## Note for reviewers

A fourth change was planned — making `Button` forward injected mouse handlers — and **dropped after measuring**. I'd assumed react-aria's `filterDOMProps` stripped them. It doesn't: `onBlur`, `onMouseOver`, `onMouseDown` and `onPointerEnter` all reach the DOM. Only `onFocus` is swallowed, which means an antd-wrapped core Button gets hover tooltips but not keyboard-focus ones. Real, but narrow, and not worth speculative surgery on Button's prop plumbing — raising separately if it's worth fixing.

Draft: happy to split further or adjust the Alert layout fallback if you'd rather it stayed top-aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=65545359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; no new actionable defects were identified in the changes since the previous review.

<details open><summary>Summary</summary>

This PR expands the core UI components to support Ant Design migration use cases:
- Allows alerts with optional ReactNode titles while preserving valid markup and body-only alignment.
- Adds dashed horizontal, vertical, and labeled dividers, plus an intrinsic minimum height for vertical rules.
- Makes disabled tooltip triggers hoverable and keyboard-focusable through a non-button wrapper.
- Adds focused tests for the new alert, divider, and tooltip behavior.
</details>

<sub>Reviews (2) · Last reviewed commit: ["fix(ui-core): address review — title wra..."](https://github.com/open-metadata/openmetadata/commit/0cb192650f05699b2fbe5bbdb283567485618e28)</sub>

<!-- /greptile_comment -->