### PR TITLE
Fixes #33227: [DQ Threshold W0.1] Seed definitions + data migration for `threshold` / `thresholdUnit`

### DIFF
--- a/bootstrap/sql/migrations/native/2.1.0/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/2.1.0/mysql/postDataMigrationSQLScript.sql
@@ -121,3 +121,106 @@ UPDATE entity_extension
 SET json = JSON_INSERT(json, '$.appConfiguration.activityCommentsRetentionPeriod', 0)
 WHERE extension LIKE 'app.version.%'
   AND json->>'$.name' = 'DataRetentionApplication';
+
+-- Data Quality failure thresholds: declare the `threshold` / `thresholdUnit` parameters on the
+-- in-scope system test definitions, plus `dimensionFailurePolicy` on the ones that support
+-- dimensional analysis. Seeding only covers fresh installs (initializeEntity returns early when the
+-- entity exists) and TestCaseRepository rejects parameters that the definition does not declare, so
+-- existing installs need this backfill. Every statement is guarded on the parameter being absent,
+-- which keeps re-runs a no-op.
+
+-- Definitions that ship without any parameter need the array before we can append to it.
+UPDATE test_definition
+SET json = JSON_SET(json, '$.parameterDefinition', JSON_ARRAY())
+WHERE name IN (
+    'columnValueMaxToBeBetween', 'columnValueMeanToBeBetween', 'columnValueMedianToBeBetween',
+    'columnValueMinToBeBetween', 'columnValueStdDevToBeBetween',
+    'columnValueToBeAtExpectedLocation', 'columnValuesLengthsToBeBetween',
+    'columnValuesMissingCountToBeEqual', 'columnValuesSumToBeBetween', 'columnValuesToBeBetween',
+    'columnValuesToBeInSet', 'columnValuesToBeNotInSet', 'columnValuesToBeNotNull',
+    'columnValuesToBeUnique', 'columnValuesToMatchRegex', 'columnValuesToNotMatchRegex',
+    'tableColumnCountToBeBetween', 'tableColumnCountToEqual', 'tableRowCountToBeBetween',
+    'tableRowCountToEqual', 'tableRowInsertedCountToBeBetween', 'tableCustomSQLQuery'
+  )
+  AND NOT JSON_CONTAINS_PATH(json, 'one', '$.parameterDefinition');
+
+UPDATE test_definition
+SET json = JSON_ARRAY_APPEND(
+    json,
+    '$.parameterDefinition',
+    JSON_OBJECT(
+        'name', 'threshold',
+        'displayName', 'Failure Threshold',
+        'description', 'Number of failures tolerated before the test is marked as failed. Read as an absolute count or as a percentage depending on `thresholdUnit` (defaults to 0).',
+        'dataType', 'NUMBER',
+        'required', false
+    )
+)
+WHERE name IN (
+    'columnValueMaxToBeBetween', 'columnValueMeanToBeBetween', 'columnValueMedianToBeBetween',
+    'columnValueMinToBeBetween', 'columnValueStdDevToBeBetween',
+    'columnValueToBeAtExpectedLocation', 'columnValuesLengthsToBeBetween',
+    'columnValuesMissingCountToBeEqual', 'columnValuesSumToBeBetween', 'columnValuesToBeBetween',
+    'columnValuesToBeInSet', 'columnValuesToBeNotInSet', 'columnValuesToBeNotNull',
+    'columnValuesToBeUnique', 'columnValuesToMatchRegex', 'columnValuesToNotMatchRegex',
+    'tableColumnCountToBeBetween', 'tableColumnCountToEqual', 'tableRowCountToBeBetween',
+    'tableRowCountToEqual', 'tableRowInsertedCountToBeBetween'
+  )
+  AND NOT JSON_CONTAINS(
+    COALESCE(JSON_EXTRACT(json, '$.parameterDefinition[*].name'), JSON_ARRAY()),
+    '"threshold"'
+  );
+
+UPDATE test_definition
+SET json = JSON_ARRAY_APPEND(
+    json,
+    '$.parameterDefinition',
+    JSON_OBJECT(
+        'name', 'thresholdUnit',
+        'displayName', 'Threshold Unit',
+        'description', 'How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).',
+        'dataType', 'STRING',
+        'required', false,
+        'optionValues', JSON_ARRAY('ABSOLUTE', 'PERCENTAGE')
+    )
+)
+WHERE name IN (
+    'columnValueMaxToBeBetween', 'columnValueMeanToBeBetween', 'columnValueMedianToBeBetween',
+    'columnValueMinToBeBetween', 'columnValueStdDevToBeBetween',
+    'columnValueToBeAtExpectedLocation', 'columnValuesLengthsToBeBetween',
+    'columnValuesMissingCountToBeEqual', 'columnValuesSumToBeBetween', 'columnValuesToBeBetween',
+    'columnValuesToBeInSet', 'columnValuesToBeNotInSet', 'columnValuesToBeNotNull',
+    'columnValuesToBeUnique', 'columnValuesToMatchRegex', 'columnValuesToNotMatchRegex',
+    'tableColumnCountToBeBetween', 'tableColumnCountToEqual', 'tableRowCountToBeBetween',
+    'tableRowCountToEqual', 'tableRowInsertedCountToBeBetween', 'tableCustomSQLQuery'
+  )
+  AND NOT JSON_CONTAINS(
+    COALESCE(JSON_EXTRACT(json, '$.parameterDefinition[*].name'), JSON_ARRAY()),
+    '"thresholdUnit"'
+  );
+
+UPDATE test_definition
+SET json = JSON_ARRAY_APPEND(
+    json,
+    '$.parameterDefinition',
+    JSON_OBJECT(
+        'name', 'dimensionFailurePolicy',
+        'displayName', 'Dimension Failure Policy',
+        'description', 'How dimensional results roll up into the overall test status: `OVERALL_ONLY` only looks at the overall result, `ANY_DIMENSION` fails the test as soon as one dimension fails (defaults to OVERALL_ONLY).',
+        'dataType', 'STRING',
+        'required', false,
+        'optionValues', JSON_ARRAY('OVERALL_ONLY', 'ANY_DIMENSION')
+    )
+)
+WHERE name IN (
+    'columnValueMaxToBeBetween', 'columnValueMeanToBeBetween', 'columnValueMedianToBeBetween',
+    'columnValueMinToBeBetween', 'columnValueStdDevToBeBetween',
+    'columnValueToBeAtExpectedLocation', 'columnValuesLengthsToBeBetween',
+    'columnValuesMissingCountToBeEqual', 'columnValuesSumToBeBetween', 'columnValuesToBeBetween',
+    'columnValuesToBeInSet', 'columnValuesToBeNotInSet', 'columnValuesToBeNotNull',
+    'columnValuesToBeUnique', 'columnValuesToMatchRegex', 'columnValuesToNotMatchRegex'
+  )
+  AND NOT JSON_CONTAINS(
+    COALESCE(JSON_EXTRACT(json, '$.parameterDefinition[*].name'), JSON_ARRAY()),
+    '"dimensionFailurePolicy"'
+  );

