### PR TITLE
fix(ui-core): keep focus in the FilterSelect search box while results load

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/filter-select/filter-select.focus.test.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/filter-select/filter-select.focus.test.tsx
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * Focus behaviour lives in its own file on purpose: react-aria tracks the
+ * active focus scope in module state, and a file that has already mounted
+ * several popovers no longer reproduces a focus steal — these assertions
+ * pass for the wrong reason when they share a file with the rest of the
+ * suite. Vitest isolates per file, so each case here starts from a clean
+ * focus-scope stack.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { FilterSelect } from './filter-select';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => (key === 'label.search' ? 'Search' : key),
+  }),
+}));
+
+const OPTIONS = [
+  { value: 'snowflake', label: 'Snowflake' },
+  { value: 'bigquery', label: 'BigQuery' },
+];
+
+describe('FilterSelect focus', () => {
+  it('keeps focus in the search box when async results arrive', () => {
+    const props = {
+      isOpen: true as const,
+      label: 'Service',
+      searchable: true,
+      selectedValues: [],
+      onChange: () => undefined,
+      onSearch: () => undefined,
+    };
+    const { rerender } = render(<FilterSelect {...props} options={OPTIONS} />);
+    const search = screen.getByPlaceholderText('Search');
+    search.focus();
+    fireEvent.change(search, { target: { value: 'big' } });
+
+    // The menu unmounts for the skeleton and remounts with the results.
+    rerender(<FilterSelect {...props} isLoading options={[]} />);
+    rerender(<FilterSelect {...props} options={[OPTIONS[1]]} />);
+
+    expect(document.activeElement).toBe(screen.getByPlaceholderText('Search'));
+  });
+
+  it('leaves the options reachable by keyboard while the search box has focus', () => {
+    render(
+      <FilterSelect
+        isOpen
+        searchable
+        label="Service"
+        options={OPTIONS}
+        selectedValues={[]}
+        onChange={() => undefined}
+      />
+    );
+
+    // Suppressing the menu's autofocus must not drop it out of the tab order.
+    expect(screen.getByRole('menu')).toHaveAttribute('tabindex', '0');
+  });
+});

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/filter-select/filter-select.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/filter-select/filter-select.tsx
@@ -555,6 +555,10 @@ export const FilterSelect = ({
         {!isLoading && !isEmpty && (
           <Dropdown.Menu
             aria-label={label}
+            // A search box owns focus while it is there: the menu remounts
+            // whenever results land, and MenuTrigger's autofocus would pull
+            // the caret out of the box mid-query.
+            autoFocus={searchable ? false : undefined}
             className="tw:max-h-64 tw:overflow-y-auto"
             disallowEmptySelection={false}
             selectedKeys={selectedKeySet}


### PR DESCRIPTION
Fixes #33198 [6120](https://github.com/open-metadata/openmetadata-collate/issues/6120)

Stacked on #33011 — based on `feat-filter-select-core` so the diff shows only this change. GitHub retargets it to `main` once #33011 merges.

## The bug

Typing in a FilterSelect search box worked for the first query, then the caret jumped out of the input; every further character needed a click back into the box first.

The option list renders as `{!isLoading && !isEmpty && <Dropdown.Menu>}`, so an async search unmounts the menu for the loading skeleton and remounts it when results arrive — and React Aria's `MenuTrigger` autofocuses a menu as it mounts. Confirmed rather than inferred: after results landed, `document.activeElement` was the menu's own `<div id="react-aria-:r1:">`.

Local filtering hits the same path whenever a query matches nothing and then matches again, because `isEmpty` toggles the menu out and back.

## The fix

A search box owns focus while it is present:

```tsx
autoFocus={searchable ? false : undefined}
```

Keyboard access is unaffected — the menu keeps `tabindex="0"`, so Tab still reaches the options and arrow keys work from there. Dropdowns without a search box are untouched and still focus the menu on open.

## Tests

The focus assertions live in a new `filter-select.focus.test.tsx` rather than the main suite. React Aria tracks the active focus scope in module state, so a file that has already mounted several popovers stops reproducing the steal — placed in the shared file, these assertions passed *without* the fix applied. Vitest isolates per file, which keeps them honest.

Verified in both directions: red with the fix reverted, green with it applied.

- `yarn vitest run src/components/application/filter-select` — 34 passing across 2 files
- `yarn type-check`, `yarn lint`, `npx prettier --check src/` — clean