### PR TITLE
Fixes #30304: Prevent zero-lifetime OIDC login tokens [2.0]

### DIFF
--- a/bootstrap/sql/migrations/native/2.0.2/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/2.0.2/mysql/postDataMigrationSQLScript.sql
@@ -1,0 +1,21 @@
+-- OpenMetadata signs its own JWT after both OIDC and SAML logins. A non-positive validity mints
+-- tokens whose expiry equals their issue time, so every request 401s and the client refreshes
+-- forever. Repair values accepted by older SSO forms that had no minimum.
+-- Idempotent: only rewrites values still at or below zero.
+UPDATE openmetadata_settings
+SET json = JSON_SET(json, '$.oidcConfiguration.tokenValidity', 3600)
+WHERE configType = 'authenticationConfiguration'
+  AND JSON_TYPE(JSON_EXTRACT(json, '$.oidcConfiguration.tokenValidity')) IN ('INTEGER', 'DOUBLE')
+  AND CAST(
+    JSON_UNQUOTE(JSON_EXTRACT(json, '$.oidcConfiguration.tokenValidity')) AS DECIMAL(65, 10)
+  ) <= 0;
+
+UPDATE openmetadata_settings
+SET json = JSON_SET(json, '$.samlConfiguration.security.tokenValidity', 3600)
+WHERE configType = 'authenticationConfiguration'
+  AND JSON_TYPE(JSON_EXTRACT(json, '$.samlConfiguration.security.tokenValidity'))
+      IN ('INTEGER', 'DOUBLE')
+  AND CAST(
+    JSON_UNQUOTE(JSON_EXTRACT(json, '$.samlConfiguration.security.tokenValidity'))
+      AS DECIMAL(65, 10)
+  ) <= 0;

