### PR TITLE
Backport #33117 to 2.0: build profiler partitioning from the form, not stale state

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/Profiler.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/Profiler.spec.ts
@@ -409,6 +409,46 @@ test.describe(
           page.getByTestId('profile-sample').locator('div')
         ).toBeVisible();
       });
+
+      await test.step('Preserve partitioning when saving without any edit', async () => {
+        // Close the drawer the previous step left open, then reopen it clean.
+        await page.getByRole('button', { name: 'Cancel' }).click();
+        await page
+          .getByTestId('profiler-settings-modal')
+          .waitFor({ state: 'detached' });
+
+        await page.click('[data-testid="profiler-setting-btn"]');
+        await page.getByTestId('profiler-settings-modal').waitFor();
+        await expect(page.getByTestId('interval-type')).toBeVisible();
+
+        const updateTableProfilerConfigResponse = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/tables/') &&
+            response.url().includes('/tableProfilerConfig') &&
+            response.request().method() === 'PUT'
+        );
+        await page.getByRole('button', { name: 'Save' }).click();
+        const updateResponse = await updateTableProfilerConfigResponse;
+        const requestBody = await updateResponse.request().postData();
+
+        // Saving without touching anything must round-trip the stored
+        // partitioning block. The backend replaces this extension wholesale,
+        // so any field missing from the payload is erased on the server.
+        expect(requestBody).toEqual(
+          JSON.stringify({
+            excludeColumns: [table.entity?.columns[0].name],
+            profileQuery: 'select * from table',
+            includeColumns: [{ columnName: table.entity?.columns[1].name }],
+            partitioning: {
+              partitionColumnName: table.entity?.columns[2].name,
+              partitionIntervalType: 'COLUMN-VALUE',
+              partitionValues: ['test'],
+              enablePartitioning: true,
+            },
+            sampleDataCount: 100,
+          })
+        );
+      });
     });
   }
 );

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ProfilerSettingsModal/ProfilerSettingsModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ProfilerSettingsModal/ProfilerSettingsModal.test.tsx
@@ -20,8 +20,17 @@ import {
   waitFor,
 } from '@testing-library/react';
 import { Column } from '../../../../../generated/entity/data/dashboardDataModel';
+import {
+  DataType,
+  PartitionIntervalTypes,
+  PartitionIntervalUnit,
+  TableProfilerConfig,
+} from '../../../../../generated/entity/data/table';
 import { MOCK_TABLE } from '../../../../../mocks/TableData.mock';
-import { getTableProfilerConfig } from '../../../../../rest/tableAPI';
+import {
+  getTableProfilerConfig,
+  putTableProfileConfig,
+} from '../../../../../rest/tableAPI';
 import { ProfilerSettingsModalProps } from '../TableProfiler.interface';
 import ProfilerSettingsModal from './ProfilerSettingsModal';
 
