### PR TITLE
Fixes #33229: [DQ Threshold W1.1] Shared row-tolerance evaluation in `BaseTestValidator` + migrate 6 validators

### DIFF
--- a/ingestion/src/metadata/data_quality/validations/base_test_handler.py
+++ b/ingestion/src/metadata/data_quality/validations/base_test_handler.py
@@ -19,6 +19,7 @@ import reprlib
 import traceback
 from abc import ABC, abstractmethod
 from collections.abc import Callable
+from enum import Enum
 from typing import (
     TYPE_CHECKING,
     TypedDict,
@@ -65,6 +66,17 @@ DIMENSION_IMPACT_SCORE_KEY = "impact_score"
 DIMENSION_FAILED_COUNT_KEY = "failed_count"
 DIMENSION_TOTAL_COUNT_KEY = "total_count"
 DIMENSION_SUM_VALUE_KEY = "sum_value"  # For statistical validators weighted calculations
+
+# Failure threshold parameters, declared on the test definitions that support them
+THRESHOLD_PARAM = "threshold"
+THRESHOLD_UNIT_PARAM = "thresholdUnit"
+
+
+class ThresholdUnit(str, Enum):
+    """How the `threshold` parameter reads the violation count"""
+
+    ABSOLUTE = "ABSOLUTE"
+    PERCENTAGE = "PERCENTAGE"
 
 
 class TestEvaluation(TypedDict, total=False):
@@ -338,6 +350,76 @@ class BaseTestValidator(ABC):
             NotImplementedError: If child class doesn't override this method
         """
         raise NotImplementedError(f"{self.__class__.__name__} must implement _evaluate_test_condition()")
+
+    def get_row_threshold(self) -> tuple[float, ThresholdUnit]:
+        """Read the failure threshold and the unit it is expressed in
+
+        Both parameters are optional. A test case that does not set them tolerates no
+        violation at all (`0` ABSOLUTE), which is the verdict tests had before thresholds
+        were introduced.
+
+        Returns:
+            Tuple[float, ThresholdUnit]: the tolerated number of violations and its unit
+        """
+        param_values = self.test_case.parameterValues or []
+
+        try:
+            threshold = self.get_test_case_param_value(param_values, THRESHOLD_PARAM, float, default=0.0) or 0.0
+        except (TypeError, ValueError):
+            logger.warning(
+                f"Unreadable {THRESHOLD_PARAM} for {self.test_case.fullyQualifiedName}. Tolerating no violation."
+            )
+            return 0.0, ThresholdUnit.ABSOLUTE
+
+        unit_value = self.get_test_case_param_value(
+            param_values, THRESHOLD_UNIT_PARAM, str, default=ThresholdUnit.ABSOLUTE.value
+        )
+        try:
+            unit = ThresholdUnit(unit_value.upper())
+        except ValueError:
+            logger.warning(
+                f"Unknown {THRESHOLD_UNIT_PARAM} '{unit_value}' for {self.test_case.fullyQualifiedName}. "
+                f"Reading the threshold as {ThresholdUnit.ABSOLUTE.value}."
+            )
+            unit = ThresholdUnit.ABSOLUTE
+
+        return threshold, unit
+
+    def _needs_row_count(self) -> bool:
+        """Whether the total row count has to be computed
+
+        Row level reporting needs it, and so does a percentage threshold: without the
+        denominator there is nothing to compute the share of failing rows against.
+        """
+        if self.test_case.computePassedFailedRowCount:
+            return True
+        return self.get_row_threshold()[1] is ThresholdUnit.PERCENTAGE
+
+    def _apply_row_threshold(self, violations: int | None, denominator: int | None) -> bool:
+        """Check a violation count against the test case failure threshold
+
+        ABSOLUTE tolerates `threshold` violations. PERCENTAGE tolerates `threshold` percent
+        of `denominator`; an empty denominator has nothing to violate, so it passes instead
+        of dividing by zero.
+
+        Args:
+            violations: Number of rows that broke the test condition
+            denominator: Rows the violations are counted against. Validator specific: tests
+                         that only look at non-null values count against those, not the
+                         table row count.
+
+        Returns:
+            bool: True if the test passes
+        """
+        violations = violations or 0
+        threshold, unit = self.get_row_threshold()
+
+        if unit is ThresholdUnit.PERCENTAGE:
+            if not denominator:
+                return True
+            return violations / denominator * 100 <= threshold
+
+        return violations <= threshold
 
     def _format_result_message(
         self,

--- a/ingestion/src/metadata/data_quality/validations/column/base/columnValuesToBeInSet.py
+++ b/ingestion/src/metadata/data_quality/validations/column/base/columnValuesToBeInSet.py
@@ -139,7 +139,8 @@ class BaseColumnValuesToBeInSetValidator(BaseTestValidator):
 
         For in-set test, behavior depends on match_enum flag:
         - match_enum=False: Pass if at least one value is in the set (count_in_set > 0)
-        - match_enum=True: Pass if ALL values are in the set (row_count - count_in_set == 0)
+        - match_enum=True: Pass if the values outside the set (row_count - count_in_set)
+          stay within the failure threshold, counted against the table row count
 
         Args:
             metric_values: Dictionary with keys from Metrics enum names
@@ -162,7 +163,7 @@ class BaseColumnValuesToBeInSetValidator(BaseTestValidator):
         if match_enum:
             row_count = metric_values.get(Metrics.rowCount.name, 0)
             failed_count = row_count - count_in_set
-            matched = failed_count == 0
+            matched = self._apply_row_threshold(failed_count, row_count)
             total_rows = row_count
         else:
             matched = count_in_set > 0

--- a/ingestion/src/metadata/data_quality/validations/column/base/columnValuesToBeNotInSet.py
+++ b/ingestion/src/metadata/data_quality/validations/column/base/columnValuesToBeNotInSet.py
@@ -61,7 +61,7 @@ class BaseColumnValuesToBeNotInSetValidator(BaseTestValidator):
 
             metric_values = {Metrics.countInSet.name: res}
 
-            if self.test_case.computePassedFailedRowCount:
+            if self._needs_row_count():
                 metric_values[Metrics.rowCount.name] = self.get_row_count()
 
         except (ValueError, RuntimeError) as exc:
@@ -117,17 +117,17 @@ class BaseColumnValuesToBeNotInSetValidator(BaseTestValidator):
             Metrics.countInSet.name: Metrics.countInSet,
         }
 
-        if self.test_case.computePassedFailedRowCount:
+        if self._needs_row_count():
             metrics[Metrics.rowCount.name] = Metrics.rowCount
 
         return metrics
 
     def _evaluate_test_condition(self, metric_values: dict, test_params: dict | None = None) -> TestEvaluation:
-        """Evaluate the in-set test condition
+        """Evaluate the not-in-set test condition
 
-        For in-set test, behavior depends on match_enum flag:
-        - match_enum=False: Pass if at least one value is in the set (count_in_set > 0)
-        - match_enum=True: Pass if ALL values are in the set (row_count - count_in_set == 0)
+        Test passes if the forbidden values found (count_in_set) stay within the failure
+        threshold, counted against the table row count. With the default threshold, that
+        means count_in_set == 0.
 
         Args:
             metric_values: Dictionary with keys from Metrics enum names
@@ -146,8 +146,8 @@ class BaseColumnValuesToBeNotInSetValidator(BaseTestValidator):
             raise ValueError("test_params is required for columnValuesToNotBeInSet._evaluate_test_condition")
         count_in_set = metric_values[Metrics.countInSet.name]
 
-        matched = count_in_set == 0
         total_rows = metric_values.get(Metrics.rowCount.name)
+        matched = self._apply_row_threshold(count_in_set, total_rows)
         failed_count = count_in_set
         if total_rows:
             passed_count = total_rows - failed_count

--- a/ingestion/src/metadata/data_quality/validations/column/base/columnValuesToBeNotNull.py
+++ b/ingestion/src/metadata/data_quality/validations/column/base/columnValuesToBeNotNull.py
@@ -59,7 +59,7 @@ class BaseColumnValuesToBeNotNullValidator(BaseTestValidator):
                 Metrics.nullCount.name: null_count,
             }
 
-            if self.test_case.computePassedFailedRowCount:
+            if self._needs_row_count():
                 metric_values[Metrics.rowCount.name] = self.get_row_count()
         except (ValueError, RuntimeError) as exc:
             msg = f"Error computing {self.test_case.fullyQualifiedName}: {exc}"  # type: ignore
@@ -99,7 +99,7 @@ class BaseColumnValuesToBeNotNullValidator(BaseTestValidator):
             Metrics.nullCount.name: Metrics.nullCount,
         }
 
-        if self.test_case.computePassedFailedRowCount:
+        if self._needs_row_count():
             metrics[Metrics.rowCount.name] = Metrics.rowCount
 
         return metrics
@@ -107,7 +107,8 @@ class BaseColumnValuesToBeNotNullValidator(BaseTestValidator):
     def _evaluate_test_condition(self, metric_values: dict, test_params: dict | None = None) -> TestEvaluation:
         """Evaluate the not null test condition
 
-        Test passes if null_count == 0 (no null values found)
+        Test passes if the null values stay within the failure threshold, counted against
+        the table row count. With the default threshold, that means null_count == 0.
 
         Args:
             metric_values: Dictionary with keys from Metrics enum names
@@ -116,7 +117,7 @@ class BaseColumnValuesToBeNotNullValidator(BaseTestValidator):
 
         Returns:
             TestEvaluation: TypedDict with keys:
-                - matched: bool - whether test passed (null_count == 0)
+                - matched: bool - whether the null values are within the threshold
                 - passed_rows: int - number of non-null values
                 - failed_rows: int - number of null values
                 - total_rows: int - total row count for reporting
@@ -124,7 +125,7 @@ class BaseColumnValuesToBeNotNullValidator(BaseTestValidator):
         null_count = metric_values[Metrics.nullCount.name]
         total_rows = metric_values.get(Metrics.rowCount.name)
 
-        matched = null_count == 0
+        matched = self._apply_row_threshold(null_count, total_rows)
         failed_count = null_count
         passed_count = total_rows - null_count if total_rows else 0
 

--- a/ingestion/src/metadata/data_quality/validations/column/base/columnValuesToBeUnique.py
+++ b/ingestion/src/metadata/data_quality/validations/column/base/columnValuesToBeUnique.py
@@ -60,7 +60,9 @@ class BaseColumnValuesToBeUniqueValidator(BaseTestValidator):
     def _evaluate_test_condition(self, metric_values: dict, test_params: dict | None = None) -> TestEvaluation:
         """Evaluate the uniqueness test condition and calculate derived values
 
-        For uniqueness test: all values should be unique, meaning COUNT == UNIQUE_COUNT
+        For uniqueness test: the duplicates (COUNT - UNIQUE_COUNT) must stay within the
+        failure threshold, counted against the non-null values. With the default threshold,
+        that means COUNT == UNIQUE_COUNT.
 
         Args:
             metric_values: Dictionary with keys from Metrics enum names
@@ -69,7 +71,7 @@ class BaseColumnValuesToBeUniqueValidator(BaseTestValidator):
 
         Returns:
             TestEvaluation: TypedDict with keys:
-                - matched: bool - whether test passed (count == unique_count)
+                - matched: bool - whether the duplicates are within the threshold
                 - passed_rows: int - number of unique values
                 - failed_rows: int - number of duplicate values
                 - total_rows: int - total row count
@@ -78,7 +80,7 @@ class BaseColumnValuesToBeUniqueValidator(BaseTestValidator):
         unique_count = metric_values[Metrics.uniqueCount.name]
 
         return {
-            "matched": count == unique_count,
+            "matched": self._apply_row_threshold(count - unique_count, count),
             "passed_rows": unique_count,
             "failed_rows": count - unique_count,
             "total_rows": count,

--- a/ingestion/src/metadata/data_quality/validations/column/base/columnValuesToMatchRegex.py
+++ b/ingestion/src/metadata/data_quality/validations/column/base/columnValuesToMatchRegex.py
@@ -130,23 +130,24 @@ class BaseColumnValuesToMatchRegexValidator(BaseTestValidator):
         return metrics
 
     def _evaluate_test_condition(self, metric_values: dict, test_params: dict | None = None) -> TestEvaluation:
-        """Evaluate the in-set test condition
+        """Evaluate the regex match test condition
 
-        For in-set test, behavior depends on match_enum flag:
-        - match_enum=False: Pass if at least one value is in the set (count_in_set > 0)
-        - match_enum=True: Pass if ALL values are in the set (row_count - count_in_set == 0)
+        Test passes if the values not matching the regex (valuesCount - regexCount) stay
+        within the failure threshold. Violations are counted against the non-null values,
+        not the table row count: a column that is half NULL and otherwise matches the regex
+        must not report half of its rows as failing. With the default threshold, that means
+        valuesCount == regexCount.
 
         Args:
             metric_values: Dictionary with keys from Metrics enum names
-                          e.g., {"COUNT_IN_SET": 50, "ROW_COUNT": 100}
-            test_params: Dictionary with 'allowed_values' and 'match_enum'.
-                        Required for this validator.
+                          e.g., {"COUNT": 50, "REGEX_COUNT": 45, "ROW_COUNT": 100}
+            test_params: Dictionary with 'regex'. Required for this validator.
 
         Returns:
             TestEvaluation: TypedDict with keys:
-                - matched: bool - whether test passed
-                - passed_rows: int - number of values in set
-                - failed_rows: int - number of values not in set (0 if not match_enum)
+                - matched: bool - whether the non-matching values are within the threshold
+                - passed_rows: int - number of values matching the regex
+                - failed_rows: int - number of values not matching the regex
                 - total_rows: int - total row count for reporting
         """
         if test_params is None:
@@ -155,7 +156,7 @@ class BaseColumnValuesToMatchRegexValidator(BaseTestValidator):
         count = metric_values[Metrics.valuesCount.name]
         total_rows = metric_values.get(Metrics.rowCount.name)
 
-        matched = count == match_regex_count
+        matched = self._apply_row_threshold(count - match_regex_count, count)
         failed_count = count - match_regex_count
         passed_count = match_regex_count
 

--- a/ingestion/src/metadata/data_quality/validations/column/base/columnValuesToNotMatchRegex.py
+++ b/ingestion/src/metadata/data_quality/validations/column/base/columnValuesToNotMatchRegex.py
@@ -63,7 +63,7 @@ class BaseColumnValuesToNotMatchRegexValidator(BaseTestValidator):
 
             metric_values = {Metrics.notRegexCount.name: not_match_count}
 
-            if self.test_case.computePassedFailedRowCount:
+            if self._needs_row_count():
                 metric_values[Metrics.rowCount.name] = self.get_row_count()
         except (ValueError, RuntimeError) as exc:
             msg = f"Error computing {self.test_case.fullyQualifiedName}: {exc}"  # type: ignore
@@ -120,7 +120,7 @@ class BaseColumnValuesToNotMatchRegexValidator(BaseTestValidator):
             Metrics.notRegexCount.name: Metrics.notRegexCount,
         }
 