--- a/bootstrap/sql/migrations/native/2.0.2/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/2.0.2/postgres/postDataMigrationSQLScript.sql
@@ -1,0 +1,23 @@
+-- OpenMetadata signs its own JWT after both OIDC and SAML logins. A non-positive validity mints
+-- tokens whose expiry equals their issue time, so every request 401s and the client refreshes
+-- forever. Repair values accepted by older SSO forms that had no minimum.
+-- Idempotent: only rewrites values still at or below zero.
+UPDATE openmetadata_settings
+SET json = jsonb_set(
+    json,
+    '{oidcConfiguration,tokenValidity}',
+    to_jsonb(3600),
+    false)
+WHERE configtype = 'authenticationConfiguration'
+  AND jsonb_typeof(json #> '{oidcConfiguration,tokenValidity}') = 'number'
+  AND (json #>> '{oidcConfiguration,tokenValidity}')::numeric <= 0;
+
+UPDATE openmetadata_settings
+SET json = jsonb_set(
+    json,
+    '{samlConfiguration,security,tokenValidity}',
+    to_jsonb(3600),
+    false)
+WHERE configtype = 'authenticationConfiguration'
+  AND jsonb_typeof(json #> '{samlConfiguration,security,tokenValidity}') = 'number'
+  AND (json #>> '{samlConfiguration,security,tokenValidity}')::numeric <= 0;

--- a/ingestion/tests/integration/containers.py
+++ b/ingestion/tests/integration/containers.py
@@ -41,6 +41,9 @@ class MySqlContainerConfigs:
 class MinioContainerConfigs:
     """MinIO Configurations"""
 
+    # testcontainers defaults to minio/minio on Docker Hub, which MinIO has deleted.
+    # The same release is still published on quay.io.
+    image: str = "quay.io/minio/minio:RELEASE.2022-12-02T19-19-22Z"
     access_key: str = "minio"
     secret_key: str = "password"
     port: int = 9000

--- a/ingestion/tests/integration/trino/conftest.py
+++ b/ingestion/tests/integration/trino/conftest.py
@@ -30,6 +30,7 @@ from metadata.generated.schema.entity.services.databaseService import (
 )
 
 from ..conftest import ingestion_config as base_ingestion_config  # noqa: F401, TID252
+from ..containers import MinioContainerConfigs  # noqa: TID252
 
 HIVE_METASTORE_IMAGE = (
     "bitsondatadev/hive-metastore@sha256:b44a186b6dcffafc6a72327aaa5912a5824feecb50718aaf661727ff6aef011b"
@@ -194,7 +195,7 @@ def hive_metastore_container(mysql_container, minio_container, docker_network):
 
 @pytest.fixture(scope="package")
 def minio_container(docker_network):
-    container = MinioContainer().with_network(docker_network).with_network_aliases("minio")
+    container = MinioContainer(MinioContainerConfigs.image).with_network(docker_network).with_network_aliases("minio")
     with try_bind(container, container.port, container.port) as minio:
         client = minio.get_client()
         client.make_bucket("hive-warehouse")

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/bootstrap/TestSuiteBootstrap.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/bootstrap/TestSuiteBootstrap.java
@@ -953,9 +953,11 @@ public class TestSuiteBootstrap implements LauncherSessionListener {
     }
     LOG.info("Starting MinIO Testcontainer on-demand...");
     // Pin the MinIO image to a known-good release so a newly-published :latest tag
-    // cannot break integration tests without a code change.
+    // cannot break integration tests without a code change. Pull from quay.io: MinIO
+    // deleted the minio/minio repository from Docker Hub, and Docker Hub reports a
+    // removed repository as "pull access denied ... may require 'docker login'".
     MINIO_CONTAINER =
-        new GenericContainer<>("minio/minio:RELEASE.2024-01-16T16-07-38Z")
+        new GenericContainer<>("quay.io/minio/minio:RELEASE.2024-01-16T16-07-38Z")
             .withExposedPorts(9000)
             .withEnv("MINIO_ROOT_USER", "minio")
             .withEnv("MINIO_ROOT_PASSWORD", "minio123")

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
@@ -41,6 +41,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
 import org.openmetadata.api.configuration.UiThemePreference;
 import org.openmetadata.catalog.security.client.SamlSSOClientConfig;
+import org.openmetadata.catalog.type.SamlSecurityConfig;
 import org.openmetadata.schema.api.configuration.LogStorageConfiguration;
 import org.openmetadata.schema.api.configuration.OpenMetadataBaseUrlConfiguration;
 import org.openmetadata.schema.api.search.SearchSettings;
@@ -90,6 +91,7 @@ import org.openmetadata.service.attachments.NoOpAssetService;
 import org.openmetadata.service.clients.llm.LlmConfigHolder;
 import org.openmetadata.service.config.ObjectStorageConfiguration;
 import org.openmetadata.service.events.scheduled.ServicesStatusJobHandler;
+import org.openmetadata.service.exception.BadRequestException;
 import org.openmetadata.service.exception.CustomExceptionMessage;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.exception.PreconditionFailedException;
@@ -112,6 +114,7 @@ import org.openmetadata.service.security.AuthenticationCodeFlowHandler;
 import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.security.JwtFilter;
 import org.openmetadata.service.security.SecurityUtil;
+import org.openmetadata.service.security.TokenValidityResolver;
 import org.openmetadata.service.security.auth.LoginAttemptCache;
 import org.openmetadata.service.security.auth.validator.Auth0Validator;
 import org.openmetadata.service.security.auth.validator.AzureAuthValidator;
@@ -316,6 +319,8 @@ public class SystemRepository {
 
     try {
       updateSetting(setting);
+    } catch (BadRequestException ex) {
+      throw ex;
     } catch (Exception ex) {
       LOG.error(FAILED_TO_UPDATE_SETTINGS, ex.getMessage());
       return Response.status(500, INTERNAL_SERVER_ERROR_WITH_REASON + ex.getMessage()).build();
@@ -332,6 +337,8 @@ public class SystemRepository {
   public Response createNewSetting(Settings setting) {
     try {
       updateSetting(setting);
+    } catch (BadRequestException ex) {
+      throw ex;
     } catch (Exception ex) {
       LOG.error(FAILED_TO_UPDATE_SETTINGS, ex.getMessage());
       return Response.status(500, INTERNAL_SERVER_ERROR_WITH_REASON + ex.getMessage()).build();
@@ -445,6 +452,8 @@ public class SystemRepository {
       String updatedJson = prepareSettingForUpdate(setting);
       dao.insertSettings(setting.getConfigType().toString(), updatedJson);
       settingUpdated(setting.getConfigType());
+    } catch (BadRequestException ex) {
+      throw ex;
     } catch (Exception ex) {
       LOG.error("Failing in Updating Setting.", ex);
       throw new CustomExceptionMessage(
@@ -465,7 +474,7 @@ public class SystemRepository {
             "Setting changed while the JSON Patch was being applied");
       }
       settingUpdated(setting.getConfigType());
-    } catch (PreconditionFailedException ex) {
+    } catch (BadRequestException | PreconditionFailedException ex) {
       throw ex;
     } catch (Exception ex) {
       LOG.error("Failing in Updating Setting.", ex);
@@ -512,6 +521,7 @@ public class SystemRepository {
     } else if (setting.getConfigType() == SettingsType.AUTHENTICATION_CONFIGURATION) {
       AuthenticationConfiguration authConfig =
           JsonUtils.convertValue(setting.getConfigValue(), AuthenticationConfiguration.class);
+      rejectInvalidTokenValidity(authConfig);
       setting.setConfigValue(authConfig);
     } else if (setting.getConfigType() == SettingsType.AUTHORIZER_CONFIGURATION) {
       AuthorizerConfiguration authorizerConfig =
@@ -520,6 +530,24 @@ public class SystemRepository {
       setting.setConfigValue(authorizerConfig);
     }
     return JsonUtils.pojoToJson(setting.getConfigValue());
+  }
+
+  /**
+   * OpenMetadata signs its own JWT after both OIDC and SAML logins, so a non-positive validity on
+   * either path mints tokens that expire the instant they are issued and locks every user out.
+   */
+  private void rejectInvalidTokenValidity(AuthenticationConfiguration authConfig) {
+    OidcClientConfig oidcConfig = authConfig.getOidcConfiguration();
+    if (oidcConfig != null
+        && TokenValidityResolver.isConfiguredInvalid(oidcConfig.getTokenValidity())) {
+      throw new BadRequestException(TokenValidityResolver.VALIDATION_MESSAGE);
+    }
+    SamlSSOClientConfig samlConfig = authConfig.getSamlConfiguration();
+    SamlSecurityConfig samlSecurity = samlConfig == null ? null : samlConfig.getSecurity();
+    if (samlSecurity != null
+        && TokenValidityResolver.isConfiguredInvalid(samlSecurity.getTokenValidity())) {
+      throw new BadRequestException(TokenValidityResolver.VALIDATION_MESSAGE);
+    }
   }
 
   private void settingUpdated(SettingsType settingsType) {
@@ -1658,13 +1686,18 @@ public class SystemRepository {
   private FieldError validateOidcConfiguration(
       AuthenticationConfiguration authConfig, AuthorizerConfiguration authzConfig) {
     try {
+      OidcClientConfig oidcConfig = authConfig.getOidcConfiguration();
+      FieldError tokenValidityError = validateOidcTokenValidity(oidcConfig);
+      if (tokenValidityError != null) {
+        return tokenValidityError;
+      }
+
       String clientType = String.valueOf(authConfig.getClientType()).toLowerCase();
       if ("confidential".equals(clientType)) {
-        if (authConfig.getOidcConfiguration() == null) {
+        if (oidcConfig == null) {
           return ValidationErrorBuilder.createFieldError(
               FieldPaths.OIDC_CLIENT_ID, "OIDC configuration is required");
         }
-        OidcClientConfig oidcConfig = authConfig.getOidcConfiguration();
 
         if (nullOrEmpty(oidcConfig.getId())) {
           return ValidationErrorBuilder.createFieldError(
@@ -1776,6 +1809,27 @@ public class SystemRepository {
     } catch (Exception e) {
       return ValidationErrorBuilder.createFieldError("", e.getMessage());
     }
+  }
+
+  @VisibleForTesting
+  static FieldError validateOidcTokenValidity(OidcClientConfig oidcConfig) {
+    if (oidcConfig != null
+        && TokenValidityResolver.isConfiguredInvalid(oidcConfig.getTokenValidity())) {
+      return ValidationErrorBuilder.createFieldError(
+          FieldPaths.OIDC_TOKEN_VALIDITY, TokenValidityResolver.VALIDATION_MESSAGE);
+    }
+    return null;
+  }
+
+  @VisibleForTesting
+  static FieldError validateSamlTokenValidity(SamlSSOClientConfig samlConfig) {
+    SamlSecurityConfig samlSecurity = samlConfig == null ? null : samlConfig.getSecurity();
+    if (samlSecurity != null
+        && TokenValidityResolver.isConfiguredInvalid(samlSecurity.getTokenValidity())) {
+      return ValidationErrorBuilder.createFieldError(
+          FieldPaths.SAML_SECURITY_TOKEN_VALIDITY, TokenValidityResolver.VALIDATION_MESSAGE);
+    }
+    return null;
   }
 
   /**
@@ -2203,6 +2257,10 @@ public class SystemRepository {
   private FieldError validateSamlConfiguration(
       SamlSSOClientConfig samlConfig, OpenMetadataApplicationConfig applicationConfig) {
     try {
+      FieldError tokenValidityError = validateSamlTokenValidity(samlConfig);
+      if (tokenValidityError != null) {
+        return tokenValidityError;
+      }
       // Use enhanced SAML validator - this performs comprehensive validation
       // without affecting production settings
       SamlValidator samlValidator = new SamlValidator();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
@@ -257,7 +257,14 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
     validatePrincipalClaimsMapping(claimsMapping);
     this.teamClaimMapping = authenticationConfiguration.getJwtTeamClaimMapping();
     this.principalDomain = authorizerConfiguration.getPrincipalDomain();
-    this.tokenValidity = authenticationConfiguration.getOidcConfiguration().getTokenValidity();
+    Integer configuredTokenValidity =
+        authenticationConfiguration.getOidcConfiguration().getTokenValidity();
+    if (!TokenValidityResolver.isValid(configuredTokenValidity)) {
+      LOG.warn(
+          "OIDC token validity must be positive; using the {} second default",
+          TokenValidityResolver.DEFAULT_TOKEN_VALIDITY_SECONDS);
+    }
+    this.tokenValidity = TokenValidityResolver.resolveOrDefault(configuredTokenValidity);
     this.maxAge = authenticationConfiguration.getOidcConfiguration().getMaxAge();
     this.promptType = authenticationConfiguration.getOidcConfiguration().getPrompt();
     this.clientAuthentication = getClientAuthentication(client.getConfiguration());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/TokenValidityResolver.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/TokenValidityResolver.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.security;
+
+/**
+ * Resolves the lifetime of the JWT that OpenMetadata issues for itself after an SSO login. Both the
+ * OIDC and SAML configurations persist this as a user-editable value, and a non-positive one mints
+ * tokens whose expiry equals their issue time, so every request 401s and the client refreshes
+ * forever. Mirrors {@link org.openmetadata.service.security.session.SessionTimeoutResolver}, which
+ * guards the sibling sessionExpiry setting the same way.
+ */
+public final class TokenValidityResolver {
+  public static final int DEFAULT_TOKEN_VALIDITY_SECONDS = 3600;
+  public static final int MIN_TOKEN_VALIDITY_SECONDS = 1;
+  public static final String VALIDATION_MESSAGE = "Token validity must be at least 1 second";
+
+  private TokenValidityResolver() {}
+
+  public static boolean isValid(Integer validitySeconds) {
+    return validitySeconds != null && validitySeconds >= MIN_TOKEN_VALIDITY_SECONDS;
+  }
+
+  /**
+   * Whether a persisted value should be rejected on write. An absent value is accepted because the
+   * schema default applies and {@link #resolveOrDefault} covers it at runtime; only an explicitly
+   * configured non-positive value is a configuration error.
+   */
+  public static boolean isConfiguredInvalid(Integer validitySeconds) {
+    return validitySeconds != null && validitySeconds < MIN_TOKEN_VALIDITY_SECONDS;
+  }
+
+  public static int resolveOrDefault(Integer validitySeconds) {
+    return isValid(validitySeconds) ? validitySeconds : DEFAULT_TOKEN_VALIDITY_SECONDS;
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/saml/SamlSettingsHolder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/saml/SamlSettingsHolder.java
@@ -31,6 +31,7 @@ import org.openmetadata.common.utils.CommonUtil;
 import org.openmetadata.schema.api.security.AuthenticationConfiguration;
 import org.openmetadata.schema.api.security.AuthorizerConfiguration;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
+import org.openmetadata.service.security.TokenValidityResolver;
 import org.openmetadata.service.security.auth.SecurityConfigurationManager;
 
 @Slf4j
@@ -161,7 +162,7 @@ public class SamlSettingsHolder {
 
       if (authConfig == null) {
         LOG.error("AuthenticationConfiguration is null in getTokenValidity()");
-        return 3600; // Default fallback
+        return TokenValidityResolver.DEFAULT_TOKEN_VALIDITY_SECONDS;
       }
 
       SamlSSOClientConfig samlConfig = authConfig.getSamlConfiguration();
@@ -169,7 +170,7 @@ public class SamlSettingsHolder {
 
       if (samlConfig == null) {
         LOG.error("SamlConfiguration is null in getTokenValidity()");
-        return 3600; // Default fallback
+        return TokenValidityResolver.DEFAULT_TOKEN_VALIDITY_SECONDS;
       }
 
       SamlSecurityConfig securityConfig = samlConfig.getSecurity();
@@ -178,16 +179,20 @@ public class SamlSettingsHolder {
       if (securityConfig == null) {
         LOG.error(
             "SAML SecurityConfig is null in getTokenValidity() - this should not happen if config is in DB");
-        return 3600; // Default fallback
+        return TokenValidityResolver.DEFAULT_TOKEN_VALIDITY_SECONDS;
       }
 
-      long tokenValidity = securityConfig.getTokenValidity();
-      LOG.debug("Retrieved token validity: {}", tokenValidity);
-      return tokenValidity;
+      Integer configuredTokenValidity = securityConfig.getTokenValidity();
+      if (!TokenValidityResolver.isValid(configuredTokenValidity)) {
+        LOG.warn(
+            "SAML token validity must be positive; using the {} second default",
+            TokenValidityResolver.DEFAULT_TOKEN_VALIDITY_SECONDS);
+      }
+      return TokenValidityResolver.resolveOrDefault(configuredTokenValidity);
 
     } catch (Exception e) {
       LOG.error("Error retrieving token validity dynamically", e);
-      return 3600; // Default fallback
+      return TokenValidityResolver.DEFAULT_TOKEN_VALIDITY_SECONDS;
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/ValidationErrorBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/ValidationErrorBuilder.java
@@ -34,6 +34,8 @@ public class ValidationErrorBuilder {
     public static final String OIDC_SERVER_URL =
         "authenticationConfiguration.oidcConfiguration.serverUrl";
     public static final String OIDC_SCOPE = "authenticationConfiguration.oidcConfiguration.scope";
+    public static final String OIDC_TOKEN_VALIDITY =
+        "authenticationConfiguration.oidcConfiguration.tokenValidity";
     public static final String OIDC_CALLBACK_URL =
         "authenticationConfiguration.oidcConfiguration.callbackUrl";
     public static final String OIDC_TENANT = "authenticationConfiguration.oidcConfiguration.tenant";
@@ -90,6 +92,8 @@ public class ValidationErrorBuilder {
         "authenticationConfiguration.samlConfiguration.sp.spPrivateKey";
     public static final String SAML_SP_CALLBACK =
         "authenticationConfiguration.samlConfiguration.sp.callback";
+    public static final String SAML_SECURITY_TOKEN_VALIDITY =
+        "authenticationConfiguration.samlConfiguration.security.tokenValidity";
     public static final String SAML_SECURITY_AUTHN_SIGNED =
         "authenticationConfiguration.samlConfiguration.security.wantAuthnRequestsSigned";
     public static final String SAML_SECURITY_ASSERTIONS_SIGNED =

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/SystemRepositoryPatchSettingTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/SystemRepositoryPatchSettingTest.java
@@ -19,12 +19,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
+import org.openmetadata.schema.api.security.AuthenticationConfiguration;
 import org.openmetadata.schema.configuration.GlossaryTermRelationSettings;
 import org.openmetadata.schema.email.SmtpSettings;
+import org.openmetadata.schema.security.client.OidcClientConfig;
 import org.openmetadata.schema.settings.Settings;
 import org.openmetadata.schema.settings.SettingsType;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
+import org.openmetadata.service.exception.BadRequestException;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.exception.PreconditionFailedException;
 import org.openmetadata.service.exception.SystemSettingsException;
@@ -32,6 +35,7 @@ import org.openmetadata.service.jdbi3.CollectionDAO.SystemDAO;
 import org.openmetadata.service.migration.MigrationValidationClient;
 import org.openmetadata.service.resources.settings.SettingsCache;
 import org.openmetadata.service.secrets.masker.PasswordEntityMasker;
+import org.openmetadata.service.security.TokenValidityResolver;
 
 class SystemRepositoryPatchSettingTest {
   private static final String SETTING_NAME = SettingsType.GLOSSARY_TERM_RELATION_SETTINGS.value();
@@ -274,6 +278,24 @@ class SystemRepositoryPatchSettingTest {
     Settings responseSettings = (Settings) response.getEntity();
     SmtpSettings responseConfig = (SmtpSettings) responseSettings.getConfigValue();
     assertEquals(PasswordEntityMasker.PASSWORD_MASK, responseConfig.getPassword());
+  }
+
+  @Test
+  void putAuthenticationSettingRejectsInvalidOidcTokenValidityAsBadRequest() {
+    Settings update =
+        new Settings()
+            .withConfigType(SettingsType.AUTHENTICATION_CONFIGURATION)
+            .withConfigValue(
+                new AuthenticationConfiguration()
+                    .withOidcConfiguration(new OidcClientConfig().withTokenValidity(0)));
+
+    BadRequestException failure =
+        assertThrows(BadRequestException.class, () -> systemRepository.createOrUpdate(update));
+
+    assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), failure.getResponse().getStatus());
+    assertEquals(TokenValidityResolver.VALIDATION_MESSAGE, failure.getMessage());
+    verify(systemDAO, never()).insertSettings(anyString(), anyString());
+    settingsCacheMock.verifyNoInteractions();
   }
 
   private JsonPatch appendRelationTypePatch() {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/SystemRepositoryTokenValidityTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/SystemRepositoryTokenValidityTest.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import org.openmetadata.catalog.security.client.SamlSSOClientConfig;
+import org.openmetadata.catalog.type.SamlSecurityConfig;
+import org.openmetadata.schema.security.client.OidcClientConfig;
+import org.openmetadata.schema.system.FieldError;
+import org.openmetadata.service.security.TokenValidityResolver;
+import org.openmetadata.service.util.ValidationErrorBuilder.FieldPaths;
+
+class SystemRepositoryTokenValidityTest {
+
+  @Test
+  void reportsZeroOidcValidityAsAFieldValidationError() {
+    FieldError error =
+        SystemRepository.validateOidcTokenValidity(new OidcClientConfig().withTokenValidity(0));
+
+    assertEquals(FieldPaths.OIDC_TOKEN_VALIDITY, error.getField());
+    assertEquals(TokenValidityResolver.VALIDATION_MESSAGE, error.getError());
+  }
+
+  @Test
+  void reportsZeroSamlValidityAsAFieldValidationError() {
+    FieldError error = SystemRepository.validateSamlTokenValidity(samlConfigWithValidity(0));
+
+    assertEquals(FieldPaths.SAML_SECURITY_TOKEN_VALIDITY, error.getField());
+    assertEquals(TokenValidityResolver.VALIDATION_MESSAGE, error.getError());
+  }
+
+  @Test
+  void acceptsPositiveValidityAndAbsentOptionalConfiguration() {
+    assertNull(
+        SystemRepository.validateOidcTokenValidity(new OidcClientConfig().withTokenValidity(3600)));
+    assertNull(SystemRepository.validateOidcTokenValidity(null));
+    assertNull(SystemRepository.validateSamlTokenValidity(samlConfigWithValidity(3600)));
+    assertNull(SystemRepository.validateSamlTokenValidity(new SamlSSOClientConfig()));
+    assertNull(SystemRepository.validateSamlTokenValidity(null));
+  }
+
+  /**
+   * A configuration that simply omits the field must stay saveable: the schema default applies and
+   * the runtime resolver covers it. Rejecting an absent value would break every existing config.
+   */
+  @Test
+  void acceptsAnOmittedValidityForBothProviders() {
+    assertNull(SystemRepository.validateOidcTokenValidity(new OidcClientConfig()));
+    assertNull(SystemRepository.validateSamlTokenValidity(samlConfigWithValidity(null)));
+  }
+
+  private SamlSSOClientConfig samlConfigWithValidity(Integer tokenValidity) {
+    return new SamlSSOClientConfig()
+        .withSecurity(new SamlSecurityConfig().withTokenValidity(tokenValidity));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v202/TokenValiditySqlMigrationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v202/TokenValiditySqlMigrationTest.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.migration.utils.v202;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Static guard over the 2.0.2 data repair. It does not execute SQL — replay behaviour against real
+ * MySQL and PostgreSQL is covered manually — but it does fail if either provider path is dropped,
+ * which is the regression that would silently leave upgraded tenants locked out.
+ */
+class TokenValiditySqlMigrationTest {
+
+  @ParameterizedTest
+  @ValueSource(strings = {"mysql", "postgres"})
+  void repairsNonPositiveTokenValidityForBothProviders(String dialect) throws IOException {
+    String sql = readPostDataMigration(dialect);
+
+    assertTrue(sql.contains("openmetadata_settings"));
+    assertTrue(sql.contains("authenticationconfiguration"));
+    assertTrue(sql.contains("3600"));
+    assertTrue(sql.contains("oidcconfiguration"), "missing the OIDC repair");
+    assertTrue(sql.contains("samlconfiguration"), "missing the SAML repair");
+  }
+
+  /** The guard is what makes a replay a no-op, so every repair statement must carry it. */
+  @ParameterizedTest
+  @ValueSource(strings = {"mysql", "postgres"})
+  void everyRepairIsGuardedSoReplayIsANoOp(String dialect) throws IOException {
+    String sql = readPostDataMigration(dialect);
+
+    assertEquals(2, countOccurrences(sql, "update openmetadata_settings"));
+    assertEquals(2, countOccurrences(sql, "<= 0"));
+  }
+
+  private String readPostDataMigration(String dialect) throws IOException {
+    return Files.readString(
+            migrationRoot().resolve(dialect).resolve("postDataMigrationSQLScript.sql"))
+        .toLowerCase(Locale.ROOT);
+  }
+
+  private int countOccurrences(String sql, String token) {
+    int count = 0;
+    int index = sql.indexOf(token);
+    while (index >= 0) {
+      count++;
+      index = sql.indexOf(token, index + token.length());
+    }
+    return count;
+  }
+
+  private static Path migrationRoot() {
+    Path current = Path.of("").toAbsolutePath();
+    while (current != null && !Files.exists(current.resolve("bootstrap/sql/schema/mysql.sql"))) {
+      current = current.getParent();
+    }
+    if (current == null) {
+      throw new IllegalStateException("Unable to locate the OpenMetadata repository root");
+    }
+    return current.resolve("bootstrap/sql/migrations/native/2.0.2");
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/TokenValidityResolverTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/TokenValidityResolverTest.java
@@ -1,0 +1,88 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.catalog.type.SamlSecurityConfig;
+import org.openmetadata.schema.security.client.OidcClientConfig;
+
+class TokenValidityResolverTest {
+  private static final Validator VALIDATOR =
+      Validation.buildDefaultValidatorFactory().getValidator();
+
+  @Test
+  void schemaAndRuntimeDefaultsStayAlignedForBothProviders() {
+    assertEquals(
+        new OidcClientConfig().getTokenValidity(),
+        TokenValidityResolver.DEFAULT_TOKEN_VALIDITY_SECONDS);
+    assertEquals(
+        new SamlSecurityConfig().getTokenValidity(),
+        TokenValidityResolver.DEFAULT_TOKEN_VALIDITY_SECONDS);
+  }
+
+  @Test
+  void invalidValuesResolveToTheDefault() {
+    assertEquals(
+        TokenValidityResolver.DEFAULT_TOKEN_VALIDITY_SECONDS,
+        TokenValidityResolver.resolveOrDefault(null));
+    assertEquals(
+        TokenValidityResolver.DEFAULT_TOKEN_VALIDITY_SECONDS,
+        TokenValidityResolver.resolveOrDefault(0));
+    assertEquals(
+        TokenValidityResolver.DEFAULT_TOKEN_VALIDITY_SECONDS,
+        TokenValidityResolver.resolveOrDefault(-1));
+  }
+
+  @Test
+  void positiveValuesArePreserved() {
+    assertTrue(TokenValidityResolver.isValid(1));
+    assertEquals(900, TokenValidityResolver.resolveOrDefault(900));
+  }
+
+  @Test
+  void zeroAndNegativeValuesAreRejected() {
+    assertFalse(TokenValidityResolver.isValid(null));
+    assertFalse(TokenValidityResolver.isValid(0));
+    assertFalse(TokenValidityResolver.isValid(-1));
+  }
+
+  /**
+   * An omitted value must remain saveable — the schema default covers it and the runtime falls back
+   * — while an explicitly configured non-positive value is a configuration error.
+   */
+  @Test
+  void onlyExplicitNonPositiveValuesAreRejectedOnWrite() {
+    assertFalse(TokenValidityResolver.isConfiguredInvalid(null));
+    assertFalse(TokenValidityResolver.isConfiguredInvalid(1));
+    assertFalse(TokenValidityResolver.isConfiguredInvalid(3600));
+    assertTrue(TokenValidityResolver.isConfiguredInvalid(0));
+    assertTrue(TokenValidityResolver.isConfiguredInvalid(-1));
+  }
+
+  @Test
+  void generatedSchemaConstraintRejectsZeroForBothProviders() {
+    assertTrue(hasTokenValidityViolation(new OidcClientConfig().withTokenValidity(0)));
+    assertTrue(hasTokenValidityViolation(new SamlSecurityConfig().withTokenValidity(0)));
+  }
+
+  private boolean hasTokenValidityViolation(Object config) {
+    return VALIDATOR.validate(config).stream()
+        .anyMatch(violation -> "tokenValidity".equals(violation.getPropertyPath().toString()));
+  }
+}

--- a/openmetadata-spec/src/main/resources/json/schema/security/client/oidcClientConfig.json
+++ b/openmetadata-spec/src/main/resources/json/schema/security/client/oidcClientConfig.json
@@ -63,9 +63,10 @@
       ]
     },
     "tokenValidity": {
-      "description": "Validity for the JWT Token created from SAML Response",
+      "description": "Lifetime in seconds of the OpenMetadata JWT issued after OIDC authentication.",
       "type": "integer",
-      "default": "3600"
+      "default": 3600,
+      "minimum": 1
     },
     "customParams": {
       "description": "Custom Params.",
@@ -95,7 +96,8 @@
     "sessionExpiry": {
       "description": "Validity for the Session in case of confidential clients",
       "type": "integer",
-      "default": "604800"
+      "default": 604800,
+      "minimum": 3600
     }
   },
   "required": ["id", "secret", "discoveryUri", "tenant"],

--- a/openmetadata-spec/src/main/resources/json/schema/security/client/samlSSOClientConfig.json
+++ b/openmetadata-spec/src/main/resources/json/schema/security/client/samlSSOClientConfig.json
@@ -85,9 +85,10 @@
           "default": false
         },
         "tokenValidity": {
-          "description": "Validity for the JWT Token created from SAML Response",
+          "description": "Lifetime in seconds of the OpenMetadata JWT issued after SAML authentication.",
           "type": "integer",
-          "default": "3600"
+          "default": 3600,
+          "minimum": 1
         },
         "sendEncryptedNameId": {
           "description": "Encrypt Name Id while sending requests from SP.",

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SSOConfiguration.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SSOConfiguration.spec.ts
@@ -121,6 +121,7 @@ test.describe('SSO Configuration Tests', () => {
       await verifyProviderFields(page, SSO_COMMON_FIELDS);
 
       // Verify OIDC specific fields with OIDC prefix in labels
+      await page.getByText(/advanced config/i).click();
 
       for (const field of OIDC_COMMON_FIELDS) {
         const fieldElement = page.getByLabel(field);
@@ -147,6 +148,8 @@ test.describe('SSO Configuration Tests', () => {
       await verifyProviderFields(page, SSO_COMMON_FIELDS);
 
       // Verify OIDC specific fields with OIDC prefix in labels
+      await page.getByText(/advanced config/i).click();
+
       const oidcFields = [...OIDC_COMMON_FIELDS, 'OIDC Tenant'];
 
       for (const field of oidcFields) {
@@ -174,6 +177,8 @@ test.describe('SSO Configuration Tests', () => {
       await verifyProviderFields(page, SSO_COMMON_FIELDS);
 
       // Verify OIDC specific fields with OIDC prefix in labels
+      await page.getByText(/advanced config/i).click();
+
       const oidcFields = [...OIDC_COMMON_FIELDS, 'OIDC Tenant'];
 
       for (const field of oidcFields) {

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/SSO/auth0SSOClientConfig.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/SSO/auth0SSOClientConfig.md
@@ -216,12 +216,14 @@ $$section
 $$
 
 $$section
-### OIDC Token Validity $(id="tokenValidity")
+### OpenMetadata Access Token Validity $(id="tokenValidity")
 
-- **Definition:** How long (in seconds) the issued tokens remain valid.
-- **Default:** 0 (use provider default)
+- **Definition:** How long (in seconds) the OpenMetadata access JWT remains valid.
+- **Default:** 3600 (1 hour)
+- **Minimum:** 1 second
 - **Example:** 3600 (1 hour)
-- **Why it matters:** Controls token lifetime and security vs usability balance.
+- **Why it matters:** Controls the lifetime of the token used for OpenMetadata API requests.
+- **Note:** This value is not inherited from the Auth0 token lifetime.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/SSO/aws-cognito.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/SSO/aws-cognito.md
@@ -145,13 +145,14 @@ $$section
 $$
 
 $$section
-## OIDC Token Validity $(id="tokenValidity")
+## OpenMetadata Access Token Validity $(id="tokenValidity")
 
-- **Definition:** How long (in seconds) the issued tokens remain valid.
-- **Default:** 0 (use provider default)
+- **Definition:** How long (in seconds) the OpenMetadata access JWT remains valid.
+- **Default:** 3600 (1 hour)
+- **Minimum:** 1 second
 - **Example:** 3600 (1 hour)
-- **Why it matters:** Controls token lifetime and security vs usability balance.
-- **Note:** Use 0 to inherit Cognito's default token lifetime settings
+- **Why it matters:** Controls the lifetime of the token used for OpenMetadata API requests.
+- **Note:** This value is not inherited from the Cognito token lifetime.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/SSO/awsCognitoSSOClientConfig.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/SSO/awsCognitoSSOClientConfig.md
@@ -135,13 +135,14 @@ $$section
 $$
 
 $$section
-## OIDC Token Validity $(id="tokenValidity")
+## OpenMetadata Access Token Validity $(id="tokenValidity")
 
-- **Definition:** How long (in seconds) the issued tokens remain valid.
-- **Default:** 0 (use provider default)
+- **Definition:** How long (in seconds) the OpenMetadata access JWT remains valid.
+- **Default:** 3600 (1 hour)
+- **Minimum:** 1 second
 - **Example:** 3600 (1 hour)
-- **Why it matters:** Controls token lifetime and security vs usability balance.
-- **Note:** Use 0 to inherit Cognito's default token lifetime settings
+- **Why it matters:** Controls the lifetime of the token used for OpenMetadata API requests.
+- **Note:** This value is not inherited from the Cognito token lifetime.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/SSO/azureSSOClientConfig.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/SSO/azureSSOClientConfig.md
@@ -216,12 +216,14 @@ $$section
 $$
 
 $$section
-### OIDC Token Validity $(id="tokenValidity")
+### OpenMetadata Access Token Validity $(id="tokenValidity")
 
-- **Definition:** How long (in seconds) the issued tokens remain valid.
-- **Default:** 0 (use provider default)
+- **Definition:** How long (in seconds) the OpenMetadata access JWT remains valid.
+- **Default:** 3600 (1 hour)
+- **Minimum:** 1 second
 - **Example:** 3600 (1 hour)
-- **Why it matters:** Controls token lifetime and security vs usability balance.
+- **Why it matters:** Controls the lifetime of the token used for OpenMetadata API requests.
+- **Note:** This value is not inherited from the Azure token lifetime.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/SSO/googleSSOClientConfig.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/SSO/googleSSOClientConfig.md
@@ -233,12 +233,14 @@ $$section
 $$
 
 $$section
-### OIDC Token Validity $(id="tokenValidity")
+### OpenMetadata Access Token Validity $(id="tokenValidity")
 
-- **Definition:** How long (in seconds) the issued tokens remain valid.
-- **Default:** 0 (use provider default)
+- **Definition:** How long (in seconds) the OpenMetadata access JWT remains valid.
+- **Default:** 3600 (1 hour)
+- **Minimum:** 1 second
 - **Example:** 3600 (1 hour)
-- **Why it matters:** Controls token lifetime and security vs usability balance.
+- **Why it matters:** Controls the lifetime of the token used for OpenMetadata API requests.
+- **Note:** This value is not inherited from the Google token lifetime.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/SSO/oktaSSOClientConfig.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/SSO/oktaSSOClientConfig.md
@@ -213,13 +213,14 @@ $$section
 $$
 
 $$section
-### OIDC Token Validity $(id="tokenValidity")
+### OpenMetadata Access Token Validity $(id="tokenValidity")
 
-- **Definition:** How long (in seconds) the issued tokens remain valid.
-- **Default:** 0 (use provider default)
+- **Definition:** How long (in seconds) the OpenMetadata access JWT remains valid.
+- **Default:** 3600 (1 hour)
+- **Minimum:** 1 second
 - **Example:** 3600 (1 hour)
-- **Why it matters:** Controls token lifetime and security vs usability balance.
-- **Note:** Use 0 to inherit Okta's default token lifetime
+- **Why it matters:** Controls the lifetime of the token used for OpenMetadata API requests.
+- **Note:** This value is not inherited from the Okta token lifetime.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/SSO/samlSSOClientConfig.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/SSO/samlSSOClientConfig.md
@@ -145,6 +145,7 @@ $$section
 
 - **Definition:** Validity period (in seconds) for JWT tokens created from SAML response.
 - **Default:** 3600 (1 hour)
+- **Minimum:** 1 second
 - **Example:** 7200 (2 hours)
 - **Why it matters:** Controls how long users stay logged in after SAML authentication.
 - **Note:** This controls the OpenMetadata JWT token lifetime, not the SAML assertion lifetime

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.test.tsx
@@ -601,6 +601,52 @@ describe('Test axios response interceptor', () => {
     expect(mockAxios).toHaveBeenCalledWith(mockError.config);
     expect(result).toEqual({ data: 'ok' });
   });
+
+  // A non-positive configured token validity mints a JWT whose exp equals its iat, so
+  // /auth/refresh answers 200 with a token that is already dead. Retrying it 401s and
+  // drives another refresh: the UI spun forever with no error. Fail the cycle instead.
+  it('should not retry when the refreshed token is already expired', async () => {
+    const mockUse = jest.spyOn(axiosClient.interceptors.response, 'use');
+    const mockAxios = jest.fn().mockResolvedValue({ data: 'retried' });
+
+    jest.spyOn(axiosClient, 'request').mockImplementation(mockAxios);
+    mockRefreshToken.mockReset();
+    mockRefreshToken.mockResolvedValue('deadOnArrivalToken');
+    mockExtractDetailsFromToken.mockReturnValue({
+      exp: 1789075036,
+      isExpired: true,
+      timeoutExpiry: 0,
+    });
+
+    await act(async () => {
+      render(<WrapperComponent />);
+    });
+
+    const [, errorHandler] = mockUse.mock.calls[0];
+    const mockError = {
+      response: {
+        status: 401,
+        data: { message: 'Expired token!' },
+      },
+      config: {
+        url: '/tables/name/foo',
+        headers: {},
+        baseURL: '',
+      },
+    };
+
+    await expect(errorHandler?.(mockError)).rejects.toBe(mockError);
+
+    // One refresh attempt, no retry with the dead token, and no second cycle.
+    expect(mockRefreshToken).toHaveBeenCalledTimes(1);
+    expect(mockAxios).not.toHaveBeenCalled();
+
+    mockExtractDetailsFromToken.mockReturnValue({
+      exp: 0,
+      isExpired: true,
+      timeoutExpiry: 0,
+    });
+  });
 });
 
 // Regression tests for the visibility handler. Before this branch every

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.test.tsx
@@ -647,6 +647,61 @@ describe('Test axios response interceptor', () => {
       timeoutExpiry: 0,
     });
   });
+
+  it('should not reset opaque-token refresh cycles for unrelated successful responses', async () => {
+    const mockUse = jest.spyOn(axiosClient.interceptors.response, 'use');
+    const mockAxios = jest.fn().mockResolvedValue({ data: 'recovered' });
+
+    jest.spyOn(axiosClient, 'request').mockImplementation(mockAxios);
+    mockRefreshToken.mockReset();
+    mockRefreshToken.mockResolvedValue('opaqueToken');
+    mockExtractDetailsFromToken.mockReturnValue({
+      exp: undefined,
+      isExpired: false,
+      timeoutExpiry: 0,
+    });
+
+    await act(async () => {
+      render(<WrapperComponent />);
+    });
+
+    const [successHandler, errorHandler] = mockUse.mock.calls[0];
+    const mockError = {
+      response: {
+        status: 401,
+        data: { message: 'Expired token!' },
+      },
+      config: {
+        url: '/tables/name/foo',
+        headers: {},
+        baseURL: '',
+      },
+    };
+
+    // Establish a recovered cycle so this assertion does not depend on module state
+    // left by an earlier test or login attempt.
+    await expect(errorHandler?.(mockError)).resolves.toEqual({
+      data: 'recovered',
+    });
+
+    mockAxios.mockClear();
+    mockRefreshToken.mockClear();
+
+    let retryAttempts = 0;
+    mockAxios.mockImplementation(() => {
+      successHandler?.({ data: 'unrelated' } as AxiosResponse);
+      retryAttempts += 1;
+
+      return retryAttempts < 4
+        ? errorHandler?.(mockError)
+        : Promise.reject(mockError);
+    });
+
+    await expect(errorHandler?.(mockError)).rejects.toBe(mockError);
+
+    expect(mockRefreshToken).toHaveBeenCalledTimes(3);
+    expect(mockAxios).toHaveBeenCalledTimes(3);
+  });
 });
 
 // Regression tests for the visibility handler. Before this branch every

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
@@ -793,13 +793,7 @@ export const AuthProvider = ({
 
     // Axios response interceptor for statusCode 401,403
     responseInterceptor = axiosClient.interceptors.response.use(
-      (response) => {
-        // Any non-401 response proves the current token works, so a later unrelated
-        // expiry still gets the full refresh budget.
-        consecutiveRefreshCycles = 0;
-
-        return response;
-      },
+      (response) => response,
       (error) => {
         if (error.response) {
           const { status } = error.response;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
@@ -223,6 +223,13 @@ let pendingRequests: {
 // them — the bug that hung the UI on a spinner.
 let isRefreshDriverActive = false;
 
+// A refresh can return HTTP 200 carrying a token that is ALREADY expired — a non-positive
+// configured token lifetime mints `exp == iat`. Retrying that token 401s, which drives
+// another refresh, forever, with the user staring at a spinner and nothing in the logs.
+// Bound the consecutive cycles so the failure surfaces as a logout instead.
+const MAX_CONSECUTIVE_REFRESH_CYCLES = 3;
+let consecutiveRefreshCycles = 0;
+
 type AuthContextType = {
   onLoginHandler: () => void;
   onLogoutHandler: () => void;
@@ -658,6 +665,94 @@ export const AuthProvider = ({
     }
   };
 
+  // Drain the queued 401 requests once a refresh settles — retry each with the
+  // new token, or reject them all with the original error. Hoisted to component
+  // scope so its forEach loops don't nest past the depth limit inside the
+  // response interceptor. `pendingRequests` / `isRefreshDriverActive` remain the
+  // module-level bindings so the single-driver invariant is unchanged.
+  const drainPendingRequests = (
+    hasNewToken: boolean,
+    rejectionError: unknown
+  ) => {
+    const queued = pendingRequests;
+    pendingRequests = [];
+    isRefreshDriverActive = false;
+    if (hasNewToken) {
+      queued.forEach(
+        ({ resolve: onResolve, reject: onReject, config: queuedConfig }) =>
+          axiosClient
+            .request(queuedConfig)
+            .then((response) => {
+              // The retry succeeded, so this cycle genuinely recovered the session and
+              // the loop budget starts fresh. A retry that 401s again leaves the budget
+              // spent, which is what eventually breaks a non-recovering loop.
+              consecutiveRefreshCycles = 0;
+              onResolve(response);
+            })
+            .catch(onReject)
+      );
+    } else {
+      queued.forEach(({ reject: onReject }) => onReject(rejectionError));
+    }
+  };
+
+  // A token that decodes to an expiry already in the past can never satisfy the retry, so
+  // retrying it only re-enters the refresh cycle. Requires a real `exp` claim: a token we
+  // cannot decode reports the same `isExpired` and is left to the cycle cap instead, so an
+  // opaque-token provider keeps working.
+  const isTokenAlreadyExpired = (token: unknown) => {
+    const { exp, isExpired } = extractDetailsFromToken(token as string);
+
+    return Boolean(exp) && Boolean(isExpired);
+  };
+
+  const abandonRefresh = (error: unknown) => {
+    drainPendingRequests(false, error);
+    resetUserDetails(true);
+  };
+
+  // Drives exactly one token refresh for a batch of 401s in THIS tab. Extracted
+  // from the response interceptor's Promise executor so the refresh-settled
+  // handlers no longer nest past the depth limit. `resolve` / `reject` belong to
+  // the failed request's own Promise; `error` / `config` are that request's
+  // rejection and axios config — all passed in so the closure observes exactly
+  // the values it did inline. `reinit` (the interceptor re-init) is passed in
+  // rather than referenced by name to avoid a use-before-define cycle.
+  const startTokenRefresh = (
+    resolve: (value?: unknown) => void,
+    reject: (reason?: unknown) => void,
+    error: unknown,
+    config: InternalAxiosRequestConfig<unknown>,
+    reinit: () => Promise<void>
+  ) => {
+    pendingRequests.push({ resolve, reject, config });
+    if (isRefreshDriverActive) {
+      return;
+    }
+    if (consecutiveRefreshCycles >= MAX_CONSECUTIVE_REFRESH_CYCLES) {
+      abandonRefresh(error);
+
+      return;
+    }
+    isRefreshDriverActive = true;
+    consecutiveRefreshCycles += 1;
+
+    tokenService.current
+      .refreshToken()
+      .then(async (token: unknown) => {
+        if (!token || isTokenAlreadyExpired(token)) {
+          abandonRefresh(error);
+
+          return;
+        }
+        await reinit();
+        drainPendingRequests(true, error);
+      })
+      .catch(() => {
+        abandonRefresh(error);
+      });
+  };
+
   /**
    * Initialize Axios interceptors to intercept every request and response
    * to handle appropriately. This should be called only when security is enabled.
@@ -698,7 +793,13 @@ export const AuthProvider = ({
 
     // Axios response interceptor for statusCode 401,403
     responseInterceptor = axiosClient.interceptors.response.use(
-      (response) => response,
+      (response) => {
+        // Any non-401 response proves the current token works, so a later unrelated
+        // expiry still gets the full refresh budget.
+        consecutiveRefreshCycles = 0;
+
+        return response;
+      },
       (error) => {
         if (error.response) {
           const { status } = error.response;
@@ -723,46 +824,15 @@ export const AuthProvider = ({
             // Nothing is left parked. The previous code queued behind a
             // cross-tab localStorage flag that no in-tab driver would clear,
             // hanging the request (and the UI spinner) indefinitely.
-            return new Promise((resolve, reject) => {
-              pendingRequests.push({ resolve, reject, config: error.config });
-              if (isRefreshDriverActive) {
-                return;
-              }
-              isRefreshDriverActive = true;
-
-              const drainPendingRequests = (hasNewToken: boolean) => {
-                const queued = pendingRequests;
-                pendingRequests = [];
-                isRefreshDriverActive = false;
-                if (hasNewToken) {
-                  queued.forEach(
-                    ({ resolve: onResolve, reject: onReject, config }) =>
-                      axiosClient
-                        .request(config)
-                        .then(onResolve)
-                        .catch(onReject)
-                  );
-                } else {
-                  queued.forEach(({ reject: onReject }) => onReject(error));
-                }
-              };
-
-              tokenService.current
-                .refreshToken()
-                .then(async (token) => {
-                  if (token) {
-                    await initializeAxiosInterceptors();
-                    drainPendingRequests(true);
-                  } else {
-                    drainPendingRequests(false);
-                    resetUserDetails(true);
-                  }
-                })
-                .catch(() => {
-                  drainPendingRequests(false);
-                  resetUserDetails(true);
-                });
-            });
+            return new Promise((resolve, reject) =>
+              startTokenRefresh(
+                resolve,
+                reject,
+                error,
+                error.config,
+                initializeAxiosInterceptors
+              )
+            );
           }
         }
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/SettingsSso/SSOGroupedFieldTemplate/SSOGroupedFieldTemplate.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SettingsSso/SSOGroupedFieldTemplate/SSOGroupedFieldTemplate.tsx
@@ -380,12 +380,18 @@ export const SSOGroupedFieldTemplate: FunctionComponent<
 
       {!isEmpty(advancedProperties) && (
         <Collapse
-          destroyInactivePanel
           className={classNames('sso-advanced-properties-collapse', {
             'm-t-sm': shouldApplyGrouping,
           })}
           expandIconPosition="end">
-          <Collapse.Panel header={t('label.advanced-config')} key="1">
+          {/* Advanced fields must stay mounted: transformErrors discards any error whose
+              field is absent from the DOM, so destroying the collapsed panel silently
+              swallowed both client and server validation errors for fields like
+              tokenValidity instead of surfacing them. */}
+          <Collapse.Panel
+            forceRender
+            header={t('label.advanced-config')}
+            key="1">
             <div
               className={classNames({
                 'sso-field-group-box': shouldApplyGrouping,

--- a/openmetadata-ui/src/main/resources/ui/src/constants/SSO.constant.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/SSO.constant.ts
@@ -125,7 +125,7 @@ export const COMMON_UI_FIELDS = {
   oidcClientAuthenticationMethod: {
     'ui:title': 'OIDC Client Authentication Method',
   },
-  oidcTokenValidity: { 'ui:title': 'OIDC Token Validity' },
+  oidcTokenValidity: { 'ui:title': 'OpenMetadata Access Token Validity' },
   oidcCustomParameters: { 'ui:title': 'OIDC Custom Parameters' },
   oidcMaxAge: { 'ui:title': 'OIDC Max Age' },
   oidcPrompt: { 'ui:title': 'OIDC Prompt' },
@@ -542,7 +542,7 @@ export const GOOGLE_OAUTH_UI_SCHEMA = {
     maxClockSkew: COMMON_UI_FIELDS.oidcMaxClockSkew,
     clientAuthenticationMethod: { 'ui:widget': 'hidden', 'ui:hideError': true },
     tokenValidity: {
-      'ui:title': 'OIDC Token Validity',
+      'ui:title': 'OpenMetadata Access Token Validity',
       'ui:placeholder': `Default: ${OIDC_SSO_DEFAULTS.tokenValidity}`,
     },
     customParams: COMMON_UI_FIELDS.oidcCustomParameters,

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/teams/createUser.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/teams/createUser.ts
@@ -307,7 +307,7 @@ export interface Security {
      */
     strictMode?: boolean;
     /**
-     * Validity for the JWT Token created from SAML Response
+     * Lifetime in seconds of the OpenMetadata JWT issued after SAML authentication.
      */
     tokenValidity?: number;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/auth/ssoAuth.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/auth/ssoAuth.ts
@@ -181,7 +181,7 @@ export interface Security {
      */
     strictMode?: boolean;
     /**
-     * Validity for the JWT Token created from SAML Response
+     * Lifetime in seconds of the OpenMetadata JWT issued after SAML authentication.
      */
     tokenValidity?: number;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/configuration/authenticationConfiguration.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/configuration/authenticationConfiguration.ts
@@ -377,7 +377,7 @@ export interface OidcClientConfig {
      */
     tenant: string;
     /**
-     * Validity for the JWT Token created from SAML Response
+     * Lifetime in seconds of the OpenMetadata JWT issued after OIDC authentication.
      */
     tokenValidity?: number;
     /**
@@ -506,7 +506,7 @@ export interface Security {
      */
     strictMode?: boolean;
     /**
-     * Validity for the JWT Token created from SAML Response
+     * Lifetime in seconds of the OpenMetadata JWT issued after SAML authentication.
      */
     tokenValidity?: number;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/configuration/securityConfiguration.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/configuration/securityConfiguration.ts
@@ -393,7 +393,7 @@ export interface OidcClientConfig {
      */
     tenant: string;
     /**
-     * Validity for the JWT Token created from SAML Response
+     * Lifetime in seconds of the OpenMetadata JWT issued after OIDC authentication.
      */
     tokenValidity?: number;
     /**
@@ -522,7 +522,7 @@ export interface Security {
      */
     strictMode?: boolean;
     /**
-     * Validity for the JWT Token created from SAML Response
+     * Lifetime in seconds of the OpenMetadata JWT issued after SAML authentication.
      */
     tokenValidity?: number;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/teams/user.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/teams/user.ts
@@ -375,7 +375,7 @@ export interface Security {
      */
     strictMode?: boolean;
     /**
-     * Validity for the JWT Token created from SAML Response
+     * Lifetime in seconds of the OpenMetadata JWT issued after SAML authentication.
      */
     tokenValidity?: number;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/security/client/oidcClientConfig.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/security/client/oidcClientConfig.ts
@@ -79,7 +79,7 @@ export interface OidcClientConfig {
      */
     tenant: string;
     /**
-     * Validity for the JWT Token created from SAML Response
+     * Lifetime in seconds of the OpenMetadata JWT issued after OIDC authentication.
      */
     tokenValidity?: number;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/security/client/samlSSOClientConfig.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/security/client/samlSSOClientConfig.ts
@@ -87,7 +87,7 @@ export interface Security {
      */
     strictMode?: boolean;
     /**
-     * Validity for the JWT Token created from SAML Response
+     * Lifetime in seconds of the OpenMetadata JWT issued after SAML authentication.
      */
     tokenValidity?: number;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/settings/settings.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/settings/settings.ts
@@ -1593,7 +1593,7 @@ export interface OidcClientConfig {
      */
     tenant: string;
     /**
-     * Validity for the JWT Token created from SAML Response
+     * Lifetime in seconds of the OpenMetadata JWT issued after OIDC authentication.
      */
     tokenValidity?: number;
     /**
@@ -1705,7 +1705,7 @@ export interface Security {
      */
     strictMode?: boolean;
     /**
-     * Validity for the JWT Token created from SAML Response
+     * Lifetime in seconds of the OpenMetadata JWT issued after SAML authentication.
      */
     tokenValidity?: number;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/system/testLoginTokenRequest.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/system/testLoginTokenRequest.ts
@@ -412,7 +412,7 @@ export interface OidcClientConfig {
      */
     tenant: string;
     /**
-     * Validity for the JWT Token created from SAML Response
+     * Lifetime in seconds of the OpenMetadata JWT issued after OIDC authentication.
      */
     tokenValidity?: number;
     /**
@@ -541,7 +541,7 @@ export interface Security {
      */
     strictMode?: boolean;
     /**
-     * Validity for the JWT Token created from SAML Response
+     * Lifetime in seconds of the OpenMetadata JWT issued after SAML authentication.
      */
     tokenValidity?: number;
     /**


### PR DESCRIPTION
### Describe your changes:

Fixes #30304

Backports #33172 to `2.0`, preventing OpenMetadata from issuing zero-lifetime JWTs after OIDC or SAML login. It adds a 3600-second runtime fallback, rejects explicitly non-positive settings, repairs affected rows in the 2.0.2 MySQL/PostgreSQL migrations, surfaces advanced-field validation, and bounds the browser refresh loop.

Also backports the test-only MinIO registry changes from #33245 and #33247. MinIO removed its Docker Hub repository while this PR's matrix was running, so the Java and Python 2.0 integration tests now pull their same pinned images from Quay; this has no production impact.

Release branch: `2.0`.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

Both SSO paths now resolve the lifetime of OpenMetadata's own API JWT through `TokenValidityResolver`; this remains independent of the identity provider token lifetime. The schemas use numeric defaults and minimums, while the idempotent post-data migrations repair existing OIDC and SAML values at or below zero. The settings write and validation paths reject new invalid values, and the UI keeps advanced fields mounted so errors remain visible while refusing already-expired refresh results.

#
### Tests:

#### Use cases covered

- Existing OIDC `0` and SAML negative validity values migrate to 3600
- Replaying either database migration is a no-op and unrelated settings remain unchanged
- New non-positive values are rejected while omitted and positive values remain valid
- Runtime falls back to 3600 if invalid persisted data bypasses migration
- The client does not retry an already-expired refreshed token indefinitely
- Unrelated successful responses cannot reset the retry cap for opaque refreshed tokens

#### Unit tests

- [x] Added focused backend and UI regression tests
- Backend: 26 tests passed across `TokenValidityResolverTest`, `SystemRepositoryTokenValidityTest`, `SystemRepositoryPatchSettingTest`, and `TokenValiditySqlMigrationTest`
- UI: all 22 `AuthProvider.test.tsx` tests passed

#### Backend integration tests

- [x] Not applicable — no new backend API endpoint

#### Ingestion integration tests

- [x] Not applicable — no ingestion changes

#### Playwright (UI) tests

- [x] Updated `SSOConfiguration.spec.ts` to expand Advanced Config before checking OIDC fields
- Playwright compiled and discovered 45 SSO/setup tests; changed-file and full Playwright lint completed with no errors

#### Manual testing performed

1. Ran the PostgreSQL 15 migration twice against representative OIDC/SAML rows and verified `3600|3600`; an unrelated row remained `0`
2. Repeated the same replay test on MySQL 8.0 and verified `3600|3600`; an unrelated row remained `0`
3. Regenerated TypeScript schema models and the Playwright impact map and verified both produced no diff
4. Ran Java Spotless, UI changed-file checkstyle, license, i18n, and application-doc generation checks
5. Verified both pinned MinIO image manifests are publicly available from Quay and ran targeted Ruff lint/format on the Python fixtures

#
### UI screen recording / screenshots:

Not re-recorded for this code backport; the behavior and UI changes originate in #33172.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

#### Bug fix

- [x] I have added a test that covers the exact scenario we are fixing.
