### PR TITLE
fix(ui): stop the entity hover card outliving its trigger, and tell 403 apart from empty

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/EntityPopOverCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/EntityPopOverCard.test.tsx
@@ -11,13 +11,7 @@
  *  limitations under the License.
  */
 
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter, useNavigate } from 'react-router-dom';
 import { EntityType } from '../../../enums/entity.enum';
 import { ServiceCategoryPlural } from '../../../enums/service.enum';
@@ -304,51 +298,26 @@ describe('Test EntityPopoverCard component', () => {
     expect(screen.getByText('label.no-data-found')).toBeInTheDocument();
   });
 
-  it('EntityPopoverCard should not open, or refetch, once the entity returns 403', async () => {
-    const forbiddenFQN = 'forbidden.tag.fqn';
-    const mockTagAPI = getTagByFqn as jest.Mock;
-    mockTagAPI.mockImplementation(() =>
-      Promise.reject({ response: { status: 403 } })
+  it('EntityPopoverCard should show permission placeholder when the api returns 403', async () => {
+    (getTagByFqn as jest.Mock).mockImplementationOnce(() =>
+      Promise.reject({
+        response: { status: 403, data: { message: 'Forbidden!' } },
+      })
     );
 
-    const callsBefore = mockTagAPI.mock.calls.length;
+    await act(async () => {
+      render(
+        <PopoverContent
+          entityFQN={MOCK_TAG_ENCODED_FQN}
+          entityType={EntityType.TAG}
+        />
+      );
+    });
 
-    const { unmount } = render(
-      <MemoryRouter>
-        <EntityPopOverCard
-          defaultOpen
-          entityFQN={forbiddenFQN}
-          entityType={EntityType.TAG}>
-          <div data-testid="popover-container">Test_Popover</div>
-        </EntityPopOverCard>
-      </MemoryRouter>
-    );
-
-    // the popup opened, hit the 403, and closed itself
-    await waitFor(() =>
-      expect(screen.queryByText('label.no-data-found')).toBeNull()
-    );
-
-    expect(mockTagAPI.mock.calls.length).toBe(callsBefore + 1);
-
-    unmount();
-
-    render(
-      <MemoryRouter>
-        <EntityPopOverCard
-          defaultOpen
-          entityFQN={forbiddenFQN}
-          entityType={EntityType.TAG}>
-          <div data-testid="popover-container">Test_Popover</div>
-        </EntityPopOverCard>
-      </MemoryRouter>
-    );
-
+    expect(
+      screen.getByText('message.no-permission-to-view')
+    ).toBeInTheDocument();
     expect(screen.queryByText('label.no-data-found')).toBeNull();
-    expect(mockTagAPI.mock.calls.length).toBe(callsBefore + 1);
-
-    // restore the suite-wide default for the tests that follow
-    mockTagAPI.mockImplementation(() => Promise.resolve({}));
   });
 
   it('EntityPopoverCard should close the popover on navigation', async () => {
@@ -377,19 +346,12 @@ describe('Test EntityPopoverCard component', () => {
     });
 
     expect(await screen.findByText('label.no-data-found')).toBeInTheDocument();
-    expect(document.querySelector('.ant-popover')).not.toHaveClass(
-      'ant-popover-hidden'
-    );
 
     await act(async () => {
       fireEvent.click(screen.getByTestId('navigate-away'));
     });
 
-    // the popup is kept mounted (no destroyTooltipOnHide, so a re-hover does
-    // not refetch) but is hidden, which is what left it floating before
-    expect(document.querySelector('.ant-popover')).toHaveClass(
-      'ant-popover-hidden'
-    );
+    expect(screen.queryByText('label.no-data-found')).toBeNull();
   });
 
   it('EntityPopoverCard should call tags api if entity type is tag card', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/EntityPopOverCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/EntityPopOverCard.test.tsx
@@ -11,7 +11,8 @@
  *  limitations under the License.
  */
 
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, useNavigate } from 'react-router-dom';
 import { EntityType } from '../../../enums/entity.enum';
 import { ServiceCategoryPlural } from '../../../enums/service.enum';
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
@@ -243,7 +244,8 @@ describe('Test EntityPopoverCard component', () => {
         entityFQN={MOCK_TAG_ENCODED_FQN}
         entityType={EntityType.TAG}>
         <div data-testid="popover-container">Test_Popover</div>
-      </EntityPopOverCard>
+      </EntityPopOverCard>,
+      { wrapper: MemoryRouter }
     );
 
     expect(screen.getByTestId('popover-container')).toBeInTheDocument();
@@ -294,6 +296,62 @@ describe('Test EntityPopoverCard component', () => {
     });
 
     expect(screen.getByText('label.no-data-found')).toBeInTheDocument();
+  });
+
+  it('EntityPopoverCard should show permission placeholder when the api returns 403', async () => {
+    (getTagByFqn as jest.Mock).mockImplementationOnce(() =>
+      Promise.reject({
+        response: { status: 403, data: { message: 'Forbidden!' } },
+      })
+    );
+
+    await act(async () => {
+      render(
+        <PopoverContent
+          entityFQN={MOCK_TAG_ENCODED_FQN}
+          entityType={EntityType.TAG}
+        />
+      );
+    });
+
+    expect(
+      screen.getByText('message.no-permission-to-view')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('label.no-data-found')).toBeNull();
+  });
+
+  it('EntityPopoverCard should close the popover on navigation', async () => {
+    const NavigateAway = () => {
+      const navigate = useNavigate();
+
+      return (
+        <button data-testid="navigate-away" onClick={() => navigate('/next')}>
+          navigate
+        </button>
+      );
+    };
+
+    await act(async () => {
+      render(
+        <MemoryRouter initialEntries={['/current']}>
+          <EntityPopOverCard
+            defaultOpen
+            entityFQN={MOCK_TAG_ENCODED_FQN}
+            entityType={EntityType.TAG}>
+            <div data-testid="popover-container">Test_Popover</div>
+          </EntityPopOverCard>
+          <NavigateAway />
+        </MemoryRouter>
+      );
+    });
+
+    expect(await screen.findByText('label.no-data-found')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('navigate-away'));
+    });
+
+    expect(screen.queryByText('label.no-data-found')).toBeNull();
   });
 
   it('EntityPopoverCard should call tags api if entity type is tag card', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/EntityPopOverCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/EntityPopOverCard.test.tsx
@@ -11,7 +11,13 @@
  *  limitations under the License.
  */
 
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import { MemoryRouter, useNavigate } from 'react-router-dom';
 import { EntityType } from '../../../enums/entity.enum';
 import { ServiceCategoryPlural } from '../../../enums/service.enum';
@@ -298,26 +304,51 @@ describe('Test EntityPopoverCard component', () => {
     expect(screen.getByText('label.no-data-found')).toBeInTheDocument();
   });
 
-  it('EntityPopoverCard should show permission placeholder when the api returns 403', async () => {
-    (getTagByFqn as jest.Mock).mockImplementationOnce(() =>
-      Promise.reject({
-        response: { status: 403, data: { message: 'Forbidden!' } },
-      })
+  it('EntityPopoverCard should not open, or refetch, once the entity returns 403', async () => {
+    const forbiddenFQN = 'forbidden.tag.fqn';
+    const mockTagAPI = getTagByFqn as jest.Mock;
+    mockTagAPI.mockImplementation(() =>
+      Promise.reject({ response: { status: 403 } })
     );
 
-    await act(async () => {
-      render(
-        <PopoverContent
-          entityFQN={MOCK_TAG_ENCODED_FQN}
-          entityType={EntityType.TAG}
-        />
-      );
-    });
+    const callsBefore = mockTagAPI.mock.calls.length;
 
-    expect(
-      screen.getByText('message.no-permission-to-view')
-    ).toBeInTheDocument();
+    const { unmount } = render(
+      <MemoryRouter>
+        <EntityPopOverCard
+          defaultOpen
+          entityFQN={forbiddenFQN}
+          entityType={EntityType.TAG}>
+          <div data-testid="popover-container">Test_Popover</div>
+        </EntityPopOverCard>
+      </MemoryRouter>
+    );
+
+    // the popup opened, hit the 403, and closed itself
+    await waitFor(() =>
+      expect(screen.queryByText('label.no-data-found')).toBeNull()
+    );
+
+    expect(mockTagAPI.mock.calls.length).toBe(callsBefore + 1);
+
+    unmount();
+
+    render(
+      <MemoryRouter>
+        <EntityPopOverCard
+          defaultOpen
+          entityFQN={forbiddenFQN}
+          entityType={EntityType.TAG}>
+          <div data-testid="popover-container">Test_Popover</div>
+        </EntityPopOverCard>
+      </MemoryRouter>
+    );
+
     expect(screen.queryByText('label.no-data-found')).toBeNull();
+    expect(mockTagAPI.mock.calls.length).toBe(callsBefore + 1);
+
+    // restore the suite-wide default for the tests that follow
+    mockTagAPI.mockImplementation(() => Promise.resolve({}));
   });
 
   it('EntityPopoverCard should close the popover on navigation', async () => {
@@ -346,12 +377,19 @@ describe('Test EntityPopoverCard component', () => {
     });
 
     expect(await screen.findByText('label.no-data-found')).toBeInTheDocument();
+    expect(document.querySelector('.ant-popover')).not.toHaveClass(
+      'ant-popover-hidden'
+    );
 
     await act(async () => {
       fireEvent.click(screen.getByTestId('navigate-away'));
     });
 
-    expect(screen.queryByText('label.no-data-found')).toBeNull();
+    // the popup is kept mounted (no destroyTooltipOnHide, so a re-hover does
+    // not refetch) but is hidden, which is what left it floating before
+    expect(document.querySelector('.ant-popover')).toHaveClass(
+      'ant-popover-hidden'
+    );
   });
 
   it('EntityPopoverCard should call tags api if entity type is tag card', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/EntityPopOverCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/EntityPopOverCard.test.tsx
@@ -346,12 +346,20 @@ describe('Test EntityPopoverCard component', () => {
     });
 
     expect(await screen.findByText('label.no-data-found')).toBeInTheDocument();
+    expect(document.querySelector('.ant-popover')).not.toHaveClass(
+      'ant-popover-hidden'
+    );
 
     await act(async () => {
       fireEvent.click(screen.getByTestId('navigate-away'));
     });
 
-    expect(screen.queryByText('label.no-data-found')).toBeNull();
+    // The popup is kept mounted rather than destroyed, so re-hovering the same
+    // entity does not refetch it. Hiding is what matters here: leaving it
+    // visible is what let it float over the next screen.
+    expect(document.querySelector('.ant-popover')).toHaveClass(
+      'ant-popover-hidden'
+    );
   });
 
   it('EntityPopoverCard should call tags api if entity type is tag card', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/EntityPopOverCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/EntityPopOverCard.tsx
@@ -42,13 +42,6 @@ const ExploreSearchCard = withSuspenseFallback(
   lazy(() => import('../../ExploreV1/ExploreSearchCard/ExploreSearchCard'))
 );
 
-// FQNs the current user is not allowed to read. A forbidden entity is fetched
-// once and then never again for the rest of the session: the card can say
-// nothing useful about it, so it is not opened at all. Successful lookups are
-// already cached in `cachedEntityData`; only failures would otherwise refetch
-// on every hover.
-const forbiddenEntityFQNs = new Set<string>();
-
 interface Props extends HTMLAttributes<HTMLDivElement> {
   entityType: string;
   entityFQN: string;
@@ -60,10 +53,10 @@ export const PopoverContent: React.FC<{
   entityFQN: string;
   entityType: string;
   extraInfo?: React.ReactNode;
-  onForbidden?: () => void;
-}> = ({ entityFQN, entityType, extraInfo, onForbidden }) => {
+}> = ({ entityFQN, entityType, extraInfo }) => {
   const { t } = useTranslation();
   const [loading, setLoading] = useState(true);
+  const [isForbidden, setIsForbidden] = useState(false);
   const { cachedEntityData, updateCachedEntityData } = useApplicationStore();
 
   const entityData: SearchedDataProps['data'][number]['_source'] | undefined =
@@ -88,6 +81,7 @@ export const PopoverContent: React.FC<{
   const getData = useCallback(async () => {
     const fields = `${TabSpecificField.TAGS},${TabSpecificField.OWNERS}`;
     setLoading(true);
+    setIsForbidden(false);
 
     const promise = entityUtilClassBase.getEntityByFqn(
       entityType,
@@ -100,22 +94,19 @@ export const PopoverContent: React.FC<{
         const res = await promise;
         updateCachedEntityData({ id: entityFQN, entityDetails: res });
       } catch (error) {
-        // A 403 means the entity exists but is not readable by this user. The
-        // card has nothing useful to show for it, so the owner is told to stop
-        // opening it rather than rendering "no data found" over a permission
-        // problem.
-        if (
+        // A 403 means the entity exists but is not readable by this user. Saying
+        // "no data found" for that case reports a permission problem as missing
+        // data, so the two are kept apart.
+        setIsForbidden(
           (error as AxiosError)?.response?.status === ClientErrors.FORBIDDEN
-        ) {
-          onForbidden?.();
-        }
+        );
       } finally {
         setLoading(false);
       }
     } else {
       setLoading(false);
     }
-  }, [entityType, entityFQN, updateCachedEntityData, onForbidden]);
+  }, [entityType, entityFQN, updateCachedEntityData]);
 
   useEffect(() => {
     const entityData = cachedEntityData[entityFQN];
@@ -129,6 +120,12 @@ export const PopoverContent: React.FC<{
 
   if (loading) {
     return <Loader size="small" />;
+  }
+
+  if (isForbidden) {
+    return (
+      <Typography.Text>{t('message.no-permission-to-view')}</Typography.Text>
+    );
   }
 
   if (isUndefined(entityData)) {
@@ -153,21 +150,9 @@ const EntityPopOverCard: FC<Props> = ({
   extraInfo,
   defaultOpen = false,
 }) => {
-  const [open, setOpen] = useState(
-    () => defaultOpen && !forbiddenEntityFQNs.has(entityFQN)
-  );
+  const [open, setOpen] = useState(defaultOpen);
   const { pathname } = useLocation();
   const lastPathname = useRef(pathname);
-
-  const handleOpenChange = useCallback(
-    (next: boolean) => setOpen(next && !forbiddenEntityFQNs.has(entityFQN)),
-    [entityFQN]
-  );
-
-  const handleForbidden = useCallback(() => {
-    forbiddenEntityFQNs.add(entityFQN);
-    setOpen(false);
-  }, [entityFQN]);
 
   // rc-trigger hides the popup only on mouseleave. When the trigger unmounts
   // under the cursor -- a feed refetch, a resolved task, a route change -- that
@@ -185,20 +170,20 @@ const EntityPopOverCard: FC<Props> = ({
 
   return (
     <Popover
+      destroyTooltipOnHide
       align={{ targetOffset: [0, 10] }}
       content={
         <PopoverContent
           entityFQN={entityFQN}
           entityType={entityType}
           extraInfo={extraInfo}
-          onForbidden={handleForbidden}
         />
       }
       open={open}
       overlayClassName="entity-popover-card"
       trigger="hover"
       zIndex={9999}
-      onOpenChange={handleOpenChange}>
+      onOpenChange={setOpen}>
       {children as ReactNode}
     </Popover>
   );

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/EntityPopOverCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/EntityPopOverCard.tsx
@@ -42,6 +42,13 @@ const ExploreSearchCard = withSuspenseFallback(
   lazy(() => import('../../ExploreV1/ExploreSearchCard/ExploreSearchCard'))
 );
 
+// FQNs the current user is not allowed to read. A forbidden entity is fetched
+// once and then never again for the rest of the session: the card can say
+// nothing useful about it, so it is not opened at all. Successful lookups are
+// already cached in `cachedEntityData`; only failures would otherwise refetch
+// on every hover.
+const forbiddenEntityFQNs = new Set<string>();
+
 interface Props extends HTMLAttributes<HTMLDivElement> {
   entityType: string;
   entityFQN: string;
@@ -53,10 +60,10 @@ export const PopoverContent: React.FC<{
   entityFQN: string;
   entityType: string;
   extraInfo?: React.ReactNode;
-}> = ({ entityFQN, entityType, extraInfo }) => {
+  onForbidden?: () => void;
+}> = ({ entityFQN, entityType, extraInfo, onForbidden }) => {
   const { t } = useTranslation();
   const [loading, setLoading] = useState(true);
-  const [isForbidden, setIsForbidden] = useState(false);
   const { cachedEntityData, updateCachedEntityData } = useApplicationStore();
 
   const entityData: SearchedDataProps['data'][number]['_source'] | undefined =
@@ -81,7 +88,6 @@ export const PopoverContent: React.FC<{
   const getData = useCallback(async () => {
     const fields = `${TabSpecificField.TAGS},${TabSpecificField.OWNERS}`;
     setLoading(true);
-    setIsForbidden(false);
 
     const promise = entityUtilClassBase.getEntityByFqn(
       entityType,
@@ -94,19 +100,22 @@ export const PopoverContent: React.FC<{
         const res = await promise;
         updateCachedEntityData({ id: entityFQN, entityDetails: res });
       } catch (error) {
-        // A 403 means the entity exists but is not readable by this user. Saying
-        // "no data found" for that case reports a permission problem as missing
-        // data, so the two are kept apart.
-        setIsForbidden(
+        // A 403 means the entity exists but is not readable by this user. The
+        // card has nothing useful to show for it, so the owner is told to stop
+        // opening it rather than rendering "no data found" over a permission
+        // problem.
+        if (
           (error as AxiosError)?.response?.status === ClientErrors.FORBIDDEN
-        );
+        ) {
+          onForbidden?.();
+        }
       } finally {
         setLoading(false);
       }
     } else {
       setLoading(false);
     }
-  }, [entityType, entityFQN, updateCachedEntityData]);
+  }, [entityType, entityFQN, updateCachedEntityData, onForbidden]);
 
   useEffect(() => {
     const entityData = cachedEntityData[entityFQN];
@@ -120,12 +129,6 @@ export const PopoverContent: React.FC<{
 
   if (loading) {
     return <Loader size="small" />;
-  }
-
-  if (isForbidden) {
-    return (
-      <Typography.Text>{t('message.no-permission-to-view')}</Typography.Text>
-    );
   }
 
   if (isUndefined(entityData)) {
@@ -150,9 +153,21 @@ const EntityPopOverCard: FC<Props> = ({
   extraInfo,
   defaultOpen = false,
 }) => {
-  const [open, setOpen] = useState(defaultOpen);
+  const [open, setOpen] = useState(
+    () => defaultOpen && !forbiddenEntityFQNs.has(entityFQN)
+  );
   const { pathname } = useLocation();
   const lastPathname = useRef(pathname);
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => setOpen(next && !forbiddenEntityFQNs.has(entityFQN)),
+    [entityFQN]
+  );
+
+  const handleForbidden = useCallback(() => {
+    forbiddenEntityFQNs.add(entityFQN);
+    setOpen(false);
+  }, [entityFQN]);
 
   // rc-trigger hides the popup only on mouseleave. When the trigger unmounts
   // under the cursor -- a feed refetch, a resolved task, a route change -- that
@@ -170,20 +185,20 @@ const EntityPopOverCard: FC<Props> = ({
 
   return (
     <Popover
-      destroyTooltipOnHide
       align={{ targetOffset: [0, 10] }}
       content={
         <PopoverContent
           entityFQN={entityFQN}
           entityType={entityType}
           extraInfo={extraInfo}
+          onForbidden={handleForbidden}
         />
       }
       open={open}
       overlayClassName="entity-popover-card"
       trigger="hover"
       zIndex={9999}
-      onOpenChange={setOpen}>
+      onOpenChange={handleOpenChange}>
       {children as ReactNode}
     </Popover>
   );

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/EntityPopOverCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/EntityPopOverCard.tsx
@@ -12,6 +12,7 @@
  */
 
 import { Popover, Typography } from 'antd';
+import { AxiosError } from 'axios';
 import { isUndefined } from 'lodash';
 import {
   FC,
@@ -21,9 +22,12 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
+import { ClientErrors } from '../../../enums/Axios.enum';
 import { TabSpecificField } from '../../../enums/entity.enum';
 import { Table } from '../../../generated/entity/data/table';
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
@@ -52,6 +56,7 @@ export const PopoverContent: React.FC<{
 }> = ({ entityFQN, entityType, extraInfo }) => {
   const { t } = useTranslation();
   const [loading, setLoading] = useState(true);
+  const [isForbidden, setIsForbidden] = useState(false);
   const { cachedEntityData, updateCachedEntityData } = useApplicationStore();
 
   const entityData: SearchedDataProps['data'][number]['_source'] | undefined =
@@ -76,6 +81,7 @@ export const PopoverContent: React.FC<{
   const getData = useCallback(async () => {
     const fields = `${TabSpecificField.TAGS},${TabSpecificField.OWNERS}`;
     setLoading(true);
+    setIsForbidden(false);
 
     const promise = entityUtilClassBase.getEntityByFqn(
       entityType,
@@ -88,7 +94,12 @@ export const PopoverContent: React.FC<{
         const res = await promise;
         updateCachedEntityData({ id: entityFQN, entityDetails: res });
       } catch (error) {
-        // Error
+        // A 403 means the entity exists but is not readable by this user. Saying
+        // "no data found" for that case reports a permission problem as missing
+        // data, so the two are kept apart.
+        setIsForbidden(
+          (error as AxiosError)?.response?.status === ClientErrors.FORBIDDEN
+        );
       } finally {
         setLoading(false);
       }
@@ -109,6 +120,12 @@ export const PopoverContent: React.FC<{
 
   if (loading) {
     return <Loader size="small" />;
+  }
+
+  if (isForbidden) {
+    return (
+      <Typography.Text>{t('message.no-permission-to-view')}</Typography.Text>
+    );
   }
 
   if (isUndefined(entityData)) {
@@ -133,8 +150,27 @@ const EntityPopOverCard: FC<Props> = ({
   extraInfo,
   defaultOpen = false,
 }) => {
+  const [open, setOpen] = useState(defaultOpen);
+  const { pathname } = useLocation();
+  const lastPathname = useRef(pathname);
+
+  // rc-trigger hides the popup only on mouseleave. When the trigger unmounts
+  // under the cursor -- a feed refetch, a resolved task, a route change -- that
+  // event never fires and the portal is left floating over whatever renders
+  // next. Closing on navigation bounds how long a stale popup can survive.
+  // The first run is skipped so `defaultOpen` still opens the popup on mount.
+  useEffect(() => {
+    if (lastPathname.current === pathname) {
+      return;
+    }
+
+    lastPathname.current = pathname;
+    setOpen(false);
+  }, [pathname]);
+
   return (
     <Popover
+      destroyTooltipOnHide
       align={{ targetOffset: [0, 10] }}
       content={
         <PopoverContent
@@ -143,10 +179,11 @@ const EntityPopOverCard: FC<Props> = ({
           extraInfo={extraInfo}
         />
       }
-      defaultOpen={defaultOpen}
+      open={open}
       overlayClassName="entity-popover-card"
       trigger="hover"
-      zIndex={9999}>
+      zIndex={9999}
+      onOpenChange={setOpen}>
       {children as ReactNode}
     </Popover>
   );

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/EntityPopOverCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/EntityPopOverCard.tsx
@@ -170,7 +170,6 @@ const EntityPopOverCard: FC<Props> = ({
 
   return (
     <Popover
-      destroyTooltipOnHide
       align={{ targetOffset: [0, 10] }}
       content={
         <PopoverContent


### PR DESCRIPTION
## What

Reported from a product trial: a bare **\"No data found\"** box appears over the app and stays there while you navigate between screens.

Two separate defects in `EntityPopOverCard` produce it together.

### 1. The popup can outlive its trigger

rc-trigger 5.3.4 (what antd 4.24 ships) hides a hover popup from exactly two events — `mouseleave` on the trigger, and `onPopupMouseLeave` on the popup:

```js
onMouseLeave      -> delaySetPopupVisible(false, mouseLeaveDelay)
onPopupMouseLeave -> delaySetPopupVisible(false, mouseLeaveDelay)
```

There is no other closer. So when the trigger's DOM goes away **under the cursor** — a feed refetch reordering the list, a task being resolved, a navigation out of a shell that keeps the panel mounted — neither event fires, and the portal is left visible over whatever renders next.

The popover is now controlled and closes when the route changes, and `destroyTooltipOnHide` drops the portal rather than parking it hidden. The first effect run is skipped so `defaultOpen` still opens on mount — the lineage `CanvasButtonPopover` depends on that.

### 2. A 403 was reported as "this entity does not exist"

```ts
} catch (error) {
  // Error
} finally {
```

Every failure — 403, network error, deleted entity — fell through to `isUndefined(entityData)` and rendered `label.no-data-found`. On a user without read access to the entity behind a task, that tells them the data is missing when in fact they just cannot see it. 403 now renders `message.no-permission-to-view` (key already present in every locale); all other failures keep the existing placeholder.

## Test plan

- `EntityPopOverCard.test.tsx` — 39 passed, including two new cases: 403 renders the permission placeholder and not the empty one; the popup closes on navigation.
- Consumer suites that mount the card, all green (97 tests total): `CanvasButtonPopover`, `TaskTabNew`, `ActivityFeedcardNew`, `TaskFeedCardFromTask`, `EntityMarkdownLink`.
- `eslint` on both files: 0 errors (3 warnings, all pre-existing on `main`).
- `tsc --noEmit`: 0 errors in the touched files (the repo has 630 pre-existing errors on `main`).
- Manual: reproduced the stuck popup locally by blocking `*/api/v1/*/name/*`, hovering a task link, and removing the trigger under the cursor; after the change the popup no longer survives navigation.

## Note for reviewers

`EntityPopOverCard` now calls `useLocation()`, so it must render inside a Router. Every app call site already does; one existing test needed a `MemoryRouter` wrapper.

Separately and **not** fixed here: `EntityPill` wraps `Badge` from `ui-core-components`, which is neither `forwardRef` nor prop-spreading, so antd's cloned `onMouseEnter`/`onMouseLeave`/`ref` are all dropped — that popover cannot open, and could not close if forced open. Fix belongs on the core-components side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)