--- a/bootstrap/sql/migrations/native/2.1.0/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/2.1.0/postgres/postDataMigrationSQLScript.sql
@@ -108,3 +108,97 @@ SET json = jsonb_set(
 WHERE extension LIKE 'app.version.%'
   AND json::jsonb ->> 'name' = 'DataRetentionApplication'
   AND NOT jsonb_exists(json::jsonb #> '{appConfiguration}', 'activityCommentsRetentionPeriod');
+
+-- Data Quality failure thresholds: declare the `threshold` / `thresholdUnit` parameters on the
+-- in-scope system test definitions, plus `dimensionFailurePolicy` on the ones that support
+-- dimensional analysis. Seeding only covers fresh installs (initializeEntity returns early when the
+-- entity exists) and TestCaseRepository rejects parameters that the definition does not declare, so
+-- existing installs need this backfill. Every statement is guarded on the parameter being absent,
+-- which keeps re-runs a no-op.
+
+-- Definitions that ship without any parameter need the array before we can append to it.
+UPDATE test_definition
+SET json = jsonb_set(json::jsonb, '{parameterDefinition}', '[]'::jsonb)
+WHERE name IN (
+    'columnValueMaxToBeBetween', 'columnValueMeanToBeBetween', 'columnValueMedianToBeBetween',
+    'columnValueMinToBeBetween', 'columnValueStdDevToBeBetween',
+    'columnValueToBeAtExpectedLocation', 'columnValuesLengthsToBeBetween',
+    'columnValuesMissingCountToBeEqual', 'columnValuesSumToBeBetween', 'columnValuesToBeBetween',
+    'columnValuesToBeInSet', 'columnValuesToBeNotInSet', 'columnValuesToBeNotNull',
+    'columnValuesToBeUnique', 'columnValuesToMatchRegex', 'columnValuesToNotMatchRegex',
+    'tableColumnCountToBeBetween', 'tableColumnCountToEqual', 'tableRowCountToBeBetween',
+    'tableRowCountToEqual', 'tableRowInsertedCountToBeBetween', 'tableCustomSQLQuery'
+  )
+  AND json->'parameterDefinition' IS NULL;
+
+UPDATE test_definition
+SET json = jsonb_set(
+    json::jsonb,
+    '{parameterDefinition}',
+    (json->'parameterDefinition')::jsonb || jsonb_build_object(
+        'name', 'threshold',
+        'displayName', 'Failure Threshold',
+        'description', 'Number of failures tolerated before the test is marked as failed. Read as an absolute count or as a percentage depending on `thresholdUnit` (defaults to 0).',
+        'dataType', 'NUMBER',
+        'required', false
+    )::jsonb
+)
+WHERE name IN (
+    'columnValueMaxToBeBetween', 'columnValueMeanToBeBetween', 'columnValueMedianToBeBetween',
+    'columnValueMinToBeBetween', 'columnValueStdDevToBeBetween',
+    'columnValueToBeAtExpectedLocation', 'columnValuesLengthsToBeBetween',
+    'columnValuesMissingCountToBeEqual', 'columnValuesSumToBeBetween', 'columnValuesToBeBetween',
+    'columnValuesToBeInSet', 'columnValuesToBeNotInSet', 'columnValuesToBeNotNull',
+    'columnValuesToBeUnique', 'columnValuesToMatchRegex', 'columnValuesToNotMatchRegex',
+    'tableColumnCountToBeBetween', 'tableColumnCountToEqual', 'tableRowCountToBeBetween',
+    'tableRowCountToEqual', 'tableRowInsertedCountToBeBetween'
+  )
+  AND NOT ((json->'parameterDefinition')::jsonb @> '[{"name": "threshold"}]'::jsonb);
+
+UPDATE test_definition
+SET json = jsonb_set(
+    json::jsonb,
+    '{parameterDefinition}',
+    (json->'parameterDefinition')::jsonb || jsonb_build_object(
+        'name', 'thresholdUnit',
+        'displayName', 'Threshold Unit',
+        'description', 'How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).',
+        'dataType', 'STRING',
+        'required', false,
+        'optionValues', '["ABSOLUTE","PERCENTAGE"]'::jsonb
+    )::jsonb
+)
+WHERE name IN (
+    'columnValueMaxToBeBetween', 'columnValueMeanToBeBetween', 'columnValueMedianToBeBetween',
+    'columnValueMinToBeBetween', 'columnValueStdDevToBeBetween',
+    'columnValueToBeAtExpectedLocation', 'columnValuesLengthsToBeBetween',
+    'columnValuesMissingCountToBeEqual', 'columnValuesSumToBeBetween', 'columnValuesToBeBetween',
+    'columnValuesToBeInSet', 'columnValuesToBeNotInSet', 'columnValuesToBeNotNull',
+    'columnValuesToBeUnique', 'columnValuesToMatchRegex', 'columnValuesToNotMatchRegex',
+    'tableColumnCountToBeBetween', 'tableColumnCountToEqual', 'tableRowCountToBeBetween',
+    'tableRowCountToEqual', 'tableRowInsertedCountToBeBetween', 'tableCustomSQLQuery'
+  )
+  AND NOT ((json->'parameterDefinition')::jsonb @> '[{"name": "thresholdUnit"}]'::jsonb);
+
+UPDATE test_definition
+SET json = jsonb_set(
+    json::jsonb,
+    '{parameterDefinition}',
+    (json->'parameterDefinition')::jsonb || jsonb_build_object(
+        'name', 'dimensionFailurePolicy',
+        'displayName', 'Dimension Failure Policy',
+        'description', 'How dimensional results roll up into the overall test status: `OVERALL_ONLY` only looks at the overall result, `ANY_DIMENSION` fails the test as soon as one dimension fails (defaults to OVERALL_ONLY).',
+        'dataType', 'STRING',
+        'required', false,
+        'optionValues', '["OVERALL_ONLY","ANY_DIMENSION"]'::jsonb
+    )::jsonb
+)
+WHERE name IN (
+    'columnValueMaxToBeBetween', 'columnValueMeanToBeBetween', 'columnValueMedianToBeBetween',
+    'columnValueMinToBeBetween', 'columnValueStdDevToBeBetween',
+    'columnValueToBeAtExpectedLocation', 'columnValuesLengthsToBeBetween',
+    'columnValuesMissingCountToBeEqual', 'columnValuesSumToBeBetween', 'columnValuesToBeBetween',
+    'columnValuesToBeInSet', 'columnValuesToBeNotInSet', 'columnValuesToBeNotNull',
+    'columnValuesToBeUnique', 'columnValuesToMatchRegex', 'columnValuesToNotMatchRegex'
+  )
+  AND NOT ((json->'parameterDefinition')::jsonb @> '[{"name": "dimensionFailurePolicy"}]'::jsonb);

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValueMaxToBeBetween.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValueMaxToBeBetween.json
@@ -26,6 +26,29 @@
         "parameterField": "minValueForMaxInCol",
         "rule": "GREATER_THAN_OR_EQUALS"
       }
+    },
+    {
+      "name": "threshold",
+      "displayName": "Failure Threshold",
+      "description": "Number of failures tolerated before the test is marked as failed. Read as an absolute count or as a percentage depending on `thresholdUnit` (defaults to 0).",
+      "dataType": "NUMBER",
+      "required": false
+    },
+    {
+      "name": "thresholdUnit",
+      "displayName": "Threshold Unit",
+      "description": "How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["ABSOLUTE", "PERCENTAGE"]
+    },
+    {
+      "name": "dimensionFailurePolicy",
+      "displayName": "Dimension Failure Policy",
+      "description": "How dimensional results roll up into the overall test status: `OVERALL_ONLY` only looks at the overall result, `ANY_DIMENSION` fails the test as soon as one dimension fails (defaults to OVERALL_ONLY).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["OVERALL_ONLY", "ANY_DIMENSION"]
     }
   ],
   "supportsDynamicAssertion": true,

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValueMeanToBeBetween.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValueMeanToBeBetween.json
@@ -26,6 +26,29 @@
             "parameterField": "minValueForMeanInCol",
             "rule": "GREATER_THAN_OR_EQUALS"
       }
