### PR TITLE
Fixes 26509: Entity Reference custom property filters return no results in Advanced Search

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.js
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.js
@@ -271,6 +271,10 @@ function buildParameters(
  * @returns {string} - The base property name
  * @private
  */
+// The entityReference sub-fields a custom-property field can name.
+const DISPLAY_NAME_SUFFIX = '.displayName';
+const FQN_SUFFIX = '.fullyQualifiedName';
+
 function getBasePropertyName(propertyName) {
   // Handle table-cp pattern: propertyName.rows.columnName.keyword -> propertyName.rows.columnName
   // Backend stores separate entries for each column with names like "propertyName.rows.columnName"
@@ -291,11 +295,11 @@ function getBasePropertyName(propertyName) {
   // Known nested field suffixes for complex custom property types
   const nestedSuffixes = [
     '.displayName.keyword',
-    '.displayName',
+    DISPLAY_NAME_SUFFIX,
     '.name.keyword',
     '.name',
     '.fullyQualifiedName.keyword',
-    '.fullyQualifiedName',
+    FQN_SUFFIX,
     '.start',
     '.end',
     '.keyword',
@@ -311,6 +315,32 @@ function getBasePropertyName(propertyName) {
   }
 
   return baseName;
+}
+
+/**
+ * The nested sub-field holding the part of an entityReference a field names.
+ *
+ * `SearchIndexUtils.populateEntityRefFields` splits a reference across the
+ * nested doc: `name` into refName, `fullyQualifiedName` into refFqn and
+ * `displayName` into stringValue. Reading refName for all three matched a
+ * displayName against a name and returned nothing.
+ *
+ * @param {string} propertyName - The full property name, `.keyword` and all
+ * @returns {string} - The customPropertiesTyped sub-field to query
+ * @private
+ */
+function getEntityRefNestedField(propertyName) {
+  const path = String(propertyName ?? '').replace(/\.keyword$/, '');
+
+  if (path.endsWith(DISPLAY_NAME_SUFFIX)) {
+    return 'stringValue';
+  }
+
+  if (path.endsWith(FQN_SUFFIX)) {
+    return 'refFqn';
+  }
+
+  return 'refName';
 }
 
 /**
@@ -331,7 +361,10 @@ function getFieldTypeInfoFromOmType(omPropertyType, propertyName) {
   switch (omPropertyType) {
     case 'entityReference':
     case 'array<entityReference>':
-      return { fieldType: 'entityReference', nestedField: 'refName' };
+      return {
+        fieldType: 'entityReference',
+        nestedField: getEntityRefNestedField(propertyName),
+      };
     case 'hyperlink-cp':
       return { fieldType: 'hyperlink', nestedField: 'stringValue' };
     case 'table-cp':
@@ -371,11 +404,14 @@ function getFieldTypeInfo(propertyName) {
   // are not misclassified. For full disambiguation when the property name itself
   // is `owner.name`, callers should pass the type via getFieldTypeInfoFromOmType.
   if (
-    propertyName.endsWith('.displayName') ||
+    propertyName.endsWith(DISPLAY_NAME_SUFFIX) ||
     propertyName.endsWith('.name') ||
-    propertyName.endsWith('.fullyQualifiedName')
+    propertyName.endsWith(FQN_SUFFIX)
   ) {
-    return { fieldType: 'entityReference', nestedField: 'refName' };
+    return {
+      fieldType: 'entityReference',
+      nestedField: getEntityRefNestedField(propertyName),
+    };
   }
 
   // Hyperlink fields: propertyName.url.keyword or propertyName.displayText.keyword
@@ -466,7 +502,13 @@ function isRangeOperator(operator) {
  * @private
  */
 // eslint-disable-next-line sonarjs/cyclomatic-complexity -- predates the budget
-function buildNestedTypedQuery(propertyName, nestedField, value, operator) {
+function buildNestedTypedQuery(
+  propertyName,
+  nestedField,
+  value,
+  operator,
+  caseInsensitive = false
+) {
   const mustClauses = [
     { term: { 'customPropertiesTyped.name': propertyName } },
   ];
@@ -497,7 +539,11 @@ function buildNestedTypedQuery(propertyName, nestedField, value, operator) {
     // Exact match
     const termValue = Array.isArray(value) ? value[0] : value;
     mustClauses.push({
-      term: { [`customPropertiesTyped.${nestedField}`]: termValue },
+      term: {
+        [`customPropertiesTyped.${nestedField}`]: caseInsensitive
+          ? { value: termValue, case_insensitive: true }
+          : termValue,
+      },
     });
   }
 
@@ -647,12 +693,12 @@ function buildExtensionQuery(
       operator
     );
   } else if (fieldType === 'entityReference') {
-    // EntityReference: use refName for exact match queries
     mainQuery = buildNestedTypedQuery(
       basePropertyName,
-      'refName',
+      nestedField ?? 'refName',
       value,
-      operator
+      operator,
+      true
     );
   } else if (
     (fieldType === 'hyperlink' || fieldType === 'table') &&

--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.test.js
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.test.js
@@ -490,3 +490,81 @@ describe('elasticSearchFormat – custom properties without an entity-type segme
     expect(json).toContain(SCOPED_TO_TABLE);
   });
 });
+
+describe('elasticSearchFormat – entityReference custom properties', () => {
+  const refConfig = {
+    ...BasicConfig,
+    fields: {
+      ...BasicConfig.fields,
+      extension: {
+        subfields: {
+          apiCollection: {
+            subfields: {
+              'testApiCp.displayName.keyword': {
+                __omPropertyType: 'entityReference',
+              },
+              'testApiCp.name.keyword': {
+                __omPropertyType: 'entityReference',
+              },
+              'testApiCp.fullyQualifiedName.keyword': {
+                __omPropertyType: 'array<entityReference>',
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const REF_FIELD = 'extension.apiCollection.testApiCp.displayName.keyword';
+
+  const queryFor = (field) =>
+    JSON.stringify(
+      elasticSearchFormat(
+        makeTree('select_equals', ['address'], field),
+        refConfig
+      )
+    );
+
+  it('should read displayName from stringValue, where the indexer puts it', () => {
+    const json = queryFor(REF_FIELD);
+
+    expect(json).toContain('"customPropertiesTyped.name":"testApiCp"');
+    expect(json).toContain(
+      '"customPropertiesTyped.stringValue":{"value":"address"'
+    );
+    expect(json).not.toContain('refName');
+  });
+
+  // The picker's options come from a terms aggregation over `displayName.keyword`, which carries a
+  // `lowercase_normalizer`. `customPropertiesTyped.*` has none and keeps the original case, so an
+  // exact keyword term could never match the lower-cased option the user actually picked.
+  it('should match a reference ignoring case', () => {
+    const json = queryFor(REF_FIELD);
+
+    expect(json).toContain('"case_insensitive":true');
+  });
+
+  it('should read name from refName', () => {
+    const json = queryFor('extension.apiCollection.testApiCp.name.keyword');
+
+    expect(json).toContain(
+      '"customPropertiesTyped.refName":{"value":"address"'
+    );
+  });
+
+  it('should read fullyQualifiedName from refFqn', () => {
+    const json = queryFor(
+      'extension.apiCollection.testApiCp.fullyQualifiedName.keyword'
+    );
+
+    expect(json).toContain('"customPropertiesTyped.refFqn":{"value":"address"');
+  });
+
+  it('should keep the property name free of the sub-field suffix', () => {
+    const json = queryFor(REF_FIELD);
+
+    expect(json).not.toContain('"customPropertiesTyped.name":"displayName"');
+    expect(json).not.toContain('"customPropertiesTyped.name":"keyword"');
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.test.js
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.test.js
@@ -492,6 +492,10 @@ describe('elasticSearchFormat – custom properties without an entity-type segme
 });
 
 describe('elasticSearchFormat – entityReference custom properties', () => {
+  // Synthetic: the builder only ever keys a reference property by `.displayName.keyword`
+  // (AdvancedSearchClassBase.resolveCustomPropertySubfieldsKey), so these three keys never coexist
+  // in a real config. They sit side by side here only to drive all three suffixes through one
+  // config — reading them as siblings would suggest a reload ambiguity that cannot occur.
   const refConfig = {
     ...BasicConfig,
     fields: {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderPureUtils.ts
@@ -16,7 +16,7 @@ import type {
   OldJsonItem,
   OldJsonTree,
 } from '@react-awesome-query-builder/ui';
-import { isBoolean, isUndefined } from 'lodash';
+import { isBoolean, isObject, isUndefined } from 'lodash';
 import { EntityReferenceFields } from '../enums/AdvancedSearch.enum';
 import { EntityType } from '../enums/entity.enum';
 import type {
@@ -451,7 +451,17 @@ const VALUE_CLAUSE_READERS: Array<
     (body: unknown) => Pick<CustomPropertyClause, 'value' | 'range'>
   ]
 > = [
-  ['term', (body) => ({ value: body })],
+  // A case-insensitive term states its value as `{ value, case_insensitive }`; a plain one is the
+  // bare value. Unwrap so the rule reloads with the value, not the clause body.
+  [
+    'term',
+    (body) => ({
+      value:
+        isObject(body) && 'value' in (body as UnknownRecord)
+          ? (body as UnknownRecord).value
+          : body,
+    }),
+  ],
   ['wildcard', (body) => ({ value: (body as { value?: unknown })?.value })],
   ['regexp', (body) => ({ value: (body as { value?: unknown })?.value })],
   ['match', (body) => ({ value: (body as { query?: unknown })?.query })],

--- a/openmetadata-ui/src/main/resources/ui/src/utils/customPropertyIndexContract.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/customPropertyIndexContract.test.ts
@@ -1,0 +1,300 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { BasicConfig } from '@react-awesome-query-builder/ui';
+import { SearchOutputType } from '../components/Explore/AdvanceSearchProvider/AdvanceSearchProvider.interface';
+import { elasticSearchFormat } from './QueryBuilderElasticsearchFormatUtils';
+
+jest.mock('./AdvancedSearchClassBase', () =>
+  jest.requireActual('./AdvancedSearchClassBase')
+);
+
+const advancedSearchClassBase = jest.requireActual(
+  './AdvancedSearchClassBase'
+).default;
+
+const INDEX_CONTRACT: Array<{
+  type: string;
+  fieldKey: string;
+  // The `customPropertiesTyped.name` term identifying the indexed entry.
+  nestedName: string;
+  // The `customPropertiesTyped.*` sub-field the value clause must target.
+  queries: string;
+}> = [
+  {
+    type: 'string',
+    fieldKey: 'strCP.keyword',
+    nestedName: 'strCP',
+    queries: 'stringValue',
+  },
+  {
+    type: 'integer',
+    fieldKey: 'intCP',
+    nestedName: 'intCP',
+    queries: 'longValue',
+  },
+  {
+    type: 'number',
+    fieldKey: 'numCP',
+    nestedName: 'numCP',
+    queries: 'longValue',
+  },
+  {
+    type: 'timestamp',
+    fieldKey: 'tsCP',
+    nestedName: 'tsCP',
+    queries: 'longValue',
+  },
+  {
+    type: 'date-cp',
+    fieldKey: 'dateCP.keyword',
+    nestedName: 'dateCP',
+    queries: 'stringValue',
+  },
+  {
+    type: 'dateTime-cp',
+    fieldKey: 'dtCP.keyword',
+    nestedName: 'dtCP',
+    queries: 'stringValue',
+  },
+  {
+    type: 'time-cp',
+    fieldKey: 'timeCP.keyword',
+    nestedName: 'timeCP',
+    queries: 'stringValue',
+  },
+  {
+    type: 'markdown',
+    fieldKey: 'mdCP.keyword',
+    nestedName: 'mdCP',
+    queries: 'stringValue',
+  },
+  {
+    type: 'sqlQuery',
+    fieldKey: 'sqlCP.keyword',
+    nestedName: 'sqlCP',
+    queries: 'stringValue',
+  },
+  {
+    type: 'enum',
+    fieldKey: 'enumCP.keyword',
+    nestedName: 'enumCP',
+    queries: 'stringValue',
+  },
+  // displayName lands in stringValue, not refName.
+  {
+    type: 'entityReference',
+    fieldKey: 'refCP.displayName.keyword',
+    nestedName: 'refCP',
+    queries: 'stringValue',
+  },
+  {
+    type: 'array<entityReference>',
+    fieldKey: 'refsCP.displayName.keyword',
+    nestedName: 'refsCP',
+    queries: 'stringValue',
+  },
+  // Each half of a hyperlink is its own indexed entry, named for the half.
+  {
+    type: 'hyperlink-cp',
+    fieldKey: 'linkCP.url',
+    nestedName: 'linkCP.url',
+    queries: 'stringValue',
+  },
+  {
+    type: 'hyperlink-cp',
+    fieldKey: 'linkCP.displayText',
+    nestedName: 'linkCP.displayText',
+    queries: 'stringValue',
+  },
+  {
+    type: 'timeInterval',
+    fieldKey: 'intervalCP.start',
+    nestedName: 'intervalCP',
+    queries: 'start',
+  },
+  {
+    type: 'timeInterval',
+    fieldKey: 'intervalCP.end',
+    nestedName: 'intervalCP',
+    queries: 'end',
+  },
+  // One entry per column, named for the column.
+  {
+    type: 'table-cp',
+    fieldKey: 'tableCP.rows.name',
+    nestedName: 'tableCP.rows.name',
+    queries: 'stringValue',
+  },
+];
+
+// Every sub-field `customPropertiesTyped` declares (indexMappingsTemplate.json).
+// A typo'd or invented name would otherwise sail through as a silent no-match.
+const MAPPED_SUB_FIELDS = [
+  'stringValue',
+  'textValue',
+  'longValue',
+  'doubleValue',
+  'start',
+  'end',
+  'refId',
+  'refType',
+  'refName',
+  'refFqn',
+];
+
+const PROPERTIES = [
+  { name: 'strCP', type: 'string' },
+  { name: 'intCP', type: 'integer' },
+  { name: 'numCP', type: 'number' },
+  { name: 'tsCP', type: 'timestamp' },
+  { name: 'dateCP', type: 'date-cp' },
+  { name: 'dtCP', type: 'dateTime-cp' },
+  { name: 'timeCP', type: 'time-cp' },
+  { name: 'mdCP', type: 'markdown' },
+  { name: 'sqlCP', type: 'sqlQuery' },
+  {
+    name: 'enumCP',
+    type: 'enum',
+    customPropertyConfig: { config: { values: ['a', 'b'] } },
+  },
+  { name: 'refCP', type: 'entityReference' },
+  { name: 'refsCP', type: 'array<entityReference>' },
+  { name: 'linkCP', type: 'hyperlink-cp' },
+  { name: 'intervalCP', type: 'timeInterval' },
+  {
+    name: 'tableCP',
+    type: 'table-cp',
+    customPropertyConfig: { config: { columns: ['name'] } },
+  },
+];
+
+// A numeric type routes on its declared type, but only a numeric value proves it.
+const NUMERIC_TYPES = ['integer', 'number', 'timestamp'];
+const SAMPLE = 'SENTINEL';
+
+const EXACT_MATCH_OPERATORS = [
+  'select_equals',
+  'multiselect_equals',
+  'equal',
+] as const;
+
+// Immutable-compatible stub: elasticSearchFormat only calls .get().
+const makeRule = (field: string, operator: string, value: unknown) => {
+  const properties: Record<string, unknown> = {
+    field,
+    operator,
+    value: { toJS: () => [value] },
+    valueSrc: { get: () => 'value' },
+    valueType: { get: () => 'text' },
+  };
+  const node: Record<string, unknown> = {
+    type: 'rule',
+    properties: { get: (prop: string) => properties[prop] },
+  };
+
+  return { get: (key: string) => node[key] };
+};
+
+type SubField = {
+  subfieldsKey: string;
+  dataObject: { operators?: string[] };
+};
+
+const buildActualContract = () =>
+  PROPERTIES.flatMap((property) => {
+    const produced = advancedSearchClassBase.getCustomPropertiesSubFields(
+      property,
+      SearchOutputType.ElasticSearch
+    );
+
+    return (Array.isArray(produced) ? produced : [produced]).map(
+      ({ subfieldsKey, dataObject }: SubField) => {
+        const operators = dataObject.operators ?? [];
+        const operator =
+          EXACT_MATCH_OPERATORS.find((candidate) =>
+            operators.includes(candidate)
+          ) ?? 'equal';
+        const value = NUMERIC_TYPES.includes(property.type) ? 42 : SAMPLE;
+        const config = {
+          ...BasicConfig,
+          fields: {
+            ...BasicConfig.fields,
+            extension: {
+              subfields: {
+                [subfieldsKey]: { __omPropertyType: property.type },
+              },
+            },
+          },
+        };
+
+        const json = JSON.stringify(
+          elasticSearchFormat(
+            makeRule(`extension.${subfieldsKey}`, operator, value) as never,
+            config as never
+          )
+        );
+
+        return {
+          type: property.type,
+          fieldKey: subfieldsKey,
+          nestedName:
+            json.match(/"customPropertiesTyped\.name":"([^"]+)"/)?.[1] ??
+            '(none)',
+          // An entityReference matches case-insensitively, so its term body is an
+          // object rather than the bare value.
+          queries:
+            json.match(
+              new RegExp(
+                `"customPropertiesTyped\\.(\\w+)":(?:\\{"value":)?"?(?:${SAMPLE}|42)"?`
+              )
+            )?.[1] ?? '(none)',
+        };
+      }
+    );
+  });
+
+describe('custom property index contract', () => {
+  it('should query the sub-field the indexer writes, for every property type', () => {
+    expect(buildActualContract()).toEqual(INDEX_CONTRACT);
+  });
+
+  it('should only reach for sub-fields customPropertiesTyped actually maps', () => {
+    const unmapped = buildActualContract().filter(
+      (row) => !MAPPED_SUB_FIELDS.includes(row.queries)
+    );
+
+    expect(unmapped).toEqual([]);
+  });
+
+  it('should cover every type the indexer branches on', () => {
+    const covered = new Set(INDEX_CONTRACT.map((row) => row.type));
+
+    expect([...covered].sort()).toEqual([
+      'array<entityReference>',
+      'date-cp',
+      'dateTime-cp',
+      'entityReference',
+      'enum',
+      'hyperlink-cp',
+      'integer',
+      'markdown',
+      'number',
+      'sqlQuery',
+      'string',
+      'table-cp',
+      'time-cp',
+      'timeInterval',
+      'timestamp',
+    ]);
+  });
+});


### PR DESCRIPTION
### Describe your changes:

Fixes #26509

Advanced Search filters built on an **Entity Reference** custom property never returned results — the asset was indexed, the property was populated, and the filter still came back empty every time.

There were two independent causes. Either one on its own was enough to break the filter, which is why fixing only the first did not make the symptom go away.

**1. The filter and the search index disagreed about where the value lives.**

When a custom property holds a reference to another entity, the index stores the reference's parts separately — its name, its fully qualified name and its display name each land in a different place. The query builder shows the display name in the UI and offers display names in the value picker, but always looked the chosen value up against the name. Those two are only the same string by coincidence, so the comparison failed for any reference where they differ.

**2. The offered values and the stored values differ in letter case.**

The value picker is populated from a source that lower-cases everything it returns, while the index preserves the original capitalisation. The comparison was exact and case-sensitive, so a reference whose display name was not already entirely lower-case could never be matched — including the one the user had just selected from the list.

### The fix

The filter now reads the same part of the reference that the UI is displaying, and compares it ignoring case. Reloading a previously saved filter was updated to stay in step with the new query shape, so saved queries still open correctly in the builder.

No backend or schema changes; this is entirely in the search-filter layer.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered

- Filtering on an Entity Reference custom property by display name returns the matching assets.
- Filtering by the reference's name or fully qualified name reads the correct stored value.
- A reference whose display name is capitalised is matched by the value offered in the picker.
- A saved filter containing an Entity Reference condition reloads into the builder unchanged.
- Every other custom property type continues to resolve to the same stored value as before.

#### Unit tests

- [x] I added unit tests for the changed logic.
- Added cases covering each part of a reference a filter can name, and the case-insensitive match.
- Added a contract test that pins, for every supported custom property type, which stored value the filter resolves to. The pre-existing round-trip coverage could not catch this class of bug because it only ever proved the filter agreed with itself; the new test compares against what the indexer actually writes.

#### Backend integration tests

- [x] Not applicable (no backend changes).

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- Not added. The failure is in how the filter is built rather than in the interaction, and it is covered by the unit tests above.

#### Manual testing performed

1. Seeded a custom property of every supported type on the Table entity and populated all of them on a sample asset, including an Entity Reference pointing at a user whose name, display name and capitalisation all differ.
2. Confirmed the values were indexed as expected.
3. Reproduced the original failure on the unfixed build — the filter returned zero results for a value picked straight out of the dropdown.
4. Verified the fixed build returns the asset for the same selection, and re-checked the originally reported scenario.
5. Re-ran the filters for the remaining custom property types to confirm none of them changed behaviour.

#
### UI screen recording / screenshots:

_To be attached._

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests and listed them above.

- [x] I have added a test that covers the exact scenario we are fixing.
