### PR TITLE
fix(ingestion): pull the MinIO test image from quay.io

### DIFF
--- a/ingestion/tests/integration/containers.py
+++ b/ingestion/tests/integration/containers.py
@@ -40,6 +40,9 @@ class MySqlContainerConfigs:
 class MinioContainerConfigs:
     """MinIO Configurations"""
 
+    # testcontainers defaults to minio/minio on Docker Hub, which MinIO has deleted.
+    # The same release is still published on quay.io.
+    image: str = "quay.io/minio/minio:RELEASE.2022-12-02T19-19-22Z"
     access_key: str = "minio"
     secret_key: str = "password"
     port: int = 9000

--- a/ingestion/tests/integration/trino/conftest.py
+++ b/ingestion/tests/integration/trino/conftest.py
@@ -30,6 +30,7 @@ from metadata.generated.schema.entity.services.databaseService import (
 )
 
 from ..conftest import ingestion_config as base_ingestion_config  # noqa: F401, TID252
+from ..containers import MinioContainerConfigs  # noqa: TID252
 
 HIVE_METASTORE_IMAGE = (
     "bitsondatadev/hive-metastore@sha256:b44a186b6dcffafc6a72327aaa5912a5824feecb50718aaf661727ff6aef011b"
@@ -194,7 +195,7 @@ def hive_metastore_container(mysql_container, minio_container, docker_network):
 
 @pytest.fixture(scope="package")
 def minio_container(docker_network):
-    container = MinioContainer().with_network(docker_network).with_network_aliases("minio")
+    container = MinioContainer(MinioContainerConfigs.image).with_network(docker_network).with_network_aliases("minio")
     with try_bind(container, container.port, container.port) as minio:
         client = minio.get_client()
         client.make_bucket("hive-warehouse")


### PR DESCRIPTION
### Describe your changes:

Follow-up to #33245, same root cause on the Python side.

**MinIO deleted the `minio/minio` repository from Docker Hub.** #33245 fixed the Java bootstrap, which named the image explicitly. The ingestion integration tests reach the same dead coordinate by a different route: nothing in this repo names the image, so they inherit `testcontainers`' default.

`testcontainers/minio/__init__.py`:
```python
def __init__(self, image: str = "minio/minio:RELEASE.2022-12-02T19-19-22Z", ...)
```

The pull 404s, so the image is never cached, and container create then fails:

```
docker.errors.ImageNotFound: 404 Client Error for
  http+docker://localhost/v1.48/containers/create?name=...:
  Not Found ("No such image: minio/minio:RELEASE.2022-12-02T19-19-22Z")
```

That is why `tests/integration/s3/**` and `tests/integration/trino/**` report **errors at setup** rather than assertion failures — ~70 of them in `python / Integration Tests (shard-3)`, none of which reflect a real product defect.

**Fix:** pin the image on `MinioContainerConfigs`, mirroring the `image` field `MySqlContainerConfigs` in the same file already carries. `get_minio_container` already forwards every config field, so the `s3`, `datalake`, `auto_classification` and `mlflow` fixtures all inherit it. `trino/conftest.py` constructed a `MinioContainer` directly, so it now references the same constant rather than repeating the coordinate.

The tag is unchanged — only the registry moves.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- The `s3` and `trino` ingestion integration suites can start their MinIO fixture again instead of erroring at setup with `ImageNotFound`.

#### Unit tests
Not applicable — this changes a test-fixture image coordinate, not product logic. The affected integration suites are themselves the test; they currently cannot start.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable as *new* tests — this repairs the existing ingestion integration fixtures.

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. Confirmed the image name is the library default, not ours — `grep -rn "minio/minio" --include="*.py"` over the tree returns nothing; the coordinate comes from `testcontainers/minio/__init__.py:45`.
2. `docker pull quay.io/minio/minio:RELEASE.2022-12-02T19-19-22Z` succeeds, digest `sha256:031fd97adca056cdbfd416a26670898d93adb9a79a3cf126aac5a41ddc22c5a3`.
3. Booted that image with the env and command the fixture uses; `/minio/health/live` returned **200 in 2s**.
4. Exercised `get_minio_container` against a stub carrying `MinioContainer`'s real signature — resolved image is the quay coordinate, and `access_key` / `secret_key` / `port` are unchanged (`minio` / `password` / `9000`).
5. `ruff format` + `ruff check` on both changed files — all checks passed.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)