### PR TITLE
fix(test): restore dropped assertNull import in JwtFilterTest (2.0 build fix)

### DIFF
--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/JwtFilterTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/JwtFilterTest.java
@@ -15,6 +15,7 @@ package org.openmetadata.service.security;
 
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
## What
Add the missing `import static org.junit.jupiter.api.Assertions.assertNull;` to `openmetadata-service/.../security/JwtFilterTest.java` on `2.0`.

## Why
The `2.0` branch tip (`384b5ed0a`) fails to compile its tests:

```
JwtFilterTest.java:[602/648/664] cannot find symbol
  method assertNull(java.util.Set<java.lang.String>)
```

This breaks the nightly **Build and push Collate** job (openmetadata-service `testCompile`).

Root cause: #32961 (*"Fixes #32960: Sync SSO roles from the provider's id_token"*) was brought to `2.0` as a **direct manual cherry-pick** (`384b5ed0a`, no backport PR, committed 2026-09-10). It added three `assertNull(context.userRoles())` role-sync tests, but the `assertNull` static import didn't come across — `2.0`'s import block had diverged from `main`, so that hunk dropped. `main` has the import (`JwtFilterTest.java:18`) and is green; `2.0` does not. With no backport PR, nothing ran test-compile on the result, so the break only surfaced in the nightly.

## Change
One line — restores the import in alphabetical order (`assertEquals` → **`assertNull`** → `assertThrows` → `assertTrue`). No test-logic change; the `assertNull(...)` calls added by the cherry-pick now resolve.