+    },
+    {
+      "name": "threshold",
+      "displayName": "Failure Threshold",
+      "description": "Number of failures tolerated before the test is marked as failed. Read as an absolute count or as a percentage depending on `thresholdUnit` (defaults to 0).",
+      "dataType": "NUMBER",
+      "required": false
+    },
+    {
+      "name": "thresholdUnit",
+      "displayName": "Threshold Unit",
+      "description": "How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["ABSOLUTE", "PERCENTAGE"]
+    },
+    {
+      "name": "dimensionFailurePolicy",
+      "displayName": "Dimension Failure Policy",
+      "description": "How dimensional results roll up into the overall test status: `OVERALL_ONLY` only looks at the overall result, `ANY_DIMENSION` fails the test as soon as one dimension fails (defaults to OVERALL_ONLY).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["OVERALL_ONLY", "ANY_DIMENSION"]
     }
   ],
   "supportsDynamicAssertion": true,

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValueMedianToBeBetween.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValueMedianToBeBetween.json
@@ -26,6 +26,29 @@
           "parameterField": "minValueForMedianInCol",
           "rule": "GREATER_THAN_OR_EQUALS"
         }
+      },
+      {
+        "name": "threshold",
+        "displayName": "Failure Threshold",
+        "description": "Number of failures tolerated before the test is marked as failed. Read as an absolute count or as a percentage depending on `thresholdUnit` (defaults to 0).",
+        "dataType": "NUMBER",
+        "required": false
+      },
+      {
+        "name": "thresholdUnit",
+        "displayName": "Threshold Unit",
+        "description": "How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).",
+        "dataType": "STRING",
+        "required": false,
+        "optionValues": ["ABSOLUTE", "PERCENTAGE"]
+      },
+      {
+        "name": "dimensionFailurePolicy",
+        "displayName": "Dimension Failure Policy",
+        "description": "How dimensional results roll up into the overall test status: `OVERALL_ONLY` only looks at the overall result, `ANY_DIMENSION` fails the test as soon as one dimension fails (defaults to OVERALL_ONLY).",
+        "dataType": "STRING",
+        "required": false,
+        "optionValues": ["OVERALL_ONLY", "ANY_DIMENSION"]
       }
   ],
   "supportsDynamicAssertion": true,

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValueMinToBeBetween.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValueMinToBeBetween.json
@@ -26,6 +26,29 @@
           "parameterField": "minValueForMeanInCol",
           "rule": "GREATER_THAN_OR_EQUALS"
         }
