### PR TITLE
Fixes #23228: enable column-level lineage between a metric and a table column

### DIFF
--- a/.github/playwright/impact-map.generated.json
+++ b/.github/playwright/impact-map.generated.json
@@ -1604,6 +1604,7 @@
         "playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts",
         "playwright/e2e/Features/TestSuitePipelineRedeploy.spec.ts",
         "playwright/e2e/Features/TierDropdown.spec.ts",
+        "playwright/e2e/Features/TierWidget.spec.ts",
         "playwright/e2e/Flow/CustomizeWidgets.spec.ts",
         "playwright/e2e/Flow/ExploreDiscovery.spec.ts",
         "playwright/e2e/Flow/LineageSettings.spec.ts",
@@ -2060,6 +2061,7 @@
         "playwright/e2e/Features/TeamsHierarchy.spec.ts",
         "playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts",
         "playwright/e2e/Features/TierDropdown.spec.ts",
+        "playwright/e2e/Features/TierWidget.spec.ts",
         "playwright/e2e/Features/UserProfileOnlineStatus.spec.ts",
         "playwright/e2e/Features/Workflows/NoOpWorkflowNodeConfig.spec.ts",
         "playwright/e2e/Features/Workflows/RecognizerFeedbackSchemaNodeLock.spec.ts",
@@ -3138,6 +3140,7 @@
         "playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts",
         "playwright/e2e/Features/TestSuitePipelineRedeploy.spec.ts",
         "playwright/e2e/Features/TierDropdown.spec.ts",
+        "playwright/e2e/Features/TierWidget.spec.ts",
         "playwright/e2e/Features/Topic.spec.ts",
         "playwright/e2e/Features/UserProfileOnlineStatus.spec.ts",
         "playwright/e2e/Features/Workflows/NoOpWorkflowNodeConfig.spec.ts",
@@ -3435,6 +3438,7 @@
         "playwright/e2e/Features/LandingPageWidgets/DomainWidgetFilter.spec.ts",
         "playwright/e2e/Features/Permissions/DataProductPermissions.spec.ts",
         "playwright/e2e/Features/SampleDataDomainDataProduct.spec.ts",
+        "playwright/e2e/Features/TierWidget.spec.ts",
         "playwright/e2e/Flow/IngestionBot.spec.ts",
         "playwright/e2e/Pages/DataContractInheritance.spec.ts",
         "playwright/e2e/Pages/DataMarketplace.spec.ts",
@@ -3597,6 +3601,7 @@
         "playwright/e2e/Features/Tasks/TaskNavigation.spec.ts",
         "playwright/e2e/Features/TeamSubscriptions.spec.ts",
         "playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts",
+        "playwright/e2e/Features/TierWidget.spec.ts",
         "playwright/e2e/Features/Topic.spec.ts",
         "playwright/e2e/Features/Workflows/NoOpWorkflowNodeConfig.spec.ts",
         "playwright/e2e/Features/Workflows/RecognizerFeedbackSchemaNodeLock.spec.ts",
