### PR TITLE
Fixes 33170: fail fast when DQ SDK credentials come back masked

### DIFF
--- a/ingestion/src/metadata/sdk/data_quality/workflow_config_builder.py
+++ b/ingestion/src/metadata/sdk/data_quality/workflow_config_builder.py
@@ -50,9 +50,36 @@ from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.ingestion.models.custom_pydantic import BaseModel
 from metadata.ingestion.ometa.client import APIError
 from metadata.ingestion.ometa.ometa_api import OpenMetadata as OMeta
+from metadata.ingestion.ometa.utils import model_str
 from metadata.utils.entity_reference import require_entity_reference_id
 
 T = TypeVar("T", bound=BaseModel)
+
+# PasswordEntityMasker.PASSWORD_MASK. The API substitutes this for every secret field
+# when the caller is not a bot (Authorizer.shouldMaskPasswords == !subjectContext.isBot()).
+SERVER_PASSWORD_MASK = "*" * 9
+
+
+def _find_masked_fields(value: Any, path: str = "") -> list[str]:
+    """Collect dotted paths of connection fields holding the server's password mask.
+
+    Walks the dumped connection rather than the model so that `secret:` references are
+    left untouched: resolving one would mean a live call to the secrets manager, which
+    a validation pass has no business making.
+    """
+    if isinstance(value, str):
+        return [path] if value == SERVER_PASSWORD_MASK else []
+    if isinstance(value, dict):
+        return [
+            masked
+            for key, child in value.items()
+            for masked in _find_masked_fields(child, f"{path}.{key}" if path else str(key))
+        ]
+    if isinstance(value, list):
+        return [
+            masked for index, child in enumerate(value) for masked in _find_masked_fields(child, f"{path}[{index}]")
+        ]
+    return []
 
 
 class WorkflowConfigBuilder:
@@ -130,7 +157,29 @@ class WorkflowConfigBuilder:
         service = self._safe_get_by_id(DatabaseService, service_id)
 
         self.service_connection = cast(DatabaseConnection, service.connection)  # noqa: TC006
+        self._raise_if_credentials_masked(model_str(service.name))
         return self
+
+    def _raise_if_credentials_masked(self, service_name: str) -> None:
+        """Fail here rather than letting a masked credential reach the source.
+
+        A workflow built from masked credentials fails much later as an authentication
+        error from the source itself, which points at the source instead of at the token
+        that caused it.
+        """
+        if self.service_connection is None:
+            return
+
+        masked_fields = _find_masked_fields(self.service_connection.model_dump())
+        if not masked_fields:
+            return
+
+        raise ValueError(
+            f"Connection credentials for service '{service_name}' came back masked "
+            f"({', '.join(masked_fields)}). OpenMetadata returns real credentials only to bot "
+            "accounts, so authenticate with a bot token (for example ingestion-bot) rather than "
+            "a personal access token."
+        )
 
     def with_force_test_update(self, force_test_update: bool) -> Self:
         self.force_test_update = force_test_update

--- a/ingestion/tests/unit/sdk/data_quality/test_workflow_config_builder.py
+++ b/ingestion/tests/unit/sdk/data_quality/test_workflow_config_builder.py
@@ -18,6 +18,9 @@ import pytest
 
 from metadata.data_quality.api.models import TestCaseDefinition
 from metadata.generated.schema.entity.data.table import Column, DataType, Table
+from metadata.generated.schema.entity.services.connections.database.common.basicAuth import (
+    BasicAuth,
+)
 from metadata.generated.schema.entity.services.connections.database.mysqlConnection import (
     MysqlConnection,
 )
@@ -40,7 +43,12 @@ from metadata.generated.schema.type.basic import (
     Markdown,
 )
 from metadata.generated.schema.type.entityReference import EntityReference
-from metadata.sdk.data_quality.workflow_config_builder import WorkflowConfigBuilder
+from metadata.ingestion.models.custom_pydantic import CustomSecretStr
+from metadata.sdk.data_quality.workflow_config_builder import (
+    SERVER_PASSWORD_MASK,
+    WorkflowConfigBuilder,
+    _find_masked_fields,
+)
 
 
 @pytest.fixture