+      },
+      {
+        "name": "threshold",
+        "displayName": "Failure Threshold",
+        "description": "Number of failures tolerated before the test is marked as failed. Read as an absolute count or as a percentage depending on `thresholdUnit` (defaults to 0).",
+        "dataType": "NUMBER",
+        "required": false
+      },
+      {
+        "name": "thresholdUnit",
+        "displayName": "Threshold Unit",
+        "description": "How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).",
+        "dataType": "STRING",
+        "required": false,
+        "optionValues": ["ABSOLUTE", "PERCENTAGE"]
+      },
+      {
+        "name": "dimensionFailurePolicy",
+        "displayName": "Dimension Failure Policy",
+        "description": "How dimensional results roll up into the overall test status: `OVERALL_ONLY` only looks at the overall result, `ANY_DIMENSION` fails the test as soon as one dimension fails (defaults to OVERALL_ONLY).",
+        "dataType": "STRING",
+        "required": false,
+        "optionValues": ["OVERALL_ONLY", "ANY_DIMENSION"]
       }
     ],
     "supportsDynamicAssertion": true,

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValueStdDevToBeBetween.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValueStdDevToBeBetween.json
@@ -26,6 +26,29 @@
           "parameterField": "minValueForStdDevInCol",
           "rule": "GREATER_THAN_OR_EQUALS"
         }
+      },
+      {
+        "name": "threshold",
+        "displayName": "Failure Threshold",
+        "description": "Number of failures tolerated before the test is marked as failed. Read as an absolute count or as a percentage depending on `thresholdUnit` (defaults to 0).",
+        "dataType": "NUMBER",
+        "required": false
+      },
+      {
+        "name": "thresholdUnit",
+        "displayName": "Threshold Unit",
+        "description": "How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).",
+        "dataType": "STRING",
+        "required": false,
+        "optionValues": ["ABSOLUTE", "PERCENTAGE"]
+      },
+      {
+        "name": "dimensionFailurePolicy",
+        "displayName": "Dimension Failure Policy",
+        "description": "How dimensional results roll up into the overall test status: `OVERALL_ONLY` only looks at the overall result, `ANY_DIMENSION` fails the test as soon as one dimension fails (defaults to OVERALL_ONLY).",
+        "dataType": "STRING",
+        "required": false,
+        "optionValues": ["OVERALL_ONLY", "ANY_DIMENSION"]
       }
     ],
     "supportsDynamicAssertion": true,

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValueToBeAtExpectedLocation.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValueToBeAtExpectedLocation.json
@@ -35,6 +35,29 @@
         "description": "The radius in meters from the expected location. The test will check if the lat/long values are within the location + the radius.",
         "dataType": "FLOAT",
         "required": true
+      },
+      {
+        "name": "threshold",
+        "displayName": "Failure Threshold",
+        "description": "Number of failures tolerated before the test is marked as failed. Read as an absolute count or as a percentage depending on `thresholdUnit` (defaults to 0).",
+        "dataType": "NUMBER",
+        "required": false
+      },
+      {
+        "name": "thresholdUnit",
+        "displayName": "Threshold Unit",
+        "description": "How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).",
+        "dataType": "STRING",
+        "required": false,
+        "optionValues": ["ABSOLUTE", "PERCENTAGE"]
+      },
+      {
+        "name": "dimensionFailurePolicy",
+        "displayName": "Dimension Failure Policy",
+        "description": "How dimensional results roll up into the overall test status: `OVERALL_ONLY` only looks at the overall result, `ANY_DIMENSION` fails the test as soon as one dimension fails (defaults to OVERALL_ONLY).",
+        "dataType": "STRING",
+        "required": false,
+        "optionValues": ["OVERALL_ONLY", "ANY_DIMENSION"]
       }
     ],
     "supportsRowLevelPassedFailed": false,

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValuesLengthsToBeBetween.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValuesLengthsToBeBetween.json
@@ -26,6 +26,29 @@
         "parameterField": "minLength",
         "rule": "GREATER_THAN_OR_EQUALS"
       }
