### PR TITLE
test(playwright): page to the Search Indexing card [2.0 backport of #32295]

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LiveIndexingTab.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LiveIndexingTab.spec.ts
@@ -12,6 +12,7 @@
  */
 import test, { expect } from '@playwright/test';
 import { GlobalSettingOptions } from '../../constant/settings';
+import { openApplicationDetails } from '../../utils/applications';
 import { getApiContext, redirectToHomePage } from '../../utils/common';
 import { settingClick } from '../../utils/sidebar';
 
@@ -93,11 +94,7 @@ test.describe(
         await redirectToHomePage(page);
         await settingClick(page, GlobalSettingOptions.APPLICATIONS);
 
-        await page
-          .locator(
-            '[data-testid="search-indexing-application-card"] [data-testid="config-btn"]'
-          )
-          .click();
+        await openApplicationDetails(page, 'search-indexing-application-card');
       });
 
       await test.step('Click Live Indexing tab', async () => {
@@ -144,11 +141,7 @@ test.describe(
         await redirectToHomePage(page);
         await settingClick(page, GlobalSettingOptions.APPLICATIONS);
 
-        await page
-          .locator(
-            '[data-testid="search-indexing-application-card"] [data-testid="config-btn"]'
-          )
-          .click();
+        await openApplicationDetails(page, 'search-indexing-application-card');
       });
 
       await test.step('Verify empty state message when queue is empty', async () => {
@@ -214,11 +207,7 @@ test.describe(
         await redirectToHomePage(page);
         await settingClick(page, GlobalSettingOptions.APPLICATIONS);
 
-        await page
-          .locator(
-            '[data-testid="search-indexing-application-card"] [data-testid="config-btn"]'
-          )
-          .click();
+        await openApplicationDetails(page, 'search-indexing-application-card');
       });
 
       await test.step('Mock and verify retry queue data', async () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchIndexApplication.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchIndexApplication.spec.ts
@@ -14,6 +14,10 @@ import test, { expect, Page, Response } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { GlobalSettingOptions } from '../../constant/settings';
 import {
+  expectApplicationInstalled,
+  openApplicationDetails,
+} from '../../utils/applications';
+import {
   clickOutside,
   getApiContext,
   redirectToHomePage,
@@ -117,9 +121,7 @@ const installSearchIndexApplication = async (page: Page) => {
 
   await getApplications;
 
-  await expect(
-    page.getByTestId('search-indexing-application-card')
-  ).toBeVisible();
+  await expectApplicationInstalled(page, 'search-indexing-application-card');
 };
 
 const verifyLastExecutionStatus = async (page: Page) => {
@@ -291,11 +293,7 @@ test.describe('Search Index Application', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       const statusAPI = page.waitForResponse(
         '/api/v1/apps/name/SearchIndexingApplication/status?offset=0&limit=1'
       );
-      await page
-        .locator(
-          '[data-testid="search-indexing-application-card"] [data-testid="config-btn"]'
-        )
-        .click();
+      await openApplicationDetails(page, 'search-indexing-application-card');
       const statusResponse = await statusAPI;
 
       expect(statusResponse.status()).toBe(200);
@@ -446,9 +444,7 @@ test.describe('Search Index Application', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       await test.step('Run application and rerun with table-only config', async () => {
         test.slow(true); // Test time shouldn't exceed while re-fetching the history API.
 
-        await page.click(
-          '[data-testid="search-indexing-application-card"] [data-testid="config-btn"]'
-        );
+        await openApplicationDetails(page, 'search-indexing-application-card');
 
         const previousRunStartTime = await getLatestRunStartTime(page);
         const triggerPipelineResponse = page.waitForResponse(

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/applications.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/applications.ts
@@ -10,7 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { APIRequestContext } from '@playwright/test';
+import { APIRequestContext, expect, Page } from '@playwright/test';
+import { clickAndWaitFor } from './waitHelpers';
 
 export const enableDisableAutoPilotApplication = async (
   apiContext: APIRequestContext,
@@ -22,4 +23,70 @@ export const enableDisableAutoPilotApplication = async (
       'Content-Type': 'application/json-patch+json',
     },
   });
+};
+
+const APPLICATION_CARD = '[data-testid$="-application-card"]';
+const APPLICATIONS_LIST_API = /\/api\/v1\/apps\?/;
+
+const waitForApplicationCards = async (page: Page) => {
+  await expect(page.locator(APPLICATION_CARD)).not.toHaveCount(0);
+};
+
+/**
+ * Walk the installed applications list from the current page onwards, stopping
+ * as soon as the card is on screen. Returns whether it was found anywhere.
+ *
+ * The list paginates at PAGE_SIZE_BASE (15) and the installed app count grows
+ * whenever a new application ships, so a card sitting on page 1 today silently
+ * moves to page 2 the next time one is added.
+ */
+const isOnAnyApplicationPage = async (page: Page, cardTestId: string) => {
+  await waitForApplicationCards(page);
+
+  const card = page.getByTestId(cardTestId);
+  const nextPage = page.getByTestId('next');
+
+  while (!(await card.isVisible())) {
+    const canPage =
+      (await nextPage.isVisible()) && (await nextPage.isEnabled());
+
+    if (!canPage) {
+      return false;
+    }
+
+    await clickAndWaitFor(page, nextPage, APPLICATIONS_LIST_API);
+
+    // The list swaps its cards for skeletons while loading, so the next card
+    // to appear can only belong to the page we just moved to.
+    await waitForApplicationCards(page);
+  }
+
+  return true;
+};
+
+/**
+ * Assert an application is installed, paging until its card is found. Use this
+ * rather than a bare toBeVisible(), which only ever asserts about page 1.
+ */
+export const expectApplicationInstalled = async (
+  page: Page,
+  cardTestId: string
+) => {
+  expect(
+    await isOnAnyApplicationPage(page, cardTestId),
+    `${cardTestId} should be on some page of the applications list`
+  ).toBe(true);
+};
+
+/**
+ * Open an installed application's details page from Settings > Applications,
+ * paging to its card first. Assumes the applications list is already open.
+ */
+export const openApplicationDetails = async (
+  page: Page,
+  cardTestId: string
+) => {
+  await expectApplicationInstalled(page, cardTestId);
+
+  await page.getByTestId(cardTestId).getByTestId('config-btn').click();
 };


### PR DESCRIPTION
### Describe your changes:

Minimal backport of #32295 to `2.0`: only the paging fix. #32295 shipped without a linked issue, so this backport has none either.

Settings > Applications paginates at `PAGE_SIZE_BASE` (15). On `2.0` these specs click the **Search Indexing** card without paging, and they started failing as 60s click timeouts in the 11 Sep AUT nightly `1.11.13 ➡ 2.0` (runs `34563613272` mysql, `34563617983` postgres), identically on both databases:

- `LiveIndexingTab.spec.ts:89`, `:140`, `:180`
- `SearchIndexApplication.spec.ts:258`

The trigger is #33098 (single-writer RDF reindex backport). Its `RdfIndexApp` constructor now resolves the repository lazily (`getInstanceOrNull()` + `rdf()`), so with RDF disabled the default install in `AppResource.loadDefaultApplications` succeeds instead of throwing `RdfRepository not initialized` and being skipped. `RdfIndexApp` sorts before `SearchIndexingApplication`, takes slot 15, and pushes the card to page 2. In the failing trace, `GET /api/v1/apps?limit=15` returns `total: 18` with page 1 ending at `RdfIndexApp`; the last green run (10 Sep) had no `RdfIndexApp` installed. #33098 is correct; the specs' page-1 assumption is the bug.

Changes:

- `playwright/utils/applications.ts`: `expectApplicationInstalled` and `openApplicationDetails`, which page the installed list until the card is on screen. Same names and call signatures as on `main`, so later backports that use them apply cleanly.
- `LiveIndexingTab.spec.ts`: the three card clicks go through `openApplicationDetails`.
- `SearchIndexApplication.spec.ts`: the two card clicks go through `openApplicationDetails`, and the post-reinstall `toBeVisible()` becomes `expectApplicationInstalled` — once the card is on page 2 that assertion would fail too.

Not backported from #32295, as this failure doesn't need them: the marketplace-loop refactor in `installSearchIndexApplication`, the `TestDefinitionPermissions` steward-switch fix, the Data Insights guard in `LiveIndexingTab`, `expectApplicationNotInstalled`, and the `eslint-suppressions.json` / `corpus.test.mjs` updates that went with them. The suppressed `.first()` calls in these specs are untouched, so the suppression baseline is unchanged.

#
### Type of change:
- [x] Bug fix (test-only)

#
### High-level design:

N/A — small test-only backport, no product code.

#
### Tests:

#### Use cases covered
- The Search Indexing app details open from Settings > Applications whichever page its card lands on.
- After the uninstall/reinstall in `SearchIndexApplication.spec.ts`, the reinstalled app is found on any page of the installed list.

#### Unit tests
Not applicable — test-only change. `yarn test:eslint-rules`: 22/22 pass.

#### Backend integration tests
Not applicable — no backend changes.

#### Ingestion integration tests
Not applicable — no ingestion changes.

#### Playwright (UI) tests
Files updated:
- `playwright/utils/applications.ts`
- `playwright/e2e/Pages/LiveIndexingTab.spec.ts`
- `playwright/e2e/Pages/SearchIndexApplication.spec.ts`

Verified on this branch with `2.0`'s own dependencies:
- `yarn lint:playwright`: 0 errors (229 existing warnings); suppression baseline unchanged.
- organize-imports → `eslint --fix` → prettier on the changed files: no diff.
- `yarn tsc:playwright`: no errors on changed lines. The two `TS2345` errors reported in `SearchIndexApplication.spec.ts` are on untouched `getAppRunRecord(response)` calls and exist independently of this change.

**The four tests have not been run locally** — no stack to run them against; CI and the next `2.0` AUT nightly will confirm.

#### Manual testing performed
Not applicable — see above.

#
### UI screen recording / screenshots:

Not applicable — test-only change.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` — N/A: backport of #32295, which has no linked issue.
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above — N/A: same.
- [ ] I have commented on my code, particularly in hard-to-understand areas — the new helpers carry doc comments on why they page.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed — N/A.
- [ ] For UI changes: I attached a screen recording and/or screenshots above — N/A: test-only.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above — N/A: this PR only changes Playwright tests, listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