@@ -539,3 +547,81 @@ def test_build_without_table_raises_assertion(mock_ometa_client, test_definition
 
     with pytest.raises(AssertionError, match="Table entity not provided"):
         builder.build()
+
+
+@pytest.fixture
+def masked_service(mock_table):
+    """Service whose password the API masked, as it does for every non-bot caller"""
+    return _service_with_password(mock_table, SERVER_PASSWORD_MASK)
+
+
+@pytest.fixture
+def secret_ref_service(mock_table):
+    """Service whose password is a secrets-manager reference rather than a value"""
+    return _service_with_password(mock_table, "secret:/cluster/databaseservice/mysql/password")
+
+
+def _service_with_password(table, password):
+    """Build a mock service carrying the given raw password value"""
+    connection = DatabaseConnection.model_construct(
+        config=MysqlConnection.model_construct(
+            type="Mysql",
+            username="test_user",
+            hostPort="localhost:3306",
+            authType=BasicAuth(password=CustomSecretStr(password)),
+        )
+    )
+    return DatabaseService.model_construct(id=table.service.id, name=EntityName("MySQL"), connection=connection)
+
+
+def test_with_table_raises_when_credentials_are_masked(mock_ometa_client, masked_service):
+    """A masked password means the caller is not a bot, so fail before building anything"""
+    mock_ometa_client.get_by_id.return_value = masked_service
+    builder = WorkflowConfigBuilder(client=mock_ometa_client)
+
+    with pytest.raises(ValueError, match="came back masked") as exc_info:
+        builder.with_table("MySQL.default.test_db.test_table")
+
+    message = str(exc_info.value)
+    assert "config.authType.password" in message
+    assert "ingestion-bot" in message
+    # EntityName is a RootModel: str() would render "root='MySQL'" instead of the name
+    assert "service 'MySQL'" in message
+
+
+def test_with_table_allows_secret_manager_reference(mock_ometa_client, secret_ref_service):
+    """A `secret:` reference is a valid credential resolved at connection time, not a mask"""
+    mock_ometa_client.get_by_id.return_value = secret_ref_service
+    builder = WorkflowConfigBuilder(client=mock_ometa_client)
+
+    builder.with_table("MySQL.default.test_db.test_table")
+
+    password = builder.service_connection.config.authType.password
+    assert password.get_secret_value(skip_secret_manager=True).startswith("secret:")
+
+
+def test_with_table_allows_real_credentials(mock_ometa_client, mock_table):
+    """A real password passes through untouched"""
+    mock_ometa_client.get_by_id.return_value = _service_with_password(mock_table, "real-password")
+    builder = WorkflowConfigBuilder(client=mock_ometa_client)
+
+    builder.with_table("MySQL.default.test_db.test_table")
+
+    password = builder.service_connection.config.authType.password
+    assert password.get_secret_value(skip_secret_manager=True) == "real-password"
+
+
+def test_find_masked_fields_reports_every_masked_path():
+    """Nested dicts and lists are both walked, and non-masked values are ignored"""
+    payload = {
+        "config": {
+            "authType": {"password": SERVER_PASSWORD_MASK},
+            "username": "not-a-secret",
+            "extras": [{"token": SERVER_PASSWORD_MASK}, {"token": "secret:/a/b"}],
+        }
+    }
+
+    assert _find_masked_fields(payload) == [
+        "config.authType.password",
+        "config.extras[0].token",
+    ]


### PR DESCRIPTION
### Describe your changes:

Fixes #33170

`WorkflowConfigBuilder.with_table()` fetches the database service with `get_by_id`, which the API masks for every caller that is not a bot (`ServiceEntityResource.decryptOrNullify` → `Authorizer.shouldMaskPasswords` → `!subjectContext.isBot()`). The masked value was stored on `service_connection` and passed straight into `Source(...)`, so a run started with a personal access token failed much later as an authentication error from the source — pointing at the source rather than at the token that actually caused it.

This detects `PasswordEntityMasker.PASSWORD_MASK` right after the service is fetched and raises with the offending field paths and the remedy.

The check walks the **dumped** connection rather than the model, which matters: `secret:` references are valid credentials resolved at connection time by `get_connection_url_common`, and reading one through `get_secret_value()` would fire a live secrets-manager call from what should be a cheap validation. `model_dump()` leaves them intact, so references pass through untouched and only the literal mask trips the guard.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- SDK driven with a personal access token gets an immediate, actionable error naming the masked field instead of a downstream source authentication failure
- SDK driven with a bot token against a server using an external secrets manager still builds — `secret:` references are not treated as masks
- SDK driven with a bot token against a server storing credentials inline still builds

#### Unit tests
- [x] I added unit tests for the new logic.
- Files updated: `ingestion/tests/unit/sdk/data_quality/test_workflow_config_builder.py`
- Added 4 tests: masked credentials raise; `secret:` reference passes; real credential passes; `_find_masked_fields` walks nested dicts and lists
- Both behaviour changes were RED-checked — reverting the guard fails exactly `test_with_table_raises_when_credentials_are_masked`, and reverting the `model_str()` call fails the same test on `service 'root='MySQL''`

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable — the change is a validation guard in the SDK builder, covered by unit tests.

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. `ruff format --check` and `ruff check` clean on both changed files
2. `pytest ingestion/tests/unit/sdk/` — 454 passed, 1 skipped
3. Reproduced the original behaviour against a live instance: with a PAT the connection came back `*********`; with the `ingestion-bot` token it came back as a `secret:` reference that resolved to a real password at engine-build time

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. (No schema changes.)
- [x] For UI changes: I attached a screen recording and/or screenshots above. (No UI changes.)
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

- [x] I have added a test that covers the exact scenario we are fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLaYpRGBYYQbd4hZKhHpgT