+    },
+    {
+      "name": "threshold",
+      "displayName": "Failure Threshold",
+      "description": "Number of failures tolerated before the test is marked as failed. Read as an absolute count or as a percentage depending on `thresholdUnit` (defaults to 0).",
+      "dataType": "NUMBER",
+      "required": false
+    },
+    {
+      "name": "thresholdUnit",
+      "displayName": "Threshold Unit",
+      "description": "How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["ABSOLUTE", "PERCENTAGE"]
+    },
+    {
+      "name": "dimensionFailurePolicy",
+      "displayName": "Dimension Failure Policy",
+      "description": "How dimensional results roll up into the overall test status: `OVERALL_ONLY` only looks at the overall result, `ANY_DIMENSION` fails the test as soon as one dimension fails (defaults to OVERALL_ONLY).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["OVERALL_ONLY", "ANY_DIMENSION"]
     }
   ],
   "supportsRowLevelPassedFailed": true,

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValuesMissingCountToBeEqual.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValuesMissingCountToBeEqual.json
@@ -19,6 +19,29 @@
       "displayName": "Missing Value to Match",
       "description": "By default match all null and empty values to be missing. This field allows us to configure additional strings such as N/A, NULL as missing strings as well.",
       "dataType": "STRING"
+    },
+    {
+      "name": "threshold",
+      "displayName": "Failure Threshold",
+      "description": "Number of failures tolerated before the test is marked as failed. Read as an absolute count or as a percentage depending on `thresholdUnit` (defaults to 0).",
+      "dataType": "NUMBER",
+      "required": false
+    },
+    {
+      "name": "thresholdUnit",
+      "displayName": "Threshold Unit",
+      "description": "How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["ABSOLUTE", "PERCENTAGE"]
+    },
+    {
+      "name": "dimensionFailurePolicy",
+      "displayName": "Dimension Failure Policy",
+      "description": "How dimensional results roll up into the overall test status: `OVERALL_ONLY` only looks at the overall result, `ANY_DIMENSION` fails the test as soon as one dimension fails (defaults to OVERALL_ONLY).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["OVERALL_ONLY", "ANY_DIMENSION"]
     }
   ],
   "provider": "system",

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValuesSumToBeBetween.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValuesSumToBeBetween.json
@@ -26,6 +26,29 @@
           "parameterField": "minValueForColSum",
           "rule": "GREATER_THAN_OR_EQUALS"
         }
+      },
+      {
+        "name": "threshold",
+        "displayName": "Failure Threshold",
+        "description": "Number of failures tolerated before the test is marked as failed. Read as an absolute count or as a percentage depending on `thresholdUnit` (defaults to 0).",
+        "dataType": "NUMBER",
+        "required": false
+      },
+      {
+        "name": "thresholdUnit",
+        "displayName": "Threshold Unit",
+        "description": "How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).",
+        "dataType": "STRING",
+        "required": false,
+        "optionValues": ["ABSOLUTE", "PERCENTAGE"]
+      },
+      {
+        "name": "dimensionFailurePolicy",
+        "displayName": "Dimension Failure Policy",
+        "description": "How dimensional results roll up into the overall test status: `OVERALL_ONLY` only looks at the overall result, `ANY_DIMENSION` fails the test as soon as one dimension fails (defaults to OVERALL_ONLY).",
+        "dataType": "STRING",
+        "required": false,
+        "optionValues": ["OVERALL_ONLY", "ANY_DIMENSION"]
       }
     ],
     "supportsDynamicAssertion": true,

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValuesToBeBetween.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValuesToBeBetween.json
@@ -26,6 +26,29 @@
           "parameterField": "minValue",
           "rule": "GREATER_THAN_OR_EQUALS"
       }
+    },
+    {
+      "name": "threshold",
+      "displayName": "Failure Threshold",
+      "description": "Number of failures tolerated before the test is marked as failed. Read as an absolute count or as a percentage depending on `thresholdUnit` (defaults to 0).",
+      "dataType": "NUMBER",
+      "required": false
+    },
+    {
+      "name": "thresholdUnit",
+      "displayName": "Threshold Unit",
+      "description": "How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["ABSOLUTE", "PERCENTAGE"]
+    },
+    {
+      "name": "dimensionFailurePolicy",
+      "displayName": "Dimension Failure Policy",
+      "description": "How dimensional results roll up into the overall test status: `OVERALL_ONLY` only looks at the overall result, `ANY_DIMENSION` fails the test as soon as one dimension fails (defaults to OVERALL_ONLY).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["OVERALL_ONLY", "ANY_DIMENSION"]
     }
   ],
   "supportsRowLevelPassedFailed": true,

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValuesToBeInSet.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValuesToBeInSet.json
@@ -20,6 +20,29 @@
       "description": "If true, every observed value must be allowed. If false or omitted, the test passes when at least one allowed value occurs, even if other values are outside the set.",
       "dataType": "BOOLEAN",
       "required": false
+    },
+    {
+      "name": "threshold",
+      "displayName": "Failure Threshold",
+      "description": "Number of failures tolerated before the test is marked as failed. Read as an absolute count or as a percentage depending on `thresholdUnit` (defaults to 0).",
+      "dataType": "NUMBER",
+      "required": false
+    },
+    {
+      "name": "thresholdUnit",
+      "displayName": "Threshold Unit",
+      "description": "How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["ABSOLUTE", "PERCENTAGE"]
+    },
+    {
+      "name": "dimensionFailurePolicy",
+      "displayName": "Dimension Failure Policy",
+      "description": "How dimensional results roll up into the overall test status: `OVERALL_ONLY` only looks at the overall result, `ANY_DIMENSION` fails the test as soon as one dimension fails (defaults to OVERALL_ONLY).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["OVERALL_ONLY", "ANY_DIMENSION"]
     }
   ],
   "supportsRowLevelPassedFailed": true,

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValuesToBeNotInSet.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValuesToBeNotInSet.json
@@ -13,6 +13,29 @@
       "description": "An Array of values.",
       "dataType": "ARRAY",
       "required": true
