### PR TITLE
Fixes #27472: Extract DynamoDB partition key and sort key as primary key

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/dynamodb/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/dynamodb/metadata.py
@@ -15,7 +15,15 @@ Dynamo source methods.
 import traceback
 from collections.abc import Iterable
 
-from metadata.generated.schema.entity.data.table import TableType
+from metadata.generated.schema.entity.data.table import (
+    Column,
+    ColumnName,
+    Constraint,
+    ConstraintType,
+    DataType,
+    TableConstraint,
+    TableType,
+)
 from metadata.generated.schema.entity.services.connections.database.dynamoDBConnection import (
     DynamoDBConnection,
 )
@@ -24,16 +32,33 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 )
 from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.ingestion.ometa.utils import model_str
+from metadata.ingestion.source.database.column_helpers import truncate_column_name
 from metadata.ingestion.source.database.common_nosql_source import (
     SAMPLE_SIZE,
     CommonNoSQLSource,
     TableNameAndType,
 )
-from metadata.ingestion.source.database.dynamodb.models import TableResponse
+from metadata.ingestion.source.database.dynamodb.models import (
+    TableKeyMetadata,
+    TableResponse,
+)
 from metadata.utils.constants import DEFAULT_DATABASE
 from metadata.utils.logger import ingestion_logger
+from metadata.utils.lru_cache import LRUCache
 
 logger = ingestion_logger()
+
+# A key schema is a handful of small dicts, but the cache is bounded so that a catalog
+# with thousands of tables cannot grow it without limit.
+KEY_METADATA_CACHE_SIZE = 128
+
+# DynamoDB only accepts scalar attributes as keys: string, number and binary.
+DYNAMODB_KEY_TYPE_MAP = {
+    "S": DataType.STRING,
+    "N": DataType.NUMBER,
+    "B": DataType.BYTES,
+}
 
 
 class DynamodbSource(CommonNoSQLSource):
@@ -45,6 +70,7 @@ class DynamodbSource(CommonNoSQLSource):
     def __init__(self, config: WorkflowSource, metadata: OpenMetadata):
         super().__init__(config, metadata)
         self.dynamodb = self.connection_obj
+        self._key_metadata_cache: LRUCache[TableKeyMetadata | None] = LRUCache(capacity=KEY_METADATA_CACHE_SIZE)
 
     @classmethod
     def create(cls, config_dict, metadata: OpenMetadata, pipeline_name: str | None = None):
@@ -97,6 +123,100 @@ class DynamodbSource(CommonNoSQLSource):
             logger.debug(traceback.format_exc())
             logger.warning(f"Failed to read DynamoDB attributes for [{table_name}]: {err}")
         return attributes
