### PR TITLE
Backport #33204 to 2.0: [Databricks] Paginate jobs by token so large workspaces ingest in full

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/databricks/client.py
+++ b/ingestion/src/metadata/ingestion/source/database/databricks/client.py
@@ -58,7 +58,14 @@ API_TIMEOUT = 10
 PAGE_SIZE = 100
 QUERIES_PATH = "/sql/history/queries"
 API_VERSION = "/api/2.0"
-JOB_API_VERSION = "/api/2.1"
+# 2.2 is the first Jobs API version that can return a job with more than 100 tasks.
+# Earlier versions omit `settings.tasks` for such a job without signalling it.
+JOB_API_VERSION = "/api/2.2"
+# runs/list rejects any limit above 26, unlike jobs/list which allows up to 100.
+RUNS_PAGE_SIZE = 25
+# A walk longer than this is a misbehaving service rather than a large workspace:
+# it is a million jobs at PAGE_SIZE. It also bounds the seen-token set.
+MAX_PAGES = 10_000
 SCIM_SERVICE_PRINCIPALS_PATH = "/preview/scim/v2/ServicePrincipals"
 SCIM_GROUPS_PATH = "/preview/scim/v2/Groups"
 
@@ -269,87 +276,137 @@ class DatabricksClient:
         query_text = row.get("query_text")
         return not (query_text.startswith(QUERY_WITH_DBT) or query_text.startswith(QUERY_WITH_OM_VERSION))  # noqa: PIE810
 
-    def list_jobs_test_connection(self) -> None:
-        data = {"limit": 1, "expand_tasks": True, "offset": 0}
+    def _get_json(self, url: str, params: dict) -> dict:
+        """
+        GET a Jobs API page, refusing to treat an error body as an empty page.
+
+        Databricks answers a rejected request with a 200-shaped JSON body, so calling
+        .json() without checking the status silently turns a failure into "no more
+        results" and truncates whatever was being paginated.
+        """
         response = self.client.get(
-            self.jobs_list_url,
-            data=json.dumps(data),
+            url,
+            params=params,
             headers=self.headers,
             timeout=self.api_timeout,
         )
         if response.status_code != 200:
-            raise DatabricksClientException(response.text)
+            raise DatabricksClientException(
+                f"Databricks API call to [{url}] failed with status {response.status_code}: {response.text}"
+            )
+        return response.json()
+
+    def _paginate_responses(self, url: str, params: dict) -> Iterable[dict]:
+        """
+        Yield each page of a token-paginated Jobs API response.
+
+        Token pagination rather than `offset` because Databricks caps `offset` at 1000,
+        and because API 2.2 drops the root-level `has_more` that the offset loop needed
+        to know when to stop.
+
+        Raises rather than stops if the walk cannot terminate, either because a token
+        is reissued (any cycle, not only an immediate repeat) or because the service
+        never stops handing out fresh ones. Stopping quietly would be one more way to
+        truncate a listing while reporting success.
+        """
+        page_params = dict(params)
+        seen_tokens: set[str] = set()
+        while True:
+            payload = self._get_json(url, page_params)
+            yield payload
+
+            next_page_token = payload.get("next_page_token")
+            if not next_page_token:
+                return
+            if next_page_token in seen_tokens:
+                raise DatabricksClientException(
+                    f"Databricks reissued a page token already seen while paginating [{url}]. "
+                    f"Refusing to loop over the same pages."
+                )
+            if len(seen_tokens) >= MAX_PAGES:
+                raise DatabricksClientException(
+                    f"Pagination of [{url}] passed {MAX_PAGES} pages without ending. Refusing to keep requesting."
+                )
+            seen_tokens.add(next_page_token)
+            page_params["page_token"] = next_page_token
+
+    def _paginate_items(self, url: str, params: dict, key: str) -> Iterable[dict]:
+        """
+        Walk a Jobs API list endpoint, flattening every page into its items.
+        """
+        for payload in self._paginate_responses(url, params):
+            yield from payload.get(key) or []
+
+    def _expand_job_tasks(self, job: dict) -> dict:
+        """
+        Fill in the tasks that jobs/list left out.
+
+        List responses carry at most 100 elements of any list field and set a per-job
+        `has_more` when a job has more. Pipeline lineage is built from the task list, so
+        a job left truncated here loses both its tasks and its lineage.
+
+        Unlike a failure to list jobs, a failure here degrades rather than raises: it
+        costs one job an accurate task list, where a short job list costs the catalogue
+        every job that never arrived.
+        """
+        if not job.get("has_more"):
+            return job
+
+        job_id = job.get("job_id")
+        try:
+            tasks: list[dict] = []
+            for payload in self._paginate_responses(f"{self.base_job_url}/get", {"job_id": job_id}):
+                tasks.extend((payload.get("settings") or {}).get("tasks") or [])
+        except Exception as exc:
+            logger.debug(traceback.format_exc())
+            logger.warning(
+                "Could not fetch the full task list for job %s, keeping the first page only. "
+                "Its tasks and lineage will be incomplete: %s",
+                job_id,
+                exc,
+            )
+            return job
+
+        expanded = {**job, "settings": {**(job.get("settings") or {}), "tasks": tasks}}
+        expanded.pop("has_more", None)
+        return expanded
+
+    def list_jobs_test_connection(self) -> None:
+        self._get_json(self.jobs_list_url, {"limit": 1, "expand_tasks": "true"})
 
     def list_jobs(self) -> Iterable[dict]:
         """
-        Method returns List all the created jobs in a Databricks Workspace
+        Yield every job in the workspace, each with its full task list.
+
+        Raises rather than stopping short if the workspace cannot be listed, because a
+        truncated job list is indistinguishable from a smaller workspace.
         """