+    },
+    {
+      "name": "threshold",
+      "displayName": "Failure Threshold",
+      "description": "Number of failures tolerated before the test is marked as failed. Read as an absolute count or as a percentage depending on `thresholdUnit` (defaults to 0).",
+      "dataType": "NUMBER",
+      "required": false
+    },
+    {
+      "name": "thresholdUnit",
+      "displayName": "Threshold Unit",
+      "description": "How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["ABSOLUTE", "PERCENTAGE"]
+    },
+    {
+      "name": "dimensionFailurePolicy",
+      "displayName": "Dimension Failure Policy",
+      "description": "How dimensional results roll up into the overall test status: `OVERALL_ONLY` only looks at the overall result, `ANY_DIMENSION` fails the test as soon as one dimension fails (defaults to OVERALL_ONLY).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["OVERALL_ONLY", "ANY_DIMENSION"]
     }
   ],
   "supportsRowLevelPassedFailed": true,

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValuesToBeNotNull.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValuesToBeNotNull.json
@@ -6,6 +6,31 @@
   "entityType": "COLUMN",
   "testPlatforms": ["OpenMetadata"],
   "supportedDataTypes": ["NUMBER","TINYINT","SMALLINT","INT","BIGINT","BYTEINT","BYTES","FLOAT","DOUBLE","DECIMAL","NUMERIC","TIMESTAMP","TIMESTAMPZ","TIME","DATE","DATETIME","INTERVAL","STRING","MEDIUMTEXT","TEXT","CHAR","VARCHAR","BOOLEAN","BINARY","VARBINARY","ARRAY","BLOB","LONGBLOB","MEDIUMBLOB","MAP","STRUCT","UNION","SET","GEOGRAPHY","ENUM","JSON","UUID","VARIANT","GEOMETRY","POINT","POLYGON","LOWCARDINALITY"],
+  "parameterDefinition": [
+    {
+      "name": "threshold",
+      "displayName": "Failure Threshold",
+      "description": "Number of failures tolerated before the test is marked as failed. Read as an absolute count or as a percentage depending on `thresholdUnit` (defaults to 0).",
+      "dataType": "NUMBER",
+      "required": false
+    },
+    {
+      "name": "thresholdUnit",
+      "displayName": "Threshold Unit",
+      "description": "How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["ABSOLUTE", "PERCENTAGE"]
+    },
+    {
+      "name": "dimensionFailurePolicy",
+      "displayName": "Dimension Failure Policy",
+      "description": "How dimensional results roll up into the overall test status: `OVERALL_ONLY` only looks at the overall result, `ANY_DIMENSION` fails the test as soon as one dimension fails (defaults to OVERALL_ONLY).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["OVERALL_ONLY", "ANY_DIMENSION"]
+    }
+  ],
   "supportsRowLevelPassedFailed": true,
   "provider": "system",
   "enabled": true,

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValuesToBeUnique.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValuesToBeUnique.json
@@ -49,6 +49,31 @@
         "POLYGON",
         "LOWCARDINALITY"
     ],
+    "parameterDefinition": [
+      {
+        "name": "threshold",
+        "displayName": "Failure Threshold",
+        "description": "Number of failures tolerated before the test is marked as failed. Read as an absolute count or as a percentage depending on `thresholdUnit` (defaults to 0).",
+        "dataType": "NUMBER",
+        "required": false
+      },
+      {
+        "name": "thresholdUnit",
+        "displayName": "Threshold Unit",
+        "description": "How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).",
+        "dataType": "STRING",
+        "required": false,
+        "optionValues": ["ABSOLUTE", "PERCENTAGE"]
+      },
+      {
+        "name": "dimensionFailurePolicy",
+        "displayName": "Dimension Failure Policy",
+        "description": "How dimensional results roll up into the overall test status: `OVERALL_ONLY` only looks at the overall result, `ANY_DIMENSION` fails the test as soon as one dimension fails (defaults to OVERALL_ONLY).",
+        "dataType": "STRING",
+        "required": false,
+        "optionValues": ["OVERALL_ONLY", "ANY_DIMENSION"]
+      }
+    ],
     "supportsRowLevelPassedFailed": true,
     "provider": "system",
   "enabled": true,

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValuesToMatchRegex.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValuesToMatchRegex.json
@@ -13,6 +13,29 @@
       "description": "The regular expression the column entries should match. For database without regex support (i.e. MSSQL, AzureSQL) this test will use `LIKE`.",
       "dataType": "STRING",
       "required": true