@@ -39,8 +48,9 @@ jest.mock('../../../../../rest/tableAPI', () => ({
 const mockProps: ProfilerSettingsModalProps = {
   tableId: MOCK_TABLE.id,
   columns: [
-    { name: 'column1', dataType: 'string' },
-    { name: 'column2', dataType: 'timestamp' },
+    { name: 'column1', dataType: DataType.String },
+    { name: 'column2', dataType: DataType.Timestamp },
+    { name: 'column3', dataType: DataType.Int },
   ] as unknown as Column[],
   visible: true,
   onVisibilityChange: mockOnVisibilityChange,
@@ -55,37 +65,11 @@ const mockTableProfilerConfig = {
   includeColumns: [{ columnName: 'column2', metrics: ['column_count'] }],
   partitioning: {
     enablePartitioning: true,
-    partitionColumnName: 'column2',
-    partitionIntervalType: 'COLUMN-VALUE',
+    partitionColumnName: 'column1',
+    partitionIntervalType: PartitionIntervalTypes.ColumnValue,
     partitionValues: ['test'],
   },
 };
-
-jest.mock('../../../../../constants/profiler.constant', () => ({
-  DEFAULT_INCLUDE_PROFILE: [],
-  INTERVAL_TYPE_OPTIONS: [
-    { label: 'Column Value', value: 'COLUMN-VALUE' },
-    { label: 'Time Unit', value: 'TIME-UNIT' },
-  ],
-  INTERVAL_UNIT_OPTIONS: [
-    { label: 'Day', value: 'DAY' },
-    { label: 'Hour', value: 'HOUR' },
-  ],
-  PROFILER_MODAL_LABEL_STYLE: {},
-  PROFILE_SAMPLE_OPTIONS: [
-    { label: 'Percentage', value: 'PERCENTAGE' },
-    { label: 'Row Count', value: 'ROW_COUNT' },
-  ],
-  SUPPORTED_COLUMN_DATA_TYPE_FOR_INTERVAL: {
-    'COLUMN-VALUE': ['string'],
-    'TIME-UNIT': ['timestamp'],
-  },
-  TIME_BASED_PARTITION: ['TIME-UNIT'],
-}));
-
-jest.mock('../../../../../utils/ObjectUtils', () => ({
-  reducerWithoutAction: jest.fn(),
-}));
 
 jest.mock('../../../../../utils/ProfilerMetricsClassBase', () => ({
   __esModule: true,
@@ -106,12 +90,58 @@ jest.mock('../../../../../utils/ToastUtils', () => ({
 }));
 
 jest.mock('../../../SchemaEditor/SchemaEditor', () => {
-  return jest.fn().mockReturnValue(<div data-testid="schema-editor" />);
+  return jest
+    .fn()
+    .mockImplementation(({ onChange }: { onChange: (v: string) => void }) => (
+      <button
+        data-testid="schema-editor"
+        onClick={() => onChange('select 1 from table')}>
+        sql editor
+      </button>
+    ));
 });
 
 jest.mock('../../../../common/SliderWithInput/SliderWithInput', () => {
   return jest.fn().mockReturnValue(<div data-testid="slider-input" />);
 });
+
+/**
+ * Renders the modal with `config` already persisted, waits for it to load, and
+ * returns the payload `putTableProfileConfig` was called with after a Save.
+ */
+const renderAndSave = async (
+  config: TableProfilerConfig,
+  beforeSave?: () => Promise<void> | void
+): Promise<TableProfilerConfig> => {
+  (getTableProfilerConfig as jest.Mock).mockResolvedValueOnce({
+    ...MOCK_TABLE,
+    tableProfilerConfig: config,
+  });
+
+  await act(async () => {
+    render(<ProfilerSettingsModal {...mockProps} />);
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId('interval-type')).toBeInTheDocument();
+  });
+
+  if (beforeSave) {
+    await act(async () => {
+      await beforeSave();
+    });
+  }
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+  });
+
+  await waitFor(() => {
+    expect(putTableProfileConfig).toHaveBeenCalled();
+  });
+
+  return (putTableProfileConfig as jest.Mock).mock.calls[0][1];
+};
 
 describe('Test ProfilerSettingsModal component', () => {
   beforeEach(() => {
@@ -195,5 +225,138 @@ describe('Test ProfilerSettingsModal component', () => {
     await waitFor(() => {
       expect(sampleDataCount).toHaveAttribute('value', '100');
     });
+  });
+});
+
+describe('ProfilerSettingsModal partitioning round-trip', () => {
+  beforeEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+  });
+
+  it('should preserve a COLUMN-VALUE partitioning config when saved untouched', async () => {
+    const payload = await renderAndSave(mockTableProfilerConfig);
+
+    expect(payload.partitioning).toEqual({
+      enablePartitioning: true,
+      partitionColumnName: 'column1',
+      partitionIntervalType: PartitionIntervalTypes.ColumnValue,
+      partitionValues: ['test'],
+    });
+  });
+
+  it('should preserve a TIME-UNIT partitioning config when saved untouched', async () => {
+    const payload = await renderAndSave({
+      ...mockTableProfilerConfig,
+      partitioning: {
+        enablePartitioning: true,
+        partitionColumnName: 'column2',
+        partitionIntervalType: PartitionIntervalTypes.TimeUnit,
+        partitionInterval: 7,
+        partitionIntervalUnit: PartitionIntervalUnit.Day,
+      },
+    });
+
+    expect(payload.partitioning).toEqual({
+      enablePartitioning: true,
+      partitionColumnName: 'column2',
+      partitionIntervalType: PartitionIntervalTypes.TimeUnit,
+      partitionInterval: 7,
+      partitionIntervalUnit: PartitionIntervalUnit.Day,
+      partitionValues: undefined,
+    });
+  });
+
+  it('should preserve an INTEGER-RANGE partitioning config when saved untouched', async () => {
+    const payload = await renderAndSave({
+      ...mockTableProfilerConfig,
+      partitioning: {
+        enablePartitioning: true,
+        partitionColumnName: 'column3',
+        partitionIntervalType: PartitionIntervalTypes.IntegerRange,
+        partitionIntegerRangeStart: 1,
+        partitionIntegerRangeEnd: 100,
+      },
+    });
+
+    expect(payload.partitioning).toEqual({
+      enablePartitioning: true,
+      partitionColumnName: 'column3',
+      partitionIntervalType: PartitionIntervalTypes.IntegerRange,
+      partitionIntegerRangeStart: 1,
+      partitionIntegerRangeEnd: 100,
+      partitionValues: undefined,
+    });
+  });
+
+  it('should preserve partitioning when only the SQL query is edited', async () => {
+    // The SQL editor sits outside any `<Form>`, so editing it never reaches the
+    // form's `onValuesChange` -- the path that masked the bug for fields that do.
+    const payload = await renderAndSave(mockTableProfilerConfig, () => {
+      fireEvent.click(screen.getByTestId('schema-editor'));
+    });
+
+    expect(payload.profileQuery).toBe('select 1 from table');
+    expect(payload.partitioning).toEqual({
+      enablePartitioning: true,
+      partitionColumnName: 'column1',
+      partitionIntervalType: PartitionIntervalTypes.ColumnValue,
+      partitionValues: ['test'],
+    });
+  });
+
+  it('should send the edited value when a partition field is changed', async () => {
+    const payload = await renderAndSave(mockTableProfilerConfig, () => {
+      fireEvent.change(screen.getByTestId('partition-value'), {
+        target: { value: 'edited' },
+      });
+    });
+
+    expect(payload.partitioning?.partitionValues).toEqual(['edited']);
+  });
+
+  // Documents current behaviour, not desired behaviour: a stored config with a
+  // blank partition value cannot be saved at all until the field is cleared.
+  it('currently blocks the save outright when a stored partition value is blank', async () => {
+    (getTableProfilerConfig as jest.Mock).mockResolvedValueOnce({
+      ...MOCK_TABLE,
+      tableProfilerConfig: {
+        ...mockTableProfilerConfig,
+        partitioning: {
+          enablePartitioning: true,
+          partitionColumnName: 'column1',
+          partitionIntervalType: PartitionIntervalTypes.ColumnValue,
+          partitionValues: ['first', '', 'second'],
+        },
+      },
+    });
+
+    await act(async () => {
+      render(<ProfilerSettingsModal {...mockProps} />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('interval-type')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    });
+
+    // The blank value fails the `required` rule, so nothing is written at all
+    // rather than a config with the blank entry silently dropped.
+    expect(putTableProfileConfig).not.toHaveBeenCalled();
+  });
+
+  it('should send no partitioning when partitioning is disabled', async () => {
+    const payload = await renderAndSave({
+      ...mockTableProfilerConfig,
+      partitioning: {
+        ...mockTableProfilerConfig.partitioning,
+        enablePartitioning: false,
+      },
+    });
+
+    expect(payload.partitioning).toBeUndefined();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ProfilerSettingsModal/ProfilerSettingsModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ProfilerSettingsModal/ProfilerSettingsModal.tsx
@@ -104,7 +104,6 @@ const ProfilerSettingsModal: React.FC<ProfilerSettingsModalProps> = ({
       excludeCol: [],
       includeCol: DEFAULT_INCLUDE_PROFILE,
       enablePartition: false,
-      partitionData: undefined,
       selectedProfileSampleType: ProfileSampleType.Percentage,
     }),
     []
@@ -286,13 +285,21 @@ const ProfilerSettingsModal: React.FC<ProfilerSettingsModalProps> = ({
 
   const handleSave: FormProps['onFinish'] = useCallback(
     async (data: ProfilerForm) => {
-      const {
-        excludeCol,
-        sqlQuery,
-        includeCol,
-        enablePartition,
-        partitionData,
-      } = state;
+      const { excludeCol, sqlQuery, includeCol, enablePartition } = state;
+
+      // Read straight from the form: the loaded config is pushed into the
+      // form with `setFieldsValue`, which never fires `onValuesChange`, so
+      // any state copy is stale until the user edits a partition field.
+      const partitionData = pick(
+        data,
+        'partitionColumnName',
+        'partitionIntegerRangeEnd',
+        'partitionIntegerRangeStart',
+        'partitionInterval',
+        'partitionIntervalType',
+        'partitionIntervalUnit',
+        'partitionValues'
+      );
 
       setIsLoading(true);
       const {
@@ -328,8 +335,9 @@ const ProfilerSettingsModal: React.FC<ProfilerSettingsModalProps> = ({
           ? {
               ...partitionData,
               partitionValues:
-                partitionIntervalType === PartitionIntervalTypes.ColumnValue
-                  ? partitionData?.partitionValues?.filter(
+                data.partitionIntervalType ===
+                PartitionIntervalTypes.ColumnValue
+                  ? partitionData.partitionValues?.filter(
                       (value) => !isEmpty(value)
                     )
                   : undefined,
@@ -415,16 +423,6 @@ const ProfilerSettingsModal: React.FC<ProfilerSettingsModalProps> = ({
 
       handleStateChange({
         includeCol: data.includeColumns,
-        partitionData: pick(
-          data,
-          'partitionColumnName',
-          'partitionIntegerRangeEnd',
-          'partitionIntegerRangeStart',
-          'partitionInterval',
-          'partitionIntervalType',
-          'partitionIntervalUnit',
-          'partitionValues'
-        ),
       });
     },
     []

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/TableProfiler.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/TableProfiler.interface.ts
@@ -110,7 +110,6 @@ export interface ProfilerSettingModalState {
   excludeCol: string[];
   includeCol: ColumnProfilerConfig[];
   enablePartition: boolean;
-  partitionData: PartitionProfilerConfig | undefined;
   selectedProfileSampleType: ProfileSampleType | undefined;
 }
 


### PR DESCRIPTION
Backport of #33117 to `2.0`.

Fixes #32661.

## What

Saving the table profiler settings could silently erase the table's stored partitioning config. The loaded config is pushed into the form with `setFieldsValue`, which never fires `onValuesChange`, so `state.partitionData` stayed `undefined` unless the user edited a partition field — and `handleSave` built the payload from that stale state. The backend replaces the stored config wholesale, so every partition field except `enablePartitioning` was erased on the server. `handleSave` now reads the partition fields from the submitted form values, and the stale state copy is removed.

## Backport notes

Cherry-picked from d6c95cb169be7fc9023908bb95c08107e166146c. One conflict, resolved by hand:

- `ProfilerSettingsModal.tsx`: on `main`, `handleSave` had already been split into `buildPartitioning` / `buildProfileConfig` helpers; `2.0` still has it inline. Kept the `2.0` structure and applied only the fix — `pick()` the partition fields from `data`, and use `data.partitionIntervalType` instead of the `Form.useWatch` value.
- The unit tests, `TableProfiler.interface.ts`, and the `Profiler.spec.ts` e2e step applied cleanly (the spec file on `2.0` is identical to `main` before the fix).

## Testing

- `ProfilerSettingsModal.test.tsx`: 11/11 pass on `2.0`, including the 7 new partitioning round-trip cases (run locally against `main`'s `node_modules`).
- organize-imports + prettier applied (one line re-wrapped). ESLint left to CI — `main`'s `node_modules` can't load `2.0`'s `eslint.config.mjs`.
- Playwright step "Preserve partitioning when saving without any edit" not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
