### PR TITLE
fix(ui): drop quick-action icons from the collapsed Observability sub…

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/platform/ai-shell/Sidebar/Sidebar.subRailIntent.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/platform/ai-shell/Sidebar/Sidebar.subRailIntent.test.tsx
@@ -11,20 +11,18 @@
  *  limitations under the License.
  */
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { act } from 'react';
-import { MemoryRouter, useLocation } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import {
   ResourceEntity,
   type UIPermission,
 } from '../../../../context/PermissionProvider/PermissionProvider.interface';
 import { Operation } from '../../../../generated/entity/policies/policy';
 import { OBSERVABILITY_ROUTES } from '../../../observability/observability.constants';
-import ObservabilityLayout from '../../../observability/ObservabilityLayout/ObservabilityLayout';
 import { observabilityModule } from '../../../observability/ObservabilityModule/observability.module';
-import { AppModule, Intent } from '../AppModule.types';
+import { AppModule } from '../AppModule.types';
 import { useActiveModuleStore } from '../state/useActiveModule';
-import { emitIntent } from '../useIntent';
 import Sidebar from './Sidebar';
 
 // Module-scoped values read by the hoisted jest.mock factories at call time
@@ -53,62 +51,27 @@ jest.mock('../../../../context/PermissionProvider/PermissionProvider', () => ({
   usePermissionProvider: () => ({ permissions: mockPermissions }),
 }));
 
-// ObservabilityLayout boundaries: the real drawers pull permissions, airflow
-// status and the whole test-case form stack, so stub them as open-state probes.
-jest.mock('../../../DataQuality/BundleSuiteForm/BundleSuiteFormDrawer', () => ({
-  __esModule: true,
-  default: ({ open }: { open?: boolean }) => (
-    <div data-open={String(open)} data-testid="bundle-suite-drawer" />
-  ),
-}));
-
-jest.mock(
-  '../../../DataQuality/AddDataQualityTest/components/TestCaseFormDrawer',
-  () => ({
-    __esModule: true,
-    default: ({ open }: { open?: boolean }) => (
-      <div data-open={String(open)} data-testid="test-case-drawer" />
-    ),
-  })
-);
-
-// The layout re-claims its intent listeners on route reactivation; not driven
-// here, so stub the hook to a no-op.
-jest.mock('../context/useRouteActivation', () => ({
-  useRouteActivation: () => {},
-}));
-
 const DATA_QUALITY_PATH = OBSERVABILITY_ROUTES.OBSERVABILITY_DATA_QUALITY_BASE;
-
-let lastPathname = '';
-const PathnameProbe = () => {
-  lastPathname = useLocation().pathname;
-
-  return null;
-};
 
 const permissionsWith = (testSuiteCreate: boolean): UIPermission =>
   ({
     [ResourceEntity.TEST_SUITE]: { [Operation.Create]: testSuiteCreate },
   } as unknown as UIPermission);
 
-const renderShell = () =>
+const renderSidebar = () =>
   render(
     <MemoryRouter initialEntries={[DATA_QUALITY_PATH]}>
-      <PathnameProbe />
-      <ObservabilityLayout>
-        <Sidebar />
-      </ObservabilityLayout>
+      <Sidebar />
     </MemoryRouter>
   );
 
