### PR TITLE
fix(bigquery): widen auto-detected partition window to avoid silent empty samples

### DIFF
--- a/ingestion/src/metadata/sampler/partition.py
+++ b/ingestion/src/metadata/sampler/partition.py
@@ -112,22 +112,28 @@ def _handle_bigquery_partition(entity: Table, table_partition: TablePartition) -
         partition = column_partitions[0]
 
         if partition.intervalType == PartitionIntervalTypes.TIME_UNIT:
+            is_hourly = partition.interval == "HOUR"
             return PartitionProfilerConfig(
                 enablePartitioning=True,
                 partitionColumnName=partition.columnName,
-                partitionIntervalUnit=PartitionIntervalUnit.DAY if partition.interval != "HOUR" else partition.interval,
-                partitionInterval=1,
+                partitionIntervalUnit=PartitionIntervalUnit.HOUR if is_hourly else PartitionIntervalUnit.DAY,
+                # Use a wider default window so tables that are not updated every day/hour
+                # (e.g. GA4 exports with a ~2-day lag, or weekly aggregates) still produce
+                # non-empty samples without requiring per-table profiler config overrides.
+                # 24 h for hourly partitions; 3 days for daily/monthly/yearly.
+                partitionInterval=24 if is_hourly else 3,
                 partitionIntervalType=partition.intervalType.value,
                 partitionValues=None,
                 partitionIntegerRangeStart=None,
                 partitionIntegerRangeEnd=None,
             )
         if partition.intervalType == PartitionIntervalTypes.INGESTION_TIME:
+            is_hourly = partition.interval == "HOUR"
             return PartitionProfilerConfig(
                 enablePartitioning=True,
                 partitionColumnName="_PARTITIONDATE" if partition.interval == "DAY" else "_PARTITIONTIME",
-                partitionIntervalUnit=PartitionIntervalUnit.DAY if partition.interval != "HOUR" else partition.interval,
-                partitionInterval=1,
+                partitionIntervalUnit=PartitionIntervalUnit.HOUR if is_hourly else PartitionIntervalUnit.DAY,
+                partitionInterval=24 if is_hourly else 3,
                 partitionIntervalType=partition.intervalType.value,
                 partitionValues=None,
                 partitionIntegerRangeStart=None,

--- a/ingestion/src/metadata/sampler/sqlalchemy/sampler.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/sampler.py
@@ -203,7 +203,19 @@ class SQASampler(SamplerInterface, SQAInterfaceMixin):
             with self.session_factory() as client:
                 query = client.query(self.raw_dataset)
                 query = self.get_partitioned_query(query)
-                return query.count()
+                row_count = query.count()
+            if row_count == 0:
+                logger.warning(
+                    "Partition filter on table '%s' returned 0 rows. "
+                    "The partition window (interval=%s %s) may not cover the table's most-recent data. "
+                    "Override the profiler partition config for this table to widen the window. "
+                    "See https://docs.open-metadata.org/latest/how-to-guides/data-quality-observability/"
+                    "profiler/workflow#4.-updating-profiler-setting-at-the-table-level",
+                    getattr(self.raw_dataset, "__tablename__", "unknown"),
+                    getattr(self.partition_details, "partitionInterval", "?"),
+                    getattr(self.partition_details, "partitionIntervalUnit", "?"),
+                )
+            return row_count
 
         with self.session_factory() as session:
             runner = QueryRunner(

--- a/ingestion/tests/unit/test_partition.py
+++ b/ingestion/tests/unit/test_partition.py
@@ -96,7 +96,9 @@ def test_get_partition_details():
     assert partition.enablePartitioning == True  # noqa: E712
     assert partition.partitionColumnName == "_PARTITIONTIME"
     assert partition.partitionIntervalType == PartitionIntervalTypes.INGESTION_TIME
-    assert partition.partitionInterval == 1
+    # Hourly ingestion-time partitions use a 24-hour window so tables updated less
+    # frequently than every hour still produce non-empty samples.
+    assert partition.partitionInterval == 24
     assert partition.partitionIntervalUnit == PartitionIntervalUnit.HOUR
 
     table_entity = MockTable(
@@ -117,7 +119,9 @@ def test_get_partition_details():
     assert partition.enablePartitioning is True
     assert partition.partitionColumnName == "_PARTITIONDATE"
     assert partition.partitionIntervalType == PartitionIntervalTypes.INGESTION_TIME
-    assert partition.partitionInterval == 1
+    # Daily ingestion-time partitions use a 3-day window so tables with common
+    # ingestion delays (e.g. GA4's ~2-day lag) still produce non-empty samples.
+    assert partition.partitionInterval == 3
     assert partition.partitionIntervalUnit == PartitionIntervalUnit.DAY
 
 
@@ -161,3 +165,59 @@ def test_athena_injected_partition():
     assert partition.partitionColumnName == "e"
     assert partition.partitionIntervalType == PartitionIntervalTypes.COLUMN_VALUE
     assert partition.partitionValues == ["red"]
+
+
+def test_bigquery_time_unit_partition_default_intervals():
+    """Auto-detected BigQuery TIME_UNIT partitions use wider default windows.
+
+    Previously the default was 1 (day / hour), which silently produced empty
+    samples for any table whose freshest partition is older than 1 day/hour —
+    a common situation for GA4 exports or any table with an ingestion lag.
+    The new defaults are 3 days (DAY granularity) and 24 hours (HOUR granularity).
+    """
+    # DAY granularity → 3-day window
+    day_entity = MockTable(
+        tablePartition=TablePartition(
+            columns=[
+                PartitionColumnDetails(
+                    columnName="event_date",
+                    intervalType=PartitionIntervalTypes.TIME_UNIT,
+                    interval="DAY",
+                )
+            ]
+        ),
+        tableProfilerConfig=None,
+    )
+    partition = get_partition_details(day_entity)
+
+    assert partition.enablePartitioning is True
+    assert partition.partitionColumnName == "event_date"
+    assert partition.partitionIntervalType == PartitionIntervalTypes.TIME_UNIT
+    assert partition.partitionIntervalUnit == PartitionIntervalUnit.DAY
+    assert partition.partitionInterval == 3, (
+        "DAY-granularity TIME_UNIT partitions should default to a 3-day window "
+        "so tables with a ~2-day ingestion lag (e.g. GA4 exports) are still sampled."
+    )
+
+    # HOUR granularity → 24-hour window
+    hour_entity = MockTable(
+        tablePartition=TablePartition(
+            columns=[
+                PartitionColumnDetails(
+                    columnName="event_timestamp",
+                    intervalType=PartitionIntervalTypes.TIME_UNIT,
+                    interval="HOUR",
+                )
+            ]
+        ),
+        tableProfilerConfig=None,
+    )
+    partition = get_partition_details(hour_entity)
+
+    assert partition.enablePartitioning is True
+    assert partition.partitionColumnName == "event_timestamp"
+    assert partition.partitionIntervalType == PartitionIntervalTypes.TIME_UNIT
+    assert partition.partitionIntervalUnit == PartitionIntervalUnit.HOUR
+    assert partition.partitionInterval == 24, (
+        "HOUR-granularity TIME_UNIT partitions should default to a 24-hour window."
+    )


### PR DESCRIPTION
## Why

Fixes #33084

BigQuery TIME_UNIT and INGESTION_TIME partitions were auto-detected with a `partitionInterval=1` (1 day for DAY granularity, 1 hour for HOUR granularity). Any table whose most-recent partition is older than that window is silently sampled as an empty result — the profiler reports success, so tables that were never actually examined are indistinguishable from tables that were examined and found clean.

Common sources of this silent failure:
- GA4 export tables (~2-day ingestion lag)
- Weekly or monthly aggregate tables
- Any source with a slow or batched load cadence

## What changed

### `ingestion/src/metadata/sampler/partition.py`
- `TIME_UNIT` auto-detection: `partitionInterval=1` → `24` (HOUR) or `3` (DAY/MONTH/YEAR)
- `INGESTION_TIME` auto-detection: same change
- Per-table profiler config overrides are fully preserved — any explicitly set `partitionInterval` in `tableProfilerConfig.partitioning` continues to take precedence via the existing `get_partition_details` early-return path

### `ingestion/src/metadata/sampler/sqlalchemy/sampler.py`
- `_get_asset_row_count()`: emit `logger.warning` when a partitioned-table `COUNT(*)` returns 0 rows, naming the table, current window, and the docs link to override it. This makes any remaining narrow-window case visible in run logs rather than silent.

### `ingestion/tests/unit/test_partition.py`
- Updated existing INGESTION_TIME assertions from `1` → `24` (HOUR) and `3` (DAY)
- Added `test_bigquery_time_unit_partition_default_intervals` covering both DAY (3-day window) and HOUR (24-hour window) for TIME_UNIT partitions

## Test evidence

The OpenMetadata ingestion package requires generated schema files not present in a shallow clone, which prevented running pytest in isolation. Logic was verified via a standalone script that mocks the pydantic models and calls the same branching logic directly — all 5 cases pass:

```
PASS TIME_UNIT DAY: interval=3 unit=DAY
PASS TIME_UNIT HOUR: interval=24 unit=HOUR
PASS INGESTION_TIME DAY: interval=3 col=_PARTITIONDATE
PASS INGESTION_TIME HOUR: interval=24 col=_PARTITIONTIME
PASS INTEGER_RANGE: interval=None rangeStart=1
```

---

*Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.*

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63094861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge, with a non-blocking correction recommended for the warning shown on empty integer-range partitions.

<h2>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Misleading Integer Partition Warning** <a href="https://github.com/open-metadata/OpenMetadata/pull/33221#discussion_r4063346393">▶</a>

<details open><summary>Summary</summary>

This PR widens automatically inferred BigQuery profiling windows and adds visibility when a partition-filtered count remains empty.
- Maps hourly partitions to a 24-hour window, daily partitions to three days, and monthly/yearly partitions to wider day-based windows.
- Preserves explicitly configured table-level partition settings.
- Logs zero-row partition counts with override guidance, although that guidance currently also applies incorrectly to integer-range partitions.
- Extends unit coverage for BigQuery time-unit and ingestion-time defaults.
</details>

<sub>Reviews (1) · Last reviewed commit: ["Merge branch &#39;main&#39; into fix/bigquery-pa..."](https://github.com/open-metadata/openmetadata/commit/4fae9d8882c1bf66d33862c01e8c9b6af3b18085)</sub>

<!-- /greptile_comment -->