### PR TITLE
test(playwright): quarantine flaky "Create Data Contract and validate for Table"

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
+++ b/openmetadata-ui/src/main/resources/ui/playwright/QUARANTINE.md
@@ -27,13 +27,14 @@ coverage, a retried one looks green.
 
 ## Entries
 
-4 tests. Most evidence is failures observed across 11 merge_group runs sampled on
+5 tests. Most evidence is failures observed across 11 merge_group runs sampled on
 2026-09-04; the threshold for quarantining is **2 or more**, counted per
 generated variant rather than per source line.
 
 | Spec | Test | Seen | Symptom |
 |---|---|---|---|
 | `e2e/Pages/ExplorePageRightPanel_KnowledgeCenter.spec.ts` | Should remove user owner for knowledgeCenter | 1/1 | Re-quarantined 2026-09-10 on fresh evidence, not the 2026-09-04 sample. The 11/11 failure it was first tagged for was real and is fixed (`openEntitySummaryPanel` waited for the NavBar `searchBox` on a page that renders `ExploreSearchInput`), but releasing it surfaced a second cause underneath. In PR #33054 it failed its first attempt and passed on retry: `expectOwnerInPanel` polled for the owner chip for the full 60s, re-navigating between attempts, and never saw it — even though `addOwnerInKCPanel` had already awaited the PATCH, so the owner was persisted. That is the *original* recorded symptom (owner chip not found), so the panel's read path lags the write rather than the navigation being wrong. A longer poll is not the fix; find what the panel reads and wait on that. |
+| `e2e/Pages/DataContracts.spec.ts` | Create Data Contract and validate for Table | 2/2 | Quarantined 2026-09-11 (BE bug, not a test flake). On both merge_group attempts of run 34588697338 the contract's quality/test-suite run finished without writing a result: `GET /dataContracts/{id}/results/{resultId}` shows `schemaValidation` (5/5) and `semanticsValidation` (1/1) populated but **`qualityValidation` absent**, so the aggregate `contractExecutionStatus` hangs on `Running` and never reaches a terminal state. The test suite + DQ ingestion pipeline were created and deployed fine (`POST …/ingestionPipelines/deploy` → 200), but the triggered Airflow DagRun completed in ~0.03s executing zero test cases, so no test-case result came back. `waitForDataContractExecution` then polls the full 600s and the fallback derives `suiteStatus = 'Running'`, failing `expect(...).toMatch(/^(Aborted\|Success\|Failed)$/)`. Fix is in BE: reap contract validation to a terminal state (`Aborted`/`Failed`) when the quality run fails to trigger or returns no result, instead of hanging on `Running`; plus BE/Ingestion should confirm test cases are attached before the pipeline is triggered so the run isn't empty. Owner: BE team. |
 | `e2e/Pages/TestSuiteDetailsPage.spec.ts` | Add test case modal — filters and select | 3/11 | `waitForResponse` on the test-case search never resolves. |
 | `e2e/Features/Glossary/GlossaryHierarchy.spec.ts` | should move term to root of different glossary | 2/11 | Drag-and-drop. |
 | `e2e/Features/DataQuality/TableLevelTests.spec.ts` | Table Difference | 2/11 | |
@@ -71,9 +72,9 @@ projects, so filtering them would make every quarantined test fail for want of
 `admin.json` instead of for its flake.
 
 Re-run `npx playwright test --list` after changing this file and update the
-default-lane count here. It is **4576 of 4580** with these 4 entries; the
-quarantined lane lists 11, which is the 4 plus the 7 fixture projects above.
-(It was 4543 of 4555 when the list held 13.)
+default-lane count here. It is **4575 of 4580** with these 5 entries; the
+quarantined lane lists 12, which is the 5 plus the 7 fixture projects above.
+(It was 4576 of 4580 with 4 entries, and 4543 of 4555 when the list held 13.)
 
 ## Not quarantined — fixed instead
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataContracts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataContracts.spec.ts
@@ -140,8 +140,12 @@ test.describe('Data Contracts', () => {
   entitiesWithDataContracts.forEach((EntityClass) => {
     const entity = new EntityClass();
     const entityType = entity.getType();
+    // Quarantined: for the Table variant the contract's quality/test-suite run
+    // can finish without producing a result, so `qualityValidation` never
+    // populates and `contractExecutionStatus` hangs on `Running` — the poll
+    // then times out. See playwright/QUARANTINE.md.
     const testDetails = entitySupportsQuality(entityType)
-      ? PLAYWRIGHT_INGESTION_TAG_OBJ
+      ? { tag: [PLAYWRIGHT_INGESTION_TAG_OBJ.tag, '@quarantine'] }
       : {};
     const testTitle = `Create Data Contract and validate for ${entityType}`;
 


### PR DESCRIPTION
## Describe your changes

Quarantines the Playwright test **`Data Contracts › Create Data Contract and validate for Table`** (`e2e/Pages/DataContracts.spec.ts`), which intermittently ejects PRs from the merge queue — e.g. [actions run 34588697338](https://github.com/open-metadata/OpenMetadata/actions/runs/34588697338/job/103235621043), failing both attempts.

Only the **Table** variant is tagged `@quarantine` (it's the only entity with quality-test support); the other 17 entity variants and the separate `Data Contracts With Persona` loop are unaffected.

## Root cause — this is a backend bug, not a test flake

On both merge_group attempts the contract's quality/test-suite run finished **without producing a result**, so the aggregate status hangs on `Running` and the 10-minute poll times out.

Backend evidence from the run's diagnostics:
- `GET /api/v1/dataContracts/{id}/results/{resultId}` → `schemaValidation` (5/5) and `semanticsValidation` (1/1) populated, but **`qualityValidation` absent**, with `contractExecutionStatus: "Running"`.
- The test suite + DQ ingestion pipeline were created and **deployed successfully** (`POST .../ingestionPipelines/deploy` → 200).
- But the triggered Airflow DagRun completed in **~0.03s executing zero test cases**, so no test-case result flowed back.

Because `contractExecutionStatus` never reaches a terminal state, `waitForDataContractExecution` polls the full 600s and the fallback derives `suiteStatus = 'Running'`, failing:
```
expect(suiteStatus).toMatch(/^(Aborted|Success|Failed)$/)
```

## Follow-up for the BE team (tracked separately)

1. **Reap contract validation to a terminal state** (`Aborted`/`Failed` with an error) when the quality/test-suite run fails to trigger or returns no result, instead of hanging on `Running` indefinitely.
2. **BE/Ingestion:** confirm test cases are attached to the suite before the DQ pipeline is triggered, so the run isn't empty.

Quarantine is a holding pen — the entry in `playwright/QUARANTINE.md` (owner: BE team) is removed once the underlying issue is fixed.

## Type of change

- [x] Test / CI stability

## Checklist

- [x] Tagged only the failing variant `@quarantine`; excluded from every lane via `grepInvert`
- [x] Documented root cause + owner in `playwright/QUARANTINE.md`, updated lane counts (4→5 entries)
- [ ] `npx playwright test --list` not re-run locally (this worktree has no `node_modules`); counts derived from the documented baseline — CI will confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)