@@ -4407,7 +4412,8 @@
         "openmetadata-ui/src/main/resources/ui/playwright/utils/tier.ts"
       ],
       "specs": [
-        "playwright/e2e/Features/TierDropdown.spec.ts"
+        "playwright/e2e/Features/TierDropdown.spec.ts",
+        "playwright/e2e/Features/TierWidget.spec.ts"
       ]
     },
     {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/LineageRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/LineageRepository.java
@@ -1191,8 +1191,13 @@ public class LineageRepository {
         return result;
       }
       case METRIC -> {
-        LOG.info("Metric column level lineage is not supported");
-        return new HashSet<>();
+        // A metric has no columns of its own -- it *is* the leaf a column feeds, e.g.
+        // Total Sales = sum(Sales.Amount). So the metric's own FQN is its single valid
+        // column endpoint. Names here are relative to the parent FQN, and stripping
+        // "<metricFqn>." off "<metricFqn>" is a no-op, hence the full FQN.
+        // singleton, not Set.of: tolerates a null FQN instead of throwing, and a
+        // singleton{null} rejects every toColumn, which is the behaviour we want there.
+        return Collections.singleton(entityReference.getFullyQualifiedName());
       }
       case PIPELINE -> {
         LOG.info("Pipeline column level lineage is not supported");

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/LineageRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/LineageRepositoryTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.type.*;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.search.IndexMapping;
@@ -205,6 +206,92 @@ class LineageRepositoryTest {
         .withId(UUID.randomUUID())
         .withType(type)
         .withFullyQualifiedName(fqn);
+  }
+
+  @Test
+  void testValidateLineageDetails_TableColumnToMetric_KeepsColumnLineage() {
+    final LineageRepository repository = new LineageRepository();
+    final EntityReference table = entityReference(Entity.TABLE, "db.schema.sales");
+    final EntityReference metric = entityReference(Entity.METRIC, "metricService.total_sales");
+    mockSalesTable(table);
+
+    final LineageDetails details =
+        columnLineageDetails("db.schema.sales.amount", metric.getFullyQualifiedName());
+
+    final LineageDetails saved =
+        JsonUtils.readValue(
+            repository.validateLineageDetails(table, metric, details), LineageDetails.class);
+
+    assertEquals(1, saved.getColumnsLineage().size());
+    assertEquals("metricService.total_sales", saved.getColumnsLineage().get(0).getToColumn());
+    assertEquals(
+        List.of("db.schema.sales.amount"), saved.getColumnsLineage().get(0).getFromColumns());
+  }
+
+  @Test
+  void testValidateLineageDetails_MetricToTableColumn_KeepsColumnLineage() {
+    final LineageRepository repository = new LineageRepository();
+    final EntityReference metric = entityReference(Entity.METRIC, "metricService.total_sales");
+    final EntityReference table = entityReference(Entity.TABLE, "db.schema.sales");
+    mockSalesTable(table);
+
+    final LineageDetails details =
+        columnLineageDetails(metric.getFullyQualifiedName(), "db.schema.sales.amount");
+
+    final LineageDetails saved =
+        JsonUtils.readValue(
+            repository.validateLineageDetails(metric, table, details), LineageDetails.class);
+
+    assertEquals(1, saved.getColumnsLineage().size());
+    assertEquals("db.schema.sales.amount", saved.getColumnsLineage().get(0).getToColumn());
+    assertEquals(
+        List.of("metricService.total_sales"), saved.getColumnsLineage().get(0).getFromColumns());
+  }
+
+  @Test
+  void testValidateLineageDetails_UnknownMetricChild_IsFilteredOut() {
+    final LineageRepository repository = new LineageRepository();
+    final EntityReference table = entityReference(Entity.TABLE, "db.schema.sales");
+    final EntityReference metric = entityReference(Entity.METRIC, "metricService.total_sales");
+    mockSalesTable(table);
+
+    final LineageDetails details =
+        columnLineageDetails(
+            "db.schema.sales.amount", metric.getFullyQualifiedName() + ".not_a_column");
+
+    final LineageDetails saved =
+        JsonUtils.readValue(
+            repository.validateLineageDetails(table, metric, details), LineageDetails.class);
+
+    assertTrue(saved.getColumnsLineage().isEmpty());
+  }
+
+  private static void mockSalesTable(final EntityReference table) {
+    final Table salesTable =
+        new Table()
+            .withId(table.getId())
+            .withName("sales")
+            .withFullyQualifiedName(table.getFullyQualifiedName())
+            .withColumns(
+                List.of(
+                    new Column()
+                        .withName("amount")
+                        .withDataType(ColumnDataType.BIGINT)
+                        .withFullyQualifiedName(table.getFullyQualifiedName() + ".amount")));
+    mockedEntity
+        .when(() -> Entity.getEntity(Entity.TABLE, table.getId(), "columns", Include.NON_DELETED))
+        .thenReturn(salesTable);
+  }
+
+  private static LineageDetails columnLineageDetails(
+      final String fromColumn, final String toColumn) {
+    return new LineageDetails()
+        .withSource(LineageDetails.Source.MANUAL)
+        .withColumnsLineage(
+            List.of(
+                new ColumnLineage()
+                    .withFromColumns(new ArrayList<>(List.of(fromColumn)))
+                    .withToColumn(toColumn)));
   }
 
   private static ListAppender<ILoggingEvent> attachListAppender(final Logger logger) {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/DataAssetLineage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/DataAssetLineage.spec.ts
@@ -48,6 +48,7 @@ import {
   editLineageClick,
   fitToScreen,
   getEntityColumns,
+  openImpactAnalysisTab,
   performZoomOut,
   rearrangeNodes,
   removeColumnLineage,
@@ -363,6 +364,82 @@ test.describe('Column Level Lineage', () => {
         await afterAction();
       });
     });
+  });
+
+  test('Column lineage between a table column and a metric', async ({
+    page,
+  }) => {
+    test.slow();
+    const { apiContext, afterAction } = await getApiContext(page);
+    const table = new TableClass();
+    const metric = new MetricClass();
+
+    await Promise.all([table.create(apiContext), metric.create(apiContext)]);
+
+    try {
+      const tableCol = get(
+        getEntityColumns(table, 'table'),
+        '[0].fullyQualifiedName',
+        ''
+      );
+      // The metric has no columns -- it is its own column-lineage endpoint.
+      const metricCol = get(
+        getEntityColumns(metric, 'metric'),
+        '[0].fullyQualifiedName',
+        ''
+      );
+
+      await test.step('Add column lineage from table column to metric', async () => {
+        await addPipelineBetweenNodes(page, table, metric);
+        await activateColumnLayer(page);
+        await addColumnLineage(page, tableCol, metricCol);
+      });
+
+      await test.step('Verify column lineage survives a reload', async () => {
+        const lineageRes = page.waitForResponse('/api/v1/lineage/getLineage?*');
+        await page.reload();
+        await lineageRes;
+        await waitForAllLoadersToDisappear(page);
+        await activateColumnLayer(page);
+
+        await expect(
+          page.getByTestId(`column-edge-${tableCol}-${metricCol}`)
+        ).toBeVisible();
+      });
+
+      await test.step('Verify the metric shows up in column level Impact Analysis', async () => {
+        await openImpactAnalysisTab(page);
+
+        const columnLineageRes = page.waitForResponse(
+          '/api/v1/lineage/getLineage/Downstream?*'
+        );
+        await page.getByRole('button', { name: 'Impact On: Table' }).click();
+        await page.getByText('Column level').click();
+        await columnLineageRes;
+        await waitForAllLoadersToDisappear(page);
+
+        const row = page.locator(`[data-row-key="${tableCol}->${metricCol}"]`);
+
+        await expect(row).toBeVisible();
+        await expect(
+          row.getByRole('gridcell', {
+            name: get(metric, 'entityResponseData.name', ''),
+          })
+        ).toBeVisible();
+      });
+
+      await test.step('Remove column lineage', async () => {
+        await table.visitEntityPage(page);
+        await visitLineageTab(page);
+        await activateColumnLayer(page);
+        await editLineageClick(page);
+
+        await removeColumnLineage(page, tableCol, metricCol);
+      });
+    } finally {
+      await Promise.all([table.delete(apiContext), metric.delete(apiContext)]);
+      await afterAction();
+    }
   });
 
   test('Verify column layer is applied on entering edit mode', async ({

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/DataAssetLineage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/DataAssetLineage.spec.ts
@@ -421,11 +421,14 @@ test.describe('Column Level Lineage', () => {
         const row = page.locator(`[data-row-key="${tableCol}->${metricCol}"]`);
 
         await expect(row).toBeVisible();
+        // Two cells, not one: the metric is both the impacted asset and -- being
+        // its own column endpoint -- the impacted column. Asserting the count
+        // pins that down and still catches the cell rendering NO_DATA.
         await expect(
           row.getByRole('gridcell', {
             name: get(metric, 'entityResponseData.name', ''),
           })
-        ).toBeVisible();
+        ).toHaveCount(2);
       });
 
       await test.step('Remove column lineage', async () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/lineage.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/lineage.ts
@@ -709,6 +709,18 @@ export const getEntityColumns = (
     return get(entity, 'entityResponseData.mlFeatures', []);
   } else if (entityName === 'searchIndex') {
     return get(entity, 'entityResponseData.fields', []);
+  } else if (entityName === 'metric') {
+    // A metric has no columns -- it is its own column-lineage endpoint.
+    return [
+      {
+        name: get(entity, 'entityResponseData.name', ''),
+        fullyQualifiedName: get(
+          entity,
+          'entityResponseData.fullyQualifiedName',
+          ''
+        ),
+      },
+    ];
   }
 
   return [];

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/NodeChildren/NodeChildren.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/NodeChildren/NodeChildren.component.test.tsx
@@ -179,6 +179,27 @@ describe('NodeChildren Component', () => {
       expect(screen.queryByTestId('column-container')).not.toBeInTheDocument();
     });
 
+    it('should render a metric node with the metric itself as its endpoint', () => {
+      const metricNode = {
+        id: 'metric-id',
+        type: EntityType.METRIC,
+        entityType: EntityType.METRIC,
+        name: 'total_sales',
+        fullyQualifiedName: 'metricService.total_sales',
+      } as unknown as LineageNodeType;
+
+      render(
+        <NodeChildren
+          isChildrenListExpanded
+          isConnectable={false}
+          node={metricNode}
+        />
+      );
+
+      expect(screen.getByTestId('column-container')).toBeInTheDocument();
+      expect(screen.getByTestId('column-total_sales')).toBeInTheDocument();
+    });
+
     it('should render when column layer is enabled', () => {
       mockLineageStoreState.activeLayer = [LineageLayer.ColumnLevelLineage];
 

--- a/openmetadata-ui/src/main/resources/ui/src/constants/Lineage.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/Lineage.constants.ts
@@ -143,6 +143,7 @@ export const LINEAGE_COLUMN_NODE_SUPPORTED = [
   EntityType.TOPIC,
   EntityType.SEARCH_INDEX,
   EntityType.API_ENDPOINT,
+  EntityType.METRIC,
 ];
 
 export const LINEAGE_EXPORT_HEADERS = [

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageNodeUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageNodeUtils.ts
@@ -117,6 +117,21 @@ const getSearchIndexEntityChildren = (
   childrenCount: node.fields?.length ?? 0,
 });
 
+/**
+ * A metric has no columns of its own -- it *is* the leaf a table column feeds,
+ * e.g. Total Sales = sum(Sales.Amount). So it exposes itself as its single
+ * column-lineage endpoint, keyed by its own FQN like the backend expects.
+ * childrenCount stays 0 so the node keeps its compact label with no
+ * "1 column" footer outside the column layer.
+ */
+const getMetricEntityChildren = (
+  node: LineageNodeType
+): EntityChildrenMapping => ({
+  data: [node],
+  label: t('label.metric'),
+  childrenCount: 0,
+});
+
 const ENTITY_CHILDREN_RESOLVERS: Partial<
   Record<EntityType, (node: LineageNodeType) => EntityChildrenMapping>
 > = {
@@ -128,6 +143,7 @@ const ENTITY_CHILDREN_RESOLVERS: Partial<
   [EntityType.TOPIC]: getTopicEntityChildren,
   [EntityType.API_ENDPOINT]: getApiEndpointEntityChildren,
   [EntityType.SEARCH_INDEX]: getSearchIndexEntityChildren,
+  [EntityType.METRIC]: getMetricEntityChildren,
 };
 
 export function getEntityChildrenAndLabel(node: LineageNodeType) {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.test.tsx
@@ -1017,6 +1017,25 @@ describe('Test EntityLineageUtils utility', () => {
         childrenCount: 0,
       });
     });
+
+    it('should expose a METRIC entity as its own single lineage endpoint', () => {
+      const node = {
+        id: 'metric-id',
+        type: EntityType.METRIC,
+        entityType: EntityType.METRIC,
+        name: 'total_sales',
+        fullyQualifiedName: 'metricService.total_sales',
+      };
+      const result = getEntityChildrenAndLabel(
+        node as unknown as LineageNodeType
+      );
+
+      expect(result).toEqual({
+        children: [node],
+        childrenHeading: 'label.metric',
+        childrenCount: 0,
+      });
+    });
   });
 
   describe('getColumnFunctionValue', () => {


### PR DESCRIPTION
### Describe your changes:

Fixes #23228

Today you can link a metric to a table, but not to a **column** of that table — even though a metric is usually an expression over one column (`Total Sales = SUM(Sales.Amount)`). The API accepted such an edge with a `200` and then silently stored nothing, and the UI never offered the connection at all.

**Why it was dropped:** `LineageRepository.getChildrenNames()` short-circuited `METRIC` to an empty set with a `LOG.info("Metric column level lineage is not supported")`. `validateLineageDetails()` filters every `columnsLineage` entry whose endpoint isn't in that set, so the mapping was discarded before it was written. On the UI side `EntityType.METRIC` was absent from `LINEAGE_COLUMN_NODE_SUPPORTED` and had no children resolver, so a metric node had nothing to attach a column edge to.

**What I changed:** a metric has no columns of its own — it *is* the leaf that a column feeds. So the metric now acts as its own single column-lineage endpoint, keyed by its own FQN. `{"fromColumns": ["…sales.amount"], "toColumn": "total_sales"}` is exactly what an API client would naturally send, and it's the same shape the backend already uses for non-nested children (a dashboard's charts).

#
### Type of change:
- [x] New feature

#
### High-level design:

**Approach.** Rather than introduce a parallel notion of "metric lineage", make the metric a first-class participant in the column-lineage machinery that already exists. Three small changes are enough because every downstream consumer is already generic over `columnsLineage`:

| Layer | Change |
|---|---|
| `LineageRepository.getChildrenNames()` | `case METRIC` returns `Collections.singleton(fqn)` instead of an empty set |
| `LINEAGE_COLUMN_NODE_SUPPORTED` | add `EntityType.METRIC` |
| `EntityLineageNodeUtils` | add `getMetricEntityChildren` — the node exposes itself as its one connectable child |

Everything else was already entity-type agnostic and needed no edits: `validateLineageDetails`, `EsLineageData.columns` / search indexing, `ColumnFilterMatcher`, the canvas edge geometry in `CanvasUtils` (it derives positions from `columnsInCurrentPages` + `getEntityChildrenAndLabel`), column tracing, the "only show columns with lineage" filter, ELK node sizing, and the column-level Impact Analysis table (`buildColumnLevelNodesForColumns`, whose `Fqn.split(col).pop()` already renders a bare metric FQN as the metric name).

**`childrenCount` stays `0`.** The resolver returns one item in `data` but `childrenCount: 0`. That is deliberate: `childrenCount` drives the node footer ("N columns" badge + expand button), and a metric genuinely has zero columns. Keeping it at 0 means metric nodes look **exactly as they do today** in the default graph — the endpoint row only appears when the Column layer or edit mode is on, which is precisely when it's needed. Reporting `1` would add a "1 Metric" footer to every metric node in every lineage graph, a visual change nobody asked for.

**`Collections.singleton` over `Set.of`.** `Set.of(null)` throws; `singleton(null)` doesn't, and a `singleton{null}` rejects every `toColumn`, which is the correct degenerate behaviour. This removes a defensive `nullOrEmpty` branch that was impossible to reach (references come from `getEntityReferenceById`, which always populates the FQN) and therefore impossible to test.

**Alternatives rejected.**
- *Allow a column→node drop, with the metric node itself as the edge target.* Would need special-casing "node as column endpoint" in `onConnect`, `getUpdatedColumnsFromEdge`, `createColumnEdges`, `CanvasUtils.getColumnLineageCoordinates` and the tracing sets — five places instead of two, for the same user-visible result.
- *Expose the metric's semantic-layer `measures` / `dimensions` as its children.* Interesting for dbt/Cube-sourced metrics, but out of scope here and absent on the vast majority of metrics; the issue asks for the metric-as-a-whole link. Easy to layer on later since the resolver is the only place that would change.

**Backward compatibility / migration.** None needed. No schema change (`columnLineage` already takes any `fullyQualifiedEntityName`), so no `make generate` and no SQL migration. Existing metric edges are untouched; the change only *stops discarding* data that clients were already permitted to send. Validation is unchanged in strictness — `toColumn: "total_sales.not_a_column"` is still filtered out (covered by a test).

#
### Tests:

#### Use cases covered
- A user links `sales.amount` (table column) to the `Total Sales` metric and the mapping is persisted rather than silently dropped
- The reverse direction — a metric as the upstream of a table column — works symmetrically
- A metric node renders a connectable endpoint row when the Column Level Lineage layer or edit mode is active, and stays compact otherwise
- Clicking the source column traces through to the metric endpoint in the graph
- The edge shows up in column-level **Impact Analysis**, which is the concrete gap the issue calls out ("*I am not able to directly see visually the impact*")
- An invalid child under a metric FQN is still rejected by validation

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Files updated:
  - `openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/LineageRepositoryTest.java` — 3 new tests: `…_TableColumnToMetric_KeepsColumnLineage`, `…_MetricToTableColumn_KeepsColumnLineage`, `…_UnknownMetricChild_IsFilteredOut`
  - `openmetadata-ui/.../src/utils/EntityLineageUtils.test.tsx` — metric resolver returns the node as its own endpoint with `childrenCount: 0`
  - `openmetadata-ui/.../NodeChildren/NodeChildren.component.test.tsx` — metric node renders the endpoint row
- Java: `mvn -pl openmetadata-service -Dtest=LineageRepositoryTest test` → **22/22 pass**. Class-level jacoco is not a meaningful figure here (one test class against a 1040-line repository), so measuring the **changed line**: `LineageRepository.java:1200` is **4/4 instructions, 0 branches — 100% covered**.
- UI: `Lineage.constants.ts` **100%**, `NodeChildren.component.tsx` **98.66% lines**, and every line of the new `getMetricEntityChildren` (`EntityLineageNodeUtils.ts:127`) is covered — the file's residual uncovered ranges are all pre-existing code elsewhere in it.
- **Regression-verified**: reverting the `LineageRepository` change makes 2 of the 3 Java tests fail (`expected: <1> but was: <0>`); reverting the resolver makes both new Jest tests fail. They fail without the fix, which is the point.
- No regressions: 26 lineage-related Jest suites / 434 tests pass.

#### Backend integration tests
- [x] Not applicable — no new or changed REST endpoint. `PUT /api/v1/lineage` already accepted this payload; the fix is in validation behaviour, covered by the unit tests above plus the manual API verification below.

#### Ingestion integration tests
- [x] Not applicable — no ingestion changes.

#### Playwright (UI) tests
- [x] I added a Playwright E2E test for the UI change.
- Files updated:
  - `openmetadata-ui/.../playwright/e2e/Pages/Lineage/DataAssetLineage.spec.ts` — `Column lineage between a table column and a metric`: adds the edge, reloads to prove it persisted server-side, asserts the column-level Impact Analysis row, then removes it
  - `openmetadata-ui/.../playwright/utils/lineage.ts` — `metric` branch in `getEntityColumns` (a metric is its own column endpoint)
- Deliberately a single targeted spec rather than adding `metric` to the `columnLevelEntities` N×N matrix, which would have added ~17 slow tests for code paths the other 8 entity types already cover.

#### Manual testing performed

Full local stack built from this branch (`./docker/run_local_docker.sh -m ui -d mysql -s false -i false -r false`), sample data created over the REST API — a `sales` fact table with an `amount` column and a `total_sales` metric (`Total Sales = SUM(sales.amount)`), i.e. the issue's own example.

1. `PUT /api/v1/lineage` with `columnsLineage: [{fromColumns: ["sales_demo.sales_db.public.sales.amount"], toColumn: "total_sales", function: "SUM"}]`
2. `GET /api/v1/lineage/table/name/sales_demo.sales_db.public.sales` → mapping present in the relationship row (**empty before this fix**)
3. `GET /api/v1/lineage/getLineage?...` → same mapping present in the search index, i.e. what the graph reads
4. Table → Lineage tab → **Layers → Column** → the edge is drawn from `amount` into the metric's `Total Sales` row
5. Clicked `amount` → both the column row and the metric endpoint row take `custom-node-header-column-tracing`, confirming a real column edge in the graph rather than just a node edge
6. **Impact Analysis → Impact On: Column** → row `sales / amount → total_sales / total_sales`, depth 1, with `data-row-key="sales_demo.sales_db.public.sales.amount->total_sales"`
7. Negative path: `PUT` with `toColumn: "total_sales.not_a_column"` alongside a valid entry → `200`, and only the valid entry is stored

> Note: steps 1–7 were run against a build carrying the functionally identical `Set.of(fqn)` form of the one-line change; the later swap to `Collections.singleton(fqn)` has identical `contains` semantics for a non-null FQN and is covered by the 22 passing unit tests.

#
### UI screen recording / screenshots:

<!-- ATTACH: drag the two PNGs here, then delete this comment -->

**Column-level lineage graph** — `sales.amount` → `Total Sales`, both endpoints traced:
<img width="1200" height="863" alt="column-lineage-graph" src="https://github.com/user-attachments/assets/33bb97d2-468a-44ea-a58f-fff097e10d1c" />

**Column-level Impact Analysis** — the impact row the issue asked for:
<img width="1200" height="863" alt="impact-analysis" src="https://github.com/user-attachments/assets/6d905a1b-8095-464e-8312-10fe5bea2848" />



#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. — no schema change; `columnLineage.toColumn` already accepts any `fullyQualifiedEntityName`.
- [x] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- New feature -->
- [x] The issue properly describes why the new feature is needed, what's the goal, and how we are building it.
- [x] I have updated the documentation. — N/A: no user-facing docs describe the per-entity-type column-lineage support matrix; behaviour is discoverable in the UI.
- [x] I have added tests around the new logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
