### PR TITLE
fix(integration-tests): pull the MinIO test image from quay.io

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/bootstrap/TestSuiteBootstrap.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/bootstrap/TestSuiteBootstrap.java
@@ -954,9 +954,11 @@ public class TestSuiteBootstrap implements LauncherSessionListener {
     }
     LOG.info("Starting MinIO Testcontainer on-demand...");
     // Pin the MinIO image to a known-good release so a newly-published :latest tag
-    // cannot break integration tests without a code change.
+    // cannot break integration tests without a code change. Pull from quay.io: MinIO
+    // deleted the minio/minio repository from Docker Hub, and Docker Hub reports a
+    // removed repository as "pull access denied ... may require 'docker login'".
     MINIO_CONTAINER =
-        new GenericContainer<>("minio/minio:RELEASE.2024-01-16T16-07-38Z")
+        new GenericContainer<>("quay.io/minio/minio:RELEASE.2024-01-16T16-07-38Z")
             .withExposedPorts(9000)
             .withEnv("MINIO_ROOT_USER", "minio")
             .withEnv("MINIO_ROOT_PASSWORD", "minio123")


### PR DESCRIPTION
### Describe your changes:

No linked issue — this is a CI-infrastructure break discovered while triaging red checks, in the same vein as #33222.

**MinIO deleted the `minio/minio` repository from Docker Hub.** Every integration-test lane now aborts before a single test runs:

```
org.testcontainers.containers.ContainerFetchException: Can't get Docker image:
  RemoteDockerImage(imageName=minio/minio:RELEASE.2024-01-16T16-07-38Z, ...)
Caused by: com.github.dockerjava.api.exception.NotFoundException: Status 404:
  {"message":"pull access denied for minio/minio, repository does not exist or may require 'docker login'"}
    at TestSuiteBootstrap.setupMinIO(TestSuiteBootstrap.java:969)
    at TestSuiteBootstrap.startApplication(TestSuiteBootstrap.java:643)
```

The message is misleading: Docker Hub reports a *removed* repository with the same text it uses for a *private* one. Nothing here ever authenticated to pull this image — it was public, and now it is gone.

| Check | Result |
|---|---|
| `hub.docker.com/v2/repositories/minio/minio/` | **404** `{"message":"object not found"}` |
| pinned tag `RELEASE.2024-01-16T16-07-38Z` | 404 |
| `minio` namespace listing (20 repos) | `minio` **absent** — `mint`, `operator`, `warp`, … but no server image |
| `opensearchproject/opensearch`, `rancher/k3s`, `openmetadata/ingestion`, `library/alpine` | all **200** |

The whole repository 404s, not just the tag, and every other Docker Hub image `TestSuiteBootstrap` pulls is unaffected — so this is specific to MinIO, not a Docker Hub outage or a rate-limit window.

`setupMinIO()` is not as on-demand as its log line suggests: `startApplication()` calls it whenever object storage is configured with the `s3` provider, so this kills the suite at setup — `Classification: setup_failure`, `JUnit: 0 tests`. The follow-on `NullPointerException: environment` in cleanup is a symptom, not a cause: `APP.before()` never ran.

**Fix:** the identical release is still published on quay.io, public and multi-arch. Pull it from there. The tag stays pinned, so the original rationale for pinning is preserved.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — one-line registry change.

#
### Tests:

#### Use cases covered
- Integration-test lanes that configure object storage with the `s3` provider can start `TestSuiteBootstrap` again instead of failing at `setup_failure` with 0 tests.

#### Unit tests
Not applicable — this changes a test-fixture image coordinate, not product logic. The existing integration suite is the test: it currently cannot boot at all.

#### Backend integration tests
- [x] Not applicable (no backend API changes) — this repairs the integration-test bootstrap itself.

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. Reproduced the CI failure locally — `docker pull minio/minio:RELEASE.2024-01-16T16-07-38Z` returns the byte-identical `pull access denied` error.
2. `docker pull quay.io/minio/minio:RELEASE.2024-01-16T16-07-38Z` succeeds, digest `sha256:4c4a4876193f030c81f57aabb22bcb9a73462010eb61fcab66908e03e5484af8`, matching quay's manifest list (8 architecture children).
3. Booted the container with the same env/command the fixture uses and polled the same wait strategy: `/minio/health/live` returned **200 in 2s**, against the fixture's 60s startup timeout.
4. Confirmed no `ImageNameSubstitutor` or registry pinning in the repo (`testcontainers.properties` only sets `reuse.enable`), so the fully-qualified name resolves directly.
5. `mvn spotless:check -pl openmetadata-integration-tests` — clean.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)