-describe('Sidebar collapsed sub-rail intent CTAs', () => {
+describe('Sidebar collapsed sub-rail', () => {
   beforeEach(() => {
     mockModules = [observabilityModule];
     mockPermissions = permissionsWith(true);
     useActiveModuleStore.setState({ activeModule: 'observability' });
+    // The sub-panel defaults to collapsed, so the sub-rail is what renders.
     localStorage.clear();
-    lastPathname = '';
   });
 
   afterEach(() => {
@@ -117,112 +80,49 @@ describe('Sidebar collapsed sub-rail intent CTAs', () => {
     });
   });
 
-  it('renders the intent-only CTAs as action buttons and keeps both drawers closed', () => {
-    renderShell();
-    const testCase = screen.getByTestId('ask-sub-rail-item-add-test-case');
-    const bundle = screen.getByTestId('ask-sub-rail-item-add-bundle-suite');
+  it('renders the sub-rail rather than the sub-panel', () => {
+    renderSidebar();
 
-    // intent-only items have no `path` → render as <button>, not an anchor.
-    expect(testCase.tagName).toBe('BUTTON');
-    expect(bundle.tagName).toBe('BUTTON');
-    expect(screen.getByTestId('test-case-drawer')).toHaveAttribute(
-      'data-open',
-      'false'
-    );
-    expect(screen.getByTestId('bundle-suite-drawer')).toHaveAttribute(
-      'data-open',
-      'false'
-    );
+    expect(screen.getByTestId('ask-sub-rail')).toBeInTheDocument();
+    expect(screen.queryByTestId('ask-sub-panel')).toBeNull();
   });
 
-  it('opens the test-case drawer when the add-test-case chip is clicked', () => {
-    renderShell();
+  it('omits the intent-only Quick Action CTAs — the rail is navigation-only', () => {
+    renderSidebar();
 
-    fireEvent.click(screen.getByTestId('ask-sub-rail-item-add-test-case'));
-
-    expect(screen.getByTestId('test-case-drawer')).toHaveAttribute(
-      'data-open',
-      'true'
-    );
-    expect(screen.getByTestId('bundle-suite-drawer')).toHaveAttribute(
-      'data-open',
-      'false'
-    );
-    // intent-only CTA must not navigate.
-    expect(lastPathname).toBe(DATA_QUALITY_PATH);
+    // An unlabeled "+" in a 65px icon strip can't convey what it creates, and
+    // two of them are indistinguishable. Create actions live in the expanded
+    // SubPanel's Quick Actions instead (see SubPanel.intent.test.tsx).
+    expect(screen.queryByTestId('ask-sub-rail-item-add-test-case')).toBeNull();
+    expect(
+      screen.queryByTestId('ask-sub-rail-item-add-bundle-suite')
+    ).toBeNull();
   });
 
-  it('opens the bundle-suite drawer when the add-bundle-suite chip is clicked', () => {
-    renderShell();
+  it('still renders every path-based sub-nav item as an anchor with its href', () => {
+    renderSidebar();
 
-    fireEvent.click(screen.getByTestId('ask-sub-rail-item-add-bundle-suite'));
-
-    expect(screen.getByTestId('bundle-suite-drawer')).toHaveAttribute(
-      'data-open',
-      'true'
-    );
-    expect(screen.getByTestId('test-case-drawer')).toHaveAttribute(
-      'data-open',
-      'false'
-    );
-    expect(lastPathname).toBe(DATA_QUALITY_PATH);
-  });
-
-  it('still renders path-only sub-rail items as anchors with the route href', () => {
-    renderShell();
+    // Regression guard for the `!item.path` skip: navigable items must be
+    // untouched by it.
     const dataQuality = screen.getByTestId('ask-sub-rail-item-data-quality');
 
-    // Navigable items keep their href → open-in-new-tab affordances survive.
     expect(dataQuality.tagName).toBe('A');
     expect(dataQuality).toHaveAttribute('href', DATA_QUALITY_PATH);
-  });
 
-  it('opens the bundle-suite drawer on a direct emitIntent (listener-wiring control)', () => {
-    renderShell();
-
-    act(() => {
-      emitIntent(Intent.AddBundleSuite);
+    ['incidents', 'alerts', 'pipeline', 'test-library'].forEach((key) => {
+      expect(screen.getByTestId(`ask-sub-rail-item-${key}`).tagName).toBe('A');
     });
-
-    expect(screen.getByTestId('bundle-suite-drawer')).toHaveAttribute(
-      'data-open',
-      'true'
-    );
   });
 
-  it('hides the add-bundle-suite chip when the user lacks TEST_SUITE.Create', () => {
+  it('keeps the nav items when the user lacks TEST_SUITE.Create', () => {
     mockPermissions = permissionsWith(false);
-    renderShell();
+    renderSidebar();
 
+    expect(
+      screen.getByTestId('ask-sub-rail-item-data-quality')
+    ).toBeInTheDocument();
     expect(
       screen.queryByTestId('ask-sub-rail-item-add-bundle-suite')
     ).toBeNull();
-    expect(
-      screen.getByTestId('ask-sub-rail-item-add-test-case')
-    ).toBeInTheDocument();
-  });
-
-  it('still opens the test-case drawer without TEST_SUITE.Create (ungated CTA)', () => {
-    mockPermissions = permissionsWith(false);
-    renderShell();
-
-    fireEvent.click(screen.getByTestId('ask-sub-rail-item-add-test-case'));
-
-    expect(screen.getByTestId('test-case-drawer')).toHaveAttribute(
-      'data-open',
-      'true'
-    );
-  });
-
-  it('hides the add-bundle-suite chip while permissions are still loading', () => {
-    mockPermissions = undefined;
-    renderShell();
-
-    expect(
-      screen.queryByTestId('ask-sub-rail-item-add-bundle-suite')
-    ).toBeNull();
-    expect(
-      screen.getByTestId('ask-sub-rail-item-add-test-case')
-    ).toBeInTheDocument();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/platform/ai-shell/Sidebar/Sidebar.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/platform/ai-shell/Sidebar/Sidebar.tsx
@@ -162,6 +162,12 @@ const Sidebar: React.FC = () => {
     return activeSubNav.sections
       .flatMap((section) => section.items)
       .flatMap((item) => {
+        // The collapsed rail is navigation-only: an unlabeled icon can't
+        // convey what a create action does. Intent-only CTAs (no `path`)
+        // stay in the expanded SubPanel's Quick Actions.
+        if (!item.path) {
+          return [];
+        }
         const icon = item.railIcon ?? item.icon;
         if (!icon) {
           return [];

--- a/openmetadata-ui/src/main/resources/ui/src/components/platform/ai-shell/Sidebar/SubPanel.intent.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/platform/ai-shell/Sidebar/SubPanel.intent.test.tsx
@@ -1,0 +1,232 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import {
+  ResourceEntity,
+  type UIPermission,
+} from '../../../../context/PermissionProvider/PermissionProvider.interface';
+import { Operation } from '../../../../generated/entity/policies/policy';
+import { OBSERVABILITY_ROUTES } from '../../../observability/observability.constants';
+import ObservabilityLayout from '../../../observability/ObservabilityLayout/ObservabilityLayout';
+import { observabilityModule } from '../../../observability/ObservabilityModule/observability.module';
+import { AppModule, Intent } from '../AppModule.types';
+import { useActiveModuleStore } from '../state/useActiveModule';
+import { emitIntent } from '../useIntent';
+import Sidebar from './Sidebar';
+import { SUB_COLLAPSED_STORAGE_KEY } from './useSidebarState';
+
+// Module-scoped values read by the hoisted jest.mock factories at call time
+// (i.e. during render), so per-test reassignment takes effect.
+let mockModules: AppModule[] = [];
+let mockPermissions: UIPermission | undefined;
+
+jest.mock('../sharedAppModules', () => ({
+  useAllAppModules: () => mockModules,
+}));
+
+jest.mock('./useCustomizedMainNav', () => ({
+  useCustomizedMainNav: () => ({ nodes: [] }),
+}));
+
+jest.mock('./useContextCenterBadges', () => ({
+  useContextCenterBadges: () => undefined,
+}));
+
+jest.mock('./MainPanel', () => ({
+  __esModule: true,
+  default: () => <div data-testid="ask-main-panel" />,
+}));
+
+jest.mock('../../../../context/PermissionProvider/PermissionProvider', () => ({
+  usePermissionProvider: () => ({ permissions: mockPermissions }),
+}));
+
+// ObservabilityLayout boundaries: the real drawers pull permissions, airflow
+// status and the whole test-case form stack, so stub them as open-state probes.
+jest.mock('../../../DataQuality/BundleSuiteForm/BundleSuiteFormDrawer', () => ({
+  __esModule: true,
+  default: ({ open }: { open?: boolean }) => (
+    <div data-open={String(open)} data-testid="bundle-suite-drawer" />
+  ),
+}));
+
+jest.mock(
+  '../../../DataQuality/AddDataQualityTest/components/TestCaseFormDrawer',
+  () => ({
+    __esModule: true,
+    default: ({ open }: { open?: boolean }) => (
+      <div data-open={String(open)} data-testid="test-case-drawer" />
+    ),
+  })
+);
+
+// The layout re-claims its intent listeners on route reactivation; not driven
+// here, so stub the hook to a no-op.
+jest.mock('../context/useRouteActivation', () => ({
+  useRouteActivation: () => {},
+}));
+
+const DATA_QUALITY_PATH = OBSERVABILITY_ROUTES.OBSERVABILITY_DATA_QUALITY_BASE;
+
+let lastPathname = '';
+const PathnameProbe = () => {
+  lastPathname = useLocation().pathname;
+
+  return null;
+};
+
+const permissionsWith = (testSuiteCreate: boolean): UIPermission =>
+  ({
+    [ResourceEntity.TEST_SUITE]: { [Operation.Create]: testSuiteCreate },
+  } as unknown as UIPermission);
+
+const renderShell = () =>
+  render(
+    <MemoryRouter initialEntries={[DATA_QUALITY_PATH]}>
+      <PathnameProbe />
+      <ObservabilityLayout>
+        <Sidebar />
+      </ObservabilityLayout>
+    </MemoryRouter>
+  );
+
+describe('SubPanel Quick Action intent CTAs (expanded panel)', () => {
+  beforeEach(() => {
+    mockModules = [observabilityModule];
+    mockPermissions = permissionsWith(true);
+    useActiveModuleStore.setState({ activeModule: 'observability' });
+    localStorage.clear();
+    // The sub-panel defaults to collapsed; expand it so the Quick Actions
+    // section — the only place these CTAs render — is on screen.
+    localStorage.setItem(SUB_COLLAPSED_STORAGE_KEY, 'false');
+    lastPathname = '';
+  });
+
+  afterEach(() => {
+    act(() => {
+      useActiveModuleStore.setState({ activeModule: null });
+    });
+  });
+
+  it('renders the intent-only CTAs as action buttons and keeps both drawers closed', () => {
+    renderShell();
+    const testCase = screen.getByTestId('ask-sub-panel-item-add-test-case');
+    const bundle = screen.getByTestId('ask-sub-panel-item-add-bundle-suite');
+
+    // intent-only items have no `path` → render as <button>, not an anchor.
+    expect(testCase.tagName).toBe('BUTTON');
+    expect(bundle.tagName).toBe('BUTTON');
+    expect(screen.getByTestId('test-case-drawer')).toHaveAttribute(
+      'data-open',
+      'false'
+    );
+    expect(screen.getByTestId('bundle-suite-drawer')).toHaveAttribute(
+      'data-open',
+      'false'
+    );
+  });
+
+  it('opens the test-case drawer when the add-test-case CTA is clicked', () => {
+    renderShell();
+
+    fireEvent.click(screen.getByTestId('ask-sub-panel-item-add-test-case'));
+
+    expect(screen.getByTestId('test-case-drawer')).toHaveAttribute(
+      'data-open',
+      'true'
+    );
+    expect(screen.getByTestId('bundle-suite-drawer')).toHaveAttribute(
+      'data-open',
+      'false'
+    );
+    // intent-only CTA must not navigate.
+    expect(lastPathname).toBe(DATA_QUALITY_PATH);
+  });
+
+  it('opens the bundle-suite drawer when the add-bundle-suite CTA is clicked', () => {
+    renderShell();
+
+    fireEvent.click(screen.getByTestId('ask-sub-panel-item-add-bundle-suite'));
+
+    expect(screen.getByTestId('bundle-suite-drawer')).toHaveAttribute(
+      'data-open',
+      'true'
+    );
+    expect(screen.getByTestId('test-case-drawer')).toHaveAttribute(
+      'data-open',
+      'false'
+    );
+    expect(lastPathname).toBe(DATA_QUALITY_PATH);
+  });
+
+  it('still renders path-only sub-nav items as anchors with the route href', () => {
+    renderShell();
+    const dataQuality = screen.getByTestId('ask-sub-panel-item-data-quality');
+
+    // Navigable items keep their href → open-in-new-tab affordances survive.
+    expect(dataQuality.tagName).toBe('A');
+    expect(dataQuality).toHaveAttribute('href', DATA_QUALITY_PATH);
+  });
+
+  it('opens the bundle-suite drawer on a direct emitIntent (listener-wiring control)', () => {
+    renderShell();
+
+    act(() => {
+      emitIntent(Intent.AddBundleSuite);
+    });
+
+    expect(screen.getByTestId('bundle-suite-drawer')).toHaveAttribute(
+      'data-open',
+      'true'
+    );
+  });
+
+  it('hides the add-bundle-suite CTA when the user lacks TEST_SUITE.Create', () => {
+    mockPermissions = permissionsWith(false);
+    renderShell();
+
+    expect(
+      screen.queryByTestId('ask-sub-panel-item-add-bundle-suite')
+    ).toBeNull();
+    expect(
+      screen.getByTestId('ask-sub-panel-item-add-test-case')
+    ).toBeInTheDocument();
+  });
+
+  it('still opens the test-case drawer without TEST_SUITE.Create (ungated CTA)', () => {
+    mockPermissions = permissionsWith(false);
+    renderShell();
+
+    fireEvent.click(screen.getByTestId('ask-sub-panel-item-add-test-case'));
+
+    expect(screen.getByTestId('test-case-drawer')).toHaveAttribute(
+      'data-open',
+      'true'
+    );
+  });
+
+  it('hides the add-bundle-suite CTA while permissions are still loading', () => {
+    mockPermissions = undefined;
+    renderShell();
+
+    expect(
+      screen.queryByTestId('ask-sub-panel-item-add-bundle-suite')
+    ).toBeNull();
+    expect(
+      screen.getByTestId('ask-sub-panel-item-add-test-case')
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
<img width="1501" height="828" alt="Screenshot 2026-09-11 at 5 00 01 PM" src="https://github.com/user-attachments/assets/e235b315-5afb-4f09-9288-3bde3738adde" />

<img width="1489" height="825" alt="Screenshot 2026-09-11 at 4 59 50 PM" src="https://github.com/user-attachments/assets/4a723a57-2f49-47bf-b07d-d7de4b903153" />
### Describe your changes:

Fixes #<issue-number>

I worked on removing two unlabeled, identical "+" icons that were appearing in the collapsed Observability sub-rail because the two Quick Actions (Add Test Case, Add Bundle Suite) have no route/path and were being swept in by an icon-only filter that didn't distinguish real navigation items from intent-only action items. I made this change because a collapsed 65px icon strip can't convey what a create action does, and having two identical plus signs there was confusing regardless — those two actions already exist, labeled and fully functional, as Quick Actions in the expanded panel, so this only removes a redundant, unclear duplicate rather than removing any capability.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- With the Observability panel collapsed, the sub-rail shows only real navigation items (Data Quality, Incidents, Alerts, Pipeline Observability, Test Library) and no longer renders Add Test Case / Add Bundle Suite icons.
- With the Observability panel expanded, Add Test Case and Add Bundle Suite still render as labeled Quick Actions and behave exactly as before, including the TEST_SUITE.Create permission gate on Add Bundle Suite (hidden when the permission is false or still loading; Add Test Case remains available in both cases).

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Files added/updated:
  - `Sidebar.subRailIntent.test.tsx` — rewritten: confirms the collapsed sub-rail renders (not the sub-panel), confirms neither Quick Action testid is present, confirms all path-based sub-nav items still render as anchors with correct hrefs, confirms nav items survive a missing `TEST_SUITE.Create` permission.
  - `SubPanel.intent.test.tsx` — new: covers the expanded-panel behavior that used to be asserted in the sub-rail test file (both Quick Actions render as buttons, open their respective drawers without navigating, leave the other drawer closed, and Add Bundle Suite stays hidden under `TEST_SUITE.Create: false` and while permissions are still loading).
- Full suite result: `20 test suites / 128 tests passed` (platform/ai-shell + observability/ObservabilityLayout).
- Negative control: temporarily reverted the guard and reran — the new "omits the intent-only Quick Action CTAs" test fails as expected, confirming it isn't vacuous.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable — no Playwright specs reference the affected testids (`ask-sub-rail`); confirmed via repo-wide search before and after the change.

#### Manual testing performed
1. Enabled AI mode, opened Observability, collapsed the sub-panel — confirmed no "+" icons render in the collapsed rail, only the five navigation icons.
2. Expanded the Observability panel — confirmed "Add Test Case" and "Add Bundle Suite" still render under Quick Actions, labeled, and open their respective drawers on click.
3. Toggled a user without `TEST_SUITE.Create` — confirmed "Add Bundle Suite" stays hidden in the expanded panel while "Add Test Case" remains visible and functional.

#
### UI screen recording / screenshots:

Before/after screenshots showing the duplicate icons in the collapsed rail vs. the expected clean rail are available — attach here before submitting.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. (N/A — no schema changes)
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->






<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63038703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the earlier pathless extension-action regression is fully addressed by preserving items that define a dedicated rail icon.

<h2>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Pathless extension actions disappear** <a href="https://github.com/open-metadata/OpenMetadata/pull/33206#discussion_r4026711086">▶</a>

<details open><summary>Summary</summary>

This PR removes ambiguous intent-only Quick Action icons from the collapsed Observability rail without removing those actions from the expanded panel.
- Excludes pathless items lacking a dedicated `railIcon` from collapsed-rail rendering.
- Preserves the supported pathless rail-action contract when an item supplies a `railIcon`.
- Adds regression coverage for collapsed navigation, extension actions, expanded Quick Actions, drawer behavior, and permission gating.
</details>

<sub>Reviews (3) · Last reviewed commit: ["Merge branch &#39;main&#39; into fix/observabili..."](https://github.com/open-metadata/openmetadata/commit/2687875d922d8c10350a3ab461d1ac3605e773dd)</sub>

<!-- /greptile_comment -->