### PR TITLE
ci(playwright): surface logs when a fast-env container exits during startup

### DIFF
--- a/.github/scripts/start_playwright_fast_environment.sh
+++ b/.github/scripts/start_playwright_fast_environment.sh
@@ -212,7 +212,8 @@ pull_image_with_retry "$PW_OPENSEARCH_IMAGE"
 docker compose -f "$compose_file" -f "$fast_compose_file" up -d --no-build postgresql opensearch
 
 for service in postgresql opensearch; do
-  container_id=$(docker compose -f "$compose_file" -f "$fast_compose_file" ps -q "$service")
+  # -a: without it an exited container yields an empty id and we never reach docker logs below
+  container_id=$(docker compose -f "$compose_file" -f "$fast_compose_file" ps -a -q "$service")
   for _ in $(seq 1 90); do
     status=$(docker inspect "$container_id" --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}')
     [[ "$status" == "healthy" ]] && break


### PR DESCRIPTION
## Summary

Merge-queue run [34515976437](https://github.com/open-metadata/OpenMetadata/actions/runs/34515976437/job/103009794529) dropped #32710 because shard `chromium-20` failed in *Restore fast Playwright environment* before any test ran:

```
Container openmetadata_opensearch  Started
invalid container name or ID: value is empty
##[error]Process completed with exit code 1.
```

OpenSearch exited ~2s after `docker compose up`. `docker compose ps -q` only lists **running** containers, so the lookup returned an empty id, `docker inspect ""` aborted the script under `set -e`, and the cleanup trap then removed the containers — so *why* OpenSearch exited was never captured.

## Fix

`ps -a -q`, so an exited container still resolves. It then reports `unhealthy`, falls into the existing `docker logs` + "did not become healthy" branch, and the next occurrence tells us the actual cause.

## Test plan

- [x] Local repro (Docker 29.6 / Compose v5.3) with a service that exits immediately: `ps -q` → empty, `ps -a -q` → container id; `docker inspect` on it → `unhealthy`, `docker logs` → the container's output.
- [x] `pytest .github/scripts/tests/test_playwright_ci_planning.py .github/scripts/tests/test_playwright_cache_assets.py` — 127 passed.
- [x] `bash -n` + `shellcheck` clean on the changed lines.

## Notes

- The script is in `FIXTURE_PREFIXES` (`playwright_cache_fingerprint.py`), so this changes the fixture fingerprint → one golden-fixture rebuild after merge.
- An exited container still waits out the existing 90×2s health loop (~3 min, inside the step's 5 min `timeout`) before its logs are dumped. Could break early on `.State.Running == false` if that turns out to matter.
- Doesn't attempt to fix *why* OpenSearch exited (1 occurrence in the last 15 failed runs of this workflow) — this makes the next one diagnosable.
- No linked issue: CI-infra-only change, following the `ci(playwright): …` convention (as in #33086 / #33061 / #33046); metadata check bypassed via `skip-pr-checks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
