### PR TITLE
Fixes #33190: Stop Mode report pagination on unseen-report exhaustion

### DIFF
--- a/ingestion/.basedpyright/baseline.json
+++ b/ingestion/.basedpyright/baseline.json
@@ -19072,30 +19072,6 @@
                 }
             },
             {
-                "code": "reportIndexIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportReturnType",
                 "range": {
                     "startColumn": 19,

--- a/ingestion/src/metadata/ingestion/source/dashboard/mode/client.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/mode/client.py
@@ -12,6 +12,7 @@
 REST Auth & Client for Mode
 """
 
+import json
 import traceback
 from base64 import b64encode
 from typing import TYPE_CHECKING, Any, cast
@@ -45,7 +46,14 @@ DESCRIPTION = "description"
 LINKS = "_links"
 SHARE = "share"
 HREF = "href"
-REPORTS_PAGE_SIZE = 30
+
+
+def _report_key(report: dict[str, Any]) -> str:
+    """Identify a report for de-duplication, tolerating a missing token."""
+    token = report.get(TOKEN)
+    if token:
+        return str(token)
+    return json.dumps(report, sort_keys=True, default=str)
 
 
 class ModeApiClient:
@@ -77,11 +85,18 @@ class ModeApiClient:
 
     def fetch_all_reports(self, workspace_name: str, filter: str | None = "all") -> list[dict[str, Any]]:
         """Method to fetch all reports for Mode
+
+        Mode neither documents a stable report page size nor guarantees an empty page
+        past the last one: an out-of-range page may be clamped back to the last page,
+        and a page parameter the API ignores repeats page one indefinitely. Pagination
+        therefore stops once a page carries no unseen report, which terminates in all
+        of those cases without assuming how many records a full page holds.
+
         Args:
             workspace_name:
             filter:
         Returns:
-            dict
+            the report records of every visible space
         """
         if filter not in ["custom", "all"]:
             raise ValueError(f"Invalid Mode filter [{filter}]. Expected one of ['custom', 'all']")
@@ -94,8 +109,8 @@ class ModeApiClient:
         )
         spaces = response_spaces[EMBEDDED][SPACES]
         for space in spaces:
+            seen_reports = set()
             page = 1
-            previous_reports = None
             while True:
                 response_reports = self.get_reports_for_space(
                     workspace_name=workspace_name,
@@ -103,14 +118,11 @@ class ModeApiClient:
                     page=page,
                 )
                 reports = response_reports[EMBEDDED][REPORTS]
-                if reports and reports == previous_reports:
-                    raise RuntimeError(
-                        f"Mode returned the same report page twice for space [{space[TOKEN]}] at page [{page}]"
-                    )
-                all_reports.extend(reports)
-                if len(reports) < REPORTS_PAGE_SIZE:
+                new_reports = [report for report in reports if _report_key(report) not in seen_reports]
+                if not new_reports:
                     break
-                previous_reports = reports
+                seen_reports.update(_report_key(report) for report in new_reports)
+                all_reports.extend(new_reports)
                 page += 1
         return all_reports
 

--- a/ingestion/tests/unit/source/dashboard/mode/test_client.py
+++ b/ingestion/tests/unit/source/dashboard/mode/test_client.py
@@ -17,8 +17,8 @@ import pytest
 from metadata.ingestion.source.dashboard.mode.client import ModeApiClient
 
 
-def _reports(prefix: str, count: int) -> list[dict]:
-    return [{"token": f"{prefix}-{index}"} for index in range(count)]
+def _reports(prefix: str, count: int, start: int = 0) -> list[dict]:
+    return [{"token": f"{prefix}-{index}"} for index in range(start, start + count)]
 
 
 def _embedded(name: str, values: list[dict]) -> dict:
@@ -40,7 +40,9 @@ def test_fetch_all_reports_paginates_every_space(mode_client):
         _embedded("spaces", [{"token": "finance"}, {"token": "operations"}]),
         _embedded("reports", first_space_page),
         _embedded("reports", second_space_page),
+        _embedded("reports", []),
         _embedded("reports", operations_page),
+        _embedded("reports", []),
     ]
 
     reports = mode_client.fetch_all_reports("acme", "custom")
@@ -50,22 +52,50 @@ def test_fetch_all_reports_paginates_every_space(mode_client):
         call("/acme/spaces?filter=custom"),
         call("/acme/spaces/finance/reports?page=1"),
         call("/acme/spaces/finance/reports?page=2"),
+        call("/acme/spaces/finance/reports?page=3"),
         call("/acme/spaces/operations/reports?page=1"),
+        call("/acme/spaces/operations/reports?page=2"),
     ]
 
 
-def test_fetch_all_reports_requests_page_after_exactly_thirty_results(mode_client):
-    first_page = _reports("report", 30)
+def test_fetch_all_reports_keeps_paging_after_a_page_smaller_than_thirty(mode_client):
+    """A page size below 30 must not be mistaken for the end of the space."""
+    first_page = _reports("report", 25)
+    second_page = _reports("report", 25, start=25)
     mode_client.client.get.side_effect = [
         _embedded("spaces", [{"token": "space-token"}]),
         _embedded("reports", first_page),
+        _embedded("reports", second_page),
         _embedded("reports", []),
     ]
 
-    reports = mode_client.fetch_all_reports("acme")
+    assert mode_client.fetch_all_reports("acme") == first_page + second_page
 
-    assert reports == first_page
+
+def test_fetch_all_reports_stops_when_a_page_repeats(mode_client):
+    """Mode may clamp an out-of-range page, or ignore the page parameter entirely."""
+    repeated_page = _reports("report", 30)
+    mode_client.client.get.side_effect = [
+        _embedded("spaces", [{"token": "space-token"}]),
+        _embedded("reports", repeated_page),
+        _embedded("reports", repeated_page),
+    ]
+
+    assert mode_client.fetch_all_reports("acme") == repeated_page
     assert mode_client.client.get.call_args_list[-1] == call("/acme/spaces/space-token/reports?page=2")
+
+
+def test_fetch_all_reports_keeps_only_the_first_copy_of_an_overlapping_report(mode_client):
+    first_page = _reports("report", 30)
+    overlapping_page = _reports("report", 4, start=28)
+    mode_client.client.get.side_effect = [
+        _embedded("spaces", [{"token": "space-token"}]),
+        _embedded("reports", first_page),
+        _embedded("reports", overlapping_page),
+        _embedded("reports", []),
+    ]
+
+    assert mode_client.fetch_all_reports("acme") == first_page + overlapping_page[2:]
 
 
 def test_fetch_all_reports_propagates_later_page_failure(mode_client):
@@ -86,20 +116,6 @@ def test_fetch_all_reports_rejects_invalid_filter(mode_client):
     mode_client.client.get.assert_not_called()
 
 
-def test_fetch_all_reports_rejects_repeated_full_page(mode_client):
-    repeated_page = _reports("report", 30)
-    mode_client.client.get.side_effect = [
-        _embedded("spaces", [{"token": "space-token"}]),
-        _embedded("reports", repeated_page),
-        _embedded("reports", repeated_page),
-    ]
-
-    with pytest.raises(RuntimeError, match="same report page twice"):
-        mode_client.fetch_all_reports("acme")
-
-    assert mode_client.client.get.call_args_list[-1] == call("/acme/spaces/space-token/reports?page=2")
-
-
 def test_fetch_all_reports_allows_distinct_tokenless_pages(mode_client):
     first_page = [{"name": f"first-{index}"} for index in range(30)]
     second_page = [{"name": f"second-{index}"} for index in range(30)]
@@ -111,3 +127,14 @@ def test_fetch_all_reports_allows_distinct_tokenless_pages(mode_client):
     ]
 
     assert mode_client.fetch_all_reports("acme") == first_page + second_page
+
+
+def test_fetch_all_reports_stops_when_a_tokenless_page_repeats(mode_client):
+    repeated_page = [{"name": f"report-{index}"} for index in range(30)]
+    mode_client.client.get.side_effect = [
+        _embedded("spaces", [{"token": "space-token"}]),
+        _embedded("reports", repeated_page),
+        _embedded("reports", repeated_page),
+    ]
+
+    assert mode_client.fetch_all_reports("acme") == repeated_page


### PR DESCRIPTION
### Describe your changes:

Fixes #33190

Hardens the pagination added for #22559; the defects below were found in review
of the 1.13 backport, so they get their own issue rather than reopening a closed one.

#32533 paginated Mode report discovery so that reports past the first page of a
space are ingested. Its termination condition — `len(reports) < REPORTS_PAGE_SIZE`
with `REPORTS_PAGE_SIZE = 30` — makes two assumptions about Mode's API that the
API does not guarantee, both of which lose reports. Review on the 1.13 backport
(#33147) raised them; this is the same fix on `main` so the two branches carry
one pagination contract.

**Silent truncation.** If a report page ever holds fewer than 30 records, the
first page satisfies `len(reports) < 30`, the walk stops, and the remainder of
that space is dropped with no warning and no error — reproducing the very
missing-reports symptom #22559 was filed about. The page size is undocumented
and is not pinned with a `per_page` parameter, so a server-side default change
silently regresses the connector.

**Hard abort.** A guard added during review raised `RuntimeError` when a page
repeated. Many paginated REST APIs clamp an out-of-range `page` to the last page
and re-return it instead of returning an empty list. A space holding an exact
multiple of 30 reports therefore takes the `page += 1` branch, receives the same
page back, and raises. `fetch_all_reports` is called from `get_dashboards_list`
without a guard, so that exception kills the whole Mode source and drops every
dashboard of every space — a benign input destroying an entire ingestion run.

Pagination now stops once a page carries no report unseen in that space.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

One condition replaces both heuristics:

```python
new_reports = [report for report in reports if _report_key(report) not in seen_reports]
if not new_reports:
    break
```

It terminates on every case the old code handled and the two it mishandled:

| Server behaviour | Old | New |
|---|---|---|
| Empty page past the last | stops | stops |
| Page size below 30 | **drops the rest of the space** | keeps paging |
| Out-of-range page clamped to the last | **raises, kills the run** | stops, keeps the reports |
| `page` parameter ignored entirely | raises | stops |
| Pages overlap after a mid-walk insert | duplicates rows | keeps the first copy |

Page size is no longer consulted, so `REPORTS_PAGE_SIZE` is removed rather than
re-tuned — the failure mode is structurally gone, not calibrated against a
guessed constant.

`_report_key` de-duplicates by report token and falls back to a sorted JSON dump
of the record when Mode omits one, so token-less pages neither collide with each
other nor loop forever.

**Cost:** one extra request per space, always — the terminal empty or repeated
page. The old code already paid that whenever a space's report count was an
exact multiple of 30. `seen_reports` is a per-space working set, reset each
space and bounded by that space's report count, which is the same order as the
`all_reports` accumulator that already existed.

**Alternative considered:** following `_links.next` from Mode's HAL response
would be contract-driven rather than heuristic, and the client already reads
`_links` for `share` and `report_viz_web`. It is the better long-term shape, but
confirming the pagination link's presence needs a live Mode Business workspace,
which is unavailable here. The unseen-report condition needs no knowledge of the
response envelope, so it is correct without that confirmation and does not block
moving to `_links.next` later.

`ingestion/.basedpyright/baseline.json` drops three suppressed diagnostics that
the removed code carried (9 → 6 for `mode/client.py`). Verified structurally
that no other file key changed: 809 keys before and after, none added or
removed.

#
### Tests:

#### Use cases covered

- A space whose pages hold fewer than 30 records is walked to the end instead of
  stopping after page one
- A last page re-returned because Mode clamped the out-of-range page ends the
  walk and keeps its reports, instead of aborting the source
- A `page` parameter the API ignores terminates instead of looping forever
- Pages that overlap after a mid-walk insert contribute each report once
- Multiple spaces, each paged independently to its terminal page
- Reports with no token, across distinct pages and across a repeated page
- A page request that fails mid-walk still propagates
- An invalid `filterQueryParam` still fails fast with a clear message

#### Unit tests

- [x] I added unit tests for the new/changed logic.
- File: `ingestion/tests/unit/source/dashboard/mode/test_client.py` — rewritten
  around the new contract, 6 → 8 tests. `test_fetch_all_reports_rejects_repeated_full_page`
  is deleted because it asserted the removed `RuntimeError`;
  `test_..._requests_page_after_exactly_thirty_results` is folded into the
  multi-space test, which now asserts the terminal page request per space.
- Both defects have a named regression test:
  `test_fetch_all_reports_keeps_paging_after_a_page_smaller_than_thirty` (two
  25-record pages return all 50; the old code returned 25) and
  `test_fetch_all_reports_stops_when_a_page_repeats` (a clamped repeat returns
  30 reports instead of raising).
- **Result: 42 passed** — Mode client (8), Mode connection (3), Mode topology
  (17), plus `burstiq` (10) and `qlikcloud` (4) run alongside so any test-module
  name collision would surface.
- **Changed-line coverage on `client.py`: 100%** — all 22 changed/added lines are
  executed; cross-referenced `--cov-report=term-missing` against the diff's line
  ranges.

#### Backend integration tests

- [x] Not applicable (no backend API changes).

#### Ingestion integration tests

- [x] Not applicable. A live Mode Business workspace and credentials are
  unavailable, so the Mode HTTP boundary stays covered with fixtures. The change
  is deliberately shaped to need no knowledge of the response envelope beyond
  `_embedded.reports`, which the connector already depended on.

#### Playwright (UI) tests

- [x] Not applicable (no UI changes).

#### Manual testing performed

Commands run on this branch, with their actual results:

1. `pytest tests/unit/source/dashboard/mode/ tests/unit/topology/dashboard/test_mode.py tests/unit/source/database/burstiq tests/unit/source/dashboard/qlikcloud` — 42 passed
2. `pytest ... --cov=metadata.ingestion.source.dashboard.mode --cov-report=term-missing` — used to confirm every changed line in `client.py` is covered
3. `ruff check ... --config pyproject.toml` — no issues
4. `python scripts/check_ruff_suppressions.py --check` — exit 0
5. `ruff format --check ... --config pyproject.toml` — already formatted
6. `basedpyright src/metadata/ingestion/source/dashboard/mode/client.py` — 0 errors, 0 warnings, 0 notes
7. Pre-commit on the commit — check json / ruff check / ruff format all passed

Not performed: a live Mode ingestion run, for lack of workspace credentials.

#
### UI screen recording / screenshots:

Not applicable — no UI changes.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas — the
      pagination contract and why it cannot rely on page size is documented on
      `fetch_all_reports`.
- [x] For JSON Schema changes: not applicable, no schema change.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.
