### PR TITLE
fix(release): wait for validation, not full publish [2.0 backport of #33201]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1298,7 +1298,12 @@
         <configuration>
           <publishingServerId>central</publishingServerId>
           <autoPublish>true</autoPublish>
-          <waitUntil>published</waitUntil>
+          <!-- Return once Sonatype has validated the bundle; autoPublish still
+               publishes it afterwards. Waiting for the terminal 'published' state
+               polls Central's async publish queue, which is slow on busy days and
+               times out (~30m) as a false BUILD FAILURE even though the upload and
+               validation succeeded (e.g. the 1.13.6 release). -->
+          <waitUntil>validated</waitUntil>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Backport of #33201 to `2.0`.

Switch the release publish plugin from `waitUntil=published` to `waitUntil=validated` so the `MVN packages` job stops false-failing on Sonatype Central publish-queue timeouts (e.g. 1.13.6). `autoPublish=true` is unchanged, so Central still auto-publishes after validation.

Flow: `VALIDATED` (fast, real failures caught here) → `PUBLISHING` (Sonatype copies bytes into Central — slow, where the ~30 min poll times out) → `PUBLISHED`. We now cut CI loose at `VALIDATED` and let Central finish on its own.

See #33201 for full rationale and verification.