-        if self.test_case.computePassedFailedRowCount:
+        if self._needs_row_count():
             metrics[Metrics.rowCount.name] = Metrics.rowCount
 
         return metrics
@@ -128,8 +128,9 @@ class BaseColumnValuesToNotMatchRegexValidator(BaseTestValidator):
     def _evaluate_test_condition(self, metric_values: dict, test_params: dict | None = None) -> TestEvaluation:
         """Evaluate the not regex match test condition
 
-        For not regex match test, pass if NO values match the forbidden regex pattern
-        (not_match_count == 0).
+        For not regex match test, pass if the values matching the forbidden regex pattern
+        stay within the failure threshold, counted against the table row count. With the
+        default threshold, that means not_match_count == 0.
 
         Args:
             metric_values: Dictionary with keys from Metrics enum names
@@ -149,7 +150,7 @@ class BaseColumnValuesToNotMatchRegexValidator(BaseTestValidator):
         not_match_count = metric_values[Metrics.notRegexCount.name]
         total_rows = metric_values.get(Metrics.rowCount.name)
 
-        matched = not_match_count == 0
+        matched = self._apply_row_threshold(not_match_count, total_rows)
         failed_count = not_match_count
         if total_rows is not None:
             passed_count = total_rows - failed_count

--- a/ingestion/tests/unit/observability/data_quality/validations/test_row_threshold.py
+++ b/ingestion/tests/unit/observability/data_quality/validations/test_row_threshold.py
@@ -1,0 +1,276 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Validate the shared row tolerance threshold against the validators that count rows.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from metadata.data_quality.validations.base_test_handler import ThresholdUnit
+from metadata.data_quality.validations.column.sqlalchemy.columnValuesToBeInSet import (
+    ColumnValuesToBeInSetValidator,
+)
+from metadata.data_quality.validations.column.sqlalchemy.columnValuesToBeNotInSet import (
+    ColumnValuesToBeNotInSetValidator,
+)
+from metadata.data_quality.validations.column.sqlalchemy.columnValuesToBeNotNull import (
+    ColumnValuesToBeNotNullValidator,
+)
+from metadata.data_quality.validations.column.sqlalchemy.columnValuesToBeUnique import (
+    ColumnValuesToBeUniqueValidator,
+)
+from metadata.data_quality.validations.column.sqlalchemy.columnValuesToMatchRegex import (
+    ColumnValuesToMatchRegexValidator,
+)
+from metadata.data_quality.validations.column.sqlalchemy.columnValuesToNotMatchRegex import (
+    ColumnValuesToNotMatchRegexValidator,
+)
+from metadata.generated.schema.tests.basic import TestCaseStatus
+from metadata.generated.schema.tests.testCase import TestCase, TestCaseParameterValue
+from metadata.generated.schema.type.entityReference import EntityReference
+from metadata.profiler.metrics.registry import Metrics
+
+EXECUTION_DATE = datetime.strptime("2021-07-03", "%Y-%m-%d")
+ENTITY_LINK = "<#E::table::service.db.users::columns::nickname>"
+
+
+def build_validator(validator_class, parameter_values, compute_passed_failed_row_count=False):
+    """Build a validator whose only live dependency is its test case"""
+    test_case = TestCase(
+        name="my_test_case",
+        entityLink=ENTITY_LINK,
+        testSuite=EntityReference(id=uuid4(), type="TestSuite"),  # type: ignore
+        testDefinition=EntityReference(id=uuid4(), type="TestDefinition"),  # type: ignore
+        parameterValues=parameter_values,
+        computePassedFailedRowCount=compute_passed_failed_row_count,
+    )  # type: ignore
+    return validator_class(MagicMock(), test_case, EXECUTION_DATE)
+
+
+def threshold_params(threshold=None, unit=None):
+    """Build the threshold parameter values, leaving out the ones that are not set"""
+    params = []
+    if threshold is not None:
+        params.append(TestCaseParameterValue(name="threshold", value=str(threshold)))
+    if unit is not None:
+        params.append(TestCaseParameterValue(name="thresholdUnit", value=unit))
+    return params
+
+
+# Each validator, the parameters it needs to evaluate, and how to express `violations` out of
+# `denominator` violating rows with the metrics that validator computes.
+VALIDATORS = [
+    pytest.param(
+        ColumnValuesToBeNotNullValidator,
+        [],
+        lambda violations, denominator: {
+            Metrics.nullCount.name: violations,
+            Metrics.rowCount.name: denominator,
+        },
+        id="columnValuesToBeNotNull",
+    ),
+    pytest.param(
+        ColumnValuesToBeUniqueValidator,
+        [],
+        lambda violations, denominator: {
+            Metrics.valuesCount.name: denominator,
+            Metrics.uniqueCount.name: denominator - violations,
+        },
+        id="columnValuesToBeUnique",
+    ),
+    pytest.param(
+        ColumnValuesToBeInSetValidator,
+        [
+            TestCaseParameterValue(name="allowedValues", value="['a','b']"),
+            TestCaseParameterValue(name="matchEnum", value="true"),
+        ],
+        lambda violations, denominator: {
+            Metrics.countInSet.name: denominator - violations,
+            Metrics.rowCount.name: denominator,
+        },
+        id="columnValuesToBeInSet",
+    ),
+    pytest.param(
+        ColumnValuesToBeNotInSetValidator,
+        [TestCaseParameterValue(name="forbiddenValues", value="['a','b']")],
+        lambda violations, denominator: {
+            Metrics.countInSet.name: violations,
+            Metrics.rowCount.name: denominator,
+        },
+        id="columnValuesToBeNotInSet",
+    ),
+    pytest.param(
+        ColumnValuesToMatchRegexValidator,
+        [TestCaseParameterValue(name="regex", value="^[a-z]+$")],
+        lambda violations, denominator: {
+            Metrics.valuesCount.name: denominator,
+            Metrics.regexCount.name: denominator - violations,
+        },
+        id="columnValuesToMatchRegex",
+    ),
+    pytest.param(
+        ColumnValuesToNotMatchRegexValidator,
+        [TestCaseParameterValue(name="forbiddenRegex", value="^[a-z]+$")],
+        lambda violations, denominator: {
+            Metrics.notRegexCount.name: violations,
+            Metrics.rowCount.name: denominator,
+        },
+        id="columnValuesToNotMatchRegex",
+    ),
+]
+
+
+def evaluate(validator, metric_values):
+    """Evaluate the test condition the way the validators do"""
+    return validator._evaluate_test_condition(metric_values, validator._get_test_parameters())
+
+
+@pytest.mark.parametrize("validator_class,test_params,metrics", VALIDATORS)
+@pytest.mark.parametrize("violations,expected", [(0, True), (1, False), (100, False)])
+def test_no_threshold_tolerates_no_violation(validator_class, test_params, metrics, violations, expected):
+    """A test case without threshold parameters keeps the pre-threshold verdict"""
+    validator = build_validator(validator_class, test_params)
+
+    assert evaluate(validator, metrics(violations, 100))["matched"] is expected
+
+
+@pytest.mark.parametrize("validator_class,test_params,metrics", VALIDATORS)
+@pytest.mark.parametrize("violations,expected", [(4, True), (5, True), (6, False)])
+def test_absolute_threshold_passes_at_the_boundary(validator_class, test_params, metrics, violations, expected):
+    """ABSOLUTE tolerates exactly `threshold` violations"""
+    validator = build_validator(validator_class, test_params + threshold_params(5, ThresholdUnit.ABSOLUTE.value))
+
+    assert evaluate(validator, metrics(violations, 100))["matched"] is expected
+
+
+@pytest.mark.parametrize("validator_class,test_params,metrics", VALIDATORS)
+@pytest.mark.parametrize("violations,expected", [(19, True), (20, True), (21, False)])
+def test_percentage_threshold_counts_against_the_denominator(
+    validator_class, test_params, metrics, violations, expected
+):
+    """PERCENTAGE tolerates `threshold` percent of the rows the validator evaluated"""
+    validator = build_validator(validator_class, test_params + threshold_params(10, ThresholdUnit.PERCENTAGE.value))
+
+    assert evaluate(validator, metrics(violations, 200))["matched"] is expected
+
+
+@pytest.mark.parametrize("validator_class,test_params,metrics", VALIDATORS)
+@pytest.mark.parametrize("unit", [ThresholdUnit.ABSOLUTE.value, ThresholdUnit.PERCENTAGE.value])
+def test_empty_denominator_passes(validator_class, test_params, metrics, unit):
+    """Nothing was evaluated, so nothing can violate the test - and nothing is divided by zero"""
+    validator = build_validator(validator_class, test_params + threshold_params(0, unit))
+
+    assert evaluate(validator, metrics(0, 0))["matched"] is True
+
+
+def test_match_regex_counts_violations_against_the_non_null_values():
+    """A column that is half NULL must not report its NULLs as regex failures"""
+    validator = build_validator(
+        ColumnValuesToMatchRegexValidator,
+        [TestCaseParameterValue(name="regex", value="^[a-z]+$")] + threshold_params(5, ThresholdUnit.PERCENTAGE.value),
+    )
+
+    # 5 of the 50 non-null values do not match: 10% of them, but only 5% of the 100 rows
+    evaluation = evaluate(
+        validator,
+        {
+            Metrics.valuesCount.name: 50,
+            Metrics.regexCount.name: 45,
+            Metrics.rowCount.name: 100,
+        },
+    )
+
+    assert evaluation["matched"] is False
+
+
+def test_in_set_without_match_enum_ignores_the_threshold():
+    """Without matchEnum the test only asks for one value in the set, there is nothing to tolerate"""
+    validator = build_validator(
+        ColumnValuesToBeInSetValidator,
+        [
+            TestCaseParameterValue(name="allowedValues", value="['a','b']"),
+            TestCaseParameterValue(name="matchEnum", value="false"),
+        ]
+        + threshold_params(10, ThresholdUnit.PERCENTAGE.value),
+    )
+
+    assert evaluate(validator, {Metrics.countInSet.name: 1})["matched"] is True
+    assert evaluate(validator, {Metrics.countInSet.name: 0})["matched"] is False
+
+
+@pytest.mark.parametrize(
+    "parameter_values,expected",
+    [
+        ([], (0.0, ThresholdUnit.ABSOLUTE)),
+        (threshold_params(5), (5.0, ThresholdUnit.ABSOLUTE)),
+        (threshold_params(5, "PERCENTAGE"), (5.0, ThresholdUnit.PERCENTAGE)),
+        (threshold_params(5, "percentage"), (5.0, ThresholdUnit.PERCENTAGE)),
+        # An unreadable threshold or unit falls back to the safest reading rather than raising
+        (threshold_params(5, "RATIO"), (5.0, ThresholdUnit.ABSOLUTE)),
+        (threshold_params("abc", "PERCENTAGE"), (0.0, ThresholdUnit.ABSOLUTE)),
+        (threshold_params(0, "PERCENTAGE"), (0.0, ThresholdUnit.PERCENTAGE)),
+    ],
+)
+def test_get_row_threshold(parameter_values, expected):
+    validator = build_validator(ColumnValuesToBeNotNullValidator, parameter_values)
+
+    assert validator.get_row_threshold() == expected
+
+
+@pytest.mark.parametrize(
+    "threshold,expected_status",
+    [
+        # `age` is NULL on 20 of the 80 rows, 25% of the column
+        (30, TestCaseStatus.Success),
+        (25, TestCaseStatus.Success),
+        (20, TestCaseStatus.Failed),
+    ],
+)
+def test_percentage_threshold_computes_its_denominator(create_sqlite_table, threshold, expected_status):
+    """The row count denominator is queried even when the test case does not ask for row counts"""
+    test_case = TestCase(
+        name="my_test_case",
+        entityLink="<#E::table::service.db.users::columns::age>",
+        testSuite=EntityReference(id=uuid4(), type="TestSuite"),  # type: ignore
+        testDefinition=EntityReference(id=uuid4(), type="TestDefinition"),  # type: ignore
+        parameterValues=threshold_params(threshold, ThresholdUnit.PERCENTAGE.value),
+        computePassedFailedRowCount=False,
+    )  # type: ignore
+    validator = ColumnValuesToBeNotNullValidator(
+        create_sqlite_table, test_case=test_case, execution_date=EXECUTION_DATE.timestamp()
+    )
+
+    result = validator.run_validation()
+
+    assert result.testCaseStatus == expected_status
+    assert result.failedRows == 20
+    assert result.passedRows == 60
+
+
+@pytest.mark.parametrize(
+    "parameter_values,compute_passed_failed_row_count,expected",
+    [
+        ([], False, False),
+        ([], True, True),
+        (threshold_params(5, "ABSOLUTE"), False, False),
+        # The denominator of a percentage threshold has to be computed even when the
+        # test case does not ask for row level results
+        (threshold_params(5, "PERCENTAGE"), False, True),
+    ],
+)
+def test_needs_row_count(parameter_values, compute_passed_failed_row_count, expected):
+    validator = build_validator(ColumnValuesToBeNotNullValidator, parameter_values, compute_passed_failed_row_count)
+
+    assert validator._needs_row_count() is expected


### PR DESCRIPTION
> **This pull request was opened by an olivaw agent.** It is an input to review, not an approved change — read the diff, not this description.
>
> Fixes #33229

## What olivaw checked (machine-observed, §8.2/A.1)

- diff: non-empty
- build: not_run
- tests: not_run
- base: `dd9673374a6dc7b231e8d20b43c876553b01a632`
- head: `420b9cb4b22ca5d7cf7f8509e1b015cccb23f1ab`

**No build or test command is configured for this workspace**, so only the diff's existence was checked. Set `run_config.build_cmd`/`test_cmd` to have olivaw verify its own work.

## What the agent says it did (unverified)

> Committed on `agent/issue-33229`.
> 
> **What changed**
> 
> `BaseTestValidator` (`ingestion/src/metadata/data_quality/validations/base_test_handler.py`):
> - `ThresholdUnit` enum (`ABSOLUTE` / `PERCENTAGE`) plus the `threshold` / `thresholdUnit` parameter names seeded by #33242.
> - `get_row_threshold()` — reads both parameters, defaulting to `0 ABSOLUTE`; an unparseable threshold or unknown unit logs a warning and falls back rather than raising mid-validation.
> - `_apply_row_threshold(violations, denominator)` — `violations <= threshold` for ABSOLUTE, `violations / denominator * 100 <= threshold` for PERCENTAGE, and an empty denominator passes instead of dividing by zero.
> - `_needs_row_count()` — see the caveat below.
> 
> Each of the six validators' `_evaluate_test_condition` now delegates instead of hand-rolling `matched`, keeping its own denominator: `rowCount` for notNull / notInSet / inSet(matchEnum) / notMatchRegex, non-null `valuesCount` for unique / matchRegex. `columnValuesToBeInSet` with `matchEnum=false` is untouched — that branch ("at least one value in the set") has no notion of a failing row.
> 
> **One judgment call worth flagging:** notNull, notInSet and notMatchRegex only computed their `rowCount` denominator when `computePassedFailedRowCount` was set. A percentage threshold without it would have had nothing to divide by and would have silently passed, so `_needs_row_count()` now also triggers the row count for `PERCENTAGE`. Side effect: such test cases now report passed/failed rows even though `computePassedFailedRowCount` is false — the numbers were computed anyway.
> 
> **Verification** — the repo had no built Python env, so I generated the pydantic/antlr models and installed the deps into a throwaway venv (one unrelated transitive package, `collate-data-diff`, can't install here; stubbed for imports only). Results:
> - 82 new tests in `ingestion/tests/unit/observability/data_quality/validations/test_row_threshold.py` pass — all four acceptance criteria across all six validators, plus an end-to-end sqlite case proving the percentage denominator is actually queried (`age` is 25% NULL over 80 rows → passes at 30/25, fails at 20).
> - Existing DQ suite: 370 passed, 4 failed. The 4 failures are `columnValuesToBeAtExpectedLocation` failing on `ModuleNotFoundError: No module named 'shapely'` — a sandbox gap, untouched by this change.
> - `ruff check` and `ruff format --check` clean.
> 
> The design spec the issue references (`docs/plans/2026-09-11-dq-failure-thresholds.md`) is not in the repo, and the dependency #33227 is not merged — so the threshold *reading* helpers landed here alongside `_apply_row_threshold`. If #33227 lands separately with its own reader, `get_row_threshold` is the piece to reconcile.






<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63361886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge because no outstanding or newly introduced actionable issue remains.

<details open><summary>Summary</summary>

This PR centralizes row-tolerance evaluation in `BaseTestValidator` and migrates six column validators to use absolute or percentage thresholds.
- Adds shared threshold parsing, denominator selection, and boundary evaluation.
- Preserves validator-specific denominator semantics for null, uniqueness, set-membership, and regex checks.
- Adds parameterized unit coverage and a SQLite validation case for percentage thresholds.
- Both previous review threads were manually resolved and no new issue was introduced in the reviewed PR files since the previous review.
</details>

<details open><summary>Diagram</summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  TC[Test-case threshold parameters] --> PARSE[BaseTestValidator parses threshold]
  PARSE --> UNIT{Threshold unit}
  V[Validator metrics] --> COUNT[Compute violations and denominator]
  COUNT --> UNIT
  UNIT -->|ABSOLUTE| ABS[violations ≤ threshold]
  UNIT -->|PERCENTAGE| PCT[violations / denominator × 100 ≤ threshold]
  ABS --> RESULT[Test result]
  PCT --> RESULT
```
</details>

<sub>Reviews (3) · Last reviewed commit: ["fix(dq): read the row threshold as a mod..."](https://github.com/open-metadata/openmetadata/commit/29f471fff2c70e27e6139f9d6abaf17143787ea0)</sub>

<!-- /greptile_comment -->