+        # "true" lowercase: Databricks ignores the Python bool's "True" encoding
+        # without complaining, which would drop every task list.
+        params = {"limit": PAGE_SIZE, "expand_tasks": "true"}
+        for job in self._paginate_items(self.jobs_list_url, params, key="jobs"):
+            yield self._expand_job_tasks(job)
+
+    def get_job_runs(self, job_id) -> Iterable[dict]:
+        """
+        Yield the completed runs of one job, newest first.
+
+        Yields nothing and logs if the runs cannot be listed, since a missing run costs
+        only pipeline status.
+        """
+        params = {
+            "job_id": job_id,
+            "limit": RUNS_PAGE_SIZE,
+            "active_only": "false",
+            "completed_only": "true",
+            "run_type": "JOB_RUN",
+            "expand_tasks": "true",
+        }
         try:
-            iteration_count = 1
-            data = {"limit": PAGE_SIZE, "expand_tasks": True, "offset": 0}
-
-            response = self.client.get(
-                self.jobs_list_url,
-                data=json.dumps(data),
-                headers=self.headers,
-                timeout=self.api_timeout,
-            ).json()
-
-            yield from response.get("jobs") or []
-
-            while response and response.get("has_more"):
-                data["offset"] = PAGE_SIZE * iteration_count
-
-                response = self.client.get(
-                    self.jobs_list_url,
-                    data=json.dumps(data),
-                    headers=self.headers,
-                    timeout=self.api_timeout,
-                ).json()
-                iteration_count += 1
-                yield from response.get("jobs") or []
-
+            yield from self._paginate_items(self.jobs_run_list_url, params, key="runs")
         except Exception as exc:
             logger.debug(traceback.format_exc())