+    },
+    {
+      "name": "threshold",
+      "displayName": "Failure Threshold",
+      "description": "Number of failures tolerated before the test is marked as failed. Read as an absolute count or as a percentage depending on `thresholdUnit` (defaults to 0).",
+      "dataType": "NUMBER",
+      "required": false
+    },
+    {
+      "name": "thresholdUnit",
+      "displayName": "Threshold Unit",
+      "description": "How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["ABSOLUTE", "PERCENTAGE"]
+    },
+    {
+      "name": "dimensionFailurePolicy",
+      "displayName": "Dimension Failure Policy",
+      "description": "How dimensional results roll up into the overall test status: `OVERALL_ONLY` only looks at the overall result, `ANY_DIMENSION` fails the test as soon as one dimension fails (defaults to OVERALL_ONLY).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["OVERALL_ONLY", "ANY_DIMENSION"]
     }
   ],
   "supportsRowLevelPassedFailed": true,

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValuesToNotMatchRegex.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValuesToNotMatchRegex.json
@@ -13,6 +13,29 @@
       "description": "The regular expression the column entries should not match. For database without regex support (i.e. MSSQL, AzureSQL) this test will use `NOT LIKE`.",
       "dataType": "STRING",
       "required": true
+    },
+    {
+      "name": "threshold",
+      "displayName": "Failure Threshold",
+      "description": "Number of failures tolerated before the test is marked as failed. Read as an absolute count or as a percentage depending on `thresholdUnit` (defaults to 0).",
+      "dataType": "NUMBER",
+      "required": false
+    },
+    {
+      "name": "thresholdUnit",
+      "displayName": "Threshold Unit",
+      "description": "How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["ABSOLUTE", "PERCENTAGE"]
+    },
+    {
+      "name": "dimensionFailurePolicy",
+      "displayName": "Dimension Failure Policy",
+      "description": "How dimensional results roll up into the overall test status: `OVERALL_ONLY` only looks at the overall result, `ANY_DIMENSION` fails the test as soon as one dimension fails (defaults to OVERALL_ONLY).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["OVERALL_ONLY", "ANY_DIMENSION"]
     }
   ],
   "supportsRowLevelPassedFailed": true,

--- a/openmetadata-service/src/main/resources/json/data/tests/tableColumnCountToBeBetween.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/tableColumnCountToBeBetween.json
@@ -25,6 +25,21 @@
           "parameterField": "minColValue",
           "rule": "GREATER_THAN_OR_EQUALS"
       }
+    },
+    {
+      "name": "threshold",
+      "displayName": "Failure Threshold",
+      "description": "Number of failures tolerated before the test is marked as failed. Read as an absolute count or as a percentage depending on `thresholdUnit` (defaults to 0).",
+      "dataType": "NUMBER",
+      "required": false
+    },
+    {
+      "name": "thresholdUnit",
+      "displayName": "Threshold Unit",
+      "description": "How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["ABSOLUTE", "PERCENTAGE"]
     }
   ],
   "provider": "system",

--- a/openmetadata-service/src/main/resources/json/data/tests/tableColumnCountToEqual.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/tableColumnCountToEqual.json
@@ -12,6 +12,21 @@
       "description": "Expected number of columns to equal to a {value}",
       "dataType": "INT",
       "required": true
+    },
+    {
+      "name": "threshold",
+      "displayName": "Failure Threshold",
+      "description": "Number of failures tolerated before the test is marked as failed. Read as an absolute count or as a percentage depending on `thresholdUnit` (defaults to 0).",
+      "dataType": "NUMBER",
+      "required": false
+    },
+    {
+      "name": "thresholdUnit",
+      "displayName": "Threshold Unit",
+      "description": "How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["ABSOLUTE", "PERCENTAGE"]
     }
   ],
   "provider": "system",

--- a/openmetadata-service/src/main/resources/json/data/tests/tableCustomSQLQuery.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/tableCustomSQLQuery.json
@@ -42,6 +42,14 @@
         "description": "Partition expression that will be used to compute the passed/failed row count, if compute row count is enabled.",
         "dataType": "STRING",
         "required": false
+      },
+      {
+        "name": "thresholdUnit",
+        "displayName": "Threshold Unit",
+        "description": "How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).",
+        "dataType": "STRING",
+        "required": false,
+        "optionValues": ["ABSOLUTE", "PERCENTAGE"]
       }
     ],
     "supportsRowLevelPassedFailed": true,

--- a/openmetadata-service/src/main/resources/json/data/tests/tableRowCountToBeBetween.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/tableRowCountToBeBetween.json
@@ -25,6 +25,21 @@
           "parameterField": "minValue",
           "rule": "GREATER_THAN_OR_EQUALS"
       }
+    },
+    {
+      "name": "threshold",
+      "displayName": "Failure Threshold",
+      "description": "Number of failures tolerated before the test is marked as failed. Read as an absolute count or as a percentage depending on `thresholdUnit` (defaults to 0).",
+      "dataType": "NUMBER",
+      "required": false
+    },
+    {
+      "name": "thresholdUnit",
+      "displayName": "Threshold Unit",
+      "description": "How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["ABSOLUTE", "PERCENTAGE"]
     }
   ],
   "supportsDynamicAssertion": true,

--- a/openmetadata-service/src/main/resources/json/data/tests/tableRowCountToEqual.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/tableRowCountToEqual.json
@@ -12,6 +12,21 @@
       "description": "Expected number of rows to be equal to {Count}",
       "dataType": "INT",
       "required": true
+    },
+    {
+      "name": "threshold",
+      "displayName": "Failure Threshold",
+      "description": "Number of failures tolerated before the test is marked as failed. Read as an absolute count or as a percentage depending on `thresholdUnit` (defaults to 0).",
+      "dataType": "NUMBER",
+      "required": false
+    },
+    {
+      "name": "thresholdUnit",
+      "displayName": "Threshold Unit",
+      "description": "How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).",
+      "dataType": "STRING",
+      "required": false,
+      "optionValues": ["ABSOLUTE", "PERCENTAGE"]
     }
   ],
   "provider": "system",

