### PR TITLE
fix(release): stop false MVN-publish failures — wait for validation, not full publish

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1304,7 +1304,12 @@
         <configuration>
           <publishingServerId>central</publishingServerId>
           <autoPublish>true</autoPublish>
-          <waitUntil>published</waitUntil>
+          <!-- Return once Sonatype has validated the bundle; autoPublish still
+               publishes it afterwards. Waiting for the terminal 'published' state
+               polls Central's async publish queue, which is slow on busy days and
+               times out (~30m) as a false BUILD FAILURE even though the upload and
+               validation succeeded (e.g. the 1.13.6 release). -->
+          <waitUntil>validated</waitUntil>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
## Problem

The `MVN packages` release job intermittently fails even though the artifacts end up on Maven Central. Latest example: **1.13.6** — the job errored with:

```
Polling for <id> timed out before the deployment completed.
```

yet `openmetadata-java-client:1.13.6` and `openmetadata-spec:1.13.6` are live on Central. It recurs whenever Sonatype Central is busy, and each time someone has to manually confirm and mark the job done.

## Root cause

The plugin is set to `waitUntil=published`, so after uploading it **blocks until Sonatype finishes copying the bundle into Maven Central** — a slow, async step on Sonatype's side. On busy days that exceeds the plugin's ~30 min poll window and fails the build, even though upload + validation already succeeded.

## Fix

```xml
<autoPublish>true</autoPublish>
- <waitUntil>published</waitUntil>
+ <waitUntil>validated</waitUntil>
```

Return once Sonatype has **validated** the bundle. `autoPublish=true` is unchanged, so Sonatype still publishes it automatically afterwards — we just stop the CI job from babysitting that last step.

## Why this is safe (verification)

Central's deployment lifecycle:

```
PENDING → VALIDATING → VALIDATED → PUBLISHING → PUBLISHED
          └─ fast, deterministic ─┘   └─ slow, Sonatype-side ─┘
                                        ^ CI times out here ^
```

- Everything that can legitimately fail your artifacts — GPG signature, missing sources/javadoc, POM requirements — is checked at **VALIDATION**, which we still wait for and which still fails the build.
- After VALIDATED, only **PUBLISHING** (Central copying bytes into the repo) and **PUBLISHED** remain. That copy is where the timeout happens — it's Sonatype's async queue, not anything about our build.
- With `autoPublish=true` the deployment is AUTOMATIC, so per Sonatype's docs it "automatically proceed[s] to publish to Maven Central" after validation regardless of whether the client keeps polling. 1.13.6 proves it: the poll timed out yet the artifacts published.

So `validated` keeps the meaningful gate and drops the flaky one.

## Backports

Cherry-pick to `2.0` and `1.13` so the recurrence actually stops.

## What to watch on the next release

The `MVN packages` job should finish in a few minutes (upload + validate) and go green, with artifacts still appearing on Central shortly after — instead of hanging ~30 min and false-failing.