-            logger.error(exc)
-
-    def get_job_runs(self, job_id) -> List[dict]:  # noqa: UP006
-        """
-        Method returns List of all runs for a job by the specified job_id
-        """
-        try:
-            params = {
-                "job_id": job_id,
-                "active_only": "false",
-                "completed_only": "true",
-                "run_type": "JOB_RUN",
-                "expand_tasks": "true",
-            }
-
-            response = self.client.get(
-                self.jobs_run_list_url,
-                params=params,
-                headers=self.headers,
-                timeout=self.api_timeout,
-            ).json()
-
-            yield from response.get("runs") or []
-
-            while response["has_more"]:
-                params.update({"start_time_to": response["runs"][-1]["start_time"]})
-
-                response = self.client.get(
-                    self.jobs_run_list_url,
-                    params=params,
-                    headers=self.headers,
-                    timeout=self.api_timeout,
-                ).json()
-
-                yield from response.get("runs") or []
-
-        except Exception as exc:
-            logger.debug(traceback.format_exc())
-            logger.error(exc)
+            logger.warning("Could not list runs for job %s: %s", job_id, exc)
 
     def get_table_lineage(self, entity_id: str) -> List[dict[str, str]]:  # noqa: UP006
         """

--- a/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/metadata.py
@@ -124,12 +124,15 @@ class DatabrickspipelineSource(PipelineServiceSource):
         return super().close()
 
     def get_pipelines_list(self) -> Iterable[DataBrickPipelineDetails]:
-        try:
-            for workflow in self.client.list_jobs() or []:
+        # A failure listing jobs is deliberately not caught here. A short job list is
+        # indistinguishable from a smaller workspace, and with markDeletedPipelines on
+        # the jobs that never arrived get removed from the catalogue.
+        for workflow in self.client.list_jobs() or []:
+            try:
                 yield DataBrickPipelineDetails(**workflow)
-        except Exception as exc:
-            logger.debug(traceback.format_exc())
-            logger.error(f"Failed to get jobs list due to : {exc}")
+            except Exception as exc:
+                logger.debug(traceback.format_exc())
+                logger.warning("Failed to parse job %s due to : %s", workflow.get("job_id"), exc)
 
         # Fetch DLT pipelines directly (new)
         try:

--- a/ingestion/tests/unit/topology/database/test_databricks_jobs_pagination.py
+++ b/ingestion/tests/unit/topology/database/test_databricks_jobs_pagination.py
@@ -1,0 +1,404 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+FakeJobsApi reproduces the Databricks Jobs API 2.2 contract as measured against a live
+workspace, including the parts the published docs do not describe:
+
+  * `offset` is capped at 1000, and going past it returns a 400 whose body is valid
+    JSON, so a client that skips status_code reads it as an ordinary empty response
+  * list responses carry at most 100 tasks per job and flag the rest with a per-job
+    `has_more`, which only `jobs/get` with a page token can satisfy
+  * `expand_tasks` is honoured as "true" but ignored as "True", which is what requests
+    makes of a Python bool in a query string
+
+The client is pinned to 2.2 because 2.1 answers 200 with `settings.tasks` missing
+entirely for a job above that cap, giving no way to detect or recover the rest.
+"""
+
+import itertools
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from metadata.generated.schema.entity.services.connections.pipeline.databricksPipelineConnection import (
+    DatabricksPipelineConnection,
+)
+from metadata.ingestion.source.database.databricks.client import (
+    RUNS_PAGE_SIZE,
+    DatabricksClient,
+    DatabricksClientException,
+)
+
+OFFSET_MAX = 1000
+TASKS_PER_PAGE = 100
+
+
+def _response(status_code: int, payload: dict) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = json.dumps(payload)
+    response.json.return_value = payload
+    return response
+
+
+class FakeJobsApi:
+    """
+    Databricks Jobs API 2.2, as measured.
+
+    It still rejects an out-of-range `offset` even though the client no longer sends
+    one. That is deliberate: it makes any return to offset pagination fail loudly here
+    rather than silently cap out in production.
+    """
+
+    def __init__(self, total_jobs: int = 3000, runs: int = 0, tasks_on_first_job: int = 1):
+        self.tasks = [{"task_key": f"t{i:03d}"} for i in range(tasks_on_first_job)]
+        self.jobs = [
+            {
+                "job_id": 1_000_000 + i,
+                "settings": {"name": f"job-{i:04d}"},
+            }
+            for i in range(total_jobs)
+        ]
+        self.runs = [{"run_id": 9_000_000 + i, "start_time": 1_700_000_000_000 - i} for i in range(runs)]
+        self.requests: list[dict] = []
+
+    def _expand(self, job: dict) -> dict:
+        """Attach tasks the way the API does, honouring the 100-element page."""
+        if job["job_id"] != self.jobs[0]["job_id"]:
+            return job
+        expanded = {**job, "settings": {**job["settings"], "tasks": self.tasks[:TASKS_PER_PAGE]}}
+        if len(self.tasks) > TASKS_PER_PAGE:
+            expanded["has_more"] = True
+        return expanded
+
+    def get(self, url, headers=None, data=None, params=None, timeout=None):
+        args = json.loads(data) if data else dict(params or {})
+        self.requests.append({"url": url, **args})
+
+        if url.endswith("/jobs/get"):
+            return self._get_job(args)
+
+        items = self.runs if url.endswith("/runs/list") else self.jobs
+        key = "runs" if url.endswith("/runs/list") else "jobs"
+
+        if "offset" in args and int(args["offset"]) > OFFSET_MAX:
+            return _response(
+                400,
+                {
+                    "error_code": "INVALID_PARAMETER_VALUE",
+                    "message": (
+                        f"The supplied offset {args['offset']} has exceeded the value of {OFFSET_MAX} "
+                        f"allowed for this parameter.Please use the page_token parameter to paginate"
+                    ),
+                },
+            )
+
+        start = int(args.get("offset", args.get("page_token", 0)))
+        limit = int(args.get("limit", 20))
+        page = items[start : start + limit]
+        # Case-sensitive on purpose: Databricks ignores "True" (what requests makes of
+        # a Python bool in a query string) and only honours "true".
+        if key == "jobs" and args.get("expand_tasks") in (True, "true"):
+            page = [self._expand(job) for job in page]
+
+        payload = {key: page}
+        if start + limit < len(items):
+            payload["next_page_token"] = str(start + limit)
+        return _response(200, payload)
+
+    def _get_job(self, args: dict) -> MagicMock:
+        job = next((j for j in self.jobs if j["job_id"] == int(args["job_id"])), None)
+        if job is None:
+            return _response(400, {"error_code": "RESOURCE_DOES_NOT_EXIST", "message": "no such job"})
+        start = int(args.get("page_token", 0))
+        page = self.tasks[start : start + TASKS_PER_PAGE]
+        payload = {**job, "settings": {**job["settings"], "tasks": page}}
+        if start + TASKS_PER_PAGE < len(self.tasks):
+            payload["next_page_token"] = str(start + TASKS_PER_PAGE)
+        return _response(200, payload)
+
+
+def build_client(fake: FakeJobsApi) -> DatabricksClient:
+    config = MagicMock(spec=DatabricksPipelineConnection)
+    config.hostPort = "dbc-test.cloud.databricks.com"
+    config.connectionTimeout = 120
+    client = DatabricksClient(config)
+    client.client = fake
+    return client
+
+
+@pytest.fixture
+def _no_auth():
+    """Pagination is what is under test here, not the auth header."""
+    with patch.object(DatabricksClient, "headers", new_callable=lambda: property(lambda self: {})):
+        yield
+
+
+@pytest.mark.usefixtures("_no_auth")
+def test_list_jobs_reaches_past_the_offset_cap():
+    fake = FakeJobsApi(total_jobs=3000)
+
+    jobs = list(build_client(fake).list_jobs())
+
+    assert len(jobs) == 3000
+    assert jobs[0]["settings"]["name"] == "job-0000"
+    assert jobs[-1]["settings"]["name"] == "job-2999"
+
+
+@pytest.mark.usefixtures("_no_auth")
+def test_list_jobs_paginates_by_token_not_offset():
+    """`offset` is the parameter Databricks caps, so the client must stop sending it."""
+    fake = FakeJobsApi(total_jobs=3000)
+
+    list(build_client(fake).list_jobs())
+
+    assert not any("offset" in request for request in fake.requests)
+    listings = [r for r in fake.requests if r["url"].endswith("/jobs/list")]
+    assert listings, "expected at least one jobs/list request"
+    assert all(request.get("limit") == 100 for request in listings)
+    # "True" is what requests makes of a Python bool, and Databricks ignores it.
+    assert all(request.get("expand_tasks") == "true" for request in listings)
+
+
+@pytest.mark.usefixtures("_no_auth")
+def test_list_jobs_below_the_cap():
+    """Small workspaces never hit the wall, so guard against regressing them."""
+    fake = FakeJobsApi(total_jobs=250)
+
+    assert len(list(build_client(fake).list_jobs())) == 250
+
+
+@pytest.mark.usefixtures("_no_auth")
+def test_list_jobs_raises_instead_of_truncating_on_an_api_error():
+    """
+    Silent truncation is the expensive half of this bug. A short job list does not
+    just skip jobs, it lets mark-deleted remove ones that are still there, so a
+    failed page has to fail the run.
+    """
+    fake = FakeJobsApi(total_jobs=3000)
+    fake.get = MagicMock(return_value=_response(429, {"error_code": "REQUEST_LIMIT_EXCEEDED", "message": "slow down"}))
+
+    with pytest.raises(DatabricksClientException, match="429"):
+        list(build_client(fake).list_jobs())
+
+
+@pytest.mark.usefixtures("_no_auth")
+def test_list_jobs_surfaces_a_failure_partway_through_pagination():
+    """Half a job list must not be reported as a whole one."""
+    fake = FakeJobsApi(total_jobs=3000)
+    healthy = fake.get
+    calls = {"n": 0}
+
+    def fail_on_the_fifth_page(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 5:
+            return _response(500, {"error_code": "INTERNAL_ERROR", "message": "boom"})
+        return healthy(*args, **kwargs)
+
+    fake.get = fail_on_the_fifth_page
+
+    with pytest.raises(DatabricksClientException):
+        list(build_client(fake).list_jobs())
+
+
+@pytest.mark.usefixtures("_no_auth")
+def test_list_jobs_pages_the_task_list_of_a_large_job():
+    """
+    jobs/list returns at most 100 tasks per job and flags the rest with a per-job
+    has_more. Without following it, a 250-task job is ingested with 100 tasks, and
+    pipeline lineage is built from the task list.
+    """
+    fake = FakeJobsApi(total_jobs=1, tasks_on_first_job=250)
+
+    jobs = list(build_client(fake).list_jobs())
+
+    assert len(jobs) == 1
+    tasks = jobs[0]["settings"]["tasks"]
+    assert len(tasks) == 250
+    assert [t["task_key"] for t in tasks[:2]] == ["t000", "t001"]
+    assert tasks[-1]["task_key"] == "t249"
+
+
+@pytest.mark.usefixtures("_no_auth")
+def test_list_jobs_leaves_small_task_lists_alone():
+    """A job under the cap must not trigger a second jobs/get round trip."""
+    fake = FakeJobsApi(total_jobs=1, tasks_on_first_job=12)
+
+    jobs = list(build_client(fake).list_jobs())
+
+    assert len(jobs[0]["settings"]["tasks"]) == 12
+    assert not any(r["url"].endswith("/jobs/get") for r in fake.requests)
+
+
+@pytest.mark.usefixtures("_no_auth")
+def test_get_job_runs_paginates_by_token():
+    """
+    runs/list drops the root has_more in 2.2 exactly as jobs/list does, and the client
+    reads it with a bare subscript today. Token pagination removes that landmine and
+    the duplicate boundary run that start_time_to paging produced.
+    """
+    fake = FakeJobsApi(total_jobs=1, runs=120)
+
+    runs = list(build_client(fake).get_job_runs(job_id=1_000_000))
+
+    assert len(runs) == 120
+    assert len({run["run_id"] for run in runs}) == 120, "boundary runs must not be yielded twice"
+
+
+@pytest.mark.usefixtures("_no_auth")
+def test_get_job_runs_respects_the_limit_ceiling():
+    """runs/list rejects any limit above 26, unlike jobs/list which allows 100."""
+    fake = FakeJobsApi(total_jobs=1, runs=120)
+
+    list(build_client(fake).get_job_runs(job_id=1_000_000))
+
+    listings = [r for r in fake.requests if r["url"].endswith("/runs/list")]
+    assert listings, "expected at least one runs/list request"
+    # Assert the explicit value, not just that it is under the ceiling: omitting
+    # `limit` entirely also satisfies "<= 26" and would prove nothing.
+    assert all(request.get("limit") == RUNS_PAGE_SIZE for request in listings)
+    assert RUNS_PAGE_SIZE <= 26, "runs/list rejects anything above 26"
+
+
+@pytest.mark.usefixtures("_no_auth")
+def test_expanded_job_no_longer_advertises_more_tasks():
+    """`has_more` is the signal to go fetch the rest, so it must not survive the fetch."""
+    fake = FakeJobsApi(total_jobs=1, tasks_on_first_job=250)
+
+    job = next(iter(build_client(fake).list_jobs()))
+
+    assert "has_more" not in job
+
+
+@pytest.mark.usefixtures("_no_auth")
+def test_a_failed_task_page_degrades_that_job_without_failing_the_run():
+    """
+    Losing page two of one job's tasks costs that job an accurate task list. Failing
+    the whole run over it would cost the catalogue every other job, so this one
+    deliberately degrades where list_jobs raises.
+    """
+    fake = FakeJobsApi(total_jobs=3, tasks_on_first_job=250)
+    healthy = fake.get
+    attempted: list[str] = []
+
+    def fail_only_jobs_get(url, **kwargs):
+        attempted.append(url)
+        if url.endswith("/jobs/get"):
+            return _response(503, {"error_code": "TEMPORARILY_UNAVAILABLE", "message": "try later"})
+        return healthy(url, **kwargs)
+
+    fake.get = fail_only_jobs_get
+
+    jobs = list(build_client(fake).list_jobs())
+
+    # Without this the test also passes against a client that never attempts the
+    # task page at all, which is exactly the behaviour it is supposed to catch.
+    assert any(url.endswith("/jobs/get") for url in attempted), "the task-page fallback never ran"
+    assert len(jobs) == 3, "the other jobs must still be ingested"
+    assert len(jobs[0]["settings"]["tasks"]) == TASKS_PER_PAGE, "the first page is kept"
+
+
+@pytest.mark.usefixtures("_no_auth")
+def test_test_connection_passes_on_a_reachable_workspace():
+    fake = FakeJobsApi(total_jobs=3)
+
+    build_client(fake).list_jobs_test_connection()
+
+    assert fake.requests[0]["limit"] == 1, "the probe must not pull a full page"
+
+
+@pytest.mark.usefixtures("_no_auth")
+def test_test_connection_raises_on_an_unreachable_workspace():
+    """The GetPipelines step has to fail loudly, it is what tells a user their token is wrong."""
+    fake = FakeJobsApi(total_jobs=3)
+    fake.get = MagicMock(return_value=_response(403, {"error_code": "PERMISSION_DENIED", "message": "nope"}))
+
+    with pytest.raises(DatabricksClientException, match="403"):
+        build_client(fake).list_jobs_test_connection()
+
+
+@pytest.mark.usefixtures("_no_auth")
+def test_a_repeated_page_token_raises_instead_of_looping():
+    """A service that hands back the token it was given must not spin forever."""
+    fake = FakeJobsApi(total_jobs=3000)
+    calls = {"n": 0}
+
+    def always_the_same_token(url, **kwargs):
+        calls["n"] += 1
+        assert calls["n"] < 50, "pagination looped instead of raising"
+        return _response(200, {"jobs": [{"job_id": 1}], "next_page_token": "stuck"})
+
+    fake.get = always_the_same_token
+
+    with pytest.raises(DatabricksClientException, match="reissued a page token"):
+        list(build_client(fake).list_jobs())
+
+
+@pytest.mark.usefixtures("_no_auth")
+def test_alternating_page_tokens_raise_instead_of_looping():
+    """
+    A->B->A->B never repeats a token back-to-back, so comparing against only the
+    previous token walks it forever. Every token seen has to be remembered.
+    """
+    fake = FakeJobsApi(total_jobs=3000)
+    tokens = itertools.cycle(["A", "B"])
+    calls = {"n": 0}
+
+    def alternating(url, **kwargs):
+        calls["n"] += 1
+        assert calls["n"] < 50, "pagination looped instead of raising"
+        return _response(200, {"jobs": [{"job_id": 1}], "next_page_token": next(tokens)})
+
+    fake.get = alternating
+
+    with pytest.raises(DatabricksClientException, match="reissued a page token"):
+        list(build_client(fake).list_jobs())
+
+
+@pytest.mark.usefixtures("_no_auth")
+def test_an_endless_stream_of_fresh_tokens_hits_the_page_cap():
+    """No token ever repeats here, so only the page cap can stop it."""
+    fake = FakeJobsApi(total_jobs=3000)
+    counter = itertools.count()
+
+    def always_a_fresh_token(url, **kwargs):
+        return _response(200, {"jobs": [{"job_id": 1}], "next_page_token": f"t{next(counter)}"})
+
+    fake.get = always_a_fresh_token
+
+    with pytest.raises(DatabricksClientException, match="without ending"):
+        list(build_client(fake).list_jobs())
+
+
+@pytest.mark.usefixtures("_no_auth")
+def test_a_failed_runs_page_keeps_what_it_already_yielded():
+    """
+    get_job_runs degrades where list_jobs raises, so a later page failing must not
+    lose the runs already read nor escape as an exception into pipeline status.
+    """
+    fake = FakeJobsApi(total_jobs=1, runs=120)
+    healthy = fake.get
+    calls = {"n": 0}
+
+    def fail_on_the_third_page(url, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 3:
+            return _response(500, {"error_code": "INTERNAL_ERROR", "message": "boom"})
+        return healthy(url, **kwargs)
+
+    fake.get = fail_on_the_third_page
+
+    runs = list(build_client(fake).get_job_runs(job_id=1_000_000))
+
+    assert len(runs) == 2 * RUNS_PAGE_SIZE, "the two good pages survive"
+    assert len(runs) < 120, "and the job is knowingly incomplete rather than failed"

--- a/ingestion/tests/unit/topology/pipeline/test_databricks_pipeline.py
+++ b/ingestion/tests/unit/topology/pipeline/test_databricks_pipeline.py
@@ -44,6 +44,9 @@ from metadata.generated.schema.type.entityLineage import (
 from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.ingestion.models.pipeline_status import OMetaBulkPipelineStatus
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.ingestion.source.database.databricks.client import (
+    DatabricksClientException,
+)
 from metadata.ingestion.source.pipeline.databrickspipeline.metadata import (
     DatabrickspipelineSource,
 )
@@ -549,3 +552,26 @@ class DatabricksPipelineTests(TestCase):
                             lineage_details.edge.lineageDetails.columnsLineage,
                             [],
                         )
+
+    @patch("metadata.ingestion.source.database.databricks.client.DatabricksClient.list_jobs")
+    def test_get_pipelines_list_propagates_a_listing_failure(self, list_jobs):
+        """
+        A short job list is indistinguishable from a smaller workspace, and with
+        markDeletedPipelines on the jobs that never arrived get removed. Catching here
+        would put that behaviour back while the client's own tests stayed green.
+        """
+        list_jobs.side_effect = DatabricksClientException("jobs/list failed with status 429")
+
+        with self.assertRaises(DatabricksClientException):
+            list(self.databricks.get_pipelines_list())
+
+    @patch("metadata.ingestion.source.database.databricks.client.DatabricksClient.list_pipelines")
+    @patch("metadata.ingestion.source.database.databricks.client.DatabricksClient.list_jobs")
+    def test_get_pipelines_list_skips_only_the_job_it_cannot_parse(self, list_jobs, list_pipelines):
+        """One malformed job must not cost the rest of the workspace."""
+        list_jobs.return_value = [{"job_id": "not-an-int"}, *mock_data]
+        list_pipelines.return_value = []
+
+        results = list(self.databricks.get_pipelines_list())
+
+        self.assertEqual(PIPELINE_LIST, results)


### PR DESCRIPTION
Backport of #33204 to 2.0.

Cherry-picked from `66348c975f7d` by hand. Two conflicts, both mechanical:

- `ingestion/.ruff-g004-baseline.json` does not exist on this branch, so the one-line deletion was dropped.
- `get_job_runs` conflicted because 2.0 still types it `List[dict]`. The superseded body was removed and the replacement taken as-is.

The added lines in `client.py` are byte-identical to main, so future backports keep applying cleanly. `JOB_API_VERSION` is `/api/2.2` on this branch, verified after the resolution.

Databricks unit tests pass on the branch:

```
25 passed
```

Original description follows.

---

Databricks caps the `offset` parameter on `jobs/list` at 1000, so offset pagination stops at 1100 jobs. The 400 body is valid JSON and the status was never checked, so the loop read it as an empty page and reported success. Separately, API 2.1 cannot return a job with more than 100 tasks: it answers 200 with `settings.tasks` missing entirely, so such a job was ingested with no tasks and no lineage.

Verified end to end against a 2504-job workspace: before, 1100 jobs ingested and 1370 task definitions lost, reported as `Workflow Success %: 100.0`. After, all 2504 jobs with complete task lists.