+
+    def _get_key_metadata(self, table_name: str) -> TableKeyMetadata | None:
+        """
+        Read the declared key schema of a table. Unlike the column sampling done in
+        `get_table_columns_dict`, DescribeTable reads no table data. The result is memoised
+        because `yield_table` asks for both the columns and the constraints of the same table.
+        """
+        if table_name in self._key_metadata_cache:
+            return self._key_metadata_cache.get(table_name)
+
+        key_metadata = None
+        try:
+            table = self.dynamodb.Table(table_name)
+            key_metadata = TableKeyMetadata(
+                KeySchema=table.key_schema,
+                AttributeDefinitions=table.attribute_definitions,
+            )
+        except Exception as err:
+            logger.debug(traceback.format_exc())
+            logger.warning("Failed to describe DynamoDB table [%s]: %s", table_name, err)
+
+        self._key_metadata_cache.put(table_name, key_metadata)
+        return key_metadata
+
+    def get_table_constraints(
+        self,
+        db_name: str,
+        schema_name: str,
+        table_name: str,
+    ) -> list[TableConstraint] | None:
+        """
+        Map the DynamoDB key schema onto table constraints. The sort key is reported on its own
+        as well, since the primary key alone does not say which of its columns is the sort key.
+        """
+        key_metadata = self._get_key_metadata(table_name)
+        if key_metadata is None or not key_metadata.primary_key:
+            return None
+
+        constraints = [
+            TableConstraint(
+                constraintType=ConstraintType.PRIMARY_KEY,
+                columns=[truncate_column_name(key) for key in key_metadata.primary_key],
+            )
+        ]
+        if key_metadata.sort_key:
+            constraints.append(
+                TableConstraint(
+                    constraintType=ConstraintType.SORT_KEY,
+                    columns=[truncate_column_name(key_metadata.sort_key)],
+                )
+            )
+        return constraints
+
+    def get_table_columns(self, schema_name: str, table_name: str) -> list[Column]:
+        """
+        Sampled columns, reconciled against the declared key schema.
+        """
+        columns = super().get_table_columns(schema_name, table_name)
+        key_metadata = self._get_key_metadata(table_name)
+        if key_metadata is None:
+            return columns
+        return self._apply_key_metadata(columns, key_metadata)
+
+    @staticmethod
+    def _apply_key_metadata(columns: list[Column], key_metadata: TableKeyMetadata) -> list[Column]:
+        """
+        Key attributes are typed from the table definition rather than from the sampled values,
+        and flagged as primary key. Keys missing from the sample - which is every key of an empty
+        table - are added, because the server rejects a constraint over a column the table lacks.
+        """
+        columns_by_name = {model_str(column.name): column for column in columns}
+        unsampled_keys = []
+        for key in key_metadata.primary_key:
+            column_name = truncate_column_name(key)
+            attribute_type = key_metadata.attribute_type(key)
+            data_type = DYNAMODB_KEY_TYPE_MAP.get(attribute_type) if attribute_type else None
+            column = columns_by_name.get(column_name)
+            if column is None:
+                data_type = data_type or DataType.UNKNOWN
+                unsampled_keys.append(
+                    Column(
+                        name=ColumnName(column_name),
+                        displayName=key,
+                        dataType=data_type,
+                        dataTypeDisplay=data_type.value,
+                        constraint=Constraint.PRIMARY_KEY,
+                    )
+                )
+                continue
+            column.constraint = Constraint.PRIMARY_KEY
+            if data_type:
+                column.dataType = data_type
+                column.dataTypeDisplay = data_type.value
+        return unsampled_keys + columns
 
     def get_source_url(
         self,

--- a/ingestion/src/metadata/ingestion/source/database/dynamodb/models.py
+++ b/ingestion/src/metadata/ingestion/source/database/dynamodb/models.py
@@ -16,6 +16,9 @@ from typing import Any
 
 from pydantic import BaseModel
 
+PARTITION_KEY_TYPE = "HASH"
+SORT_KEY_TYPE = "RANGE"
+
 
 class TableResponse(BaseModel):
     """
@@ -24,3 +27,62 @@ class TableResponse(BaseModel):
 
     Items: list[dict] | None = []
     LastEvaluatedKey: Any | None = None
+
+
+class KeySchemaElement(BaseModel):
+    """
+    One entry of a DynamoDB table key schema
+    """
+
+    AttributeName: str
+    KeyType: str
+
+
+class AttributeDefinition(BaseModel):
+    """
+    Declared type of a DynamoDB key attribute
+    """
+
+    AttributeName: str
+    AttributeType: str
+
+
+class TableKeyMetadata(BaseModel):
+    """
+    Key schema of a DynamoDB table, as returned by DescribeTable
+    """
+
+    KeySchema: list[KeySchemaElement] = []
+    AttributeDefinitions: list[AttributeDefinition] = []
+
+    def _key_of_type(self, key_type: str) -> str | None:
+        return next(
+            (element.AttributeName for element in self.KeySchema if element.KeyType == key_type),
+            None,
+        )
+
+    @property
+    def partition_key(self) -> str | None:
+        return self._key_of_type(PARTITION_KEY_TYPE)
+
+    @property
+    def sort_key(self) -> str | None:
+        return self._key_of_type(SORT_KEY_TYPE)
+
+    @property
+    def primary_key(self) -> list[str]:
+        """
+        A DynamoDB primary key is the partition key on its own, or the partition key
+        together with the sort key when the table defines one.
+        """
+        return [key for key in (self.partition_key, self.sort_key) if key]
+
+    def attribute_type(self, attribute_name: str) -> str | None:
+        return next(
+            (
+                definition.AttributeType
+                for definition in self.AttributeDefinitions
+                if definition.AttributeName == attribute_name
+            ),
+            None,
+        )

--- a/ingestion/tests/integration/profiler/test_dynamodb.py
+++ b/ingestion/tests/integration/profiler/test_dynamodb.py
@@ -1,6 +1,12 @@
 import pytest
 
-from metadata.generated.schema.entity.data.table import Table
+from metadata.generated.schema.entity.data.table import (
+    Constraint,
+    ConstraintType,
+    DataType,
+    Table,
+    TableConstraint,
+)
 from metadata.generated.schema.entity.services.databaseService import DatabaseService
 from metadata.generated.schema.metadataIngestion.databaseServiceAutoClassificationPipeline import (
     AutoClassificationConfigType,
@@ -48,6 +54,20 @@ def db_fqn(db_service: DatabaseService):
             "default",
         ]
     )
+
+
+def test_primary_key_from_key_schema(db_fqn, metadata):
+    """
+    test_table is created with a single HASH key `id` of type S. The server rejects a constraint
+    over an unknown column, so getting it back proves the key columns were ingested too.
+    """
+    table = metadata.get_by_name(entity=Table, fqn=f"{db_fqn}.test_table", fields=["tableConstraints"])
+
+    assert table.tableConstraints == [TableConstraint(constraintType=ConstraintType.PRIMARY_KEY, columns=["id"])]
+    id_column = next(column for column in table.columns if column.name.root == "id")
+    assert id_column.constraint == Constraint.PRIMARY_KEY
+    # the ids are "1" and "2": inferred from the sample they would be INT, the table declares them S
+    assert id_column.dataType == DataType.STRING
 
 
 def test_sample_data(db_service, db_fqn, metadata):

--- a/ingestion/tests/unit/topology/database/test_dynamodb.py
+++ b/ingestion/tests/unit/topology/database/test_dynamodb.py
@@ -1,0 +1,213 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Test that the DynamoDB source turns the table key schema into primary key metadata
+"""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.generated.schema.entity.data.table import (
+    Constraint,
+    ConstraintType,
+    DataType,
+    TableConstraint,
+)
+from metadata.generated.schema.metadataIngestion.workflow import (
+    OpenMetadataWorkflowConfig,
+)
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.ingestion.source.database.dynamodb.metadata import DynamodbSource
+
+MOCK_DYNAMODB_CONFIG = {
+    "source": {
+        "type": "dynamodb",
+        "serviceName": "local_dynamodb",
+        "serviceConnection": {
+            "config": {
+                "type": "DynamoDB",
+                "awsConfig": {
+                    "awsAccessKeyId": "aws_access_key_id",
+                    "awsSecretAccessKey": "aws_secret_access_key",
+                    "awsRegion": "us-east-1",
+                },
+            },
+        },
+        "sourceConfig": {"config": {"type": "DatabaseMetadata"}},
+    },
+    "sink": {"type": "metadata-rest", "config": {}},
+    "workflowConfig": {
+        "openMetadataServerConfig": {
+            "hostPort": "http://localhost:8585/api",
+            "authProvider": "openmetadata",
+            "securityConfig": {"jwtToken": "dynamodb"},
+        }
+    },
+}
+
+# A user_id declared as a string but holding digits is the case pandas gets wrong: it reads
+# "1001" back as an int. created_at is a genuine DynamoDB number.
+COMPOSITE_KEY_SCHEMA = [
+    {"AttributeName": "user_id", "KeyType": "HASH"},
+    {"AttributeName": "created_at", "KeyType": "RANGE"},
+]
+COMPOSITE_ATTRIBUTE_DEFINITIONS = [
+    {"AttributeName": "user_id", "AttributeType": "S"},
+    {"AttributeName": "created_at", "AttributeType": "N"},
+]
+COMPOSITE_ITEMS = [
+    {"user_id": "1001", "created_at": 1700000000, "email": "alice@example.com"},
+    {"user_id": "1002", "created_at": 1700000001, "email": "bob@example.com"},
+]
+
+
+class StubTable:
+    """
+    Stands in for a boto3 DynamoDB Table resource. Reading key_schema is what triggers the
+    DescribeTable call on the real resource, so it also counts how often we describe.
+    """
+
+    def __init__(self, key_schema, attribute_definitions, items, describe_error=None):
+        self._key_schema = key_schema
+        self._attribute_definitions = attribute_definitions
+        self._items = items
+        self._describe_error = describe_error
+        self.describe_calls = 0
+
+    @property
+    def key_schema(self):
+        self.describe_calls += 1
+        if self._describe_error:
+            raise self._describe_error
+        return self._key_schema
+
+    @property
+    def attribute_definitions(self):
+        return self._attribute_definitions
+
+    def scan(self, **_):
+        return {"Items": self._items, "LastEvaluatedKey": None}
+
+
+def build_source(
+    key_schema=None,
+    attribute_definitions=None,
+    items=None,
+    describe_error=None,
+) -> tuple[DynamodbSource, StubTable]:
+    """Build a DynamodbSource whose boto3 resource hands back the given table."""
+    table = StubTable(
+        key_schema if key_schema is not None else COMPOSITE_KEY_SCHEMA,
+        attribute_definitions if attribute_definitions is not None else COMPOSITE_ATTRIBUTE_DEFINITIONS,
+        items if items is not None else COMPOSITE_ITEMS,
+        describe_error=describe_error,
+    )
+    resource = MagicMock()
+    resource.Table.return_value = table
+
+    workflow_config = OpenMetadataWorkflowConfig.model_validate(MOCK_DYNAMODB_CONFIG)
+    with (
+        patch("metadata.ingestion.source.database.dynamodb.metadata.DynamodbSource.test_connection"),
+        patch(
+            "metadata.ingestion.source.database.dynamodb.connection.DynamoDBConnection._get_client",
+            return_value=resource,
+        ),
+    ):
+        source = DynamodbSource.create(
+            MOCK_DYNAMODB_CONFIG["source"],
+            OpenMetadata(workflow_config.workflowConfig.openMetadataServerConfig),
+        )
+
+    source.context.get().__dict__["database_service"] = "local_dynamodb"
+    source.context.get().__dict__["database"] = "default"
+    source.context.get().__dict__["database_schema"] = "default"
+    return source, table
+
+
+def columns_by_name(columns) -> dict:
+    return {column.name.root: column for column in columns}
+
+
+def test_composite_key_is_ingested_as_a_primary_key():
+    source, _ = build_source()
+
+    requests = [either.right for either in source.yield_table(("users", "Regular"))]
+
+    assert len(requests) == 1
+    table_request = requests[0]
+    assert table_request.tableConstraints == [
+        # DynamoDB's primary key is the partition key together with the sort key
+        TableConstraint(
+            constraintType=ConstraintType.PRIMARY_KEY,
+            columns=["user_id", "created_at"],
+        ),
+        TableConstraint(constraintType=ConstraintType.SORT_KEY, columns=["created_at"]),
+    ]
+    columns = columns_by_name(table_request.columns)
+    assert columns["user_id"].constraint == Constraint.PRIMARY_KEY
+    assert columns["created_at"].constraint == Constraint.PRIMARY_KEY
+    assert columns["email"].constraint is None
+
+
+def test_partition_key_only_has_no_sort_key_constraint():
+    source, _ = build_source(
+        key_schema=[{"AttributeName": "id", "KeyType": "HASH"}],
+        attribute_definitions=[{"AttributeName": "id", "AttributeType": "S"}],
+        items=[{"id": "a", "name": "Alice"}],
+    )
+
+    constraints = source.get_table_constraints(db_name="default", schema_name="default", table_name="users")
+
+    assert constraints == [TableConstraint(constraintType=ConstraintType.PRIMARY_KEY, columns=["id"])]
+
+
+def test_key_column_types_come_from_the_table_definition_not_the_sample():
+    source, _ = build_source()
+
+    columns = columns_by_name(source.get_table_columns("default", "users"))
+
+    # pandas reads the digits in "1001" back as an int; the table says the key is a string
+    assert columns["user_id"].dataType == DataType.STRING
+    assert columns["user_id"].dataTypeDisplay == DataType.STRING.value
+    assert columns["created_at"].dataType == DataType.NUMBER
+    # non-key columns keep whatever the sample inferred
+    assert columns["email"].dataType == DataType.STRING
+
+
+def test_empty_table_still_reports_its_key_columns():
+    source, _ = build_source(items=[])
+
+    columns = source.get_table_columns("default", "users")
+
+    # Without this the primary key would point at columns the table does not have and the
+    # server would reject it.
+    assert [column.name.root for column in columns] == ["user_id", "created_at"]
+    assert [column.dataType for column in columns] == [DataType.STRING, DataType.NUMBER]
+    assert all(column.constraint == Constraint.PRIMARY_KEY for column in columns)
+
+
+def test_describe_failure_leaves_the_table_ingestible():
+    source, _ = build_source(describe_error=RuntimeError("AccessDeniedException"))
+
+    requests = [either.right for either in source.yield_table(("users", "Regular"))]
+
+    assert len(requests) == 1
+    assert requests[0].tableConstraints is None
+    assert sorted(columns_by_name(requests[0].columns)) == ["created_at", "email", "user_id"]
+
+
+def test_a_table_is_described_only_once():
+    source, table = build_source()
+
+    source.get_table_columns("default", "users")
+    source.get_table_constraints(db_name="default", schema_name="default", table_name="users")
+
+    assert table.describe_calls == 1


### PR DESCRIPTION
### Describe your changes:

Fixes #27472

The DynamoDB connector built its column list purely from a sample `scan()` and never looked at the table's key schema. Every DynamoDB table therefore landed in OpenMetadata with `tableConstraints=None`, no key icon on any column, and key columns typed by pandas inference rather than by DynamoDB's own type definitions.

`DescribeTable` already returns `KeySchema` and `AttributeDefinitions`, and reads **no table data** — so this costs one metadata call per table and no extra scanning.

**Root cause:** `CommonNoSQLSource.yield_table` already passes `get_table_constraints(...)` straight into `CreateTableRequest(tableConstraints=...)`. The wiring was there; `DynamodbSource` simply never overrode the hook, so it inherited the base implementation that returns `None`. (`BigtableSource`, the sibling NoSQL source, does override it.)

**What changed:**

- `DynamodbSource.get_table_constraints` now maps the key schema onto constraints: `PRIMARY_KEY` over the partition key plus the sort key when the table has one (that composite *is* DynamoDB's primary key), and `SORT_KEY` over the sort key on its own so the HASH/RANGE roles aren't lost. `ConstraintType.SORT_KEY` already exists and Redshift uses it the same way.
- `DynamodbSource.get_table_columns` types key columns from `AttributeDefinitions` instead of from sampled values, and sets the column-level `Constraint.PRIMARY_KEY`. A string key holding digits (`"1001"`) was previously read back as `INT`, because the inference path runs `ast.literal_eval` over sampled values.
- Keys **absent from the sample are added to the column list**. An empty table scans to zero rows, which would otherwise leave the primary key pointing at columns the table doesn't have — and `TableRepository.validateTableConstraints` rejects that outright, failing the whole table.
- The key schema is memoised in a **bounded** LRU cache (`metadata.utils.lru_cache.LRUCache`, capacity 128), because `yield_table` asks for both the columns and the constraints of the same table and would otherwise describe it twice.
- A `DescribeTable` failure logs a warning and returns `None`; the table still ingests exactly as it does today.

No schema change, no generated-model change, no backend change, no UI change — the UI already renders both `Column.constraint` (the key icon in the schema table, via `TableUtils.CONSTRAINT_ICON_CONFIG`) and `tableConstraints`.

Global/Local Secondary Indexes are deliberately out of scope: GSIs are not unique, so no `ConstraintType` maps onto them cleanly.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change, 2 source files.

#
### Tests:

#### Use cases covered
- A DynamoDB table with a composite key (partition + sort) ingests with a `PRIMARY_KEY` over both columns and a `SORT_KEY` over the sort key; both columns carry the column-level `PRIMARY_KEY` constraint, non-key columns do not.
- A table with only a partition key gets a single-column `PRIMARY_KEY` and no `SORT_KEY` constraint.
- A key declared `S` whose values are digit strings stays `STRING` instead of being inferred as `INT`; an `N` key becomes `NUMBER`. Non-key columns keep whatever the sample inferred.
- An **empty** table still reports its key columns, so the primary key is not left dangling.
- A `DescribeTable` failure (e.g. `AccessDeniedException` on `dynamodb:DescribeTable`) leaves the table ingestible, just without constraints.
- A table is described only once per ingestion.

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Files added/updated: `ingestion/tests/unit/topology/database/test_dynamodb.py` (new — there were no DynamoDB topology tests before this).
- All 6 pass. **5 of the 6 fail against `main`** — verified by reverting just the source changes and re-running, which reproduces the exact symptoms from the issue (`constraints == None`, `created_at` typed `INT` instead of `NUMBER`, empty table yielding zero columns, `describe_calls == 0`).
- No regressions: `ingestion/tests/unit/topology/database/` goes from `24 failed, 621 passed` on `main` to `19 failed, 626 passed` — a delta of exactly the 5 new tests. The remaining failures are missing optional connector dependencies (`pymongo`, `oracledb`, `pinotdb`, …) in the local env and are identical in both runs.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] I added/updated ingestion integration tests for connector changes.
- Files added/updated: `ingestion/tests/integration/profiler/test_dynamodb.py` — `test_primary_key_from_key_schema`. The existing LocalStack fixture already creates `test_table` with `KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}]` / `AttributeType: "S"` and rows whose ids are `"1"` and `"2"`, so the new test covers both the constraint and the type fix end to end. Reading the constraint back from the API is also the real proof that the server accepted it, since it validates every constraint column against the table's columns.

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Verified locally in a fresh venv (`make generate`, editable install):

```
$ python -m pytest ingestion/tests/unit/topology/database/test_dynamodb.py \
                   ingestion/tests/unit/source/database/dynamodb/ -q
8 passed

$ cd ingestion && make py_format_check
All checks passed!
2755 files already formatted

$ make static-checks     # basedpyright, filtered to the changed files
(no errors in dynamodb/*)
```

The ingestion integration test was **not** run locally — it needs a live OpenMetadata server on `localhost:8585`. It collects cleanly and will run in CI.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not needed — no schema change.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit / integration as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
