### PR TITLE
Backport #32746 to 2.0: render error state on TestSuiteDetailsPage fetch failure

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/TestSuiteDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/TestSuiteDetailsPage.component.tsx
@@ -25,6 +25,7 @@ import {
 import { Copy01 } from '@untitledui/icons';
 import { Tabs, TabsProps } from 'antd';
 import classNames from 'classnames';
+import { isUndefined } from 'lodash';
 import { ComponentProps, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -255,6 +256,10 @@ const TestSuiteDetailsPage = () => {
         type={ERROR_PLACEHOLDER_TYPE.PERMISSION}
       />
     );
+  }
+
+  if (isUndefined(testSuite)) {
+    return <ErrorPlaceHolder />;
   }
 
   return (

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/TestSuiteDetailsPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/TestSuiteDetailsPage.test.tsx
@@ -1102,9 +1102,10 @@ describe('TestSuiteDetailsPage component', () => {
         renderWithQueryClient(<TestSuiteDetailsPage />);
       });
 
-      // Component should still render without crashing
+      // When the suite fetch resolves to no data, the page should fall back to
+      // the error placeholder rather than rendering a degraded empty header.
       expect(
-        await screen.findByText('HeaderBreadcrumb.component')
+        await screen.findByText('ErrorPlaceHolder.component')
       ).toBeInTheDocument();
     });
 


### PR DESCRIPTION
Backport of #32746 to `2.0`.

Fixes #32683.

## What

When the test suite fetch fails (e.g. a 404 for a just-deleted suite, or a 5xx after retries), `testSuite` is `undefined` while `isLoading` is `false`, so `TestSuiteDetailsPage` fell through its loading and permission guards and rendered an empty header with a malformed ` Details` tab title. It now renders `<ErrorPlaceHolder />`, matching the sibling detail pages.

## Backport notes

Cherry-picked from f8098d5f959953a006855397a518862b2f7a0e46. One delta vs. the `main` PR:

- The app-mode `TestSuiteDetail` component (`components/observability/TestSuiteDetail/*`) does not exist on `2.0`, so that half of the fix was dropped. Only the classic `TestSuiteDetailsPage` guard and its test are included.

## Testing

- `TestSuiteDetailsPage.test.tsx`: 39/39 pass on `2.0` (run locally against `main`'s `node_modules`).
- organize-imports + prettier: no changes. ESLint left to CI — `main`'s `node_modules` can't load `2.0`'s `eslint.config.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
