### PR TITLE
Fixes 33182: match oneOf option labels case-insensitively

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/serviceFormUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/serviceFormUtils.ts
@@ -24,6 +24,17 @@ const getOneOfOptionLabels = (optionName: string) => {
   return [...new Set([optionName, spacedLabel])];
 };
 
+// Callers name a oneOf branch by its schema title, but the form renders the title
+// through getFormDisplayLabel, which spaces camelCase and re-cases known acronyms —
+// `"DBT S3 Config"` is rendered as `"dbt S3 Config"`. Anchor the match so it stays as
+// strict as `exact: true`, but compare case-insensitively so that re-casing does not
+// have to be mirrored in every test.
+const getOneOfOptionNamePattern = (optionName: string) =>
+  new RegExp(
+    `^(${getOneOfOptionLabels(optionName).map(escapeRegExp).join('|')})$`,
+    'i'
+  );
+
 export const selectOneOfOption = async (
   page: Page,
   fieldId: string,
@@ -31,17 +42,14 @@ export const selectOneOfOption = async (
   optionName: string
 ) => {
   const field = page.locator(`[data-field-id="${fieldId}"]`);
+  const optionNamePattern = getOneOfOptionNamePattern(optionName);
 
-  for (const optionLabel of getOneOfOptionLabels(optionName)) {
-    const tab = field.getByRole('tab', {
-      name: new RegExp(`^${escapeRegExp(optionLabel)}$`, 'i'),
-    });
+  const tab = field.getByRole('tab', { name: optionNamePattern });
 
-    if (await tab.isVisible({ timeout: 1000 }).catch(() => false)) {
-      await tab.click();
+  if (await tab.isVisible({ timeout: 1000 }).catch(() => false)) {
+    await tab.click();
 
-      return;
-    }
+    return;
   }
 
   const selectWidget = page.getByTestId(selectTestId);
@@ -50,7 +58,7 @@ export const selectOneOfOption = async (
     const trigger = selectWidget.getByRole('button');
     const option = page
       .locator('.core-one-of-field-select-popover')
-      .getByRole('option', { name: optionName, exact: true });
+      .getByRole('option', { name: optionNamePattern });
 
     await selectOptionWithRetry(trigger, option);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/serviceFormUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/serviceFormUtils.ts
@@ -24,11 +24,16 @@ const getOneOfOptionLabels = (optionName: string) => {
   return [...new Set([optionName, spacedLabel])];
 };
 
-// Callers name a oneOf branch by its schema title, but the form renders the title
-// through getFormDisplayLabel, which spaces camelCase and re-cases known acronyms —
-// `"DBT S3 Config"` is rendered as `"dbt S3 Config"`. Anchor the match so it stays as
-// strict as `exact: true`, but compare case-insensitively so that re-casing does not
-// have to be mirrored in every test.
+// Callers name a oneOf branch by its schema title, but CoreOneOfField renders every
+// option through `getFormDisplayLabel`, which spaces camelCase and re-cases known
+// acronyms — the title "DBT S3 Config" renders as "dbt S3 Config".
+//
+// Playwright may not import that function (app code outside src/generated and src/enums
+// is restricted), and copying its acronym table here would reintroduce the same drift
+// from the other side. Casing is the only thing the table changes, so matching the title
+// and its spaced form case-insensitively covers the transform without restating it.
+// The pattern stays anchored, so it is as strict as `exact: true` about substrings.
+// `getFormDisplayLabel`'s own behaviour is pinned in formBuilderV1LabelUtils.test.ts.
 const getOneOfOptionNamePattern = (optionName: string) =>
   new RegExp(
     `^(${getOneOfOptionLabels(optionName).map(escapeRegExp).join('|')})$`,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilderV1/formBuilderV1LabelUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilderV1/formBuilderV1LabelUtils.test.ts
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { getFormDisplayLabel } from './formBuilderV1LabelUtils';
+
+describe('getFormDisplayLabel', () => {
+  it('splits camelCase and snake_case field names into words', () => {
+    expect(getFormDisplayLabel('hostPort')).toBe('Host Port');
+    expect(getFormDisplayLabel('supportsMetadataExtraction')).toBe(
+      'Supports Metadata Extraction'
+    );
+    expect(getFormDisplayLabel('connection_options')).toBe(
+      'Connection Options'
+    );
+  });
+
+  it('restores the casing of known acronyms', () => {
+    expect(getFormDisplayLabel('apiVersion')).toBe('API Version');
+    expect(getFormDisplayLabel('awsRegion')).toBe('AWS Region');
+    expect(getFormDisplayLabel('sslMode')).toBe('SSL Mode');
+  });
+
+  it('lowercases dbt, which is styled lowercase even at the start of a label', () => {
+    expect(getFormDisplayLabel('dbtConfigSource')).toBe('dbt Config Source');
+    expect(getFormDisplayLabel('DBT Cloud Config')).toBe('dbt Cloud Config');
+  });
+
+  it('keeps a letter-number acronym together instead of splitting the digit off', () => {
+    // startCase alone yields "S 3", which would not match the S3 acronym entry.
+    expect(getFormDisplayLabel('s3Config')).toBe('S3 Config');
+    expect(getFormDisplayLabel('DBT S3 Config')).toBe('dbt S3 Config');
+  });
+
+  it('collapses the two spellings OAuth is split into', () => {
+    expect(getFormDisplayLabel('oAuthToken')).toBe('OAuth Token');
+    expect(getFormDisplayLabel('oauthConfig')).toBe('OAuth Config');
+  });
+
+  it('is idempotent, so an already-rendered label survives a second pass', () => {
+    // selectOneOfOption (playwright/utils/serviceFormUtils.ts) is called with either a
+    // schema title or the label it renders as, and both must resolve the same option.
+    const rendered = getFormDisplayLabel('DBT S3 Config');
+
+    expect(getFormDisplayLabel(rendered)).toBe(rendered);
+  });
+
+  it('changes only the casing of the oneOf titles the service-form E2E selects', () => {
+    // selectOneOfOption matches these case-insensitively rather than importing this
+    // function (playwright may not import app code). That holds only while the transform
+    // leaves the letters and spacing alone — this pins that, so a future acronym entry
+    // which also respaces a title fails here rather than in the nightly ingestion run.
+    const oneOfTitlesSelectedInE2E = [
+      'DBT S3 Config',
+      'Backend Connection',
+      'Local Path',
+    ];
+
+    oneOfTitlesSelectedInE2E.forEach((title) => {
+      expect(getFormDisplayLabel(title).toLowerCase()).toBe(
+        title.toLowerCase()
+      );
+    });
+  });
+});


### PR DESCRIPTION
### Describe your changes:

Fixes #33182

`selectOneOfOption` could not select a oneOf branch whose schema title contains an acronym that the form re-cases on render.

Callers name the branch by its **schema title**, but `CoreOneOfField` renders each option label through `getFormDisplayLabel`, which maps known acronyms via `FORM_LABEL_ACRONYMS` — including `dbt -> 'dbt'` (lowercase). So the title `"DBT S3 Config"` renders as `"dbt S3 Config"`.

#32940 changed the option locator to `{ name: optionName, exact: true }`. `exact: true` is case-sensitive, so the option stopped matching, `selectOptionWithRetry` burned its full 15s `toPass` budget, and the test failed. That PR also removed the non-exact fallbacks that had been masking the mismatch.

**Why not just call `getFormDisplayLabel` from the test helper.** That was the first thing I tried, and the repo rejects it on purpose:

> `no-restricted-imports`: Playwright tests must not import app code from `src/` — it pulls the app dependency graph (i18n, `@openmetadata/ui-core-components`) into the test process. Only `src/generated/**` and `src/enums/**` are allowed; duplicate anything else under `playwright/`.

Copying the acronym table under `playwright/` is the sanctioned escape hatch, but it reintroduces exactly the drift that caused this bug, just from the other side — and nothing would catch the copy going stale, since jest's `roots` is `src/` only, so no test can live next to it.

So the helper matches the title and its spaced form **anchored but case-insensitively**. Casing is the only thing `FORM_LABEL_ACRONYMS` changes, so this absorbs the transform without restating it, and the anchoring keeps what `exact: true` was there for — `"dbt S3 Config Extra"` is still rejected.

**What backs that assumption up.** `getFormDisplayLabel` drives every label the form builder renders and had **no test at all** — that gap is how this re-casing reached the nightly unnoticed. This PR covers it, and the last case pins the specific oneOf titles the service-form E2E selects, asserting the transform changes *only their casing*. If someone later adds an acronym entry that also respaces one of those titles, it fails in jest instead of in a nightly ingestion run.

The `role="tab"` branch of `selectOneOfOption` already matched anchored + case-insensitively; only the select-popover branch had drifted to `exact: true`. Both now share one matcher, and the tab branch loses its per-label loop.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered

- `ServiceIngestion.spec.ts:127 › Redshift Service › Service specific tests › Add DBT ingestion` selects the `DBT S3 Config` branch of `root/dbtConfigSource` again.
- The unaffected callers keep working: `'Backend Connection'` (`AirflowIngestionClass`) and `'Local Path'` (`ServiceForm.spec.ts`) pass through `getFormDisplayLabel` unchanged.
- `getFormDisplayLabel` itself: word splitting, the acronym table, the letter-number merge that keeps `"S3"` from becoming `"S 3"`, the OAuth collapse, and idempotence.

#### Unit tests

- [x] Added `src/components/common/FormBuilderV1/formBuilderV1LabelUtils.test.ts` — 7 cases, first coverage this module has had.

```
PASS  src/components/common/FormBuilderV1/formBuilderV1LabelUtils.test.ts
  ✓ splits camelCase and snake_case field names into words
  ✓ restores the casing of known acronyms
  ✓ lowercases dbt, which is styled lowercase even at the start of a label
  ✓ keeps a letter-number acronym together instead of splitting the digit off
  ✓ collapses the two spellings OAuth is split into
  ✓ is idempotent, so an already-rendered label survives a second pass
  ✓ changes only the casing of the oneOf titles the service-form E2E selects
Tests: 7 passed, 7 total
```

Mutation-checked rather than assumed — both regressions fail the suite:

| Mutation to `formBuilderV1LabelUtils.ts` | Result |
|---|---|
| drop `getMergedLetterNumberTokens` (so `"S3"` renders `"S 3"`) | 2 failed, 5 passed |
| respell the acronym entry `dbt: 'dbt'` as `'DBT'` | 2 failed, 5 passed |

The second mutation deliberately does **not** fail the E2E-guard case — a casing-only change is precisely what the helper's matcher absorbs, so failing there would be a false alarm.

#### Backend integration tests

Not applicable (no backend changes).

#### Ingestion integration tests

Not applicable (no ingestion changes).

#### Playwright (UI) tests

No new spec. The regression test is the existing `ServiceIngestion.spec.ts:127` — a nightly-only, credentialed Redshift + DBT-on-S3 flow that cannot run in local or PR CI. The jest case above is the part of this that is runnable on every PR.

#### Manual testing performed

1. Confirmed the transform against the real implementation: `"DBT S3 Config"` renders as `"dbt S3 Config"`.
2. Confirmed `shouldRenderSegmentedOptions` returns `false` for `root/dbtConfigSource` (`COMPACT_SELECTOR_ID_PATTERN` matches the `Source` suffix), so this field takes the select-popover branch rather than the tab branch.
3. Checked the matcher against the substring cases `exact: true` existed to reject — `"dbt S3 Config Extra"` and `"Local Path Two"` both still fail to match.
4. `yarn lint:playwright` — 0 errors (214 warnings, all pre-existing, none in the changed file).
5. `npx tsc --noEmit -p playwright/tsconfig.json` — 164 errors, byte-identical to the `main` baseline.
6. `yarn ui-checkstyle:changed src/components/common/FormBuilderV1/formBuilderV1LabelUtils.test.ts` — 0 errors, 0 warnings.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [x] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
