### PR TITLE
fix(playwright): stabilize bulk re-deploy and Persona AI Context entity-type tests

### DIFF
--- a/.github/playwright/impact-map.generated.json
+++ b/.github/playwright/impact-map.generated.json
@@ -4079,6 +4079,7 @@
       "specs": [
         "playwright/e2e/Features/BulkEditEntity.spec.ts",
         "playwright/e2e/Features/OnlineUsers.spec.ts",
+        "playwright/e2e/Features/TestSuitePipelineRedeploy.spec.ts",
         "playwright/e2e/Pages/Teams.spec.ts"
       ]
     },

--- a/openmetadata-ui/src/main/resources/ui/eslint-suppressions.json
+++ b/openmetadata-ui/src/main/resources/ui/eslint-suppressions.json
@@ -518,11 +518,6 @@
       "count": 3
     }
   },
-  "playwright/e2e/Features/TestSuitePipelineRedeploy.spec.ts": {
-    "om-playwright/no-positional-locator": {
-      "count": 1
-    }
-  },
   "playwright/e2e/Features/Topic.spec.ts": {
     "om-playwright/no-positional-locator": {
       "count": 3

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaAIContextRules.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaAIContextRules.spec.ts
@@ -452,14 +452,18 @@ test.describe.serial('Persona AI Context — Rule Builder', () => {
       await openAddRuleDrawer(page);
 
       await test.step('switch to a knowledge entity type', async () => {
-        await page.getByTestId('context-rule-entity-type').click();
+        // The popover can close on its own right after opening, while the drawer
+        // is still settling (the match preview and filter builder re-render as
+        // their requests land). The pending option click then waits out the test
+        // budget for a listbox that never comes back. selectOptionWithRetry
+        // reopens the popover and retries, as the entity-type switch test does.
         // Each option carries its EntityType as data-key. Matching the
         // "Knowledge" supporting text instead would match all three knowledge
         // types and leave DOM order to decide which one the test exercises.
-        await page
-          .getByRole('listbox')
-          .locator('[data-key="glossaryTerm"]')
-          .click();
+        await selectOptionWithRetry(
+          page.getByTestId('context-rule-entity-type'),
+          page.getByRole('listbox').locator('[data-key="glossaryTerm"]')
+        );
       });
 
       await test.step('Fully rendered switch must be checked and disabled', async () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuitePipelineRedeploy.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuitePipelineRedeploy.spec.ts
@@ -19,6 +19,7 @@ import {
   redirectToHomePage,
   toastNotification,
 } from '../../utils/common';
+import { getRowByName } from '../../utils/scopedLocators';
 import { settingClick } from '../../utils/sidebar';
 
 // use the admin user to login
@@ -26,6 +27,12 @@ test.use({ storageState: 'playwright/.auth/admin.json' });
 
 const table1 = new TableClass();
 const table2 = new TableClass();
+
+// The grid lists every test-suite pipeline in the deployment, not just this spec's, and the
+// default page holds 15. Widen it so both pipelines below are always on the page the test
+// reads -- the listing is name-ordered and pipelines named with a bare UUID (how
+// DataContractRepository names a contract's DQ pipeline) sort ahead of every `pw-*` one.
+const PIPELINE_PAGE_SIZE = 100;
 
 test.describe('Bulk Re-Deploy pipelines ', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
   test.beforeAll('Setup pre-requests', async ({ browser }) => {
@@ -36,6 +43,17 @@ test.describe('Bulk Re-Deploy pipelines ', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
 
     await table1.createTestSuiteAndPipelines(apiContext);
     await table2.createTestSuiteAndPipelines(apiContext);
+
+    await afterAction();
+  });
+
+  // Without this the two services -- and the test-suite pipelines under them -- outlive the
+  // spec and stay in the shared Data Observability listing for every later test in the shard.
+  test.afterAll('Cleanup', async ({ browser }) => {
+    const { afterAction, apiContext } = await createNewPage(browser);
+
+    await table1.delete(apiContext);
+    await table2.delete(apiContext);
 
     await afterAction();
   });
@@ -52,32 +70,36 @@ test.describe('Bulk Re-Deploy pipelines ', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
   test('Re-deploy all test-suite ingestion pipelines', async ({ page }) => {
     await settingClick(page, GlobalSettingOptions.DATA_OBSERVABILITY);
 
+    // usePaging seeds pageSize from the URL on first render, so widening the page is a
+    // navigation rather than a click through the (conditionally rendered) size selector.
+    const listUrl = new URL(page.url());
+    listUrl.searchParams.set('pageSize', String(PIPELINE_PAGE_SIZE));
+    await page.goto(listUrl.toString());
+
     await expect(
       page.getByRole('button', { name: 'Re Deploy' })
     ).not.toBeEnabled();
     await expect(page.getByTestId('ingestion-list-table')).toBeVisible();
 
-    // beforeAll creates one test-suite pipeline per table, and there are two
-    // tables -- so this is the fixture's count, not an arbitrary number. One
-    // source for it, so the deploy assertion below cannot drift from the
-    // selection here.
-    const selectedPipelineCount = 2;
-    // TableV2 selection: the sr-only checkbox input is pointer-intercepted, so
-    // target the pressable label slot rather than the raw input.
-    const rowCheckboxes = page.locator('td label[slot="selection"]');
+    // Select this spec's own pipelines by name. Selecting by row position instead meant the
+    // test never touched them: the listing is global, so the top rows belong to whatever else
+    // exists in the deployment, and the assertion below then tracked a foreign pipeline whose
+    // deployability this spec does not control.
+    const pipelines = [
+      table1.testSuitePipelineResponseData[0],
+      table2.testSuitePipelineResponseData[0],
+    ];
 
-    // The listing is global and can lag behind the pipelines this spec just
-    // created. Wait for enough rows first: nth() on a shorter list auto-waits
-    // and would spend the whole budget instead of saying what was missing.
-    await expect
-      .poll(() => rowCheckboxes.count(), {
-        message: `Wait for at least ${selectedPipelineCount} test-suite pipelines to be listed`,
-        timeout: 30_000,
-      })
-      .toBeGreaterThanOrEqual(selectedPipelineCount);
+    for (const pipeline of pipelines) {
+      const row = getRowByName(page, pipeline.name);
 
-    for (let index = 0; index < selectedPipelineCount; index++) {
-      await rowCheckboxes.nth(index).click();
+      // hasText is a substring match, so pin it to exactly one row before selecting it --
+      // otherwise a near-miss silently selects the wrong pipeline, or several.
+      await expect(row).toHaveCount(1);
+      // TableV2 selection: the sr-only checkbox input is pointer-intercepted, so
+      // target the pressable label slot rather than the raw input.
+      await row.locator('label[slot="selection"]').click();
+      await expect(row.getByRole('checkbox')).toBeChecked();
     }
 
     await expect(page.getByRole('button', { name: 'Re Deploy' })).toBeEnabled();
@@ -88,13 +110,20 @@ test.describe('Bulk Re-Deploy pipelines ', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
     // toast instead, and the test then waits out its whole budget for a success
     // toast that can never arrive. Collect every deploy and report the real
     // status, so a genuine deploy failure fails fast and says why.
-    const deployStatuses: number[] = [];
+    //
+    // Keyed by pipeline id rather than pushed onto a list: an id says which pipeline failed
+    // straight from the assertion diff, and a deploy this test did not ask for cannot pad the
+    // count into passing.
+    const deployStatuses: Record<string, number> = {};
     const collectDeploy = (response: Response) => {
-      if (
-        response.request().method() === 'POST' &&
-        response.url().includes('/api/v1/services/ingestionPipelines/deploy')
-      ) {
-        deployStatuses.push(response.status());
+      const deployedId = response
+        .url()
+        .match(
+          /\/api\/v1\/services\/ingestionPipelines\/deploy\/([^/?]+)/
+        )?.[1];
+
+      if (response.request().method() === 'POST' && deployedId) {
+        deployStatuses[deployedId] = response.status();
       }
     };
     page.on('response', collectDeploy);
@@ -103,16 +132,18 @@ test.describe('Bulk Re-Deploy pipelines ', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
       await page.getByRole('button', { name: 'Re Deploy' }).click();
 
       await expect
-        .poll(() => deployStatuses.length, {
+        .poll(() => Object.keys(deployStatuses).length, {
           message: 'Wait for every selected pipeline to report a deploy result',
           timeout: 30_000,
         })
-        .toBe(selectedPipelineCount);
+        .toBe(pipelines.length);
 
       expect(
         deployStatuses,
         'every selected pipeline must deploy for the success toast to appear'
-      ).toEqual(Array(selectedPipelineCount).fill(200));
+      ).toEqual(
+        Object.fromEntries(pipelines.map((pipeline) => [pipeline.id, 200]))
+      );
     } finally {
       // Scope the listener to the action it observes: left attached it would
       // keep collecting for the page's lifetime, and a second test in this

--- a/openmetadata-ui/src/main/resources/ui/playwright/eslint-rules/tests/corpus.test.mjs
+++ b/openmetadata-ui/src/main/resources/ui/playwright/eslint-rules/tests/corpus.test.mjs
@@ -41,7 +41,7 @@ test('the suppressions baseline matches its recorded state exactly', () => {
   // of the same rule in the same file stays invisible here.
   const EXPECTED = {
     'om-playwright/justified-rule-disable': 12,
-    'om-playwright/no-positional-locator': 1298,
+    'om-playwright/no-positional-locator': 1297,
     'om-playwright/require-assertion-per-test': 1,
     'playwright/no-skipped-test': 4,
     'playwright/no-wait-for-selector': 35,


### PR DESCRIPTION
### Describe your changes:

<!-- Fixes #<issue-number> -->
_No linked issue: test-only merge-queue flake fixes, bypassed with `skip-pr-checks`._

Fixes two merge-queue Playwright flakes, plus the checkstyle baseline the first one touches.

#### 1. Bulk re-deploy picked pipelines it does not own

`TestSuitePipelineRedeploy.spec.ts` › *Re-deploy all test-suite ingestion pipelines* selected the **first two rows** of the Data Observability grid. That grid lists every test-suite pipeline in the deployment, ordered by pipeline `name`. Data Contract DQ pipelines are named with a bare UUID (`DataContractRepository.createIngestionPipeline` → `UUID.randomUUID()`), so they always sort ahead of the spec's own `pw-test-suite-pipeline-*` pipelines — including the `dim_address_comprehensive_contract` pipeline that ships in sample data. The test was redeploying pipelines it does not own, and failed whenever one of those did not deploy.

Seen in merge-queue run [34475633731](https://github.com/open-metadata/OpenMetadata/actions/runs/34475633731) (`ingestion-01`): the deploy of a foreign Data Contract pipeline returned 400 (Airflow returned 500 while refreshing the DAG) on both attempts. The PR in the queue did not touch this area.

Changes:
- Select the spec's own two pipelines by name (`getRowByName` pinned with `toHaveCount(1)`), click TableV2's `label[slot="selection"]`, and assert `toBeChecked()`.
- Widen the grid with `?pageSize=100` (`usePaging` seeds `pageSize` from the URL) so both pipelines are always on the page the test reads.
- Key collected deploy statuses by pipeline id: a failure names the pipeline in the assertion diff, and an unrelated deploy cannot pad the count.
- Add `afterAll` cleanup: the spec leaked both database services (and their suites/pipelines) into the shared listing for the rest of the shard.
- Prune the now-stale `om-playwright/no-positional-locator` suppression and regenerate `impact-map.generated.json`.
- Lower the recorded `om-playwright/no-positional-locator` total in `playwright/eslint-rules/tests/corpus.test.mjs` from 1298 to 1297 to match the pruned baseline (UI Checkstyle's "suppressions baseline matches its recorded state exactly" test).

#### 2. Persona AI Context: entity-type popover closed under the click

`PersonaAIContextRules.spec.ts` › *knowledge entity type forces Fully rendered on and disables it* failed on both attempts in merge-queue run [34521159069](https://github.com/open-metadata/OpenMetadata/actions/runs/34521159069) (`chromium-07`) and was flaky in this branch's dispatch run. The trace shows the Add Rule drawer's entity-type popover closing on its own about 0.1s after it opened — while the match preview and filter builder were still re-rendering as their requests landed — with the value still `Table`. The pending click on the `glossaryTerm` option then waited out the 60s budget for a listbox that never came back.

- Use the existing `selectOptionWithRetry` helper, which reopens the popover and retries the option click — the same helper the entity-type switch test in this spec already uses on this dropdown.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small, test-only change (5 files).

#
### Tests:

#### Use cases covered
- Bulk re-deploy of selected test-suite pipelines from Settings › Services › Data Observability succeeds and shows the success toast, regardless of which other test-suite pipelines exist in the deployment.
- Switching a Persona AI Context rule to a knowledge entity type (Glossary Term) forces *Fully rendered* on and disables it, even when the entity-type popover closes before the option click lands.

#### Unit tests
Not applicable — Playwright spec change only; no product code changed.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- Files updated: `openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuitePipelineRedeploy.spec.ts`, `openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaAIContextRules.spec.ts`, `openmetadata-ui/src/main/resources/ui/playwright/eslint-rules/tests/corpus.test.mjs`
- CI: full-suite dispatch run [34564006493](https://github.com/open-metadata/OpenMetadata/actions/runs/34564006493) on this branch (before the PersonaAIContextRules fix) — **passed**. `TestSuitePipelineRedeploy` passed on the first attempt in `ingestion-02` (6.1s); run totals: 4505 passed, 0 failed, 7 flaky (all unrelated chromium specs).
- Static, on the branch after merging main: `yarn lint:playwright` 0 errors, `yarn test:eslint-rules` 114/114, rule-table `--check` clean, `tsc` 0 errors in both specs, prettier clean, `generate_playwright_impact_map.py --check` up to date.

#### Manual testing performed
1. Ran the spec against a local stack (OpenMetadata server + Airflow) with `PW_DEDICATED_INGESTION=true PW_PRESEEDED_STATE=true npx playwright test playwright/e2e/Features/TestSuitePipelineRedeploy.spec.ts --project=Ingestion`.
2. Fixed spec: the server log shows exactly two `POST /ingestionPipelines/deploy/{id}` calls, both 200, for the two pipelines `beforeAll` created; `afterAll` then hard-deleted both services.
3. Pre-fix spec on the same instance: it deployed the `Data Contract - dim_address_comprehensive_contract` pipeline, reproducing the CI selection bug.
4. Caveats: that local instance's sidebar had no Settings entry, so `settingClick` was swapped for a direct `goto` to the same route for these runs, and it served the pre-TableV2 grid. The committed spec (TableV2 selection + `settingClick`) passed in the CI run above; its deploy assertion is keyed to the spec's own pipeline ids, so the pass confirms it deployed exactly those two.
5. PersonaAIContextRules: diagnosed from the merge-queue trace (DOM snapshots and screencast frames), not reproduced locally. The fix reuses a helper already proven on this dropdown in the same spec; this PR's Playwright run exercises it.

#
### UI screen recording / screenshots:

Not applicable — no product UI change; Playwright spec only.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` — N/A, no linked issue (`skip-pr-checks`).
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above. — N/A, bypassed with `skip-pr-checks`.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. — N/A, no schema changes.
- [ ] For UI changes: I attached a screen recording and/or screenshots above. — N/A, no product UI change.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

- [x] I have added a test that covers the exact scenario we are fixing. (The fix is to the test itself; verified locally that the pre-fix selection deploys a foreign Data Contract pipeline and the fixed selection does not.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

