### PR TITLE
Fixes 32697: ignore stale responses in Data Quality chart widgets

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/ChartWidgets.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/ChartWidgets.constants.ts
@@ -12,6 +12,10 @@
  */
 
 import { TestCaseStatus } from '../../../generated/entity/feed/testCaseResult';
+import type { CustomAreaChartData } from '../../Visualisations/Chart/Chart.interface';
+
+/** Stable fallback while an area chart has no data, so its memoized body doesn't recompute. */
+export const EMPTY_CHART_DATA: CustomAreaChartData[] = [];
 
 /** Segment order for TestCaseStatusPieChartWidget: Success, Failed, Aborted */
 export const TEST_CASE_STATUS_PIE_SEGMENT_ORDER: TestCaseStatus[] = [

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/DataAssetsCoveragePieChartWidget/DataAssetsCoveragePieChartWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/DataAssetsCoveragePieChartWidget/DataAssetsCoveragePieChartWidget.component.tsx
@@ -87,40 +87,56 @@ const DataAssetsCoveragePieChartWidget = ({
     [dataAssetsCoverageStates]
   );
 
-  const fetchDataAssetsCoverage = async () => {
-    setIsLoading(true);
-    try {
-      const [{ data: coverageData }, { data: totalData }] = await Promise.all([
-        fetchEntityCoveredWithDQ(chartFilter, false),
-        fetchTotalEntityCount(chartFilter),
-      ]);
-      if (coverageData.length === 0 || totalData.length === 0) {
-        setDataAssetsCoverageStates(INITIAL_DATA_ASSETS_COVERAGE_STATES);
-
-        return;
-      }
-
-      const covered = parseInt(coverageData[0].originEntityFQN, 10);
-      let total = parseInt(totalData[0].fullyQualifiedName, 10);
-
-      if (covered > total) {
-        total = covered;
-      }
-
-      setDataAssetsCoverageStates({
-        covered,
-        notCovered: total - covered,
-        total: total,
-      });
-    } catch {
-      setDataAssetsCoverageStates(INITIAL_DATA_ASSETS_COVERAGE_STATES);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
   useEffect(() => {
+    let ignore = false;
+
+    const fetchDataAssetsCoverage = async () => {
+      setIsLoading(true);
+      try {
+        const [{ data: coverageData }, { data: totalData }] = await Promise.all(
+          [
+            fetchEntityCoveredWithDQ(chartFilter, false),
+            fetchTotalEntityCount(chartFilter),
+          ]
+        );
+        if (ignore) {
+          return;
+        }
+
+        if (coverageData.length === 0 || totalData.length === 0) {
+          setDataAssetsCoverageStates(INITIAL_DATA_ASSETS_COVERAGE_STATES);
+
+          return;
+        }
+
+        const covered = parseInt(coverageData[0].originEntityFQN, 10);
+        let total = parseInt(totalData[0].fullyQualifiedName, 10);
+
+        if (covered > total) {
+          total = covered;
+        }
+
+        setDataAssetsCoverageStates({
+          covered,
+          notCovered: total - covered,
+          total: total,
+        });
+      } catch {
+        if (!ignore) {
+          setDataAssetsCoverageStates(INITIAL_DATA_ASSETS_COVERAGE_STATES);
+        }
+      } finally {
+        if (!ignore) {
+          setIsLoading(false);
+        }
+      }
+    };
+
     fetchDataAssetsCoverage();
+
+    return () => {
+      ignore = true;
+    };
   }, [chartFilter]);
 
   if (isLoading) {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/DataAssetsCoveragePieChartWidget/DataAssetsCoveragePieChartWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/DataAssetsCoveragePieChartWidget/DataAssetsCoveragePieChartWidget.component.tsx
@@ -11,8 +11,9 @@
  *  limitations under the License.
  */
 import { Card, Skeleton, Typography } from '@openmetadata/ui-core-components';
+import { useQuery } from '@tanstack/react-query';
 import { parseInt } from 'lodash';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { ReactComponent as DataAssetsCoverageIcon } from '../../../../assets/svg/ic-data-assets-coverage.svg';
@@ -43,12 +44,30 @@ const DataAssetsCoveragePieChartWidget = ({
   const { t } = useTranslation();
   const routerNavigate = useNavigate();
   const navigate = navigateProp ?? routerNavigate;
-  const [isLoading, setIsLoading] = useState(true);
-  const [dataAssetsCoverageStates, setDataAssetsCoverageStates] = useState<{
-    covered: number;
-    notCovered: number;
-    total: number;
-  }>(INITIAL_DATA_ASSETS_COVERAGE_STATES);
+  const {
+    data: dataAssetsCoverageStates = INITIAL_DATA_ASSETS_COVERAGE_STATES,
+    isLoading,
+  } = useQuery({
+    queryKey: ['dq-dashboard', 'data-assets-coverage', chartFilter],
+    queryFn: async () => {
+      const [{ data: coverageData }, { data: totalData }] = await Promise.all([
+        fetchEntityCoveredWithDQ(chartFilter, false),
+        fetchTotalEntityCount(chartFilter),
+      ]);
+      if (coverageData.length === 0 || totalData.length === 0) {
+        return INITIAL_DATA_ASSETS_COVERAGE_STATES;
+      }
+
+      const covered = parseInt(coverageData[0].originEntityFQN, 10);
+      let total = parseInt(totalData[0].fullyQualifiedName, 10);
+
+      if (covered > total) {
+        total = covered;
+      }
+
+      return { covered, notCovered: total - covered, total };
+    },
+  });
 
   const handleSegmentClick = useCallback(
     (_entry: CustomPieChartData, index: number) => {
@@ -86,58 +105,6 @@ const DataAssetsCoveragePieChartWidget = ({
     }),
     [dataAssetsCoverageStates]
   );
-
-  useEffect(() => {
-    let ignore = false;
-
-    const fetchDataAssetsCoverage = async () => {
-      setIsLoading(true);
-      try {
-        const [{ data: coverageData }, { data: totalData }] = await Promise.all(
-          [
-            fetchEntityCoveredWithDQ(chartFilter, false),
-            fetchTotalEntityCount(chartFilter),
-          ]
-        );
-        if (ignore) {
-          return;
-        }
-
-        if (coverageData.length === 0 || totalData.length === 0) {
-          setDataAssetsCoverageStates(INITIAL_DATA_ASSETS_COVERAGE_STATES);
-
-          return;
-        }
-
-        const covered = parseInt(coverageData[0].originEntityFQN, 10);
-        let total = parseInt(totalData[0].fullyQualifiedName, 10);
-
-        if (covered > total) {
-          total = covered;
-        }
-
-        setDataAssetsCoverageStates({
-          covered,
-          notCovered: total - covered,
-          total: total,
-        });
-      } catch {
-        if (!ignore) {
-          setDataAssetsCoverageStates(INITIAL_DATA_ASSETS_COVERAGE_STATES);
-        }
-      } finally {
-        if (!ignore) {
-          setIsLoading(false);
-        }
-      }
-    };
-
-    fetchDataAssetsCoverage();
-
-    return () => {
-      ignore = true;
-    };
-  }, [chartFilter]);
 
   if (isLoading) {
     return (

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/DataAssetsCoveragePieChartWidget/DataAssetsCoveragePieChartWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/DataAssetsCoveragePieChartWidget/DataAssetsCoveragePieChartWidget.test.tsx
@@ -200,4 +200,54 @@ describe('DataAssetsCoveragePieChartWidget', () => {
 
     expect(navigate).toHaveBeenCalledWith('/explore');
   });
+
+  it('should keep the latest chartFilter data when a stale request resolves last', async () => {
+    const release: Record<number, () => void> = {};
+    const gates: Record<number, Promise<void>> = {
+      1: new Promise((resolve) => {
+        release[1] = resolve;
+      }),
+      100: new Promise((resolve) => {
+        release[100] = resolve;
+      }),
+    };
+    (fetchEntityCoveredWithDQ as jest.Mock).mockImplementation(
+      async (filters: { startTs: number }) => {
+        await gates[filters.startTs];
+
+        return { data: [{ originEntityFQN: String(filters.startTs) }] };
+      }
+    );
+    (fetchTotalEntityCount as jest.Mock).mockImplementation(
+      async (filters: { startTs: number }) => {
+        await gates[filters.startTs];
+
+        return { data: [{ fullyQualifiedName: '1000' }] };
+      }
+    );
+
+    const { rerender } = render(
+      <DataAssetsCoveragePieChartWidget
+        chartFilter={{ startTs: 1, endTs: 10 }}
+      />
+    );
+    rerender(
+      <DataAssetsCoveragePieChartWidget
+        chartFilter={{ startTs: 100, endTs: 200 }}
+      />
+    );
+
+    await act(async () => release[100]());
+    await act(async () => release[1]());
+
+    expect(CustomPieChart).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        data: [
+          expect.objectContaining({ value: 100 }),
+          expect.objectContaining({ value: 900 }),
+        ],
+      }),
+      expect.anything()
+    );
+  });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/DataAssetsCoveragePieChartWidget/DataAssetsCoveragePieChartWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/DataAssetsCoveragePieChartWidget/DataAssetsCoveragePieChartWidget.test.tsx
@@ -10,12 +10,13 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { act } from 'react';
 import {
   fetchEntityCoveredWithDQ,
   fetchTotalEntityCount,
 } from '../../../../rest/dataQualityDashboardAPI';
+import { renderWithQueryClient } from '../../../../test/unit/test-utils';
 import CustomPieChart from '../../../Visualisations/Chart/CustomPieChart.component';
 import DataAssetsCoveragePieChartWidget from './DataAssetsCoveragePieChartWidget.component';
 
@@ -75,7 +76,7 @@ describe('DataAssetsCoveragePieChartWidget', () => {
   });
 
   it('should render the component', async () => {
-    render(<DataAssetsCoveragePieChartWidget />);
+    renderWithQueryClient(<DataAssetsCoveragePieChartWidget />);
 
     expect(
       await screen.findByText('label.data-asset-plural-coverage')
@@ -86,7 +87,7 @@ describe('DataAssetsCoveragePieChartWidget', () => {
   });
 
   it('fetchEntityCoveredWithDQ & fetchTotalEntityCount should be called', async () => {
-    render(<DataAssetsCoveragePieChartWidget />);
+    renderWithQueryClient(<DataAssetsCoveragePieChartWidget />);
 
     await act(async () => {
       await Promise.resolve();
@@ -102,7 +103,9 @@ describe('DataAssetsCoveragePieChartWidget', () => {
       tags: ['tag1', 'tag2'],
       ownerFqn: 'ownerFqn',
     };
-    render(<DataAssetsCoveragePieChartWidget chartFilter={filters} />);
+    renderWithQueryClient(
+      <DataAssetsCoveragePieChartWidget chartFilter={filters} />
+    );
 
     await act(async () => {
       await Promise.resolve();
@@ -119,11 +122,9 @@ describe('DataAssetsCoveragePieChartWidget', () => {
       }
     ).__getMockNavigate();
 
-    render(<DataAssetsCoveragePieChartWidget />);
+    renderWithQueryClient(<DataAssetsCoveragePieChartWidget />);
 
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await screen.findByText('CustomPieChart.component');
 
     expect(CustomPieChart).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -154,7 +155,7 @@ describe('DataAssetsCoveragePieChartWidget', () => {
       }
     ).__getMockNavigate();
 
-    render(<DataAssetsCoveragePieChartWidget />);
+    renderWithQueryClient(<DataAssetsCoveragePieChartWidget />);
 
     await act(async () => {
       await Promise.resolve();
@@ -171,7 +172,7 @@ describe('DataAssetsCoveragePieChartWidget', () => {
   it('should use the supplied navigate function and test suites path', async () => {
     const navigate = jest.fn();
 
-    render(
+    renderWithQueryClient(
       <DataAssetsCoveragePieChartWidget
         navigate={navigate}
         redirectPath="/observability/data-quality/test-suites"
@@ -226,7 +227,7 @@ describe('DataAssetsCoveragePieChartWidget', () => {
       }
     );
 
-    const { rerender } = render(
+    const { rerender } = renderWithQueryClient(
       <DataAssetsCoveragePieChartWidget
         chartFilter={{ startTs: 1, endTs: 10 }}
       />
@@ -238,7 +239,11 @@ describe('DataAssetsCoveragePieChartWidget', () => {
     );
 
     await act(async () => release[100]());
+    await screen.findByText('CustomPieChart.component');
     await act(async () => release[1]());
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
 
     expect(CustomPieChart).toHaveBeenLastCalledWith(
       expect.objectContaining({

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/EntityHealthStatusPieChartWidget/EntityHealthStatusPieChartWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/EntityHealthStatusPieChartWidget/EntityHealthStatusPieChartWidget.component.tsx
@@ -11,8 +11,9 @@
  *  limitations under the License.
  */
 import { Card, Skeleton, Typography } from '@openmetadata/ui-core-components';
+import { useQuery } from '@tanstack/react-query';
 import { parseInt } from 'lodash';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { ReactComponent as HealthCheckIcon } from '../../../../assets/svg/ic-green-heart-border.svg';
@@ -38,12 +39,24 @@ const EntityHealthStatusPieChartWidget = ({
   const { t } = useTranslation();
   const routerNavigate = useNavigate();
   const navigate = navigateProp ?? routerNavigate;
-  const [isLoading, setIsLoading] = useState(true);
-  const [entityHealthStates, setEntityHealthStates] = useState<{
-    healthy: number;
-    unhealthy: number;
-    total: number;
-  }>(INITIAL_ENTITY_HEALTH_MATRIX);
+  const { data: entityHealthStates = INITIAL_ENTITY_HEALTH_MATRIX, isLoading } =
+    useQuery({
+      queryKey: ['dq-dashboard', 'entity-health', chartFilter],
+      queryFn: async () => {
+        const [{ data: unhealthyData }, { data: totalData }] =
+          await Promise.all([
+            fetchEntityCoveredWithDQ(chartFilter, true),
+            fetchEntityCoveredWithDQ(chartFilter, false),
+          ]);
+        if (unhealthyData.length === 0 || totalData.length === 0) {
+          return INITIAL_ENTITY_HEALTH_MATRIX;
+        }
+        const unhealthy = parseInt(unhealthyData[0].originEntityFQN, 10);
+        const total = parseInt(totalData[0].originEntityFQN, 10);
+
+        return { unhealthy, healthy: total - unhealthy, total };
+      },
+    });
 
   const handleSegmentClick = useCallback(
     (_entry: CustomPieChartData, index: number) => {
@@ -80,48 +93,6 @@ const EntityHealthStatusPieChartWidget = ({
     }),
     [entityHealthStates]
   );
-
-  useEffect(() => {
-    let ignore = false;
-
-    const fetchEntityHealthSummary = async () => {
-      setIsLoading(true);
-      try {
-        const [{ data: unhealthyData }, { data: totalData }] =
-          await Promise.all([
-            fetchEntityCoveredWithDQ(chartFilter, true),
-            fetchEntityCoveredWithDQ(chartFilter, false),
-          ]);
-        if (ignore) {
-          return;
-        }
-
-        if (unhealthyData.length === 0 || totalData.length === 0) {
-          setEntityHealthStates(INITIAL_ENTITY_HEALTH_MATRIX);
-
-          return;
-        }
-        const unhealthy = parseInt(unhealthyData[0].originEntityFQN, 10);
-        const total = parseInt(totalData[0].originEntityFQN, 10);
-
-        setEntityHealthStates({ unhealthy, healthy: total - unhealthy, total });
-      } catch {
-        if (!ignore) {
-          setEntityHealthStates(INITIAL_ENTITY_HEALTH_MATRIX);
-        }
-      } finally {
-        if (!ignore) {
-          setIsLoading(false);
-        }
-      }
-    };
-
-    fetchEntityHealthSummary();
-
-    return () => {
-      ignore = true;
-    };
-  }, [chartFilter]);
 
   if (isLoading) {
     return (

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/EntityHealthStatusPieChartWidget/EntityHealthStatusPieChartWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/EntityHealthStatusPieChartWidget/EntityHealthStatusPieChartWidget.component.tsx
@@ -81,31 +81,46 @@ const EntityHealthStatusPieChartWidget = ({
     [entityHealthStates]
   );
 
-  const fetchEntityHealthSummary = async () => {
-    setIsLoading(true);
-    try {
-      const [{ data: unhealthyData }, { data: totalData }] = await Promise.all([
-        fetchEntityCoveredWithDQ(chartFilter, true),
-        fetchEntityCoveredWithDQ(chartFilter, false),
-      ]);
-      if (unhealthyData.length === 0 || totalData.length === 0) {
-        setEntityHealthStates(INITIAL_ENTITY_HEALTH_MATRIX);
-
-        return;
-      }
-      const unhealthy = parseInt(unhealthyData[0].originEntityFQN, 10);
-      const total = parseInt(totalData[0].originEntityFQN, 10);
-
-      setEntityHealthStates({ unhealthy, healthy: total - unhealthy, total });
-    } catch {
-      setEntityHealthStates(INITIAL_ENTITY_HEALTH_MATRIX);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
   useEffect(() => {
+    let ignore = false;
+
+    const fetchEntityHealthSummary = async () => {
+      setIsLoading(true);
+      try {
+        const [{ data: unhealthyData }, { data: totalData }] =
+          await Promise.all([
+            fetchEntityCoveredWithDQ(chartFilter, true),
+            fetchEntityCoveredWithDQ(chartFilter, false),
+          ]);
+        if (ignore) {
+          return;
+        }
+
+        if (unhealthyData.length === 0 || totalData.length === 0) {
+          setEntityHealthStates(INITIAL_ENTITY_HEALTH_MATRIX);
+
+          return;
+        }
+        const unhealthy = parseInt(unhealthyData[0].originEntityFQN, 10);
+        const total = parseInt(totalData[0].originEntityFQN, 10);
+
+        setEntityHealthStates({ unhealthy, healthy: total - unhealthy, total });
+      } catch {
+        if (!ignore) {
+          setEntityHealthStates(INITIAL_ENTITY_HEALTH_MATRIX);
+        }
+      } finally {
+        if (!ignore) {
+          setIsLoading(false);
+        }
+      }
+    };
+
     fetchEntityHealthSummary();
+
+    return () => {
+      ignore = true;
+    };
   }, [chartFilter]);
 
   if (isLoading) {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/EntityHealthStatusPieChartWidget/EntityHealthStatusPieChartWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/EntityHealthStatusPieChartWidget/EntityHealthStatusPieChartWidget.test.tsx
@@ -10,9 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { act, render, screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import { TestCaseStatus } from '../../../../generated/entity/feed/testCaseResult';
 import { fetchEntityCoveredWithDQ } from '../../../../rest/dataQualityDashboardAPI';
+import { renderWithQueryClient } from '../../../../test/unit/test-utils';
 import { formatDate } from '../../../../utils/date-time/DateTimeUtils';
 import CustomPieChart from '../../../Visualisations/Chart/CustomPieChart.component';
 import EntityHealthStatusPieChartWidget from './EntityHealthStatusPieChartWidget.component';
@@ -80,7 +81,7 @@ describe('EntityHealthStatusPieChartWidget', () => {
   });
 
   it('should render the component', async () => {
-    render(<EntityHealthStatusPieChartWidget />);
+    renderWithQueryClient(<EntityHealthStatusPieChartWidget />);
 
     expect(
       await screen.findByText('label.healthy-data-asset-plural')
@@ -91,7 +92,7 @@ describe('EntityHealthStatusPieChartWidget', () => {
   });
 
   it('fetchEntityCoveredWithDQ should be called', async () => {
-    render(<EntityHealthStatusPieChartWidget />);
+    renderWithQueryClient(<EntityHealthStatusPieChartWidget />);
 
     await act(async () => {
       await Promise.resolve();
@@ -106,7 +107,9 @@ describe('EntityHealthStatusPieChartWidget', () => {
       tags: ['tag1', 'tag2'],
       ownerFqn: 'ownerFqn',
     };
-    render(<EntityHealthStatusPieChartWidget chartFilter={filters} />);
+    renderWithQueryClient(
+      <EntityHealthStatusPieChartWidget chartFilter={filters} />
+    );
 
     await act(async () => {
       await Promise.resolve();
@@ -126,11 +129,9 @@ describe('EntityHealthStatusPieChartWidget', () => {
       }
     ).__getMockNavigate();
 
-    render(<EntityHealthStatusPieChartWidget />);
+    renderWithQueryClient(<EntityHealthStatusPieChartWidget />);
 
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await screen.findByText('CustomPieChart.component');
 
     expect(CustomPieChart).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -178,7 +179,7 @@ describe('EntityHealthStatusPieChartWidget', () => {
   it('should use the supplied navigate function and test cases path', async () => {
     const navigate = jest.fn();
 
-    render(
+    renderWithQueryClient(
       <EntityHealthStatusPieChartWidget
         chartFilter={{ startTs: 100, endTs: 200 }}
         navigate={navigate}
@@ -245,7 +246,7 @@ describe('EntityHealthStatusPieChartWidget', () => {
       }
     );
 
-    const { rerender } = render(
+    const { rerender } = renderWithQueryClient(
       <EntityHealthStatusPieChartWidget
         chartFilter={{ startTs: 1, endTs: 10 }}
       />
@@ -257,7 +258,11 @@ describe('EntityHealthStatusPieChartWidget', () => {
     );
 
     await act(async () => release[100]());
+    await screen.findByText('CustomPieChart.component');
     await act(async () => release[1]());
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
 
     expect(CustomPieChart).toHaveBeenLastCalledWith(
       expect.objectContaining({

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/EntityHealthStatusPieChartWidget/EntityHealthStatusPieChartWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/EntityHealthStatusPieChartWidget/EntityHealthStatusPieChartWidget.test.tsx
@@ -222,4 +222,51 @@ describe('EntityHealthStatusPieChartWidget', () => {
       }
     );
   });
+
+  it('should keep the latest chartFilter data when a stale request resolves last', async () => {
+    const release: Record<number, () => void> = {};
+    const gates: Record<number, Promise<void>> = {
+      1: new Promise((resolve) => {
+        release[1] = resolve;
+      }),
+      100: new Promise((resolve) => {
+        release[100] = resolve;
+      }),
+    };
+    (fetchEntityCoveredWithDQ as jest.Mock).mockImplementation(
+      async (filters: { startTs: number }, unhealthy: boolean) => {
+        await gates[filters.startTs];
+
+        return {
+          data: [
+            { originEntityFQN: unhealthy ? String(filters.startTs) : '1000' },
+          ],
+        };
+      }
+    );
+
+    const { rerender } = render(
+      <EntityHealthStatusPieChartWidget
+        chartFilter={{ startTs: 1, endTs: 10 }}
+      />
+    );
+    rerender(
+      <EntityHealthStatusPieChartWidget
+        chartFilter={{ startTs: 100, endTs: 200 }}
+      />
+    );
+
+    await act(async () => release[100]());
+    await act(async () => release[1]());
+
+    expect(CustomPieChart).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        data: [
+          expect.objectContaining({ value: 900 }),
+          expect.objectContaining({ value: 100 }),
+        ],
+      }),
+      expect.anything()
+    );
+  });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/IncidentTimeChartWidget/IncidentTimeChartWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/IncidentTimeChartWidget/IncidentTimeChartWidget.component.tsx
@@ -11,8 +11,9 @@
  *  limitations under the License.
  */
 import { Card, Skeleton, Typography } from '@openmetadata/ui-core-components';
+import { useQuery } from '@tanstack/react-query';
 import { isNull, isUndefined } from 'lodash';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { fetchIncidentTimeMetrics } from '../../../../rest/dataQualityDashboardAPI';
 import { convertMillisecondsToHumanReadableFormat } from '../../../../utils/date-time/DateTimeUtils';
@@ -20,6 +21,7 @@ import { CustomAreaChartData } from '../../../Visualisations/Chart/Chart.interfa
 import CustomAreaChart from '../../../Visualisations/Chart/CustomAreaChart.component';
 import { IncidentTimeChartWidgetProps } from '../../DataQuality.interface';
 import '../chart-widgets.less';
+import { EMPTY_CHART_DATA } from '../ChartWidgets.constants';
 
 const IncidentTimeChartWidget = ({
   incidentMetricType,
@@ -29,8 +31,35 @@ const IncidentTimeChartWidget = ({
   height,
   redirectPath,
 }: IncidentTimeChartWidgetProps) => {
-  const [chartData, setChartData] = useState<CustomAreaChartData[]>([]);
-  const [isChartLoading, setIsChartLoading] = useState(true);
+  const { data: chartData = EMPTY_CHART_DATA, isLoading: isChartLoading } =
+    useQuery({
+      queryKey: [
+        'dq-dashboard',
+        'incident-time-metrics',
+        incidentMetricType,
+        chartFilter,
+      ],
+      queryFn: async () => {
+        const { data } = await fetchIncidentTimeMetrics(
+          incidentMetricType,
+          chartFilter
+        );
+
+        return data.reduce((act, cur) => {
+          if (isNull(cur['metrics.value'])) {
+            return act;
+          }
+
+          return [
+            ...act,
+            {
+              timestamp: +cur.timestamp,
+              count: +cur['metrics.value'],
+            },
+          ];
+        }, [] as CustomAreaChartData[]);
+      },
+    });
 
   const avgTimeValue = useMemo(() => {
     const totalTime = chartData.reduce((acc, curr) => {
@@ -51,53 +80,6 @@ const IncidentTimeChartWidget = ({
       </Typography>
     );
   }, [chartData]);
-
-  useEffect(() => {
-    let ignore = false;
-
-    const getRespondTimeMetrics = async () => {
-      setIsChartLoading(true);
-      try {
-        const { data } = await fetchIncidentTimeMetrics(
-          incidentMetricType,
-          chartFilter
-        );
-        if (ignore) {
-          return;
-        }
-
-        const updatedData = data.reduce((act, cur) => {
-          if (isNull(cur['metrics.value'])) {
-            return act;
-          }
-
-          return [
-            ...act,
-            {
-              timestamp: +cur.timestamp,
-              count: +cur['metrics.value'],
-            },
-          ];
-        }, [] as CustomAreaChartData[]);
-
-        setChartData(updatedData);
-      } catch {
-        if (!ignore) {
-          setChartData([]);
-        }
-      } finally {
-        if (!ignore) {
-          setIsChartLoading(false);
-        }
-      }
-    };
-
-    getRespondTimeMetrics();
-
-    return () => {
-      ignore = true;
-    };
-  }, [chartFilter, incidentMetricType]);
 
   if (isChartLoading) {
     return (

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/IncidentTimeChartWidget/IncidentTimeChartWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/IncidentTimeChartWidget/IncidentTimeChartWidget.component.tsx
@@ -52,37 +52,51 @@ const IncidentTimeChartWidget = ({
     );
   }, [chartData]);
 
-  const getRespondTimeMetrics = async () => {
-    setIsChartLoading(true);
-    try {
-      const { data } = await fetchIncidentTimeMetrics(
-        incidentMetricType,
-        chartFilter
-      );
-      const updatedData = data.reduce((act, cur) => {
-        if (isNull(cur['metrics.value'])) {
-          return act;
+  useEffect(() => {
+    let ignore = false;
+
+    const getRespondTimeMetrics = async () => {
+      setIsChartLoading(true);
+      try {
+        const { data } = await fetchIncidentTimeMetrics(
+          incidentMetricType,
+          chartFilter
+        );
+        if (ignore) {
+          return;
         }
 
-        return [
-          ...act,
-          {
-            timestamp: +cur.timestamp,
-            count: +cur['metrics.value'],
-          },
-        ];
-      }, [] as CustomAreaChartData[]);
+        const updatedData = data.reduce((act, cur) => {
+          if (isNull(cur['metrics.value'])) {
+            return act;
+          }
 
-      setChartData(updatedData);
-    } catch {
-      setChartData([]);
-    } finally {
-      setIsChartLoading(false);
-    }
-  };
+          return [
+            ...act,
+            {
+              timestamp: +cur.timestamp,
+              count: +cur['metrics.value'],
+            },
+          ];
+        }, [] as CustomAreaChartData[]);
 
-  useEffect(() => {
+        setChartData(updatedData);
+      } catch {
+        if (!ignore) {
+          setChartData([]);
+        }
+      } finally {
+        if (!ignore) {
+          setIsChartLoading(false);
+        }
+      }
+    };
+
     getRespondTimeMetrics();
+
+    return () => {
+      ignore = true;
+    };
   }, [chartFilter, incidentMetricType]);
 
   if (isChartLoading) {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/IncidentTimeChartWidget/IncidentTimeChartWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/IncidentTimeChartWidget/IncidentTimeChartWidget.test.tsx
@@ -11,8 +11,9 @@
  *  limitations under the License.
  */
 import '@testing-library/jest-dom/extend-expect';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import { fetchIncidentTimeMetrics } from '../../../../rest/dataQualityDashboardAPI';
+import { renderWithQueryClient } from '../../../../test/unit/test-utils';
 import {
   IncidentTimeChartWidgetProps,
   IncidentTimeMetricsType,
@@ -56,7 +57,7 @@ const defaultProps: IncidentTimeChartWidgetProps = {
 
 describe('IncidentTimeChartWidget', () => {
   it('should render the component', async () => {
-    render(<IncidentTimeChartWidget {...defaultProps} />);
+    renderWithQueryClient(<IncidentTimeChartWidget {...defaultProps} />);
 
     expect(await screen.findByText(defaultProps.title)).toBeInTheDocument();
     expect(
@@ -68,7 +69,7 @@ describe('IncidentTimeChartWidget', () => {
   });
 
   it('should call fetchIncidentTimeMetrics function', async () => {
-    render(<IncidentTimeChartWidget {...defaultProps} />);
+    renderWithQueryClient(<IncidentTimeChartWidget {...defaultProps} />);
 
     expect(fetchIncidentTimeMetrics).toHaveBeenCalledWith(
       defaultProps.incidentMetricType,
@@ -85,7 +86,7 @@ describe('IncidentTimeChartWidget', () => {
       tier: ['tier1'],
     };
     const status = IncidentTimeMetricsType.TIME_TO_RESPONSE;
-    render(
+    renderWithQueryClient(
       <IncidentTimeChartWidget
         {...defaultProps}
         chartFilter={filters}
@@ -100,7 +101,7 @@ describe('IncidentTimeChartWidget', () => {
     (fetchIncidentTimeMetrics as jest.Mock).mockRejectedValue(
       new Error('API Error')
     );
-    render(<IncidentTimeChartWidget {...defaultProps} />);
+    renderWithQueryClient(<IncidentTimeChartWidget {...defaultProps} />);
     await waitFor(() => expect(fetchIncidentTimeMetrics).toHaveBeenCalled());
 
     expect(await screen.findByText(defaultProps.title)).toBeInTheDocument();
@@ -121,7 +122,8 @@ describe('IncidentTimeChartWidget', () => {
       100: new Promise((resolve) => {
         release[100] = resolve;
       }),
-    }; // The stale filter has no metric value, so applying it would render '--'.
+    };
+    // The stale filter has no metric value, so applying it would render '--'.
     (fetchIncidentTimeMetrics as jest.Mock).mockImplementation(
       async (_type: IncidentTimeMetricsType, filters: { startTs: number }) => {
         await gates[filters.startTs];
@@ -139,7 +141,7 @@ describe('IncidentTimeChartWidget', () => {
       }
     );
 
-    const { rerender } = render(
+    const { rerender } = renderWithQueryClient(
       <IncidentTimeChartWidget
         {...defaultProps}
         chartFilter={{ startTs: 1, endTs: 10 }}
@@ -153,7 +155,15 @@ describe('IncidentTimeChartWidget', () => {
     );
 
     await act(async () => release[100]());
+
+    expect(await screen.findByTestId('average-time')).toHaveTextContent(
+      '1h 32m'
+    );
+
     await act(async () => release[1]());
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
 
     expect(screen.getByTestId('average-time')).toHaveTextContent('1h 32m');
   });

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/IncidentTimeChartWidget/IncidentTimeChartWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/IncidentTimeChartWidget/IncidentTimeChartWidget.test.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import '@testing-library/jest-dom/extend-expect';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { fetchIncidentTimeMetrics } from '../../../../rest/dataQualityDashboardAPI';
 import {
   IncidentTimeChartWidgetProps,
@@ -110,5 +110,51 @@ describe('IncidentTimeChartWidget', () => {
     expect((await screen.findByTestId('average-time')).textContent).toEqual(
       '--'
     );
+  });
+
+  it('should keep the latest chartFilter data when a stale request resolves last', async () => {
+    const release: Record<number, () => void> = {};
+    const gates: Record<number, Promise<void>> = {
+      1: new Promise((resolve) => {
+        release[1] = resolve;
+      }),
+      100: new Promise((resolve) => {
+        release[100] = resolve;
+      }),
+    }; // The stale filter has no metric value, so applying it would render '--'.
+    (fetchIncidentTimeMetrics as jest.Mock).mockImplementation(
+      async (_type: IncidentTimeMetricsType, filters: { startTs: number }) => {
+        await gates[filters.startTs];
+
+        return {
+          data: [
+            {
+              'metrics.value':
+                filters.startTs === 100 ? '5549.916666666667' : null,
+              'metrics.name.keyword': 'timeToResponse',
+              timestamp: '1729468800000',
+            },
+          ],
+        };
+      }
+    );
+
+    const { rerender } = render(
+      <IncidentTimeChartWidget
+        {...defaultProps}
+        chartFilter={{ startTs: 1, endTs: 10 }}
+      />
+    );
+    rerender(
+      <IncidentTimeChartWidget
+        {...defaultProps}
+        chartFilter={{ startTs: 100, endTs: 200 }}
+      />
+    );
+
+    await act(async () => release[100]());
+    await act(async () => release[1]());
+
+    expect(screen.getByTestId('average-time')).toHaveTextContent('1h 32m');
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/IncidentTypeAreaChartWidget/IncidentTypeAreaChartWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/IncidentTypeAreaChartWidget/IncidentTypeAreaChartWidget.component.tsx
@@ -11,15 +11,16 @@
  *  limitations under the License.
  */
 import { Card, Skeleton, Typography } from '@openmetadata/ui-core-components';
+import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames';
 import { isUndefined, last } from 'lodash';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { fetchCountOfIncidentStatusTypeByDays } from '../../../../rest/dataQualityDashboardAPI';
-import { CustomAreaChartData } from '../../../Visualisations/Chart/Chart.interface';
 import CustomAreaChart from '../../../Visualisations/Chart/CustomAreaChart.component';
 import { IncidentTypeAreaChartWidgetProps } from '../../DataQuality.interface';
 import '../chart-widgets.less';
+import { EMPTY_CHART_DATA } from '../ChartWidgets.constants';
 
 const IncidentTypeAreaChartWidget = ({
   incidentStatusType,
@@ -29,8 +30,26 @@ const IncidentTypeAreaChartWidget = ({
   redirectPath,
   height,
 }: IncidentTypeAreaChartWidgetProps) => {
-  const [isChartLoading, setIsChartLoading] = useState(true);
-  const [chartData, setChartData] = useState<CustomAreaChartData[]>([]);
+  const { data: chartData = EMPTY_CHART_DATA, isLoading: isChartLoading } =
+    useQuery({
+      queryKey: [
+        'dq-dashboard',
+        'incident-status-count',
+        incidentStatusType,
+        chartFilter,
+      ],
+      queryFn: async () => {
+        const { data } = await fetchCountOfIncidentStatusTypeByDays(
+          incidentStatusType,
+          chartFilter
+        );
+
+        return data.map((item) => ({
+          timestamp: +item.timestamp,
+          count: +item.stateId,
+        }));
+      },
+    });
 
   const bodyElement = useMemo(() => {
     const latestValue = last(chartData)?.count ?? 0;
@@ -54,43 +73,6 @@ const IncidentTypeAreaChartWidget = ({
       </>
     );
   }, [title, chartData, name, height]);
-
-  useEffect(() => {
-    let ignore = false;
-
-    const getCountOfIncidentStatus = async () => {
-      setIsChartLoading(true);
-      try {
-        const { data } = await fetchCountOfIncidentStatusTypeByDays(
-          incidentStatusType,
-          chartFilter
-        );
-        if (ignore) {
-          return;
-        }
-
-        const updatedData = data.map((item) => ({
-          timestamp: +item.timestamp,
-          count: +item.stateId,
-        }));
-        setChartData(updatedData);
-      } catch {
-        if (!ignore) {
-          setChartData([]);
-        }
-      } finally {
-        if (!ignore) {
-          setIsChartLoading(false);
-        }
-      }
-    };
-
-    getCountOfIncidentStatus();
-
-    return () => {
-      ignore = true;
-    };
-  }, [chartFilter, incidentStatusType]);
 
   if (isChartLoading) {
     return (

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/IncidentTypeAreaChartWidget/IncidentTypeAreaChartWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/IncidentTypeAreaChartWidget/IncidentTypeAreaChartWidget.component.tsx
@@ -55,27 +55,41 @@ const IncidentTypeAreaChartWidget = ({
     );
   }, [title, chartData, name, height]);
 
-  const getCountOfIncidentStatus = async () => {
-    setIsChartLoading(true);
-    try {
-      const { data } = await fetchCountOfIncidentStatusTypeByDays(
-        incidentStatusType,
-        chartFilter
-      );
-      const updatedData = data.map((item) => ({
-        timestamp: +item.timestamp,
-        count: +item.stateId,
-      }));
-      setChartData(updatedData);
-    } catch {
-      setChartData([]);
-    } finally {
-      setIsChartLoading(false);
-    }
-  };
-
   useEffect(() => {
+    let ignore = false;
+
+    const getCountOfIncidentStatus = async () => {
+      setIsChartLoading(true);
+      try {
+        const { data } = await fetchCountOfIncidentStatusTypeByDays(
+          incidentStatusType,
+          chartFilter
+        );
+        if (ignore) {
+          return;
+        }
+
+        const updatedData = data.map((item) => ({
+          timestamp: +item.timestamp,
+          count: +item.stateId,
+        }));
+        setChartData(updatedData);
+      } catch {
+        if (!ignore) {
+          setChartData([]);
+        }
+      } finally {
+        if (!ignore) {
+          setIsChartLoading(false);
+        }
+      }
+    };
+
     getCountOfIncidentStatus();
+
+    return () => {
+      ignore = true;
+    };
   }, [chartFilter, incidentStatusType]);
 
   if (isChartLoading) {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/IncidentTypeAreaChartWidget/IncidentTypeAreaChartWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/IncidentTypeAreaChartWidget/IncidentTypeAreaChartWidget.test.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import '@testing-library/jest-dom/extend-expect';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { TestCaseResolutionStatusTypes } from '../../../../generated/tests/testCaseResolutionStatus';
 import { fetchCountOfIncidentStatusTypeByDays } from '../../../../rest/dataQualityDashboardAPI';
 import { IncidentTypeAreaChartWidgetProps } from '../../DataQuality.interface';
@@ -98,5 +98,49 @@ describe('IncidentTypeAreaChartWidget', () => {
       await screen.findByText('CustomAreaChart.component')
     ).toBeInTheDocument();
     expect((await screen.findByTestId('total-value')).textContent).toEqual('0');
+  });
+
+  it('should keep the latest chartFilter data when a stale request resolves last', async () => {
+    const release: Record<number, () => void> = {};
+    const gates: Record<number, Promise<void>> = {
+      1: new Promise((resolve) => {
+        release[1] = resolve;
+      }),
+      100: new Promise((resolve) => {
+        release[100] = resolve;
+      }),
+    };
+    (fetchCountOfIncidentStatusTypeByDays as jest.Mock).mockImplementation(
+      async (
+        _status: TestCaseResolutionStatusTypes,
+        filters: { startTs: number }
+      ) => {
+        await gates[filters.startTs];
+
+        return {
+          data: [
+            { stateId: String(filters.startTs), timestamp: '1729468800000' },
+          ],
+        };
+      }
+    );
+
+    const { rerender } = render(
+      <IncidentTypeAreaChartWidget
+        {...defaultProps}
+        chartFilter={{ startTs: 1, endTs: 10 }}
+      />
+    );
+    rerender(
+      <IncidentTypeAreaChartWidget
+        {...defaultProps}
+        chartFilter={{ startTs: 100, endTs: 200 }}
+      />
+    );
+
+    await act(async () => release[100]());
+    await act(async () => release[1]());
+
+    expect(screen.getByTestId('total-value')).toHaveTextContent('100');
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/IncidentTypeAreaChartWidget/IncidentTypeAreaChartWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/IncidentTypeAreaChartWidget/IncidentTypeAreaChartWidget.test.tsx
@@ -11,9 +11,10 @@
  *  limitations under the License.
  */
 import '@testing-library/jest-dom/extend-expect';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import { TestCaseResolutionStatusTypes } from '../../../../generated/tests/testCaseResolutionStatus';
 import { fetchCountOfIncidentStatusTypeByDays } from '../../../../rest/dataQualityDashboardAPI';
+import { renderWithQueryClient } from '../../../../test/unit/test-utils';
 import { IncidentTypeAreaChartWidgetProps } from '../../DataQuality.interface';
 import IncidentTypeAreaChartWidget from './IncidentTypeAreaChartWidget.component';
 
@@ -41,7 +42,7 @@ const defaultProps: IncidentTypeAreaChartWidgetProps = {
 
 describe('IncidentTypeAreaChartWidget', () => {
   it('should render the component', async () => {
-    render(<IncidentTypeAreaChartWidget {...defaultProps} />);
+    renderWithQueryClient(<IncidentTypeAreaChartWidget {...defaultProps} />);
 
     expect(await screen.findByText(defaultProps.title)).toBeInTheDocument();
     expect(
@@ -53,7 +54,7 @@ describe('IncidentTypeAreaChartWidget', () => {
   });
 
   it('should call fetchCountOfIncidentStatusTypeByDays function', async () => {
-    render(<IncidentTypeAreaChartWidget {...defaultProps} />);
+    renderWithQueryClient(<IncidentTypeAreaChartWidget {...defaultProps} />);
 
     expect(fetchCountOfIncidentStatusTypeByDays).toHaveBeenCalledWith(
       defaultProps.incidentStatusType,
@@ -70,7 +71,7 @@ describe('IncidentTypeAreaChartWidget', () => {
       tier: ['tier1'],
     };
     const status = TestCaseResolutionStatusTypes.Assigned;
-    render(
+    renderWithQueryClient(
       <IncidentTypeAreaChartWidget
         {...defaultProps}
         chartFilter={filters}
@@ -88,7 +89,7 @@ describe('IncidentTypeAreaChartWidget', () => {
     (fetchCountOfIncidentStatusTypeByDays as jest.Mock).mockRejectedValue(
       new Error('API Error')
     );
-    render(<IncidentTypeAreaChartWidget {...defaultProps} />);
+    renderWithQueryClient(<IncidentTypeAreaChartWidget {...defaultProps} />);
     await waitFor(() =>
       expect(fetchCountOfIncidentStatusTypeByDays).toHaveBeenCalled()
     );
@@ -125,7 +126,7 @@ describe('IncidentTypeAreaChartWidget', () => {
       }
     );
 
-    const { rerender } = render(
+    const { rerender } = renderWithQueryClient(
       <IncidentTypeAreaChartWidget
         {...defaultProps}
         chartFilter={{ startTs: 1, endTs: 10 }}
@@ -139,7 +140,13 @@ describe('IncidentTypeAreaChartWidget', () => {
     );
 
     await act(async () => release[100]());
+
+    expect(await screen.findByTestId('total-value')).toHaveTextContent('100');
+
     await act(async () => release[1]());
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
 
     expect(screen.getByTestId('total-value')).toHaveTextContent('100');
   });

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.component.tsx
@@ -10,11 +10,11 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames';
 import { isUndefined } from 'lodash';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { DIMENSIONS_DATA } from '../../../../constants/DataQuality.constants';
-import { DataQualityReport } from '../../../../generated/tests/dataQualityReport';
 import { DataQualityDimensions } from '../../../../generated/tests/testDefinition';
 import { DataQualityPageTabs } from '../../../../pages/DataQuality/DataQualityPage.interface';
 import {
@@ -33,9 +33,20 @@ import './status-by-dimension-card-widget.less';
 const StatusByDimensionCardWidget = ({
   chartFilter,
 }: PieChartWidgetCommonProps) => {
-  const [isDqByDimensionLoading, setIsDqByDimensionLoading] = useState(true);
-  const [dqByDimensionData, setDqByDimensionData] =
-    useState<DataQualityReport['data']>();
+  const { data: dqByDimensionData, isLoading: isDqByDimensionLoading } =
+    useQuery({
+      queryKey: ['dq-dashboard', 'status-by-dimension', chartFilter],
+      queryFn: async () => {
+        // Dimensioned and unclassified test cases are separate aggregations;
+        // fetch them together and merge them into one set of status cards.
+        const [{ data }, { data: noDimensionData }] = await Promise.all([
+          fetchTestCaseSummaryByDimension(chartFilter),
+          fetchTestCaseSummaryByNoDimension(chartFilter),
+        ]);
+
+        return [...data, ...noDimensionData];
+      },
+    });
 
   const dqDimensions = useMemo(
     () =>
@@ -50,40 +61,6 @@ const StatusByDimensionCardWidget = ({
         : transformToTestCaseStatusByDimension(dqByDimensionData),
     [dqByDimensionData]
   );
-
-  useEffect(() => {
-    let ignore = false;
-
-    const getStatusByDimension = async () => {
-      setIsDqByDimensionLoading(true);
-      try {
-        // Dimensioned and unclassified test cases are separate aggregations;
-        // fetch them together and merge them into one set of status cards.
-        const [{ data }, { data: noDimensionData }] = await Promise.all([
-          fetchTestCaseSummaryByDimension(chartFilter),
-          fetchTestCaseSummaryByNoDimension(chartFilter),
-        ]);
-
-        if (!ignore) {
-          setDqByDimensionData([...data, ...noDimensionData]);
-        }
-      } catch {
-        if (!ignore) {
-          setDqByDimensionData(undefined);
-        }
-      } finally {
-        if (!ignore) {
-          setIsDqByDimensionLoading(false);
-        }
-      }
-    };
-
-    getStatusByDimension();
-
-    return () => {
-      ignore = true;
-    };
-  }, [chartFilter]);
 
   return (
     <div className="tw:@container">

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.test.tsx
@@ -11,13 +11,14 @@
  *  limitations under the License.
  */
 import '@testing-library/jest-dom/extend-expect';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import { DataQualityDimensions } from '../../../../generated/tests/testDefinition';
 import { DataQualityDashboardChartFilters } from '../../../../pages/DataQuality/DataQualityPage.interface';
 import {
   fetchTestCaseSummaryByDimension,
   fetchTestCaseSummaryByNoDimension,
 } from '../../../../rest/dataQualityDashboardAPI';
+import { renderWithQueryClient } from '../../../../test/unit/test-utils';
 import StatusByDimensionCardWidget from './StatusByDimensionCardWidget.component';
 
 const mockStatusByDimensionWidgetTestId = 'status-by-dimension-widget';
@@ -152,7 +153,9 @@ describe('StatusByDimensionCardWidget', () => {
     });
 
     await act(async () => {
-      render(<StatusByDimensionCardWidget chartFilter={chartFilter} />);
+      renderWithQueryClient(
+        <StatusByDimensionCardWidget chartFilter={chartFilter} />
+      );
     });
 
     await waitFor(() =>
@@ -175,7 +178,9 @@ describe('StatusByDimensionCardWidget', () => {
       data: [],
     });
 
-    render(<StatusByDimensionCardWidget chartFilter={chartFilter} />);
+    renderWithQueryClient(
+      <StatusByDimensionCardWidget chartFilter={chartFilter} />
+    );
 
     await waitFor(() =>
       expect(fetchTestCaseSummaryByNoDimension).toHaveBeenCalledWith(
@@ -196,7 +201,9 @@ describe('StatusByDimensionCardWidget', () => {
       data: [],
     });
 
-    render(<StatusByDimensionCardWidget chartFilter={chartFilter} />);
+    renderWithQueryClient(
+      <StatusByDimensionCardWidget chartFilter={chartFilter} />
+    );
 
     const firstDimension = (
       await screen.findAllByTestId(mockStatusByDimensionWidgetTestId)
@@ -230,7 +237,9 @@ describe('StatusByDimensionCardWidget', () => {
     );
 
     await act(async () => {
-      render(<StatusByDimensionCardWidget chartFilter={chartFilter} />);
+      renderWithQueryClient(
+        <StatusByDimensionCardWidget chartFilter={chartFilter} />
+      );
     });
 
     await waitFor(() =>
@@ -264,7 +273,7 @@ describe('StatusByDimensionCardWidget', () => {
       data: [],
     });
 
-    const { rerender } = render(
+    const { rerender } = renderWithQueryClient(
       <StatusByDimensionCardWidget chartFilter={chartFilter} />
     );
 
@@ -315,7 +324,7 @@ describe('StatusByDimensionCardWidget', () => {
       data: [],
     });
 
-    const { container } = render(
+    const { container } = renderWithQueryClient(
       <StatusByDimensionCardWidget chartFilter={chartFilter} />
     );
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusAreaChartWidget/TestCaseStatusAreaChartWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusAreaChartWidget/TestCaseStatusAreaChartWidget.component.tsx
@@ -15,19 +15,20 @@ import {
   Tooltip,
   Typography,
 } from '@openmetadata/ui-core-components';
+import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames';
 import { isUndefined, last, toLower } from 'lodash';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { ReactComponent as SuccessIcon } from '../../../../assets/svg/ic-check.svg';
 import { ReactComponent as FailedIcon } from '../../../../assets/svg/ic-warning-2.svg';
 import { TestCaseStatus } from '../../../../generated/entity/feed/testCaseResult';
 import { fetchTestCaseStatusMetricsByDays } from '../../../../rest/dataQualityDashboardAPI';
-import { CustomAreaChartData } from '../../../Visualisations/Chart/Chart.interface';
 import CustomAreaChart from '../../../Visualisations/Chart/CustomAreaChart.component';
 import { TestCaseStatusAreaChartWidgetProps } from '../../DataQuality.interface';
 import '../chart-widgets.less';
+import { EMPTY_CHART_DATA } from '../ChartWidgets.constants';
 import './test-case-status-area-chart-widget.less';
 
 const TestCaseStatusAreaChartWidget = ({
@@ -43,8 +44,32 @@ const TestCaseStatusAreaChartWidget = ({
   footerWhenEmpty,
 }: TestCaseStatusAreaChartWidgetProps) => {
   const { t } = useTranslation();
-  const [chartData, setChartData] = useState<CustomAreaChartData[]>([]);
-  const [isChartLoading, setIsChartLoading] = useState(true);
+  const { data: chartData = EMPTY_CHART_DATA, isLoading: isChartLoading } =
+    useQuery({
+      queryKey: [
+        'dq-dashboard',
+        'test-case-status-metrics',
+        testCaseStatus,
+        chartFilter,
+      ],
+      queryFn: async () => {
+        const { data } = await fetchTestCaseStatusMetricsByDays(
+          testCaseStatus,
+          chartFilter
+        );
+        const updatedData = data.map((cur) => {
+          return {
+            timestamp: +cur.timestamp,
+            count: +cur['testCase.fullyQualifiedName'],
+          };
+        });
+        // Aggregation buckets are not guaranteed to arrive chronologically;
+        // Recharts expects an ascending x-axis for a stable trend line.
+        updatedData.sort((first, second) => first.timestamp - second.timestamp);
+
+        return updatedData;
+      },
+    });
 
   const bodyElement = useMemo(() => {
     const latestValue = last(chartData)?.count ?? 0;
@@ -119,49 +144,6 @@ const TestCaseStatusAreaChartWidget = ({
     testCaseStatus,
     showIcon,
   ]);
-
-  useEffect(() => {
-    let ignore = false;
-
-    const getTestCaseStatusMetrics = async () => {
-      setIsChartLoading(true);
-      try {
-        const { data } = await fetchTestCaseStatusMetricsByDays(
-          testCaseStatus,
-          chartFilter
-        );
-        if (ignore) {
-          return;
-        }
-
-        const updatedData = data.map((cur) => {
-          return {
-            timestamp: +cur.timestamp,
-            count: +cur['testCase.fullyQualifiedName'],
-          };
-        });
-        // Aggregation buckets are not guaranteed to arrive chronologically;
-        // Recharts expects an ascending x-axis for a stable trend line.
-        updatedData.sort((first, second) => first.timestamp - second.timestamp);
-
-        setChartData(updatedData);
-      } catch {
-        if (!ignore) {
-          setChartData([]);
-        }
-      } finally {
-        if (!ignore) {
-          setIsChartLoading(false);
-        }
-      }
-    };
-
-    getTestCaseStatusMetrics();
-
-    return () => {
-      ignore = true;
-    };
-  }, [chartFilter, testCaseStatus]);
 
   const containerClassName = classNames(
     'test-case-area-chart-widget-container tw:p-4',

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusAreaChartWidget/TestCaseStatusAreaChartWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusAreaChartWidget/TestCaseStatusAreaChartWidget.component.tsx
@@ -120,33 +120,47 @@ const TestCaseStatusAreaChartWidget = ({
     showIcon,
   ]);
 
-  const getTestCaseStatusMetrics = async () => {
-    setIsChartLoading(true);
-    try {
-      const { data } = await fetchTestCaseStatusMetricsByDays(
-        testCaseStatus,
-        chartFilter
-      );
-      const updatedData = data.map((cur) => {
-        return {
-          timestamp: +cur.timestamp,
-          count: +cur['testCase.fullyQualifiedName'],
-        };
-      });
-      // Aggregation buckets are not guaranteed to arrive chronologically;
-      // Recharts expects an ascending x-axis for a stable trend line.
-      updatedData.sort((first, second) => first.timestamp - second.timestamp);
-
-      setChartData(updatedData);
-    } catch {
-      setChartData([]);
-    } finally {
-      setIsChartLoading(false);
-    }
-  };
-
   useEffect(() => {
+    let ignore = false;
+
+    const getTestCaseStatusMetrics = async () => {
+      setIsChartLoading(true);
+      try {
+        const { data } = await fetchTestCaseStatusMetricsByDays(
+          testCaseStatus,
+          chartFilter
+        );
+        if (ignore) {
+          return;
+        }
+
+        const updatedData = data.map((cur) => {
+          return {
+            timestamp: +cur.timestamp,
+            count: +cur['testCase.fullyQualifiedName'],
+          };
+        });
+        // Aggregation buckets are not guaranteed to arrive chronologically;
+        // Recharts expects an ascending x-axis for a stable trend line.
+        updatedData.sort((first, second) => first.timestamp - second.timestamp);
+
+        setChartData(updatedData);
+      } catch {
+        if (!ignore) {
+          setChartData([]);
+        }
+      } finally {
+        if (!ignore) {
+          setIsChartLoading(false);
+        }
+      }
+    };
+
     getTestCaseStatusMetrics();
+
+    return () => {
+      ignore = true;
+    };
   }, [chartFilter, testCaseStatus]);
 
   const containerClassName = classNames(

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusAreaChartWidget/TestCaseStatusAreaChartWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusAreaChartWidget/TestCaseStatusAreaChartWidget.test.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import '@testing-library/jest-dom/extend-expect';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { DataQualityReport } from '../../../../generated/tests/dataQualityReport';
@@ -534,5 +534,50 @@ describe('TestCaseStatusAreaChartWidget', () => {
         screen.getByTestId('test-case-Success-area-chart-widget')
       ).toBeInTheDocument();
     });
+  });
+
+  it('should keep the latest chartFilter data when a stale request resolves last', async () => {
+    const release: Record<number, () => void> = {};
+    const gates: Record<number, Promise<void>> = {
+      1: new Promise((resolve) => {
+        release[1] = resolve;
+      }),
+      100: new Promise((resolve) => {
+        release[100] = resolve;
+      }),
+    };
+    mockFetchTestCaseStatusMetricsByDays.mockImplementation(
+      async (_status, filters) => {
+        await gates[filters?.startTs ?? 0];
+
+        return {
+          data: [
+            {
+              timestamp: '1625097600000',
+              'testCase.fullyQualifiedName': String(filters?.startTs),
+            },
+          ],
+          metadata: { dimensions: [] },
+        };
+      }
+    );
+
+    const { rerender } = render(
+      <TestCaseStatusAreaChartWidget
+        {...defaultProps}
+        chartFilter={{ startTs: 1, endTs: 10 }}
+      />
+    );
+    rerender(
+      <TestCaseStatusAreaChartWidget
+        {...defaultProps}
+        chartFilter={{ startTs: 100, endTs: 200 }}
+      />
+    );
+
+    await act(async () => release[100]());
+    await act(async () => release[1]());
+
+    expect(screen.getByTestId('total-value')).toHaveTextContent('100');
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusAreaChartWidget/TestCaseStatusAreaChartWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusAreaChartWidget/TestCaseStatusAreaChartWidget.test.tsx
@@ -11,12 +11,13 @@
  *  limitations under the License.
  */
 import '@testing-library/jest-dom/extend-expect';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { DataQualityReport } from '../../../../generated/tests/dataQualityReport';
 import { TestCaseStatus } from '../../../../generated/tests/testCase';
 import { fetchTestCaseStatusMetricsByDays } from '../../../../rest/dataQualityDashboardAPI';
+import { renderWithQueryClient } from '../../../../test/unit/test-utils';
 import { AreaChartColorScheme } from '../../../Visualisations/Chart/Chart.interface';
 import { TestCaseStatusAreaChartWidgetProps } from '../../DataQuality.interface';
 import TestCaseStatusAreaChartWidget from './TestCaseStatusAreaChartWidget.component';
@@ -119,7 +120,7 @@ describe('TestCaseStatusAreaChartWidget', () => {
   });
 
   it('should render the component with basic props', async () => {
-    render(<TestCaseStatusAreaChartWidget {...defaultProps} />);
+    renderWithQueryClient(<TestCaseStatusAreaChartWidget {...defaultProps} />);
 
     await waitFor(() => {
       expect(screen.getByText(defaultProps.title)).toBeInTheDocument();
@@ -138,7 +139,7 @@ describe('TestCaseStatusAreaChartWidget', () => {
       data: [...mockChartData.data].reverse(),
     });
 
-    render(<TestCaseStatusAreaChartWidget {...defaultProps} />);
+    renderWithQueryClient(<TestCaseStatusAreaChartWidget {...defaultProps} />);
 
     await waitFor(() => {
       expect(screen.getByTestId('total-value')).toHaveTextContent('15');
@@ -154,7 +155,7 @@ describe('TestCaseStatusAreaChartWidget', () => {
   });
 
   it('should show loading state initially', () => {
-    render(<TestCaseStatusAreaChartWidget {...defaultProps} />);
+    renderWithQueryClient(<TestCaseStatusAreaChartWidget {...defaultProps} />);
 
     // With Skeleton loading pattern, the widget card is replaced by Skeleton during loading
     expect(
@@ -163,7 +164,7 @@ describe('TestCaseStatusAreaChartWidget', () => {
   });
 
   it('should call fetchTestCaseStatusMetricsByDays on mount', async () => {
-    render(<TestCaseStatusAreaChartWidget {...defaultProps} />);
+    renderWithQueryClient(<TestCaseStatusAreaChartWidget {...defaultProps} />);
 
     await waitFor(() => {
       expect(mockFetchTestCaseStatusMetricsByDays).toHaveBeenCalledWith(
@@ -182,7 +183,7 @@ describe('TestCaseStatusAreaChartWidget', () => {
       tier: ['tier1'],
     };
 
-    render(
+    renderWithQueryClient(
       <TestCaseStatusAreaChartWidget {...defaultProps} chartFilter={filters} />
     );
 
@@ -196,7 +197,7 @@ describe('TestCaseStatusAreaChartWidget', () => {
 
   it('should render with custom height', async () => {
     const customHeight = 300;
-    render(
+    renderWithQueryClient(
       <TestCaseStatusAreaChartWidget {...defaultProps} height={customHeight} />
     );
 
@@ -212,7 +213,7 @@ describe('TestCaseStatusAreaChartWidget', () => {
       strokeColor: '#00FF00',
     };
 
-    render(
+    renderWithQueryClient(
       <TestCaseStatusAreaChartWidget
         {...defaultProps}
         chartColorScheme={colorScheme}
@@ -227,7 +228,7 @@ describe('TestCaseStatusAreaChartWidget', () => {
   });
 
   it('should render success icon when showIcon is true and status is Success', async () => {
-    render(
+    renderWithQueryClient(
       <TestCaseStatusAreaChartWidget
         {...defaultProps}
         showIcon
@@ -256,7 +257,7 @@ describe('TestCaseStatusAreaChartWidget', () => {
   });
 
   it('should render failed icon when showIcon is true and status is Failed', async () => {
-    render(
+    renderWithQueryClient(
       <TestCaseStatusAreaChartWidget
         {...defaultProps}
         showIcon
@@ -283,7 +284,7 @@ describe('TestCaseStatusAreaChartWidget', () => {
   });
 
   it('should not render icon when showIcon is false', async () => {
-    render(
+    renderWithQueryClient(
       <TestCaseStatusAreaChartWidget {...defaultProps} showIcon={false} />
     );
 
@@ -303,7 +304,7 @@ describe('TestCaseStatusAreaChartWidget', () => {
   it('should render as a link when redirectPath is provided', async () => {
     const redirectPath = '/test-cases/failed';
 
-    render(
+    renderWithQueryClient(
       <MemoryRouter>
         <TestCaseStatusAreaChartWidget
           {...defaultProps}
@@ -325,7 +326,7 @@ describe('TestCaseStatusAreaChartWidget', () => {
   });
 
   it('should not render as a link when redirectPath is not provided', async () => {
-    render(<TestCaseStatusAreaChartWidget {...defaultProps} />);
+    renderWithQueryClient(<TestCaseStatusAreaChartWidget {...defaultProps} />);
 
     // Wait for loading to complete
     await waitFor(() => {
@@ -340,7 +341,7 @@ describe('TestCaseStatusAreaChartWidget', () => {
       new Error('API Error')
     );
 
-    render(<TestCaseStatusAreaChartWidget {...defaultProps} />);
+    renderWithQueryClient(<TestCaseStatusAreaChartWidget {...defaultProps} />);
 
     // Wait for loading to complete
     await waitFor(() => {
@@ -353,7 +354,7 @@ describe('TestCaseStatusAreaChartWidget', () => {
   });
 
   it('should update chart data when chartFilter changes', async () => {
-    const { rerender } = render(
+    const { rerender } = renderWithQueryClient(
       <TestCaseStatusAreaChartWidget {...defaultProps} />
     );
 
@@ -383,7 +384,7 @@ describe('TestCaseStatusAreaChartWidget', () => {
   });
 
   it('should transform API data correctly', async () => {
-    render(<TestCaseStatusAreaChartWidget {...defaultProps} />);
+    renderWithQueryClient(<TestCaseStatusAreaChartWidget {...defaultProps} />);
 
     // Wait for loading to complete
     await waitFor(() => {
@@ -406,7 +407,7 @@ describe('TestCaseStatusAreaChartWidget', () => {
       metadata: { dimensions: [] },
     });
 
-    render(<TestCaseStatusAreaChartWidget {...defaultProps} />);
+    renderWithQueryClient(<TestCaseStatusAreaChartWidget {...defaultProps} />);
 
     // Wait for loading to complete
     await waitFor(() => {
@@ -425,7 +426,7 @@ describe('TestCaseStatusAreaChartWidget', () => {
     ];
 
     for (const status of statuses) {
-      const { unmount } = render(
+      const { unmount } = renderWithQueryClient(
         <TestCaseStatusAreaChartWidget
           {...defaultProps}
           testCaseStatus={status}
@@ -443,7 +444,9 @@ describe('TestCaseStatusAreaChartWidget', () => {
   });
 
   it('should apply correct CSS classes for typography', async () => {
-    render(<TestCaseStatusAreaChartWidget {...defaultProps} showIcon />);
+    renderWithQueryClient(
+      <TestCaseStatusAreaChartWidget {...defaultProps} showIcon />
+    );
 
     // Wait for loading to complete
     await waitFor(() => {
@@ -461,7 +464,7 @@ describe('TestCaseStatusAreaChartWidget', () => {
   });
 
   it('should apply correct CSS classes for typography without icon', async () => {
-    render(
+    renderWithQueryClient(
       <TestCaseStatusAreaChartWidget {...defaultProps} showIcon={false} />
     );
 
@@ -488,7 +491,7 @@ describe('TestCaseStatusAreaChartWidget', () => {
     };
     const height = 250;
 
-    render(
+    renderWithQueryClient(
       <TestCaseStatusAreaChartWidget
         {...defaultProps}
         chartColorScheme={colorScheme}
@@ -517,7 +520,7 @@ describe('TestCaseStatusAreaChartWidget', () => {
 
     mockFetchTestCaseStatusMetricsByDays.mockReturnValue(delayedPromise);
 
-    render(<TestCaseStatusAreaChartWidget {...defaultProps} />);
+    renderWithQueryClient(<TestCaseStatusAreaChartWidget {...defaultProps} />);
 
     // During loading, the card widget is not rendered (Skeleton takes its place)
     expect(
@@ -562,7 +565,7 @@ describe('TestCaseStatusAreaChartWidget', () => {
       }
     );
 
-    const { rerender } = render(
+    const { rerender } = renderWithQueryClient(
       <TestCaseStatusAreaChartWidget
         {...defaultProps}
         chartFilter={{ startTs: 1, endTs: 10 }}
@@ -576,7 +579,13 @@ describe('TestCaseStatusAreaChartWidget', () => {
     );
 
     await act(async () => release[100]());
+
+    expect(await screen.findByTestId('total-value')).toHaveTextContent('100');
+
     await act(async () => release[1]());
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
 
     expect(screen.getByTestId('total-value')).toHaveTextContent('100');
   });

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusPieChartWidget/TestCaseStatusPieChartWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusPieChartWidget/TestCaseStatusPieChartWidget.component.tsx
@@ -46,21 +46,35 @@ const TestCaseStatusPieChartWidget = ({
   const [isTestCaseSummaryLoading, setIsTestCaseSummaryLoading] =
     useState(true);
 
-  const fetchTestSummary = async () => {
-    setIsTestCaseSummaryLoading(true);
-    try {
-      const { data } = await fetchTestCaseSummary(chartFilter);
-      const updatedData = transformToTestCaseStatusObject(data);
-      setTestCaseSummary(updatedData);
-    } catch {
-      setTestCaseSummary(INITIAL_TEST_SUMMARY);
-    } finally {
-      setIsTestCaseSummaryLoading(false);
-    }
-  };
-
   useEffect(() => {
+    let ignore = false;
+
+    const fetchTestSummary = async () => {
+      setIsTestCaseSummaryLoading(true);
+      try {
+        const { data } = await fetchTestCaseSummary(chartFilter);
+        if (ignore) {
+          return;
+        }
+
+        const updatedData = transformToTestCaseStatusObject(data);
+        setTestCaseSummary(updatedData);
+      } catch {
+        if (!ignore) {
+          setTestCaseSummary(INITIAL_TEST_SUMMARY);
+        }
+      } finally {
+        if (!ignore) {
+          setIsTestCaseSummaryLoading(false);
+        }
+      }
+    };
+
     fetchTestSummary();
+
+    return () => {
+      ignore = true;
+    };
   }, [chartFilter]);
 
   const handleSegmentClick = useCallback(

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusPieChartWidget/TestCaseStatusPieChartWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusPieChartWidget/TestCaseStatusPieChartWidget.component.tsx
@@ -11,7 +11,8 @@
  *  limitations under the License.
  */
 import { Card, Skeleton, Typography } from '@openmetadata/ui-core-components';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { ReactComponent as TestCaseIcon } from '../../../../assets/svg/all-activity-v2.svg';
@@ -42,40 +43,17 @@ const TestCaseStatusPieChartWidget = ({
   const routerNavigate = useNavigate();
   const navigate = navigateProp ?? routerNavigate;
 
-  const [testCaseSummary, setTestCaseSummary] = useState(INITIAL_TEST_SUMMARY);
-  const [isTestCaseSummaryLoading, setIsTestCaseSummaryLoading] =
-    useState(true);
+  const {
+    data: testCaseSummary = INITIAL_TEST_SUMMARY,
+    isLoading: isTestCaseSummaryLoading,
+  } = useQuery({
+    queryKey: ['dq-dashboard', 'test-case-summary', chartFilter],
+    queryFn: async () => {
+      const { data } = await fetchTestCaseSummary(chartFilter);
 
-  useEffect(() => {
-    let ignore = false;
-
-    const fetchTestSummary = async () => {
-      setIsTestCaseSummaryLoading(true);
-      try {
-        const { data } = await fetchTestCaseSummary(chartFilter);
-        if (ignore) {
-          return;
-        }
-
-        const updatedData = transformToTestCaseStatusObject(data);
-        setTestCaseSummary(updatedData);
-      } catch {
-        if (!ignore) {
-          setTestCaseSummary(INITIAL_TEST_SUMMARY);
-        }
-      } finally {
-        if (!ignore) {
-          setIsTestCaseSummaryLoading(false);
-        }
-      }
-    };
-
-    fetchTestSummary();
-
-    return () => {
-      ignore = true;
-    };
-  }, [chartFilter]);
+      return transformToTestCaseStatusObject(data);
+    },
+  });
 
   const handleSegmentClick = useCallback(
     (_entry: CustomPieChartData, index: number) => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusPieChartWidget/TestCaseStatusPieChartWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusPieChartWidget/TestCaseStatusPieChartWidget.test.tsx
@@ -11,9 +11,10 @@
  *  limitations under the License.
  */
 import '@testing-library/jest-dom/extend-expect';
-import { act, render, screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import { TestCaseStatus } from '../../../../generated/entity/feed/testCaseResult';
 import { fetchTestCaseSummary } from '../../../../rest/dataQualityDashboardAPI';
+import { renderWithQueryClient } from '../../../../test/unit/test-utils';
 import { formatDate } from '../../../../utils/date-time/DateTimeUtils';
 import CustomPieChart from '../../../Visualisations/Chart/CustomPieChart.component';
 import TestCaseStatusPieChartWidget from './TestCaseStatusPieChartWidget.component';
@@ -110,7 +111,7 @@ describe('TestCaseStatusPieChartWidget', () => {
   });
 
   it('should render the component', async () => {
-    render(<TestCaseStatusPieChartWidget />);
+    renderWithQueryClient(<TestCaseStatusPieChartWidget />);
 
     expect(
       await screen.findByText('label.test-case-result')
@@ -121,7 +122,7 @@ describe('TestCaseStatusPieChartWidget', () => {
   });
 
   it('fetchTestCaseSummary should be called', async () => {
-    render(<TestCaseStatusPieChartWidget />);
+    renderWithQueryClient(<TestCaseStatusPieChartWidget />);
 
     await act(async () => {
       await Promise.resolve();
@@ -136,7 +137,9 @@ describe('TestCaseStatusPieChartWidget', () => {
       tags: ['tag1', 'tag2'],
       ownerFqn: 'ownerFqn',
     };
-    render(<TestCaseStatusPieChartWidget chartFilter={filters} />);
+    renderWithQueryClient(
+      <TestCaseStatusPieChartWidget chartFilter={filters} />
+    );
 
     await act(async () => {
       await Promise.resolve();
@@ -155,11 +158,9 @@ describe('TestCaseStatusPieChartWidget', () => {
       }
     ).__getMockNavigate();
 
-    render(<TestCaseStatusPieChartWidget />);
+    renderWithQueryClient(<TestCaseStatusPieChartWidget />);
 
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await screen.findByText('CustomPieChart.component');
 
     expect(CustomPieChart).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -220,7 +221,7 @@ describe('TestCaseStatusPieChartWidget', () => {
   it('should use the supplied navigate function and test cases path', async () => {
     const navigate = jest.fn();
 
-    render(
+    renderWithQueryClient(
       <TestCaseStatusPieChartWidget
         chartFilter={{ startTs: 100, endTs: 200 }}
         navigate={navigate}
@@ -286,7 +287,7 @@ describe('TestCaseStatusPieChartWidget', () => {
       }
     );
 
-    const { rerender } = render(
+    const { rerender } = renderWithQueryClient(
       <TestCaseStatusPieChartWidget chartFilter={{ startTs: 1, endTs: 10 }} />
     );
     rerender(
@@ -296,7 +297,11 @@ describe('TestCaseStatusPieChartWidget', () => {
     );
 
     await act(async () => release[100]());
+    await screen.findByText('CustomPieChart.component');
     await act(async () => release[1]());
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
 
     expect(CustomPieChart).toHaveBeenLastCalledWith(
       expect.objectContaining({

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusPieChartWidget/TestCaseStatusPieChartWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusPieChartWidget/TestCaseStatusPieChartWidget.test.tsx
@@ -260,4 +260,53 @@ describe('TestCaseStatusPieChartWidget', () => {
       endTs: 200,
     });
   });
+
+  it('should keep the latest chartFilter data when a stale request resolves last', async () => {
+    const release: Record<number, () => void> = {};
+    const gates: Record<number, Promise<void>> = {
+      1: new Promise((resolve) => {
+        release[1] = resolve;
+      }),
+      100: new Promise((resolve) => {
+        release[100] = resolve;
+      }),
+    };
+    (fetchTestCaseSummary as jest.Mock).mockImplementation(
+      async (filters: { startTs: number }) => {
+        await gates[filters.startTs];
+
+        return {
+          data: [
+            {
+              document_count: String(filters.startTs),
+              'testCaseResult.testCaseStatus': 'success',
+            },
+          ],
+        };
+      }
+    );
+
+    const { rerender } = render(
+      <TestCaseStatusPieChartWidget chartFilter={{ startTs: 1, endTs: 10 }} />
+    );
+    rerender(
+      <TestCaseStatusPieChartWidget
+        chartFilter={{ startTs: 100, endTs: 200 }}
+      />
+    );
+
+    await act(async () => release[100]());
+    await act(async () => release[1]());
+
+    expect(CustomPieChart).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        data: [
+          expect.objectContaining({ value: 100 }),
+          expect.objectContaining({ value: 0 }),
+          expect.objectContaining({ value: 0 }),
+        ],
+      }),
+      expect.anything()
+    );
+  });
 });


### PR DESCRIPTION
### Describe your changes:

Fixes #32697

The Data Quality dashboard's chart widgets refetch every time the dashboard filter changes, but each widget applied whichever response resolved **last**. When an earlier filter's request was slower than the current one, its response overwrote the fresh data: after switching quickly from **Last 7 days** to **Yesterday**, the cards kept showing 7-day numbers while the date picker said *Yesterday*. The wrong values stayed until the next filter change.

The issue names 3 widgets; the same unguarded fetch exists in 6, and all 6 showed stale data in a live reproduction:

- `IncidentTypeAreaChartWidget`: Open / Resolved incidents
- `IncidentTimeChartWidget`: Response / Resolution time
- `TestCaseStatusAreaChartWidget`: Success / Aborted / Failed
- `DataAssetsCoveragePieChartWidget`
- `EntityHealthStatusPieChartWidget`
- `TestCaseStatusPieChartWidget`

These six, plus `StatusByDimensionCardWidget` (which already guarded against this by hand) so the dashboard uses one pattern, now fetch with `useQuery` from `@tanstack/react-query`.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

- **Approach:** each widget's `useState` + `useEffect` + `try/catch` is replaced by one `useQuery` keyed on the widget and its inputs, for example `['dq-dashboard', 'incident-status-count', incidentStatusType, chartFilter]`. The existing fetch-and-transform code moves into `queryFn` unchanged. React Query stores each result under its key, and a widget only renders data for its current key, so a late response for an earlier filter can no longer reach the screen.
- **Behavior that changes, on purpose:**
  - Query keys are compared by content, so a new `chartFilter` object with the same values no longer triggers a refetch.
  - Returning to a recently used filter shows its cached numbers immediately while they refresh in the background (`staleTime: 0`, `gcTime: 30 min`, from the app's shared `QueryClient`).
  - Under the app's retry policy, a 5xx is retried up to twice before a widget falls back to its empty state; 4xx is not retried. Previously the empty state appeared on the first failure.
- **Unchanged:** the request batcher still merges the dashboard's calls into one `POST /dataQualityReport/batch`, since the queries still start in the same tick. Loading skeletons and empty/error fallbacks render as before.
- **Why not `AbortController`:** `batchedDataQualityReport` merges every widget request made in the same tick into one POST, shares identical requests across callers, and accepts no signal; aborting one widget's call would fail the others in the same batch.
- **Why React Query over a hand-written guard:** the repo's frontend guidance prefers it for server state, it removes each widget's manual loading/error state, and 2.0 already ships `@tanstack/react-query`, so this backports cleanly.
- `EMPTY_CHART_DATA` is added to `ChartWidgets.constants.ts` as the shared empty default for the area charts, so their memoized bodies don't recompute while data is loading.
- No API, schema, or migration changes. The app already mounts `QueryClientProvider` in `App.tsx`; the dashboard suites (`DataQualityDashboard.test.tsx`, `DqDashboardSectionContent.test.tsx`) mock these widgets, so they need no provider.

#
### Tests:

#### Use cases covered
- Changing a dashboard filter while an earlier request is still in flight: when the older response arrives last, every widget keeps showing the latest filter's data.
- Existing behavior unchanged: initial load, empty-data and error fallbacks, loading state, and segment / link navigation.

#### Unit tests
- [x] Each widget's tests now render through `renderWithQueryClient` (`src/test/unit/test-utils.tsx`, retries off).
- [x] Added one race test per affected widget (`should keep the latest chartFilter data when a stale request resolves last`): render with filter A, switch to filter B, resolve B's response and then A's, flush pending timers, and assert B's data is what's shown. All six **fail against `main`'s widgets** (for example `Expected 100, Received 1`, `Expected "1h 32m", Received "--"`, and the pie charts' last render carries the stale slices, `1 / 999` instead of `100 / 900`) and pass with this change. `StatusByDimensionCardWidget`'s existing stale-response test still passes.
- React Query delivers its updates on `setTimeout(0)`, and Jest fakes timers globally here, so the three pie-chart `onSegmentClick` tests now wait for the chart with `findByText` instead of a single-microtask flush.
- Files updated: the `*.test.tsx` next to each of the seven widgets.
- `yarn test` on the chart widgets, both dashboard renderers, and the incident manager: 22 suites, 247 tests passing. Coverage on the changed components:

  | Component | Lines | Branches |
  |---|---|---|
  | `DataAssetsCoveragePieChartWidget` | 97.61% | 94.44% |
  | `EntityHealthStatusPieChartWidget` | 100% | 100% |
  | `IncidentTimeChartWidget` | 100% | 88.88% |
  | `IncidentTypeAreaChartWidget` | 100% | 91.66% |
  | `StatusByDimensionCardWidget` | 100% | 100% |
  | `TestCaseStatusAreaChartWidget` | 100% | 95.23% |
  | `TestCaseStatusPieChartWidget` | 100% | 100% |

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- Not added. The bug only appears when responses arrive out of order; the unit tests control that order deterministically, while an E2E version would depend on route-level response delays and add flakiness without covering more logic.

#### Manual testing performed
1. Local stack on `:8585` with incidents dated Sep 7–9; opened **Data Quality → Summary** as admin.
2. In DevTools, held back the dashboard's batch request (snippet below), selected **Last 7 days**, then **Yesterday** before that request finished.
3. On `main`: once the held-back response landed, all six widgets switched to 7-day values (Open / Resolved incidents `2 / 18`, response / resolution time `3s / 4s`, test cases `12 / 1 / 2`, pie charts `3` tables covered, `3` entities, `5` tests) while the picker still read *Yesterday · Sep 10 – Sep 11*. `StatusByDimensionCardWidget`, which already had a guard, correctly stayed at 0.
4. With this branch (Vite dev server on `:3000` against the same backend and data), same steps: the held-back 7-day response landed at 11.0 s, after Yesterday's at 2.1 s, and nothing on the dashboard changed. Incidents stayed `0 / 0`, response / resolution time `-- / --`, test cases `0 / 0 / 0`, all three pie charts `0`, and the dimension cards `0`, with the picker on *Yesterday · Sep 10 – Sep 11*.

<details><summary>DevTools snippet: hold back the next dashboard batch request by 10 s</summary>

```js
const open = XMLHttpRequest.prototype.open;
const send = XMLHttpRequest.prototype.send;
let delayNext = true;
XMLHttpRequest.prototype.open = function (method, url, ...rest) {
  this.__url = String(url);
  return open.call(this, method, url, ...rest);
};
XMLHttpRequest.prototype.send = function (body) {
  if (delayNext && this.__url.includes('dataQualityReport/batch')) {
    delayNext = false;
    setTimeout(() => send.call(this, body), 10000);
    return;
  }
  return send.call(this, body);
};
```

</details>

#
### UI screen recording / screenshots:

TODO: attach a before/after recording of the steps above.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