--- a/openmetadata-service/src/main/resources/json/data/tests/tableRowInsertedCountToBeBetween.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/tableRowInsertedCountToBeBetween.json
@@ -48,6 +48,21 @@
         "description": "Interval Range. E.g. if rangeInterval=1 and rangeType=DAY, we'll check the numbers of rows inserted where columnName=-1 DAY",
         "dataType": "INT",
         "required": true
+      },
+      {
+        "name": "threshold",
+        "displayName": "Failure Threshold",
+        "description": "Number of failures tolerated before the test is marked as failed. Read as an absolute count or as a percentage depending on `thresholdUnit` (defaults to 0).",
+        "dataType": "NUMBER",
+        "required": false
+      },
+      {
+        "name": "thresholdUnit",
+        "displayName": "Threshold Unit",
+        "description": "How to read `threshold`: `ABSOLUTE` for a raw count of failures, `PERCENTAGE` for a share of the evaluated rows (defaults to ABSOLUTE).",
+        "dataType": "STRING",
+        "required": false,
+        "optionValues": ["ABSOLUTE", "PERCENTAGE"]
       }
     ],
     "provider": "system",

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/OpenMetadata/TestCaseForm.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/OpenMetadata/TestCaseForm.md
@@ -374,7 +374,10 @@ $$section
 
 **Description**: Tests that values in a column are not null. Empty strings don't count as null - values must be explicitly null.
 
-**Parameters**: None
+**Parameters**:
+- **Failure Threshold** (NUMBER, Optional) - How many failures to tolerate before the test is marked as failed (default is 0)
+- **Threshold Unit** (STRING, Optional) - How to read the threshold: `ABSOLUTE` (a raw count of failures) or `PERCENTAGE` (a share of the evaluated rows)
+- **Dimension Failure Policy** (STRING, Optional) - How dimensional results roll up: `OVERALL_ONLY` (only the overall result counts) or `ANY_DIMENSION` (one failing dimension fails the test)
 
 **Supported Data Types**: All data types supported
 
@@ -394,7 +397,10 @@ $$section
 
 **Description**: Tests that all values in a column are unique (no duplicates).
 
-**Parameters**: None
+**Parameters**:
+- **Failure Threshold** (NUMBER, Optional) - How many failures to tolerate before the test is marked as failed (default is 0)
+- **Threshold Unit** (STRING, Optional) - How to read the threshold: `ABSOLUTE` (a raw count of failures) or `PERCENTAGE` (a share of the evaluated rows)
+- **Dimension Failure Policy** (STRING, Optional) - How dimensional results roll up: `OVERALL_ONLY` (only the overall result counts) or `ANY_DIMENSION` (one failing dimension fails the test)
 
 **Supported Data Types**: All data types supported
 


### PR DESCRIPTION
> **This pull request was opened by an olivaw agent.** It is an input to review, not an approved change — read the diff, not this description.
>
> Fixes #33227

## What olivaw checked (machine-observed, §8.2/A.1)

- diff: non-empty
- build: not_run
- tests: not_run
- base: `95847bcb855ad02cb04143160947ca97754eea84`
- head: `1536aba703dd5edaa03bd0540dc45d1db9ebc60b`

**No build or test command is configured for this workspace**, so only the diff's existence was checked. Set `run_config.build_cmd`/`test_cmd` to have olivaw verify its own work.

## What the agent says it did (unverified)

> The compatibility scan finished and found no test that breaks — I've folded its one actionable finding into the commit.
> 
> **Scan result (no breakage):** the new parameters are all `required: false`, and `TestCaseRepository.validateTestParameters` only rejects non-empty values against an empty definition and only enforces `required: true` params, so the Java ITs that pass `List.of()` for `columnValuesToBeNotNull` / `columnValuesToBeUnique` still pass. UI jest tests use hand-written fixtures rather than the seed JSON and there are no `.snap` files. The one Python test that reads the seed directory (`ingestion/tests/integration/data_quality/test_data_quality.py:54`) only checks that each `name` resolves. `additionalProperties: false` is on the top-level TestDefinition object, not on `testCaseParameterDefinition`, so the new parameter objects validate.
> 
> **What I fixed as a result:** `TestCaseForm.md` said `**Parameters**: None` for those same two definitions — that's the live doc panel beside the create-test-case form, and my change made it false. Both sections now list the three new parameters in the file's existing `- **Display Name** (TYPE, Optional) - …` style. The other 20 sections list their existing parameters and omit the new optional ones; that's incomplete rather than wrong, and rewriting all of them is doc work for the UI sub-task, so I left them.
> 
> Two things worth passing to the downstream sub-tasks:
> 
> - `thresholdUnit` and `dimensionFailurePolicy` exist only in the seed JSON and the migration — no validator consumes them yet, so the form will accept and persist values that currently do nothing. That's expected for a foundation ticket, but it is user-visible from this commit onward.
> - `TestSummaryGraph` draws a reference line when a test case has exactly one parameter value, so a lone `threshold` on `columnValuesToBeNotNull` / `columnValuesToBeUnique` would now plot a line where those tests previously had none.
> 
> The two acceptance criteria needing a database (runs twice with no second-run change; fresh install matches migrated install) remain verified only by the Python simulation of the SQL semantics described earlier, not by executing against MySQL or Postgres — no DB or Docker in this environment.
