### PR TITLE
fix(ui): show original casing for tag-like options in Advanced Search [2.0 backport, retry]

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AdvancedSearch.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AdvancedSearch.spec.ts
@@ -1212,9 +1212,9 @@ test.describe(
       await test.step('Filter chip reflects the applied column tag', async () => {
         await expect(
           page.getByTestId('advance-search-filter-container')
-        ).toContainText(
-          columnTag1.responseData.fullyQualifiedName.toLowerCase()
-        );
+        ).toContainText(columnTag1.responseData.fullyQualifiedName, {
+          ignoreCase: true,
+        });
       });
 
       await test.step('table1 (tagged with tag1) is visible', async () => {
@@ -1262,9 +1262,9 @@ test.describe(
       await test.step('Filter chip reflects the applied column tag', async () => {
         await expect(
           page.getByTestId('advance-search-filter-container')
-        ).toContainText(
-          columnTag2.responseData.fullyQualifiedName.toLowerCase()
-        );
+        ).toContainText(columnTag2.responseData.fullyQualifiedName, {
+          ignoreCase: true,
+        });
       });
 
       await test.step('table2 (tagged with tag2) is visible', async () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AdvancedSearchSuggestions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AdvancedSearchSuggestions.spec.ts
@@ -93,9 +93,12 @@ test.describe('Advanced Search Suggestions', () => {
 
       await aggregateRes2;
 
+      // Tag-like fields (tags, tier, certification) render the original-cased
+      // FQN from the top_hits source while the typed search text stays
+      // lowercased, so match the option title case-insensitively.
       await test
         .expect(
-          page.locator(`.ant-select-dropdown:visible [title="${searchText}"]`)
+          page.locator('.ant-select-dropdown:visible').getByTitle(searchText)
         )
         .toBeVisible();
     });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CuratedAssets.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CuratedAssets.spec.ts
@@ -609,7 +609,7 @@ test.describe('Curated Assets Widget', () => {
     await selectOption(
       page,
       ruleLocator3.locator('.rule--value .ant-select'),
-      'tier.tier5',
+      'Tier.Tier5',
       true
     );
 
@@ -620,7 +620,7 @@ test.describe('Curated Assets Widget', () => {
       (response) =>
         response.url().includes('/api/v1/search/query') &&
         response.url().includes('index=all') &&
-        response.url().includes('tier.tier5')
+        response.url().toLowerCase().includes('tier.tier5')
     );
 
     await page.locator('[data-testid="saveButton"]').click();

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/advancedSearch.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/advancedSearch.ts
@@ -332,6 +332,22 @@ export const fillRule = async (
   }
 };
 
+// Tag-like fields (tags, tier, certification, glossary) now apply the
+// original-cased value while other fields still apply the lowercased
+// aggregation key, so URL and chip expectations must be case-insensitive.
+const waitForSearchQueryWithValues = (page: Page, values: string[]) =>
+  page.waitForResponse((response) => {
+    const url = response.url().toLowerCase();
+
+    return (
+      url.includes('/api/v1/search/query') &&
+      url.includes('index=dataasset&from=0&size=15') &&
+      values.every((value) =>
+        url.includes(getEncodedFqn(value, true).toLowerCase())
+      )
+    );
+  });
+
 export const checkMustPaths = async (
   page: Page,
   {
@@ -355,17 +371,14 @@ export const checkMustPaths = async (
     index,
   });
 
-  const searchRes = page.waitForResponse(
-    `/api/v1/search/query?*index=dataAsset&from=0&size=15*${getEncodedFqn(
-      searchData,
-      true
-    )}*`
-  );
+  const searchRes = waitForSearchQueryWithValues(page, [searchData]);
   await page.getByTestId('apply-btn').click();
 
   const res = await searchRes;
 
-  expect(res.request().url()).toContain(getEncodedFqn(searchData, true));
+  expect(res.request().url().toLowerCase()).toContain(
+    getEncodedFqn(searchData, true).toLowerCase()
+  );
 
   const json = await res.json();
 
@@ -373,7 +386,7 @@ export const checkMustPaths = async (
 
   await expect(
     page.getByTestId('advance-search-filter-container')
-  ).toContainText(searchData);
+  ).toContainText(searchData, { ignoreCase: true });
 };
 
 export const checkMustNotPaths = async (
@@ -399,16 +412,13 @@ export const checkMustNotPaths = async (
     index,
   });
 
-  const searchRes = page.waitForResponse(
-    `/api/v1/search/query?*index=dataAsset&from=0&size=15*${getEncodedFqn(
-      searchData,
-      true
-    )}*`
-  );
+  const searchRes = waitForSearchQueryWithValues(page, [searchData]);
   await page.getByTestId('apply-btn').click();
   const res = await searchRes;
 
-  expect(res.request().url()).toContain(getEncodedFqn(searchData, true));
+  expect(res.request().url().toLowerCase()).toContain(
+    getEncodedFqn(searchData, true).toLowerCase()
+  );
 
   if (!['columns.name.keyword'].includes(field.name)) {
     const json = await res.json();
@@ -418,7 +428,7 @@ export const checkMustNotPaths = async (
 
   await expect(
     page.getByTestId('advance-search-filter-container')
-  ).toContainText(searchData);
+  ).toContainText(searchData, { ignoreCase: true });
 };
 
 export const checkNullPaths = async (
@@ -591,12 +601,10 @@ export const checkAddRuleOrGroupWithOperator = async (
   if (field.id === 'Column') {
     await page.getByTestId('apply-btn').click();
   } else {
-    const searchRes = page.waitForResponse(
-      `/api/v1/search/query?*index=dataAsset&from=0&size=15*${getEncodedFqn(
-        searchCriteria1.toLowerCase(),
-        true
-      )}*${getEncodedFqn(searchCriteria2.toLowerCase(), true)}*`
-    );
+    const searchRes = waitForSearchQueryWithValues(page, [
+      searchCriteria1,
+      searchCriteria2,
+    ]);
     await page.getByTestId('apply-btn').click();
     const res = await searchRes;
     const json = await res.json();

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.test.ts
@@ -20,6 +20,7 @@ import {
 import { EntityFields } from '../enums/AdvancedSearch.enum';
 import { SearchIndex } from '../enums/search.enum';
 import { CustomPropertySummary } from '../rest/metadataTypeAPI.interface';
+import { getAggregateFieldOptions } from '../rest/miscAPI';
 import { AdvancedSearchClassBase } from './AdvancedSearchClassBase';
 import { getCustomPropertyAdvanceSearchEnumOptions } from './AdvancedSearchPureUtils';
 import { getEntityName } from './EntityNameUtils';
@@ -1244,5 +1245,65 @@ describe('buildEnumAsyncFetch', () => {
 
     expect(result.values).toHaveLength(2);
     expect(result.values.map((v) => v.value)).toEqual(['Active', 'ACTIVE']);
+  });
+});
+
+describe('tag-like field autocomplete casing (#31999)', () => {
+  // Terms aggregations on lowercase_normalizer fields return lowercased bucket
+  // keys; without a sourceFields top-hits sub-aggregation the option label falls
+  // back to that lowercased key. These configs must request fullyQualifiedName.
+  let advancedSearchClassBase: AdvancedSearchClassBase;
+
+  beforeEach(() => {
+    advancedSearchClassBase = new AdvancedSearchClassBase();
+    jest.useFakeTimers();
+    (getAggregateFieldOptions as jest.Mock).mockClear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const expectSourceFieldsRequested = (field: {
+    fieldSettings?: { asyncFetch?: unknown };
+  }) => {
+    const asyncFetch = field.fieldSettings?.asyncFetch as (
+      search: string
+    ) => Promise<unknown>;
+    asyncFetch('pii');
+    jest.advanceTimersByTime(300);
+
+    expect(getAggregateFieldOptions).toHaveBeenCalledWith(
+      expect.anything(),
+      EntityFields.FULLY_QUALIFIED_NAME,
+      'pii',
+      expect.anything(),
+      'fullyQualifiedName'
+    );
+  };
+
+  it.each([
+    EntityFields.TAG,
+    EntityFields.GLOSSARY_TERMS,
+    EntityFields.CERTIFICATION,
+    EntityFields.TIER,
+  ])('%s config should request fullyQualifiedName source field', (key) => {
+    const config = advancedSearchClassBase.getCommonConfig({});
+
+    expectSourceFieldsRequested(
+      config[key] as { fieldSettings?: { asyncFetch?: unknown } }
+    );
+  });
+
+  it('column tag config should request fullyQualifiedName source field', () => {
+    const config = advancedSearchClassBase.getColumnTagConfig([
+      SearchIndex.TABLE,
+    ]);
+
+    expectSourceFieldsRequested(
+      config[EntityFields.COLUMN_TAG] as {
+        fieldSettings?: { asyncFetch?: unknown };
+      }
+    );
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
@@ -940,6 +940,7 @@ class AdvancedSearchClassBase {
           asyncFetch: this.autocomplete({
             searchIndex: [SearchIndex.TAG, SearchIndex.GLOSSARY_TERM],
             entityField: EntityFields.FULLY_QUALIFIED_NAME,
+            sourceFields: 'fullyQualifiedName',
             q: buildTermQuery(
               [
                 {
@@ -968,6 +969,7 @@ class AdvancedSearchClassBase {
           asyncFetch: this.autocomplete({
             searchIndex: SearchIndex.GLOSSARY_TERM,
             entityField: EntityFields.FULLY_QUALIFIED_NAME,
+            sourceFields: 'fullyQualifiedName',
           }),
           useAsyncSearch: true,
         },
@@ -981,6 +983,7 @@ class AdvancedSearchClassBase {
           asyncFetch: this.autocomplete({
             searchIndex: [SearchIndex.TAG],
             entityField: EntityFields.FULLY_QUALIFIED_NAME,
+            sourceFields: 'fullyQualifiedName',
             q: buildTermQuery(
               {
                 field: 'classification.name.keyword',
@@ -1001,6 +1004,7 @@ class AdvancedSearchClassBase {
           asyncFetch: this.autocomplete({
             searchIndex: [SearchIndex.TAG],
             entityField: EntityFields.FULLY_QUALIFIED_NAME,
+            sourceFields: 'fullyQualifiedName',
             q: buildTermQuery(
               {
                 field: 'classification.name.keyword',
@@ -1156,6 +1160,7 @@ class AdvancedSearchClassBase {
               asyncFetch: this.autocomplete({
                 searchIndex: [SearchIndex.TAG, SearchIndex.GLOSSARY_TERM],
                 entityField: EntityFields.FULLY_QUALIFIED_NAME,
+                sourceFields: 'fullyQualifiedName',
               }),
               useAsyncSearch: true,
             },


### PR DESCRIPTION
Reapplies #33146 (backport of #33007), reverted in #33215.

## Why the first attempt failed

Nightly AUT [`34593897556`](https://github.com/open-metadata/openmetadata-nightly/actions/runs/34593897556) (and the MySQL twin [`34593890586`](https://github.com/open-metadata/openmetadata-nightly/actions/runs/34593890586)): **3 unexpected out of 7736**, all in `AdvancedSearchSuggestions.spec.ts` — `Tags`, `Certification`, `Tier`.

```
Locator: locator('.ant-select-dropdown:visible [title="tier.pw-tier-pandad7e74cc6"]')
Expected: visible
Error: element(s) not found
```

The spec asserts the rendered option with an **exact attribute selector**:

```ts
const searchText = toLower(getFieldsSuggestionSearchText(...));   // tier.pw-tier-pandad7e74cc6
page.locator(`.ant-select-dropdown:visible [title="${searchText}"]`)
```

Generated fixture names carry capitals (`Tier.pw-tier-Panda...`). Once the option renders the original-cased FQN from `_source`, the lowercased selector matches nothing. The other 6 fields in `ADVANCED_SEARCH_SUGGESTION_FIELDS` are `displayName.keyword`-backed and untouched by this change, so they stayed green.

## Why main is green

On `main` this spec was already rewritten onto `react-aria` and matches with

```ts
page.locator('[role="listbox"]:visible [role="option"]').filter({ hasText: searchText })
```

`hasText` with a string is a **case-insensitive** substring match, so main never saw the breakage. `2.0` still runs the antd `[title=...]` variant — a test-harness difference, not a behavioral one.

## The fix

Same code change as #33146, plus the one assertion the backport missed:

```diff
-          page.locator(`.ant-select-dropdown:visible [title="${searchText}"]`)
+          page.locator('.ant-select-dropdown:visible').getByTitle(searchText)
```

`getByTitle` with a plain string is a case-insensitive substring match, so it keeps asserting the actual value while tolerating either casing. The typed search text stays lowercased, so the `aggregate` URL wait above it is unaffected.

No product behavior change beyond the original fix: the aggregation bucket key remains the filter value, only the displayed label changes.

<img width="1512" height="902" alt="Screenshot 2026-09-11 at 9 43 57 PM" src="https://github.com/user-attachments/assets/06748a54-0745-4257-b8ff-f49f85895c77" />


Fixes #31999

🤖 Generated with [Claude Code](https://claude.com/claude-code)